### PR TITLE
Fix e2e false positives

### DIFF
--- a/tests/e2e/tutorials/mattward.js
+++ b/tests/e2e/tutorials/mattward.js
@@ -31,7 +31,7 @@ async function runTutorial () {
   await tutorial.waitForService(workbenchData["studyId"], workbenchData["nodeIds"][0]);
 
   // Wait for the output files to be pushed
-  await tutorial.waitFor(10000);
+  await tutorial.waitFor(30000);
 
   // This study opens in fullscreen mode
   await tutorial.restoreIFrame();

--- a/tests/e2e/tutorials/mattward.js
+++ b/tests/e2e/tutorials/mattward.js
@@ -26,10 +26,12 @@ async function runTutorial () {
 
   await tutorial.registerIfNeeded();
   await tutorial.login();
-  await tutorial.openTemplate(1000);
+  const studyData = await tutorial.openTemplate(1000);
+  const workbenchData = utils.extractWorkbenchData(studyData["data"]);
+  await tutorial.waitForService(workbenchData["studyId"], workbenchData["nodeIds"][0]);
 
   // Wait service to start and output files to be pushed
-  await tutorial.waitFor(60000);
+  await tutorial.waitFor(5000);
 
   // This study opens in fullscreen mode
   await tutorial.restoreIFrame();

--- a/tests/e2e/tutorials/mattward.js
+++ b/tests/e2e/tutorials/mattward.js
@@ -30,8 +30,8 @@ async function runTutorial () {
   const workbenchData = utils.extractWorkbenchData(studyData["data"]);
   await tutorial.waitForService(workbenchData["studyId"], workbenchData["nodeIds"][0]);
 
-  // Wait service to start and output files to be pushed
-  await tutorial.waitFor(5000);
+  // Wait for the output files to be pushed
+  await tutorial.waitFor(10000);
 
   // This study opens in fullscreen mode
   await tutorial.restoreIFrame();

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -90,6 +90,18 @@ class TutorialBase {
     }
   }
 
+  async waitForOpen() {
+    this.__responsesQueue.addResponseListener("open");
+    let resp = null;
+    try {
+      resp = await this.__responsesQueue.waitUntilResponse("open");
+    }
+    catch(err) {
+      console.error(this.__templateName, "could not be started", err);
+    }
+    return resp;
+  }
+
   async openTemplate(waitFor = 1000) {
     await utils.takeScreenshot(this.__page, this.__templateName + "_dashboardOpenFirstTemplate_before");
     this.__responsesQueue.addResponseListener("projects?from_template=");

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -93,15 +93,29 @@ class TutorialBase {
   async openTemplate(waitFor = 1000) {
     await utils.takeScreenshot(this.__page, this.__templateName + "_dashboardOpenFirstTemplate_before");
     this.__responsesQueue.addResponseListener("projects?from_template=");
+    let resp = null;
     try {
       await auto.dashboardOpenFirstTemplate(this.__page, this.__templateName);
-      await this.__responsesQueue.waitUntilResponse("projects?from_template=");
+      resp = await this.__responsesQueue.waitUntilResponse("projects?from_template=");
     }
     catch(err) {
       console.error(this.__templateName, "could not be started", err);
     }
     await this.__page.waitFor(waitFor);
     await utils.takeScreenshot(this.__page, this.__templateName + "_dashboardOpenFirstTemplate_after");
+    return resp;
+  }
+
+  async waitForService(studyId, nodeId) {
+    this.__responsesQueue.addResponseServiceListener(studyId, nodeId);
+    let resp = null;
+    try {
+      resp = await this.__responsesQueue.waitUntilServiceReady(studyId, nodeId);
+    }
+    catch(err) {
+      console.error(this.__templateName, "could not be started", err);
+    }
+    return resp;
   }
 
   async restoreIFrame() {

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -93,10 +93,12 @@ class TutorialBase {
   async openTemplate(waitFor = 1000) {
     await utils.takeScreenshot(this.__page, this.__templateName + "_dashboardOpenFirstTemplate_before");
     this.__responsesQueue.addResponseListener("projects?from_template=");
+    this.__responsesQueue.addResponseListener("open");
     let resp = null;
     try {
       await auto.dashboardOpenFirstTemplate(this.__page, this.__templateName);
-      resp = await this.__responsesQueue.waitUntilResponse("projects?from_template=");
+      await this.__responsesQueue.waitUntilResponse("projects?from_template=");
+      resp = await this.__responsesQueue.waitUntilResponse("open");
     }
     catch(err) {
       console.error(this.__templateName, "could not be started", err);

--- a/tests/e2e/utils/responsesQueue.js
+++ b/tests/e2e/utils/responsesQueue.js
@@ -78,7 +78,7 @@ class ResponsesQueue {
       if (resp.url().includes(url) && resp.status() === 200) {
         resp.json().then(data => {
           console.log((new Date).toUTCString(), "-- Queued services status response received", resp.url(), ":");
-          const status = data["service_state"];
+          const status = data["data"]["service_state"];
           console.log("Status:", status);
           const stopListening = [
             "running",

--- a/tests/e2e/utils/responsesQueue.js
+++ b/tests/e2e/utils/responsesQueue.js
@@ -8,6 +8,14 @@ class ResponsesQueue {
     this.__respReceivedQueue = {};
   }
 
+  isRequestInQueue(url) {
+    return this.__reqQueue.includes(url);
+  }
+
+  isResponseInQueue(url) {
+    return this.__respPendingQueue.includes(url);
+  }
+
   addResponseListener(url) {
     const page = this.__page;
     const reqQueue = this.__reqQueue;
@@ -50,14 +58,6 @@ class ResponsesQueue {
         }
       }
     });
-  }
-
-  isRequestInQueue(url) {
-    return this.__reqQueue.includes(url);
-  }
-
-  isResponseInQueue(url) {
-    return this.__respPendingQueue.includes(url);
   }
 
   async waitUntilResponse(url, timeout = 10000) {

--- a/tests/e2e/utils/responsesQueue.js
+++ b/tests/e2e/utils/responsesQueue.js
@@ -16,7 +16,7 @@ class ResponsesQueue {
     return this.__respPendingQueue.includes(url);
   }
 
-  addResponseListener(url) {
+  __addRequestListener(url) {
     const page = this.__page;
     const reqQueue = this.__reqQueue;
     const respPendingQueue = this.__respPendingQueue;
@@ -33,6 +33,12 @@ class ResponsesQueue {
         }
       }
     });
+  }
+
+  addResponseListener(url) {
+    this.__addRequestListener(url);
+
+    const respPendingQueue = this.__respPendingQueue;
     const that = this;
     page.on("response", function callback(resp) {
       if (resp.url().includes(url)) {

--- a/tests/e2e/utils/responsesQueue.js
+++ b/tests/e2e/utils/responsesQueue.js
@@ -122,7 +122,7 @@ class ResponsesQueue {
   async waitUntilServiceReady(studyId, nodeId, timeout = 30000) {
     const url = "projects/" + studyId +"/nodes/" + nodeId;
     const resp = await this.waitUntilResponse(url, timeout);
-    const status = resp["service_state"];
+    const status = resp["data"]["service_state"];
     if (status !== "running") {
       throw("-- Failed starting service" + nodeId + ":" + status);
     }

--- a/tests/e2e/utils/responsesQueue.js
+++ b/tests/e2e/utils/responsesQueue.js
@@ -66,6 +66,38 @@ class ResponsesQueue {
     });
   }
 
+  addResponseServiceListener(studyId, nodeId) {
+    const url = "projects/" + studyId +"/nodes/" + nodeId;
+    this.__addRequestListener(url);
+
+    const page = this.__page;
+    const respPendingQueue = this.__respPendingQueue;
+    respPendingQueue.push(url);
+    const that = this;
+    page.on("response", function callback(resp) {
+      if (resp.url().includes(url) && resp.status() === 200) {
+        resp.json().then(data => {
+          console.log((new Date).toUTCString(), "-- Queued services status response received", resp.url(), ":");
+          const status = data["service_state"];
+          console.log("Status:", status);
+          const stopListening = [
+            "running",
+            "complete",
+            "failed"
+          ];
+          if (stopListening.includes(status)) {
+            that.__respReceivedQueue[url] = data;
+            page.removeListener("response", callback);
+            const index = respPendingQueue.indexOf(url);
+            if (index > -1) {
+              respPendingQueue.splice(index, 1);
+            }
+          }
+        });
+      }
+    });
+  }
+
   async waitUntilResponse(url, timeout = 10000) {
     let sleptFor = 0;
     const sleepFor = 100;
@@ -85,6 +117,16 @@ class ResponsesQueue {
       delete this.__respReceivedQueue[url];
       return resp;
     }
+  }
+
+  async waitUntilServiceReady(studyId, nodeId, timeout = 30000) {
+    const url = "projects/" + studyId +"/nodes/" + nodeId;
+    const resp = await this.waitUntilResponse(url, timeout);
+    const status = resp["service_state"];
+    if (status !== "running") {
+      throw("-- Failed starting service" + nodeId + ":" + status);
+    }
+    return resp;
   }
 }
 

--- a/tests/e2e/utils/responsesQueue.js
+++ b/tests/e2e/utils/responsesQueue.js
@@ -19,9 +19,7 @@ class ResponsesQueue {
   __addRequestListener(url) {
     const page = this.__page;
     const reqQueue = this.__reqQueue;
-    const respPendingQueue = this.__respPendingQueue;
     reqQueue.push(url);
-    respPendingQueue.push(url);
     console.log("-- Expected response added to queue", url);
     page.on("request", function callback(req) {
       if (req.url().includes(url)) {
@@ -38,7 +36,9 @@ class ResponsesQueue {
   addResponseListener(url) {
     this.__addRequestListener(url);
 
+    const page = this.__page;
     const respPendingQueue = this.__respPendingQueue;
+    respPendingQueue.push(url);
     const that = this;
     page.on("response", function callback(resp) {
       if (resp.url().includes(url)) {

--- a/tests/e2e/utils/utils.js
+++ b/tests/e2e/utils/utils.js
@@ -168,6 +168,18 @@ async function takeScreenshot(page, captureName) {
   })
 }
 
+function extractWorkbenchData(data) {
+  const workbenchData = {
+    studyId: null,
+    nodeIds: []
+  };
+  workbenchData.studyId = data["uuid"];
+  if ("workbench" in data) {
+    workbenchData.nodeIds = Object.keys(data["workbench"]);
+  }
+  return workbenchData;
+}
+
 module.exports = {
   getUserAndPass,
   getDomain,
@@ -182,4 +194,5 @@ module.exports = {
   waitAndClick,
   sleep,
   takeScreenshot,
+  extractWorkbenchData,
 }


### PR DESCRIPTION
## What do these changes do?
Instead of waiting a hardcoded amount of time for the service to be ready, a Node status listener was added. Now puppeteer waits until the service_state says running.

## Related issue number
related to #1426 


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
