### PR TITLE
fix testing if node has gpu support

### DIFF
--- a/services/sidecar/src/simcore_service_sidecar/utils.py
+++ b/services/sidecar/src/simcore_service_sidecar/utils.py
@@ -102,6 +102,7 @@ def is_gpu_node() -> bool:
         docker = aiodocker.Docker()
 
         config = {
+            "Cmd": "nvidia-smi",
             "Image": "nvidia/cuda:10.0-base",
             "AttachStdin": False,
             "AttachStdout": False,
@@ -110,10 +111,13 @@ def is_gpu_node() -> bool:
             "OpenStdin": False,
         }
         try:
-            docker.containers.run(config=config, name=f"sidecar_{id}_test_gpu")
+            await docker.containers.run(
+                config=config, name=f"sidecar_{os.getpid()}_test_gpu"
+            )
+            return True
         except aiodocker.exceptions.DockerError:
-            return False
-        return True
+            pass
+        return False
 
     return wrap_async_call(async_is_gpu_node())
 

--- a/services/sidecar/src/simcore_service_sidecar/utils.py
+++ b/services/sidecar/src/simcore_service_sidecar/utils.py
@@ -1,13 +1,14 @@
 import asyncio
 import logging
+import os
 import re
 from typing import Awaitable, List
 
+import aiodocker
 import aiopg
 import networkx as nx
 from sqlalchemy import and_
 
-import aiodocker
 from celery import Celery
 from simcore_postgres_database.sidecar_models import SUCCESS, comp_pipeline, comp_tasks
 from simcore_sdk.config.rabbit import Config as RabbitConfig


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?
executing ```docker node inspect self``` is not allowed on non-manager nodes in a swarm.
Therefore, alternative proposal is to try run a nvidia-smi container that will fail if the nvidia runtime is not set as default on the node.

@GitHK : please test on your GPU enabled machine.

<!-- Please give a short brief about these changes. -->

fixes #1603 (after being tested by @GitHK )
## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
