### PR TITLE
Excludes e2e job from travis CI  until fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -387,7 +387,9 @@ jobs:
 
     # system testing e2e testing -----------------------------------------------------------------
     # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-on-travis-ci
-    - stage: integration-testing / system-testing
+    # FIXME: skip the job until make it faster and more reliable https://github.com/ITISFoundation/osparc-simcore/issues/1594
+    - if: false
+      stage: integration-testing / system-testing
       name: e2e testing
       language: node_js
       node_js:


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

Currently, e2e job was disabled in GitHub-actions (required) but NOT in travis (not required)

For that reason, the e2e job inn [travis runs](https://github.com/ITISFoundation/osparc-simcore/runs/831170681) on integration testing stage still failing. This prevents deployment stage from starting which might stop building images !

This PR completely excludes the e2e job in travis allowing the last step to run

