### PR TITLE
Fix: Avoid black/empty NodeViews

### DIFF
--- a/services/web/client/source/class/qxapp/component/widget/NodeView.js
+++ b/services/web/client/source/class/qxapp/component/widget/NodeView.js
@@ -244,6 +244,19 @@ qx.Class.define("qxapp.component.widget.NodeView", {
       this.__buttonsLayout.setVisibility(othersStatus);
     },
 
+    hasIFrame: function() {
+      return (this.isPropertyInitialized("node") && this.getNode().getIFrame());
+    },
+
+    restoreIFrame: function() {
+      if (this.hasIFrame()) {
+        const iFrame = this.getNode().getIFrame();
+        if (iFrame) {
+          iFrame.maximizeIFrame(false);
+        }
+      }
+    },
+
     __addButtons: function() {
       this.__buttonsLayout.removeAll();
       let retrieveIFrameButton = this.getNode().getRetrieveIFrameButton();

--- a/services/web/client/source/class/qxapp/component/widget/PersistentIframe.js
+++ b/services/web/client/source/class/qxapp/component/widget/PersistentIframe.js
@@ -74,16 +74,8 @@ qx.Class.define("qxapp.component.widget.PersistentIframe", {
         top:-10000
       });
       actionButton.addListener("execute", e => {
-        if (this.hasState("maximized")) {
-          this.fireEvent("restore");
-          this.removeState("maximized");
-          actionButton.setIcon(osparc.theme.osparcdark.Image.URLS["window-maximize"]+"/20");
-        } else {
-          this.fireEvent("maximize");
-          this.addState("maximized");
-          actionButton.setIcon(osparc.theme.osparcdark.Image.URLS["window-restore"]+"/20");
-        }
-      });
+        this.maximizeIFrame(!this.hasState("maximized"));
+      }, this);
       appRoot.add(actionButton);
       standin.addListener("appear", e => {
         this.__syncIframePos();
@@ -116,6 +108,20 @@ qx.Class.define("qxapp.component.widget.PersistentIframe", {
       });
       return standin;
     },
+
+    maximizeIFrame: function(maximize) {
+      const actionButton = this.__actionButton;
+      if (maximize) {
+        this.fireEvent("maximize");
+        this.addState("maximized");
+        actionButton.setIcon(osparc.theme.osparcdark.Image.URLS["window-restore"]+"/20");
+      } else {
+        this.fireEvent("restore");
+        this.removeState("maximized");
+        actionButton.setIcon(osparc.theme.osparcdark.Image.URLS["window-maximize"]+"/20");
+      }
+    },
+
     __syncIframePos: function() {
       if (this.__syncScheduled) {
         return;

--- a/services/web/client/source/class/qxapp/desktop/PrjEditor.js
+++ b/services/web/client/source/class/qxapp/desktop/PrjEditor.js
@@ -209,6 +209,9 @@ qx.Class.define("qxapp.desktop.PrjEditor", {
       if (!nodeId) {
         return;
       }
+      if (this.__nodeView) {
+        this.__nodeView.restoreIFrame();
+      }
       this.__currentNodeId = nodeId;
       let widget = this.__getWidgetForNode(nodeId);
       this.showInMainView(widget, nodeId);

--- a/services/web/client/source/class/qxapp/desktop/PrjEditor.js
+++ b/services/web/client/source/class/qxapp/desktop/PrjEditor.js
@@ -252,6 +252,14 @@ qx.Class.define("qxapp.desktop.PrjEditor", {
           this.__nodeView.buildLayout();
           if (node.isInKey("file-picker")) {
             widget = new qxapp.file.FilePicker(node, this.getProject().getUuid());
+            widget.addListener("finished", function() {
+              let loadNodeId = "root";
+              const filePicker = widget.getNode();
+              if (filePicker.isPropertyInitialized("parentNodeId")) {
+                loadNodeId = filePicker.getParentNodeId();
+              }
+              this.nodeSelected(loadNodeId);
+            }, this);
           } else {
             widget = this.__nodeView;
           }
@@ -323,13 +331,6 @@ qx.Class.define("qxapp.desktop.PrjEditor", {
     },
 
     showInMainView: function(widget, nodeId) {
-      if (this.__mainPanel.isPropertyInitialized("mainView")) {
-        let previousWidget = this.__mainPanel.getMainView();
-        widget.addListener("finished", function() {
-          this.__mainPanel.setMainView(previousWidget);
-        }, this);
-      }
-
       const node = this.getProject().getWorkbench().getNode(nodeId);
       if (node && node.hasDedicatedWidget()) {
         let dedicatedWrapper = new qx.ui.container.Composite(new qx.ui.layout.VBox());


### PR DESCRIPTION
## What do these changes do?

Fixes the two empty NodeView cases:
- When an iFrame is maximized and the user selects a different node, an empty view is shown. To prevent that bug PrjEditor restores the iFrame before changing node.
- When selecting a file and closing the FilePicker an empty view may be shown. To prevent PrjDitor will show FilePicker's parent layout.