### PR TITLE
upgrades aiohttp-session to patch version 2.7.0

### DIFF
--- a/services/web/server/requirements/base.txt
+++ b/services/web/server/requirements/base.txt
@@ -2,7 +2,7 @@
 #   Outsourced here so can be installed in base-stage of the web/Dockerfile
 psycopg2-binary==2.7.5
 aiohttp==3.3.2
-aiohttp_session[secure]==2.5.1
+aiohttp_session[secure]==2.7.0
 aiohttp-security==0.2.0
 aiopg[sa]
 aio-pika==2.9.0


### PR DESCRIPTION
aio-libs aiohttp-session version 2.6.0 and earlier contains a Other/Unknown vulnerability in
 EncryptedCookieStorage and NaClCookieStorage that can result in Non-expiring sessions / Infinite lifespan.
This attack appear to be exploitable via Recreation of a cookie post-expiry with the same value.
