### PR TITLE
[bugfix] Invalidate cache before starting a study

### DIFF
--- a/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -265,8 +265,9 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
         position.x = 50 + farthestRight;
         position.y = 200;
       }
-      nodeUI.getNode().setPosition(position.x, position.y);
-      nodeUI.moveTo(position.x, position.y);
+      const node = nodeUI.getNode();
+      node.setPosition(position.x, position.y);
+      nodeUI.moveTo(node.getPosition().x, node.getPosition().y);
       this.__addWindowToDesktop(nodeUI);
       this.__nodesUI.push(nodeUI);
 

--- a/services/web/client/source/class/osparc/dashboard/ExploreBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/ExploreBrowser.js
@@ -206,7 +206,7 @@ qx.Class.define("osparc.dashboard.ExploreBrowser", {
     __createServicesLayout: function() {
       const servicesContainer = this.__servicesContainer = this.__createResourceListLayout();
       osparc.utils.Utils.setIdToWidget(servicesContainer, "servicesList");
-      const servicesLayout = this.__createButtonsLayout(this.tr("Apps"), servicesContainer);
+      const servicesLayout = this.__createButtonsLayout(this.tr("Services"), servicesContainer);
 
       const servicesTitleContainer = servicesLayout.getTitleBar();
       this.__addNewServiceButtons(servicesTitleContainer);

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -323,9 +323,16 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
 
     __startStudy: function(studyData) {
       this.__showLoadingPage(this.tr("Starting ") + (studyData.name || this.tr("Study")));
-      osparc.store.Store.getInstance().getServicesDAGs()
-        .then(() => {
+
+      // Before starting a study, make sure the latest version is fetched
+      const promises = [
+        osparc.store.Store.getInstance().getStudyWState(studyData.uuid, true),
+        osparc.store.Store.getInstance().getServicesDAGs()
+      ];
+      Promise.all(promises)
+        .then(values => {
           this.__hideLoadingPage();
+          studyData = values[0];
           this.__loadStudy(studyData);
         });
     },

--- a/services/web/client/source/class/osparc/data/Resources.js
+++ b/services/web/client/source/class/osparc/data/Resources.js
@@ -68,7 +68,7 @@ qx.Class.define("osparc.data.Resources", {
        * STUDIES
        */
       "studies": {
-        useCache: true,
+        useCache: false,
         endpoints: {
           get: {
             method: "GET",

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -1116,8 +1116,9 @@ qx.Class.define("osparc.data.model.Node", {
     },
 
     setPosition: function(x, y) {
-      this.__posX = parseInt(x);
-      this.__posY = parseInt(y);
+      // keep positions positive
+      this.__posX = parseInt(x) < 0 ? 0 : parseInt(x);
+      this.__posY = parseInt(y) < 0 ? 0 : parseInt(y);
     },
 
     getPosition: function() {

--- a/services/web/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/web/client/source/class/osparc/desktop/StudyEditor.js
@@ -27,7 +27,7 @@ qx.Class.define("osparc.desktop.StudyEditor", {
       minWidth: 0,
       width: 400
     });
-    // osparc.utils.Utils.addBorder(sidePanel, 2, "right");
+    osparc.utils.Utils.addBorder(sidePanel, 2, "right");
     const scroll = this.__scrollContainer = new qx.ui.container.Scroll().set({
       minWidth: 0
     });

--- a/services/web/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/web/client/source/class/osparc/desktop/StudyEditor.js
@@ -23,18 +23,19 @@ qx.Class.define("osparc.desktop.StudyEditor", {
   construct: function() {
     this.base(arguments, "horizontal");
 
-    const mainPanel = this.__mainPanel = new osparc.desktop.MainPanel();
     const sidePanel = this.__sidePanel = new osparc.desktop.SidePanel().set({
       minWidth: 0,
       width: 400
     });
-    osparc.utils.Utils.addBorder(sidePanel, 2, "right");
+    // osparc.utils.Utils.addBorder(sidePanel, 2, "right");
     const scroll = this.__scrollContainer = new qx.ui.container.Scroll().set({
       minWidth: 0
     });
     scroll.add(sidePanel);
 
     this.add(scroll, 0); // flex 0
+
+    const mainPanel = this.__mainPanel = new osparc.desktop.MainPanel();
     this.add(mainPanel, 1); // flex 1
 
     this.__attachEventHandlers();


### PR DESCRIPTION
## What do these changes do?
This PR fixes a bug with the cached studies in the fronted by making sure the latest version is fetched before starting it.

### Bonus
- Do not allow negative node position values