### PR TITLE
portainer compatible fix

### DIFF
--- a/packages/postgres-database/tests/docker-compose.yml
+++ b/packages/postgres-database/tests/docker-compose.yml
@@ -19,15 +19,21 @@ services:
         "-c", "log_connections=true",
         "-c", "log_disconnections=true",
         "-c", "log_duration=true",
-        "-c", "log_line_prefix=[%p] [%a] [%c] [%x] "
+        "-c", "log_line_prefix=[%p] [%a] [%c] [%x] ",
+        "-c", "tcp_keepalives_idle=600",
+        "-c", "tcp_keepalives_interval=600",
+        "-c", "tcp_keepalives_count=5"
       ]
-    sysctls:
-      # NOTES: these values are needed here because docker swarm kills long running idle 
-      # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
-      # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
-      - net.ipv4.tcp_keepalive_intvl=600
-      - net.ipv4.tcp_keepalive_probes=9
-      - net.ipv4.tcp_keepalive_time=600
+    # NOTES: this is not yet compatible with portainer deployment but could work also for other containers
+    # works with Docker 19.03 and not yet with Portainer 1.23.0 (see https://github.com/portainer/portainer/issues/3551)
+    # in the meantime postgres allows to set a configuration through CLI.
+    # sysctls:
+    #   # NOTES: these values are needed here because docker swarm kills long running idle 
+    #   # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
+    #   # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
+    #   - net.ipv4.tcp_keepalive_intvl=600
+    #   - net.ipv4.tcp_keepalive_probes=9
+    #   - net.ipv4.tcp_keepalive_time=600    
   adminer:
     image: adminer
     ports:

--- a/packages/service-library/tests/with_postgres/docker-compose.yml
+++ b/packages/service-library/tests/with_postgres/docker-compose.yml
@@ -9,13 +9,17 @@ services:
       POSTGRES_PASSWORD: secret
     ports:
       - '5432:5432'
-    sysctls:
-      # NOTES: these values are needed here because docker swarm kills long running idle 
-      # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
-      # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
-      - net.ipv4.tcp_keepalive_intvl=600
-      - net.ipv4.tcp_keepalive_probes=9
-      - net.ipv4.tcp_keepalive_time=600
+    # NOTES: this is not yet compatible with portainer deployment but could work also for other containers
+    # works with Docker 19.03 and not yet with Portainer 1.23.0 (see https://github.com/portainer/portainer/issues/3551)
+    # in the meantime postgres allows to set a configuration through CLI.
+    # sysctls:
+    #   # NOTES: these values are needed here because docker swarm kills long running idle 
+    #   # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
+    #   # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
+    #   - net.ipv4.tcp_keepalive_intvl=600
+    #   - net.ipv4.tcp_keepalive_probes=9
+    #   - net.ipv4.tcp_keepalive_time=600
+    command: postgres -c tcp_keepalives_idle=600 -c tcp_keepalives_interval=600 -c tcp_keepalives_count=5
   adminer:
     image: adminer
     restart: always

--- a/packages/simcore-sdk/tests/unit/docker-compose.yml
+++ b/packages/simcore-sdk/tests/unit/docker-compose.yml
@@ -9,9 +9,14 @@ services:
       POSTGRES_PASSWORD: ${TEST_POSTGRES_PASSWORD}
     ports:
       - '5432:5432'
-    sysctls:
-      # NOTES: these values are needed here because docker swarm kills long running idle 
-      # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
-      - net.ipv4.tcp_keepalive_intvl=600
-      - net.ipv4.tcp_keepalive_probes=15
-      - net.ipv4.tcp_keepalive_time=600
+    # NOTES: this is not yet compatible with portainer deployment but could work also for other containers
+    # works with Docker 19.03 and not yet with Portainer 1.23.0 (see https://github.com/portainer/portainer/issues/3551)
+    # in the meantime postgres allows to set a configuration through CLI.
+    # sysctls:
+    #   # NOTES: these values are needed here because docker swarm kills long running idle 
+    #   # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
+    #   # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
+    #   - net.ipv4.tcp_keepalive_intvl=600
+    #   - net.ipv4.tcp_keepalive_probes=9
+    #   - net.ipv4.tcp_keepalive_time=600
+    command: postgres -c tcp_keepalives_idle=600 -c tcp_keepalives_interval=600 -c tcp_keepalives_count=5

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -153,7 +153,7 @@ services:
 
   postgres:
     image: postgres:10.11
-    init: true
+    init: true    
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -164,13 +164,17 @@ services:
       - default
       - interactive_services_subnet
       - computational_services_subnet
-    sysctls:
-      # NOTES: these values are needed here because docker swarm kills long running idle 
-      # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
-      # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
-      - net.ipv4.tcp_keepalive_intvl=600
-      - net.ipv4.tcp_keepalive_probes=9
-      - net.ipv4.tcp_keepalive_time=600
+    # NOTES: this is not yet compatible with portainer deployment but could work also for other containers
+    # works with Docker 19.03 and not yet with Portainer 1.23.0 (see https://github.com/portainer/portainer/issues/3551)
+    # in the meantime postgres allows to set a configuration through CLI.
+    # sysctls:
+    #   # NOTES: these values are needed here because docker swarm kills long running idle 
+    #   # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
+    #   # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
+    #   - net.ipv4.tcp_keepalive_intvl=600
+    #   - net.ipv4.tcp_keepalive_probes=9
+    #   - net.ipv4.tcp_keepalive_time=600
+    command: postgres -c tcp_keepalives_idle=600 -c tcp_keepalives_interval=600 -c tcp_keepalives_count=5
 
   redis:
     image: redis:5.0-alpine

--- a/services/sidecar/tests/docker-compose.yml
+++ b/services/sidecar/tests/docker-compose.yml
@@ -9,13 +9,17 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-scu}
     ports:
       - '5432:5432'
-    sysctls:
-      # NOTES: these values are needed here because docker swarm kills long running idle 
-      # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
-      # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
-      - net.ipv4.tcp_keepalive_intvl=600
-      - net.ipv4.tcp_keepalive_probes=9
-      - net.ipv4.tcp_keepalive_time=600
+    # NOTES: this is not yet compatible with portainer deployment but could work also for other containers
+    # works with Docker 19.03 and not yet with Portainer 1.23.0 (see https://github.com/portainer/portainer/issues/3551)
+    # in the meantime postgres allows to set a configuration through CLI.
+    # sysctls:
+    #   # NOTES: these values are needed here because docker swarm kills long running idle 
+    #   # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
+    #   # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
+    #   - net.ipv4.tcp_keepalive_intvl=600
+    #   - net.ipv4.tcp_keepalive_probes=9
+    #   - net.ipv4.tcp_keepalive_time=600
+    command: postgres -c tcp_keepalives_idle=600 -c tcp_keepalives_interval=600 -c tcp_keepalives_count=5
   adminer:
     image: adminer
     restart: always

--- a/services/storage/tests/docker-compose.yml
+++ b/services/storage/tests/docker-compose.yml
@@ -9,13 +9,17 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin}
     ports:
       - '5432:5432'
-    sysctls:
-      # NOTES: these values are needed here because docker swarm kills long running idle 
-      # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
-      # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
-      - net.ipv4.tcp_keepalive_intvl=600
-      - net.ipv4.tcp_keepalive_probes=9
-      - net.ipv4.tcp_keepalive_time=600
+    # NOTES: this is not yet compatible with portainer deployment but could work also for other containers
+    # works with Docker 19.03 and not yet with Portainer 1.23.0 (see https://github.com/portainer/portainer/issues/3551)
+    # in the meantime postgres allows to set a configuration through CLI.
+    # sysctls:
+    #   # NOTES: these values are needed here because docker swarm kills long running idle 
+    #   # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
+    #   # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
+    #   - net.ipv4.tcp_keepalive_intvl=600
+    #   - net.ipv4.tcp_keepalive_probes=9
+    #   - net.ipv4.tcp_keepalive_time=600
+    command: postgres -c tcp_keepalives_idle=600 -c tcp_keepalives_interval=600 -c tcp_keepalives_count=5
   # adminer:
   #   image: adminer
   #   restart: always

--- a/services/web/server/tests/unit/with_dbs/docker-compose.debug.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose.debug.yml
@@ -10,13 +10,17 @@ services:
       POSTGRES_DB: ${TEST_POSTGRES_DB:-test}
     ports:
       - '5432:5432'
-    sysctls:
-      # NOTES: these values are needed here because docker swarm kills long running idle 
-      # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
-      # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
-      - net.ipv4.tcp_keepalive_intvl=600
-      - net.ipv4.tcp_keepalive_probes=9
-      - net.ipv4.tcp_keepalive_time=600
+    # NOTES: this is not yet compatible with portainer deployment but could work also for other containers
+    # works with Docker 19.03 and not yet with Portainer 1.23.0 (see https://github.com/portainer/portainer/issues/3551)
+    # in the meantime postgres allows to set a configuration through CLI.
+    # sysctls:
+    #   # NOTES: these values are needed here because docker swarm kills long running idle 
+    #   # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
+    #   # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
+    #   - net.ipv4.tcp_keepalive_intvl=600
+    #   - net.ipv4.tcp_keepalive_probes=9
+    #   - net.ipv4.tcp_keepalive_time=600
+    command: postgres -c tcp_keepalives_idle=600 -c tcp_keepalives_interval=600 -c tcp_keepalives_count=5
   # ONLY FOR DEBUGGING
   adminer:
     image: adminer

--- a/services/web/server/tests/unit/with_dbs/docker-compose.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose.yml
@@ -9,13 +9,17 @@ services:
       POSTGRES_PASSWORD: ${TEST_POSTGRES_PASSWORD}
     ports:
       - '5432:5432'
-    sysctls:
-      # NOTES: these values are needed here because docker swarm kills long running idle 
-      # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
-      # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
-      - net.ipv4.tcp_keepalive_intvl=600
-      - net.ipv4.tcp_keepalive_probes=9
-      - net.ipv4.tcp_keepalive_time=600
+    # NOTES: this is not yet compatible with portainer deployment but could work also for other containers
+    # works with Docker 19.03 and not yet with Portainer 1.23.0 (see https://github.com/portainer/portainer/issues/3551)
+    # in the meantime postgres allows to set a configuration through CLI.
+    # sysctls:
+    #   # NOTES: these values are needed here because docker swarm kills long running idle 
+    #   # connections by default after 15 minutes see https://github.com/moby/moby/issues/31208
+    #   # info about these values are here https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html
+    #   - net.ipv4.tcp_keepalive_intvl=600
+    #   - net.ipv4.tcp_keepalive_probes=9
+    #   - net.ipv4.tcp_keepalive_time=600
+    command: postgres -c tcp_keepalives_idle=600 -c tcp_keepalives_interval=600 -c tcp_keepalives_count=5
 
   redis:
     image: redis:5.0-alpine


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
The last fix, although valid from docker 19.03 is not compatible yet with portainer [see here](https://github.com/portainer/portainer/issues/3551).
Luckily there is an alternative to configure postgreSQL itself to override the system defaults.

## Related issue number

<!-- Please add #issues -->
fixes #1242 

## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
