### PR TITLE
Is31/stabilise platform

### DIFF
--- a/ci/build/test-images
+++ b/ci/build/test-images
@@ -3,7 +3,8 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+export DOCKER_IMAGE_TAG
 
 pull_images() {
     {

--- a/ci/deploy/dockerhub-deploy
+++ b/ci/deploy/dockerhub-deploy
@@ -12,7 +12,8 @@ if [ ! -v TAG_PREFIX ]; then
 fi
 
 # pull the current tested build
-export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+export DOCKER_IMAGE_TAG
 make pull-version tag-local
 
 # show current images on system
@@ -20,11 +21,13 @@ echo "## Before push"
 make info-images
 
 # re-tag build
-export DOCKER_IMAGE_TAG="$TAG_PREFIX-latest"
+DOCKER_IMAGE_TAG="$TAG_PREFIX-latest"
+export DOCKER_IMAGE_TAG
 make push-version
 
 # re-tag build to master-github-DATE.GIT_SHA
-export DOCKER_IMAGE_TAG=$TAG_PREFIX-$(date --utc +"%Y-%m-%d--%H-%M").$(git rev-parse HEAD)
+DOCKER_IMAGE_TAG=$TAG_PREFIX-$(date --utc +"%Y-%m-%d--%H-%M").$(git rev-parse HEAD)
+export DOCKER_IMAGE_TAG
 make push-version
 
 # show update of images on system

--- a/ci/deploy/dockerhub-release
+++ b/ci/deploy/dockerhub-release
@@ -17,7 +17,8 @@ export ORG=${DOCKER_REGISTRY}
 export REPO="webserver"
 # staging-github-DATE.GIT_SHA
 export TAG_PATTERN="^${TAG_PREFIX}-.+\..+"
-export DOCKER_IMAGE_TAG=$(./ci/helpers/find_staging_version | awk 'END{print}') || exit $?
+DOCKER_IMAGE_TAG=$(./ci/helpers/find_staging_version | awk 'END{print}') || exit $?
+export DOCKER_IMAGE_TAG
 make pull-version tag-local
 
 # show current images on system
@@ -25,7 +26,8 @@ echo "## Before push"
 make info-images
 
 # re-tag staging to {GIT_TAG}-DATE.GIT_SHA
-export DOCKER_IMAGE_TAG=${GIT_TAG}-$(date --utc +"%Y-%m-%d--%H-%M").$(git rev-parse HEAD)
+DOCKER_IMAGE_TAG=${GIT_TAG}-$(date --utc +"%Y-%m-%d--%H-%M").$(git rev-parse HEAD)
+export DOCKER_IMAGE_TAG
 make push-version push-latest
 
 echo "## After push"

--- a/ci/deploy/dockerhub-test-images
+++ b/ci/deploy/dockerhub-test-images
@@ -6,7 +6,8 @@ IFS=$'\n\t'
 bash ci/helpers/dockerhub_login
 
 # define the local image tag
-export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+export DOCKER_IMAGE_TAG
 
 # push the local cache
 make push-cache

--- a/ci/github/integration-testing/simcore-sdk
+++ b/ci/github/integration-testing/simcore-sdk
@@ -3,16 +3,15 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # in case it's a Pull request, the env are never available, default to itisfoundation to get a maybe not too old version for caching
-export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
-
-FOLDER_CHECKS=(packages/ simcore-sdk storage/ simcore-sdk .travis.yml)
+DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+export DOCKER_IMAGE_TAG
 
 install() {
     bash ci/helpers/ensure_python_pip
     pushd packages/simcore-sdk; pip3 install -r requirements/ci.txt; popd;
     pip list -v
     # pull the test images if registry is set up, else build the images
-    make pull-version || ((make pull-cache || true) && make build tag-version)
+    make pull-version || ( (make pull-cache || true) && make build tag-version)
     make info-images
     # pip3 install services/storage/client-sdk/python
 }

--- a/ci/github/integration-testing/webserver
+++ b/ci/github/integration-testing/webserver
@@ -4,13 +4,14 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # in case it's a Pull request, the env are never available, default to itisfoundation to get a maybe not too old version for caching
-export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+export DOCKER_IMAGE_TAG
 
 install() {
     bash ci/helpers/ensure_python_pip
     pushd services/web/server; pip3 install -r requirements/ci.txt; popd;
     pip list -v
-    make pull-version || ((make pull-cache || true) && make build tag-version)
+    make pull-version || ( (make pull-cache || true) && make build tag-version)
     make info-images
 }
 

--- a/ci/github/system-testing/e2e
+++ b/ci/github/system-testing/e2e
@@ -5,13 +5,14 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # in case it's a Pull request, the env are never available, default to itisfoundation to get a maybe not too old version for caching
-export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+export DOCKER_IMAGE_TAG
 
 install() {
     echo "--------------- installing psql client..."
-    sudo apt install -y postgresql-client
+    /bin/bash -c 'sudo apt install -y postgresql-client'
     echo "--------------- getting simcore docker images..."
-    make pull-version || ((make pull-cache || true) && make build tag-version)
+    make pull-version || ( (make pull-cache || true) && make build tag-version)
     make info-images
     # configure simcore for testing with a private registry
     bash tests/e2e/setup_env_insecure_registry
@@ -21,6 +22,7 @@ install() {
     echo "-------------- installing test framework..."
     # create a python venv and activate
     make .venv
+    # shellcheck disable=SC1091
     source .venv/bin/activate
     bash ci/helpers/ensure_python_pip
     pushd tests/e2e;
@@ -46,10 +48,11 @@ recover_artifacts() {
 
     # get docker logs
     mkdir simcore_logs
-    (docker service logs simcore_webserver > simcore_logs/webserver.log) || true
-    (docker service logs simcore_director > simcore_logs/director.log ) || true
-    (docker service logs simcore_storage > simcore_logs/storage.log) || true
-    (docker service logs simcore_sidecar > simcore_logs/sidecar.log) || true
+    (docker service logs --timestamps simcore_webserver > simcore_logs/webserver.log) || true
+    (docker service logs --timestamps simcore_director > simcore_logs/director.log ) || true
+    (docker service logs --timestamps simcore_storage > simcore_logs/storage.log) || true
+    (docker service logs --timestamps simcore_sidecar > simcore_logs/sidecar.log) || true
+    (docker service logs --timestamps simcore_catalog > simcore_logs/catalog.log) || true
 }
 
 clean_up() {

--- a/ci/github/system-testing/swarm-deploy
+++ b/ci/github/system-testing/swarm-deploy
@@ -16,6 +16,8 @@ install() {
     bash ci/helpers/ensure_python_pip
     pip3 install -r tests/swarm-deploy/requirements.txt
     make pull-version || ((make pull-cache || true) && make build tag-version)
+    make .env
+    echo WEBSERVER_DB_INITTABLES=1 >> .env
     pip list -v
     make info-images
 }

--- a/ci/github/system-testing/swarm-deploy
+++ b/ci/github/system-testing/swarm-deploy
@@ -10,12 +10,13 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # in case it's a Pull request, the env are never available, default to itisfoundation to get a maybe not too old version for caching
-export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+export DOCKER_IMAGE_TAG
 
 install() {
     bash ci/helpers/ensure_python_pip
     pip3 install -r tests/swarm-deploy/requirements.txt
-    make pull-version || ((make pull-cache || true) && make build tag-version)
+    make pull-version || ( (make pull-cache || true) && make build tag-version)
     make .env
     echo WEBSERVER_DB_INITTABLES=1 >> .env
     pip list -v

--- a/ci/github/unit-testing/api
+++ b/ci/github/unit-testing/api
@@ -3,8 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-FOLDER_CHECKS=(api/ .travis.yml)
-
 install() {
     bash ci/helpers/ensure_python_pip
     pip3 install --requirement api/tests/requirements.txt

--- a/ci/github/unit-testing/catalog
+++ b/ci/github/unit-testing/catalog
@@ -3,8 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-FOLDER_CHECKS=(api/ catalog packages/ .travis.yml)
-
 install() {
     bash ci/helpers/ensure_python_pip
     pushd services/catalog; pip3 install -r requirements/ci.txt; popd

--- a/ci/github/unit-testing/director
+++ b/ci/github/unit-testing/director
@@ -3,8 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-FOLDER_CHECKS=(api/ director packages/ .travis.yml)
-
 install() {
     bash ci/helpers/ensure_python_pip
     pushd services/director; pip3 install -r requirements/ci.txt; popd

--- a/ci/github/unit-testing/frontend
+++ b/ci/github/unit-testing/frontend
@@ -3,8 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-FOLDER_CHECKS=(js eslintrc json .travis.yml)
-
 install() {
     npm install
     make -C services/web/client clean

--- a/ci/github/unit-testing/python-linting
+++ b/ci/github/unit-testing/python-linting
@@ -3,8 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-FOLDER_CHECKS=(.py .pylintrc .travis.yml)
-
 install() {
     bash ci/helpers/ensure_python_pip
     pip3 install pylint~=2.0

--- a/ci/github/unit-testing/service-library
+++ b/ci/github/unit-testing/service-library
@@ -3,8 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-FOLDER_CHECKS=(packages/ service-library .travis.yml)
-
 install() {
     bash ci/helpers/ensure_python_pip
     pushd packages/service-library; pip3 install -r requirements/ci.txt; popd;

--- a/ci/github/unit-testing/sidecar
+++ b/ci/github/unit-testing/sidecar
@@ -3,8 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-FOLDER_CHECKS=(api/ sidecar packages/ .travis.yml)
-
 install() {
     bash ci/helpers/ensure_python_pip;
     pushd services/sidecar; pip3 install -r requirements/ci.txt; popd;

--- a/ci/github/unit-testing/simcore-sdk
+++ b/ci/github/unit-testing/simcore-sdk
@@ -3,9 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # in case it's a Pull request, the env are never available, default to itisfoundation to get a maybe not too old version for caching
-export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
-
-FOLDER_CHECKS=(packages/ simcore-sdk storage/ simcore-sdk .travis.yml)
+DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+export DOCKER_IMAGE_TAG
 
 install() {
     bash ci/helpers/ensure_python_pip

--- a/ci/github/unit-testing/storage
+++ b/ci/github/unit-testing/storage
@@ -3,8 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-FOLDER_CHECKS=(api/ storage packages/ .travis.yml)
-
 install() {
     bash ci/helpers/ensure_python_pip
     pushd services/storage; pip3 install -r requirements/ci.txt; popd

--- a/ci/github/unit-testing/webserver
+++ b/ci/github/unit-testing/webserver
@@ -3,8 +3,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-FOLDER_CHECKS=(api/ webserver packages/ services/web .travis.yml)
-
 install() {
     bash ci/helpers/ensure_python_pip
     pushd services/web/server; pip3 install -r requirements/ci.txt; popd;

--- a/ci/helpers/build_docker_image_tag
+++ b/ci/helpers/build_docker_image_tag
@@ -28,6 +28,6 @@ else
     image_tag=$(git rev-parse --abbrev-ref HEAD)
 fi
 
-slugified_name=$(exec ci/helpers/slugify_name $image_tag)
+slugified_name=$(exec ci/helpers/slugify_name "$image_tag")
 
 echo "$slugified_name-testbuild-latest"

--- a/ci/helpers/dockerhub_login
+++ b/ci/helpers/dockerhub_login
@@ -19,7 +19,7 @@ fi
 
 # only upstream is allowed to push to itisfoundation repo
 if [ "${OWNER,,}" != "itisfoundation" ] &&\
-    ([ ! -v DOCKER_REGISTRY ] || [ -z $DOCKER_REGISTRY ] || [ "$DOCKER_REGISTRY" = "itisfoundation" ]); then
+    { [ ! -v DOCKER_REGISTRY ] || [ -z "${DOCKER_REGISTRY}" ] || [ "$DOCKER_REGISTRY" = "itisfoundation" ]; }; then
     echo "## ERROR: it is not allowed to push to the main dockerhub repository from a fork!"
     echo "## Please adapt your CI-defined environs (DOCKER_USERNAME, DOCKER_PASSWORD, DOCKER_REGISTRY)"
     exit 1

--- a/ci/helpers/ensure_python_pip
+++ b/ci/helpers/ensure_python_pip
@@ -11,12 +11,12 @@ IFS=$'\n\t'
 # Pin pip version to a compatible release https://www.python.org/dev/peps/pep-0440/#compatible-release
 PIP_VERSION=19.3.1
 
-echo "INFO:" $(python --version) "@" $(which python)
+echo "INFO:" "$(python --version)" "@" "$(command -v python)"
 
 # installs pip if not in place
 python -m ensurepip
 
-echo "INFO:" $(pip --version) "@" $(which pip)
+echo "INFO:" "$(pip --version)" "@" "$(command -v pip)"
 
 pip3 install --upgrade \
   pip~=$PIP_VERSION \

--- a/ci/helpers/find_staging_version
+++ b/ci/helpers/find_staging_version
@@ -8,18 +8,18 @@ set -euo pipefail
 IFS=$'\n\t'
 
 echo "Retrieving SHA for tag ${GIT_TAG}"
-GIT_COMMIT_SHA=$(git show-ref -s ${GIT_TAG})
+GIT_COMMIT_SHA=$(git show-ref -s "${GIT_TAG}")
 echo "Found SHA for tag ${GIT_COMMIT_SHA}"
 
 # get token
 echo "Retrieving token ..."
-TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
+TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'"${DOCKER_USERNAME}"'", "password": "'"${DOCKER_PASSWORD}"'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
 
 # output images & tags
 echo
 echo "Images and tags for organization: ${ORG}"
 echo "in repo ${REPO}"
-IMAGE_TAGS=$(curl -s -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/${ORG}/${REPO}/tags/?page_size=100 | jq -r '.results|.[]|.name')
+IMAGE_TAGS=$(curl -s -H "Authorization: JWT ${TOKEN}" https://hub.docker.com/v2/repositories/"${ORG}"/"${REPO}"/tags/?page_size=100 | jq -r '.results|.[]|.name')
 for j in ${IMAGE_TAGS}
 do
     if [[ ${j} =~ ${TAG_PATTERN} ]]; then

--- a/ci/helpers/slugify_name
+++ b/ci/helpers/slugify_name
@@ -4,7 +4,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 slugify () {
-    echo "$1" | iconv -t ascii//TRANSLIT | sed -r s/[~\^]+//g | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z
+    echo "$1" | iconv -t ascii//TRANSLIT | sed -r s/[~$'\^']+//g | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z
 }
 
-echo $(slugify $1)
+"slugify $1"

--- a/ci/helpers/slugify_name
+++ b/ci/helpers/slugify_name
@@ -7,4 +7,4 @@ slugify () {
     echo "$1" | iconv -t ascii//TRANSLIT | sed -r s/[~$'\^']+//g | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z
 }
 
-"slugify $1"
+echo "$(slugify $1)"

--- a/ci/travis/system-testing/swarm-deploy
+++ b/ci/travis/system-testing/swarm-deploy
@@ -10,7 +10,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # in case it's a Pull request, the env are never available, default to itisfoundation to get a maybe not too old version for caching
-export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag)
+export DOCKER_IMAGE_TAG
 
 before_install() {
     bash ci/travis/helpers/update_docker
@@ -21,7 +22,7 @@ before_install() {
 install() {
     bash ci/helpers/ensure_python_pip
     pip3 install -r tests/swarm-deploy/requirements.txt
-    make pull-version || ((make pull-cache || true) && make build tag-version)
+    make pull-version || ( (make pull-cache || true) && make build tag-version)
     make .env
     echo WEBSERVER_DB_INITTABLES=1 >> .env
 }

--- a/ci/travis/system-testing/swarm-deploy
+++ b/ci/travis/system-testing/swarm-deploy
@@ -22,6 +22,8 @@ install() {
     bash ci/helpers/ensure_python_pip
     pip3 install -r tests/swarm-deploy/requirements.txt
     make pull-version || ((make pull-cache || true) && make build tag-version)
+    make .env
+    echo WEBSERVER_DB_INITTABLES=1 >> .env
 }
 
 before_script() {
@@ -30,7 +32,7 @@ before_script() {
 }
 
 script() {
-    pytest -v tests/swarm-deploy
+    pytest  --color=yes --cov-report=term-missing -v tests/swarm-deploy
 }
 
 after_success() {

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -82,9 +82,10 @@ services:
 
   sidecar:
     image: ${DOCKER_REGISTRY:-itisfoundation}/sidecar:${DOCKER_IMAGE_TAG:-latest}
-    init: true
+    init: true    
     deploy:
       mode: replicated
+      replicas: 4
       endpoint_mode: dnsrr
       resources:
         reservations:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -82,7 +82,7 @@ services:
 
   sidecar:
     image: ${DOCKER_REGISTRY:-itisfoundation}/sidecar:${DOCKER_IMAGE_TAG:-latest}
-    init: true    
+    init: true
     deploy:
       mode: replicated
       replicas: 4

--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -9,7 +9,7 @@ psycopg2-binary     # enforces binary version
 sqlalchemy>=1.3.3   # https://nvd.nist.gov/vuln/detail/CVE-2019-7164
 
 
-aio-pika==2.9.0     # TODO: upgrade code before !!
+aio-pika
 aiohttp
 aiohttp_jinja2
 aiohttp_session[secure]

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -18,12 +18,12 @@ aiozipkin==0.6.0
 amqp==2.4.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
 async-timeout==3.0.1      # via aiohttp, aioredis
-asyncpg==0.18.3
-attrs==19.1.0
+asyncpg==0.18.3           # via -r _base.in (line 22)
+attrs==19.1.0             # via -r ../../../../packages/service-library/requirements/_base.in (line 19), aiohttp, jsonschema, openapi-core
 billiard==3.6.0.0         # via celery
-celery==4.3.0
+celery==4.3.0             # via -r _base.in (line 23)
 cffi==1.12.3              # via cryptography
-change-case==0.5.2
+change-case==0.5.2        # via -r _base.in (line 25)
 chardet==3.0.4            # via aiohttp
 cryptography==2.6.1
 expiringdict==1.2.0
@@ -32,16 +32,16 @@ idna-ssl==1.1.0           # via aiohttp
 idna==2.8                 # via idna-ssl, yarl
 importlib-metadata==0.23  # via jsonschema
 isodate==0.6.0            # via openapi-core
-jinja-app-loader==1.0.2
+jinja-app-loader==1.0.2   # via -r _base.in (line 27)
 jinja2==2.10.1            # via aiohttp-jinja2, aiohttp-swagger
-jsondiff==1.1.2
-jsonschema==3.2.0
+jsondiff==1.1.2           # via -r _base.in (line 28)
+jsonschema==3.2.0         # via -r ../../../../packages/service-library/requirements/_base.in (line 15), openapi-spec-validator
 kombu==4.5.0              # via celery
 lazy-object-proxy==1.4.3  # via openapi-core
 markupsafe==1.1.1         # via jinja2
 more-itertools==7.2.0     # via zipp
 multidict==4.5.2          # via aiohttp, yarl
-openapi-core==0.12.0
+openapi-core==0.12.0      # via -r ../../../../packages/service-library/requirements/_base.in (line 16)
 openapi-spec-validator==0.2.8  # via openapi-core
 passlib==1.7.1
 pika==0.10.0              # via aio-pika
@@ -50,7 +50,7 @@ psycopg2-binary==2.8.4
 pycparser==2.19           # via cffi
 pyrsistent==0.15.6        # via jsonschema
 python-engineio==3.9.3    # via python-socketio
-python-socketio==4.3.1
+python-socketio==4.3.1    # via -r _base.in (line 31)
 pytz==2019.1              # via celery
 pyyaml==5.3
 semantic-version==2.6.0
@@ -58,15 +58,15 @@ shortuuid==0.5.0          # via aio-pika
 six==1.12.0               # via cryptography, isodate, jsonschema, openapi-core, openapi-spec-validator, pyrsistent, python-engineio, python-socketio, tenacity
 sqlalchemy[postgresql_psycopg2binary]==1.3.4
 strict-rfc3339==0.7       # via openapi-core
-tenacity==6.0.0
-trafaret-config==2.0.2
-trafaret==1.2.0
+tenacity==6.0.0           # via -r ../../../../packages/service-library/requirements/_base.in (line 18), -r _base.in (line 33)
+trafaret-config==2.0.2    # via -r _base.in (line 35)
+trafaret==1.2.0           # via -r ../../../../packages/service-library/requirements/_base.in (line 20), -r _base.in (line 34), trafaret-config
 typing-extensions==3.7.2  # via aiohttp
 typing==3.7.4.1           # via expiringdict
-ujson==1.35
+ujson==1.35               # via -r ../../../../packages/service-library/requirements/_base.in (line 13), aiohttp-swagger
 vine==1.3.0               # via amqp, celery
-werkzeug==0.16.0
-yarl==1.3.0
+werkzeug==0.16.0          # via -r ../../../../packages/service-library/requirements/_base.in (line 14)
+yarl==1.3.0               # via -r ../../../../packages/postgres-database/requirements/_base.in (line 9), aio-pika, aiohttp, aiormq
 zipp==1.0.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -4,37 +4,38 @@
 #
 #    pip-compile --output-file=_base.txt _base.in
 #
-aio-pika==2.9.0
-aiodebug==1.1.2
-aiohttp-jinja2==1.1.1
-aiohttp-security==0.4.0
-aiohttp-session[secure]==2.7.0
-aiohttp-swagger[performance]==1.0.14
-aiohttp==3.6.2
-aiopg[sa]==1.0.0
-aioredis==1.3.0
-aiosmtplib==1.0.5
-aiozipkin==0.6.0
+aio-pika==6.5.2           # via -r _base.in (line 12)
+aiodebug==1.1.2           # via -r _base.in (line 34)
+aiohttp-jinja2==1.1.1     # via -r _base.in (line 14)
+aiohttp-security==0.4.0   # via -r _base.in (line 16)
+aiohttp-session[secure]==2.7.0  # via -r _base.in (line 15)
+aiohttp-swagger[performance]==1.0.14  # via -r _base.in (line 17)
+aiohttp==3.6.2            # via -r ../../../../packages/service-library/requirements/_base.in (line 10), -r _base.in (line 13), aiohttp-jinja2, aiohttp-security, aiohttp-session, aiohttp-swagger, aiozipkin
+aiopg[sa]==1.0.0          # via -r ../../../../packages/service-library/requirements/_base.in (line 11), -r _base.in (line 18)
+aioredis==1.3.0           # via -r _base.in (line 19)
+aiormq==3.2.1             # via aio-pika
+aiosmtplib==1.0.5         # via -r _base.in (line 20)
+aiozipkin==0.6.0          # via -r ../../../../packages/service-library/requirements/_base.in (line 12)
 amqp==2.4.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
 async-timeout==3.0.1      # via aiohttp, aioredis
-asyncpg==0.18.3           # via -r _base.in (line 22)
+asyncpg==0.18.3           # via -r _base.in (line 21)
 attrs==19.1.0             # via -r ../../../../packages/service-library/requirements/_base.in (line 19), aiohttp, jsonschema, openapi-core
 billiard==3.6.0.0         # via celery
-celery==4.3.0             # via -r _base.in (line 23)
+celery==4.3.0             # via -r _base.in (line 22)
 cffi==1.12.3              # via cryptography
-change-case==0.5.2        # via -r _base.in (line 25)
+change-case==0.5.2        # via -r _base.in (line 24)
 chardet==3.0.4            # via aiohttp
-cryptography==2.6.1
-expiringdict==1.2.0
+cryptography==2.6.1       # via -r _base.in (line 23), aiohttp-session
+expiringdict==1.2.0       # via -r _base.in (line 25)
 hiredis==1.0.1            # via aioredis
 idna-ssl==1.1.0           # via aiohttp
 idna==2.8                 # via idna-ssl, yarl
 importlib-metadata==0.23  # via jsonschema
 isodate==0.6.0            # via openapi-core
-jinja-app-loader==1.0.2   # via -r _base.in (line 27)
+jinja-app-loader==1.0.2   # via -r _base.in (line 26)
 jinja2==2.10.1            # via aiohttp-jinja2, aiohttp-swagger
-jsondiff==1.1.2           # via -r _base.in (line 28)
+jsondiff==1.1.2           # via -r _base.in (line 27)
 jsonschema==3.2.0         # via -r ../../../../packages/service-library/requirements/_base.in (line 15), openapi-spec-validator
 kombu==4.5.0              # via celery
 lazy-object-proxy==1.4.3  # via openapi-core
@@ -43,24 +44,23 @@ more-itertools==7.2.0     # via zipp
 multidict==4.5.2          # via aiohttp, yarl
 openapi-core==0.12.0      # via -r ../../../../packages/service-library/requirements/_base.in (line 16)
 openapi-spec-validator==0.2.8  # via openapi-core
-passlib==1.7.1
-pika==0.10.0              # via aio-pika
-prometheus-client==0.7.1
-psycopg2-binary==2.8.4
+pamqp==2.3.0              # via aiormq
+passlib==1.7.1            # via -r _base.in (line 28)
+prometheus-client==0.7.1  # via -r ../../../../packages/service-library/requirements/_base.in (line 17)
+psycopg2-binary==2.8.4    # via -r ../../../../packages/service-library/requirements/_base.in (line 7), -r _base.in (line 8), aiopg, sqlalchemy
 pycparser==2.19           # via cffi
 pyrsistent==0.15.6        # via jsonschema
 python-engineio==3.9.3    # via python-socketio
-python-socketio==4.3.1    # via -r _base.in (line 31)
+python-socketio==4.3.1    # via -r _base.in (line 29)
 pytz==2019.1              # via celery
-pyyaml==5.3
-semantic-version==2.6.0
-shortuuid==0.5.0          # via aio-pika
+pyyaml==5.3               # via -r ../../../../packages/service-library/requirements/_base.in (line 6), aiohttp-swagger, openapi-spec-validator, trafaret-config
+semantic-version==2.6.0   # via -r _base.in (line 30)
 six==1.12.0               # via cryptography, isodate, jsonschema, openapi-core, openapi-spec-validator, pyrsistent, python-engineio, python-socketio, tenacity
-sqlalchemy[postgresql_psycopg2binary]==1.3.4
+sqlalchemy[postgresql_psycopg2binary]==1.3.4  # via -r ../../../../packages/postgres-database/requirements/_base.in (line 7), -r ../../../../packages/service-library/requirements/_base.in (line 5), -r _base.in (line 9), aiopg
 strict-rfc3339==0.7       # via openapi-core
-tenacity==6.0.0           # via -r ../../../../packages/service-library/requirements/_base.in (line 18), -r _base.in (line 33)
-trafaret-config==2.0.2    # via -r _base.in (line 35)
-trafaret==1.2.0           # via -r ../../../../packages/service-library/requirements/_base.in (line 20), -r _base.in (line 34), trafaret-config
+tenacity==6.0.0           # via -r ../../../../packages/service-library/requirements/_base.in (line 18), -r _base.in (line 31)
+trafaret-config==2.0.2    # via -r _base.in (line 33)
+trafaret==1.2.0           # via -r ../../../../packages/service-library/requirements/_base.in (line 20), -r _base.in (line 32), trafaret-config
 typing-extensions==3.7.2  # via aiohttp
 typing==3.7.4.1           # via expiringdict
 ujson==1.35               # via -r ../../../../packages/service-library/requirements/_base.in (line 13), aiohttp-swagger

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -4,68 +4,69 @@
 #
 #    pip-compile --output-file=_test.txt _test.in
 #
-aio-pika==2.9.0
-aiodebug==1.1.2
-aiohttp-jinja2==1.1.1
-aiohttp-security==0.4.0
-aiohttp-session[secure]==2.7.0
-aiohttp-swagger[performance]==1.0.14
-aiohttp==3.6.2
-aiopg[sa]==1.0.0
-aioredis==1.3.0
-aiosmtplib==1.0.5
-aiozipkin==0.6.0
-amqp==2.4.2
-asn1crypto==0.24.0
+aio-pika==6.5.2           # via -r _base.txt (line 7)
+aiodebug==1.1.2           # via -r _base.txt (line 8)
+aiohttp-jinja2==1.1.1     # via -r _base.txt (line 9)
+aiohttp-security==0.4.0   # via -r _base.txt (line 10)
+aiohttp-session[secure]==2.7.0  # via -r _base.txt (line 11)
+aiohttp-swagger[performance]==1.0.14  # via -r _base.txt (line 12)
+aiohttp==3.6.2            # via -r _base.txt (line 13), aiohttp-jinja2, aiohttp-security, aiohttp-session, aiohttp-swagger, aiozipkin, pytest-aiohttp
+aiopg[sa]==1.0.0          # via -r _base.txt (line 14)
+aioredis==1.3.0           # via -r _base.txt (line 15)
+aiormq==3.2.1             # via -r _base.txt (line 16), aio-pika
+aiosmtplib==1.0.5         # via -r _base.txt (line 17)
+aiozipkin==0.6.0          # via -r _base.txt (line 18)
+amqp==2.4.2               # via -r _base.txt (line 19), kombu
+asn1crypto==0.24.0        # via -r _base.txt (line 20), cryptography
 astroid==2.3.3            # via pylint
-async-timeout==3.0.1      # via -r _base.txt (line 22), aiohttp, aioredis
-asyncpg==0.18.3           # via -r _base.txt (line 23)
-attrs==19.1.0             # via -r _base.txt (line 24), aiohttp, jsonschema, openapi-core, pytest, pytest-docker
-billiard==3.6.0.0         # via -r _base.txt (line 25), celery
-celery==4.3.0             # via -r _base.txt (line 26)
+async-timeout==3.0.1      # via -r _base.txt (line 21), aiohttp, aioredis
+asyncpg==0.18.3           # via -r _base.txt (line 22)
+attrs==19.1.0             # via -r _base.txt (line 23), aiohttp, jsonschema, openapi-core, pytest, pytest-docker
+billiard==3.6.0.0         # via -r _base.txt (line 24), celery
+celery==4.3.0             # via -r _base.txt (line 25)
 certifi==2019.11.28       # via requests
-cffi==1.12.3              # via -r _base.txt (line 27), cryptography
-change-case==0.5.2        # via -r _base.txt (line 28)
-chardet==3.0.4            # via -r _base.txt (line 29), aiohttp, requests
+cffi==1.12.3              # via -r _base.txt (line 26), cryptography
+change-case==0.5.2        # via -r _base.txt (line 27)
+chardet==3.0.4            # via -r _base.txt (line 28), aiohttp, requests
 codecov==2.0.15           # via -r _test.in (line 36)
 coverage==4.5.1           # via -r _test.in (line 12), codecov, coveralls, pytest-cov
 coveralls==1.10.0         # via -r _test.in (line 35)
-cryptography==2.6.1       # via -r _base.txt (line 30), aiohttp-session
+cryptography==2.6.1       # via -r _base.txt (line 29), aiohttp-session
 docker==4.1.0             # via -r _test.in (line 30)
 docopt==0.6.2             # via coveralls
-expiringdict==1.2.0
-faker==3.0.0
-hiredis==1.0.1
-idna-ssl==1.1.0
-idna==2.8
-importlib-metadata==0.23
-isodate==0.6.0
+expiringdict==1.2.0       # via -r _base.txt (line 30)
+faker==3.0.0              # via -r _test.in (line 26)
+hiredis==1.0.1            # via -r _base.txt (line 31), aioredis
+idna-ssl==1.1.0           # via -r _base.txt (line 32), aiohttp
+idna==2.8                 # via -r _base.txt (line 33), idna-ssl, requests, yarl
+importlib-metadata==0.23  # via -r _base.txt (line 34), jsonschema, pluggy, pytest
+isodate==0.6.0            # via -r _base.txt (line 35), openapi-core
 isort==4.3.21             # via pylint
-jinja-app-loader==1.0.2   # via -r _base.txt (line 38)
-jinja2==2.10.1            # via -r _base.txt (line 39), aiohttp-jinja2, aiohttp-swagger
-jsondiff==1.1.2           # via -r _base.txt (line 40)
-jsonschema==3.2.0         # via -r _base.txt (line 41), -r _test.in (line 28), openapi-spec-validator
-kombu==4.5.0              # via -r _base.txt (line 42), celery
-lazy-object-proxy==1.4.3  # via -r _base.txt (line 43), astroid, openapi-core
-markupsafe==1.1.1         # via -r _base.txt (line 44), jinja2
+jinja-app-loader==1.0.2   # via -r _base.txt (line 36)
+jinja2==2.10.1            # via -r _base.txt (line 37), aiohttp-jinja2, aiohttp-swagger
+jsondiff==1.1.2           # via -r _base.txt (line 38)
+jsonschema==3.2.0         # via -r _base.txt (line 39), -r _test.in (line 28), openapi-spec-validator
+kombu==4.5.0              # via -r _base.txt (line 40), celery
+lazy-object-proxy==1.4.3  # via -r _base.txt (line 41), astroid, openapi-core
+markupsafe==1.1.1         # via -r _base.txt (line 42), jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r _test.in (line 14)
-more-itertools==7.2.0     # via -r _base.txt (line 45), pytest, zipp
-multidict==4.5.2          # via -r _base.txt (line 46), aiohttp, yarl
-openapi-core==0.12.0      # via -r _base.txt (line 47)
-openapi-spec-validator==0.2.8  # via -r _base.txt (line 48), -r _test.in (line 27), openapi-core
+more-itertools==7.2.0     # via -r _base.txt (line 43), pytest, zipp
+multidict==4.5.2          # via -r _base.txt (line 44), aiohttp, yarl
+openapi-core==0.12.0      # via -r _base.txt (line 45)
+openapi-spec-validator==0.2.8  # via -r _base.txt (line 46), -r _test.in (line 27), openapi-core
 packaging==20.0           # via pytest, pytest-sugar
-passlib==1.7.1
-pika==0.10.0
+pamqp==2.3.0              # via -r _base.txt (line 47), aiormq
+passlib==1.7.1            # via -r _base.txt (line 48)
 pluggy==0.13.1            # via pytest
-prometheus-client==0.7.1  # via -r _base.txt (line 52)
-psycopg2-binary==2.8.4    # via -r _base.txt (line 53), aiopg, sqlalchemy
+prometheus-client==0.7.1  # via -r _base.txt (line 49)
+psycopg2-binary==2.8.4    # via -r _base.txt (line 50), aiopg, sqlalchemy
 ptvsd==4.3.2              # via -r _test.in (line 37)
 py==1.8.1                 # via pytest
-pycparser==2.19           # via -r _base.txt (line 54), cffi
+pycparser==2.19           # via -r _base.txt (line 51), cffi
 pylint==2.4.4             # via -r _test.in (line 34)
 pyparsing==2.4.6          # via packaging
-pyrsistent==0.15.6        # via -r _base.txt (line 55), jsonschema
+pyrsistent==0.15.6        # via -r _base.txt (line 52), jsonschema
 pytest-aiohttp==0.3.0     # via -r _test.in (line 16)
 pytest-cov==2.8.1         # via -r _test.in (line 17)
 pytest-docker==0.6.1      # via -r _test.in (line 18)
@@ -75,34 +76,34 @@ pytest-runner==5.2        # via -r _test.in (line 21)
 pytest-sugar==0.9.2       # via -r _test.in (line 22)
 pytest==5.3.2             # via -r _test.in (line 15), pytest-aiohttp, pytest-cov, pytest-instafail, pytest-mock, pytest-sugar
 python-dateutil==2.8.1    # via faker
-python-engineio==3.9.3
-python-socketio==4.3.1
-pytz==2019.1
-pyyaml==5.3
-redis==3.3.11
+python-engineio==3.9.3    # via -r _base.txt (line 53), python-socketio
+python-socketio==4.3.1    # via -r _base.txt (line 54)
+pytz==2019.1              # via -r _base.txt (line 55), celery
+pyyaml==5.3               # via -r _base.txt (line 56), aiohttp-swagger, openapi-spec-validator, trafaret-config
+redis==3.3.11             # via -r _test.in (line 31)
 requests==2.22.0          # via codecov, coveralls, docker
-semantic-version==2.6.0   # via -r _base.txt (line 60)
-six==1.12.0               # via -r _base.txt (line 61), aadict, asset, astroid, cryptography, docker, faker, isodate, jsonschema, mock, openapi-core, openapi-spec-validator, packaging, pyrsistent, python-dateutil, python-engineio, python-socketio, tenacity, websocket-client
-sqlalchemy[postgresql_psycopg2binary]==1.3.4  # via -r _base.txt (line 62), aiopg
-strict-rfc3339==0.7       # via -r _base.txt (line 63), openapi-core
-tenacity==6.0.0           # via -r _base.txt (line 64), -r _test.in (line 29)
+semantic-version==2.6.0   # via -r _base.txt (line 57)
+six==1.12.0               # via -r _base.txt (line 58), astroid, cryptography, docker, faker, isodate, jsonschema, mock, openapi-core, openapi-spec-validator, packaging, pyrsistent, python-dateutil, python-engineio, python-socketio, tenacity, websocket-client
+sqlalchemy[postgresql_psycopg2binary]==1.3.4  # via -r _base.txt (line 59), aiopg
+strict-rfc3339==0.7       # via -r _base.txt (line 60), openapi-core
+tenacity==6.0.0           # via -r _base.txt (line 61), -r _test.in (line 29)
 termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.3       # via faker
-trafaret-config==2.0.2    # via -r _base.txt (line 65)
-trafaret==1.2.0           # via -r _base.txt (line 66), trafaret-config
+trafaret-config==2.0.2    # via -r _base.txt (line 62)
+trafaret==1.2.0           # via -r _base.txt (line 63), trafaret-config
 typed-ast==1.4.0          # via astroid
-typing-extensions==3.7.2  # via -r _base.txt (line 67), aiohttp
-typing==3.7.4.1           # via -r _base.txt (line 68), expiringdict
-ujson==1.35               # via -r _base.txt (line 69), aiohttp-swagger
+typing-extensions==3.7.2  # via -r _base.txt (line 64), aiohttp
+typing==3.7.4.1           # via -r _base.txt (line 65), expiringdict
+ujson==1.35               # via -r _base.txt (line 66), aiohttp-swagger
 urllib3==1.25.7           # via requests
-vine==1.3.0               # via -r _base.txt (line 70), amqp, celery
+vine==1.3.0               # via -r _base.txt (line 67), amqp, celery
 wcwidth==0.1.8            # via pytest
 websocket-client==0.57.0  # via docker
 websockets==8.1           # via -r _test.in (line 23)
-werkzeug==0.16.0          # via -r _base.txt (line 71)
+werkzeug==0.16.0          # via -r _base.txt (line 68)
 wrapt==1.11.2             # via astroid
-yarl==1.3.0               # via -r _base.txt (line 72), aio-pika, aiohttp, aiormq
-zipp==1.0.0               # via -r _base.txt (line 73), importlib-metadata
+yarl==1.3.0               # via -r _base.txt (line 69), aio-pika, aiohttp, aiormq
+zipp==1.0.0               # via -r _base.txt (line 70), importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -18,20 +18,20 @@ aiozipkin==0.6.0
 amqp==2.4.2
 asn1crypto==0.24.0
 astroid==2.3.3            # via pylint
-async-timeout==3.0.1
-asyncpg==0.18.3
-attrs==19.1.0
-billiard==3.6.0.0
-celery==4.3.0
+async-timeout==3.0.1      # via -r _base.txt (line 22), aiohttp, aioredis
+asyncpg==0.18.3           # via -r _base.txt (line 23)
+attrs==19.1.0             # via -r _base.txt (line 24), aiohttp, jsonschema, openapi-core, pytest, pytest-docker
+billiard==3.6.0.0         # via -r _base.txt (line 25), celery
+celery==4.3.0             # via -r _base.txt (line 26)
 certifi==2019.11.28       # via requests
-cffi==1.12.3
-change-case==0.5.2
-chardet==3.0.4
-codecov==2.0.15
-coverage==4.5.1
-coveralls==1.10.0
-cryptography==2.6.1
-docker==4.1.0
+cffi==1.12.3              # via -r _base.txt (line 27), cryptography
+change-case==0.5.2        # via -r _base.txt (line 28)
+chardet==3.0.4            # via -r _base.txt (line 29), aiohttp, requests
+codecov==2.0.15           # via -r _test.in (line 36)
+coverage==4.5.1           # via -r _test.in (line 12), codecov, coveralls, pytest-cov
+coveralls==1.10.0         # via -r _test.in (line 35)
+cryptography==2.6.1       # via -r _base.txt (line 30), aiohttp-session
+docker==4.1.0             # via -r _test.in (line 30)
 docopt==0.6.2             # via coveralls
 expiringdict==1.2.0
 faker==3.0.0
@@ -41,39 +41,39 @@ idna==2.8
 importlib-metadata==0.23
 isodate==0.6.0
 isort==4.3.21             # via pylint
-jinja-app-loader==1.0.2
-jinja2==2.10.1
-jsondiff==1.1.2
-jsonschema==3.2.0
-kombu==4.5.0
-lazy-object-proxy==1.4.3
-markupsafe==1.1.1
+jinja-app-loader==1.0.2   # via -r _base.txt (line 38)
+jinja2==2.10.1            # via -r _base.txt (line 39), aiohttp-jinja2, aiohttp-swagger
+jsondiff==1.1.2           # via -r _base.txt (line 40)
+jsonschema==3.2.0         # via -r _base.txt (line 41), -r _test.in (line 28), openapi-spec-validator
+kombu==4.5.0              # via -r _base.txt (line 42), celery
+lazy-object-proxy==1.4.3  # via -r _base.txt (line 43), astroid, openapi-core
+markupsafe==1.1.1         # via -r _base.txt (line 44), jinja2
 mccabe==0.6.1             # via pylint
-mock==3.0.5
-more-itertools==7.2.0
-multidict==4.5.2
-openapi-core==0.12.0
-openapi-spec-validator==0.2.8
+mock==3.0.5               # via -r _test.in (line 14)
+more-itertools==7.2.0     # via -r _base.txt (line 45), pytest, zipp
+multidict==4.5.2          # via -r _base.txt (line 46), aiohttp, yarl
+openapi-core==0.12.0      # via -r _base.txt (line 47)
+openapi-spec-validator==0.2.8  # via -r _base.txt (line 48), -r _test.in (line 27), openapi-core
 packaging==20.0           # via pytest, pytest-sugar
 passlib==1.7.1
 pika==0.10.0
 pluggy==0.13.1            # via pytest
-prometheus-client==0.7.1
-psycopg2-binary==2.8.4
-ptvsd==4.3.2
+prometheus-client==0.7.1  # via -r _base.txt (line 52)
+psycopg2-binary==2.8.4    # via -r _base.txt (line 53), aiopg, sqlalchemy
+ptvsd==4.3.2              # via -r _test.in (line 37)
 py==1.8.1                 # via pytest
-pycparser==2.19
-pylint==2.4.4
+pycparser==2.19           # via -r _base.txt (line 54), cffi
+pylint==2.4.4             # via -r _test.in (line 34)
 pyparsing==2.4.6          # via packaging
-pyrsistent==0.15.6
-pytest-aiohttp==0.3.0
-pytest-cov==2.8.1
-pytest-docker==0.6.1
-pytest-instafail==0.4.1.post0
-pytest-mock==2.0.0
-pytest-runner==5.2
-pytest-sugar==0.9.2
-pytest==5.3.2
+pyrsistent==0.15.6        # via -r _base.txt (line 55), jsonschema
+pytest-aiohttp==0.3.0     # via -r _test.in (line 16)
+pytest-cov==2.8.1         # via -r _test.in (line 17)
+pytest-docker==0.6.1      # via -r _test.in (line 18)
+pytest-instafail==0.4.1.post0  # via -r _test.in (line 19)
+pytest-mock==2.0.0        # via -r _test.in (line 20)
+pytest-runner==5.2        # via -r _test.in (line 21)
+pytest-sugar==0.9.2       # via -r _test.in (line 22)
+pytest==5.3.2             # via -r _test.in (line 15), pytest-aiohttp, pytest-cov, pytest-instafail, pytest-mock, pytest-sugar
 python-dateutil==2.8.1    # via faker
 python-engineio==3.9.3
 python-socketio==4.3.1
@@ -81,29 +81,28 @@ pytz==2019.1
 pyyaml==5.3
 redis==3.3.11
 requests==2.22.0          # via codecov, coveralls, docker
-semantic-version==2.6.0
-shortuuid==0.5.0
-six==1.12.0
-sqlalchemy[postgresql_psycopg2binary]==1.3.4
-strict-rfc3339==0.7
-tenacity==6.0.0
+semantic-version==2.6.0   # via -r _base.txt (line 60)
+six==1.12.0               # via -r _base.txt (line 61), aadict, asset, astroid, cryptography, docker, faker, isodate, jsonschema, mock, openapi-core, openapi-spec-validator, packaging, pyrsistent, python-dateutil, python-engineio, python-socketio, tenacity, websocket-client
+sqlalchemy[postgresql_psycopg2binary]==1.3.4  # via -r _base.txt (line 62), aiopg
+strict-rfc3339==0.7       # via -r _base.txt (line 63), openapi-core
+tenacity==6.0.0           # via -r _base.txt (line 64), -r _test.in (line 29)
 termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.3       # via faker
-trafaret-config==2.0.2
-trafaret==1.2.0
+trafaret-config==2.0.2    # via -r _base.txt (line 65)
+trafaret==1.2.0           # via -r _base.txt (line 66), trafaret-config
 typed-ast==1.4.0          # via astroid
-typing-extensions==3.7.2
-typing==3.7.4.1
-ujson==1.35
+typing-extensions==3.7.2  # via -r _base.txt (line 67), aiohttp
+typing==3.7.4.1           # via -r _base.txt (line 68), expiringdict
+ujson==1.35               # via -r _base.txt (line 69), aiohttp-swagger
 urllib3==1.25.7           # via requests
-vine==1.3.0
+vine==1.3.0               # via -r _base.txt (line 70), amqp, celery
 wcwidth==0.1.8            # via pytest
 websocket-client==0.57.0  # via docker
-websockets==8.1
-werkzeug==0.16.0
+websockets==8.1           # via -r _test.in (line 23)
+werkzeug==0.16.0          # via -r _base.txt (line 71)
 wrapt==1.11.2             # via astroid
-yarl==1.3.0
-zipp==1.0.0
+yarl==1.3.0               # via -r _base.txt (line 72), aio-pika, aiohttp, aiormq
+zipp==1.0.0               # via -r _base.txt (line 73), importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/services/web/server/src/simcore_service_webserver/computation_subscribe.py
+++ b/services/web/server/src/simcore_service_webserver/computation_subscribe.py
@@ -111,7 +111,7 @@ async def subscribe(app: web.Application) -> None:
     app[APP_CLIENT_RABBIT_DECORATED_HANDLERS_KEY] = [partial_rabbit_message_handler]
     await queue.consume(partial_rabbit_message_handler, exclusive=True, no_ack=True)
 
-@tenacity.retry(**RabbitMQRetryPolicyUponInitialization().kwargs)
+@retry(**RabbitMQRetryPolicyUponInitialization().kwargs)
 async def wait_till_rabbitmq_responsive(url):
     """Check if something responds to ``url`` """
     connection = await aio_pika.connect(url)

--- a/services/web/server/src/simcore_service_webserver/computation_subscribe.py
+++ b/services/web/server/src/simcore_service_webserver/computation_subscribe.py
@@ -78,9 +78,6 @@ async def subscribe(app: web.Application) -> None:
     rb_config: Dict = app[APP_CONFIG_KEY][CONFIG_SECTION_NAME]
     rabbit_broker = eval_broker(rb_config)
 
-    # FIXME: This tmp resolves ``aio pika 169: IncompatibleProtocolError`` upon apio_pika.connect
-    await asyncio.sleep(5)
-
     # TODO: connection attempts should be configurable??
     # TODO: A contingency plan or connection policy should be defined per service! E.g. critical, lazy, partial (i.e. some parts of the service cannot run now)
     connection = await aio_pika.connect(rabbit_broker, connection_attempts=100)

--- a/services/web/server/src/simcore_service_webserver/computation_subscribe.py
+++ b/services/web/server/src/simcore_service_webserver/computation_subscribe.py
@@ -89,14 +89,12 @@ async def subscribe(app: web.Application) -> None:
 
     pika_log_channel = rb_config["channels"]["log"]
     logs_exchange = await channel.declare_exchange(
-        pika_log_channel, aio_pika.ExchangeType.FANOUT,
-        auto_delete=True
+        pika_log_channel, aio_pika.ExchangeType.FANOUT
     )
 
     pika_progress_channel = rb_config["channels"]["progress"]
     progress_exchange = await channel.declare_exchange(
-        pika_progress_channel, aio_pika.ExchangeType.FANOUT,
-        auto_delete=True
+        pika_progress_channel, aio_pika.ExchangeType.FANOUT
     )
 
     # Declaring queue

--- a/services/web/server/src/simcore_service_webserver/computation_subscribe.py
+++ b/services/web/server/src/simcore_service_webserver/computation_subscribe.py
@@ -110,4 +110,4 @@ async def subscribe(app: web.Application) -> None:
     # Start listening the queue with name 'task_queue'
     partial_rabbit_message_handler = rabbit_adapter(app)(rabbit_message_handler)
     app[APP_CLIENT_RABBIT_DECORATED_HANDLERS_KEY] = [partial_rabbit_message_handler]
-    await queue.consume(partial_rabbit_message_handler)
+    await queue.consume(partial_rabbit_message_handler, exclusive=True, no_ack=True)

--- a/services/web/server/src/simcore_service_webserver/config/server-defaults.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-defaults.yaml
@@ -15,7 +15,7 @@ director:
   port: 8001
   version: v0
 socketio:
-  enabled: True  
+  enabled: True
 db:
   init_tables: False
   postgres:

--- a/services/web/server/src/simcore_service_webserver/config/server-defaults.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-defaults.yaml
@@ -15,10 +15,7 @@ director:
   port: 8001
   version: v0
 socketio:
-  enabled: True
-  message_queue:
-    user: simcore
-    password: simcore
+  enabled: True  
 db:
   init_tables: False
   postgres:

--- a/services/web/server/src/simcore_service_webserver/config/server-docker-dev.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-docker-dev.yaml
@@ -11,11 +11,6 @@ main:
   monitoring_enabled: True
 socketio:
   enabled: True
-  message_queue:
-    host: ${RABBIT_HOST}
-    port: ${RABBIT_PORT}
-    user: ${RABBIT_USER}
-    password: ${RABBIT_PASSWORD}
 tracing:
   enabled: True
   zipkin_endpoint: ${TRACING_ZIPKIN_ENDPOINT}

--- a/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
@@ -17,11 +17,7 @@ tracing:
   enabled: ${TRACING_ENABLED}
   zipkin_endpoint: ${TRACING_ZIPKIN_ENDPOINT}
 socketio:
-  message_queue:
-    host: ${RABBIT_HOST}
-    port: ${RABBIT_PORT}
-    user: ${RABBIT_USER}
-    password: ${RABBIT_PASSWORD}
+  enabled: True
 director:
   host: ${DIRECTOR_HOST}
   port: ${DIRECTOR_PORT}

--- a/services/web/server/src/simcore_service_webserver/socketio/__init__.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/__init__.py
@@ -19,11 +19,6 @@ log = logging.getLogger(__name__)
 def setup(app: web.Application):
     mgr = None
     cfg = app[APP_CONFIG_KEY][CONFIG_SECTION_NAME]
-    if "message_queue" in cfg and cfg["message_queue"]:
-        mq_config = cfg["message_queue"]
-        url = f"amqp://{mq_config['user']}:{mq_config['password']}@{mq_config['host']}:{mq_config['port']}"
-        mgr = AsyncAioPikaManager(url=url, logger=log)
-
     sio = AsyncServer(async_mode="aiohttp", client_manager=mgr, logging=log)
     sio.attach(app)
     app[APP_CLIENT_SOCKET_SERVER_KEY] = sio    

--- a/services/web/server/src/simcore_service_webserver/socketio/__init__.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/__init__.py
@@ -7,7 +7,7 @@ import logging
 from aiohttp import web
 from servicelib.application_keys import APP_CONFIG_KEY
 from servicelib.application_setup import ModuleCategory, app_module_setup
-from socketio import AsyncAioPikaManager, AsyncServer
+from socketio import AsyncServer
 
 from . import handlers, handlers_utils
 from .config import APP_CLIENT_SOCKET_SERVER_KEY, CONFIG_SECTION_NAME
@@ -18,7 +18,6 @@ log = logging.getLogger(__name__)
 @app_module_setup(__name__, ModuleCategory.SYSTEM, logger=log)
 def setup(app: web.Application):
     mgr = None
-    cfg = app[APP_CONFIG_KEY][CONFIG_SECTION_NAME]
     sio = AsyncServer(async_mode="aiohttp", client_manager=mgr, logging=log)
     sio.attach(app)
     app[APP_CLIENT_SOCKET_SERVER_KEY] = sio    

--- a/services/web/server/src/simcore_service_webserver/socketio/config.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/config.py
@@ -17,13 +17,6 @@ APP_CLIENT_SOCKET_DECORATED_HANDLERS_KEY = __name__ + ".socketio_handlers"
 
 schema = T.Dict({
     T.Key("enabled", default=True, optional=True): T.Or(T.Bool(), T.Int()),    
-    T.Key("message_queue", optional=True): T.Dict({
-        T.Key("host", default='rabbit', optional=True): T.String(),
-        T.Key("port", default=5672, optional=True): T.Int(),
-        "user": T.String(allow_blank=True),
-        "password": T.String(allow_blank=True),
-        T.Key("channel", default="socketio"): T.String()
-    }),
 })
 
 def get_config(app: web.Application) -> Dict:

--- a/services/web/server/tests/integration/computation/test_rabbit.py
+++ b/services/web/server/tests/integration/computation/test_rabbit.py
@@ -93,8 +93,7 @@ async def rabbit_channels(loop, pika_connection, rabbit_config: Dict) -> Dict[st
         channel = await pika_connection.channel()
         pika_channel = rabbit_config["channels"][channel_name]
         pika_exchange = await channel.declare_exchange(
-            pika_channel, aio_pika.ExchangeType.FANOUT,
-            auto_delete=True
+            pika_channel, aio_pika.ExchangeType.FANOUT
         )
         return pika_exchange
 

--- a/tests/e2e/utils/wait_for_services.py
+++ b/tests/e2e/utils/wait_for_services.py
@@ -106,12 +106,13 @@ def wait_for_services() -> bool:
     # now check they are in running mode
     for service in running_services:
         for n in range(RETRY_COUNT):
-            task = service.tasks()[-1]
+            task = service.tasks()[0]
             if task['Status']['State'].upper() in pre_states:
-                print("Waiting [{}/{}] ...\n{}".format(n, RETRY_COUNT, get_tasks_summary(service.tasks())))
+                print("Waiting [{}/{}] for {}...\n{}".format(n, RETRY_COUNT, service.name, get_tasks_summary(service.tasks())))
                 time.sleep(WAIT_TIME_SECS)
             elif task['Status']['State'].upper() in failed_states:
-                print(f"Waiting [{n}/{RETRY_COUNT}] Service failed once...\n{get_tasks_summary(service.tasks())}")
+                print(f"Waiting [{n}/{RETRY_COUNT}] Service {service.name} failed once...\n{get_tasks_summary(service.tasks())}")
+                time.sleep(WAIT_TIME_SECS)
             else:
                 break
         assert task['Status']['State'].upper() == "RUNNING",\

--- a/tests/swarm-deploy/requirements.in
+++ b/tests/swarm-deploy/requirements.in
@@ -1,8 +1,12 @@
 coverage==4.5.1 # TODO: Downgraded because of a bug https://github.com/nedbat/coveragepy/issues/716
 
 pytest
-pytest-cov
 pytest-aiohttp
+pytest-cov
+pytest-instafail
+pytest-mock
+pytest-runner
+pytest-sugar
 
 docker
 tenacity

--- a/tests/swarm-deploy/requirements.txt
+++ b/tests/swarm-deploy/requirements.txt
@@ -9,27 +9,32 @@ async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, pytest
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via aiohttp, requests
-coverage==4.5.1
-docker==4.1.0
+coverage==4.5.1           # via -r requirements.in (line 1), pytest-cov
+docker==4.2.0             # via -r requirements.in (line 11)
 idna-ssl==1.1.0           # via aiohttp
-idna==2.8                 # via idna-ssl, requests, yarl
-importlib-metadata==1.3.0  # via pluggy, pytest
-more-itertools==8.0.2     # via pytest, zipp
-multidict==4.7.3          # via aiohttp, yarl
-packaging==20.0           # via pytest
+idna==2.9                 # via idna-ssl, requests, yarl
+importlib-metadata==1.5.0  # via pluggy, pytest
+more-itertools==8.2.0     # via pytest
+multidict==4.7.5          # via aiohttp, yarl
+packaging==20.1           # via pytest, pytest-sugar
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pyparsing==2.4.6          # via packaging
-pytest-aiohttp==0.3.0
-pytest-cov==2.8.1
-pytest==5.3.2
-pyyaml==5.3
-requests==2.22.0          # via docker
-six==1.13.0               # via docker, packaging, tenacity, websocket-client
-tenacity==6.0.0
+pytest-aiohttp==0.3.0     # via -r requirements.in (line 4)
+pytest-cov==2.8.1         # via -r requirements.in (line 5)
+pytest-instafail==0.4.1.post0  # via -r requirements.in (line 6)
+pytest-mock==2.0.0        # via -r requirements.in (line 7)
+pytest-runner==5.2        # via -r requirements.in (line 8)
+pytest-sugar==0.9.2       # via -r requirements.in (line 9)
+pytest==5.3.5             # via -r requirements.in (line 3), pytest-aiohttp, pytest-cov, pytest-instafail, pytest-mock, pytest-sugar
+pyyaml==5.3               # via -r requirements.in (line 13)
+requests==2.23.0          # via docker
+six==1.14.0               # via docker, packaging, tenacity, websocket-client
+tenacity==6.1.0           # via -r requirements.in (line 12)
+termcolor==1.1.0          # via pytest-sugar
 typing-extensions==3.7.4.1  # via aiohttp
-urllib3==1.25.7           # via requests
+urllib3==1.25.8           # via requests
 wcwidth==0.1.8            # via pytest
 websocket-client==0.57.0  # via docker
 yarl==1.4.2               # via aiohttp
-zipp==0.6.0               # via importlib-metadata
+zipp==3.0.0               # via importlib-metadata

--- a/tests/swarm-deploy/test_service_restart.py
+++ b/tests/swarm-deploy/test_service_restart.py
@@ -24,7 +24,7 @@ current_dir =  Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve
 
 # time measured from command 'up' finished until *all* tasks are running
 MAX_TIME_TO_DEPLOY_SECS = 60
-MAX_TIME_TO_RESTART_SERVICE = 5
+MAX_TIME_TO_RESTART_SERVICE = 10
 
 
 @pytest.fixture("module")

--- a/tests/swarm-deploy/test_swarm_runs.py
+++ b/tests/swarm-deploy/test_swarm_runs.py
@@ -105,33 +105,35 @@ async def test_core_service_running(
     # find core_service_name
     running_service = next( s for s in core_services_running  if s.name == core_service_name )
 
-    # Every service in the fixture runs a single task, but they might have failed!
+    # Every service in the fixture runs a number of tasks, but they might have failed!
     #
     # $ docker service ps simcore_storage
     # ID                  NAME                     IMAGE                     NODE                DESIRED STATE       CURRENT STATE            ERROR                       PORTS
     # puiaevvmtbs1        simcore_storage.1       simcore_storage:latest   crespo-wkstn        Running             Running 18 minutes ago
     # j5xtlrnn684y         \_ simcore_storage.1   simcore_storage:latest   crespo-wkstn        Shutdown            Failed 18 minutes ago    "task: non-zero exit (1)"
     tasks = running_service.tasks()
-
-    assert len(tasks) == 1, "Expected a single task for '{0}',"\
+    service_config = osparc_deploy['simcore']['services'][core_service_name.split(sep="_")[1]]
+    num_tasks = get_replicas(service_config)
+    assert len(tasks) == num_tasks, f"Expected a {num_tasks} task(s) for '{0}',"\
         " got:\n{1}\n{2}".format(core_service_name,
                                  get_tasks_summary(tasks),
                                  get_failed_tasks_logs(running_service, docker_client))
 
 
-    for n in range(RETRY_COUNT):
-        task = running_service.tasks()[0]
-        if task['Status']['State'].upper() in pre_states:
-            print("Waiting [{}/{}] ...\n{}".format(n, RETRY_COUNT, get_tasks_summary(tasks)))
-            await asyncio.sleep(WAIT_TIME_SECS)
-        else:
-            break
+    for i in range(num_tasks):
+        for n in range(RETRY_COUNT):
+            task = running_service.tasks()[i]
+            if task['Status']['State'].upper() in pre_states:
+                print("Waiting [{}/{}] ...\n{}".format(n, RETRY_COUNT, get_tasks_summary(tasks)))
+                await asyncio.sleep(WAIT_TIME_SECS)
+            else:
+                break
 
-    # should be running
-    assert task['Status']['State'].upper() == "RUNNING", \
-        "Expected running, got \n{}\n{}".format(
-                pformat(task),
-                get_failed_tasks_logs(running_service, docker_client))
+        # should be running
+        assert task['Status']['State'].upper() == "RUNNING", \
+            "Expected running, got \n{}\n{}".format(
+                    pformat(task),
+                    get_failed_tasks_logs(running_service, docker_client))
 
 
 async def test_check_serve_root(osparc_deploy: Dict):
@@ -153,6 +155,14 @@ async def test_check_serve_root(osparc_deploy: Dict):
 
 
 # UTILS --------------------------------
+
+def get_replicas(service: Dict) -> int:
+    replicas = 1
+    if "deploy" in service:
+        if "replicas" in service["deploy"]:
+            replicas = service["deploy"]["replicas"]
+    return replicas
+
 
 def get_tasks_summary(tasks):
     msg = ""


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
- [x] updated aio-pika to 6.5.2
- [x] removed socket.io asynciopikamanager that was creating a lot of connections/channels/queues without removing them
- [x] ensure consumed queue on webserver side does not need to be acknowledged (should prevent memory from raising in rabbit to keep messages)
- [x] set sidecar number to 4 for development mode
- [x] some cleanup in the sidecar code to ensure pika connections are correctly closed

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
