### PR TITLE
Fixes boot failure in devel mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,10 @@
 # NOTE: None of thes tools are part of the automatic testing
 # NOTE: pylint is already included as test dependency
 
+# FIXME: this file cannot be referenced by services/{}/requirements/dev.txt
+#        because it is NOT mounted in devel container. Therefore the question is
+#        how to sync??
+
 # formatter
 black
 # dependency manager

--- a/services/api-gateway/requirements/dev.txt
+++ b/services/api-gateway/requirements/dev.txt
@@ -13,5 +13,12 @@
 -e .
 
 # basic dev tools
--r ../../../requirements.txt
 watchdog[watchmedo]
+
+## NOTE: Copied from ../../../requirements.txt to avoid mounting
+#        basedir in docker during devel-mode.
+#  TODO: Better solution needed!
+black
+pip-tools
+bump2version
+rope

--- a/services/catalog/requirements/dev.txt
+++ b/services/catalog/requirements/dev.txt
@@ -6,9 +6,6 @@
 #   pip install -r requirements/dev.txt
 #
 
-# basic dev tools
--r ../../../requirements.txt
-
 # installs base + tests requirements
 -r _test.txt
 
@@ -17,3 +14,13 @@
 
 # installs current package
 -e .
+
+# basic dev tools
+
+## NOTE: Copied from ../../../requirements.txt to avoid mounting
+#        basedir in docker during devel-mode.
+#  TODO: Better solution needed!
+black
+pip-tools
+bump2version
+rope

--- a/services/director/requirements/dev.txt
+++ b/services/director/requirements/dev.txt
@@ -18,5 +18,12 @@
 -e .
 
 # basic dev tools
--r ../../../requirements.txt
 watchdog[watchmedo]
+
+## NOTE: Copied from ../../../requirements.txt to avoid mounting
+#        basedir in docker during devel-mode.
+#  TODO: Better solution needed!
+black
+pip-tools
+bump2version
+rope

--- a/services/sidecar/requirements/dev.txt
+++ b/services/sidecar/requirements/dev.txt
@@ -21,5 +21,12 @@
 -e .
 
 # basic dev tools
--r ../../../requirements.txt
 watchdog[watchmedo]
+
+## NOTE: Copied from ../../../requirements.txt to avoid mounting
+#        basedir in docker during devel-mode.
+#  TODO: Better solution needed!
+black
+pip-tools
+bump2version
+rope

--- a/services/storage/requirements/dev.txt
+++ b/services/storage/requirements/dev.txt
@@ -19,5 +19,12 @@
 -e .
 
 # basic dev tools
--r ../../../requirements.txt
 watchdog[watchmedo]
+
+## NOTE: Copied from ../../../requirements.txt to avoid mounting
+#        basedir in docker during devel-mode.
+#  TODO: Better solution needed!
+black
+pip-tools
+bump2version
+rope

--- a/services/web/server/requirements/dev.txt
+++ b/services/web/server/requirements/dev.txt
@@ -20,5 +20,12 @@
 -e .
 
 # basic dev tools
--r ../../../../requirements.txt
 watchdog[watchmedo]
+
+## NOTE: Copied from ../../../requirements.txt to avoid mounting
+#        basedir in docker during devel-mode.
+#  TODO: Better solution needed!
+black
+pip-tools
+bump2version
+rope


### PR DESCRIPTION
Reference to common requirements.txt cannot be reached in devel containers
because the file is not mounted.
The most cost effective solution is to copy&past common requirements (they
do not change much) since COPYing the file in the Dockefile is more
disruptive


## Checklist


- [x] Runs in the swarm in devel mode
