### PR TITLE
Disables fake-projects

### DIFF
--- a/services/web/server/src/simcore_service_webserver/application.py
+++ b/services/web/server/src/simcore_service_webserver/application.py
@@ -60,7 +60,7 @@ def create_application(config: dict):
     setup_s3(app)
     setup_storage(app)
     setup_users(app)
-    setup_projects(app, enable_fake_data=True) # TODO: deactivate fakes i.e. debug=testing
+    setup_projects(app)
     setup_studies_access(app)
 
     if config['director']["enabled"]:

--- a/services/web/server/src/simcore_service_webserver/projects/__init__.py
+++ b/services/web/server/src/simcore_service_webserver/projects/__init__.py
@@ -65,9 +65,9 @@ def setup(app: web.Application, *, enable_fake_data=False) -> bool:
 
     :param app: main web application
     :type app: web.Application
-    :param enable_fake_data: will inject some fake projects, defaults to False
+    :param enable_fake_data: if True it injects template projects under /data, defaults to False (USE ONLY FOR TESTING)
     :param enable_fake_data: bool, optional
-    :return: False if subystem setup was skipped (e.g. explicitly disabled in config), otherwise True
+    :return: False if setup skips (e.g. explicitly disabled in config), otherwise True
     :rtype: bool
     """
     logger.debug("Setting up %s ...", __name__)
@@ -106,7 +106,6 @@ def setup(app: web.Application, *, enable_fake_data=False) -> bool:
         app[APP_JSONSCHEMA_SPECS_KEY] = {CONFIG_SECTION_NAME: specs}
 
     if enable_fake_data:
-        # TODO: inject data in database instead of keeping in memory!?
         Fake.load_template_projects()
 
     return True

--- a/services/web/server/src/simcore_service_webserver/projects/projects_access.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_access.py
@@ -3,7 +3,6 @@ import jsondiff
 from aiohttp import web
 
 from ..security_api import get_access_model, UserRole
-from .projects_fakes import Fake
 
 
 async def can_update_node_inputs(context):
@@ -20,11 +19,7 @@ async def can_update_node_inputs(context):
         return False
 
     # get current version
-    # TODO: unify call
-    if project_uuid in Fake.projects:
-        current_project = Fake.projects[project_uuid].data
-    else:
-        current_project = await db.get_user_project(user_id, project_uuid)
+    current_project = await db.get_user_project(user_id, project_uuid)
 
     diffs = jsondiff.diff(current_project, updated_project)
 

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -19,7 +19,6 @@ from ..security_api import check_permission
 from .config import CONFIG_SECTION_NAME
 from .projects_db import APP_PROJECT_DBAPI
 from .projects_exceptions import ProjectNotFoundError
-from .projects_fakes import Fake
 
 BASE_UUID = uuidlib.UUID("71e0eb5e-0797-4469-89ba-00a0df4d338a")
 TEMPLATE_PREFIX = "template-uuid"
@@ -43,9 +42,6 @@ def validate_project(app: web.Application, project: Dict):
 
 async def get_project_for_user(request: web.Request, project_uuid, user_id) -> Dict:
     await check_permission(request, "project.read")
-
-    if project_uuid in Fake.projects:
-        return Fake.projects[project_uuid].data
 
     try:
         db = request.config_dict[APP_PROJECT_DBAPI]

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -11,7 +11,6 @@ from .projects_api import create_data_from_template, validate_project
 from .projects_db import APP_PROJECT_DBAPI
 from .projects_exceptions import (ProjectInvalidRightsError,
                                   ProjectNotFoundError)
-from .projects_fakes import Fake
 
 log = logging.getLogger(__name__)
 
@@ -30,12 +29,6 @@ async def create_projects(request: web.Request):
         if template_uuid:
             # create from template
             template_prj = await db.get_template_project(template_uuid)
-
-            if not template_prj: # TODO: inject these projects in db instead!
-                for prj in Fake.projects.values():
-                    if prj.template and prj.data['uuid']==template_uuid:
-                        template_prj = prj.data
-                        break
             if not template_prj:
                 raise web.HTTPNotFound(reason="Invalid template uuid {}".format(template_uuid))
 
@@ -83,7 +76,6 @@ async def list_projects(request: web.Request):
 
     projects_list = []
     if ptype in ("template", "all"):
-        projects_list += [prj.data for prj in Fake.projects.values() if prj.template]
         projects_list += await db.load_template_projects()
 
     if ptype in ("user", "all"):

--- a/services/web/server/src/simcore_service_webserver/studies_access.py
+++ b/services/web/server/src/simcore_service_webserver/studies_access.py
@@ -42,14 +42,12 @@ SHARABLE_TEMPLATE_STUDY_IDS = load_isan_template_uuids()
 async def get_template_project(app: web.Application, project_uuid: str):
     # TODO: remove projects_ prefix from name
     from .projects.projects_db import APP_PROJECT_DBAPI
-    from .projects.projects_fakes import Fake
 
     db = app[APP_PROJECT_DBAPI]
 
     # TODO: user search queries in DB instead
     # BUG: ensure items in project_list have unique UUIDs
-    projects_list = [prj.data for prj in Fake.projects.values() if prj.template]
-    projects_list += await db.load_template_projects()
+    projects_list = await db.load_template_projects()
 
     for prj in projects_list:
         if prj.get('uuid') == project_uuid:

--- a/services/web/server/tests/integration/test_project_workflow.py
+++ b/services/web/server/tests/integration/test_project_workflow.py
@@ -25,7 +25,7 @@ from servicelib.rest_responses import unwrap_envelope
 from simcore_service_webserver.db import setup_db
 from simcore_service_webserver.login import setup_login
 from simcore_service_webserver.projects import setup_projects
-from simcore_service_webserver.projects.projects_handlers import Fake
+from simcore_service_webserver.projects.projects_fakes import Fake
 from simcore_service_webserver.rest import setup_rest
 from simcore_service_webserver.security import setup_security
 from simcore_service_webserver.security_roles import UserRole


### PR DESCRIPTION
## What do these changes do?

- Application does not load template projects via fakes
- Moves all calls to get fakes under project's db api (in mid term this should e completely removed)


## Related issue number

Implements changes in #866 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] **Runs in the swarm**
- [ ] If you design a new module, add your user to .github/CODEOWNERS
