### PR TITLE
Maintenance/minio endpoint and qooxdoo compiler logs

### DIFF
--- a/.env-devel
+++ b/.env-devel
@@ -32,7 +32,8 @@ DIRECTOR_REGISTRY_CACHING_TTL=900
 
 S3_ACCESS_KEY=12345678
 S3_BUCKET_NAME=simcore
-S3_ENDPOINT=minio:9000
+# 172.17.0.1 is the docker0 interface, which redirect from inside a container onto the host network interface.
+S3_ENDPOINT=172.17.0.1:9001
 S3_SECRET_KEY=12345678
 S3_SECURE=0
 

--- a/Makefile
+++ b/Makefile
@@ -190,11 +190,11 @@ endif
 
 up-devel: .stack-simcore-development.yml .init-swarm $(CLIENT_WEB_OUTPUT) ## Deploys local development stack, qx-compile+watch and ops stack (pass 'make ops_disabled=1 up-...' to disable)
 	# Start compile+watch front-end container [front-end]	
-	$(MAKE) -C services/web/client compile-dev flags=--watch
+	$(MAKE_C) services/web/client compile-dev flags=--watch
 	# Deploy stack $(SWARM_STACK_NAME) [back-end]
 	@docker stack deploy -c $< $(SWARM_STACK_NAME)
 	$(MAKE) .deploy-ops
-	$(MAKE) -C services/web/client follow-dev-logs
+	$(MAKE_C) services/web/client follow-dev-logs
 	
 
 up-prod: .stack-simcore-production.yml .init-swarm ## Deploys local production stack and ops stack (pass 'make ops_disabled=1 up-...' to disable)

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,7 @@ up-devel: .stack-simcore-development.yml .init-swarm $(CLIENT_WEB_OUTPUT) ## Dep
 	# Deploy stack $(SWARM_STACK_NAME) [back-end]
 	@docker stack deploy -c $< $(SWARM_STACK_NAME)
 	$(MAKE) .deploy-ops
+	$(MAKE) -C services/web/client follow-dev-logs
 	
 
 up-prod: .stack-simcore-production.yml .init-swarm ## Deploys local production stack and ops stack (pass 'make ops_disabled=1 up-...' to disable)

--- a/services/web/client/Makefile
+++ b/services/web/client/Makefile
@@ -11,6 +11,7 @@ docker_compose := docker-compose -f tools/docker-compose.yml
 docker_file    := tools/qooxdoo-kit/builder/Dockerfile
 docker_image   := client/$(subst /Dockerfile,,$(docker_file)):latest
 
+container_name := qooxdoo-compiler
 
 # qx compile --------------------------
 
@@ -25,12 +26,17 @@ source-output:
 .PHONY: compile-dev
 compile-dev: qx_packages source-output ## qx compiles host' 'source' -> host's 'source-output'. Use 'make compile-dev flags=--watch' for continuous compilation.
 	# qx compile 'source' $(flags) --> 'source-output' [itisfoundation/qooxdoo-kit:${QOOXDOO_KIT_TAG}]
-	$(docker_compose) run --detach --rm qooxdoo-kit \
+	$(docker_compose) run --detach --rm --name=$(container_name) qooxdoo-kit \
 		qx compile $(flags) \
 			--set-env osparc.vcsRef="${VCS_REF}" \
 			--set-env osparc.vcsRefClient="${VCS_REF_CLIENT}" \
 			--set-env osparc.vcsStatusClient="${VCS_STATUS_CLIENT}" \
 			--set-env osparc.vcsOriginUrl="${VCS_URL}"
+
+.PHONY: follow-dev-logs
+follow-dev-logs: ## follow the logs of the qx compiler
+	@docker logs --follow $(container_name)
+
 
 .PHONY: compile touch upgrade
 compile compile-x: ## qx compiles host' 'source' -> image's 'build-output'


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
- sets the devel S3_STORAGE_ENDPOINT to use the docker0 network interface -> it is now possible to use the storage from the frontend in local mode with this trick
- when starting in devel mode with ```make up-devel``` now also follow the logs of the qooxdoo-kit container as before

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
