### PR TITLE
Is1165/fix sidecar db conn leak

### DIFF
--- a/.vscode-template/launch.json
+++ b/.vscode-template/launch.json
@@ -17,6 +17,19 @@
         }
       ]
     },
+      {
+        "name": "Python: Remote Attach sidecar",
+        "type": "python",
+        "request": "attach",
+        "port": 3002,
+        "host": "127.0.0.1",
+        "pathMappings": [
+          {
+            "localRoot": "${workspaceFolder}/services/sidecar",
+            "remoteRoot": "/devel/services/sidecar"
+          }
+        ]
+      },
     {
       "name": "Python: Remote Attach storage",
       "type": "python",

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports/dbmanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports/dbmanager.py
@@ -73,7 +73,10 @@ class DBManager:
         with session_scope(self._db_settings.Session) as session:
             # pylint: disable=no-member
             # project id should be also defined but was not the case before
-            criteria = (NodeModel.node_id == config.NODE_UUID if config.PROJECT_ID == 'undefined' else and_(NodeModel.node_id == config.NODE_UUID, NodeModel.project_id == config.PROJECT_ID))
+            criteria = (NodeModel.node_id == config.NODE_UUID
+                if config.PROJECT_ID == 'undefined'
+                else and_(NodeModel.node_id == config.NODE_UUID, NodeModel.project_id == config.PROJECT_ID)
+            )
             node = session.query(NodeModel).filter(criteria).one()
             if config.PROJECT_ID == 'undefined':
                 config.PROJECT_ID = node.project_id

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports/nodeports.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports/nodeports.py
@@ -4,6 +4,7 @@
 """
 import logging
 from pathlib import Path
+from typing import Optional
 
 from . import data_items_utils, dbmanager, exceptions, serialization
 from ._data_items_list import DataItemsList
@@ -144,7 +145,10 @@ class Nodeports:
         return serialization.create_nodeports_from_uuid(self.db_mgr, node_uuid)
 
 
-def ports():
-    _db_manager = dbmanager.DBManager()
+def ports(db_manager: Optional[dbmanager.DBManager]=None):
+    # FIXME: warning every dbmanager create a new db engine!
+    if db_manager is None: # NOTE: keeps backwards compatibility
+        db_manager = dbmanager.DBManager()
+
     # create initial Simcore object
-    return serialization.create_from_json(_db_manager, auto_read=True, auto_write=True)
+    return serialization.create_from_json(db_manager, auto_read=True, auto_write=True)

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports/nodeports.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports/nodeports.py
@@ -145,7 +145,7 @@ class Nodeports:
         return serialization.create_nodeports_from_uuid(self.db_mgr, node_uuid)
 
 
-def ports(db_manager: Optional[dbmanager.DBManager]=None):
+def ports(db_manager: Optional[dbmanager.DBManager]=None) -> Nodeports:
     # FIXME: warning every dbmanager create a new db engine!
     if db_manager is None: # NOTE: keeps backwards compatibility
         db_manager = dbmanager.DBManager()

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports/serialization.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports/serialization.py
@@ -3,16 +3,18 @@
 """
 import json
 import logging
+from typing import Dict
 
-from . import config, exceptions, nodeports  # pylint: disable=R0401
+from . import config, exceptions, nodeports
 from ._data_item import DataItem
 from ._data_items_list import DataItemsList
 from ._schema_item import SchemaItem
 from ._schema_items_list import SchemaItemsList
+from .dbmanager import DBManager
 
 log = logging.getLogger(__name__)
 
-def create_from_json(db_mgr, auto_read=False, auto_write=False):
+def create_from_json(db_mgr: DBManager, auto_read: bool=False, auto_write: bool=False)-> nodeports.Nodeports:
     """ creates a Nodeports object provided a json configuration in form of a callback function
 
     :param db_mgr: interface object to connect to nodeports description
@@ -35,7 +37,7 @@ def create_from_json(db_mgr, auto_read=False, auto_write=False):
     log.debug("Created Nodeports object")
     return nodeports_obj
 
-def create_nodeports_from_uuid(db_mgr, node_uuid):
+def create_nodeports_from_uuid(db_mgr: DBManager, node_uuid: str)-> nodeports.Nodeports:
     log.debug("Creating Nodeports object from node uuid: %s", node_uuid)
     if not db_mgr:
         raise exceptions.NodeportsException("Invalid call to create nodeports from uuid")
@@ -44,7 +46,7 @@ def create_nodeports_from_uuid(db_mgr, node_uuid):
     log.debug("Created Nodeports object")
     return nodeports_obj
 
-def save_to_json(nodeports_obj):
+def save_to_json(nodeports_obj: nodeports.Nodeports):
     """ Encodes a Nodeports object to json and calls a linked writer if available.
 
     :param nodeports_obj:  the object to encode
@@ -90,7 +92,7 @@ class _NodeportsEncoder(json.JSONEncoder):
         log.debug("Encoding object using defaults")
         return json.JSONEncoder.default(self, o)
 
-def __decodeNodePorts(dct):
+def __decodeNodePorts(dct: Dict) -> nodeports.Nodeports:
     if not all(k in dct for k in config.NODE_KEYS.keys()):
         raise exceptions.InvalidProtocolError(dct)
     # decode schema

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports/serialization.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports/serialization.py
@@ -5,6 +5,7 @@ import json
 import logging
 from typing import Dict
 
+# FIXME: : nodeports.Nodeports produces recursive import
 from . import config, exceptions, nodeports
 from ._data_item import DataItem
 from ._data_items_list import DataItemsList
@@ -14,7 +15,7 @@ from .dbmanager import DBManager
 
 log = logging.getLogger(__name__)
 
-def create_from_json(db_mgr: DBManager, auto_read: bool=False, auto_write: bool=False)-> nodeports.Nodeports:
+def create_from_json(db_mgr: DBManager, auto_read: bool=False, auto_write: bool=False):
     """ creates a Nodeports object provided a json configuration in form of a callback function
 
     :param db_mgr: interface object to connect to nodeports description
@@ -37,7 +38,7 @@ def create_from_json(db_mgr: DBManager, auto_read: bool=False, auto_write: bool=
     log.debug("Created Nodeports object")
     return nodeports_obj
 
-def create_nodeports_from_uuid(db_mgr: DBManager, node_uuid: str)-> nodeports.Nodeports:
+def create_nodeports_from_uuid(db_mgr: DBManager, node_uuid: str):
     log.debug("Creating Nodeports object from node uuid: %s", node_uuid)
     if not db_mgr:
         raise exceptions.NodeportsException("Invalid call to create nodeports from uuid")
@@ -46,7 +47,7 @@ def create_nodeports_from_uuid(db_mgr: DBManager, node_uuid: str)-> nodeports.No
     log.debug("Created Nodeports object")
     return nodeports_obj
 
-def save_to_json(nodeports_obj: nodeports.Nodeports):
+def save_to_json(nodeports_obj):
     """ Encodes a Nodeports object to json and calls a linked writer if available.
 
     :param nodeports_obj:  the object to encode
@@ -92,7 +93,7 @@ class _NodeportsEncoder(json.JSONEncoder):
         log.debug("Encoding object using defaults")
         return json.JSONEncoder.default(self, o)
 
-def __decodeNodePorts(dct: Dict) -> nodeports.Nodeports:
+def __decodeNodePorts(dct: Dict):
     if not all(k in dct for k in config.NODE_KEYS.keys()):
         raise exceptions.InvalidProtocolError(dct)
     # decode schema

--- a/services/docker-compose.devel.yml
+++ b/services/docker-compose.devel.yml
@@ -33,6 +33,13 @@ services:
       - ./sidecar:/devel/services/sidecar
       - ./storage/client-sdk:/devel/services/storage/client-sdk
       - ../packages:/devel/packages
+    environment:
+      - SC_BOOT_MODE=debug-ptvsd
+    ports:
+      - "3002:3000"
+    deploy:
+      # NOTE: Allows 3002 to be exposed for ptvsd
+      endpoint_mode: vip
 
   storage:
     volumes:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -87,6 +87,8 @@ services:
       - log:/home/scu/log
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      - RABBIT_HOST=${RABBIT_HOST}
+      - RABBIT_PORT=${RABBIT_PORT}
       - RABBIT_USER=${RABBIT_USER}
       - RABBIT_PASSWORD=${RABBIT_PASSWORD}
       - RABBIT_LOG_CHANNEL=${RABBIT_LOG_CHANNEL}

--- a/services/sidecar/docker/boot.sh
+++ b/services/sidecar/docker/boot.sh
@@ -32,15 +32,28 @@ then
   DEBUG_LEVEL=info
 fi
 
-
 # RUNNING application ----------------------------------------
-if [[ ${SC_BOOT_MODE} == "debug" ]]
+
+# default
+DEBUG_LEVEL=info
+CONCURRENCY=2
+POOL=prefork
+
+
+if [[ ${SC_BOOT_MODE} == "debug-ptvsd" ]]
 then
-  # TODO: activate pdb??
+  # NOTE: in this case, remote debugging is only available in development mode!
+  # FIXME: workaround since PTVSD does not support prefork subprocess debugging: https://github.com/microsoft/ptvsd/issues/943
+  POOL=solo
+
+elif [[ ${SC_BOOT_MODE} == "debug" ]]
+then
   DEBUG_LEVEL=debug
   CONCURRENCY=1
-else
-  CONCURRENCY=2
 fi
 
-exec celery worker --app sidecar.celery:app --concurrency ${CONCURRENCY} --loglevel=${DEBUG_LEVEL}
+exec celery worker \
+    --app sidecar.celery:app \
+    --concurrency ${CONCURRENCY} \
+    --loglevel=${DEBUG_LEVEL} \
+    --pool=${POOL}

--- a/services/sidecar/requirements/_test.in
+++ b/services/sidecar/requirements/_test.in
@@ -16,3 +16,4 @@ aiopg
 # tools for CI
 pylint
 coveralls
+ptvsd

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -34,6 +34,7 @@ networkx==2.3
 pika==1.0.1
 pluggy==0.11.0            # via pytest
 psycopg2-binary==2.8.2
+ptvsd==4.3.2
 py==1.8.0                 # via pytest
 pylint==2.3.1
 pytest-cov==2.7.1
@@ -55,4 +56,4 @@ wrapt==1.11.1             # via astroid
 yarl==1.3.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.4.0        # via pytest
+# setuptools==42.0.0        # via pytest

--- a/services/sidecar/src/sidecar/celery.py
+++ b/services/sidecar/src/sidecar/celery.py
@@ -1,14 +1,15 @@
 from celery import Celery
-
 from simcore_sdk.config.rabbit import Config as RabbitConfig
 
 from .celery_log_setup import get_task_logger
+from .remote_debug import setup_remote_debugging
 
 log = get_task_logger(__name__)
+log.info("Inititalizing celery app ...")
 
 rabbit_config = RabbitConfig()
 
-log.info("Inititalizing celery app ...")
+setup_remote_debugging()
 
 # TODO: make it a singleton?
 app= Celery(rabbit_config.name,

--- a/services/sidecar/src/sidecar/core.py
+++ b/services/sidecar/src/sidecar/core.py
@@ -12,13 +12,13 @@ import pika
 import requests
 from celery.states import SUCCESS as CSUCCESS
 from celery.utils.log import get_task_logger
-from sqlalchemy import and_, exc
-
 from simcore_sdk import node_ports
 from simcore_sdk.models.pipeline_models import (RUNNING, SUCCESS,
                                                 ComputationalPipeline,
                                                 ComputationalTask)
 from simcore_sdk.node_ports import log as node_port_log
+from simcore_sdk.node_ports.dbmanager import DBManager
+from sqlalchemy import and_, exc
 
 from . import config
 from .utils import (DbSettings, DockerSettings, ExecutorSettings,
@@ -55,7 +55,8 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
         self._s3 = S3Settings()
 
         # db config
-        self._db = DbSettings()
+        self._db = DbSettings() # keeps single db engine: sidecar.utils_{id}
+        self._db_manager = DBManager() # Keeps single db engine: simcore_sdk.node_ports.dbmanager_{id}
 
         # current task
         self._task = None
@@ -68,6 +69,9 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
 
         # executor options
         self._executor = ExecutorSettings()
+
+    def _get_node_ports(self):
+        return node_ports.ports(self._db_manager)
 
     def _create_shared_folders(self):
         for folder in [self._executor.in_dir, self._executor.log_dir, self._executor.out_dir]:
@@ -108,7 +112,7 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
         log.debug('Input parsing for %s and node %s from container', self._task.project_id, self._task.internal_id)
 
         input_ports = dict()
-        PORTS = node_ports.ports()
+        PORTS = self._get_node_ports()
         for port in PORTS.inputs:
             log.debug(port)
             self._process_task_input(port, input_ports)
@@ -134,7 +138,6 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
         except docker.errors.APIError:
             log.exception("Pulling image failed")
             raise docker.errors.APIError
-
 
     def _log(self, channel: pika.channel.Channel, msg: Union[str, List[str]]):
         log_data = {"Channel" : "Log",
@@ -226,7 +229,7 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
             Files will be pushed to S3 with reference in db. output.json will be parsed
             and the db updated
         """
-        PORTS = node_ports.ports()
+        PORTS = self._get_node_ports()
         directory = self._executor.out_dir
         if not os.path.exists(directory):
             return
@@ -251,6 +254,7 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
         except (OSError, IOError) as _e:
             logging.exception("Could not process output")
 
+
     # pylint: disable=no-self-use
     def _process_task_log(self):
         """ There will be some files in the /log
@@ -266,6 +270,7 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
         #            object_name = str(self._task.project_id) + "/" + self._task.node_id + "/log/" + name
         #            # if not self._s3.client.upload_file(self._s3.bucket, object_name, filepath):
         #            #     log.error("Error uploading file to S3")
+
 
     def initialize(self, task, user_id):
         self._task = task
@@ -295,11 +300,13 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
         node_ports.node_config.NODE_UUID = task.node_id
         node_ports.node_config.PROJECT_ID = task.project_id
 
+
     def preprocess(self):
         log.debug('Pre-Processing Pipeline %s and node %s from container', self._task.project_id, self._task.internal_id)
         self._create_shared_folders()
         self._process_task_inputs()
         self._pull_image()
+
 
     def process(self):
         log.debug('Processing Pipeline %s and node %s from container', self._task.project_id, self._task.internal_id)
@@ -315,8 +322,8 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
         start_time = time.perf_counter()
         container = None
         try:
-            docker_image = self._docker.image_name + ":" + self._docker.image_tag            
-            container = self._docker.client.containers.run(docker_image, "run", 
+            docker_image = self._docker.image_name + ":" + self._docker.image_tag
+            container = self._docker.client.containers.run(docker_image, "run",
                                                             init=True,
                                                             detach=True, remove=False,
                                                             volumes = {'{}_input'.format(self._stack_name)  : {'bind' : '/input'},
@@ -343,7 +350,7 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
                 if config.SERVICES_TIMEOUT_SECONDS > 0:
                     wait_arguments["timeout"] = int(config.SERVICES_TIMEOUT_SECONDS)
                 response = container.wait(**wait_arguments)
-                log.info("container completed with response %s\nlogs: %s", response, container.logs())        
+                log.info("container completed with response %s\nlogs: %s", response, container.logs())
             except requests.exceptions.ConnectionError:
                 log.exception("Running container timed-out after %ss and will be killed now\nlogs: %s", config.SERVICES_TIMEOUT_SECONDS, container.logs())
             except docker.errors.APIError:
@@ -370,6 +377,7 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
             yield channel
         finally:
             connection.close()
+
 
     def run(self):
         with self.safe_log_channel() as channel:
@@ -417,6 +425,7 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
             _session.rollback()
         finally:
             _session.close()
+
 
     def inspect(self, celery_task, user_id, project_id, node_id):
         log.debug("ENTERING inspect pipeline:node %s: %s", project_id, node_id)

--- a/services/sidecar/src/sidecar/core.py
+++ b/services/sidecar/src/sidecar/core.py
@@ -56,7 +56,7 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
 
         # db config
         self._db = DbSettings() # keeps single db engine: sidecar.utils_{id}
-        self._db_manager = DBManager() # Keeps single db engine: simcore_sdk.node_ports.dbmanager_{id}
+        self._db_manager = None # lazy init because still not configured. SEE _get_node_ports
 
         # current task
         self._task = None
@@ -71,6 +71,8 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
         self._executor = ExecutorSettings()
 
     def _get_node_ports(self):
+        if self._db_manager is None:
+            self._db_manager = DBManager() # Keeps single db engine: simcore_sdk.node_ports.dbmanager_{id}
         return node_ports.ports(self._db_manager)
 
     def _create_shared_folders(self):

--- a/services/sidecar/src/sidecar/core.py
+++ b/services/sidecar/src/sidecar/core.py
@@ -133,13 +133,17 @@ class Sidecar: # pylint: disable=too-many-instance-attributes
         log.debug('reg %s user %s pwd %s', self._docker.registry, self._docker.registry_user,self._docker.registry_pwd )
 
         try:
-            self._docker.client.login(registry=self._docker.registry,
-                username=self._docker.registry_user, password=self._docker.registry_pwd)
+            self._docker.client.login(
+                registry=self._docker.registry,
+                username=self._docker.registry_user,
+                password=self._docker.registry_pwd)
             log.debug('img %s tag %s', self._docker.image_name, self._docker.image_tag)
+
             self._docker.client.images.pull(self._docker.image_name, tag=self._docker.image_tag)
         except docker.errors.APIError:
-            log.exception("Pulling image failed")
-            raise docker.errors.APIError
+            msg = f"Failed to pull image '{self._docker.image_name}:{self._docker.image_tag}' from {self._docker.registry,}"
+            log.exception(msg)
+            raise docker.errors.APIError(msg)
 
     def _log(self, channel: pika.channel.Channel, msg: Union[str, List[str]]):
         log_data = {"Channel" : "Log",

--- a/services/sidecar/src/sidecar/remote_debug.py
+++ b/services/sidecar/src/sidecar/remote_debug.py
@@ -1,0 +1,37 @@
+""" Setup remote debugger with Python Tools for Visual Studio (PTVSD)
+
+"""
+import os
+
+from .celery_log_setup import get_task_logger
+
+log = get_task_logger(__name__)
+
+
+def setup_remote_debugging(force_enabled=False):
+    """ Programaticaly enables remote debugging if SC_BOOT_MODE==debug-ptvsd
+
+    """
+    boot_mode = os.environ["SC_BOOT_MODE"]
+
+    if boot_mode == "debug-ptvsd" or force_enabled:
+        try:
+            log.debug("Enabling attach ptvsd ...")
+            #
+            # SEE https://github.com/microsoft/ptvsd#enabling-debugging
+            #
+            import ptvsd
+            ptvsd.enable_attach(address=('0.0.0.0', 3000), redirect_output=True)
+
+        except ImportError:
+            log.exception("Unable to use remote debugging. ptvsd is not installed")
+
+        else:
+            log.info("Remote debugging enabled")
+    else:
+        log.debug("Booting without remote debugging since SC_BOOT_MODE=%s", boot_mode)
+
+
+__all__ = [
+    'setup_remote_debugging'
+]

--- a/services/sidecar/src/sidecar/tasks.py
+++ b/services/sidecar/src/sidecar/tasks.py
@@ -2,9 +2,9 @@ import logging
 
 from .celery import app
 
-
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG) # FIXME: set level via config
+
 
 @app.task(name='comp.task', bind=True)
 def pipeline(self, user_id, project_id, node_id=None):

--- a/services/sidecar/tests/conftest.py
+++ b/services/sidecar/tests/conftest.py
@@ -78,6 +78,8 @@ def postgres_service(docker_services, docker_ip):
         'host' : docker_ip,
         'port' : docker_services.port_for('postgres', 5432)
     }
+    # FIXME: use monkeypatch.setenv("POSTGRES_ENDPOINT", ...) instead
+
     # set env var here that is explicitly used from sidecar
     os.environ['POSTGRES_ENDPOINT'] = "{host}:{port}".format(host=docker_ip, port=docker_services.port_for('postgres', 5432))
     return postgres_service
@@ -85,8 +87,9 @@ def postgres_service(docker_services, docker_ip):
 @pytest.fixture(scope='session')
 def rabbit_service(docker_services, docker_ip):
     # set env var here that is explicitly used from sidecar
+    # FIXME: use monkeypatch.setenv("RABBIT_HOST", ...) instead
     os.environ['RABBIT_HOST'] = "{host}".format(host=docker_ip)
-    os.environ['RABBIT_PORT'] = "{port}".format(port=docker_services.port_for('rabbit', 15672))
+    os.environ['RABBIT_PORT'] = "{port}".format(port=docker_services.port_for('rabbit', 5672))
 
     rabbit_service = "dummy"
     return rabbit_service
@@ -130,6 +133,7 @@ def minio_service(docker_services, docker_ip):
         pause=0.1,
     )
 
+    # FIXME: use monkeypatch.setenv("S3_BUCKET_NAME", ...) instead
     os.environ['S3_BUCKET_NAME'] = "simcore-testing"
     os.environ['S3_ENDPOINT'] = '{ip}:{port}'.format(ip=docker_ip, port=docker_services.port_for('minio', 9000))
     os.environ['S3_ACCESS_KEY'] = ACCESS_KEY

--- a/services/web/server/Makefile
+++ b/services/web/server/Makefile
@@ -6,8 +6,8 @@
 APP_NAME     := webserver
 APP_CLI_NAME  = simcore-service-${APP_NAME}
 
-ROOT_DIR     = $(realpath $(CURDIR)/../../../)
-VENV_DIR    ?= $(realpath $(ROOT_DIR)/.venv)
+ROOT_DIR     = $(abspath $(CURDIR)/../../../)
+VENV_DIR    ?= $(abspath $(ROOT_DIR)/.venv)
 
 
 .PHONY: install
@@ -16,11 +16,19 @@ install: ## install app in edit mode for development [DEV]
 	@$(VENV_DIR)/bin/pip3 install -r requirements/dev.txt
 
 
-.PHONY: tests
-tests: ## runs all tests [DEV]
+.PHONY: tests tunit tintegration
+tests: tunit tintegration## runs all tests [DEV]
+	# All tests run
+
+tunit:
 	# running unit tests
 	@$(VENV_DIR)/bin/pytest -vv -x --ff --pdb $(CURDIR)/tests/unit
-	# running integration tests
+
+
+export DOCKER_REGISTRY=local
+export DOCKER_IMAGE_TAG=production
+tintegration:
+	# running integration tests ${DOCKER_REGISTRY}/(service):${DOCKER_IMAGE_TAG} images ...
 	@$(VENV_DIR)/bin/pytest -vv -x --ff --pdb $(CURDIR)/tests/integration
 
 


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

- Minor modifications ``node_ports`` to avoid connection leak from ``sidecar``
- adds setup to remote debug sidecar service

## Related issue number

Might fix #1165


## How to test

- ``make up-*``
- open osparc and create a pipeline with sleepers
- open admirer -> Process list
- Run sleepers
- Process from application ``sidecar_*`` and ``simcore_sdk..`` should not constantly rise
This is how it looks in my pc
![image](https://user-images.githubusercontent.com/32402063/69547086-3f041f80-0f95-11ea-96ed-098833b8dd0c.png)


## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] **Runs in the swarm**
- [ ] If you design a new module, add your user to .github/CODEOWNERS
