### PR TITLE
Names instead of Uuids

### DIFF
--- a/services/web/client/source/class/qxapp/Application.js
+++ b/services/web/client/source/class/qxapp/Application.js
@@ -123,15 +123,6 @@ qx.Class.define("qxapp.Application", {
             let check = ajv.validate(map[key]);
             console.log("services validation result " + key + ":", check);
           }
-          /*
-          let servicesPromise = new qx.Promise(qxapp.data.Store.getInstance().getServices, this);
-          servicesPromise.then(function(map) {
-            for (let key in map) {
-              let check = ajv.validate(map[key]);
-              console.log("services validation result " + key + ":", check);
-            }
-          });
-          */
         } catch (err) {
           console.error(err);
         }

--- a/services/web/client/source/class/qxapp/component/workbench/servicesCatalogue/ServicesCatalogue.js
+++ b/services/web/client/source/class/qxapp/component/workbench/servicesCatalogue/ServicesCatalogue.js
@@ -109,10 +109,14 @@ qx.Class.define("qxapp.component.workbench.servicesCatalogue.ServicesCatalogue",
 
     __populateList: function() {
       let store = qxapp.data.Store.getInstance();
-      store.addListener("servicesRegistered", e => {
-        this.__addNewData(e.getData());
-      }, this);
-      store.getServices();
+      let services = store.getServices();
+      if (services === null) {
+        store.addListener("servicesRegistered", e => {
+          this.__addNewData(e.getData());
+        }, this);
+      } else {
+        this.__addNewData(services);
+      }
     },
 
     __getServiceNameInList: function(service) {

--- a/services/web/client/source/class/qxapp/data/Store.js
+++ b/services/web/client/source/class/qxapp/data/Store.js
@@ -28,7 +28,7 @@ qx.Class.define("qxapp.data.Store", {
   },
 
   members: {
-    __servicesCache: null,
+    __servicesCached: null,
 
     __getMimeType: function(type) {
       let match = type.match(/^data:([^/\s]+\/[^/;\s])/);
@@ -79,8 +79,8 @@ qx.Class.define("qxapp.data.Store", {
       let metaData = {};
       if (key && version) {
         const nodeImageId = key + "-" + version;
-        if (nodeImageId in this.__servicesCache) {
-          return this.__servicesCache[nodeImageId];
+        if (nodeImageId in this.__servicesCached) {
+          return this.__servicesCached[nodeImageId];
         }
         metaData = this.getFakeServices()[nodeImageId];
         if (metaData === undefined) {
@@ -681,40 +681,44 @@ qx.Class.define("qxapp.data.Store", {
       return services;
     },
 
-    getServices: function() {
-      let req = new qxapp.io.request.ApiRequest("/services", "GET");
-      req.addListener("success", e => {
-        let requ = e.getTarget();
-        const {
-          data
-        } = requ.getResponse();
-        const listOfRepositories = data;
-        let services = Object.assign({}, this.getBuiltInServices());
-        for (const key in listOfRepositories) {
-          const repoData = listOfRepositories[key];
-          const nodeImageId = repoData.key + "-" + repoData.version;
-          services[nodeImageId] = repoData;
-        }
-        if (this.__servicesCache === null) {
-          this.__servicesCache = {};
-        }
-        this.__servicesCache = Object.assign(this.__servicesCache, services);
-        this.fireDataEvent("servicesRegistered", services);
-      }, this);
+    getServices: function(reload) {
+      if (reload || Object.keys(this.__servicesCached).length === 0) {
+        let req = new qxapp.io.request.ApiRequest("/services", "GET");
+        req.addListener("success", e => {
+          let requ = e.getTarget();
+          const {
+            data
+          } = requ.getResponse();
+          const newServices = data;
+          let services = Object.assign({}, this.getBuiltInServices());
+          for (const key in newServices) {
+            const service = newServices[key];
+            const nodeImageId = service.key + "-" + service.version;
+            services[nodeImageId] = service;
+          }
+          if (this.__servicesCached === null) {
+            this.__servicesCached = {};
+          }
+          this.__servicesCached = Object.assign(this.__servicesCached, services);
+          this.fireDataEvent("servicesRegistered", services);
+        }, this);
 
-      req.addListener("fail", e => {
-        const {
-          error
-        } = e.getTarget().getResponse();
-        console.log("getServices failed", error);
-        let services = this.getFakeServices();
-        if (this.__servicesCache === null) {
-          this.__servicesCache = {};
-        }
-        this.__servicesCache = Object.assign(this.__servicesCache, services);
-        this.fireDataEvent("servicesRegistered", services);
-      }, this);
-      req.send();
+        req.addListener("fail", e => {
+          const {
+            error
+          } = e.getTarget().getResponse();
+          console.log("getServices failed", error);
+          let services = this.getFakeServices();
+          if (this.__servicesCached === null) {
+            this.__servicesCached = {};
+          }
+          this.__servicesCached = Object.assign(this.__servicesCached, services);
+          this.fireDataEvent("servicesRegistered", services);
+        }, this);
+        req.send();
+        return null;
+      }
+      return this.__servicesCached;
     },
 
     getFakeFiles: function() {

--- a/services/web/client/source/class/qxapp/desktop/PrjEditor.js
+++ b/services/web/client/source/class/qxapp/desktop/PrjEditor.js
@@ -8,6 +8,8 @@ qx.Class.define("qxapp.desktop.PrjEditor", {
   construct: function(projectModel) {
     this.base(arguments, "horizontal");
 
+    qxapp.utils.UuidToName.getInstance().setProjectModel(projectModel);
+
     this.__projectResources = qxapp.io.rest.ResourceFactory.getInstance().createProjectResources();
 
     this.setProjectModel(projectModel);


### PR DESCRIPTION
It was lost in a bad merge.

Show Project/Node names instead of Uuids in:
* FilePicker
* FileManager
* NodeOutputLabel

Bonus:
* Cache services