### PR TITLE
Storage extension for deep copy of project files

### DIFF
--- a/api/specs/storage/v0/openapi.yaml
+++ b/api/specs/storage/v0/openapi.yaml
@@ -273,6 +273,64 @@ paths:
         default:
           $ref: '#/components/responses/DefaultErrorResponse'
 
+  /folders/{folder_id}:
+    post:
+      tags:
+        - users
+      summary: Copies files from one project to another
+      operationId: copy_project_files
+      parameters:
+      - name: folder_Id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: user_id
+        in: query
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: './openapi-projects.yaml#/components/schemas/Project'
+      responses:
+        '201':
+          description: project created
+          content:
+            application/json:
+              schema:
+                $ref: './openapi-projects.yaml#/components/schemas/ProjectEnveloped'
+        default:
+          $ref: './openapi.yaml#/components/responses/DefaultErrorResponse'
+    delete:
+      tags:
+        - users
+      summary: Deletes File
+      operationId: delete_file
+      parameters:
+      - name: fileId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: location_id
+        in : path
+        required: true
+        schema:
+          type: string
+      - name: user_id
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          $ref: '#/components/responses/OK_NoContent_204'
+        default:
+          $ref: '#/components/responses/DefaultErrorResponse'
+
 components:
   responses:
     OK_NoContent_204:

--- a/api/specs/storage/v0/openapi.yaml
+++ b/api/specs/storage/v0/openapi.yaml
@@ -273,12 +273,49 @@ paths:
         default:
           $ref: '#/components/responses/DefaultErrorResponse'
 
-  /folders/{folder_id}:
+  /simcore-s3/folders:
     post:
       tags:
         - users
-      summary: Creates new folder and copies all files from source project
+      summary: Deep copies of all data from source to destination project in s3
       operationId: copy_folders_from_project
+      parameters:
+      - name: user_id
+        in: query
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                source:
+                  $ref: './openapi.yaml#/components/schemas/Project'
+                destination:
+                  $ref: './openapi.yaml#/components/schemas/Project'
+                nodes_map:
+                  type: object
+                  description: maps source and destination node uuids
+                  additionalProperties:
+                    type: string
+      responses:
+        '201':
+          description: Data from destination project copied and returns project
+          content:
+            application/json:
+              schema:
+                $ref: './openapi.yaml#/components/schemas/Project'
+        default:
+          $ref: './openapi.yaml#/components/responses/DefaultErrorResponse'
+
+  /simcore-s3/folders/{folder_id}:
+    delete:
+      tags:
+        - users
+      summary: Deletes all objects with folder_id prefix
+      operationId: delete_folders_of_project
       parameters:
       - name: folder_id
         in: path
@@ -290,44 +327,14 @@ paths:
         required: true
         schema:
           type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-               $ref: '../../webserver/v0/openapi-projects.yaml#/components/schemas/Project'
       responses:
-        '201':
-          description: folder created
-          content:
-            application/json:
-              schema:
-                $ref: '../../webserver/v0/openapi-projects.yaml#/components/schemas/ProjectEnveloped'
-                #$ref: '#/components/requestBodies/FileMetaDataBody'
-        default:
-          $ref: './openapi.yaml#/components/responses/DefaultErrorResponse'
-    #delete:
-    #  tags:
-    #    - users
-    #  summary: Deletes a folder
-    #  operationId: delete_folder
-    #  parameters:
-    #  - name: folder_id
-    #    in: path
-    #    required: true
-    #    schema:
-    #      type: string
-    #  - name: user_id
-    #    in: query
-    #    required: true
-    #    schema:
-    #      type: string
-    #  responses:
-    #    '204':
-    #      $ref: '#/components/responses/OK_NoContent_204'
-    #    default:
-    #      $ref: '#/components/responses/DefaultErrorResponse'
+        '204':
+          description: folder has been successfully deleted
 
 components:
+  schemas:
+    Project:
+      $ref: '../../webserver/v0/openapi-projects.yaml#/components/schemas/Project'
   responses:
     OK_NoContent_204:
       description: everything is OK, but there is no content to return

--- a/api/specs/storage/v0/openapi.yaml
+++ b/api/specs/storage/v0/openapi.yaml
@@ -277,10 +277,10 @@ paths:
     post:
       tags:
         - users
-      summary: Copies files from one project to another
-      operationId: copy_project_files
+      summary: Creates new folder and copies all files from source project
+      operationId: copy_folders_from_project
       parameters:
-      - name: folder_Id
+      - name: folder_id
         in: path
         required: true
         schema:
@@ -294,42 +294,38 @@ paths:
         content:
           application/json:
             schema:
-              $ref: './openapi-projects.yaml#/components/schemas/Project'
+               $ref: '../../webserver/v0/openapi-projects.yaml#/components/schemas/Project'
       responses:
         '201':
-          description: project created
+          description: folder created
           content:
             application/json:
               schema:
-                $ref: './openapi-projects.yaml#/components/schemas/ProjectEnveloped'
+                $ref: '../../webserver/v0/openapi-projects.yaml#/components/schemas/ProjectEnveloped'
+                #$ref: '#/components/requestBodies/FileMetaDataBody'
         default:
           $ref: './openapi.yaml#/components/responses/DefaultErrorResponse'
-    delete:
-      tags:
-        - users
-      summary: Deletes File
-      operationId: delete_file
-      parameters:
-      - name: fileId
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: location_id
-        in : path
-        required: true
-        schema:
-          type: string
-      - name: user_id
-        in: query
-        required: true
-        schema:
-          type: string
-      responses:
-        '204':
-          $ref: '#/components/responses/OK_NoContent_204'
-        default:
-          $ref: '#/components/responses/DefaultErrorResponse'
+    #delete:
+    #  tags:
+    #    - users
+    #  summary: Deletes a folder
+    #  operationId: delete_folder
+    #  parameters:
+    #  - name: folder_id
+    #    in: path
+    #    required: true
+    #    schema:
+    #      type: string
+    #  - name: user_id
+    #    in: query
+    #    required: true
+    #    schema:
+    #      type: string
+    #  responses:
+    #    '204':
+    #      $ref: '#/components/responses/OK_NoContent_204'
+    #    default:
+    #      $ref: '#/components/responses/DefaultErrorResponse'
 
 components:
   responses:

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -18,13 +18,12 @@ SHARED = 'shared'
 OPENAPI_MAIN_FILENAME = 'openapi.yaml'
 
 
-def current_dir():
-    return Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
+current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
 
 @pytest.fixture(scope='session')
 def here():
-    return current_dir()
+    return current_dir
 
 
 @pytest.fixture(scope='session')
@@ -91,7 +90,7 @@ def list_openapi_tails():
         SEE api_specs_tail to get one at a time
     """
     tails = []
-    specs_dir = _api_specs_dir_impl(current_dir())
+    specs_dir = _api_specs_dir_impl(current_dir)
     for tail in _all_api_specs_tails_impl(specs_dir):
         specs = load_specs( specs_dir / tail)
         if not is_json_schema(specs):

--- a/services/storage/src/simcore_service_storage/application.py
+++ b/services/storage/src/simcore_service_storage/application.py
@@ -6,11 +6,11 @@ import logging
 
 from aiohttp import web
 
-from .s3 import setup_s3
 from .db import setup_db
-from .rest import setup_rest
-from .settings import APP_CONFIG_KEY
 from .dsm import setup_dsm
+from .rest import setup_rest
+from .s3 import setup_s3
+from .settings import APP_CONFIG_KEY
 
 log = logging.getLogger(__name__)
 

--- a/services/storage/src/simcore_service_storage/cli.py
+++ b/services/storage/src/simcore_service_storage/cli.py
@@ -14,12 +14,12 @@ Why does this file exist, and why not put this in __main__?
 """
 import argparse
 import logging
-import sys
 import os
+import sys
 
-from . import application, cli_config
 from servicelib.utils import search_osparc_repo_dir
 
+from . import application, cli_config
 
 log = logging.getLogger(__name__)
 

--- a/services/storage/src/simcore_service_storage/cli_config.py
+++ b/services/storage/src/simcore_service_storage/cli_config.py
@@ -6,8 +6,8 @@ import os
 import trafaret_config
 import trafaret_config.commandline as commandline
 
-from .resources import RSC_CONFIG_DIR_KEY, resources
 from .config_schema import schema
+from .resources import RSC_CONFIG_DIR_KEY, resources
 from .settings import DEFAULT_CONFIG
 
 log = logging.getLogger(__name__)

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -473,9 +473,12 @@ class DataStorageManager:
                         new_node_id = node_mapping.get(old_node_id)
                         if new_node_id is not None:
                             old_filename = source_object_parts[2]
-                            dest_object_name = str(Path(dest_folder) / Path(new_node_id) / Path(old_filename))
+                            dest_object_name = str(Path(dest_folder) / new_node_id / old_filename)
                             copy_source = {'Bucket' : self.simcore_bucket_name, 'Key': source_object_name}
                             response = await client.copy_object(CopySource=copy_source, Bucket=self.simcore_bucket_name, Key=dest_object_name)
+                    else:
+                        # This may happen once we have shared/home folders
+                        logger.info("len(object.parts != 3")
 
 
             # Step 2: List all references in outputs that point to datcore and copy over
@@ -483,7 +486,7 @@ class DataStorageManager:
                 outputs = node.get("outputs")
                 if outputs is not None:
                     for _output_key, output in outputs.items():
-                        if "store" in output and output["store"]==1:
+                        if "store" in output and output["store"]==DATCORE_ID:
                             src = output["path"]
                             dest = str(Path(dest_folder) / Path(node_id) / Path(src).name)
                             logger.info("Need to copy %s to %s", src, dest)

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -426,3 +426,23 @@ class DataStorageManager:
             destination, filename = _parse_datcore(file_uuid)
             link = await dcw.download_link(destination, filename)
         return link
+
+    async def deep_copy_project_simcore_s3(self, user_id: str, source_project, destination_project):
+        """ Parses a given source project and copies all related files to the destination project
+
+            Since all files are organized as
+
+                project_id/node_id/filename or links to datcore
+
+            this function creates a new folder structure
+
+                project_id/node_id/filename
+
+            and copies all files to the corresponding places.
+
+            Additionally, all external files from datcore are being copied and the paths in the destination
+            project are adapted accordingly
+        """
+        # read the source_project
+        source_folder = source_project["uuid"]
+        dest_folder = dest_project["uuid"]

--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -246,6 +246,30 @@ async def delete_file(request: web.Request):
         }
 
 
+async def create_folders_from_project(request: web.Request):
+    import pdb; pdb.set_trace()
+
+    params, query, body = await extract_and_validate(request)
+
+    assert params, "params %s" % params
+    assert query, "query %s" % query
+    assert body, "body %s" % body
+
+    assert params["folder_id"]
+    assert query["user_id"]
+
+    #user_id = query["user_id"]
+    folder_id = params["folder_id"]
+    source_project = body["source_project"]
+    dest_project = body["dest_project"]
+    dsm = await _prepare_storage_manager(params, query, request)
+    #_discard = await dsm.delete_file(user_id=user_id, location=location, file_uuid=file_uuid)
+
+    return {
+        'error': None,
+        'data': dest_project
+        }
+
 # HELPERS -----------------------------------------------------
 INIT_STR = "init"
 

--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -275,7 +275,6 @@ async def delete_folders_of_project(request: web.Request):
     folder_id = request.match_info['folder_id']
     user_id = request.query.get("user_id")
 
-    # TODO: implement
     params = { "location_id" : SIMCORE_S3_ID }
     query = { "user_id": user_id}
     dsm = await _prepare_storage_manager(params, query, request)

--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import attr
@@ -160,7 +161,6 @@ async def update_file_meta_data(request: web.Request):
     _location = dsm.location_from_id(location_id)
 
 
-
 async def download_file(request: web.Request):
     params, query, body = await extract_and_validate(request)
 
@@ -247,28 +247,41 @@ async def delete_file(request: web.Request):
 
 
 async def create_folders_from_project(request: web.Request):
-    import pdb; pdb.set_trace()
+    #FIXME: Update openapi-core. Fails with additionalProperties https://github.com/p1c2u/openapi-core/issues/124. Fails with project
+    # params, query, body = await extract_and_validate(request)
 
-    params, query, body = await extract_and_validate(request)
+    user_id = request.query.get("user_id")
 
-    assert params, "params %s" % params
-    assert query, "query %s" % query
-    assert body, "body %s" % body
+    body = await request.json()
+    source_project = body.get('source', {})
+    destination_project = body.get('destination', {})
+    nodes_map = body.get('nodes_map', {})
 
-    assert params["folder_id"]
-    assert query["user_id"]
+    # TODO: remove this for production
+    assert set(nodes_map.keys()) == set(source_project['workbench'].keys())
+    assert set(nodes_map.values()) == set(destination_project['workbench'].keys())
 
-    #user_id = query["user_id"]
-    folder_id = params["folder_id"]
-    source_project = body["source_project"]
-    dest_project = body["dest_project"]
-    dsm = await _prepare_storage_manager(params, query, request)
+    # TODO: validate project with jsonschema instead??
+
+
+    # TODO: implement
+    # dsm = await _prepare_storage_manager(params, request.query, request)
     #_discard = await dsm.delete_file(user_id=user_id, location=location, file_uuid=file_uuid)
 
-    return {
-        'error': None,
-        'data': dest_project
-        }
+    raise web.HTTPCreated(text=json.dumps(destination_project),
+                                content_type='application/json')
+
+async def delete_folders_of_project(request: web.Request):
+    folder_id = request.match_info['folder_id']
+    user_id = request.query.get("user_id")
+
+    # TODO: implement
+
+    raise web.HTTPNoContent(content_type='application/json')
+
+
+
+
 
 # HELPERS -----------------------------------------------------
 INIT_STR = "init"

--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -10,7 +10,7 @@ from . import __version__
 from .db_tokens import get_api_token_and_secret
 from .dsm import DataStorageManager, DatCoreApiToken
 from .rest_models import FileMetaDataSchema
-from .settings import APP_DSM_KEY, DATCORE_STR
+from .settings import APP_DSM_KEY, DATCORE_STR, SIMCORE_S3_ID
 
 log = logging.getLogger(__name__)
 
@@ -263,10 +263,10 @@ async def create_folders_from_project(request: web.Request):
 
     # TODO: validate project with jsonschema instead??
 
-
-    # TODO: implement
-    # dsm = await _prepare_storage_manager(params, request.query, request)
-    #_discard = await dsm.delete_file(user_id=user_id, location=location, file_uuid=file_uuid)
+    params = { "location_id" : SIMCORE_S3_ID }
+    query = { "user_id": user_id}
+    dsm = await _prepare_storage_manager(params, query, request)
+    await dsm.deep_copy_project_simcore_s3(user_id, source_project, destination_project, nodes_map)
 
     raise web.HTTPCreated(text=json.dumps(destination_project),
                                 content_type='application/json')
@@ -276,6 +276,10 @@ async def delete_folders_of_project(request: web.Request):
     user_id = request.query.get("user_id")
 
     # TODO: implement
+    params = { "location_id" : SIMCORE_S3_ID }
+    query = { "user_id": user_id}
+    dsm = await _prepare_storage_manager(params, query, request)
+    await dsm.delete_project_simcore_s3(user_id, folder_id)
 
     raise web.HTTPNoContent(content_type='application/json')
 

--- a/services/storage/src/simcore_service_storage/models.py
+++ b/services/storage/src/simcore_service_storage/models.py
@@ -9,7 +9,8 @@ from typing import Tuple
 import attr
 
 from simcore_postgres_database.storage_models import (file_meta_data, metadata,
-                                                      projects, tokens, user_to_projects, users)
+                                                      projects, tokens,
+                                                      user_to_projects, users)
 from simcore_service_storage.settings import (DATCORE_STR, SIMCORE_S3_ID,
                                               SIMCORE_S3_STR)
 

--- a/services/storage/src/simcore_service_storage/resources.py
+++ b/services/storage/src/simcore_service_storage/resources.py
@@ -2,7 +2,8 @@
 
 """
 from servicelib.resources import ResourcesFacade
-from .settings import RSC_CONFIG_DIR_KEY # pylint: disable=unused-import
+
+from .settings import RSC_CONFIG_DIR_KEY  # pylint: disable=unused-import
 
 resources = ResourcesFacade(
     package_name=__name__,

--- a/services/storage/src/simcore_service_storage/rest_routes.py
+++ b/services/storage/src/simcore_service_storage/rest_routes.py
@@ -64,5 +64,9 @@ def create(specs: OpenApiSpec) -> List[web.RouteDef]:
     operation_id = specs.paths[path].operations['put'].operation_id
     routes.append( web.put(BASEPATH+path, handle, name=operation_id) )
 
+    path, handle = '/folders/{folder_id}', handlers.create_folders_from_project
+    operation_id = specs.paths[path].operations['post'].operation_id
+    routes.append( web.post(BASEPATH+path, handle, name=operation_id) )
+
 
     return routes

--- a/services/storage/src/simcore_service_storage/rest_routes.py
+++ b/services/storage/src/simcore_service_storage/rest_routes.py
@@ -64,9 +64,12 @@ def create(specs: OpenApiSpec) -> List[web.RouteDef]:
     operation_id = specs.paths[path].operations['put'].operation_id
     routes.append( web.put(BASEPATH+path, handle, name=operation_id) )
 
-    path, handle = '/folders/{folder_id}', handlers.create_folders_from_project
+    path, handle = '/simcore-s3/folders', handlers.create_folders_from_project
     operation_id = specs.paths[path].operations['post'].operation_id
     routes.append( web.post(BASEPATH+path, handle, name=operation_id) )
 
+    path, handle = '/simcore-s3/folders/{folder_id}', handlers.delete_folders_of_project
+    operation_id = specs.paths[path].operations['delete'].operation_id
+    routes.append( web.delete(BASEPATH+path, handle, name=operation_id) )
 
     return routes

--- a/services/storage/src/simcore_service_storage/settings.py
+++ b/services/storage/src/simcore_service_storage/settings.py
@@ -23,7 +23,6 @@ from servicelib import application_keys
 #   DO NOT IMPORT ANYTHING from . (except for __version__)
 from .__version__ import get_version_object
 
-
 log = logging.getLogger(__name__)
 
 

--- a/services/storage/src/simcore_service_storage/utils.py
+++ b/services/storage/src/simcore_service_storage/utils.py
@@ -1,8 +1,8 @@
-import tenacity
-from yarl import URL
-from aiohttp import ClientSession
-
 import logging
+
+import tenacity
+from aiohttp import ClientSession
+from yarl import URL
 
 logger = logging.getLogger(__name__)
 

--- a/services/storage/tests/_test_rawdatcore.py
+++ b/services/storage/tests/_test_rawdatcore.py
@@ -32,7 +32,6 @@ if utils.has_datcore_tokens():
     finally:
         os.remove(path)
 
-    aa
     files =  []
     if True:
         dataset = client.get_dataset("mag")

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -29,11 +29,12 @@ from simcore_service_storage.settings import (DATCORE_ID, DATCORE_STR,
 from utils import (ACCESS_KEY, BUCKET_NAME, DATABASE, PASS, SECRET_KEY, USER,
                    USER_ID)
 
+current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
+sys.path.append(str(current_dir / 'helpers'))
 
 @pytest.fixture(scope='session')
 def here():
-    return Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
-
+    return current_dir
 
 @pytest.fixture(scope='session')
 def package_dir(here):

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -299,7 +299,7 @@ async def datcore_testbucket(loop, mock_files_factory):
     for f in tmp_files:
         await dcw.upload_file(BUCKET_NAME, os.path.normpath(f))
 
-    yield BUCKET_NAME
+    yield BUCKET_NAME, tmp_files[0], tmp_files[1]
 
     await dcw.delete_test_dataset(BUCKET_NAME)
 

--- a/services/storage/tests/data/projects_with_data.json
+++ b/services/storage/tests/data/projects_with_data.json
@@ -1,0 +1,173 @@
+[
+  {
+  "uuid": "template-uuid-518d-a25d-8887bcae93f8",
+  "name": "ISAN2019: 3D Paraview",
+  "description": "3D Paraview viewer with two inputs",
+  "thumbnail": "https://user-images.githubusercontent.com/33152403/60168939-073a5580-9806-11e9-8dad-8a7caa3eb5ab.png",
+  "prjOwner": "maiz@itis.swiss",
+  "creationDate": "2019-06-06 14:33:43.065",
+  "lastChangeDate": "2019-06-06 14:33:44.747",
+  "workbench": {
+    "template-uuid-5753-af37-e6aec8120bf2": {
+      "key": "simcore/services/frontend/file-picker",
+      "version": "1.0.0",
+      "label": "File Picker 1",
+      "inputs": {},
+      "inputNodes": [],
+      "outputNode": false,
+      "outputs": {
+        "outFile": {
+          "store": 1,
+          "path": "Shared Data/HField_Big.vtk"
+        }
+      },
+      "progress": 100,
+      "thumbnail": "",
+      "position": {
+        "x": 100,
+        "y": 100
+      }
+    },
+    "template-uuid-522c-a377-dd8d7cd1265b": {
+      "key": "simcore/services/frontend/file-picker",
+      "version": "1.0.0",
+      "label": "File Picker 2",
+      "inputs": {},
+      "inputNodes": [],
+      "outputNode": false,
+      "outputs": {
+        "outFile": {
+          "store": 1,
+          "path": "Shared Data/bunny.vtk"
+        }
+      },
+      "progress": 100,
+      "thumbnail": "",
+      "position": {
+        "x": 100,
+        "y": 250
+      }
+    },
+    "template-uuid-9b0f-67677a20996c": {
+      "key": "simcore/services/dynamic/3d-viewer",
+      "version": "2.10.0",
+      "label": "3D ParaViewer",
+      "inputs": {
+        "A": {
+          "nodeUuid": "template-uuid-5753-af37-e6aec8120bf2",
+          "output": "outFile"
+        },
+        "B": {
+          "nodeUuid": "template-uuid-522c-a377-dd8d7cd1265b",
+          "output": "outFile"
+        }
+      },
+      "inputNodes": [
+        "template-uuid-5753-af37-e6aec8120bf2",
+        "template-uuid-522c-a377-dd8d7cd1265b"
+      ],
+      "outputNode": false,
+      "outputs": {},
+      "progress": 85,
+      "thumbnail": "",
+      "position": {
+        "x": 400,
+        "y": 175
+      }
+    }
+  }
+},
+{
+  "uuid": "template-uuid-5d82-b08d-d39c436ca738",
+  "name": "ISAN: UCDavis use case: 0D",
+  "description": "Colleen Clancy Single Cell solver with a file picker and PostPro viewer",
+  "thumbnail": "https://user-images.githubusercontent.com/33152403/60168940-073a5580-9806-11e9-9a44-ae5266eeb020.png",
+  "prjOwner": "maiz@itis.swiss",
+  "creationDate": "2019-06-06 14:33:51.94",
+  "lastChangeDate": "2019-06-06 14:33:54.329",
+  "workbench": {
+    "template-uuid-59d6-b1a5-6e7b2773636b": {
+      "key": "simcore/services/frontend/file-picker",
+      "version": "1.0.0",
+      "label": "File Picker 0D",
+      "inputs": {},
+      "inputNodes": [],
+      "outputNode": false,
+      "outputs": {
+        "outFile": {
+          "store": 1,
+          "path": "Shared Data/initial_WStates"
+        }
+      },
+      "progress": 100,
+      "thumbnail": "",
+      "position": {
+        "x": 50,
+        "y": 150
+      }
+    },
+    "template-uuid-562f-afd1-cca5105c8844": {
+      "key": "simcore/services/comp/ucdavis-singlecell-cardiac-model",
+      "version": "1.0.0",
+      "label": "DBP-Clancy-Rabbit-Single-Cell solver",
+      "inputs": {
+        "Na": 0,
+        "Kr": 0,
+        "BCL": 200,
+        "NBeats": 5,
+        "Ligand": 0,
+        "cAMKII": "WT",
+        "initfile": {
+          "nodeUuid": "template-uuid-59d6-b1a5-6e7b2773636b",
+          "output": "outFile"
+        }
+      },
+      "inputAccess": {
+        "Na": "ReadAndWrite",
+        "Kr": "ReadOnly",
+        "BCL": "ReadAndWrite",
+        "NBeats": "ReadOnly",
+        "Ligand": "Invisible",
+        "cAMKII": "Invisible"
+      },
+      "inputNodes": [
+        "template-uuid-59d6-b1a5-6e7b2773636b"
+      ],
+      "outputNode": false,
+      "outputs": {},
+      "progress": 0,
+      "thumbnail": "",
+      "position": {
+        "x": 300,
+        "y": 150
+      }
+    },
+    "template-uuid-5fdd-9daa-cb03c51d8138": {
+      "key": "simcore/services/dynamic/cc-0d-viewer",
+      "version": "2.8.0",
+      "label": "cc-0d-viewer",
+      "inputs": {
+        "vm_1Hz": {
+          "nodeUuid": "template-uuid-562f-afd1-cca5105c8844",
+          "output": "out_4"
+        },
+        "all_results_1Hz": {
+          "nodeUuid": "template-uuid-562f-afd1-cca5105c8844",
+          "output": "out_1"
+        }
+      },
+      "inputNodes": [
+        "template-uuid-562f-afd1-cca5105c8844"
+      ],
+      "outputNode": false,
+      "outputs": {},
+      "progress": 20,
+      "thumbnail": "",
+      "position": {
+        "x": 550,
+        "y": 150
+      }
+    }
+  }
+}
+]

--- a/services/storage/tests/docker-compose.yml
+++ b/services/storage/tests/docker-compose.yml
@@ -9,13 +9,13 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin}
     ports:
       - '5432:5432'
-  adminer:
-    image: adminer
-    restart: always
-    ports:
-      - 18080:8080
-    depends_on:
-      - postgres
+  # adminer:
+  #   image: adminer
+  #   restart: always
+  #   ports:
+  #     - 18080:8080
+  #   depends_on:
+  #     - postgres
   minio:
     image: minio/minio
     environment:

--- a/services/storage/tests/helpers/utils_assert.py
+++ b/services/storage/tests/helpers/utils_assert.py
@@ -1,0 +1,44 @@
+from pprint import pformat
+
+from aiohttp import web
+
+from servicelib.rest_responses import unwrap_envelope
+
+
+async def assert_status(response: web.Response, expected_cls:web.HTTPException, expected_msg: str=None):
+    data, error = unwrap_envelope(await response.json())
+    assert response.status == expected_cls.status_code, \
+        f"got {response.status}, expected {expected_cls.status_code}:\n data:{data},\n error:{error}"
+
+    if issubclass(expected_cls, web.HTTPError):
+        do_assert_error(data, error, expected_cls, expected_msg)
+
+    elif issubclass(expected_cls, web.HTTPNoContent):
+        assert not data, pformat(data)
+        assert not error, pformat(error)
+    else:
+        assert data is not None, pformat(data)
+        assert not error, pformat(error)
+
+        if expected_msg:
+            assert expected_msg in data["message"]
+
+    return data, error
+
+async def assert_error(response: web.Response, expected_cls:web.HTTPException, expected_msg: str=None):
+    data, error = unwrap_envelope(await response.json())
+    return do_assert_error(data, error, expected_cls, expected_msg)
+
+def do_assert_error(data, error, expected_cls:web.HTTPException, expected_msg: str=None):
+    assert not data, pformat(data)
+    assert error, pformat(error)
+
+    # TODO: improve error messages
+    assert len(error['errors']) == 1
+
+    err = error['errors'][0]
+    if expected_msg:
+        assert expected_msg in err['message']
+    assert expected_cls.__name__  == err['code']
+
+    return data, error

--- a/services/storage/tests/helpers/utils_project.py
+++ b/services/storage/tests/helpers/utils_project.py
@@ -1,0 +1,38 @@
+import uuid as uuidlib
+from copy import deepcopy
+from typing import Dict, Tuple
+
+
+def clone_project_data(project: Dict) -> Tuple[Dict, Dict]:
+    project_copy = deepcopy(project)
+
+    # Update project id
+    # NOTE: this can be re-assigned by dbapi if not unique
+    project_copy_uuid = uuidlib.uuid1() # random project id
+    project_copy['uuid'] = str(project_copy_uuid)
+
+    # Workbench nodes shall be unique within the project context
+    def _create_new_node_uuid(old_uuid):
+        return str( uuidlib.uuid5(project_copy_uuid, str(old_uuid)) )
+
+    nodes_map = {}
+    for node_uuid in project.get('workbench', {}).keys():
+        nodes_map[node_uuid] = _create_new_node_uuid(node_uuid)
+
+    def _replace_uuids(node):
+        if isinstance(node, str):
+            node = nodes_map.get(node, node)
+        elif isinstance(node, list):
+            node = [_replace_uuids(item) for item in node]
+        elif isinstance(node, dict):
+            _frozen_items = tuple(node.items())
+            for key, value in _frozen_items:
+                if key in nodes_map:
+                    new_key = nodes_map[key]
+                    node[new_key] = node.pop(key)
+                    key = new_key
+                node[key] = _replace_uuids(value)
+        return node
+
+    project_copy['workbench'] = _replace_uuids(project_copy.get('workbench', {}))
+    return project_copy, nodes_map

--- a/services/storage/tests/test_configs.py
+++ b/services/storage/tests/test_configs.py
@@ -11,7 +11,7 @@ import unittest.mock as mock
 import pytest
 import yaml
 
-from simcore_service_storage.cli import parse, setup_parser
+from simcore_service_storage.cli import create_environ, parse, setup_parser
 from simcore_service_storage.resources import resources
 
 THIS_SERVICE = 'storage'
@@ -41,7 +41,6 @@ def devel_environ(env_devel_file):
                 env_devel[key] = value
     return env_devel
 
-from simcore_service_storage.cli import create_environ
 
 @pytest.fixture("session")
 def container_environ(services_docker_compose_file, devel_environ, osparc_simcore_root_dir):

--- a/services/storage/tests/test_datcore.py
+++ b/services/storage/tests/test_datcore.py
@@ -5,13 +5,13 @@
 
 import os
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import pytest
 
 import utils
 from simcore_service_storage.datcore_wrapper import DatcoreWrapper
 
-from pathlib import Path
 
 async def test_datcore_ping(loop):
     if not utils.has_datcore_tokens():

--- a/services/storage/tests/test_dsm.py
+++ b/services/storage/tests/test_dsm.py
@@ -458,24 +458,10 @@ async def test_deep_copy_project_simcore_s3(dsm_fixture, s3_client, postgres_ser
     assert new_path != path_in_datcore
     files = await dsm.list_files(user_id=user_id, location=SIMCORE_S3_STR)
     assert len(files) == 3
-    found = False
-    for f in files:
-        if f.file_uuid == new_path:
-            found = True
-
-    assert found
+    assert any(f.file_uuid == new_path for f in files)
 
     response = await dsm.delete_project_simcore_s3(user_id, destination_project["uuid"])
     print(response)
 
     files = await dsm.list_files(user_id=user_id, location=SIMCORE_S3_STR)
     assert len(files) == 0
-
-async def test_mock(mocker, dsm_fixture):
-    mock_dsm = mocker.patch.object(dsm_fixture,"copy_file")
-    mock_dsm.return_value = Future()
-    mock_dsm.return_value.set_result("Howdie")
-
-    res = await dsm_fixture.copy_file(user_id ="1", dest_location ="", dest_uuid ="", source_location="", source_uuid ="")
-
-    assert res == "Howdie"

--- a/services/storage/tests/test_rest.py
+++ b/services/storage/tests/test_rest.py
@@ -5,6 +5,8 @@ from urllib.parse import quote
 
 import pytest
 from aiohttp import web
+from yarl import URL
+
 
 from simcore_service_storage.db import setup_db
 from simcore_service_storage.dsm import setup_dsm
@@ -239,3 +241,27 @@ async def test_action_check(client):
 
     assert data['path_value'] == ACTION
     assert data['query_value'] == QUERY
+
+
+async def test_create_folders_from_project(client, dsm_mockup_db):
+    default_project = {
+        "uuid": "0000000-invalid-uuid",
+        "name": "Minimal name",
+        "description": "this description should not change",
+        "prjOwner": "me but I will be removed anyway",
+        "creationDate": "today",
+        "lastChangeDate": "tomorrow",
+        "thumbnail": "",
+        "workbench": {}
+    }
+
+    folder_id = "asdf"
+    url = URL("/v0/folders/{}".format(folder_id)).with_query(user_id="1")
+    import pdb; pdb.set_trace()
+
+    resp = await client.post(url, json=default_project)
+
+    payload = await resp.json()
+    import pdb; pdb.set_trace()
+
+    data, error = tuple( payload.get(k) for k in ('data', 'error') )

--- a/services/storage/tests/test_rest.py
+++ b/services/storage/tests/test_rest.py
@@ -170,7 +170,7 @@ async def test_copy(client, dsm_mockup_db, datcore_testbucket):
     for d in dsm_mockup_db.keys():
         fmd = dsm_mockup_db[d]
         source_uuid = fmd.file_uuid
-        datcore_uuid = os.path.join(datcore_testbucket, fmd.file_name)
+        datcore_uuid = os.path.join(datcore_testbucket[0], fmd.file_name)
         resp = await client.put("/v0/locations/1/files/{}?user_id={}&extra_location={}&extra_source={}".format(quote(datcore_uuid, safe=''),
             fmd.user_id, SIMCORE_S3_ID, quote(source_uuid, safe='')))
         payload = await resp.json()

--- a/services/storage/tests/utils.py
+++ b/services/storage/tests/utils.py
@@ -1,12 +1,12 @@
 import logging
 import os
+import sys
 from pathlib import Path
 
 import pandas as pd
 import pytest
 import requests
 import sqlalchemy as sa
-import sys
 
 from simcore_service_storage.models import (FileMetaData, file_meta_data,
                                             projects, user_to_projects, users)

--- a/services/web/server/tests/unit/with_postgres/test_projects.py
+++ b/services/web/server/tests/unit/with_postgres/test_projects.py
@@ -204,8 +204,8 @@ async def test_new_project(client, logged_user, expected):
         "name": "Minimal name",
         "description": "this description should not change",
         "prjOwner": "me but I will be removed anyway",
-        "creationDate": "today",
-        "lastChangeDate": "tomorrow",
+        "creationDate": now_str(),
+        "lastChangeDate": now_str(),
         "thumbnail": "",
         "workbench": {}
     }

--- a/services/web/server/tests/unit/with_postgres/test_projects.py
+++ b/services/web/server/tests/unit/with_postgres/test_projects.py
@@ -204,8 +204,8 @@ async def test_new_project(client, logged_user, expected):
         "name": "Minimal name",
         "description": "this description should not change",
         "prjOwner": "me but I will be removed anyway",
-        "creationDate": now_str(),
-        "lastChangeDate": now_str(),
+        "creationDate": "today",
+        "lastChangeDate": "tomorrow",
         "thumbnail": "",
         "workbench": {}
     }


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?
Extension of storage api:

- Implements deep clone of a project on storage level (i.e. copying of all files related to a project into internal simcore.s3 storage and, if any, from datcore to simcore.s3)
- Implements deletion of files in internal simcore.s3 storage


## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] **Runs in the swarm**
- [ ] If you design a new module, add your user to .github/CODEOWNERS
