### PR TITLE
Sidecar retries pull on error

### DIFF
--- a/services/sidecar/src/simcore_service_sidecar/executor.py
+++ b/services/sidecar/src/simcore_service_sidecar/executor.py
@@ -10,6 +10,7 @@ import aiopg
 import attr
 from celery.utils.log import get_task_logger
 from packaging import version
+from tenacity import retry, stop_after_attempt
 
 from servicelib.utils import fire_and_forget_task, logged_gather
 from simcore_sdk import node_data, node_ports
@@ -156,6 +157,7 @@ class Executor:
             file_name.write_text(json.dumps(inputs))
             log.debug("Writing input file DONE")
 
+    @retry(reraise=True, stop=stop_after_attempt(3))
     async def _pull_image(self):
         docker_image = f"{config.DOCKER_REGISTRY}/{self.task.image['name']}:{self.task.image['tag']}"
         log.debug(


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
If an error occurs during a pull operation (registry sometimes times out), the sidecar will retry to fetch this image again.

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
