### PR TITLE
Make login form password save friendly

### DIFF
--- a/services/web/client/source/class/qxapp/auth/core/BaseAuthPage.js
+++ b/services/web/client/source/class/qxapp/auth/core/BaseAuthPage.js
@@ -23,7 +23,17 @@ qx.Class.define("qxapp.auth.core.BaseAuthPage", {
       width: 300,
       height: 250
     });
-
+    // at least chrome hates it when a password input field exists
+    // outside a form, so lets accomodate him
+    this.addListenerOnce("appear", e => {
+      let el = this.getContentElement();
+      let form = this._form = new qx.html.Element("form", null, {
+        name: "fakeLoginform",
+        autocomplete: "on"
+      });
+      form.insertBefore(el);
+      el.insertInto(form);
+    });
     this._buildPage();
   },
 
@@ -44,7 +54,11 @@ qx.Class.define("qxapp.auth.core.BaseAuthPage", {
   */
 
   members: {
-
+    /**
+     * when all is said and done we should remove the form so that the password manager
+     * knows to save the content of the form. so we save it here.
+     */
+    _form: null,
     /**
      * This method gets called upon construction and
      * must be overriden in a subclass

--- a/services/web/client/source/class/qxapp/auth/ui/LoginPage.js
+++ b/services/web/client/source/class/qxapp/auth/ui/LoginPage.js
@@ -35,6 +35,8 @@ qx.Class.define("qxapp.auth.ui.LoginPage", {
 
     // overrides base
     _buildPage: function() {
+
+
       this.__form = new qx.ui.form.Form();
 
       let atm = new qx.ui.basic.Atom().set({
@@ -47,11 +49,13 @@ qx.Class.define("qxapp.auth.ui.LoginPage", {
       email.setPlaceholder(this.tr("Your email address"));
       email.setRequired(true);
       this.add(email);
+      email.getContentElement().setAttribute("autocomplete", "username");
       this.__form.add(email, "", qx.util.Validate.email(), "email", null);
 
       let pass = new qx.ui.form.PasswordField();
       pass.setPlaceholder(this.tr("Your password"));
       pass.setRequired(true);
+      pass.getContentElement().setAttribute("autocomplete", "current-password");
       this.add(pass);
       this.__form.add(pass, "", null, "password", null);
 
@@ -130,6 +134,9 @@ qx.Class.define("qxapp.auth.ui.LoginPage", {
 
       let successFun = function(log) {
         this.fireDataEvent("done", log.message);
+        // we don't need the form any more, so remove it
+        // and thus tell the password manager to save the content
+        this._form.dispose();
       };
 
       let failFun = function(msg) {

--- a/services/web/client/source/class/qxapp/auth/ui/LoginPage.js
+++ b/services/web/client/source/class/qxapp/auth/ui/LoginPage.js
@@ -35,8 +35,6 @@ qx.Class.define("qxapp.auth.ui.LoginPage", {
 
     // overrides base
     _buildPage: function() {
-
-
       this.__form = new qx.ui.form.Form();
 
       let atm = new qx.ui.basic.Atom().set({


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

If we want to have the browser save the content of a form (like the login form) we must provide some annotations as explained in in: https://www.chromium.org/developers/design-documents/create-amazing-password-forms

## Related issue number

<!--
 Use [waffle.io] keywords in title/descriptions to trigger bot actions:

   - close, closes, close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved #[issueNumber]
   - connect to, connects to, connected to, connect, connects, connected #[issueNumber]
-->

connected to #19 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] **Runs in the swarm**
- [ ] If you design a new module, add your user to .github/CODEOWNERS

[waffle.io]:https://waffle.io/marketing-assets/documents/waffleio_cheatsheet_v1.pdf?utm_source=blog&utm_medium=cheatsheet-ctabutton&utm_campaign=cheatsheet
