### PR TITLE
hot fix1229: fails db query (#1231)

### DIFF
--- a/services/storage/src/simcore_service_storage/db_tokens.py
+++ b/services/storage/src/simcore_service_storage/db_tokens.py
@@ -38,7 +38,8 @@ async def get_api_token_and_secret(request: web.Request, userid) -> Tuple[str, s
         try:
             data = await _get_tokens_from_db(engine, userid)
         except DbApiError:
-            log.exception("Cannot retrieve tokens for user %s in pgdb %s", userid, engine)
+            # NOTE this shall not log as error since is a possible outcome with an alternative
+            log.warning("Cannot retrieve tokens for user %s in pgdb %s", userid, engine, exc_info=True)
         else:
             data = data.get('token_data', {})
             api_token = data.get('token_key', api_token)

--- a/services/web/server/src/simcore_service_webserver/users_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/users_handlers.py
@@ -6,8 +6,9 @@ import logging
 import sqlalchemy as sa
 import sqlalchemy.sql as sql
 from aiohttp import web
-
+from servicelib.aiopg_utils import PostgresRetryPolicyUponOperation
 from servicelib.application_keys import APP_DB_ENGINE_KEY
+from tenacity import retry
 
 from .db_models import tokens, users
 from .login.decorators import RQT_USERID_KEY, login_required
@@ -20,14 +21,19 @@ logger = logging.getLogger(__name__)
 # me/ -----------------------------------------------------------
 @login_required
 async def get_my_profile(request: web.Request):
-    # ONLY login required to see its profile. E.g. anonymous can never see its profile
-    uid, engine = request[RQT_USERID_KEY], request.app[APP_DB_ENGINE_KEY]
+    # NOTE: ONLY login required to see its profile. E.g. anonymous can never see its profile
 
-    async with engine.acquire() as conn:
-        query = sa.select([users.c.email, users.c.role, users.c.name]).where(users.c.id == uid)
-        result = await conn.execute(query)
-        row = await result.first()
+    @retry(**PostgresRetryPolicyUponOperation(logger).kwargs)
+    async def _query_db(uid, engine):
+        async with engine.acquire() as conn:
+            query = sa.select([
+                users.c.email,
+                users.c.role,
+                users.c.name]).where(users.c.id == uid)
+            result = await conn.execute(query)
+            return await result.first()
 
+    row = await _query_db(uid=request[RQT_USERID_KEY], engine=request.app[APP_DB_ENGINE_KEY])
     parts = row['name'].split(".") + [""]
 
     return {


### PR DESCRIPTION
Re-applies hotfix already added in staging by cherry-picking 5fd24212409f958bb7b3fb5c98e208a4d61f3260

* Applied retry policy to db query for /me endpoint

* fixes log: user w/o access tokens shall not log error
