### PR TITLE
Computational services can determine on which queue they were scheduled

### DIFF
--- a/services/sidecar/src/simcore_service_sidecar/boot_mode.py
+++ b/services/sidecar/src/simcore_service_sidecar/boot_mode.py
@@ -1,0 +1,22 @@
+# pylint: disable=global-statement
+
+from enum import Enum
+
+
+class BootMode(Enum):
+    CPU = "CPU"
+    GPU = "GPU"
+    MPI = "MPI"
+
+
+_sidecar_boot_mode: BootMode = None
+
+
+def get_boot_mode() -> BootMode:
+    global _sidecar_boot_mode
+    return _sidecar_boot_mode
+
+
+def set_boot_mode(boot_mode: BootMode) -> None:
+    global _sidecar_boot_mode
+    _sidecar_boot_mode = boot_mode

--- a/services/sidecar/src/simcore_service_sidecar/celery_configurator.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery_configurator.py
@@ -16,6 +16,7 @@ from .utils import wrap_async_call, is_gpu_node, start_as_mpi_node
 from .celery_log_setup import get_task_logger
 from .utils import assemble_celery_app
 from .core import task_required_resources
+from .boot_mode import BootMode, set_boot_mode, get_boot_mode
 
 log = get_task_logger(__name__)
 
@@ -100,7 +101,7 @@ def shared_task_dispatch(
 
 def configure_cpu_mode() -> Tuple[RabbitConfig, Celery]:
     """Will configure and return a celery app targetting CPU mode nodes."""
-    log.info("Initializing celery app in CPU MODE ...")
+    log.info("Initializing celery app...")
     app = _celery_app_cpu
 
     # pylint: disable=unused-variable,unused-argument
@@ -112,12 +113,14 @@ def configure_cpu_mode() -> Tuple[RabbitConfig, Celery]:
     def pipeline(self, user_id: str, project_id: str, node_id: str = None) -> None:
         shared_task_dispatch(self, user_id, project_id, node_id)
 
+    set_boot_mode(BootMode.CPU)
+    log.info("Initialized celery app in %s ", get_boot_mode())
     return (_rabbit_config, app)
 
 
 def configure_gpu_mode() -> Tuple[RabbitConfig, Celery]:
     """Will configure and return a celery app targetting GPU mode nodes."""
-    log.info("Initializing celery app in GPU MODE ...")
+    log.info("Initializing celery app...")
     app = _celery_app_gpu
 
     # pylint: disable=unused-variable
@@ -125,12 +128,14 @@ def configure_gpu_mode() -> Tuple[RabbitConfig, Celery]:
     def pipeline(self, user_id: str, project_id: str, node_id: str = None) -> None:
         shared_task_dispatch(self, user_id, project_id, node_id)
 
+    set_boot_mode(BootMode.GPU)
+    log.info("Initialized celery app in %s", get_boot_mode())
     return (_rabbit_config, app)
 
 
 def configure_mpi_node() -> Tuple[RabbitConfig, Celery]:
     """Will configure and return a celery app targetting GPU mode nodes."""
-    log.info("Initializing celery app in MPI MODE ...")
+    log.info("Initializing celery app...")
     app = _celery_app_mpi
 
     # pylint: disable=unused-variable
@@ -138,6 +143,8 @@ def configure_mpi_node() -> Tuple[RabbitConfig, Celery]:
     def pipeline(self, user_id: str, project_id: str, node_id: str = None) -> None:
         shared_task_dispatch(self, user_id, project_id, node_id)
 
+    set_boot_mode(BootMode.MPI)
+    log.info("Initialized celery app in %s", get_boot_mode())
     return (_rabbit_config, app)
 
 

--- a/services/sidecar/src/simcore_service_sidecar/cli.py
+++ b/services/sidecar/src/simcore_service_sidecar/cli.py
@@ -58,5 +58,5 @@ async def run_sidecar(
                 return next_task_nodes, None
     except Exception as e:  # pylint: disable=broad-except
         error_message = f"run_sidecar caught the following exception: {str(e)}"
-        log.warning(error_message)
+        log.exception(error_message)
         return None, error_message

--- a/services/sidecar/tests/integration/conftest.py
+++ b/services/sidecar/tests/integration/conftest.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from simcore_service_sidecar.boot_mode import set_boot_mode, BootMode
+
 current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
 # imports the fixtures for the integration tests
@@ -34,3 +36,9 @@ def python_sample_script(mock_dir: Path) -> Path:
     file_path = mock_dir / "osparc_python_sample.py"
     assert file_path.exists()
     return file_path
+
+
+@pytest.fixture()
+def mock_boot_mode():
+    """by default only CPU is mocked which is enough"""
+    set_boot_mode(BootMode.CPU)

--- a/services/sidecar/tests/integration/test_sidecar.py
+++ b/services/sidecar/tests/integration/test_sidecar.py
@@ -304,13 +304,13 @@ async def test_run_services(
     pipeline_cfg: Dict,
     user_id: int,
     mocker,
+    mock_boot_mode,
 ):
     """
 
     :param osparc_service: Fixture defined in pytest-simcore.docker_registry. Uses parameters service_repo, service_tag
     :type osparc_service: Dict[str, str]
     """
-
     incoming_data = []
 
     async def rabbit_message_handler(message: aio_pika.IncomingMessage):
@@ -324,7 +324,9 @@ async def test_run_services(
     from simcore_service_sidecar import cli
 
     # runs None first
-    next_task_nodes, _ = await cli.run_sidecar(job_id, user_id, pipeline.project_id, None)
+    next_task_nodes, _ = await cli.run_sidecar(
+        job_id, user_id, pipeline.project_id, None
+    )
     await asyncio.sleep(5)
     assert not incoming_data
 


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Some computational services support more then one type of boot mode, some of these require special resources.
These services can now check the env var `SC_COMP_SERVICES_SCHEDULED_AS` to determine the node they were booted on. See https://github.com/ITISFoundation/osparc-simcore/issues/1716 for details.

## Related issue number

<!-- Please add #issues -->

closes https://github.com/ITISFoundation/osparc-simcore/issues/1716
## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
