### PR TITLE
fix env already shows published port

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/minio_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/minio_service.py
@@ -23,7 +23,7 @@ def minio_config(docker_stack: Dict, devel_environ: Dict) -> Dict[str, str]:
     # container onto the host network interface.
     config = {
         "client": {
-            "endpoint": f"172.17.0.1:{get_service_published_port('minio', devel_environ['S3_ENDPOINT'].split(':')[1])}",
+            "endpoint": f"172.17.0.1:{get_service_published_port('minio')}",
             "access_key": devel_environ["S3_ACCESS_KEY"],
             "secret_key": devel_environ["S3_SECRET_KEY"],
             "secure": strtobool(devel_environ["S3_SECURE"]) != 0,


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
fix: minio fixture trying to find the published port when it is already the published port

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
