### PR TITLE
initial drop of new settings builder

### DIFF
--- a/services/web/client/source/class/qxapp/components/form/Auto.js
+++ b/services/web/client/source/class/qxapp/components/form/Auto.js
@@ -22,7 +22,7 @@
  *     ]
  *
  * The following widgets are supported:
- *
+ *     header: { label: "header text"},
  *     text: { },
  *     integer: {},
  *     selectBox: { cfg: { structure: [ {key: x, label: y}, ...] } },
@@ -326,19 +326,24 @@ qx.Class.define("qxapp.components.form.Auto", {
       ctrl.setModel(sbModel);
     },
     __addField: function(s) {
-      let extra = s.note ? {
-        note: this["tr"](s.note)
-      } : null;
+      let option = {
+        exposable: s.exposable
+      }; // for passing info into the form renderer
 
       if (s.widget == "header") {
-        this.addGroupHeader(s.label === null ? null : this["tr"](s.label), extra);
+        this.addGroupHeader(s.label === null ? null : this["tr"](s.label), option);
         return;
       }
 
       if (s.key === null) {
         throw new Error("the key property is required");
       }
-
+      if (s.defaultValue) {
+        if (!s.set) {
+          s.set = {};
+        }
+     //   s.set.value = s.defaultValue;
+      }
       let control;
       let setup;
       switch (s.widget) {
@@ -384,9 +389,9 @@ qx.Class.define("qxapp.components.form.Auto", {
           throw new Error("unknown widget type " + s.widget);
       }
       this.__ctrlMap[s.key] = control;
-      this.add(control, s.label === null ? null : this["tr"](s.label), null, s.key, null, extra);
+      this.add(control, s.label === null ? null : this["tr"](s.label), null, s.key, null, option);
 
-      setup.call(this,s, control);
+      setup.call(this, s, control);
 
       if (s.set) {
         if (s.set.filter) {

--- a/services/web/client/source/class/qxapp/components/form/Auto.js
+++ b/services/web/client/source/class/qxapp/components/form/Auto.js
@@ -1,0 +1,406 @@
+/* ************************************************************************
+   Copyright: 2013 OETIKER+PARTNER AG
+              2018 ITIS Foundation
+   License:   MIT
+   Authors:   Tobi Oetiker <tobi@oetiker.ch>
+   Utf8Check: äöü
+************************************************************************ */
+
+/**
+ * Create a form. The argument to the form
+ * widget defines the structure of the form.
+ *
+ *     [
+ *         {
+ *           key: 'xyc',             // unique name
+ *           label: 'label',
+ *           widget: 'text',
+ *           cfg: {},                // widget specific configuration
+ *           set: {}                 // normal qx porperties to apply
+ *          },
+ *          ....
+ *     ]
+ *
+ * The following widgets are supported:
+ *
+ *     text: { },
+ *     integer: {},
+ *     selectBox: { cfg: { structure: [ {key: x, label: y}, ...] } },
+ *     date: { }, // following unix tradition, dates are represented in epoc seconds
+ *     password: {},
+ *     textArea: {},
+ *     hiddenText: {},
+ *     checkBox: {},
+ *     comboBox: {},
+ *
+ *
+ * Populate the new form using the setData method, providing a map
+ * with the required data.
+ *
+ */
+
+qx.Class.define("qxapp.components.form.Auto", {
+  extend : qx.ui.form.Form,
+  include : [qx.locale.MTranslation],
+
+  /**
+     * @param structure {Array} form structure
+     */
+  construct : function(structure) {
+    this.base(arguments);
+    this.__ctrlMap = {};
+    let formCtrl = this.__formCtrl = new qx.data.controller.Form(null, this);
+    this.__boxCtrl = {};
+    this.__typeMap = {};
+
+    structure.forEach(this.__addField, this);
+
+    let model = this.__model = formCtrl.createModel(true);
+
+    model.addListener("changeBubble", function(e) {
+      if (!this.__settingData) {
+        this.fireDataEvent("changeData", this.getData());
+      }
+    },
+    this);
+  },
+
+  events : {
+    /**
+     * fire when the form changes content and
+     * and provide access to the data
+     */
+    changeData : "qx.event.type.Data"
+  },
+
+  members : {
+    __boxCtrl : null,
+    __ctrlMap : null,
+    __formCtrl: null,
+    __model : null,
+    __settingData : false,
+    __typeMap : null,
+
+
+    /**
+     * Use normal Form validation to validate the content of the form
+     *
+     * @return {let} validation output
+     */
+    validate : function() {
+      return this.__formCtrl.validate();
+    },
+
+
+    /**
+     * Reset the form content
+     *
+     */
+    reset : function() {
+      this.__formCtrl.reset();
+    },
+
+
+    /**
+     * get a handle to the control with the given name
+     *
+     * @param key {let} key of the the field
+     * @return {let} control associated with the field
+     */
+    getControl : function(key) {
+      return this.__ctrlMap[key];
+    },
+
+
+    /**
+     * fetch the data for this form
+     *
+     * @return {let} all data from the form
+     */
+    getData : function() {
+      return this.__getData(this.__model);
+    },
+
+    /**
+     * load new data into the data main model
+     *
+     * @param data {let} map with key value pairs to apply
+     * @param relax {let} ignore non existing keys
+     */
+    setData : function(data, relax) {
+      this.__setData(this.__model, data, relax);
+    },
+
+
+    /**
+     * set the data in a selectbox
+     *
+     * @param box {let} selectbox name
+     * @param data {let} configuration of the box
+     */
+    setSelectBoxData : function(box, data) {
+      let model;
+      this.__settingData = true;
+
+      if (data.length == 0) {
+        model = qx.data.marshal.Json.createModel([{
+          label : "",
+          key   : null
+        }]);
+      } else {
+        model = qx.data.marshal.Json.createModel(data);
+      }
+
+      this.__boxCtrl[box].setModel(model);
+      this.__boxCtrl[box].getTarget().resetSelection();
+      this.__settingData = false;
+    },
+
+
+    /**
+     * load new data into a model
+     * if relax is set unknown properties will be ignored
+     *
+     * @param model {let} TODOC
+     * @param data {let} TODOC
+     * @param relax {let} TODOC
+     */
+    __setData : function(model, data, relax) {
+      this.__settingData = true;
+
+      for (let key in data) {
+        let upkey = qx.lang.String.firstUp(key);
+        let setter = "set" + upkey;
+        let value = data[key];
+        if (relax && !model[setter]) {
+          continue;
+        }
+        model[setter](value);
+      }
+
+      this.__settingData = false;
+
+      /* only fire ONE if there was an attempt at change */
+
+      this.fireDataEvent("changeData", this.getData());
+    },
+
+
+    /**
+     * turn a model object into a plain data structure
+     *
+     * @param model {let} TODOC
+     * @return {let} TODOC
+     */
+    __getData : function(model) {
+      let props = model.constructor.$$properties;
+      let data = {};
+
+      for (let key in props) {
+        let getter = "get" + qx.lang.String.firstUp(key);
+        data[key] = model[getter]();
+      }
+
+      return data;
+    },
+    __setupDateField: function(s) {
+      this.__formCtrl.addBindingOptions(s.key,
+        { // model2target
+          converter : function(data) {
+            if (/^\d+$/.test(String(data))) {
+              let d = new Date();
+              d.setTime(parseInt(data) * 1000);
+              let d2 = new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), 0, 0, 0, 0);
+              return d2;
+            }
+            if (qx.lang.Type.isDate(data)) {
+              return data;
+            }
+            return null;
+          }
+        },
+        { // target2model
+          converter : function(data) {
+            if (qx.lang.Type.isDate(data)) {
+              let d = new Date(Date.UTC(data.getFullYear(), data.getMonth(), data.getDate(), 0, 0, 0, 0));
+              return Math.round(d.getTime()/1000);
+            }
+            return null;
+          }
+        }
+      );
+      if (!s.set) {
+        s.set = {};
+      }
+      s.set.dateFormat = new qx.util.format.DateFormat(
+        this["tr"](
+          s.set.dateFormat ?
+            s.set.dateFormat :
+            "dd.MM.yyyy"
+        )
+      );
+      let dateValue = s.set.value;
+      if (dateValue !== null) {
+        if (typeof dateValue == "number") {
+          s.set.value = new Date(dateValue * 1000);
+        } else {
+          s.set.value = new Date(dateValue);
+        }
+      }
+    },
+    __setupTextField: function(s) {
+      this.__formCtrl.addBindingOptions(s.key,
+        { // model2target
+          converter : function(data) {
+            return String(data);
+          }
+        },
+        { // target2model
+          converter : function(data) {
+            return data;
+          }
+        }
+      );
+    },
+    __setupIntegerField: function(s) {
+      if (!s.set) {
+        s.set = {};
+      }
+      if (!s.set.filter) {
+        s.set.filter = "/\d/";
+      }
+      if (s.set.value) {
+        s.set.value = parseInt(s.set.value);
+      }
+      this.__formCtrl.addBindingOptions(s.key,
+        { // model2target
+          converter : function(data) {
+            let d = String(data);
+            if (/^\d+$/.test(d)) {
+              return parseInt(d);
+            }
+            return null;
+          }
+        },
+        { // target2model
+          converter : function(data) {
+            return parseInt(data);
+          }
+        }
+      );
+    },
+    __setupSelectBox: function(s, control) {
+      let controller = this.__boxCtrl[s.key] = new qx.data.controller.List(null, control, "label");
+      controller.setDelegate({
+        bindItem : function(ctrl, item, index) {
+          ctrl.bindProperty("key", "model", null, item, index);
+          ctrl.bindProperty("label", "label", null, item, index);
+        }
+      });
+      let cfg = s.cfg;
+      if (cfg.structure) {
+        cfg.structure.forEach(function(item) {
+          item.label = item.label === null ? null : this["tr"](item.label);
+        }, this);
+      } else {
+        cfg.strucuture = [{
+          label : "",
+          key   : null
+        }];
+      }
+      console.log(cfg.structure);
+      let sbModel = qx.data.marshal.Json.createModel(cfg.structure);
+      controller.setModel(sbModel);
+    },
+    __setupComboBox: function(s, control) {
+      let ctrl = this.__boxCtrl[s.key] = new qx.data.controller.List(null, control);
+      let cfg = s.cfg;
+      if (cfg.structure) {
+        cfg.structure.forEach(function(item) {
+          item = item === null ? null : this["tr"](item);
+        }, this);
+      } else {
+        cfg.structure = [];
+      }
+      let sbModel = qx.data.marshal.Json.createModel(cfg.structure);
+      ctrl.setModel(sbModel);
+    },
+    __addField: function(s) {
+      let extra = s.note ? {
+        note: this["tr"](s.note)
+      } : null;
+
+      if (s.widget == "header") {
+        this.addGroupHeader(s.label === null ? null : this["tr"](s.label), extra);
+        return;
+      }
+
+      if (s.key === null) {
+        throw new Error("the key property is required");
+      }
+
+      let control;
+      let setup;
+      switch (s.widget) {
+        case "date":
+          control = new qx.ui.form.DateField();
+          setup = this.__setupDateField;
+          break;
+        case "text":
+          control = new qx.ui.form.DateField();
+          setup = this.__setupTextField;
+          break;
+        case "integer":
+          control = new qx.ui.form.TextField();
+          setup = this.__setupIntegerField;
+          break;
+        case "password":
+          control = new qx.ui.form.PasswordField();
+          setup = this.__setupTextField;
+          break;
+        case "textArea":
+          control = new qx.ui.form.TextArea();
+          setup = this.__setupTextField;
+          break;
+        case "hiddenText":
+          control = new qx.ui.form.TextField();
+          control.exclude();
+          setup = this.__setupTextField;
+          break;
+        case "checkBox":
+          control = new qx.ui.form.CheckBox();
+          setup = this.__setupBooleanField;
+          break;
+        case "selectBox":
+          control = new qx.ui.form.SelectBox();
+          setup = this.__setupSelectBox;
+          break;
+
+        case "comboBox":
+          control = new qx.ui.form.ComboBox();
+          setup = this.__setupComboBox;
+          break;
+        default:
+          throw new Error("unknown widget type " + s.widget);
+      }
+      this.__ctrlMap[s.key] = control;
+      this.add(control, s.label === null ? null : this["tr"](s.label), null, s.key, null, extra);
+
+      setup.call(this,s, control);
+
+      if (s.set) {
+        if (s.set.filter) {
+          s.set.filter = RegExp(s.filter);
+        }
+        if (s.set.placeholder) {
+          s.set.placeholder = this["tr"](s.set.placeholder);
+        }
+        if (s.set.label) {
+          s.set.label = this["tr"](s.set.label);
+        }
+        control.set(s.set);
+      }
+      this.__ctrlMap[s.key] = control;
+    }
+  }
+});

--- a/services/web/client/source/class/qxapp/components/form/Auto.js
+++ b/services/web/client/source/class/qxapp/components/form/Auto.js
@@ -342,7 +342,7 @@ qx.Class.define("qxapp.components.form.Auto", {
         if (!s.set) {
           s.set = {};
         }
-     //   s.set.value = s.defaultValue;
+        //   s.set.value = s.defaultValue;
       }
       let control;
       let setup;

--- a/services/web/client/source/class/qxapp/components/form/renderer/NoteForm.js
+++ b/services/web/client/source/class/qxapp/components/form/renderer/NoteForm.js
@@ -1,0 +1,91 @@
+/* ************************************************************************
+   Copyright: 2013 OETIKER+PARTNER AG
+              2018 ITIS Foundation
+   License:   MIT
+   Authors:   Tobi Oetiker <tobi@oetiker.ch>
+   Utf8Check: äöü
+************************************************************************ */
+
+/**
+ * A special renderer for AutoForms which includes notes below the section header
+ * widget and next to the individual form widgets.
+ */
+qx.Class.define("qxapp.components.form.renderer.NoteForm", {
+  extend : qx.ui.form.renderer.Single,
+  /**
+     * create a page for the View Tab with the given title
+     *
+     * @param vizWidget {Widget} visualization widget to embedd
+     */
+  construct: function(form) {
+    this.base(arguments, form);
+    var fl = this._getLayout();
+    // have plenty of space for input, not for the labels
+    fl.setColumnFlex(0, 0);
+    fl.setColumnAlign(0, "left", "top");
+    fl.setColumnFlex(1, 1);
+    fl.setColumnMinWidth(1, 130);
+  },
+
+  members: {
+    addItems: function(items, names, title, itemOptions, headerOptions) {
+      // add the header
+      if (title !== null) {
+        this._add(
+          this._createHeader(title), {
+            row: this._row,
+            column: 0,
+            colSpan: 3
+          }
+        );
+        this._row++;
+        if (headerOptions !== null && headerOptions.note !== null) {
+          this._add(new qx.ui.basic.Label(headerOptions.note).set({
+            rich: true,
+            alignX: "left"
+          }), {
+            row: this._row,
+            column: 0,
+            colSpan: 3
+          });
+          this._row++;
+        }
+      }
+
+      // add the items
+      for (var i = 0; i < items.length; i++) {
+        var label = this._createLabel(names[i], items[i]);
+        this._add(label, {
+          row: this._row,
+          column: 0
+        });
+        var item = items[i];
+        label.setBuddy(item);
+        this._add(item, {
+          row: this._row,
+          column: 1
+        });
+        if (itemOptions !== null && itemOptions[i] !== null && itemOptions[i].note) {
+          this._add(new qx.ui.basic.Label(itemOptions[i].note).set({
+            rich: true,
+            marginLeft: 20,
+            marginRight: 20
+          }), {
+            row: this._row,
+            column: 2
+          });
+        }
+        this._row++;
+        this._connectVisibility(item, label);
+        // store the names for translation
+        if (qx.core.Environment.get("qx.dynlocale")) {
+          this._names.push({
+            name: names[i],
+            label: label,
+            item: items[i]
+          });
+        }
+      }
+    }
+  }
+});

--- a/services/web/client/source/class/qxapp/components/form/renderer/PropForm.js
+++ b/services/web/client/source/class/qxapp/components/form/renderer/PropForm.js
@@ -10,7 +10,7 @@
  * A special renderer for AutoForms which includes notes below the section header
  * widget and next to the individual form widgets.
  */
-qx.Class.define("qxapp.components.form.renderer.NoteForm", {
+qx.Class.define("qxapp.components.form.renderer.PropForm", {
   extend : qx.ui.form.renderer.Single,
   /**
      * create a page for the View Tab with the given title
@@ -19,7 +19,7 @@ qx.Class.define("qxapp.components.form.renderer.NoteForm", {
      */
   construct: function(form) {
     this.base(arguments, form);
-    var fl = this._getLayout();
+    let fl = this._getLayout();
     // have plenty of space for input, not for the labels
     fl.setColumnFlex(0, 0);
     fl.setColumnAlign(0, "left", "top");
@@ -39,41 +39,33 @@ qx.Class.define("qxapp.components.form.renderer.NoteForm", {
           }
         );
         this._row++;
-        if (headerOptions !== null && headerOptions.note !== null) {
-          this._add(new qx.ui.basic.Label(headerOptions.note).set({
-            rich: true,
-            alignX: "left"
-          }), {
-            row: this._row,
-            column: 0,
-            colSpan: 3
-          });
-          this._row++;
-        }
       }
 
       // add the items
-      for (var i = 0; i < items.length; i++) {
-        var label = this._createLabel(names[i], items[i]);
+      for (let i = 0; i < items.length; i++) {
+        let label = this._createLabel(names[i], items[i]);
         this._add(label, {
           row: this._row,
           column: 0
         });
-        var item = items[i];
+        let item = items[i];
         label.setBuddy(item);
         this._add(item, {
           row: this._row,
           column: 1
         });
-        if (itemOptions !== null && itemOptions[i] !== null && itemOptions[i].note) {
-          this._add(new qx.ui.basic.Label(itemOptions[i].note).set({
-            rich: true,
+        if (itemOptions !== null && itemOptions[i] !== null && itemOptions[i].exposable) {
+          let exposeCtrl = new qx.ui.form.CheckBox().set({
             marginLeft: 20,
             marginRight: 20
-          }), {
+          });
+          this._add(exposeCtrl, {
             row: this._row,
             column: 2
           });
+          exposeCtrl.addListener("changeValue", function(e) {
+            item.setEnabled(!e.getData());
+          }, this);
         }
         this._row++;
         this._connectVisibility(item, label);

--- a/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
+++ b/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
@@ -76,18 +76,6 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
       apply : "__applyMetadata"
     },
 
-    inputLinkIDs: {
-      check: "Array",
-      init: [],
-      nullable: false
-    },
-
-    outputLinkIDs: {
-      check: "Array",
-      init: [],
-      nullable: false
-    },
-
     settingsWidget: {
       check: "qxapp.components.form.renderer.PropForm"
     }

--- a/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
+++ b/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
@@ -58,7 +58,7 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
     },
 
     metadata: {
-      apply : "_applyMetadata"
+      apply : "__applyMetadata"
     },
 
     inputLinkIDs: {
@@ -74,7 +74,7 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
     },
 
     settingsWidget: {
-      check: "qxapp.components.form.renderer.NoteForm"
+      check: "qxapp.components.form.renderer.PropForm"
     }
   },
 
@@ -84,13 +84,13 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
     __progressLabel: null,
     __settingForm: null,
 
-    _applyMetadata: function(metaData, old) {
+    __applyMetadata: function(metaData, old) {
       if (metaData != undefined) {
         this.setMetadata(metaData);
         this.setServiceName(metaData.name);
         this.setNodeImageId(metaData.id);
         let form = this.__settingsForm = new qxapp.components.form.Auto(metaData.settings);
-        this.setSettingsWidget(new qxapp.components.form.renderer.NoteForm(form));
+        this.setSettingsWidget(new qxapp.components.form.renderer.PropForm(form));
 
         metaData.input.forEach(input => {
           let label = new qx.ui.basic.Label(input.name);

--- a/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
+++ b/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
@@ -149,7 +149,7 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
     setServiceName: function(name) {
       this.setCaption(name);
     },
- 
+
     addSettings: function(settings) {
       let form = this.__settingsForm = new qxapp.components.form.Auto(settings);
       this.setSettingsWidget(new qxapp.components.form.renderer.PropForm(form));

--- a/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
+++ b/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
@@ -149,7 +149,7 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
     setServiceName: function(name) {
       this.setCaption(name);
     },
-    
+ 
     addSettings: function(settings) {
       let form = this.__settingsForm = new qxapp.components.form.Auto(settings);
       this.setSettingsWidget(new qxapp.components.form.renderer.PropForm(form));

--- a/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
+++ b/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
@@ -152,16 +152,16 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
       return bounds;
     },
 
-    __applyMetadata: function(metadata, old) {
-      if (metadata != undefined) {
+    __applyMetadata: function(metaData, old) {
+      if (metaData != undefined) {
         let form = this.__settingsForm = new qxapp.components.form.Auto(metaData.settings);
         this.set({
-          serviceName: metadata.label,
-          nodeImageId: metadata.key,
+          serviceName: metaData.label,
+          nodeImageId: metaData.key,
           settingsWidget: new qxapp.components.form.renderer.PropForm(form)
         });
-        this.addInputs(metadata.inputs);
-        this.addOutputs(metadata.outputs);
+        this.addInputs(metaData.inputs);
+        this.addOutputs(metaData.outputs);
       }
     },
 

--- a/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
+++ b/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
@@ -58,7 +58,7 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
     },
 
     metadata: {
-      apply : "__applyMetadata"
+      apply : "_applyMetadata"
     },
 
     inputLinkIDs: {
@@ -71,6 +71,10 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
       check: "Array",
       init: [],
       nullable: false
+    },
+
+    settingsWidget: {
+      check: "qxapp.components.form.renderer.NoteForm"
     }
   },
 
@@ -78,23 +82,27 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
     __inputPorts: null,
     __outputPorts: null,
     __progressLabel: null,
+    __settingForm: null,
 
-    __applyMetadata: function(value, old) {
-      if (value != undefined) {
-        this.setMetadata(value);
-        this.setServiceName(this.getMetadata().name);
-        this.getMetadata().input.forEach(input => {
+    _applyMetadata: function(metaData, old) {
+      if (metaData != undefined) {
+        this.setMetadata(metaData);
+        this.setServiceName(metaData.name);
+        this.setNodeImageId(metaData.id);
+        let form = this.__settingsForm = new qxapp.components.form.Auto(metaData.settings);
+        this.setSettingsWidget(new qxapp.components.form.renderer.NoteForm(form));
+
+        metaData.input.forEach(input => {
           let label = new qx.ui.basic.Label(input.name);
           label.portId = qxapp.utils.Utils.uuidv4();
           this.__inputPorts.add(label);
         });
-        this.getMetadata().output.forEach(output => {
+
+        metaData.output.forEach(output => {
           let label = new qx.ui.basic.Label(output.name);
           label.portId = qxapp.utils.Utils.uuidv4();
           this.__outputPorts.add(label);
         });
-
-        this.setNodeImageId(this.getMetadata().id);
       }
     },
 

--- a/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
+++ b/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
@@ -149,6 +149,7 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
     setServiceName: function(name) {
       this.setCaption(name);
     },
+    
     addSettings: function(settings) {
       let form = this.__settingsForm = new qxapp.components.form.Auto(settings);
       this.setSettingsWidget(new qxapp.components.form.renderer.PropForm(form));

--- a/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
+++ b/services/web/client/source/class/qxapp/components/workbench/NodeBase.js
@@ -107,7 +107,7 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
     __inputPortsUI: null,
     __outputPortsUI: null,
     __progressLabel: null,
-    __settingForm: null,
+    __settingsForm: null,
     __progressBar: null,
 
     getInputPorts: function() {
@@ -118,14 +118,8 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
       return this.__outputPorts;
     },
 
-    getSetting: function(settingId) {
-      let settings = this.getMetadata().settings;
-      for (let i = 0; i < settings.length; i++) {
-        if (settings[i].key === settingId) {
-          return settings[i];
-        }
-      }
-      return null;
+    getSetting: function(key) {
+      return this.getSettingsWidget().getData()[key];
     },
 
     // override qx.ui.window.Window "move" event listener
@@ -154,12 +148,11 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
 
     __applyMetadata: function(metaData, old) {
       if (metaData != undefined) {
-        let form = this.__settingsForm = new qxapp.components.form.Auto(metaData.settings);
         this.set({
           serviceName: metaData.label,
-          nodeImageId: metaData.key,
-          settingsWidget: new qxapp.components.form.renderer.PropForm(form)
+          nodeImageId: metaData.key
         });
+        this.addSettings(metaData.settings);
         this.addInputs(metaData.inputs);
         this.addOutputs(metaData.outputs);
       }
@@ -167,6 +160,10 @@ qx.Class.define("qxapp.components.workbench.NodeBase", {
 
     setServiceName: function(name) {
       this.setCaption(name);
+    },
+    addSettings: function(settings) {
+      let form = this.__settingsForm = new qxapp.components.form.Auto(settings);
+      this.setSettingsWidget(new qxapp.components.form.renderer.PropForm(form));
     },
 
     __addInputPort: function(input) {

--- a/services/web/client/source/class/qxapp/components/workbench/SettingsView.js
+++ b/services/web/client/source/class/qxapp/components/workbench/SettingsView.js
@@ -4,7 +4,7 @@ qx.Class.define("qxapp.components.workbench.SettingsView", {
   construct: function() {
     this.base();
 
-    let box = new qx.ui.layout.VBox(10, null, "separator-vertical");
+    let box = new qx.ui.layout.VBox(10);
     box.set({
       alignX: "center"
     });
@@ -23,6 +23,12 @@ qx.Class.define("qxapp.components.workbench.SettingsView", {
     "ShowViewer": "qx.event.type.Data"
   },
 
+  properties: {
+    node: {
+      check: "qxapp.components.workbench.NodeBase",
+      apply: "_applyNode"
+    }
+  },
   members: {
     __settingsBox: null,
 
@@ -52,10 +58,18 @@ qx.Class.define("qxapp.components.workbench.SettingsView", {
     },
 
     __initSettings: function() {
-      this.__settingsBox = new qx.ui.container.Composite(new qx.ui.layout.VBox(10));
+      this.__settingsBox = new qx.ui.container.Composite(new qx.ui.layout.Grow());
       this.add(this.__settingsBox);
     },
 
+    _applyNode: function(node, oldNode, propertyName) {
+      this.__settingsBox.removeAll();
+      this.__settingsBox.add(node.getSettingsWidget());
+    },
+
+    /**
+     * DEPRECATED ... the node settings from is now stored in a property of the node.
+     */
     setNodeMetadata: function(node) {
       this.__settingsBox.removeAll();
 

--- a/services/web/client/source/class/qxapp/components/workbench/SettingsView.js
+++ b/services/web/client/source/class/qxapp/components/workbench/SettingsView.js
@@ -26,7 +26,7 @@ qx.Class.define("qxapp.components.workbench.SettingsView", {
   properties: {
     node: {
       check: "qxapp.components.workbench.NodeBase",
-      apply: "_applyNode"
+      apply: "__applyNode"
     }
   },
   members: {
@@ -62,7 +62,7 @@ qx.Class.define("qxapp.components.workbench.SettingsView", {
       this.add(this.__settingsBox);
     },
 
-    _applyNode: function(node, oldNode, propertyName) {
+    __applyNode: function(node, oldNode, propertyName) {
       this.__settingsBox.removeAll();
       this.__settingsBox.add(node.getSettingsWidget());
     },
@@ -70,7 +70,7 @@ qx.Class.define("qxapp.components.workbench.SettingsView", {
     /**
      * DEPRECATED ... the node settings from is now stored in a property of the node.
      */
-    setNodeMetadata: function(node) {
+    XXXsetNodeMetadata: function(node) {
       this.__settingsBox.removeAll();
 
       let form = new qx.ui.form.Form();

--- a/services/web/client/source/class/qxapp/data/Fake.js
+++ b/services/web/client/source/class/qxapp/data/Fake.js
@@ -232,13 +232,21 @@ qx.Class.define("qxapp.data.Fake", {
           "value": ""
         }],
         "settings": [{
-          "name": "ViPModel",
-          "options": [
-            "Rat",
-            "Sphere"
-          ],
-          "text": "Select ViP Model",
-          "type": "select",
+          "key": "ViPModel",
+          "label": "Select ViP Model",
+          "widget": "selectBox",
+          "cfg": {
+            structure: [
+              {
+                key: "rat",
+                label: "Rat"
+              },
+              {
+                key: "phere",
+                label: "Sphere"
+              }
+            ]
+          },
           "value": 0
         }],
         "viewer": {
@@ -256,10 +264,12 @@ qx.Class.define("qxapp.data.Fake", {
           "value": ""
         }],
         "settings": [{
-          "name": "number",
-          "text": "Number",
-          "type": "number",
-          "value": 0
+          "key": "number",
+          "label": "Number",
+          "widget": "integer",
+          set: {
+            value: 0
+          }
         }]
       }];
       return producers;
@@ -299,50 +309,70 @@ qx.Class.define("qxapp.data.Fake", {
         ],
         "settings": [
           {
-            "name": "NaValue",
-            "text": "Na blocker drug concentration",
-            "type": "number",
+            "key": "NaValue",
+            "label": "Na blocker drug concentration",
+            "widget": "integer",
             "exposed": false,
-            "value": 10
+            "defaultValue": 10
           },
           {
-            "name": "KrValue",
-            "text": "Kr blocker drug concentration",
-            "type": "number",
+            "key": "KrValue",
+            "label": "Kr blocker drug concentration",
+            "widget": "integer",
             "exposed": false,
-            "value": 10
+            "defaultValue": 10
           },
           {
-            "name": "BCLValue",
-            "text": "Basic cycle length (BCL)",
-            "type": "number",
+            "key": "BCLValue",
+            "label": "Basic cycle length (BCL)",
+            "widget": "integer",
             "exposed": false,
-            "value": 10
+            "defaultValue": 10
           },
           {
-            "name": "beatsValue",
-            "text": "Number of beats",
-            "type": "number",
+            "key": "beatsValue",
+            "label": "Number of beats",
+            "widget": "integer",
             "exposed": false,
-            "value": 10
+            "defaultValue": 10
           },
           {
-            "name": "LigandValue",
-            "text": "Ligand concentration",
-            "type": "number",
+            "key": "LigandValue",
+            "label": "Ligand concentration",
+            "widget": "integer",
             "exposed": false,
-            "value": 10
+            "defaultValue": 10
           },
           {
-            "name": "cAMKIIValue",
+            "key": "cAMKIIValue",
             "options": [
               "A",
               "B",
               "C",
               "D"
             ],
-            "text": "Adjust cAMKII activity level",
-            "type": "select",
+            "label": "Adjust cAMKII activity level",
+            "widget": "selectBox",
+            "cfg": {
+              structure: [
+                {
+                  key: "a",
+                  label: "A"
+                },
+                {
+                  key: "b",
+                  label: "B"
+                },
+                {
+                  key: "c",
+                  label: "C"
+                },
+                {
+                  key: "d",
+                  label: "D"
+                }
+              ]
+            },
             "exposed": false,
             "value": 0
           }

--- a/services/web/client/source/class/qxapp/data/Fake.js
+++ b/services/web/client/source/class/qxapp/data/Fake.js
@@ -581,20 +581,21 @@ qx.Class.define("qxapp.data.Fake", {
           "key": "sett_1",
           "label": "ViPModel",
           "desc": "Select ViP Model",
+          "type": "string",
+          "defaultValue": "rat",
           "widget": "selectBox",
           "cfg": {
             structure: [
               {
-                key: "Rat",
+                key: "rat",
                 label: "Rat"
               },
               {
-                key: "Sphere",
+                key: "sphere",
                 label: "Sphere"
               }
             ]
-          },
-          "value": 0
+          }
         }],
         "viewer": {
           "ip": "http://" + window.location.hostname,
@@ -616,14 +617,12 @@ qx.Class.define("qxapp.data.Fake", {
           "key": "sett_1",
           "label": "File",
           "desc": "File",
-          "type": "file",
-          "value": null
+          "type": "string"
         }, {
           "key": "sett_2",
           "label": "File type",
           "desc": "File type",
-          "type": "text",
-          "value": null
+          "type": "string"
         }]
       }, {
         "key": "RandomNumberGeneratorID",
@@ -641,14 +640,14 @@ qx.Class.define("qxapp.data.Fake", {
           "key": "sett_1",
           "label": "Number Min",
           "desc": "Number Min",
-          "widget": "integer",
-          "value": 0
+          "type": "integer",
+          "defaultValue": 0
         }, {
           "key": "sett_2",
           "label": "Number Max",
           "desc": "Number Max",
-          "widget": "integer",
-          "value": 10
+          "type": "integer",
+          "defaultValue": 10
         }]
       }];
       return producers;
@@ -663,13 +662,13 @@ qx.Class.define("qxapp.data.Fake", {
           "key": "in_1",
           "label": "File-url",
           "desc": "File-url",
-          "widget": "upload",
+          "type": "upload",
           "value": null
         }, {
           "key": "in_2",
           "label": "File-url",
           "desc": "File-url",
-          "widget": "upload",
+          "type": "upload",
           "value": null
         }],
         "outputs": [{
@@ -679,49 +678,56 @@ qx.Class.define("qxapp.data.Fake", {
           "type": "csv-url",
           "value": null
         }],
-        "settings": [{
-          "key": "sett_1",
-          "label": "NaValue",
-          "desc": "Na blocker drug concentration",
-          "type": "number",
-          "value": 10
-        }, {
-          "key": "sett_2",
-          "label": "KrValue",
-          "desc": "Kr blocker drug concentration",
-          "type": "number",
-          "value": 10
-        }, {
-          "key": "sett_3",
-          "label": "BCLValue",
-          "desc": "Basic cycle length (BCL)",
-          "type": "number",
-          "value": 10
-        }, {
-          "key": "sett_4",
-          "label": "beatsValue",
-          "desc": "Number of beats",
-          "type": "number",
-          "value": 10
-        }, {
-          "key": "sett_5",
-          "label": "LigandValue",
-          "desc": "Ligand concentration",
-          "type": "number",
-          "value": 10
-        }, {
-          "key": "sett_6",
-          "label": "cAMKIIValue",
-          "desc": "Adjust cAMKII activity level",
-          "type": "select",
-          "options": [
-            "A",
-            "B",
-            "C",
-            "D"
-          ],
-          "value": 0
-        }]
+        "settings": [
+          {
+            "key": "sett_1",
+            "label": "NaValue",
+            "desc": "Na blocker drug concentration",
+            "type": "integer",
+            "defaultValue": 10
+          }, {
+            "key": "sett_2",
+            "label": "KrValue",
+            "desc": "Kr blocker drug concentration",
+            "type": "integer",
+            "defaultValue": 10
+          }, {
+            "key": "sett_3",
+            "label": "BCLValue",
+            "desc": "Basic cycle length (BCL)",
+            "type": "integer",
+            "defaultValue": 10
+          }, {
+            "key": "sett_4",
+            "label": "beatsValue",
+            "desc": "Number of beats",
+            "type": "integer",
+            "defaultValue": 10
+          }, {
+            "key": "sett_5",
+            "label": "LigandValue",
+            "desc": "Ligand concentration",
+            "type": "integer",
+            "defaultValue": 10
+          }, {
+            "key": "sett_6",
+            "label": "cAMKIIValue",
+            "desc": "Adjust cAMKII activity level",
+            "type": "string",
+            "widget": "selectBox",
+            "cfg": {
+              structure:
+                ["A", "B", "C", "D"].map(
+                  k => ({
+                    key: k.toLowerCase(),
+                    label: k
+                  })
+                )
+
+            },
+            "defaultValue": "c"
+          }
+        ]
       }, {
         "key": "Computational2",
         "label": "Computational 2",
@@ -775,8 +781,8 @@ qx.Class.define("qxapp.data.Fake", {
           "key": "sett_1",
           "label": "Number",
           "desc": "Sleep extra sec",
-          "widget": "integer",
-          "value": 0
+          "type": "integer",
+          "defaultValue": 0
         }]
       }];
       return computationals;

--- a/services/web/client/source/class/qxapp/data/Fake.js
+++ b/services/web/client/source/class/qxapp/data/Fake.js
@@ -312,35 +312,35 @@ qx.Class.define("qxapp.data.Fake", {
             "key": "NaValue",
             "label": "Na blocker drug concentration",
             "widget": "integer",
-            "exposed": false,
+            "exposable": true,
             "defaultValue": 10
           },
           {
             "key": "KrValue",
             "label": "Kr blocker drug concentration",
             "widget": "integer",
-            "exposed": false,
+            "exposable": true,
             "defaultValue": 10
           },
           {
             "key": "BCLValue",
             "label": "Basic cycle length (BCL)",
             "widget": "integer",
-            "exposed": false,
+            "exposable": true,
             "defaultValue": 10
           },
           {
             "key": "beatsValue",
             "label": "Number of beats",
             "widget": "integer",
-            "exposed": false,
+            "exposable": true,
             "defaultValue": 10
           },
           {
             "key": "LigandValue",
             "label": "Ligand concentration",
             "widget": "integer",
-            "exposed": false,
+            "exposable": true,
             "defaultValue": 10
           },
           {

--- a/services/web/client/source/class/qxapp/desktop/PrjEditor.js
+++ b/services/web/client/source/class/qxapp/desktop/PrjEditor.js
@@ -84,7 +84,7 @@ qx.Class.define("qxapp.desktop.PrjEditor", {
 
     this.__workbench.addListener("NodeDoubleClicked", function(e) {
       let node = e.getData();
-      this.__settingsView.setNodeMetadata(node);
+      this.__settingsView.setNode(node);
       this.__showSettings(true);
     }, this);
 

--- a/services/web/client/source/class/qxapp/desktop/PrjEditor.js
+++ b/services/web/client/source/class/qxapp/desktop/PrjEditor.js
@@ -64,8 +64,9 @@ qx.Class.define("qxapp.desktop.PrjEditor", {
     }, this);
 
     this.__workbench.addListener("NodeDoubleClicked", function(e) {
+      let node = e.getData();
+      this.__settingsView.setNode(node);
       this.__showSettings(true);
-      this.__settingsView.setNodeMetadata(e.getData());
     }, this);
 
     this.__transDeco = new qx.ui.decoration.Decorator().set({


### PR DESCRIPTION
The new infrastructure attaches a settings form to the node and shows it in the settings viewer. The form uses databinding to convert incoming values.

The data flow will probably have to be altered once the data model is available.