### PR TITLE
e2e: Check number of output files

### DIFF
--- a/tests/e2e/tutorials/mattward.js
+++ b/tests/e2e/tutorials/mattward.js
@@ -32,7 +32,17 @@ async function runTutorial () {
   await tutorial.waitFor(60000);
 
   await tutorial.openNodeFiles(0);
-  await tutorial.checkResults();
+  const outFiles = [
+    "CAP_plot.csv",
+    "CV_plot.csv",
+    "Lpred_plot.csv",
+    "V_pred_plot.csv",
+    "input.csv",
+    "t_plot.csv",
+    "tst_plot.csv"
+  ];
+  await tutorial.checkResults(outFiles.length);
+
   await tutorial.removeStudy();
   await tutorial.logOut();
   await tutorial.close();

--- a/tests/e2e/tutorials/sleepers.js
+++ b/tests/e2e/tutorials/sleepers.js
@@ -32,7 +32,12 @@ async function runTutorial () {
 
   await tutorial.runPipeline(25000);
   await tutorial.openNodeFiles(0);
-  await tutorial.checkResults();
+  const outFiles = [
+    "logs.zip",
+    "out_1"
+  ];
+  await tutorial.checkResults(outFiles.length);
+
   await tutorial.removeStudy();
   await tutorial.logOut();
   await tutorial.close();

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -105,10 +105,10 @@ class TutorialBase {
     await utils.takeScreenshot("openNodeRetrieveAndRestart_after");
   }
 
-  async checkResults() {
+  async checkResults(expecedNFiles = 1) {
     await utils.takeScreenshot(this.__page, this.__templateName + "_checkResults_before");
     try {
-      await auto.checkDataProducedByNode(this.__page);
+      await auto.checkDataProducedByNode(this.__page, expecedNFiles);
     }
     catch(err) {
       console.error("Failed checking Data Produced By Node", err);

--- a/tests/e2e/utils/auto.js
+++ b/tests/e2e/utils/auto.js
@@ -318,8 +318,8 @@ async function openNodeFiles(page) {
   await page.click('[osparc-test-id="nodeViewFilesBtn"]')
 }
 
-async function checkDataProducedByNode(page) {
-  console.log("checking Data produced by Node");
+async function checkDataProducedByNode(page, nFiles = 1) {
+  console.log("checking Data produced by Node. Expecting", nFiles, "file(s)");
   const tries = 3;
   let children = [];
   for (let i=0; i<tries && children.length === 0; i++) {
@@ -328,8 +328,9 @@ async function checkDataProducedByNode(page) {
     children = await utils.getFileTreeItemIDs(page, "NodeFiles");
     console.log(i+1, 'try: ', children);
   }
-  if (children.length < 4) { // 4 = location + study + node + file
-    throw("file items not found");
+  const nFolders = 3;
+  if (children.length < (nFolders+nFiles)) { // 4 = location + study + node + file
+    throw("Expected files not found");
   }
 
   const lastChildId = '[osparc-test-id="' + children.pop() + '"]';


### PR DESCRIPTION
## What do these changes do?
Puppeteer checks number of output files produced by a node.

So far we were only checking if some output was produced. Now we can check a specific number of outputs.

P.S. Since the node's logs file was hiding the lack of other outputs, this PR will make master red again.

## Related issue number
closes #1341
