### PR TITLE
Is1178/logs format

### DIFF
--- a/services/director/docker/boot.sh
+++ b/services/director/docker/boot.sh
@@ -1,15 +1,17 @@
 #!/bin/sh
 #
+INFO="INFO: [`basename "$0"`] "
+ERROR="ERROR: [`basename "$0"`] "
 
 # BOOTING application ---------------------------------------------
-echo "Booting in ${SC_BOOT_MODE} mode ..."
+echo $INFO "Booting in ${SC_BOOT_MODE} mode ..."
 echo "  User    :`id $(whoami)`"
 echo "  Workdir :`pwd`"
 
 LOG_LEVEL=info
 if [[ ${SC_BUILD_TARGET} == "development" ]]
 then
-  echo "  Environment :"
+  echo $INFO "Environment :"
   printenv  | sed 's/=/: /' | sed 's/^/    /' | sort
   #--------------------
 
@@ -20,10 +22,10 @@ then
   cd /devel
 
   #--------------------
-  echo "  Python :"
+  echo $INFO "Python :"
   python --version | sed 's/^/    /'
   which python | sed 's/^/    /'
-  echo "  PIP :"
+  echo $INFO "PIP :"
   $SC_PIP list | sed 's/^/    /'
 fi
 
@@ -31,7 +33,7 @@ fi
 if [[ ${SC_BOOT_MODE} == "debug-ptvsd" ]]
 then
   echo
-  echo "PTVSD Debugger initializing in port 3004"
+  echo $INFO "PTVSD Debugger initializing in port 3004"
   python3 -m ptvsd --host 0.0.0.0 --port 3000 -m simcore_service_director --loglevel=$LOG_LEVEL
 else
   simcore-service-director --loglevel=$LOG_LEVEL

--- a/services/director/docker/boot.sh
+++ b/services/director/docker/boot.sh
@@ -34,7 +34,8 @@ if [[ ${SC_BOOT_MODE} == "debug-ptvsd" ]]
 then
   echo
   echo $INFO "PTVSD Debugger initializing in port 3004"
-  python3 -m ptvsd --host 0.0.0.0 --port 3000 -m simcore_service_director --loglevel=$LOG_LEVEL
+  python3 -m ptvsd --host 0.0.0.0 --port 3000 -m \
+    simcore_service_director --loglevel=$LOG_LEVEL
 else
-  simcore-service-director --loglevel=$LOG_LEVEL
+  exec simcore-service-director --loglevel=$LOG_LEVEL
 fi

--- a/services/director/docker/entrypoint.sh
+++ b/services/director/docker/entrypoint.sh
@@ -70,4 +70,4 @@ then
     addgroup scu $GROUPNAME
 fi
 
-su-exec scu "$@"
+exec su-exec scu "$@"

--- a/services/director/docker/entrypoint.sh
+++ b/services/director/docker/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+INFO="INFO: [`basename "$0"`] "
+ERROR="ERROR: [`basename "$0"`] "
 
 # This entrypoint script:
 #

--- a/services/director/docker/entrypoint.sh
+++ b/services/director/docker/entrypoint.sh
@@ -9,19 +9,18 @@ ERROR="ERROR: [`basename "$0"`] "
 # - Notice that the container *starts* as --user [default root] but
 #   *runs* as non-root user [scu]
 #
-echo "Entrypoint for stage ${SC_BUILD_TARGET} ..."
-echo "  User    :`id $(whoami)`"
-echo "  Workdir :`pwd`"
+echo $INFO "Entrypoint for stage ${SC_BUILD_TARGET} ..."
+echo $INFO "User    :`id $(whoami)`"
+echo $INFO "Workdir :`pwd`"
 
 
 if [[ ${SC_BUILD_TARGET} == "development" ]]
 then
-
     # NOTE: expects docker run ... -v $(pwd):/devel/services/director
     DEVEL_MOUNT=/devel/services/director
 
     stat $DEVEL_MOUNT &> /dev/null || \
-        (echo "ERROR: You must mount '$DEVEL_MOUNT' to deduce user and group ids" && exit 1) # FIXME: exit does not stop script
+        (echo $ERROR "You must mount '$DEVEL_MOUNT' to deduce user and group ids" && exit 1) # FIXME: exit does not stop script
 
     USERID=$(stat -c %u $DEVEL_MOUNT)
     GROUPID=$(stat -c %g $DEVEL_MOUNT)

--- a/services/sidecar/docker/boot.sh
+++ b/services/sidecar/docker/boot.sh
@@ -1,14 +1,16 @@
 #!/bin/sh
 #
+INFO="INFO: [`basename "$0"`] "
+ERROR="ERROR: [`basename "$0"`] "
 
 # BOOTING application ---------------------------------------------
-echo "Booting in ${SC_BOOT_MODE} mode ..."
+echo $INFO "Booting in ${SC_BOOT_MODE} mode ..."
 echo "  User    :`id $(whoami)`"
 echo "  Workdir :`pwd`"
 
 if [[ ${SC_BUILD_TARGET} == "development" ]]
 then
-  echo "  Environment :"
+  echo $INFO "Environment :"
   printenv  | sed 's/=/: /' | sed 's/^/    /' | sort
   #--------------------
 
@@ -18,10 +20,10 @@ then
 
   DEBUG_LEVEL=debug
   #--------------------
-  echo "  Python :"
+  echo $INFO "Python :"
   python --version | sed 's/^/    /'
   which python | sed 's/^/    /'
-  echo "  PIP :"
+  echo $INFO "PIP :"
   $SC_PIP list | sed 's/^/    /'
 
 

--- a/services/sidecar/docker/entrypoint.sh
+++ b/services/sidecar/docker/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+INFO="INFO: [`basename "$0"`] "
+ERROR="ERROR: [`basename "$0"`] "
 
 # This entrypoint script:
 #
@@ -6,7 +9,7 @@
 # - Notice that the container *starts* as --user [default root] but
 #   *runs* as non-root user [scu]
 #
-echo "Entrypoint for stage ${SC_BUILD_TARGET} ..."
+echo $INFO "Entrypoint for stage ${SC_BUILD_TARGET} ..."
 echo "  User    :`id $(whoami)`"
 echo "  Workdir :`pwd`"
 echo "  scuUser :`id scu`"
@@ -17,12 +20,12 @@ GROUPNAME=scu
 
 if [[ ${SC_BUILD_TARGET} == "development" ]]
 then
-    echo "development mode detected..."
+    echo $INFO "development mode detected..."
     # NOTE: expects docker run ... -v $(pwd):/devel/services/sidecar
     DEVEL_MOUNT=/devel/services/sidecar
 
     stat $DEVEL_MOUNT &> /dev/null || \
-        (echo "ERROR: You must mount '$DEVEL_MOUNT' to deduce user and group ids" && exit 1) # FIXME: exit does not stop script
+        (echo $ERROR "You must mount '$DEVEL_MOUNT' to deduce user and group ids" && exit 1) # FIXME: exit does not stop script
 
     USERID=$(stat -c %u $DEVEL_MOUNT)
     GROUPID=$(stat -c %g $DEVEL_MOUNT)
@@ -30,17 +33,17 @@ then
 
     if [[ $USERID -eq 0 ]]
     then
-        echo "mounted folder from root, adding scu to root..."
+        echo $INFO "mounted folder from root, adding scu to root..."
         addgroup scu root
     else
         # take host's credentials in scu
         if [[ -z "$GROUPNAME" ]]
         then
-            echo "mounted folder from $USERID, creating new group..."
+            echo $INFO "mounted folder from $USERID, creating new group..."
             GROUPNAME=host_group
             addgroup -g $GROUPID $GROUPNAME
         else
-            echo "mounted folder from $USERID, adding scu to $GROUPNAME..."
+            echo $INFO "mounted folder from $USERID, adding scu to $GROUPNAME..."
             addgroup scu $GROUPNAME
         fi
 
@@ -69,7 +72,7 @@ then
     addgroup scu $GROUPNAME
 fi
 
-echo "Starting boot ..."
+echo $INFO "Starting boot ..."
 chown -R $USERNAME:$GROUPNAME /home/scu/input
 chown -R $USERNAME:$GROUPNAME /home/scu/output
 chown -R $USERNAME:$GROUPNAME /home/scu/log

--- a/services/sidecar/src/sidecar/celery.py
+++ b/services/sidecar/src/sidecar/celery.py
@@ -1,26 +1,19 @@
-import logging
-
 from celery import Celery
-from celery.utils.log import get_task_logger
 
 from simcore_sdk.config.rabbit import Config as RabbitConfig
 
-# TODO: configure via command line or config file. Add in config.yaml
-logging.basicConfig(level=logging.DEBUG)
+from .celery_log_setup import get_task_logger
 
 log = get_task_logger(__name__)
-log.setLevel(logging.DEBUG)
-
 
 rabbit_config = RabbitConfig()
+
+log.info("Inititalizing celery app ...")
 
 # TODO: make it a singleton?
 app= Celery(rabbit_config.name,
     broker=rabbit_config.broker,
     backend=rabbit_config.backend)
-
-
-
 
 __all__ = [
     "rabbit_config",

--- a/services/sidecar/src/sidecar/celery_log_setup.py
+++ b/services/sidecar/src/sidecar/celery_log_setup.py
@@ -1,0 +1,39 @@
+""" setup logging formatters to fit logspout's multiline pattern "^(ERROR|WARNING|INFO|DEBUG|CRITICAL)[:]"
+
+    NOTE: import to connect signals!
+
+    SEE https://github.com/ITISFoundation/osparc-ops/blob/master/services/graylog/docker-compose.yml#L113
+"""
+# NOTES:
+#  https://docs.celeryproject.org/en/latest/userguide/signals.html#setup-logging
+#  https://www.distributedpython.com/2018/08/28/celery-logging/
+#  https://www.distributedpython.com/2018/11/06/celery-task-logger-format/
+
+import logging
+
+from celery.app.log import TaskFormatter
+from celery.signals import after_setup_logger, after_setup_task_logger
+from celery.utils.log import get_task_logger
+
+@after_setup_logger.connect
+def setup_loggers(logger, *_args, **_kwargs):
+    """ Customizes global loggers """
+    for handler in logger.handlers:
+        handler.setFormatter(logging.Formatter('%(levelname)s: [%(asctime)s/%(processName)s] %(message)s'))
+
+
+@after_setup_task_logger.connect
+def setup_task_logger(logger, *_args, **_kwargs):
+    """ Customizes task loggers """
+    for handler in logger.handlers:
+        handler.setFormatter(TaskFormatter('%(levelname)s: [%(asctime)s/%(processName)s][%(task_name)s(%(task_id)s)] %(message)s'))
+
+
+# TODO: configure via command line or config file. Add in config.yaml
+logging.basicConfig(level=logging.DEBUG)
+log = get_task_logger(__name__)
+log.info("Setting up loggers")
+
+__all__ = [
+    'get_task_logger'
+]

--- a/services/storage/docker/boot.sh
+++ b/services/storage/docker/boot.sh
@@ -1,15 +1,17 @@
 #!/bin/sh
 #
+INFO="INFO: [`basename "$0"`] "
+ERROR="ERROR: [`basename "$0"`] "
 
 # BOOTING application ---------------------------------------------
-echo "Booting in ${SC_BOOT_MODE} mode ..."
+echo $INFO "Booting in ${SC_BOOT_MODE} mode ..."
 
 
 if [[ ${SC_BUILD_TARGET} == "development" ]]
 then
-  echo "  User    :`id $(whoami)`"
-  echo "  Workdir :`pwd`"
-  echo "  Environment :"
+  echo $INFO "User    :`id $(whoami)`"
+  echo $INFO "Workdir :`pwd`"
+  echo $INFO "Environment :"
   printenv  | sed 's/=/: /' | sed 's/^/    /' | sort
   #--------------------
 
@@ -20,10 +22,10 @@ then
   cd /devel
 
   #--------------------
-  echo "  Python :"
+  echo $INFO "Python :"
   python --version | sed 's/^/    /'
   which python | sed 's/^/    /'
-  echo "  PIP :"
+  echo $INFO "PIP :"
   $SC_PIP list | sed 's/^/    /'
 
   #------------
@@ -41,14 +43,15 @@ fi
 if [[ ${SC_BOOT_MODE} == "debug-pdb" ]]
 then
   # NOTE: needs stdin_open: true and tty: true
-  echo "Debugger attached: https://docs.python.org/3.6/library/pdb.html#debugger-commands  ..."
-  echo "Running: import pdb, simcore_service_storage.cli; pdb.run('simcore_service_storage.cli.main([\'-c\',\'${APP_CONFIG}\'])')"
-  eval "$entrypoint" python -c "import pdb, simcore_service_storage.cli; \
+  echo $INFO "Debugger attached: https://docs.python.org/3.6/library/pdb.html#debugger-commands  ..."
+  echo $INFO "Running: import pdb, simcore_service_storage.cli; pdb.run('simcore_service_storage.cli.main([\'-c\',\'${APP_CONFIG}\'])')"
+  eval $INFO "$entrypoint" python -c "import pdb, simcore_service_storage.cli; \
              pdb.run('simcore_service_storage.cli.main([\'-c\',\'${APP_CONFIG}\'])')"
 elif [[ ${SC_BOOT_MODE} == "debug-ptvsd" ]]
 then
-  echo "PTVSD Debugger initializing in port 3003 with ${APP_CONFIG}"
-  eval "$entrypoint" python3 -m ptvsd --host 0.0.0.0 --port 3000 -m simcore_service_storage --config $APP_CONFIG
+  echo $INFO "PTVSD Debugger initializing in port 3003 with ${APP_CONFIG}"
+  eval "$entrypoint" python3 -m ptvsd --host 0.0.0.0 --port 3000 -m \
+      simcore_service_storage --config $APP_CONFIG
 else
   exec simcore-service-storage --config $APP_CONFIG
 fi

--- a/services/storage/docker/entrypoint.sh
+++ b/services/storage/docker/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+INFO="INFO: [`basename "$0"`] "
+ERROR="ERROR: [`basename "$0"`] "
 
 # This entrypoint script:
 #
@@ -6,13 +9,13 @@
 # - Notice that the container *starts* as --user [default root] but
 #   *runs* as non-root user [scu]
 #
-echo "Entrypoint for stage ${SC_BUILD_TARGET} ..."
+echo $INFO "Entrypoint for stage ${SC_BUILD_TARGET} ..."
 echo "  User    :`id $(whoami)`"
 echo "  Workdir :`pwd`"
 
-echo "updating certificates..."
+echo $INFO "updating certificates..."
 update-ca-certificates
-echo "certificates updated"
+echo $INFO "certificates updated"
 
 if [[ ${SC_BUILD_TARGET} == "development" ]]
 then
@@ -20,7 +23,7 @@ then
     DEVEL_MOUNT=/devel/services/storage
 
     stat $DEVEL_MOUNT &> /dev/null || \
-        (echo "ERROR: You must mount '$DEVEL_MOUNT' to deduce user and group ids" && exit 1) # FIXME: exit does not stop script
+        (echo $ERROR "You must mount '$DEVEL_MOUNT' to deduce user and group ids" && exit 1) # FIXME: exit does not stop script
 
     USERID=$(stat -c %u $DEVEL_MOUNT)
     GROUPID=$(stat -c %g $DEVEL_MOUNT)
@@ -50,5 +53,5 @@ then
   python3 -m pip install ptvsd
 fi
 
-echo "Starting boot ..."
+echo $INFO "Starting boot ..."
 exec su-exec scu "$@"

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -1,14 +1,17 @@
 #!/bin/sh
 #
+INFO="INFO: [`basename "$0"`] "
+ERROR="ERROR: [`basename "$0"`] "
+
 
 # BOOTING application ---------------------------------------------
-echo "Booting in ${SC_BOOT_MODE} mode ..."
+echo $INFO "Booting in ${SC_BOOT_MODE} mode ..."
 echo "  User    :`id $(whoami)`"
 echo "  Workdir :`pwd`"
 
 if [[ ${SC_BUILD_TARGET} == "development" ]]
 then
-  echo "  Environment :"
+  echo $INFO "Environment :"
   printenv  | sed 's/=/: /' | sed 's/^/    /' | sort
 
   #------------
@@ -19,14 +22,14 @@ then
   cd /devel
 
   #------------
-  echo "  Python :"
+  echo $INFO "Python :"
   python --version | sed 's/^/    /'
   which python | sed 's/^/    /'
-  echo "  PIP :"
+  echo $INFO "PIP :"
   $SC_PIP list | sed 's/^/    /'
 
   #------------
-  echo "  setting entrypoint to use watchmedo autorestart..."
+  echo $INFO "setting entrypoint to use watchmedo autorestart..."
   entrypoint='watchmedo auto-restart --recursive --pattern="*.py" --'
 
 elif [[ ${SC_BUILD_TARGET} == "production" ]]
@@ -40,15 +43,16 @@ fi
 if [[ ${SC_BOOT_MODE} == "debug-pdb" ]]
 then
   # NOTE: needs stdin_open: true and tty: true
-  echo "Debugger attached: https://docs.python.org/3.6/library/pdb.html#debugger-commands  ..."
-  echo "Running: import pdb, simcore_service_server.cli; pdb.run('simcore_service_server.cli.main([\'-c\',\'${APP_CONFIG}\'])')"
+  echo $INFO "Debugger attached: https://docs.python.org/3.6/library/pdb.html#debugger-commands  ..."
+  echo $INFO "Running: import pdb, simcore_service_server.cli; pdb.run('simcore_service_server.cli.main([\'-c\',\'${APP_CONFIG}\'])')"
   eval "$entrypoint" python -c "import pdb, simcore_service_server.cli; \
              pdb.run('simcore_service_server.cli.main([\'-c\',\'${APP_CONFIG}\'])')"
 elif [[ ${SC_BOOT_MODE} == "debug-ptvsd" ]]
 then
   # NOTE: needs ptvsd installed
-  echo "PTVSD Debugger initializing in port 3000 with ${APP_CONFIG}"
-  eval "$entrypoint" python3 -m ptvsd --host 0.0.0.0 --port 3000 -m simcore_service_webserver --config $APP_CONFIG
+  echo $INFO "PTVSD Debugger initializing in port 3000 with ${APP_CONFIG}"
+  eval "$entrypoint" python3 -m ptvsd --host 0.0.0.0 --port 3000 -m \
+    simcore_service_webserver --config $APP_CONFIG
 else
   exec simcore-service-webserver --config $APP_CONFIG
 fi

--- a/services/web/server/docker/entrypoint.sh
+++ b/services/web/server/docker/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+#
+INFO="INFO: [`basename "$0"`] "
+ERROR="ERROR: [`basename "$0"`] "
 
 # This entrypoint script:
 #
@@ -6,7 +9,7 @@
 # - Notice that the container *starts* as --user [default root] but
 #   *runs* as non-root user [scu]
 #
-echo "Entrypoint for stage ${SC_BUILD_TARGET} ..."
+echo $INFO "Entrypoint for stage ${SC_BUILD_TARGET} ..."
 echo "  User    :`id $(whoami)`"
 echo "  Workdir :`pwd`"
 
@@ -17,7 +20,7 @@ then
     DEVEL_MOUNT=/devel/services/web/server
 
     stat $DEVEL_MOUNT &> /dev/null || \
-        (echo "ERROR: You must mount '$DEVEL_MOUNT' to deduce user and group ids" && exit 1) # FIXME: exit does not stop script
+        (echo $ERROR "You must mount '$DEVEL_MOUNT' to deduce user and group ids" && exit 1) # FIXME: exit does not stop script
 
     USERID=$(stat -c %u $DEVEL_MOUNT)
     GROUPID=$(stat -c %g $DEVEL_MOUNT)


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

Setup logging formatters to fit logspout's multiline reqex pattern ``^(ERROR|WARNING|INFO|DEBUG|CRITICAL)[:]`` setup in [osparc-ops config](https://github.com/ITISFoundation/osparc-ops/blob/master/services/graylog/docker-compose.yml#L113)

- sidecar celery logs uses normalized format
- all services use default formatter 
- all boot and entrypoint scripts log with ``echo $INFO ...``
- EXTRA: added missing ``exec`` in boot and entrypoint of director for graceful shutdown
   
## Related issue number

Implements #1178 


## How to test

- run swarm
- All logs in sidecar, webserver, director and storage satisfy regex pattern

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] **Runs in the swarm**
