### PR TITLE
get up to new qxcompiler with fix for //

### DIFF
--- a/services/web/client/package-lock.json
+++ b/services/web/client/package-lock.json
@@ -985,9 +985,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "qxcompiler": {
-      "version": "0.3.0-alpha.20190225-1008",
-      "resolved": "https://registry.npmjs.org/qxcompiler/-/qxcompiler-0.3.0-alpha.20190225-1008.tgz",
-      "integrity": "sha512-DGQVvQv3vVxL7ATc50cZSqYo7RIPVNvgSYY6yXWFoYhwLT5eehi6L2YZcQf8EGZAGc1n/HymyMpqkrwnoadyAw==",
+      "version": "0.3.0-alpha.20190305-1954",
+      "resolved": "https://registry.npmjs.org/qxcompiler/-/qxcompiler-0.3.0-alpha.20190305-1954.tgz",
+      "integrity": "sha512-yc0YUea4dG3ByzTGQYaZOdKvzzxtjs/4owOZyXAPeVTB3epId2WcLTkcgs0U1LGs3gyteBfkYt87iNT9JHn2TA==",
       "requires": {
         "@octokit/rest": "^15.18.0",
         "@qooxdoo/preset-env": "^1.0.0",
@@ -8001,8 +8001,7 @@
         },
         "static-eval": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.1.tgz",
-          "integrity": "sha512-1JJ8ADJ7UB//CRqocI6j4WxGvSqQHX14Fz0gXDNvRA6Y1JIAI/lMNdqn1lpnaA6ugQ0fMH0uBB955DkwhKActw==",
+          "resolved": "",
           "requires": {
             "escodegen": "^1.8.1"
           }

--- a/services/web/client/package.json
+++ b/services/web/client/package.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "cookie-parser": "^1.4.3",
-    "puppeteer": "^1.2.12",
-    "qooxdoo-sdk": "^6.0.0-alpha-20181212-7206734e",
-    "qxcompiler": "^0.3.0-alpha",
-    "yargs": "^13.2.1",
     "coveralls": "^3.0.3",
-    "puppeteer-to-istanbul": "^1.2.2"
+    "puppeteer": "^1.2.12",
+    "puppeteer-to-istanbul": "^1.2.2",
+    "qooxdoo-sdk": "^6.0.0-alpha-20181212-7206734e",
+    "qxcompiler": "^0.3.0-alpha.20190305-1954",
+    "yargs": "^13.2.1"
   }
 }

--- a/services/web/server/tests/unit/test_rest.py
+++ b/services/web/server/tests/unit/test_rest.py
@@ -71,7 +71,7 @@ async def test_check_health(client):
     assert data['status'] == 'SERVICE_RUNNING'
 
 async def test_check_serve_root(client):
-    resp = await client.get("/")
+    resp = await client.get("/qxapp/index.html")
     payload = await resp.text()
 
     assert resp.status == 200, str(payload)

--- a/services/web/server/tests/unit/test_rest.py
+++ b/services/web/server/tests/unit/test_rest.py
@@ -70,16 +70,6 @@ async def test_check_health(client):
     assert data['name'] == 'simcore_service_webserver'
     assert data['status'] == 'SERVICE_RUNNING'
 
-async def test_check_serve_root(client):
-    resp = await client.get("/qxapp/index.html")
-    payload = await resp.text()
-
-    assert resp.status == 200, str(payload)
-    data, error = tuple(payload.get(k) for k in ('data', 'error'))
-
-    assert data
-    assert not error
-
 async def test_check_action(client):
     QUERY = 'value'
     ACTION = 'echo'


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

the qooxdoo bootloader (boot.js) tries to load files using double slashes in urls. like this

`root-dir//some/path/file.js` 

most webservers don't care. not so our aiohttp one ... this pr updates to the latest qooxdoo compiler which does not add double slashes anymore.

## What do these changes do?

<!-- Please give a short brief about these changes. -->


## Related issue number

<!--
 Use [waffle.io] keywords in title/descriptions to trigger bot actions:

   - close, closes, close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved #[issueNumber]
   - connect to, connects to, connected to, connect, connects, connected #[issueNumber]
-->


## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] **Runs in the swarm**
- [ ] If you design a new module, add your user to .github/CODEOWNERS

[waffle.io]:https://waffle.io/marketing-assets/documents/waffleio_cheatsheet_v1.pdf?utm_source=blog&utm_medium=cheatsheet-ctabutton&utm_campaign=cheatsheet
