### PR TITLE
Fix: Director raise an exception when tags are not following X.X.X

### DIFF
--- a/services/director/Makefile
+++ b/services/director/Makefile
@@ -62,5 +62,5 @@ clean: ## cleans all unversioned files in project and temp files create by this 
 help: ## this colorful help
 	@echo "Recipes for '${APP_NAME}':"
 	@echo ""
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_- ]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo ""

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import re
 from distutils.version import StrictVersion
 from enum import Enum
 from typing import Dict, List, Optional, Tuple
@@ -402,7 +403,11 @@ async def _find_service_tag(list_of_images: Dict, service_key: str, service_tag:
     if not service_key in list_of_images:
         raise exceptions.ServiceNotAvailableError(
             service_name=service_key, service_tag=service_tag)
-    available_tags_list = sorted(list_of_images[service_key], key=StrictVersion)
+    # filter incorrect chars
+    regex = re.compile(r'^\d+\.\d+\.\d+$')
+    filtered_tags_list = filter(regex.search, list_of_images[service_key])
+    # sort them now
+    available_tags_list = sorted(filtered_tags_list, key=StrictVersion)
     # not tags available... probably an undefined service there...
     if not available_tags_list:
         raise exceptions.ServiceNotAvailableError(service_key, service_tag)

--- a/services/director/tests/test_producer.py
+++ b/services/director/tests/test_producer.py
@@ -80,7 +80,7 @@ async def run_services(aiohttp_mock_app, configure_registry_access, configure_sc
 
 async def test_find_service_tag(loop):
     my_service_key = "myservice-key"
-    list_of_images = {my_service_key: ["2.4.0", "2.11.0", "2.8.0", "1.2.1", "1.2.0", "1.2.3"]}
+    list_of_images = {my_service_key: ["2.4.0", "2.11.0", "2.8.0", "1.2.1", "some wrong value", "latest", "1.2.0", "1.2.3"]}
     with pytest.raises(exceptions.ServiceNotAvailableError):
         await producer._find_service_tag(list_of_images, "some_wrong_key", None)
     with pytest.raises(exceptions.ServiceNotAvailableError):


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
fix an issue where services provide other tags than x.x.x and the director raise an exception about it.

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
