### PR TITLE
Is1097/fix build devel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ build-nc: .env ## As build but w/o cache (alias: rebuild)
 .PHONY: build-devel
 build-devel: .env ## Builds development images and tags them as 'local/{service-name}:development'
 	# Compiling front-end
-	@$(MAKE) -C services/web/client compile-dev
+	@$(MAKE) -C services/web/client touch compile-dev
 	# Building services
 	@export BUILD_TARGET=development; \
 	$(DOCKER_COMPOSE) -f services/docker-compose.build.yml build --parallel

--- a/services/web/client/Makefile
+++ b/services/web/client/Makefile
@@ -28,10 +28,14 @@ compile-dev: qx_packages ## qx compiles host' 'source' -> host's 'source-output'
 			--set osparc.vcsStatusClient='"${VCS_STATUS_CLIENT}"' \
 			--set osparc.vcsOriginUrl='"${VCS_URL}"'
 
-.PHONY: compile
+.PHONY: compile touch
 compile: ## qx compiles host' 'source' -> image's 'build-output'
 	# qx compile 'source' within $(docker_image) image  [itisfoundation/qooxdoo-kit:${QOOXDOO_KIT_TAG}]
-	@docker build -f $(docker_file) -t $(docker_image) --build-arg tag=${QOOXDOO_KIT_TAG} .
+	@docker build -f $(docker_file) -t $(docker_image) --build-arg tag=${QOOXDOO_KIT_TAG} --target=build-client .
+
+touch: ## minimal image build with /project/output-build inside
+	# touch /project/output-build such that multi-stage 'services/web/Dockerfile' can build development target (fixes #1097)
+	@docker build -f $(docker_file) -t $(docker_image) --build-arg tag=${QOOXDOO_KIT_TAG} --target=touch .
 
 
 # qx serve --------------------------

--- a/services/web/client/tools/qooxdoo-kit/builder/Dockerfile
+++ b/services/web/client/tools/qooxdoo-kit/builder/Dockerfile
@@ -4,10 +4,14 @@
 # Note: context at osparc-simcore/services/web/client expected
 #
 ARG tag
-FROM itisfoundation/qooxdoo-kit:${tag} as build-client
+FROM itisfoundation/qooxdoo-kit:${tag} as touch
 
 WORKDIR /project
 ENV PATH=/home/node/node_modules/.bin:${PATH}
+
+RUN mkdir /project/build-output
+
+FROM touch as build-client
 
 # Installs contributions
 COPY --chown=node:node compile.json compile.json


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?
The problem is that to build ``services/web/server/Dockerfile`` with target=development builds as well the production stage and the latter expects an image produced by the client that is not there. This is a limitation of the multi-staging mechanism of Dockerfile!

Overcomes this limitation we create a minimal image for the client that we add in the following recipe: ``make -C services/web/client touch``.

## Related issue number

Fixes #1097 

## How to test

```bash
$ make clean-images
$ make build-devel
```
Should not fail now

