### PR TITLE
Fix opencor e2e test

### DIFF
--- a/services/web/client/source/class/osparc/component/widget/NodesTree.js
+++ b/services/web/client/source/class/osparc/component/widget/NodesTree.js
@@ -187,7 +187,9 @@ qx.Class.define("osparc.component.widget.NodesTree", {
             }, this);
             item.addListener("tap", e => {
               this.fireDataEvent("changeSelectedNode", item.getModel().getNodeId());
-              this.__exportButton.setEnabled((Boolean(item.getLevel()) && item.getModel().getIsContainer()));
+              if (this.__exportButton) {
+                this.__exportButton.setEnabled((Boolean(item.getLevel()) && item.getModel().getIsContainer()));
+              }
             }, this);
           }
         });


### PR DESCRIPTION
## What do these changes do?
The issue was not the opencor test itself, but this test is the first one that has to click on a NodesTree item. The problem is that some context checks are done when clicking an item and since the export button does not exist for GUEST users, the enable/disable operation on the button fails, not letting the item-clicking-routine go through.