### PR TITLE
[bugfix] fixes projects_api and sets larger pool to webserver

### DIFF
--- a/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
@@ -32,7 +32,7 @@ db:
     host: ${POSTGRES_HOST}
     port: ${POSTGRES_PORT}
     minsize: 4
-    maxsize: 0
+    maxsize: 15
 resource_manager:
   enabled: True
   resource_deletion_timeout_seconds: ${WEBSERVER_RESOURCES_DELETION_TIMEOUT_SECONDS}

--- a/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
@@ -32,7 +32,7 @@ db:
     host: ${POSTGRES_HOST}
     port: ${POSTGRES_PORT}
     minsize: 4
-    maxsize: 4
+    maxsize: 0
 resource_manager:
   enabled: True
   resource_deletion_timeout_seconds: ${WEBSERVER_RESOURCES_DELETION_TIMEOUT_SECONDS}

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -289,9 +289,9 @@ async def update_project_node_outputs(
         raise NodeNotFoundError(project_id, node_id)
 
     if data:
-        # NOTE: update outputs if necessary as the UI expects a
+        # NOTE: update outputs (not required) if necessary as the UI expects a
         # dataset/label field that is missing
-        outputs: Dict[str,Any] = project["workbench"][node_id]["outputs"]
+        outputs: Dict[str,Any] = project["workbench"][node_id].setdefault("outputs", {})
         outputs.update(data)
 
         for output_key in outputs.keys():


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

Minor fixes to overcome some e2e test failures

- Fixes output update in projects_api
- Sets max. size of psycopg2 pool to ~unlimited~ a large number at the webserver (want to check if it reduces ``CancelledError`` in aiopg). Asyngpg does not accept 0.



