### PR TITLE
set notebook startup parameters to use the reverse proxy base path

### DIFF
--- a/services/dy-2Dgraph/use-cases/Makefile
+++ b/services/dy-2Dgraph/use-cases/Makefile
@@ -11,7 +11,7 @@ endif
 # export SERVICES_VERSION=1.2.0
 export VCS_REF=$(shell git rev-parse --short HEAD) 
 export BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-export BASE_IMAGE=masu.speag.com/simcore/services/dynamic/jupyter-base-notebook:${SERVICES_VERSION}
+export BASE_IMAGE=masu.speag.com/simcore/services/dynamic/jupyter-base-notebook:1.7.0
 # export SERVICE_PATH=simcore/services/dynamic/3d-viewer
 all:
 	@echo 'run `make build-devel` to build your dev environment'

--- a/services/dy-2Dgraph/use-cases/docker/boot.sh
+++ b/services/dy-2Dgraph/use-cases/docker/boot.sh
@@ -18,6 +18,7 @@ fi
 
 jupyter trust ${NOTEBOOK_URL}
 start-notebook.sh \
+    --NotebookApp.base_url=${SIMCORE_NODE_BASEPATH} \
+    --NotebookApp.extra_static_paths="['${SIMCORE_NODE_BASEPATH}/static']" \
     --NotebookApp.token='' \
-    --NotebookApp.tornado_settings="{\"headers\":{\"Content-Security-Policy\":\"frame-ancestors+'self'+http://osparc01.speag.com:9081;+report-uri/api/security/csp-report\"}}" \
     --NotebookApp.default_url=/notebooks/${NOTEBOOK_URL}

--- a/services/web/server/src/simcore_service_webserver/reverse_proxy/__init__.py
+++ b/services/web/server/src/simcore_service_webserver/reverse_proxy/__init__.py
@@ -33,8 +33,10 @@ def setup(app: web.Application, service_resolver: ServiceResolutionPolicy):
     chooser = ReverseChooser(resolver=service_resolver)
 
     # Registers reverse proxy handlers customized for specific service types
-    chooser.register_handler(jupyter.handler,
-                             image_name=jupyter.SUPPORTED_IMAGE_NAME)
+    for name in jupyter.SUPPORTED_IMAGE_NAME:
+        chooser.register_handler(jupyter.handler,
+                             image_name=name)
+        
 
     chooser.register_handler(paraview.handler,
                              image_name=paraview.SUPPORTED_IMAGE_NAME)

--- a/services/web/server/src/simcore_service_webserver/reverse_proxy/handlers/jupyter.py
+++ b/services/web/server/src/simcore_service_webserver/reverse_proxy/handlers/jupyter.py
@@ -10,7 +10,12 @@ import aiohttp
 from aiohttp import client, web
 from yarl import URL
 
-SUPPORTED_IMAGE_NAME = "simcore/services/dynamic/jupyter-base-notebook"
+#FIXME: make this more generic
+SUPPORTED_IMAGE_NAME = ["simcore/services/dynamic/jupyter-base-notebook",
+                        "simcore/services/dynamic/kember-viewer", 
+                        "simcore/services/dynamic/cc-2d-viewer", 
+                        "simcore/services/dynamic/cc-1d-viewer", 
+                        "simcore/services/dynamic/cc-0d-viewer"]
 SUPPORTED_IMAGE_TAG = ">=1.5.0"
 
 logger = logging.getLogger(__name__)
@@ -31,7 +36,7 @@ async def handler(req: web.Request, service_url: str, **_kwargs):
     target_url = URL(service_url).origin() / req.path.lstrip('/')
 
     reqH = req.headers.copy()
-    
+
     if reqH['connection'].lower() == 'upgrade' and reqH['upgrade'].lower() == 'websocket' and req.method == 'GET':
         ws_server = web.WebSocketResponse()
         await ws_server.prepare(req)
@@ -71,13 +76,12 @@ async def handler(req: web.Request, service_url: str, **_kwargs):
             data=await req.read()
         ) as res:
             body = await res.read()
-            response= web.Response(
+            response = web.Response(
                 headers=res.headers.copy(),
                 status=res.status,
                 body=body
             )
             return response
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

start the 2D visualizer using the reverse proxy base path


## Related issue number

<!--
 Use [waffle.io] keywords in title/descriptions to trigger bot actions:

   - close, closes, close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved #[issueNumber]
   - connect to, connects to, connected to, connect, connects, connected #[issueNumber]
-->


## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] **Runs in the swarm**
- [ ] If you design a new module, add your user to .github/CODEOWNERS

[waffle.io]:https://waffle.io/marketing-assets/documents/waffleio_cheatsheet_v1.pdf?utm_source=blog&utm_medium=cheatsheet-ctabutton&utm_campaign=cheatsheet
