### PR TITLE
[maintenance] requirements upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 [![github.io]](https://itisfoundation.github.io/)
 [![itis.dockerhub]](https://hub.docker.com/u/itisfoundation)
 
-**WARNING** This application is **still under development**.
 
 
 <!-- ADD HERE ALL BADGE URLS -->
@@ -36,7 +35,6 @@ To achieve this, the platform will comprise both state-of-the art and highly det
 
 
 ## Getting Started
-
 
 
 This is the common workflow to build and deploy locally:
@@ -106,6 +104,8 @@ In **windows**, it works under [WSL] (windows subsystem for linux). Some details
 In **MacOS**, [replacing the MacOS utilities with GNU utils](https://apple.stackexchange.com/a/69332) might be required.
 
 ## Releases
+
+**WARNING** This application is **still under development**.
 
 - [Git release workflow](ops/README.md)
 - Public [releases](https://github.com/ITISFoundation/osparc-simcore/releases)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # osparc-simcore platform
 
-**WARNING** This application is **still under development**.
+![oSPARC_Neuroman_Img](https://user-images.githubusercontent.com/32800795/61083844-ff48fb00-a42c-11e9-8e63-fa2d709c8baf.png)
+
 
 <!-- NOTE: when branched replace `master` in urls -->
 [`master`](https://github.com/itisfoundation/osparc-simcore/tree/master)
@@ -13,6 +14,7 @@
 [![github.io]](https://itisfoundation.github.io/)
 [![itis.dockerhub]](https://hub.docker.com/u/itisfoundation)
 
+**WARNING** This application is **still under development**.
 
 
 <!-- ADD HERE ALL BADGE URLS -->
@@ -26,19 +28,17 @@
 
 <!---------------------------->
 
-## Contributing
+
+The SIM-CORE, named **o<sup>2</sup>S<sup>2</sup>PARC** – **O**pen **O**nline **S**imulations for **S**timulating **P**eripheral **A**ctivity to **R**elieve **C**onditions – is one of the three integrative cores of the SPARC program’s Data Resource Center (DRC).
+The aim of o<sup>2</sup>S<sup>2</sup>PARC is to establish a comprehensive, freely accessible, intuitive, and interactive online platform for simulating peripheral nerve system neuromodulation/ stimulation and its impact on organ physiology in a precise and predictive manner.
+To achieve this, the platform will comprise both state-of-the art and highly detailed animal and human anatomical models with realistic tissue property distributions that make it possible to perform simulations ranging from the molecular scale up to the complexity of the human body.
 
 
-Would you like to make a change or add something new? Please read the [contributing guidelines](CONTRIBUTING.md).
+## Getting Started
 
 
-## Overview
 
-simcore-stack when deployed locally:
-
-![](docs/img/.stack-simcore-version.yml.png)
-
-## Usage
+This is the common workflow to build and deploy locally:
 
 ```bash
   # clone repo
@@ -54,7 +54,7 @@ simcore-stack when deployed locally:
   # display swarm configuration
   make info-swarm
 
-  # open browser in:
+  # open front-end in the browser
   #  localhost:9081 - simcore front-end site
   #
   xdg-open http://localhost:9081/
@@ -63,7 +63,14 @@ simcore-stack when deployed locally:
   make down
 ```
 
-## Requirements
+Services are deployed in two stacks:``simcore-stack`` comprises all core-services in the framework
+and ``ops-stack`` is a subset of services from [ITISFoundation/osparc-ops](ITISFoundation/osparc-ops) used
+for operations during development. This is a representation of ``simcore-stack``:
+
+![](docs/img/.stack-simcore-version.yml.png)
+
+
+### Requirements
 
 To verify current base OS, Docker and Python build versions have a look at:
 - Travis CI [config](.travis.yml)
@@ -84,7 +91,7 @@ To develop, in addition:
 
 This project works and is developed under **linux (Ubuntu recommended)**.
 
-##### Other OSes setup
+##### Setting up Other Operating Systems
 
 When developing on these platforms you are on your own.
 
@@ -103,8 +110,16 @@ In **MacOS**, [replacing the MacOS utilities with GNU utils](https://apple.stack
 - Public [releases](https://github.com/ITISFoundation/osparc-simcore/releases)
 - Production in https://osparc.io
 - [Staging instructions](docs/staging-instructions.md)
+- [User Manual](https://itisfoundation.github.io/osparc-manual/)
+
+## Contributing
+
+Would you like to make a change or add something new? Please read the [contributing guidelines](CONTRIBUTING.md).
 
 
+## License
+
+This project is licensed under the terms of the [MIT license](LICENSE).
 
 
 <!-- ADD REFERENCES BELOW AND KEEP THEM IN ALPHABETICAL ORDER -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # osparc-simcore platform
 
-![oSPARC_Neuroman_Img](https://user-images.githubusercontent.com/32800795/61083844-ff48fb00-a42c-11e9-8e63-fa2d709c8baf.png)
-
+<p align="center">
+<img src="https://user-images.githubusercontent.com/32800795/61083844-ff48fb00-a42c-11e9-8e63-fa2d709c8baf.png" width="700">
+</p>
 
 <!-- NOTE: when branched replace `master` in urls -->
 [`master`](https://github.com/itisfoundation/osparc-simcore/tree/master)
@@ -64,7 +65,7 @@ This is the common workflow to build and deploy locally:
 ```
 
 Services are deployed in two stacks:``simcore-stack`` comprises all core-services in the framework
-and ``ops-stack`` is a subset of services from [ITISFoundation/osparc-ops](ITISFoundation/osparc-ops) used
+and ``ops-stack`` is a subset of services from [ITISFoundation/osparc-ops](https://github.com/ITISFoundation/osparc-ops) used
 for operations during development. This is a representation of ``simcore-stack``:
 
 ![](docs/img/.stack-simcore-version.yml.png)

--- a/api/tests/Makefile
+++ b/api/tests/Makefile
@@ -2,6 +2,8 @@
 
 ROOT_DIR  = $(abspath $(CURDIR)/../../)
 VENV_DIR ?= $(abspath $(ROOT_DIR)/.venv)
+UPGRADE_OPTION := $(if $(upgrade),--upgrade-package $(upgrade),--upgrade)
+
 
 .PHONY: all
 all: install tests
@@ -9,7 +11,7 @@ all: install tests
 .PHONY: reqs
 requirements.txt: requirements.in
 	# pip compiling $<
-	@$(VENV_DIR)/bin/pip-compile --output-file $@ $<
+	@$(VENV_DIR)/bin/pip-compile $(UPGRADE_OPTION) --build-isolation --output-file $@ $<
 
 reqs: requirements.txt ## alias to compile requirements.txt
 

--- a/api/tests/requirements.in
+++ b/api/tests/requirements.in
@@ -2,12 +2,11 @@
 # testing
 coverage==4.5.1 # TODO: Downgraded because of a bug https://github.com/nedbat/coveragepy/issues/716
 
-pytest~=5.3.5  # Bug in pytest-sugar https://github.com/Teemu/pytest-sugar/issues/187
+pytest
 pytest-cov
 pytest-aiohttp
 pytest-instafail
 pytest-sugar
-
 
 # fixtures
 aiohttp

--- a/api/tests/requirements.in
+++ b/api/tests/requirements.in
@@ -1,7 +1,6 @@
 
 # testing
-coverage==4.5.1 # TODO: Downgraded because of a bug https://github.com/nedbat/coveragepy/issues/716
-
+coverage
 pytest
 pytest-cov
 pytest-aiohttp

--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -8,7 +8,7 @@ aiohttp==3.6.2            # via -r requirements.in, pytest-aiohttp
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, jsonschema, openapi-core, pytest
 chardet==3.0.4            # via aiohttp
-coverage==4.5.1           # via -r requirements.in, pytest-cov
+coverage==5.1             # via -r requirements.in, pytest-cov
 idna-ssl==1.1.0           # via aiohttp
 idna==2.9                 # via idna-ssl, yarl
 importlib-metadata==1.6.0  # via jsonschema, pluggy, pytest

--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via aiohttp
 coverage==4.5.1           # via -r requirements.in, pytest-cov
 idna-ssl==1.1.0           # via aiohttp
 idna==2.9                 # via idna-ssl, yarl
-importlib-metadata==1.5.0  # via jsonschema, pluggy, pytest
+importlib-metadata==1.6.0  # via jsonschema, pluggy, pytest
 isodate==0.6.0            # via openapi-schema-validator
 jsonschema==3.2.0         # via openapi-schema-validator, openapi-spec-validator
 lazy-object-proxy==1.4.3  # via openapi-core
@@ -24,20 +24,20 @@ packaging==20.3           # via pytest, pytest-sugar
 parse==1.15.0             # via openapi-core
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pyparsing==2.4.6          # via packaging
-pyrsistent==0.15.7        # via jsonschema
+pyparsing==2.4.7          # via packaging
+pyrsistent==0.16.0        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements.in
 pytest-cov==2.8.1         # via -r requirements.in
 pytest-instafail==0.4.1.post0  # via -r requirements.in
-pytest-sugar==0.9.2       # via -r requirements.in
-pytest==5.3.5             # via -r requirements.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-sugar
-pyyaml==5.3               # via openapi-spec-validator
+pytest-sugar==0.9.3       # via -r requirements.in
+pytest==5.4.2             # via -r requirements.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-sugar
+pyyaml==5.3.1             # via openapi-spec-validator
 six==1.14.0               # via isodate, jsonschema, openapi-core, openapi-schema-validator, openapi-spec-validator, packaging
 strict-rfc3339==0.7       # via openapi-schema-validator
 termcolor==1.1.0          # via pytest-sugar
-typing-extensions==3.7.4.1  # via aiohttp
-wcwidth==0.1.8            # via pytest
-werkzeug==1.0.0           # via openapi-core
+typing-extensions==3.7.4.2  # via aiohttp
+wcwidth==0.1.9            # via pytest
+werkzeug==1.0.1           # via openapi-core
 yarl==1.4.2               # via aiohttp
 zipp==3.1.0               # via importlib-metadata
 

--- a/packages/postgres-database/requirements/_migration.in
+++ b/packages/postgres-database/requirements/_migration.in
@@ -4,7 +4,6 @@
 # frozen specs
 -r _base.txt
 
-certifi==2019.11.28 # added contraint to fit pre-installation of jupyter/base-notebook:python-3.7.3 (cannot uninstall)
 urllib3>=1.25.8    # Vulnerability
 
 alembic

--- a/packages/postgres-database/requirements/_migration.txt
+++ b/packages/postgres-database/requirements/_migration.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=requirements/_migration.txt requirements/_migration.in
 #
 alembic==1.4.2            # via -r requirements/_migration.in
-certifi==2019.11.28       # via -r requirements/_migration.in, requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r requirements/_migration.in
 docker==4.2.0             # via -r requirements/_migration.in

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -10,7 +10,7 @@ alembic==1.4.2            # via -r requirements/_migration.txt
 astroid==2.4.1            # via pylint
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, pytest, pytest-docker
-certifi==2019.11.28       # via -r requirements/_migration.txt, requests
+certifi==2020.4.5.1       # via -r requirements/_migration.txt, requests
 chardet==3.0.4            # via -r requirements/_migration.txt, aiohttp, requests
 click==7.1.2              # via -r requirements/_migration.txt
 coverage==5.1             # via -r requirements/_test.in, coveralls, pytest-cov

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -17,7 +17,7 @@ coverage==5.1             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.0.0          # via -r requirements/_test.in
 docker==4.2.0             # via -r requirements/_migration.txt
 docopt==0.6.2             # via coveralls
-faker==4.0.3              # via -r requirements/_test.in
+faker==4.1.0              # via -r requirements/_test.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.9                 # via -r requirements/_migration.txt, requests, yarl
 importlib-metadata==1.6.0  # via pluggy, pytest

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -13,7 +13,7 @@ aiohttp-swagger[performance]==1.0.14  # via -r requirements/_base.in
 aiohttp==3.6.2            # via -r requirements/../../../../packages/service-library/requirements/_base.in, aiohttp-jinja2, aiohttp-security, aiohttp-session, aiohttp-swagger, aiozipkin
 aiopg[sa]==1.0.0          # via -r requirements/../../../../packages/service-library/requirements/_base.in, -r requirements/_base.in
 aioredis==1.3.1           # via -r requirements/_base.in
-aiormq==3.2.1             # via aio-pika
+aiormq==3.2.2             # via aio-pika
 aiosmtplib==1.1.3         # via -r requirements/_base.in
 aiozipkin==0.6.0          # via -r requirements/../../../../packages/service-library/requirements/_base.in
 amqp==2.5.2               # via kombu

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -13,7 +13,7 @@ aiohttp-swagger[performance]==1.0.14  # via -r requirements/_base.txt
 aiohttp==3.6.2            # via -r requirements/_base.txt, aiohttp-jinja2, aiohttp-security, aiohttp-session, aiohttp-swagger, aiozipkin, pytest-aiohttp
 aiopg[sa]==1.0.0          # via -r requirements/_base.txt
 aioredis==1.3.1           # via -r requirements/_base.txt
-aiormq==3.2.1             # via -r requirements/_base.txt, aio-pika
+aiormq==3.2.2             # via -r requirements/_base.txt, aio-pika
 aiosmtplib==1.1.3         # via -r requirements/_base.txt
 aiozipkin==0.6.0          # via -r requirements/_base.txt
 amqp==2.5.2               # via -r requirements/_base.txt, kombu
@@ -34,7 +34,7 @@ cryptography==2.9.2       # via -r requirements/_base.txt, aiohttp-session
 docker==4.2.0             # via -r requirements/_test.in
 docopt==0.6.2             # via coveralls
 expiringdict==1.2.0       # via -r requirements/_base.txt
-faker==4.0.3              # via -r requirements/_test.in
+faker==4.1.0              # via -r requirements/_test.in
 hiredis==1.0.1            # via -r requirements/_base.txt, aioredis
 idna-ssl==1.1.0           # via -r requirements/_base.txt, aiohttp
 idna==2.9                 # via -r requirements/_base.txt, idna-ssl, requests, yarl
@@ -80,7 +80,7 @@ python-engineio==3.12.1   # via -r requirements/_base.txt, python-socketio
 python-socketio==4.5.1    # via -r requirements/_base.txt
 pytz==2020.1              # via -r requirements/_base.txt, celery
 pyyaml==5.3.1             # via -r requirements/_base.txt, aiohttp-swagger, openapi-spec-validator
-redis==3.5.0              # via -r requirements/_test.in
+redis==3.5.1              # via -r requirements/_test.in
 requests==2.23.0          # via codecov, coveralls, docker
 semantic-version==2.8.5   # via -r requirements/_base.txt
 six==1.14.0               # via -r requirements/_base.txt, astroid, cryptography, docker, isodate, jsonschema, openapi-core, openapi-spec-validator, packaging, pyrsistent, python-dateutil, python-engineio, python-socketio, tenacity, websocket-client

--- a/tests/swarm-deploy/requirements/requirements.in
+++ b/tests/swarm-deploy/requirements/requirements.in
@@ -1,5 +1,5 @@
 aio-pika
-coverage==4.5.1 # TODO: Downgraded because of a bug https://github.com/nedbat/coveragepy/issues/716
+coverage
 pytest
 pytest-aiohttp
 pytest-cov

--- a/tests/swarm-deploy/requirements/requirements.txt
+++ b/tests/swarm-deploy/requirements/requirements.txt
@@ -6,37 +6,37 @@
 #
 aio-pika==6.6.0           # via -r requirements/requirements.in
 aiohttp==3.6.2            # via pytest-aiohttp
-aiormq==3.2.1             # via aio-pika
+aiormq==3.2.2             # via aio-pika
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, pytest
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via aiohttp, requests
-coverage==4.5.1           # via -r requirements/requirements.in, pytest-cov
+coverage==5.1             # via -r requirements/requirements.in, pytest-cov
 docker==4.2.0             # via -r requirements/requirements.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.9                 # via requests, yarl
-importlib-metadata==1.5.2  # via pluggy, pytest
+importlib-metadata==1.6.0  # via pluggy, pytest
 more-itertools==8.2.0     # via pytest
 multidict==4.7.5          # via aiohttp, yarl
 packaging==20.3           # via pytest, pytest-sugar
 pamqp==2.3.0              # via aiormq
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via -r requirements/requirements.in
 pytest-cov==2.8.1         # via -r requirements/requirements.in
 pytest-instafail==0.4.1.post0  # via -r requirements/requirements.in
-pytest-mock==2.0.0        # via -r requirements/requirements.in
+pytest-mock==3.1.0        # via -r requirements/requirements.in
 pytest-runner==5.2        # via -r requirements/requirements.in
-pytest-sugar==0.9.2       # via -r requirements/requirements.in
+pytest-sugar==0.9.3       # via -r requirements/requirements.in
 pytest==5.4.2             # via -r requirements/requirements.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-mock, pytest-sugar
 pyyaml==5.3.1             # via -r requirements/requirements.in
 requests==2.23.0          # via docker
 six==1.14.0               # via docker, packaging, tenacity, websocket-client
-tenacity==6.1.0           # via -r requirements/requirements.in
+tenacity==6.2.0           # via -r requirements/requirements.in
 termcolor==1.1.0          # via pytest-sugar
-typing-extensions==3.7.4.1  # via aiohttp
-urllib3==1.25.8           # via requests
+typing-extensions==3.7.4.2  # via aiohttp
+urllib3==1.25.9           # via requests
 wcwidth==0.1.9            # via pytest
 websocket-client==0.57.0  # via docker
 yarl==1.4.2               # via aio-pika, aiohttp, aiormq


### PR DESCRIPTION
## What do these changes do?

- upgrade to latest ``Fake`` and ``redis`` packages (replaces faulty PR ##1501) both in ``packages`` and ``services/web/server``
- upgrades api/tests requirements and Makefile
- upgrades missing requirements from non-packages/services folders (e.g. ``coverage``, ``pytest``)

