### PR TITLE
Improving storage performance

### DIFF
--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -240,24 +240,26 @@ class DataStorageManager:
                 clean_data = deque()
                 for dx in data:
                     d = dx.fmd
-                    if d.project_id in uuid_name_dict:
-                        d.project_name = uuid_name_dict[d.project_id]
-                        if d.node_id in uuid_name_dict:
-                            d.node_name = uuid_name_dict[d.node_id]
-
-                        d.raw_file_path = str(
-                            Path(d.project_id) / Path(d.node_id) / Path(d.file_name)
+                    if d.project_id not in uuid_name_dict:
+                        continue
+                    
+                    d.project_name = uuid_name_dict[d.project_id]
+                    if d.node_id in uuid_name_dict:
+                        d.node_name = uuid_name_dict[d.node_id]
+                    
+                    d.raw_file_path = str(
+                        Path(d.project_id) / Path(d.node_id) / Path(d.file_name)
+                    )
+                    d.display_file_path = d.raw_file_path
+                    d.file_id = d.file_uuid
+                    if d.node_name and d.project_name:
+                        d.display_file_path = str(
+                            Path(d.project_name)
+                            / Path(d.node_name)
+                            / Path(d.file_name)
                         )
-                        d.display_file_path = d.raw_file_path
-                        d.file_id = d.file_uuid
-                        if d.node_name and d.project_name:
-                            d.display_file_path = str(
-                                Path(d.project_name)
-                                / Path(d.node_name)
-                                / Path(d.file_name)
-                            )
-                            # once the data was sync to postgres metadata table at this point
-                            clean_data.append(dx)
+                        # once the data was sync to postgres metadata table at this point
+                        clean_data.append(dx)
 
                 data = clean_data
 

--- a/services/storage/src/simcore_service_storage/utils.py
+++ b/services/storage/src/simcore_service_storage/utils.py
@@ -39,3 +39,20 @@ async def assert_enpoint_is_ok(
 
 def is_url(location):
     return bool(URL(str(location)).host)
+
+
+def expo(base=1.2, factor=0.1, max_value=2):
+    """Generator for exponential decay.
+    Args:
+        base: The mathematical base of the exponentiation operation
+        factor: Factor to multiply the exponentation by.
+        max_value: The maximum value until it will yield
+    """
+    n = 0
+    while True:
+        a = factor * base ** n
+        if max_value is None or a < max_value:
+            yield a
+            n += 1
+        else:
+            yield max_value


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
The `list_files` function is now optimised to run with big datasets, and no longer depends on third party S3 calls when listing files in the storage service.

### Removed
- database updates when retrieving the real file names (which might have been renamed) => responsible for 40% of the slowdown
- file metadata updates in the database after invoking an S3 call for each file when listing all the files => responsible for the majority of the reminding slowdown

### Added
- a `metadata_file_updater` launched before returning the upload link for each file to be uploaded. It will try to update the metadata for each file. It uses an exponential backoff retry to account for huge file uploads. It also has a maximum amount of possible retries. If it fails to update the metadata, an error message will be logged.

Changes


## Related issue number

<!-- Please add #issues -->
Closes #1559

## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->
Start the project and make sure to have lots of files in your storage. With the old implementation performances degraded after 200 uploaded files.


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
