### PR TITLE
Check if a new study is already being created

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports/serialization.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports/serialization.py
@@ -61,7 +61,7 @@ def save_to_json(nodeports_obj):
 
     if nodeports_obj.autowrite:
         nodeports_obj.db_mgr.write_ports_configuration(nodeports_json, config.NODE_UUID)
-    log.info("Saved Nodeports object to json: %s", nodeports_json)
+    log.debug("Saved Nodeports object to json: %s", nodeports_json)
 
 class _NodeportsEncoder(json.JSONEncoder):
     # SAN: looks like pylint is having an issue here

--- a/services/web/client/source/class/qxapp/desktop/PrjBrowser.js
+++ b/services/web/client/source/class/qxapp/desktop/PrjBrowser.js
@@ -81,6 +81,7 @@ qx.Class.define("qxapp.desktop.PrjBrowser", {
     __userProjectList: null,
     __publicProjectList: null,
     __editPrjLayout: null,
+    __creatingNewStudy: null,
 
     __initResources: function() {
       this.__getUserProfile();
@@ -145,6 +146,11 @@ qx.Class.define("qxapp.desktop.PrjBrowser", {
     },
 
     __newPrjBtnClkd: function() {
+      if (this.__creatingNewStudy) {
+        return;
+      }
+      this.__creatingNewStudy = true;
+
       let win = new qx.ui.window.Window(this.tr("Create New Study")).set({
         layout: new qx.ui.layout.Grow(),
         contentPadding: 0,
@@ -167,6 +173,9 @@ qx.Class.define("qxapp.desktop.PrjBrowser", {
       }, this);
       win.add(newProjectDlg);
       win.open();
+      win.addListener("close", () => {
+        this.__creatingNewStudy = false;
+      }, this);
     },
 
     __startProject: function(prjData, isNew = false) {
@@ -366,8 +375,6 @@ qx.Class.define("qxapp.desktop.PrjBrowser", {
             const prjUuid = item.getModel();
             if (prjUuid) {
               that.__createProject(prjUuid, fromTemplate); // eslint-disable-line no-underscore-dangle
-            } else {
-              that.__newPrjBtnClkd(); // eslint-disable-line no-underscore-dangle
             }
           });
           item.addListener("tap", e => {
@@ -375,7 +382,7 @@ qx.Class.define("qxapp.desktop.PrjBrowser", {
             if (prjUuid) {
               list.setSelection([item]); // eslint-disable-line no-underscore-dangle
             } else {
-              item.fireEvent("dbltap");
+              that.__newPrjBtnClkd(); // eslint-disable-line no-underscore-dangle
             }
           });
           return item;

--- a/services/web/server/src/simcore_service_webserver/projects/projects_models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_models.py
@@ -41,7 +41,7 @@ projects = sa.Table("projects", metadata,
     sa.Column("id", sa.BigInteger, nullable=False, primary_key=True),
     sa.Column("type", sa.Enum(ProjectType), nullable=False, default=ProjectType.STANDARD),
 
-    sa.Column("uuid", sa.String, nullable=False),
+    sa.Column("uuid", sa.String, nullable=False, unique=True),
     sa.Column("name", sa.String, nullable=False),
     sa.Column("description", sa.String, nullable=False),
     sa.Column("notes", sa.String, nullable=False),
@@ -161,7 +161,7 @@ class ProjectDB:
             if not row:
                 raise ProjectNotFoundError(project_uuid)
             result_dict = {key:value for key,value in row.items()}
-            log.info("found project: %s", result_dict)
+            log.debug("found project: %s", result_dict)
             return _convert_to_schema_names(result_dict)
 
     @classmethod

--- a/services/web/server/tests/integration/projects/test_projects.py
+++ b/services/web/server/tests/integration/projects/test_projects.py
@@ -235,3 +235,14 @@ async def test_list_template_projects(loop, client, fake_db, fake_template_proje
         assert not error, pprint(error)
         # fake-template-projects.json + fake-template-projects.osparc.json
         assert len(projects) == (len(fake_template_projects) + len(fake_template_projects_osparc))
+
+async def test_project_uuid_uniqueness(loop, client, fake_project):
+    async with LoggedUser(client):
+        # create the project once
+        await _create_project(client, fake_project)
+        # create a second project with same uuid shall fail
+        with pytest.raises(AssertionError):
+            await _create_project(client, fake_project)
+        # delete
+        pid = fake_project["uuid"]
+        await _delete_project(client, pid)


### PR DESCRIPTION
## What do these changes do?

Fixes the bug of opening two "Create new study" instances when double clicking the plus button. This was also causing an inconsistency in the DB having two projects with the same uuid.

Includes #687, that fixes the inconsistency in the DB