### PR TITLE
add traefik endpoint to api-gateway

### DIFF
--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -176,7 +176,7 @@ async def _create_docker_service_params(
             f"traefik.http.routers.{service_name}.rule": f"PathPrefix(`/x/{node_uuid}`)",
             f"traefik.http.routers.{service_name}.entrypoints": "http",
             f"traefik.http.routers.{service_name}.priority": "10",
-            f"traefik.http.routers.{service_name}.middlewares": "gzip@docker",
+            f"traefik.http.routers.{service_name}.middlewares": f"{config.SWARM_STACK_NAME}_gzip@docker",
         },
         "networks": [internal_network_id] if internal_network_id else [],
     }

--- a/services/docker-compose.local.yml
+++ b/services/docker-compose.local.yml
@@ -83,6 +83,8 @@ services:
     ports:
       - target: 80
         published: 9081
+      - target: 10081
+        published: 10081
       - target: 8080
         published: 8080
     deploy:

--- a/services/docker-compose.local.yml
+++ b/services/docker-compose.local.yml
@@ -96,7 +96,7 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_api_internal.service=api@internal
         - traefik.http.routers.${SWARM_STACK_NAME}_api_internal.rule=PathPrefix(`/dashboard`) || PathPrefix(`/api`)
         - traefik.http.routers.${SWARM_STACK_NAME}_api_internal.entrypoints=traefik_monitor
-        - traefik.http.routers.${SWARM_STACK_NAME}_api_internal.middlewares=gzip@docker
+        - traefik.http.routers.${SWARM_STACK_NAME}_api_internal.middlewares=${SWARM_STACK_NAME}_gzip@docker
         - traefik.http.services.${SWARM_STACK_NAME}_api_internal.loadbalancer.server.port=8080
 
   whoami:
@@ -110,4 +110,4 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_whoami.loadbalancer.server.port=80
         - traefik.http.routers.${SWARM_STACK_NAME}_whoami.rule=PathPrefix(`/whoami`)
         - traefik.http.routers.${SWARM_STACK_NAME}_whoami.entrypoints=traefik_monitor
-        - traefik.http.routers.${SWARM_STACK_NAME}_whoami.middlewares=gzip@docker
+        - traefik.http.routers.${SWARM_STACK_NAME}_whoami.middlewares=${SWARM_STACK_NAME}_gzip@docker

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -17,6 +17,8 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.entrypoints=simcore_api
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.priority=1
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.middlewares=gzip@docker
+    networks:
+      - default
 
   catalog:
     image: ${DOCKER_REGISTRY:-itisfoundation}/catalog:${DOCKER_IMAGE_TAG:-latest}

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -11,6 +11,8 @@ services:
         - io.simcore.zone=${TRAEFIK_SIMCORE_ZONE}
         # gzip compression
         - traefik.http.middlewares.gzip.compress=true
+        # ssl header necessary so that socket.io upgrades correctly from polling to websocket mode. the middleware must be attached to the right connection.
+        - traefik.http.middlewares.simcore_sslheader.headers.customrequestheaders.X-Forwarded-Proto=http
         - traefik.enable=true
         - traefik.http.services.${SWARM_STACK_NAME}_api-gateway.loadbalancer.server.port=1080
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.rule=hostregexp(`{host:.+}`)

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -11,14 +11,12 @@ services:
         - io.simcore.zone=${TRAEFIK_SIMCORE_ZONE}
         # gzip compression
         - traefik.http.middlewares.gzip.compress=true
-        # ssl header necessary so that socket.io upgrades correctly from polling to websocket mode. the middleware must be attached to the right connection.
-        - traefik.http.middlewares.simcore_sslheader.headers.customrequestheaders.X-Forwarded-Proto=http
         - traefik.enable=true
         - traefik.http.services.${SWARM_STACK_NAME}_api-gateway.loadbalancer.server.port=1080
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.rule=hostregexp(`{host:.+}`)
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.entrypoints=api
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.priority=1
-        - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.middlewares=gzip@docker, simcore_sslheader@docker
+        - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.middlewares=gzip@docker
 
   catalog:
     image: ${DOCKER_REGISTRY:-itisfoundation}/catalog:${DOCKER_IMAGE_TAG:-latest}

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -10,13 +10,15 @@ services:
       labels:
         - io.simcore.zone=${TRAEFIK_SIMCORE_ZONE}
         # gzip compression
-        - traefik.http.middlewares.gzip.compress=true
+        - traefik.http.middlewares.${SWARM_STACK_NAME}_gzip.compress=true
+        # ssl header necessary so that socket.io upgrades correctly from polling to websocket mode. the middleware must be attached to the right connection.
+        - traefik.http.middlewares.${SWARM_STACK_NAME}_sslheader.headers.customrequestheaders.X-Forwarded-Proto=http
         - traefik.enable=true
         - traefik.http.services.${SWARM_STACK_NAME}_api-gateway.loadbalancer.server.port=1080
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.rule=hostregexp(`{host:.+}`)
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.entrypoints=simcore_api
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.priority=1
-        - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.middlewares=gzip@docker
+        - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.middlewares=${SWARM_STACK_NAME}_gzip@docker, ${SWARM_STACK_NAME}_sslheader
     networks:
       - default
 
@@ -108,15 +110,15 @@ services:
       labels:
         - io.simcore.zone=${TRAEFIK_SIMCORE_ZONE}
         # gzip compression
-        - traefik.http.middlewares.gzip.compress=true
+        - traefik.http.middlewares.${SWARM_STACK_NAME}_gzip.compress=true
         # ssl header necessary so that socket.io upgrades correctly from polling to websocket mode. the middleware must be attached to the right connection.
-        - traefik.http.middlewares.simcore_sslheader.headers.customrequestheaders.X-Forwarded-Proto=http
+        - traefik.http.middlewares.${SWARM_STACK_NAME}_sslheader.headers.customrequestheaders.X-Forwarded-Proto=http
         - traefik.enable=true
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.server.port=8080
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.rule=hostregexp(`{host:.+}`)
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.priority=1
-        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.middlewares=gzip@docker, simcore_sslheader@docker
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.middlewares=${SWARM_STACK_NAME}_gzip@docker, ${SWARM_STACK_NAME}_sslheader
     networks:
       - default
       - interactive_services_subnet

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         - traefik.enable=true
         - traefik.http.services.${SWARM_STACK_NAME}_api-gateway.loadbalancer.server.port=1080
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.rule=hostregexp(`{host:.+}`)
-        - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.entrypoints=api
+        - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.entrypoints=simcore_api
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.priority=1
         - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.middlewares=gzip@docker
 
@@ -259,8 +259,8 @@ services:
       - "--metrics.prometheus.entryPoint=metrics"
       - "--entryPoints.http.address=:80"
       - "--entryPoints.http.forwardedHeaders.insecure"
-      - "--entryPoints.api.address=:10081"
-      - "--entryPoints.api.forwardedHeaders.insecure"
+      - "--entryPoints.simcore_api.address=:10081"
+      - "--entryPoints.simcore_api.forwardedHeaders.insecure"
       - "--entryPoints.traefik_monitor.address=:8080"
       - "--entryPoints.traefik_monitor.forwardedHeaders.insecure"
       - "--providers.docker.endpoint=unix:///var/run/docker.sock"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -1,5 +1,23 @@
 version: "3.7"
 services:
+  api-gateway:
+    # get info here: https://www.mock-server.com
+    image: mockserver/mockserver
+    init: true
+    environment:
+      - MOCKSERVER_LIVENESS_HTTP_GET_PATH=/live
+    deploy:
+      labels:
+        - io.simcore.zone=${TRAEFIK_SIMCORE_ZONE}
+        # gzip compression
+        - traefik.http.middlewares.gzip.compress=true
+        - traefik.enable=true
+        - traefik.http.services.${SWARM_STACK_NAME}_api-gateway.loadbalancer.server.port=1080
+        - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.rule=hostregexp(`{host:.+}`)
+        - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.entrypoints=api
+        - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.priority=1
+        - traefik.http.routers.${SWARM_STACK_NAME}_api-gateway.middlewares=gzip@docker, simcore_sslheader@docker
+
   catalog:
     image: ${DOCKER_REGISTRY:-itisfoundation}/catalog:${DOCKER_IMAGE_TAG:-latest}
     init: true
@@ -227,7 +245,7 @@ services:
       - default
 
   traefik:
-    image: traefik:v2.2.0
+    image: traefik:v2.2.1
     init: true
     command:
       - "--api=true"
@@ -241,6 +259,8 @@ services:
       - "--metrics.prometheus.entryPoint=metrics"
       - "--entryPoints.http.address=:80"
       - "--entryPoints.http.forwardedHeaders.insecure"
+      - "--entryPoints.api.address=:10081"
+      - "--entryPoints.api.forwardedHeaders.insecure"
       - "--entryPoints.traefik_monitor.address=:8080"
       - "--entryPoints.traefik_monitor.forwardedHeaders.insecure"
       - "--providers.docker.endpoint=unix:///var/run/docker.sock"

--- a/tests/swarm-deploy/test_swarm_runs.py
+++ b/tests/swarm-deploy/test_swarm_runs.py
@@ -27,6 +27,7 @@ MAX_WAIT_TIME = 240
 
 
 docker_compose_service_names = [
+    "api-gateway",
     "catalog",
     "director",
     "sidecar",


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
- adds the entrypoint in the simcore stack
Port 10081 -> api-gateway currently impersonated by the amazing [mockserver](https://www.mock-server.com/#what-is-mockserver)

## Related issue number
#1474
<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->
```bash
curl -X GET 127.0.0.1:10081/live
```

## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
