### PR TITLE
webserver does not respond when many logs are coming in from rabbitMQ

### DIFF
--- a/services/web/server/src/simcore_service_webserver/computation_subscribe.py
+++ b/services/web/server/src/simcore_service_webserver/computation_subscribe.py
@@ -67,6 +67,8 @@ async def rabbit_message_handler(message: aio_pika.IncomingMessage, app: web.App
     with message.process():
         data = json.loads(message.body)
         await parse_rabbit_message_data(app, data)
+        # NOTE: this allows the webserver to breath if a lot of messages are entering
+        await asyncio.sleep(2)
 
 async def subscribe(app: web.Application) -> None:
     # TODO: catch and deal with missing connections:


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
re-adds a sleep time when webserver is processing messages coming from rabbitMQ.
Since an issue arose that production becomes unresponsive when the CC-Human template is running this could be the problem.

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
