### PR TITLE
fix logging out, logging in failing

### DIFF
--- a/api/specs/webserver/openapi-auth.yaml
+++ b/api/specs/webserver/openapi-auth.yaml
@@ -39,8 +39,13 @@ paths:
           $ref: "#/components/responses/DefaultErrorResponse"
 
   /auth/logout:
-    get:
+    post:
       operationId: auth_logout
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LogoutRequest"
       responses:
         "200":
           description: Succesfully logged out
@@ -212,3 +217,11 @@ components:
   responses:
     DefaultErrorResponse:
       $ref: "./openapi.yaml#/components/responses/DefaultErrorResponse"
+  schemas:
+    LogoutRequest:
+      type: object
+      properties:
+        client_session_id:
+          type: string
+          example: 5ac57685-c40f-448f-8711-70be1936fd63
+      

--- a/services/web/client/source/class/osparc/auth/Manager.js
+++ b/services/web/client/source/class/osparc/auth/Manager.js
@@ -99,12 +99,12 @@ qx.Class.define("osparc.auth.Manager", {
         data: {
           clientSessionId: sessionStorage.getItem("clientsessionid")
         }
-      }
+      };
       osparc.data.Resources.fetch("auth", "postLogout", params)
         .then(data => {
           this.__logoutUser();
           this.fireEvent("logout");
-        })
+        });
     },
 
     register: function(userData, successCbk, failCbk, context) {

--- a/services/web/client/source/class/osparc/auth/Manager.js
+++ b/services/web/client/source/class/osparc/auth/Manager.js
@@ -97,7 +97,7 @@ qx.Class.define("osparc.auth.Manager", {
     logout: function() {
       const params = {
         data: {
-          "client_session_id": sessionStorage.getItem("clientsessionid")
+          "client_session_id": osparc.utils.Utils.getClientSessionID()
         }
       };
       osparc.data.Resources.fetch("auth", "postLogout", params)

--- a/services/web/client/source/class/osparc/auth/Manager.js
+++ b/services/web/client/source/class/osparc/auth/Manager.js
@@ -102,9 +102,10 @@ qx.Class.define("osparc.auth.Manager", {
       };
       osparc.data.Resources.fetch("auth", "postLogout", params)
         .then(data => {
-          this.__logoutUser();
           this.fireEvent("logout");
-        });
+        })
+        .catch(error => console.log("already logged out"))
+        .finally(this.__logoutUser());
     },
 
     register: function(userData, successCbk, failCbk, context) {

--- a/services/web/client/source/class/osparc/auth/Manager.js
+++ b/services/web/client/source/class/osparc/auth/Manager.js
@@ -95,9 +95,16 @@ qx.Class.define("osparc.auth.Manager", {
     },
 
     logout: function() {
-      osparc.data.Resources.fetch("auth", "getLogout");
-      this.__logoutUser();
-      this.fireEvent("logout");
+      const params = {
+        data: {
+          clientSessionId: sessionStorage.getItem("clientsessionid")
+        }
+      }
+      osparc.data.Resources.fetch("auth", "postLogout", params)
+        .then(data => {
+          this.__logoutUser();
+          this.fireEvent("logout");
+        })
     },
 
     register: function(userData, successCbk, failCbk, context) {

--- a/services/web/client/source/class/osparc/auth/Manager.js
+++ b/services/web/client/source/class/osparc/auth/Manager.js
@@ -97,7 +97,7 @@ qx.Class.define("osparc.auth.Manager", {
     logout: function() {
       const params = {
         data: {
-          clientSessionId: sessionStorage.getItem("clientsessionid")
+          "client_session_id": sessionStorage.getItem("clientsessionid")
         }
       };
       osparc.data.Resources.fetch("auth", "postLogout", params)

--- a/services/web/client/source/class/osparc/data/Resources.js
+++ b/services/web/client/source/class/osparc/data/Resources.js
@@ -253,8 +253,8 @@ qx.Class.define("osparc.data.Resources", {
             method: "POST",
             url: statics.API + "/auth/login"
           },
-          getLogout: {
-            method: "GET",
+          postLogout: {
+            method: "POST",
             url: statics.API + "/auth/logout"
           },
           postRegister: {

--- a/services/web/client/source/resource/api/openapi.yaml
+++ b/services/web/client/source/resource/api/openapi.yaml
@@ -642,8 +642,17 @@ paths:
                             field: pasword
                         status: 400
   /auth/logout:
-    get:
+    post:
       operationId: auth_logout
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                client_session_id:
+                  type: string
+                  example: 5ac57685-c40f-448f-8711-70be1936fd63
       responses:
         '200':
           description: Succesfully logged out

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -642,8 +642,17 @@ paths:
                             field: pasword
                         status: 400
   /auth/logout:
-    get:
+    post:
       operationId: auth_logout
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                client_session_id:
+                  type: string
+                  example: 5ac57685-c40f-448f-8711-70be1936fd63
       responses:
         '200':
           description: Succesfully logged out

--- a/services/web/server/src/simcore_service_webserver/director/handlers.py
+++ b/services/web/server/src/simcore_service_webserver/director/handlers.py
@@ -155,7 +155,3 @@ async def running_interactive_services_delete_all(request: web.Request) -> web.R
     userid = request.get(RQT_USERID_KEY, ANONYMOUS_USER_ID)
     await director_api.stop_services(request.app, user_id=userid)
     return web.json_response({'data': ''}, status=204)
-
-@observe(event="SIGNAL_USER_LOGOUT")
-async def delete_all_services_for_user_signal_handler(user_id: str, app: web.Application) -> None:
-    await director_api.stop_services(app, user_id=user_id)

--- a/services/web/server/src/simcore_service_webserver/director/handlers.py
+++ b/services/web/server/src/simcore_service_webserver/director/handlers.py
@@ -3,7 +3,6 @@ import logging
 from aiohttp import web
 from yarl import URL
 
-from servicelib.observer import observe
 from servicelib.request_keys import RQT_USERID_KEY
 from servicelib.rest_utils import extract_and_validate
 

--- a/services/web/server/src/simcore_service_webserver/login/handlers.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers.py
@@ -1,5 +1,4 @@
 import logging
-from asyncio import ensure_future
 
 import passwordmeter
 from aiohttp import web
@@ -138,7 +137,7 @@ async def login(request: web.Request):
 async def logout(request: web.Request):
     response = flash_response(cfg.MSG_LOGGED_OUT, "INFO")
     user_id = request.get(RQT_USERID_KEY, -1)
-    ensure_future(observer.emit("SIGNAL_USER_LOGOUT", user_id, request.app))
+    await observer.emit("SIGNAL_USER_LOGOUT", user_id, request.app)
     await forget(request, response)
     return response
 

--- a/services/web/server/src/simcore_service_webserver/login/handlers.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers.py
@@ -134,10 +134,14 @@ async def login(request: web.Request):
 
 
 @login_required
-async def logout(request: web.Request):
+async def logout(request: web.Request) -> web.Response:
     response = flash_response(cfg.MSG_LOGGED_OUT, "INFO")
     user_id = request.get(RQT_USERID_KEY, -1)
-    await observer.emit("SIGNAL_USER_LOGOUT", user_id, request.app)
+    client_session_id = None
+    if request.can_read_body:
+        body = await request.json()
+        client_session_id = body.get("client_session_id", None)
+    await observer.emit("SIGNAL_USER_LOGOUT", user_id, client_session_id, request.app)
     await forget(request, response)
     return response
 

--- a/services/web/server/src/simcore_service_webserver/login/handlers.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers.py
@@ -1,11 +1,11 @@
 import logging
-
-from aiohttp import web
-from yarl import URL
+from asyncio import ensure_future
 
 import passwordmeter
+from aiohttp import web
 from servicelib import observer
 from servicelib.rest_utils import extract_and_validate
+from yarl import URL
 
 from ..db_models import ConfirmationAction, UserRole, UserStatus
 from ..security_api import check_password, encrypt_password, forget, remember
@@ -138,7 +138,7 @@ async def login(request: web.Request):
 async def logout(request: web.Request):
     response = flash_response(cfg.MSG_LOGGED_OUT, "INFO")
     user_id = request.get(RQT_USERID_KEY, -1)
-    await observer.emit("SIGNAL_USER_LOGOUT", user_id, request.app)
+    ensure_future(observer.emit("SIGNAL_USER_LOGOUT", user_id, request.app))
     await forget(request, response)
     return response
 

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -50,7 +50,7 @@ class WebsocketRegistry:
         log.debug("user %s/tab %s removing socket from registry...", self.user_id, self.client_session_id)
         registry = get_registry(self.app)
         resources = await registry.get_resources(self._resource_key())
-        return resources[SOCKET_ID_KEY]
+        return resources.get(SOCKET_ID_KEY, None)
 
     async def remove_socket_id(self) -> None:
         log.debug("user %s/tab %s removing socket from registry...", self.user_id, self.client_session_id)

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -46,11 +46,13 @@ class WebsocketRegistry:
         await registry.set_resource(self._resource_key(), (SOCKET_ID_KEY, socket_id))
         await registry.set_key_alive(self._resource_key(), True)
 
-    async def remove_socket_id(self) -> None:
+    async def remove_socket_id(self) -> str:
         log.debug("user %s/tab %s removing socket from registry...", self.user_id, self.client_session_id)
         registry = get_registry(self.app)
+        resources = await registry.get_resources(self._resource_key())
         await registry.remove_resource(self._resource_key(), SOCKET_ID_KEY)
         await registry.set_key_alive(self._resource_key(), False, get_service_deletion_timeout(self.app))
+        return resources[SOCKET_ID_KEY]
 
     async def find_socket_ids(self) -> List[str]:
         log.debug("user %s/tab %s finding %s from registry...", self.user_id, self.client_session_id, SOCKET_ID_KEY)

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -46,13 +46,17 @@ class WebsocketRegistry:
         await registry.set_resource(self._resource_key(), (SOCKET_ID_KEY, socket_id))
         await registry.set_key_alive(self._resource_key(), True)
 
-    async def remove_socket_id(self) -> str:
+    async def get_socket_id(self) -> str:
         log.debug("user %s/tab %s removing socket from registry...", self.user_id, self.client_session_id)
         registry = get_registry(self.app)
         resources = await registry.get_resources(self._resource_key())
+        return resources[SOCKET_ID_KEY]
+
+    async def remove_socket_id(self) -> None:
+        log.debug("user %s/tab %s removing socket from registry...", self.user_id, self.client_session_id)
+        registry = get_registry(self.app)
         await registry.remove_resource(self._resource_key(), SOCKET_ID_KEY)
         await registry.set_key_alive(self._resource_key(), False, get_service_deletion_timeout(self.app))
-        return resources[SOCKET_ID_KEY]
 
     async def find_socket_ids(self) -> List[str]:
         log.debug("user %s/tab %s finding %s from registry...", self.user_id, self.client_session_id, SOCKET_ID_KEY)

--- a/services/web/server/src/simcore_service_webserver/socketio/handlers.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/handlers.py
@@ -85,7 +85,8 @@ async def user_logged_out(user_id: str, client_session_id: Optional[str], app: w
         # start by disconnecting this client if possible
         if client_session_id:
             socket_id = await rt.get_socket_id()
-            await sio.disconnect(sid=socket_id)
+            if socket_id:
+                await sio.disconnect(sid=socket_id)
 
         # now let's give a chance to all the clients to properly logout
         sockets = await rt.find_socket_ids()

--- a/services/web/server/src/simcore_service_webserver/socketio/handlers.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/handlers.py
@@ -79,13 +79,12 @@ async def disconnect_other_sockets(sio, sockets: List[str]) -> None:
 @observe(event="SIGNAL_USER_LOGOUT")
 async def user_logged_out(user_id: str, client_session_id: Optional[str], app: web.Application) -> None:
     log.debug("user %s must be disconnected", user_id)    
-
     # find the sockets related to the user
     sio = get_socket_server(app)
     with managed_resource(user_id, client_session_id, app) as rt:
         # start by disconnecting this client if possible
         if client_session_id:
-            socket_id = await rt.remove_socket_id()
+            socket_id = await rt.get_socket_id()
             await sio.disconnect(sid=socket_id)
 
         # now let's give a chance to all the clients to properly logout

--- a/services/web/server/tests/unit/with_dbs/test_change_email.py
+++ b/services/web/server/tests/unit/with_dbs/test_change_email.py
@@ -59,7 +59,7 @@ async def test_change_and_confirm(client, capsys):
         link = parse_link(out)
 
         # try new email but logout first
-        rsp = await client.get(logout_url)
+        rsp = await client.post(logout_url)
         assert rsp.url_obj.path == logout_url.path
         await assert_status(rsp, web.HTTPOk, cfg.MSG_LOGGED_OUT)
 

--- a/services/web/server/tests/unit/with_dbs/test_change_password.py
+++ b/services/web/server/tests/unit/with_dbs/test_change_password.py
@@ -75,7 +75,7 @@ async def test_success(client):
         assert cfg.MSG_PASSWORD_CHANGED in await rsp.text()
         await assert_status(rsp, web.HTTPOk, cfg.MSG_PASSWORD_CHANGED)
 
-        rsp = await client.get(logout_url)
+        rsp = await client.post(logout_url)
         assert rsp.status == 200
         assert rsp.url_obj.path == logout_url.path
 

--- a/services/web/server/tests/unit/with_dbs/test_logout.py
+++ b/services/web/server/tests/unit/with_dbs/test_logout.py
@@ -19,7 +19,7 @@ async def test_logout(client):
         await assert_status(r, web.HTTPOk)
 
         # logout
-        r = await client.get(logout_url)
+        r = await client.post(logout_url)
         assert r.url_obj.path == logout_url.path
         await assert_status(r, web.HTTPOk)
 

--- a/services/web/server/tests/unit/with_dbs/test_redis_registry.py
+++ b/services/web/server/tests/unit/with_dbs/test_redis_registry.py
@@ -142,6 +142,7 @@ async def test_websocket_manager(loop, redis_enabled_app, redis_registry, user_i
 
                 # set the socket id and check it is rightfully there
                 await rt.set_socket_id(socket_id)
+                assert await rt.get_socket_id() == socket_id
                 assert await redis_registry.get_resources(resource_key) == {"socket_id": socket_id}
                 list_of_sockets_of_user = await rt.find_socket_ids()
                 assert socket_id in list_of_sockets_of_user

--- a/services/web/server/tests/unit/with_dbs/test_reset_password.py
+++ b/services/web/server/tests/unit/with_dbs/test_reset_password.py
@@ -122,7 +122,7 @@ async def test_reset_and_confirm(client, capsys, cfg):
 
         # Try new password
         logout_url = client.app.router['auth_logout'].url_for()
-        rp = await client.get(logout_url)
+        rp = await client.post(logout_url)
         assert rp.url_obj.path == logout_url.path
         await assert_status(rp, web.HTTPUnauthorized, "Unauthorized")
 

--- a/services/web/server/tests/unit/with_dbs/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/test_resource_manager.py
@@ -223,7 +223,7 @@ async def test_websocket_disconnected_after_logout(client, logged_user, socketio
     sio2 = await socketio_client(cur_client_session_id2)
     # logout
     logout_url = client.app.router['auth_logout'].url_for()
-    r = await client.get(logout_url)
+    r = await client.post(logout_url)
     assert r.url_obj.path == logout_url.path
     await assert_status(r, expected)
 
@@ -251,7 +251,7 @@ async def test_interactive_services_removed_after_logout(loop, client, logged_us
     await open_project(client, empty_user_project["uuid"], client_session_id1)
     # logout
     logout_url = client.app.router['auth_logout'].url_for()
-    r = await client.get(logout_url)
+    r = await client.post(logout_url)
     assert r.url_obj.path == logout_url.path
     await assert_status(r, web.HTTPOk)
     # ensure sufficient time is wasted here

--- a/services/web/server/tests/unit/with_dbs/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/test_resource_manager.py
@@ -278,11 +278,11 @@ async def test_interactive_services_removed_after_logout(loop, client, logged_us
     await open_project(client, empty_user_project["uuid"], client_session_id1)
     # logout
     logout_url = client.app.router['auth_logout'].url_for()
-    r = await client.post(logout_url)
+    r = await client.post(logout_url, json={"client_session_id": client_session_id1})
     assert r.url_obj.path == logout_url.path
     await assert_status(r, web.HTTPOk)
     # ensure sufficient time is wasted here
-    await sleep(SERVICE_DELETION_DELAY+GARBAGE_COLLECTOR_INTERVAL)
+    await sleep(SERVICE_DELETION_DELAY+GARBAGE_COLLECTOR_INTERVAL+1)
     # assert dynamic service is removed
     calls = [call(client.server.app, service["service_uuid"])]
     mocked_director_api["stop_service"].assert_has_calls(calls)


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?
**fix the issue arising from logout handler taking too much time**

**description of the problem**:
1. A user logs in and logs out
2. if the user logs in again in the next 5seconds then the websocket will be disconnected, thus it is not possible to use simcore


description of the log out procedure:
1. user opens several tabs on osparc
2. user logs out in one tab
3. the webserver receives the log out command, then sends a logout signal over the websockets to the other opened tabs (so they can properly log out)
4. the webserver waits 5sec so the frontends can react, then it disconnects all the user websockets

analysis:
1. the frontend does not wait for the logout response
2. the logout procedure is too long for the frontend, user cannot wait 5secs to be properly logged out
3. the backend also disconnects websockets that were newly connected during the 5 secs timeout

description of the fix:
1. logout API endpoint is now a POST, the client session id can optionaly be passed
2. logout procedure now first disconnects the client that actively logged out if possible, then send the logout signal to the other connected clients, waits 3 seconds and disconnect their websockets. This second part happens in a fire^forget way so the frontend does not need to wait.
3. the backend does only disconnects the websockets that were connected at the time of logout
4. the logout procedure no longer directly stops dynamic services as this is taken care of by the garbage collector already.


<!-- Please give a short brief about these changes. -->


## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] **Runs in the swarm**
- [ ] If you design a new module, add your user to .github/CODEOWNERS
