### PR TITLE
[maintenance] improve stability of deploy tests

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/simcore_webserver_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/simcore_webserver_service.py
@@ -1,0 +1,43 @@
+# pylint:disable=unused-variable
+# pylint:disable=unused-argument
+# pylint:disable=redefined-outer-name
+
+from typing import Dict
+
+import aiohttp
+import pytest
+import tenacity
+from yarl import URL
+
+from servicelib.minio_utils import MinioRetryPolicyUponInitialization
+
+from .helpers.utils_docker import get_service_published_port
+
+
+@pytest.fixture(scope="module")
+def webserver_endpoint(docker_stack: Dict, devel_environ: Dict) -> URL:
+    assert "simcore_webserver" in docker_stack["services"]
+    endpoint = f"127.0.0.1:{get_service_published_port('webserver', '8080')}"
+
+    return URL(f"http://{endpoint}")
+
+
+@pytest.fixture(scope="function")
+async def webserver_service(webserver_endpoint: URL, docker_stack: Dict) -> URL:
+    await wait_till_webserver_responsive(webserver_endpoint)
+
+    yield webserver_endpoint
+
+
+# HELPERS --
+
+# TODO: this can be used by ANY of the simcore services!
+@tenacity.retry(**MinioRetryPolicyUponInitialization().kwargs)
+async def wait_till_webserver_responsive(webserver_endpoint: URL):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(webserver_endpoint.with_path("/v0/")) as resp:
+            assert resp.status == 200
+            data = await resp.json()
+            assert "data" in data
+            assert "status" in data["data"]
+            assert data["data"]["status"] == "SERVICE_RUNNING"

--- a/tests/swarm-deploy/conftest.py
+++ b/tests/swarm-deploy/conftest.py
@@ -19,7 +19,8 @@ pytest_plugins = [
     "pytest_simcore.rabbit_service",
     "pytest_simcore.postgres_service",
     "pytest_simcore.minio_service",
-    "pytest_simcore.traefik_service"
+    "pytest_simcore.traefik_service",
+    "pytest_simcore.simcore_webserver_service",
 ]
 log = logging.getLogger(__name__)
 
@@ -45,7 +46,13 @@ def prepare_all_services(
 
 
 @pytest.fixture(scope="module")
+def create_db_on_start(devel_environ: Dict[str, str]):
+    devel_environ["WEBSERVER_DB_INITTABLES"] = "1"
+
+
+@pytest.fixture(scope="module")
 def make_up_prod(
+    create_db_on_start,
     prepare_all_services: Dict,
     simcore_docker_compose: Dict,
     ops_docker_compose: Dict,


### PR DESCRIPTION
ensure the database is filled up

<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?
- retry checking of root (http://127.0.0.1:9081) since it can take a small amount of time until traefik redirects and the webserver answers correctly
- ensure the database is correctly setup on start for the e2e testing preventing webserver to crash unexpectedly
<!-- Please give a short brief about these changes. -->


## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
