### PR TITLE
Is1098/persistent sessions

### DIFF
--- a/packages/service-library/src/servicelib/application_keys.py
+++ b/packages/service-library/src/servicelib/application_keys.py
@@ -26,6 +26,8 @@ APP_DB_ENGINE_KEY      = __name__ + '.db_engine'
 APP_DB_SESSION_KEY     = __name__ + '.db_session'
 APP_DB_POOL_KEY        = __name__ + '.db_pool'
 
+APP_CLIENT_SESSION_KEY = f"{__name__ }.session"
+
 # RSP=response
 
 

--- a/packages/service-library/src/servicelib/client_session.py
+++ b/packages/service-library/src/servicelib/client_session.py
@@ -1,0 +1,44 @@
+""" async client session
+
+
+    SEE https://docs.aiohttp.org/en/latest/client_advanced.html#persistent-session
+"""
+from aiohttp import ClientSession, web
+
+from .application_keys import APP_CLIENT_SESSION_KEY
+
+
+def get_client_session(app: web.Application) -> ClientSession:
+    """ Lazy initialization of ClientSession
+
+    Ensures unique session
+    """
+    session = app.get(APP_CLIENT_SESSION_KEY)
+    if session is None or session.closed:
+        app[APP_CLIENT_SESSION_KEY] = session = ClientSession()
+    return session
+
+
+async def persistent_client_session(app: web.Application):
+    """ Ensures a single client session per application
+
+    IMPORTANT: Use this function ONLY in cleanup context , i.e.
+        app.cleanup_ctx.append(persistent_client_session)
+
+    SEE https://docs.aiohttp.org/en/latest/client_advanced.html#aiohttp-persistent-session
+    """
+    session = get_client_session(app)
+
+    yield
+
+    await session.close()
+
+# FIXME: if get_client_session upon startup fails and session is NOT closed. Implement some kind of gracefull shutdonw https://docs.aiohttp.org/en/latest/client_advanced.html#graceful-shutdown
+# TODO: add some tests
+
+
+__all__ = [
+    'APP_CLIENT_SESSION_KEY',
+    'get_client_session',
+    'persistent_client_session'
+]

--- a/packages/service-library/src/servicelib/client_session.py
+++ b/packages/service-library/src/servicelib/client_session.py
@@ -3,10 +3,13 @@
 
     SEE https://docs.aiohttp.org/en/latest/client_advanced.html#persistent-session
 """
+import logging
+
 from aiohttp import ClientSession, web
 
 from .application_keys import APP_CLIENT_SESSION_KEY
 
+log = logging.getLogger(__name__)
 
 def get_client_session(app: web.Application) -> ClientSession:
     """ Lazy initialization of ClientSession
@@ -27,9 +30,16 @@ async def persistent_client_session(app: web.Application):
 
     SEE https://docs.aiohttp.org/en/latest/client_advanced.html#aiohttp-persistent-session
     """
+    # lazy creation and holds reference to session at this point
     session = get_client_session(app)
 
     yield
+
+    # closes held session
+    if session is not app.get(APP_CLIENT_SESSION_KEY):
+        log.error("Unexpected client session upon cleanup! expected %s, got %s",
+            session,
+            app.get(APP_CLIENT_SESSION_KEY))
 
     await session.close()
 

--- a/packages/service-library/src/servicelib/jsonschema_specs.py
+++ b/packages/service-library/src/servicelib/jsonschema_specs.py
@@ -20,7 +20,7 @@ async def _load_from_url(session: ClientSession, url: URL) -> Dict:
         spec_dict = json.loads(text)
         return spec_dict
 
-async def create_jsonschema_specs(session: ClientSession, location: Path) -> Dict:
+async def create_jsonschema_specs(location: Path, session: ClientSession=None) -> Dict:
     """ Loads specs from a given location (url or path),
         validates them and returns a working instance
 

--- a/packages/service-library/src/servicelib/jsonschema_specs.py
+++ b/packages/service-library/src/servicelib/jsonschema_specs.py
@@ -15,14 +15,13 @@ def _load_from_path(filepath: Path) -> Dict:
         return spec_dict
 
 
-async def _load_from_url(url: URL) -> Dict:
-    async with ClientSession() as session:
-        async with session.get(url) as resp:
-            text = await resp.text()
-            spec_dict = json.loads(text)
-            return spec_dict
+async def _load_from_url(session: ClientSession, url: URL) -> Dict:
+    async with session.get(url) as resp:
+        text = await resp.text()
+        spec_dict = json.loads(text)
+        return spec_dict
 
-async def create_jsonschema_specs(location: Path) -> Dict:
+async def create_jsonschema_specs(session: ClientSession, location: Path) -> Dict:
     """ Loads specs from a given location (url or path),
         validates them and returns a working instance
 
@@ -38,7 +37,7 @@ async def create_jsonschema_specs(location: Path) -> Dict:
     :rtype: Dict
     """
     if URL(str(location)).host:
-        spec_dict = await _load_from_url(URL(location))
+        spec_dict = await _load_from_url(session, URL(location))
     else:
         path = Path(location).expanduser().resolve() #pylint: disable=no-member
         spec_dict = _load_from_path(path)

--- a/packages/service-library/src/servicelib/jsonschema_specs.py
+++ b/packages/service-library/src/servicelib/jsonschema_specs.py
@@ -1,19 +1,18 @@
 import json
 from pathlib import Path
 from typing import Dict
-from .jsonschema_validation import validate_instance
-
 
 from aiohttp import ClientSession
 from jsonschema import ValidationError
 from yarl import URL
+
+from .jsonschema_validation import validate_instance
 
 
 def _load_from_path(filepath: Path) -> Dict:
     with filepath.open() as f:
         spec_dict = json.load(f)
         return spec_dict
-
 
 async def _load_from_url(session: ClientSession, url: URL) -> Dict:
     async with session.get(url) as resp:

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports/filemanager.py
@@ -146,7 +146,7 @@ async def download_file(*, store_name: str=None, store_id:str=None, s3_object:st
                 if active_session is not session:
                     warnings.warn("Optional session will be deprecated, pass instead controled session (e.g. from app[APP_CLIENT_SESSION_KEY])",
                         category=DeprecationWarning)
-                    await session.close()
+                    await active_session.close()
 
             return local_file_path
 
@@ -188,7 +188,7 @@ async def upload_file(*, store_id:str=None, store_name:str=None, s3_object:str, 
                 if active_session is not session:
                     warnings.warn("Optional session will be deprecated, pass instead controled session (e.g. from app[APP_CLIENT_SESSION_KEY])",
                         category=DeprecationWarning)
-                    await session.close()
+                    await active_session.close()
 
             return store_id
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports/filemanager.py
@@ -139,11 +139,11 @@ async def download_file(*, store_name: str=None, store_id:str=None, s3_object:st
             # This package has no app so session is passed as optional arguments
             # See https://github.com/ITISFoundation/osparc-simcore/issues/1098
             #
-            actual_session = session or ClientSession()
+            active_session = session or ClientSession()
             try:
-                await _download_link_to_file(session, download_link, local_file_path, store_id, s3_object)
+                await _download_link_to_file(active_session, download_link, local_file_path, store_id, s3_object)
             finally:
-                if actual_session is not session:
+                if active_session is not session:
                     warnings.warn("Optional session will be deprecated, pass instead controled session (e.g. from app[APP_CLIENT_SESSION_KEY])",
                         category=DeprecationWarning)
                     await session.close()
@@ -181,11 +181,11 @@ async def upload_file(*, store_id:str=None, store_name:str=None, s3_object:str, 
             # This package has no app so session is passed as optional arguments
             # See https://github.com/ITISFoundation/osparc-simcore/issues/1098
             #
-            actual_session = session or ClientSession()
+            active_session = session or ClientSession()
             try:
-                await _upload_file_to_link(session, upload_link, local_file_path)
+                await _upload_file_to_link(active_session, upload_link, local_file_path)
             finally:
-                if actual_session is not session:
+                if active_session is not session:
                     warnings.warn("Optional session will be deprecated, pass instead controled session (e.g. from app[APP_CLIENT_SESSION_KEY])",
                         category=DeprecationWarning)
                     await session.close()

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports/filemanager.py
@@ -1,5 +1,6 @@
 #pylint: disable=too-many-arguments
 import logging
+import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
@@ -143,6 +144,8 @@ async def download_file(*, store_name: str=None, store_id:str=None, s3_object:st
                 await _download_link_to_file(session, download_link, local_file_path, store_id, s3_object)
             finally:
                 if actual_session is not session:
+                    warnings.warn("Optional session will be deprecated, pass instead controled session (e.g. from app[APP_CLIENT_SESSION_KEY])",
+                        category=DeprecationWarning)
                     await session.close()
 
             return local_file_path
@@ -183,6 +186,8 @@ async def upload_file(*, store_id:str=None, store_name:str=None, s3_object:str, 
                 await _upload_file_to_link(session, upload_link, local_file_path)
             finally:
                 if actual_session is not session:
+                    warnings.warn("Optional session will be deprecated, pass instead controled session (e.g. from app[APP_CLIENT_SESSION_KEY])",
+                        category=DeprecationWarning)
                     await session.close()
 
             return store_id

--- a/services/director/src/simcore_service_director/config.py
+++ b/services/director/src/simcore_service_director/config.py
@@ -44,3 +44,7 @@ NODE_SCHEMA_LOCATION = os.environ.get("NODE_SCHEMA_LOCATION",
 SIMCORE_SERVICES_NETWORK_NAME = os.environ.get("SIMCORE_SERVICES_NETWORK_NAME")
 # useful when developing with an alternative registry namespace
 SIMCORE_SERVICES_PREFIX = os.environ.get("SIMCORE_SERVICES_PREFIX", "simcore/services")
+
+
+# app keys for persistend aiohttp.ClientSession
+CLIENT_SESSION_KEY = __name__ + '.session'

--- a/services/director/src/simcore_service_director/config.py
+++ b/services/director/src/simcore_service_director/config.py
@@ -4,6 +4,8 @@
 import logging
 import os
 
+from servicelib.client_session import APP_CLIENT_SESSION_KEY
+
 DEBUG_MODE = os.environ.get("DEBUG", False) in ["true", "True", True]
 
 logging.basicConfig(
@@ -46,5 +48,6 @@ SIMCORE_SERVICES_NETWORK_NAME = os.environ.get("SIMCORE_SERVICES_NETWORK_NAME")
 SIMCORE_SERVICES_PREFIX = os.environ.get("SIMCORE_SERVICES_PREFIX", "simcore/services")
 
 
-# app keys for persistend aiohttp.ClientSession
-CLIENT_SESSION_KEY = __name__ + '.session'
+__all__ = [
+    'APP_CLIENT_SESSION_KEY'
+]

--- a/services/director/src/simcore_service_director/main.py
+++ b/services/director/src/simcore_service_director/main.py
@@ -2,20 +2,14 @@
 
 import logging
 
-from aiohttp import ClientSession, web
+from aiohttp import web
+from servicelib.client_session import persistent_client_session
 from servicelib.monitoring import setup_monitoring
 from simcore_service_director import registry_cache_task, resources
 from simcore_service_director.rest import routing
 
-from .config import CLIENT_SESSION_KEY
 
 log = logging.getLogger(__name__)
-
-
-async def _persistent_session(app: web.Application):
-    app[CLIENT_SESSION_KEY] = session = ClientSession()
-    yield
-    await session.close()
 
 
 def setup_app() -> web.Application:
@@ -28,7 +22,7 @@ def setup_app() -> web.Application:
     if False: #pylint: disable=using-constant-test
         setup_monitoring(app, "simcore_service_director")
 
-    app.cleanup_ctx.append(_persistent_session)
+    app.cleanup_ctx.append(persistent_client_session)
 
     return app
 

--- a/services/director/src/simcore_service_director/main.py
+++ b/services/director/src/simcore_service_director/main.py
@@ -2,21 +2,34 @@
 
 import logging
 
-from aiohttp import web
-
+from aiohttp import ClientSession, web
 from servicelib.monitoring import setup_monitoring
 from simcore_service_director import registry_cache_task, resources
 from simcore_service_director.rest import routing
 
+from .config import CLIENT_SESSION_KEY
+
 log = logging.getLogger(__name__)
+
+
+async def _persistent_session(app: web.Application):
+    app[CLIENT_SESSION_KEY] = session = ClientSession()
+    yield
+    await session.close()
+
 
 def setup_app() -> web.Application:
     api_spec_path = resources.get_path(resources.RESOURCE_OPEN_API)
     app = routing.create_web_app(api_spec_path.parent, api_spec_path.name)
+
     registry_cache_task.setup(app)
+
     # TODO: temporary disabled until service is updated
     if False: #pylint: disable=using-constant-test
         setup_monitoring(app, "simcore_service_director")
+
+    app.cleanup_ctx.append(_persistent_session)
+
     return app
 
 def main():

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -7,11 +7,11 @@ from enum import Enum
 from typing import Dict, List, Tuple
 
 import aiodocker
-import aiohttp
 import tenacity
+from aiohttp import ClientConnectionError, ClientSession, web
 
 from . import config, docker_utils, exceptions, registry_proxy
-from .config import CLIENT_SESSION_KEY
+from .config import APP_CLIENT_SESSION_KEY
 from .system_utils import get_system_extra_hosts_raw
 
 SERVICE_RUNTIME_SETTINGS = 'simcore.service.settings'
@@ -54,7 +54,7 @@ async def _check_setting_correctness(setting: Dict):
         raise exceptions.DirectorException("Invalid setting in %s" % setting)
 
 
-async def _read_service_settings(app: aiohttp.web.Application, key: str, tag: str) -> Dict:
+async def _read_service_settings(app: web.Application, key: str, tag: str) -> Dict:
     # pylint: disable=C0103
     image_labels = await registry_proxy.get_image_labels(app, key, tag)
     runtime_parameters = json.loads(image_labels[SERVICE_RUNTIME_SETTINGS]) if SERVICE_RUNTIME_SETTINGS in image_labels else {}
@@ -62,7 +62,7 @@ async def _read_service_settings(app: aiohttp.web.Application, key: str, tag: st
     return runtime_parameters
 
 
-async def _get_service_boot_parameters_labels(app: aiohttp.web.Application, key: str, tag: str) -> Dict:
+async def _get_service_boot_parameters_labels(app: web.Application, key: str, tag: str) -> Dict:
     # pylint: disable=C0103
     image_labels = await registry_proxy.get_image_labels(app, key, tag)
     boot_params = json.loads(image_labels[SERVICE_RUNTIME_BOOTSETTINGS]) if SERVICE_RUNTIME_BOOTSETTINGS in image_labels else {}
@@ -71,7 +71,7 @@ async def _get_service_boot_parameters_labels(app: aiohttp.web.Application, key:
 
 
 # pylint: disable=too-many-branches
-async def _create_docker_service_params(app: aiohttp.web.Application,
+async def _create_docker_service_params(app: web.Application,
                                         client: aiodocker.docker.Docker,
                                         service_key: str,
                                         service_tag: str,
@@ -362,7 +362,7 @@ async def _wait_until_service_running_or_failed(client: aiodocker.docker.Docker,
     log.debug("Waited for service %s to start", service_name)
 
 
-async def _get_repos_from_key(app: aiohttp.web.Application, service_key: str) -> List[Dict]:
+async def _get_repos_from_key(app: web.Application, service_key: str) -> List[Dict]:
     # get the available image for the main service (syntax is image:tag)
     list_of_images = {
         service_key: await registry_proxy.list_image_tags(app, service_key)
@@ -377,7 +377,7 @@ async def _get_repos_from_key(app: aiohttp.web.Application, service_key: str) ->
     return list_of_images
 
 
-async def _get_dependant_repos(app: aiohttp.web.Application, service_key: str, service_tag: str) -> Dict:
+async def _get_dependant_repos(app: web.Application, service_key: str, service_tag: str) -> Dict:
     list_of_images = await _get_repos_from_key(app, service_key)
     tag = await _find_service_tag(list_of_images, service_key, service_tag)
     # look for dependencies
@@ -401,7 +401,7 @@ async def _find_service_tag(list_of_images: Dict, service_key: str, service_tag:
     log.debug("Service tag found is %s ", service_tag)
     return tag
 
-async def _start_docker_service(app: aiohttp.web.Application,
+async def _start_docker_service(app: web.Application,
                                 client: aiodocker.docker.Docker,
                                 user_id: str,
                                 project_id: str,
@@ -437,7 +437,7 @@ async def _start_docker_service(app: aiohttp.web.Application,
         service_boot_parameters_labels = await _get_service_boot_parameters_labels(app, service_key, service_tag)
         service_entrypoint = await _get_service_entrypoint(service_boot_parameters_labels)
         if published_port:
-            session = app[CLIENT_SESSION_KEY]
+            session = app[APP_CLIENT_SESSION_KEY]
             await _pass_port_to_service(service_name, published_port, service_boot_parameters_labels, session)
 
         container_meta_data = {
@@ -465,14 +465,14 @@ async def _start_docker_service(app: aiohttp.web.Application,
             service_key, service_tag) from err
 
 
-async def _silent_service_cleanup(app: aiohttp.web.Application, node_uuid):
+async def _silent_service_cleanup(app: web.Application, node_uuid):
     try:
         await stop_service(app, node_uuid)
     except exceptions.DirectorException:
         pass
 
 
-async def _create_node(app: aiohttp.web.Application,
+async def _create_node(app: web.Application,
                         client: aiodocker.docker.Docker,
                         user_id: str,
                         project_id: str,
@@ -525,7 +525,7 @@ async def _get_service_basepath_from_docker_service(service: Dict) -> str:
     envs_dict = dict(x.split("=") for x in envs_list)
     return envs_dict["SIMCORE_NODE_BASEPATH"]
 
-async def start_service(app: aiohttp.web.Application, user_id: str, project_id: str, service_key: str, service_tag: str, node_uuid: str, node_base_path: str) -> Dict:
+async def start_service(app: web.Application, user_id: str, project_id: str, service_key: str, service_tag: str, node_uuid: str, node_base_path: str) -> Dict:
     # pylint: disable=C0103
     log.debug("starting service %s:%s using uuid %s, basepath %s",
               service_key, service_tag, node_uuid, node_base_path)
@@ -549,7 +549,7 @@ async def start_service(app: aiohttp.web.Application, user_id: str, project_id: 
         # we return only the info of the main service
         return node_details
 
-async def get_service_details(app: aiohttp.web.Application, node_uuid: str) -> Dict:
+async def get_service_details(app: web.Application, node_uuid: str) -> Dict:
     async with docker_utils.docker_client() as client:  # pylint: disable=not-async-context-manager
         try:
             list_running_services_with_uuid = await client.services.list(
@@ -594,7 +594,7 @@ async def get_service_details(app: aiohttp.web.Application, node_uuid: str) -> D
                 "Error while accessing container", err) from err
 
 
-async def stop_service(app: aiohttp.web.Application, node_uuid: str):
+async def stop_service(app: web.Application, node_uuid: str):
     log.debug("stopping service with uuid %s", node_uuid)
     # get the docker client
     async with docker_utils.docker_client() as client: # pylint: disable=not-async-context-manager
@@ -616,14 +616,14 @@ async def stop_service(app: aiohttp.web.Application, node_uuid: str):
                                             service_details["service_basepath"])
         log.debug("saving state of service %s...", service_host_name)
         try:
-            session = app[CLIENT_SESSION_KEY]
+            session = app[APP_CLIENT_SESSION_KEY]
             service_url = "http://" + service_host_name + "/" + "state"
             async with session.post(service_url) as response:
                 if 199 < response.status < 300:
                     log.debug("service %s successfully saved its state", service_host_name)
                 else:
                     log.warning("service %s does not allow saving state, answered %s", service_host_name, await response.text())
-        except aiohttp.ClientConnectionError:
+        except ClientConnectionError:
             log.exception("service %s could not be contacted, state not saved")
 
 

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -10,7 +10,7 @@ from simcore_service_director import config, exceptions
 from simcore_service_director.cache_request_decorator import cache_requests
 from yarl import URL
 
-from .config import CLIENT_SESSION_KEY
+from .config import APP_CLIENT_SESSION_KEY
 
 DEPENDENCIES_LABEL_KEY = 'simcore.service.dependencies'
 
@@ -88,7 +88,7 @@ async def _registry_request(app: web.Application, path: URL, method: str ="GET")
         if config.REGISTRY_AUTH and config.REGISTRY_USER and config.REGISTRY_PW \
             else None
 
-    session = app[CLIENT_SESSION_KEY]
+    session = app[APP_CLIENT_SESSION_KEY]
     async with getattr(session, method.lower())(url, auth=auth) as response:
         if response.status == 404:
             _logger.exception("path to registry not found: %s", url)

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -6,10 +6,11 @@ import logging
 from typing import Dict, List, Tuple
 
 from aiohttp import BasicAuth, ClientSession, web
-from yarl import URL
-
 from simcore_service_director import config, exceptions
 from simcore_service_director.cache_request_decorator import cache_requests
+from yarl import URL
+
+from .config import CLIENT_SESSION_KEY
 
 DEPENDENCIES_LABEL_KEY = 'simcore.service.dependencies'
 
@@ -23,7 +24,7 @@ class ServiceType(enum.Enum):
     COMPUTATIONAL = "comp"
     DYNAMIC = "dynamic"
 
-async def _auth_registry_request(url: URL, method: str, auth_headers: Dict) -> Tuple[Dict, Dict]:
+async def _auth_registry_request(url: URL, method: str, auth_headers: Dict, session: ClientSession) -> Tuple[Dict, Dict]:
     if not config.REGISTRY_AUTH or not config.REGISTRY_USER or not config.REGISTRY_PW:
         raise exceptions.RegistryConnectionError("Wrong configuration: Authentication to registry is needed!")
     # auth issue let's try some authentication get the auth type
@@ -40,44 +41,43 @@ async def _auth_registry_request(url: URL, method: str, auth_headers: Dict) -> T
 
     # bearer type, it needs a token with all communications
     if auth_type == "Bearer":
-        async with ClientSession() as session:
-            # get the token
-            token_url = URL(auth_details["realm"]).with_query(service=auth_details["service"], scope=auth_details["scope"])
-            async with session.get(token_url, auth=auth) as token_resp:
-                if not token_resp.status == 200:
-                    raise exceptions.RegistryConnectionError("Unknown error while authentifying with registry: {}".format(str(token_resp)))
-                bearer_code = (await token_resp.json())["token"]
-                headers = {"Authorization": "Bearer {}".format(bearer_code)}
-                async with getattr(session, method.lower())(url, headers=headers) as resp_wtoken:
-                    if resp_wtoken.status == 404:
-                        _logger.exception("path to registry not found: %s", url)
-                        raise exceptions.ServiceNotAvailableError(url)
-                    if resp_wtoken.status > 399:
-                        _logger.exception("Unknown error while accessing with token authorized registry: %s", str(resp_wtoken))
-                        raise exceptions.RegistryConnectionError(str(resp_wtoken))
-                    resp_data = await resp_wtoken.json(content_type=None)
-                    resp_headers = resp_wtoken.headers
-                    return (resp_data, resp_headers)
-    elif auth_type == "Basic":
-        async with ClientSession() as session:
-            # basic authentication
-            async with getattr(session, method.lower())(url, auth=auth) as resp_wbasic:
-                if resp_wbasic.status == 404:
+        # get the token
+        token_url = URL(auth_details["realm"]).with_query(service=auth_details["service"], scope=auth_details["scope"])
+        async with session.get(token_url, auth=auth) as token_resp:
+            if not token_resp.status == 200:
+                raise exceptions.RegistryConnectionError("Unknown error while authentifying with registry: {}".format(str(token_resp)))
+            bearer_code = (await token_resp.json())["token"]
+            headers = {"Authorization": "Bearer {}".format(bearer_code)}
+            async with getattr(session, method.lower())(url, headers=headers) as resp_wtoken:
+                if resp_wtoken.status == 404:
                     _logger.exception("path to registry not found: %s", url)
                     raise exceptions.ServiceNotAvailableError(url)
-                if resp_wbasic.status > 399:
-                    _logger.exception("Unknown error while accessing with token authorized registry: %s", str(resp_wbasic))
-                    raise exceptions.RegistryConnectionError(str(resp_wbasic))
-                resp_data = await resp_wbasic.json(content_type=None)
-                resp_headers = resp_wbasic.headers
+                if resp_wtoken.status > 399:
+                    _logger.exception("Unknown error while accessing with token authorized registry: %s", str(resp_wtoken))
+                    raise exceptions.RegistryConnectionError(str(resp_wtoken))
+                resp_data = await resp_wtoken.json(content_type=None)
+                resp_headers = resp_wtoken.headers
                 return (resp_data, resp_headers)
+    elif auth_type == "Basic":
+        # basic authentication
+        async with getattr(session, method.lower())(url, auth=auth) as resp_wbasic:
+            if resp_wbasic.status == 404:
+                _logger.exception("path to registry not found: %s", url)
+                raise exceptions.ServiceNotAvailableError(url)
+            if resp_wbasic.status > 399:
+                _logger.exception("Unknown error while accessing with token authorized registry: %s", str(resp_wbasic))
+                raise exceptions.RegistryConnectionError(str(resp_wbasic))
+            resp_data = await resp_wbasic.json(content_type=None)
+            resp_headers = resp_wbasic.headers
+            return (resp_data, resp_headers)
     raise exceptions.RegistryConnectionError("Unknown registry authentification type: {}".format(url))
 
 
 @cache_requests
-async def _registry_request(_: web.Application, path: URL, method: str ="GET") -> Tuple[Dict, Dict]:    
+async def _registry_request(app: web.Application, path: URL, method: str ="GET") -> Tuple[Dict, Dict]:
     if not config.REGISTRY_URL:
         raise exceptions.DirectorException("URL to registry is not defined")
+
     url = URL("{scheme}://{url}".format(scheme="https" if config.REGISTRY_SSL else "http",
                                 url=config.REGISTRY_URL))
     url = url.join(path)
@@ -87,22 +87,23 @@ async def _registry_request(_: web.Application, path: URL, method: str ="GET") -
     auth = BasicAuth(login=config.REGISTRY_USER, password=config.REGISTRY_PW) \
         if config.REGISTRY_AUTH and config.REGISTRY_USER and config.REGISTRY_PW \
             else None
-    async with ClientSession() as session:
-        async with getattr(session, method.lower())(url, auth=auth) as response:
-            if response.status == 404:
-                _logger.exception("path to registry not found: %s", url)
-                raise exceptions.ServiceNotAvailableError(path)
-            if response.status == 401:
-                resp_data, resp_headers = await _auth_registry_request(url, method, response.headers)
-            elif response.status > 399:
-                _logger.exception("Unknown error while accessing registry: %s", str(response))
-                raise exceptions.RegistryConnectionError(str(response))
-            else:
-                # registry that does not need an auth
-                resp_data = await response.json(content_type=None)
-                resp_headers = response.headers
 
-            return (resp_data, resp_headers)
+    session = app[CLIENT_SESSION_KEY]
+    async with getattr(session, method.lower())(url, auth=auth) as response:
+        if response.status == 404:
+            _logger.exception("path to registry not found: %s", url)
+            raise exceptions.ServiceNotAvailableError(path)
+        if response.status == 401:
+            resp_data, resp_headers = await _auth_registry_request(url, method, response.headers, session)
+        elif response.status > 399:
+            _logger.exception("Unknown error while accessing registry: %s", str(response))
+            raise exceptions.RegistryConnectionError(str(response))
+        else:
+            # registry that does not need an auth
+            resp_data = await response.json(content_type=None)
+            resp_headers = response.headers
+
+        return (resp_data, resp_headers)
 
 async def _list_repositories(app: web.Application) -> List[str]:
     _logger.debug("listing repositories")

--- a/services/director/tests/conftest.py
+++ b/services/director/tests/conftest.py
@@ -94,9 +94,12 @@ async def aiohttp_mock_app(loop, mocker):
     print("client session started ...")
     session = ClientSession()
 
-    # mocks app[APP_CLIENT_SESSION_KEY]
+    mock_app_storage = {
+        config.APP_CLIENT_SESSION_KEY: session,
+        config.APP_REGISTRY_CACHE_DATA_KEY: dict()
+    }
     def _get_item(self, key):
-        return session if key==config.APP_CLIENT_SESSION_KEY else None
+        return mock_app_storage[key]
 
     aiohttp_app = mocker.patch('aiohttp.web.Application')
     aiohttp_app.__getitem__ = _get_item

--- a/services/director/tests/test_producer.py
+++ b/services/director/tests/test_producer.py
@@ -14,25 +14,6 @@ import pytest
 
 from simcore_service_director import config, exceptions, producer
 
-from aiohttp import ClientSession
-
-@pytest.fixture
-async def aiohttp_mock_app(loop, mocker):
-    print("client session started ...")
-    session = ClientSession()
-
-    # mocks app[APP_CLIENT_SESSION_KEY]
-    def _get_item(self, key):
-        return session if key==config.APP_CLIENT_SESSION_KEY else None
-
-    aiohttp_app = mocker.patch('aiohttp.web.Application')
-    aiohttp_app.__getitem__ = _get_item
-
-    yield aiohttp_app
-
-    # cleanup session
-    await session.close()
-    print("client session closed")
 
 @pytest.fixture
 async def run_services(aiohttp_mock_app, configure_registry_access, configure_schemas_location, push_services, docker_swarm, user_id, project_id):

--- a/services/director/tests/test_registry_proxy.py
+++ b/services/director/tests/test_registry_proxy.py
@@ -7,14 +7,9 @@ import pytest
 
 from simcore_service_director import registry_proxy, config
 
-@pytest.fixture
-async def aiohttp_mock_app(loop, mocker):
-    aiohttp_app = mocker.patch('aiohttp.web.Application')
-    return aiohttp_mock_app
-
 
 async def test_list_no_services_available(aiohttp_mock_app, docker_registry, configure_registry_access, configure_schemas_location):
-    
+
     computational_services = await registry_proxy.list_services(aiohttp_mock_app, registry_proxy.ServiceType.COMPUTATIONAL)
     assert not computational_services # it's empty
     interactive_services = await registry_proxy.list_services(aiohttp_mock_app, registry_proxy.ServiceType.DYNAMIC)

--- a/services/storage/src/simcore_service_storage/application.py
+++ b/services/storage/src/simcore_service_storage/application.py
@@ -4,9 +4,9 @@
 """
 import logging
 
-from aiohttp import web, ClientSession
+from aiohttp import web
 from servicelib.monitoring import setup_monitoring
-from servicelib.application_keys import APP_CLIENT_SESSION_KEY
+from servicelib.client_session import persistent_client_session
 
 from .db import setup_db
 from .dsm import setup_dsm
@@ -17,11 +17,6 @@ from .settings import APP_CONFIG_KEY
 log = logging.getLogger(__name__)
 
 
-async def persistent_client_session(app: web.Application):
-    # see https://docs.aiohttp.org/en/latest/client_advanced.html#aiohttp-persistent-session
-    app[APP_CLIENT_SESSION_KEY] = session = ClientSession()
-    yield
-    await session.close()
 
 
 def create(config):

--- a/services/storage/src/simcore_service_storage/rest.py
+++ b/services/storage/src/simcore_service_storage/rest.py
@@ -37,10 +37,10 @@ def setup(app: web.Application):
 
     # TODO: refactor this and into something more maintainable
     loop = asyncio.get_event_loop()
+    session = get_client_session(app)
     if is_url(location):
-        session = get_client_session(app)
         loop.run_until_complete( assert_enpoint_is_ok(session, URL(location)) )
-    api_specs = loop.run_until_complete( create_openapi_specs(location) )
+    api_specs = loop.run_until_complete( create_openapi_specs(location, session) )
 
     # validated openapi specs
     app[APP_OPENAPI_SPECS_KEY] = api_specs

--- a/services/storage/src/simcore_service_storage/rest.py
+++ b/services/storage/src/simcore_service_storage/rest.py
@@ -5,10 +5,10 @@ import asyncio
 import logging
 
 from aiohttp import web
-from yarl import URL
-
+from servicelib.client_session import get_client_session
 from servicelib.openapi import create_openapi_specs, get_base_path
 from servicelib.rest_middlewares import append_rest_middlewares
+from yarl import URL
 
 from . import rest_routes
 from .rest_config import CONFIG_SECTION_NAME
@@ -33,14 +33,13 @@ def setup(app: web.Application):
     log.debug("Setting up %s ...", __name__)
 
     cfg = app[APP_CONFIG_KEY][CONFIG_SECTION_NAME]
-
-    # app_config = app[APP_CONFIG_KEY]['main'] # TODO: define appconfig key based on config schema
-    # api_specs = create_apispecs(app_config)
-
-    loop = asyncio.get_event_loop()
     location = "{}/storage/{}/openapi.yaml".format(cfg["oas_repo"], API_VERSION_TAG)
+
+    # TODO: refactor this and into something more maintainable
+    loop = asyncio.get_event_loop()
     if is_url(location):
-        loop.run_until_complete( assert_enpoint_is_ok(URL(location)) )
+        session = get_client_session(app)
+        loop.run_until_complete( assert_enpoint_is_ok(session, URL(location)) )
     api_specs = loop.run_until_complete( create_openapi_specs(location) )
 
     # validated openapi specs

--- a/services/storage/src/simcore_service_storage/utils.py
+++ b/services/storage/src/simcore_service_storage/utils.py
@@ -31,6 +31,7 @@ async def assert_enpoint_is_ok(url: URL, expected_response:int =200):
     :param expected_response: expected http status, defaults to 200 (OK)
     :param expected_response: int, optional
     """
+    # FIXME:  READ https://docs.aiohttp.org/en/latest/client_advanced.html#persistent-session
     async with ClientSession() as session:
         async with session.get(url) as resp:
             assert resp.status == expected_response

--- a/services/storage/src/simcore_service_storage/utils.py
+++ b/services/storage/src/simcore_service_storage/utils.py
@@ -11,14 +11,13 @@ RETRY_WAIT_SECS = 2
 RETRY_COUNT = 20
 CONNECT_TIMEOUT_SECS = 30
 
-
 @tenacity.retry(
     wait=tenacity.wait_fixed(RETRY_WAIT_SECS),
     stop=tenacity.stop_after_attempt(RETRY_COUNT),
     before_sleep=tenacity.before_sleep_log(logger, logging.INFO),
     #retry=tenacity.retry_if_exception_type(AssertionError)
     )
-async def assert_enpoint_is_ok(url: URL, expected_response:int =200):
+async def assert_enpoint_is_ok(session: ClientSession, url: URL, expected_response:int =200):
     """ Tenace check to GET given url endpoint
 
     Typically used to check connectivity to a given service
@@ -31,10 +30,8 @@ async def assert_enpoint_is_ok(url: URL, expected_response:int =200):
     :param expected_response: expected http status, defaults to 200 (OK)
     :param expected_response: int, optional
     """
-    # FIXME:  READ https://docs.aiohttp.org/en/latest/client_advanced.html#persistent-session
-    async with ClientSession() as session:
-        async with session.get(url) as resp:
-            assert resp.status == expected_response
+    async with session.get(url) as resp:
+        assert resp.status == expected_response
 
 def is_url(location):
     return bool(URL(str(location)).host)

--- a/services/web/server/src/simcore_service_webserver/application.py
+++ b/services/web/server/src/simcore_service_webserver/application.py
@@ -5,8 +5,9 @@ import json
 import logging
 from typing import Dict
 
-from aiohttp import ClientSession, web
-from servicelib.application_keys import APP_CLIENT_SESSION_KEY, APP_CONFIG_KEY
+from aiohttp import web
+from servicelib.application_keys import APP_CONFIG_KEY
+from servicelib.client_session import persistent_client_session
 from servicelib.monitoring import setup_monitoring
 
 from .application_proxy import setup_app_proxy
@@ -28,13 +29,6 @@ from .users import setup_users
 
 log = logging.getLogger(__name__)
 
-
-
-async def _persistent_session(app: web.Application):
-    # see https://docs.aiohttp.org/en/latest/client_advanced.html#aiohttp-persistent-session
-    app[APP_CLIENT_SESSION_KEY] = session = ClientSession()
-    yield
-    await session.close()
 
 
 def create_application(config: Dict) -> web.Application:
@@ -75,7 +69,8 @@ def create_application(config: Dict) -> web.Application:
     if config['director']["enabled"]:
         setup_app_proxy(app) # TODO: under development!!!
 
-    app.cleanup_ctx.append(_persistent_session)
+    # The last
+    app.cleanup_ctx.append(persistent_client_session)
 
     return app
 

--- a/services/web/server/src/simcore_service_webserver/director/__init__.py
+++ b/services/web/server/src/simcore_service_webserver/director/__init__.py
@@ -6,45 +6,19 @@
 import logging
 
 from aiohttp import ClientSession, web
-from yarl import URL
-
 from servicelib.application_keys import APP_CONFIG_KEY
 from servicelib.rest_routing import (get_handlers_from_namespace,
                                      iter_path_operations,
                                      map_handlers_with_operations)
+from yarl import URL
 
-from . import handlers
 from ..rest_config import APP_OPENAPI_SPECS_KEY
-from .config import (APP_DIRECTOR_API_KEY, APP_DIRECTOR_SESSION_KEY,
-                     CONFIG_SECTION_NAME, build_api_url)
+from . import handlers
+from .config import APP_DIRECTOR_API_KEY, CONFIG_SECTION_NAME, build_api_url
 from .registry import InteractiveServiceLocalRegistry, set_registry
-
 
 logger = logging.getLogger(__name__)
 
-
-async def director_client_ctx(app: web.Application):
-    """
-        - Resolves director service base url, e.g. http://director:8080/v0
-        - Creates client session to query this API
-
-    :param app: main application
-    :type app: web.Application
-    """
-    cfg = app[APP_CONFIG_KEY][CONFIG_SECTION_NAME]
-
-    # TODO: create instead a class that wraps the session and hold all information known upon setup
-    session = ClientSession(loop=app.loop)
-    session.base_url = build_api_url(cfg)
-
-    # TODO: test if service health via API healthcheck call
-    # TODO: fix warning osparc-simcore/services/web/server/src/simcore_service_webserver/director/__init__.py:46: RuntimeWarning: coroutine 'ClientSession.close' was never awaited
-    app[APP_DIRECTOR_SESSION_KEY] = session
-
-    yield
-
-    session.close()
-    app.pop(APP_DIRECTOR_SESSION_KEY, None)
 
 
 
@@ -96,9 +70,6 @@ def setup(app: web.Application,* , disable_login=False):
         strict=True
     )
     app.router.add_routes(routes)
-
-    # setup cleanup context --------------
-    app.cleanup_ctx.append(director_client_ctx)
 
 
 # alias

--- a/services/web/server/src/simcore_service_webserver/director/config.py
+++ b/services/web/server/src/simcore_service_webserver/director/config.py
@@ -7,10 +7,9 @@ from typing import Dict
 
 import trafaret as T
 from aiohttp import ClientSession, web
-from servicelib.application_keys import APP_CONFIG_KEY
+from servicelib.application_keys import APP_CONFIG_KEY, APP_CLIENT_SESSION_KEY
 from yarl import URL
 
-APP_DIRECTOR_SESSION_KEY = __name__ + ".director_session"
 APP_DIRECTOR_API_KEY = __name__ + ".director_api"
 
 CONFIG_SECTION_NAME = 'director'
@@ -32,4 +31,4 @@ def get_config(app: web.Application) -> Dict:
     return app[APP_CONFIG_KEY][CONFIG_SECTION_NAME]
 
 def get_client_session(app: web.Application) -> ClientSession:
-    return app[APP_DIRECTOR_SESSION_KEY]
+    return app[APP_CLIENT_SESSION_KEY]

--- a/services/web/server/src/simcore_service_webserver/director/director_api.py
+++ b/services/web/server/src/simcore_service_webserver/director/director_api.py
@@ -15,6 +15,8 @@ def _get_director_client(app: web.Application) -> URL:
 
     # director service API endpoint
     # TODO: service API endpoint could be deduced and checked upon setup (e.g. health check on startup)
+    # Use director.
+    # TODO: this is also in app[APP_DIRECTOR_API_KEY] upon startup
     api_endpoint = URL.build(
         scheme='http',
         host=cfg['host'],

--- a/services/web/server/src/simcore_service_webserver/director/director_sdk.py
+++ b/services/web/server/src/simcore_service_webserver/director/director_sdk.py
@@ -1,16 +1,16 @@
 #pylint: disable=C0111
-from aiohttp import web
-from yarl import URL
-
 import simcore_director_sdk
+from aiohttp import web
 from simcore_director_sdk import UsersApi
 from simcore_director_sdk.rest import ApiException  # pylint: disable=W0611
+from yarl import URL
 
 from .config import get_config
 
 
 def create_director_api_client(app: web.Application):
     cfg = get_config(app)
+    # TODO: redundant with director_api._get_director_client!
     endpoint = URL.build(scheme='http',
                          host=cfg['host'],
                          port=cfg['port']).with_path(cfg['version'])

--- a/services/web/server/src/simcore_service_webserver/director/handlers.py
+++ b/services/web/server/src/simcore_service_webserver/director/handlers.py
@@ -1,10 +1,9 @@
 import logging
 
 from aiohttp import web
-from yarl import URL
-
 from servicelib.request_keys import RQT_USERID_KEY
 from servicelib.rest_utils import extract_and_validate
+from yarl import URL
 
 from ..login.decorators import login_required
 from ..security_api import check_permission

--- a/services/web/server/src/simcore_service_webserver/projects/__init__.py
+++ b/services/web/server/src/simcore_service_webserver/projects/__init__.py
@@ -7,11 +7,12 @@ import asyncio
 import logging
 from pprint import pformat
 
-from aiohttp import web, ClientSession
+from aiohttp import ClientSession, web
 from tenacity import before_sleep_log, retry, stop_after_attempt, wait_fixed
 
 from servicelib.application_keys import (APP_CONFIG_KEY,
                                          APP_JSONSCHEMA_SPECS_KEY)
+from servicelib.client_session import get_client_session
 from servicelib.jsonschema_specs import create_jsonschema_specs
 from servicelib.rest_routing import (get_handlers_from_namespace,
                                      iter_path_operations,
@@ -54,14 +55,9 @@ def _create_routes(prefix, handlers_module, specs, *, disable_login=False):
 @retry( wait=wait_fixed(RETRY_WAIT_SECS),
         stop=stop_after_attempt(RETRY_COUNT),
         before_sleep=before_sleep_log(logger, logging.INFO) )
-async def _get_specs(location):
-    try:
-        # NOTE: special case since app[CLIENT_SESSION_KEY] is created later in app.cleanup_ctx
-        # FIXME: ideally this would use the app[APP_CLIENT_SESSION_KEY] but it still does not exists at this point
-        session = ClientSession()
-        specs = await create_jsonschema_specs(session, location)
-    finally:
-        session.close()
+async def _get_specs(app, location):
+    session = get_client_session(app)
+    specs = await create_jsonschema_specs(location, session)
     return specs
 
 
@@ -104,7 +100,7 @@ def setup(app: web.Application, *, enable_fake_data=False) -> bool:
     # json-schemas for projects datasets
     project_schema_location = cfg['location']
     loop = asyncio.get_event_loop()
-    specs = loop.run_until_complete( _get_specs(project_schema_location) )
+    specs = loop.run_until_complete( _get_specs(app, project_schema_location) )
 
     if APP_JSONSCHEMA_SPECS_KEY in app:
         app[APP_JSONSCHEMA_SPECS_KEY][CONFIG_SECTION_NAME] = specs

--- a/services/web/server/src/simcore_service_webserver/storage.py
+++ b/services/web/server/src/simcore_service_webserver/storage.py
@@ -4,24 +4,14 @@
 
 import logging
 
-from aiohttp import ClientSession, web
-
+from aiohttp import web
 from servicelib.application_keys import APP_OPENAPI_SPECS_KEY
 
 from . import storage_routes
-from .storage_config import APP_STORAGE_SESSION_KEY, get_config
+from .storage_config import get_config
 
 log = logging.getLogger(__name__)
 
-
-
-async def storage_client_ctx(app: web.Application):
-    # TODO: deduce base url from configuration and add to session
-    async with ClientSession() as session: # TODO: check if should keep webserver->storage session?
-        app[APP_STORAGE_SESSION_KEY] = session
-        yield
-
-    log.debug("cleanup session")
 
 
 
@@ -33,7 +23,6 @@ def setup(app: web.Application):
     routes = storage_routes.create(specs)
     app.router.add_routes(routes)
 
-    app.cleanup_ctx.append(storage_client_ctx)
 
 # alias
 setup_storage = setup

--- a/services/web/server/src/simcore_service_webserver/storage_config.py
+++ b/services/web/server/src/simcore_service_webserver/storage_config.py
@@ -7,10 +7,7 @@ from typing import Dict
 
 import trafaret as T
 from aiohttp import ClientSession, web
-
-from servicelib.application_keys import APP_CONFIG_KEY
-
-APP_STORAGE_SESSION_KEY = __name__ + ".storage_session"
+from servicelib.application_keys import APP_CLIENT_SESSION_KEY, APP_CONFIG_KEY
 
 CONFIG_SECTION_NAME = 'storage'
 
@@ -25,4 +22,4 @@ def get_config(app: web.Application) -> Dict:
     return app[APP_CONFIG_KEY][CONFIG_SECTION_NAME]
 
 def get_client_session(app: web.Application) -> ClientSession:
-    return app[APP_STORAGE_SESSION_KEY]
+    return app[APP_CLIENT_SESSION_KEY]

--- a/services/web/server/src/simcore_service_webserver/storage_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/storage_handlers.py
@@ -4,10 +4,9 @@
 """
 
 from aiohttp import web
-from yarl import URL
-
 from servicelib.request_keys import RQT_USERID_KEY
 from servicelib.rest_utils import extract_and_validate
+from yarl import URL
 
 from .login.decorators import login_required
 from .security_api import check_permission

--- a/services/web/server/src/simcore_service_webserver/storage_routes.py
+++ b/services/web/server/src/simcore_service_webserver/storage_routes.py
@@ -7,7 +7,6 @@ import logging
 from typing import List
 
 from aiohttp import web
-
 from servicelib import openapi
 
 from . import storage_handlers

--- a/services/web/server/tests/unit/test_template_projects.py
+++ b/services/web/server/tests/unit/test_template_projects.py
@@ -23,13 +23,12 @@ from yarl import URL
 @pytest.fixture
 async def project_specs(loop, project_schema_file: Path) -> Dict:
     # should not raise any exception
-    async with aiohttp.ClientSession() as session:
-        try:
-            specs = await create_jsonschema_specs(session, project_schema_file)
-        except SchemaError:
-            pytest.fail("validation of schema {} failed".format(project_schema_file))
-        else:
-            yield specs
+    try:
+        specs = await create_jsonschema_specs(project_schema_file, session=None)
+    except SchemaError:
+        pytest.fail("validation of schema {} failed".format(project_schema_file))
+    else:
+        yield specs
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

aiohttp [recommends persistent sessions per app](https://docs.aiohttp.org/en/latest/client_quickstart.html#make-a-request). 

This PR implements some base functionality in [packages/service-library/src/servicelib/client_session.py](packages/service-library/src/servicelib/client_session.py)  to deal with this.

All core services are adapted to use a single client session using base functionality of servicelib
- [x] ``simcore_sdk/node_ports``: added session as optional argument and print deprecation warning if not used
- [x] ``director``
   - fixes and extends mockup for ``aiohttp.web.Application``
- [x] ``webserver``: all subsystems use now same client session
- [x] ``storage``
- [x] sidecar - Has no calls at all (in the future will have ``simcore_sdk/node_ports``)

Next steps:
- upgrade core-service cookiecutter to add this paradigm


## Related issue number

Resolves #1098 


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] **Runs in the swarm**
- [x] If you design a new module, add your user to .github/CODEOWNERS
