### PR TITLE
[bugfix] storage service fails when blackfynn API is not responsive

### DIFF
--- a/services/storage/src/simcore_service_storage/datcore.py
+++ b/services/storage/src/simcore_service_storage/datcore.py
@@ -22,14 +22,6 @@ logger = logging.getLogger(__name__)
 DatasetMetaDataVec = List[DatasetMetaData]
 
 
-# FIXME: W0611:Unused IOAPI imported from blackfynn.api.transfers
-# from blackfynn.api.transfers import IOAPI
-
-
-# FIXME: W0212:Access to a protected member _api of a client class
-# pylint: disable=W0212
-
-
 def _get_collection_id(
     folder: BaseCollection, _collections: List[str], collection_id: str
 ) -> str:
@@ -53,7 +45,7 @@ def _get_collection_id(
 
 class DatcoreClient(object):
     def __init__(self, api_token=None, api_secret=None, host=None, streaming_host=None):
-        # WARNING: contruction raise exception if service is not available
+        # WARNING: contruction raise exception if service is not available. Use datacore_wrapper for safe calls
         self.client = Blackfynn(
             profile=None,
             api_token=api_token,
@@ -311,8 +303,9 @@ class DatcoreClient(object):
         if collection is None:
             return False
 
-        files = [filepath]
-        # pylint: disable = E1101
+        files = [
+            filepath,
+        ]
         self.client._api.io.upload_files(collection, files, display_progress=True)
         collection.update()
 
@@ -350,7 +343,6 @@ class DatcoreClient(object):
             destination__apth (str): Path on host for storing file
         """
 
-        # pylint: disable = E1101
         url = self.download_link(source, filename)
         if url:
             _file = urllib.URLopener()
@@ -363,7 +355,7 @@ class DatcoreClient(object):
             returns presigned url for download, destination is a dataset or collection
         """
         collection, collection_id = self._collection_from_destination(destination)
-        # pylint: disable = E1101
+
         for item in collection:
             if isinstance(item, DataPackage):
                 if Path(item.files[0].as_dict()["content"]["s3key"]).name == filename:

--- a/services/storage/src/simcore_service_storage/datcore.py
+++ b/services/storage/src/simcore_service_storage/datcore.py
@@ -53,6 +53,7 @@ def _get_collection_id(
 
 class DatcoreClient(object):
     def __init__(self, api_token=None, api_secret=None, host=None, streaming_host=None):
+        # NOTE: if service is down, this raise exception!
         self.client = Blackfynn(
             profile=None,
             api_token=api_token,

--- a/services/storage/src/simcore_service_storage/datcore.py
+++ b/services/storage/src/simcore_service_storage/datcore.py
@@ -53,7 +53,7 @@ def _get_collection_id(
 
 class DatcoreClient(object):
     def __init__(self, api_token=None, api_secret=None, host=None, streaming_host=None):
-        # NOTE: if service is down, this raise exception!
+        # WARNING: contruction raise exception if service is not available
         self.client = Blackfynn(
             profile=None,
             api_token=api_token,

--- a/services/storage/src/simcore_service_storage/datcore.py
+++ b/services/storage/src/simcore_service_storage/datcore.py
@@ -345,7 +345,7 @@ class DatcoreClient(object):
 
         url = self.download_link(source, filename)
         if url:
-            _file = urllib.URLopener()
+            _file = urllib.URLopener() # nosec
             _file.retrieve(url, destination_path)
             return True
         return False

--- a/services/storage/src/simcore_service_storage/datcore_wrapper.py
+++ b/services/storage/src/simcore_service_storage/datcore_wrapper.py
@@ -28,7 +28,7 @@ def safe_call(error_msg: str = "", *, skip_logs: bool = False):
     except AttributeError:
         if not skip_logs:
             logger.warning("Calling disabled client. %s", error_msg)
-    except Exception: # pylint: disable=broad-except
+    except Exception:  # pylint: disable=broad-except
         if error_msg and not skip_logs:
             logger.warning(error_msg, exc_info=True)
 
@@ -53,7 +53,10 @@ class DatcoreWrapper:
 
         This can go away now. Next cleanup round...
 
+        NOTE: Auto-disables client
+
     """
+
     def __init__(
         self, api_token: str, api_secret: str, loop: object, pool: ThreadPoolExecutor
     ):
@@ -72,8 +75,19 @@ class DatcoreWrapper:
         except Exception:
             self.d_client = None  # Disabled: any call will raise AttributeError
             logger.warning(
-                "Failed to connect to datcore. Disabling client.", exc_info=True
+                "Failed to setup datcore. Disabling client.", exc_info=True
             )
+
+    @property
+    def is_communication_enabled(self) -> bool:
+        """ Wrapper class auto-disables if client cannot be created
+
+            e.g. if endpoint service is down
+
+        :return: True if communication with datcore is enabled
+        :rtype: bool
+        """
+        return self.d_client is not None
 
     @make_async
     def list_files_recursively(self) -> FileMetaDataVec:  # pylint: disable=W0613

--- a/services/storage/src/simcore_service_storage/datcore_wrapper.py
+++ b/services/storage/src/simcore_service_storage/datcore_wrapper.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from functools import wraps
 from pathlib import Path
 from typing import List
@@ -17,8 +18,19 @@ FileMetaDataExVec = List[FileMetaDataEx]
 CURRENT_DIR = Path(__file__).resolve().parent
 logger = logging.getLogger(__name__)
 
-# FIXME: W0703: Catching too general exception Exception (broad-except)
 # pylint: disable=W0703
+
+
+@contextmanager
+def safe_call(error_msg: str = "", *, skip_logs: bool = False):
+    try:
+        yield
+    except AttributeError:
+        if not skip_logs:
+            logger.warning("Calling disabled client. %s", error_msg)
+    except Exception: # pylint: disable=broad-except
+        if error_msg and not skip_logs:
+            logger.warning(error_msg, exc_info=True)
 
 
 # TODO: Use async callbacks for retreival of progress and pass via rabbit to server
@@ -42,9 +54,6 @@ class DatcoreWrapper:
         This can go away now. Next cleanup round...
 
     """
-
-    # pylint: disable=R0913
-    # Too many arguments
     def __init__(
         self, api_token: str, api_secret: str, loop: object, pool: ThreadPoolExecutor
     ):
@@ -54,27 +63,33 @@ class DatcoreWrapper:
         self.loop = loop
         self.pool = pool
 
-        self.d_client = DatcoreClient(
-            api_token=api_token, api_secret=api_secret, host="https://api.blackfynn.io"
-        )
+        try:
+            self.d_client = DatcoreClient(
+                api_token=api_token,
+                api_secret=api_secret,
+                host="https://api.blackfynn.io",
+            )
+        except Exception:
+            self.d_client = None  # Disabled: any call will raise AttributeError
+            logger.warning(
+                "Failed to connect to datcore. Disabling client.", exc_info=True
+            )
 
     @make_async
     def list_files_recursively(self) -> FileMetaDataVec:  # pylint: disable=W0613
         files = []
-        try:
+
+        with safe_call(error_msg="Error listing datcore files"):
             files = self.d_client.list_files_recursively()
-        except Exception:
-            logger.exception("Error listing datcore files")
 
         return files
 
     @make_async
     def list_files_raw(self) -> FileMetaDataExVec:  # pylint: disable=W0613
         files = []
-        try:
+
+        with safe_call(error_msg="Error listing datcore files"):
             files = self.d_client.list_files_raw()
-        except Exception:
-            logger.exception("Error listing datcore files")
 
         return files
 
@@ -83,35 +98,28 @@ class DatcoreWrapper:
         self, dataset_id: str
     ) -> FileMetaDataExVec:  # pylint: disable=W0613
         files = []
-        try:
+        with safe_call(error_msg="Error listing datcore files"):
             files = self.d_client.list_files_raw_dataset(dataset_id)
-        except Exception:
-            logger.exception("Error listing datcore files")
 
         return files
 
     @make_async
     def delete_file(self, destination: str, filename: str):
         # the object can be found in dataset/filename <-> bucket_name/object_name
-        try:
+        with safe_call(error_msg="Error deleting datcore file"):
             self.d_client.delete_file(destination, filename)
-        except Exception:
-            logger.exception("Error deleting datcore file")
 
     @make_async
     def delete_file_by_id(self, file_id: str):
-        try:
+
+        with safe_call(error_msg="Error deleting datcore file"):
             self.d_client.delete_file_by_id(file_id)
-        except Exception:
-            logger.exception("Error deleting datcore file")
 
     @make_async
     def download_link(self, destination: str, filename: str):
         url = ""
-        try:
+        with safe_call(error_msg="Error getting datcore download link"):
             url = self.d_client.download_link(destination, filename)
-        except Exception:
-            logger.exception("Error getting datcore download link")
 
         return url
 
@@ -119,91 +127,73 @@ class DatcoreWrapper:
     def download_link_by_id(self, file_id: str):
         url = ""
         filename = ""
-        try:
+        with safe_call(error_msg="Error getting datcore download link"):
             url, filename = self.d_client.download_link_by_id(file_id)
-        except Exception:
-            logger.exception("Error getting datcore download link")
 
         return url, filename
 
     @make_async
     def create_test_dataset(self, dataset):
-        try:
+
+        with safe_call(error_msg="Error creating test dataset"):
             ds = self.d_client.get_dataset(dataset)
             if ds is not None:
                 self.d_client.delete_files(dataset)
             else:
                 ds = self.d_client.create_dataset(dataset)
             return ds.id
-        except Exception:
-            logger.exception("Error creating test dataset")
-
         return ""
 
     @make_async
     def delete_test_dataset(self, dataset):
-        try:
+
+        with safe_call(error_msg="Error deleting test dataset"):
             ds = self.d_client.get_dataset(dataset)
             if ds is not None:
                 self.d_client.delete_files(dataset)
-        except Exception:
-            logger.exception("Error deleting test dataset")
 
     @make_async
     def upload_file(
         self, destination: str, local_path: str, meta_data: FileMetaData = None
     ):
-        json_meta = ""
-        if meta_data:
-            json_meta = json.dumps(attr.asdict(meta_data))
-        try:
-            str_meta = json_meta
-            result = False
+        result = False
+        str_meta = json.dumps(attr.asdict(meta_data)) if meta_data else ""
+
+        with safe_call(error_msg="Error uploading file to datcore"):
             if str_meta:
                 meta_data = json.loads(str_meta)
                 result = self.d_client.upload_file(destination, local_path, meta_data)
             else:
                 result = self.d_client.upload_file(destination, local_path)
-            return result
-        except Exception:
-            logger.exception("Error uploading file to datcore")
-            return False
+        return result
 
     @make_async
     def upload_file_to_id(self, destination_id: str, local_path: str):
         _id = ""
-        try:
+
+        with safe_call(error_msg="Error uploading file to datcore"):
             _id = self.d_client.upload_file_to_id(destination_id, local_path)
-        except Exception:
-            logger.exception("Error uploading file to datcore")
 
         return _id
 
     @make_async
     def create_collection(self, destination_id: str, collection_name: str):
-
         _id = ""
-        try:
+        with safe_call(error_msg="Error creating collection in datcore"):
             _id = self.d_client.create_collection(destination_id, collection_name)
-        except Exception:
-            logger.exception("Error creating collection in datcore")
         return _id
 
     @make_async
     def list_datasets(self):
         data = []
-        try:
+        with safe_call(error_msg="Error creating collection in datcore"):
             data = self.d_client.list_datasets()
-        except Exception:
-            logger.exception("Error creating collection in datcore")
         return data
 
     @make_async
     def ping(self):
-        try:
+        ok = False
+        with safe_call(skip_logs=True):
             profile = self.d_client.profile()
             ok = profile is not None
-            return ok
-        except Exception:
-            logger.exception("Error pinging")
-            return False
+        return ok

--- a/services/storage/tests/test_datcore.py
+++ b/services/storage/tests/test_datcore.py
@@ -1,8 +1,8 @@
-# TODO: W0611:Unused import ...
-# pylint: disable=W0611
-# TODO: W0613:Unused argument ...
-# pylint: disable=W0613
+# pylint:disable=unused-variable
+# pylint:disable=unused-argument
+# pylint:disable=redefined-outer-name
 
+import importlib
 import os
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -10,7 +10,35 @@ from pathlib import Path
 import pytest
 
 import utils
+from simcore_service_storage import datcore
 from simcore_service_storage.datcore_wrapper import DatcoreWrapper
+
+
+@pytest.fixture()
+def mocked_blackfynn_unavailable(mocker):
+    def raise_error(*args, **kargs):
+        raise RuntimeError("mocked_blackfynn_unavailable")
+
+    mock = mocker.patch("blackfynn.Blackfynn", raise_error)
+    importlib.reload(datcore)
+    return mock
+
+
+async def test_datcore_unavailable(loop, mocked_blackfynn_unavailable):
+    api_token = os.environ.get("BF_API_KEY", "none")
+    api_secret = os.environ.get("BF_API_SECRET", "none")
+    pool = ThreadPoolExecutor(2)
+
+    # must NOT raise but only returns empties
+    dcw = DatcoreWrapper(api_token, api_secret, loop, pool)
+
+    assert not dcw.is_communication_enabled
+
+    responsive = await dcw.ping()
+    assert not responsive
+
+    res = await dcw.list_files_raw()
+    assert res == []
 
 
 async def test_datcore_ping(loop):


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
If bf is down, storage handlers raise exceptions and stops working. 

This fix removes this hard dependency and catches exceptions raised by bf client when their service is unavailable

This fix does not totally solves the problems of storage that is designed to be very silent with bf operations, ie. nothing happens if there are errors in the interaction with bf. I think this needs a deeper refactoring that is outside the scope of this PR.

## Related issue number

<!-- Please add #issues -->
#1506 


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [x] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
