### PR TITLE
UI/UX Study Editor

### DIFF
--- a/services/web/client/source/class/osparc/component/node/BaseNodeView.js
+++ b/services/web/client/source/class/osparc/component/node/BaseNodeView.js
@@ -172,33 +172,33 @@ qx.Class.define("osparc.component.node.BaseNodeView", {
     },
 
     __buildCollapsedSideView: function(isInput) {
-      const inText = this.tr("Inputs");
-      const outText = this.tr("Outputs");
-      const inIcon = "@FontAwesome5Solid/chevron-down/12";
-      const outIcon = "@FontAwesome5Solid/chevron-up/12";
+      const text = isInput ? this.tr("Inputs") : this.tr("Outputs");
+      const icon = isInput ? "@FontAwesome5Solid/chevron-down/12" : "@FontAwesome5Solid/chevron-up/12";
+      const minWidth = isInput ? 120 : 130;
+      const view = isInput ? this.__inputsView : this.__outputsView;
+      const container = isInput ? this.__inputNodesLayout : this.__outputNodesLayout;
+
       const collapsedView = new qx.ui.basic.Atom().set({
-        label: (isInput ? inText : outText) + " (0)",
-        icon: isInput ? inIcon : outIcon,
+        label: text + " (0)",
+        icon: icon,
         iconPosition: "right",
         gap: 6,
         padding: 8,
         alignX: "center",
         alignY: "middle",
-        minWidth: isInput ? 120 : 130,
+        minWidth: minWidth,
         font: "title-18"
       });
       collapsedView.getContentElement().addClass("verticalText");
-      const view = isInput ? this.__inputsView : this.__outputsView;
       collapsedView.addListener("tap", view.toggleCollapsed.bind(view));
 
-      const container = isInput ? this.__inputNodesLayout : this.__outputNodesLayout;
       [
         "addChildWidget",
         "removeChildWidget"
       ].forEach(event => {
         container.addListener(event, () => {
           const nChildren = container.getChildren().length;
-          collapsedView.setLabel((isInput ? inText : outText) + " (" + nChildren + ")");
+          collapsedView.setLabel(text + " (" + nChildren + ")");
         });
       });
 

--- a/services/web/client/source/class/osparc/component/node/BaseNodeView.js
+++ b/services/web/client/source/class/osparc/component/node/BaseNodeView.js
@@ -293,12 +293,7 @@ qx.Class.define("osparc.component.node.BaseNodeView", {
     },
 
     __createInputPortsUI: function(inputNode, isInputModel = true) {
-      let nodePorts = null;
-      if (isInputModel) {
-        nodePorts = inputNode.getOutputWidget();
-      } else {
-        nodePorts = inputNode.getInputsDefaultWidget();
-      }
+      const nodePorts = isInputModel ? inputNode.getOutputWidget() : inputNode.getInputsDefaultWidget();
       if (nodePorts) {
         this.__inputNodesLayout.add(nodePorts, {
           flex: 1

--- a/services/web/client/source/class/osparc/component/node/BaseNodeView.js
+++ b/services/web/client/source/class/osparc/component/node/BaseNodeView.js
@@ -159,13 +159,6 @@ qx.Class.define("osparc.component.node.BaseNodeView", {
       }, this);
 
       const collapsedView = this.__buildCollapsedSideView(isInput);
-      collapsedView.addListenerOnce("appear", () => {
-        const elem = collapsedView.getContentElement();
-        console.log(elem);
-        // const size = qx.bom.element.Dimension.getSize(collapsedView);
-        // collapsedView.setDomLeft(-1 * (size.width/2) - (size.height/2));
-        collapsedView.setDomLeft(-45);
-      });
       sidePanel.setCollapsedView(collapsedView);
 
       return sidePanel;
@@ -191,6 +184,13 @@ qx.Class.define("osparc.component.node.BaseNodeView", {
       });
       collapsedView.getContentElement().addClass("verticalText");
       collapsedView.addListener("tap", view.toggleCollapsed.bind(view));
+      collapsedView.addListenerOnce("appear", () => {
+        const elem = collapsedView.getContentElement();
+        console.log(elem);
+        // const size = qx.bom.element.Dimension.getSize(collapsedView);
+        // collapsedView.setDomLeft(-1 * (size.width/2) - (size.height/2));
+        collapsedView.setDomLeft(-45);
+      });
 
       [
         "addChildWidget",

--- a/services/web/client/source/class/osparc/component/widget/CollapsibleView.js
+++ b/services/web/client/source/class/osparc/component/widget/CollapsibleView.js
@@ -52,8 +52,8 @@ qx.Class.define("osparc.component.widget.CollapsibleView", {
   },
 
   statics: {
-    MORE_CARET: "@MaterialIcons/expand_more/",
-    LESS_CARET: "@MaterialIcons/expand_less/"
+    COLLAPSED_CARET: "@MaterialIcons/chevron_right/",
+    EXPANDED_CARET: "@MaterialIcons/expand_more/"
   },
 
   properties: {
@@ -193,8 +193,8 @@ qx.Class.define("osparc.component.widget.CollapsibleView", {
 
     __getCaretId: function(collapsed) {
       const caretSize = this.getCaretSize();
-      const moreCaret = this.self().MORE_CARET;
-      const lessCaret = this.self().LESS_CARET;
+      const moreCaret = this.self().COLLAPSED_CARET;
+      const lessCaret = this.self().EXPANDED_CARET;
       return collapsed ? moreCaret + caretSize : lessCaret + caretSize;
     },
 

--- a/services/web/client/source/class/osparc/component/widget/CollapsibleView.js
+++ b/services/web/client/source/class/osparc/component/widget/CollapsibleView.js
@@ -96,14 +96,14 @@ qx.Class.define("osparc.component.widget.CollapsibleView", {
     _createChildControlImpl: function(id) {
       let control;
       switch (id) {
-        case "title":
-          control = new qx.ui.basic.Atom(this.getTitle());
-          this.__titleBar.addAt(control, 0);
-          break;
         case "caret":
           control = new qx.ui.basic.Image(this.__getCaretId(this.getCollapsed())).set({
             visibility: "excluded"
           });
+          this.__titleBar.addAt(control, 0);
+          break;
+        case "title":
+          control = new qx.ui.basic.Atom(this.getTitle());
           this.__titleBar.addAt(control, 1);
           break;
       }

--- a/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -196,11 +196,10 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
     },
 
     __createServiceCatalog: function(pos) {
-      let srvCat = new osparc.component.workbench.ServiceCatalog();
+      const srvCat = new osparc.component.workbench.ServiceCatalog();
       if (pos) {
-        srvCat.moveTo(pos.x, pos.y);
+        srvCat.moveTo(pos.x + this.__getSidePanelWidth(), pos.y);
       } else {
-        // srvCat.center();
         const bounds = this.getLayoutParent().getBounds();
         const workbenchUICenter = {
           x: bounds.left + parseInt((bounds.left + bounds.width) / 2),
@@ -602,11 +601,17 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
       });
     },
 
+    __getSidePanelWidth: function() {
+      const sidePanelWidth = window.screen.width - this.getInnerSize().width;
+      return sidePanelWidth;
+    },
+
     __getPointEventPosition: function(pointerEvent) {
       const navBarHeight = 50;
+      const sidePanelWidth = this.__getSidePanelWidth();
       const inputNodesLayoutWidth = this.__inputNodesLayout.isVisible() ? this.__inputNodesLayout.getWidth() : 0;
-      const x = pointerEvent.getViewportLeft() - this.getBounds().left - inputNodesLayoutWidth;
-      const y = pointerEvent.getViewportTop() - navBarHeight;
+      const x = pointerEvent.getDocumentLeft() - sidePanelWidth - inputNodesLayoutWidth;
+      const y = pointerEvent.getDocumentTop() - navBarHeight;
       return [x, y];
     },
 

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonBase.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonBase.js
@@ -94,13 +94,16 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonBase", {
           break;
         case "description":
           control = new osparc.ui.markdown.Markdown().set({
+            anonymous: true,
             font: "text-13",
             maxHeight: 30
           });
           this._mainLayout.addAt(control, 1);
           break;
         case "shared-creator":
-          control = new qx.ui.container.Composite(new qx.ui.layout.HBox(6));
+          control = new qx.ui.container.Composite(new qx.ui.layout.HBox(6)).set({
+            anonymous: true
+          });
           this._mainLayout.addAt(control, 2);
           break;
         case "shared": {
@@ -111,6 +114,7 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonBase", {
         }
         case "creator": {
           control = new qx.ui.basic.Label().set({
+            anonymous: true,
             font: "text-13",
             allowGrowY: false
           });
@@ -121,11 +125,14 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonBase", {
           break;
         }
         case "tags":
-          control = new qx.ui.container.Composite(new qx.ui.layout.Flow(5, 3));
+          control = new qx.ui.container.Composite(new qx.ui.layout.Flow(5, 3)).set({
+            anonymous: true
+          });
           this._mainLayout.addAt(control, 3);
           break;
         case "icon": {
           control = new qx.ui.basic.Image().set({
+            anonymous: true,
             scale: true,
             allowStretchX: true,
             allowStretchY: true,
@@ -152,9 +159,6 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonBase", {
           break;
         }
       }
-      control.set({
-        anonymous: true
-      });
       return control || this.base(arguments, id);
     },
 

--- a/services/web/client/source/class/osparc/desktop/ControlsBar.js
+++ b/services/web/client/source/class/osparc/desktop/ControlsBar.js
@@ -96,9 +96,9 @@ qx.Class.define("osparc.desktop.ControlsBar", {
 
       const simCtrls = new qx.ui.toolbar.Part();
       const startButton = this.__startButton = this.__createStartButton();
-      const stopButton = this.__stopButton = this.__createStopButton();
       simCtrls.add(startButton);
-      simCtrls.add(stopButton);
+      // const stopButton = this.__stopButton = this.__createStopButton();
+      // simCtrls.add(stopButton);
       this.add(simCtrls);
     },
 

--- a/services/web/client/source/class/osparc/desktop/ControlsBar.js
+++ b/services/web/client/source/class/osparc/desktop/ControlsBar.js
@@ -97,8 +97,8 @@ qx.Class.define("osparc.desktop.ControlsBar", {
       const simCtrls = new qx.ui.toolbar.Part();
       const startButton = this.__startButton = this.__createStartButton();
       simCtrls.add(startButton);
-      // const stopButton = this.__stopButton = this.__createStopButton();
-      // simCtrls.add(stopButton);
+      const stopButton = this.__stopButton = this.__createStopButton();
+      simCtrls.add(stopButton);
       this.add(simCtrls);
     },
 
@@ -139,6 +139,8 @@ qx.Class.define("osparc.desktop.ControlsBar", {
 
     __createStopButton: function() {
       const stopButton = this.__createButton(this.tr("Stop"), "stop-circle", "stopStudyBtn", "stopPipeline");
+      // do not show until it Stops the pipeline
+      stopButton.setVisibility("excluded");
       return stopButton;
     },
 

--- a/services/web/client/source/class/osparc/desktop/NavigationBar.js
+++ b/services/web/client/source/class/osparc/desktop/NavigationBar.js
@@ -192,6 +192,7 @@ qx.Class.define("osparc.desktop.NavigationBar", {
         this.__dashboardContext(true);
         return;
       }
+      this.__dashboardContext(false);
       if (nodeIds.length === 1) {
         return;
       }

--- a/services/web/client/source/class/osparc/desktop/PanelView.js
+++ b/services/web/client/source/class/osparc/desktop/PanelView.js
@@ -26,7 +26,7 @@ qx.Class.define("osparc.desktop.PanelView", {
     this.base(arguments, title, content);
 
     // Title bar
-    this.__titleBar.set({
+    this.getTitleBar().set({
       appearance: "panelview-titlebar"
     });
   },

--- a/services/web/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/web/client/source/class/osparc/desktop/StudyEditor.js
@@ -117,14 +117,23 @@ qx.Class.define("osparc.desktop.StudyEditor", {
         const nodeId = e.getData();
         this.__removeNode(nodeId);
       }, this);
-      this.__sidePanel.addOrReplaceAt(new osparc.desktop.PanelView(this.tr("Service tree"), nodesTree), 0);
+      this.__sidePanel.addOrReplaceAt(new osparc.desktop.PanelView(this.tr("Service tree"), nodesTree), 0, {
+        flex: 1
+      });
 
       const extraView = this.__extraView = new osparc.component.metadata.StudyInfo(study);
-      extraView.setMaxHeight(300);
-      this.__sidePanel.addOrReplaceAt(new osparc.desktop.PanelView(this.tr("Study information"), extraView), 1);
+      this.__sidePanel.addOrReplaceAt(new osparc.desktop.PanelView(this.tr("Study information"), extraView), 1, {
+        flex: 1
+      });
 
       const loggerView = this.__loggerView = new osparc.component.widget.logger.LoggerView(study.getWorkbench());
-      this.__sidePanel.addOrReplaceAt(new osparc.desktop.PanelView(this.tr("Logger"), loggerView), 2);
+      const loggerPanel = new osparc.desktop.PanelView(this.tr("Logger"), loggerView);
+      this.__sidePanel.addOrReplaceAt(loggerPanel, 2, {
+        flex: 1
+      });
+      if (!osparc.data.Permissions.getInstance().canDo("study.logger.debug.read")) {
+        loggerPanel.setCollapsed(true);
+      }
 
       const workbenchUI = this.__workbenchUI = new osparc.component.workbench.WorkbenchUI(study.getWorkbench());
       workbenchUI.addListener("removeEdge", e => {

--- a/services/web/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/web/client/source/class/osparc/desktop/StudyEditor.js
@@ -28,15 +28,14 @@ qx.Class.define("osparc.desktop.StudyEditor", {
       minWidth: 0,
       width: 400
     });
-    sidePanel.getContentElement().setStyle("border-left", "1px solid " + qx.theme.manager.Color.getInstance().resolve("material-button-background"));
-
+    sidePanel.getContentElement().setStyle("border-right", "1px solid " + qx.theme.manager.Color.getInstance().resolve("material-button-background"));
     const scroll = this.__scrollContainer = new qx.ui.container.Scroll().set({
       minWidth: 0
     });
     scroll.add(sidePanel);
 
-    this.add(mainPanel, 1); // flex 1
     this.add(scroll, 0); // flex 0
+    this.add(mainPanel, 1); // flex 1
 
     this.__attachEventHandlers();
   },

--- a/services/web/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/web/client/source/class/osparc/desktop/StudyEditor.js
@@ -28,7 +28,7 @@ qx.Class.define("osparc.desktop.StudyEditor", {
       minWidth: 0,
       width: 400
     });
-    sidePanel.getContentElement().setStyle("border-right", "1px solid " + qx.theme.manager.Color.getInstance().resolve("material-button-background"));
+    osparc.utils.Utils.addBorder(sidePanel, "right");
     const scroll = this.__scrollContainer = new qx.ui.container.Scroll().set({
       minWidth: 0
     });

--- a/services/web/client/source/class/osparc/utils/Utils.js
+++ b/services/web/client/source/class/osparc/utils/Utils.js
@@ -49,6 +49,10 @@ qx.Class.define("osparc.utils.Utils", {
       return loadingUri;
     },
 
+    addBorder: function(sidePanel, where = "right") {
+      sidePanel.getContentElement().setStyle("border-"+where, "1px solid " + qx.theme.manager.Color.getInstance().resolve("material-button-background"));
+    },
+
     __setStyleToIFrame: function(domEl) {
       if (domEl && domEl.contentDocument && domEl.contentDocument.documentElement) {
         const iframeDocument = domEl.contentDocument.documentElement;


### PR DESCRIPTION
## What do these changes do?
- [x] Fix. Brought back the hover functions (tooltips) on the Study sheets
- [x] Fix. Dashboard was still a Label instead of a Button when opening a study
- [x] Side Panel on the left side and collapsing works more Visual Code like
- [x] Logger collapsed by default
- [x] Stop button hidden

## Related issue number
ITISFoundation/osparc-issues#168

Before:
![image](https://user-images.githubusercontent.com/33152403/82226017-3da12780-9926-11ea-8621-b4d07c43d7ad.png)

After:
![image](https://user-images.githubusercontent.com/33152403/82225822-f7e45f00-9925-11ea-9c43-b2695318572b.png)
