### PR TITLE
WIP: Maintenance/cleanup webserver test fixtures

### DIFF
--- a/services/web/server/tests/unit/isolated/test_activity.py
+++ b/services/web/server/tests/unit/isolated/test_activity.py
@@ -3,7 +3,6 @@
 # pylint:disable=redefined-outer-name
 
 import importlib
-from asyncio import Future
 from pathlib import Path
 
 import pytest
@@ -12,17 +11,12 @@ from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionError
 
 from pytest_simcore.helpers.utils_assert import assert_status
+from pytest_simcore.helpers.utils_mock import future_with_result
 from servicelib.application import create_safe_application
 from simcore_service_webserver.activity import handlers, setup_activity
 from simcore_service_webserver.rest import setup_rest
 from simcore_service_webserver.security import setup_security
 from simcore_service_webserver.session import setup_session
-
-
-def future_with_result(result):
-    f = Future()
-    f.set_result(result)
-    return f
 
 
 @pytest.fixture

--- a/services/web/server/tests/unit/with_dbs/_helpers.py
+++ b/services/web/server/tests/unit/with_dbs/_helpers.py
@@ -63,9 +63,3 @@ def standard_role_response() -> Tuple[str, List[Tuple[UserRole, ExpectedResponse
             ),
         ],
     )
-
-
-def future_with_result(result) -> Future:
-    f = Future()
-    f.set_result(result)
-    return f

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -128,6 +128,14 @@ def client(loop, aiohttp_client, web_server, mock_orphaned_services):
 # Add mocks for web-server subsystems here
 #
 
+@pytest.fixture
+def computational_system_mock(mocker):
+    mock_fun = mocker.patch(
+        "simcore_service_webserver.projects.projects_handlers.update_pipeline_db",
+        return_value=Future(),
+    )
+    mock_fun.return_value.set_result("")
+    return mock_fun
 
 @pytest.fixture
 async def storage_subsystem_mock(loop, mocker):

--- a/services/web/server/tests/unit/with_dbs/slow/test_projects.py
+++ b/services/web/server/tests/unit/with_dbs/slow/test_projects.py
@@ -50,25 +50,6 @@ RESOURCE_NAME = "projects"
 API_PREFIX = "/" + API_VERSION
 
 
-@pytest.fixture
-def mocked_director_subsystem(mocker):
-    mock_director_api = {
-        "get_running_interactive_services": mocker.patch(
-            "simcore_service_webserver.director.director_api.get_running_interactive_services",
-            return_value=future_with_result(""),
-        ),
-        "start_service": mocker.patch(
-            "simcore_service_webserver.director.director_api.start_service",
-            return_value=future_with_result(""),
-        ),
-        "stop_service": mocker.patch(
-            "simcore_service_webserver.director.director_api.stop_service",
-            return_value=future_with_result(""),
-        ),
-    }
-    return mock_director_api
-
-
 DEFAULT_GARBAGE_COLLECTOR_INTERVAL_SECONDS: int = 3
 DEFAULT_GARBAGE_COLLECTOR_DELETION_TIMEOUT_SECONDS: int = 3
 
@@ -182,16 +163,6 @@ async def template_project(
         print("-----> added template project", template_project["name"])
         yield template_project
         print("<----- removed template project", template_project["name"])
-
-
-@pytest.fixture
-def computational_system_mock(mocker):
-    mock_fun = mocker.patch(
-        "simcore_service_webserver.projects.projects_handlers.update_pipeline_db",
-        return_value=Future(),
-    )
-    mock_fun.return_value.set_result("")
-    return mock_fun
 
 
 @pytest.fixture

--- a/services/web/server/tests/unit/with_dbs/slow/test_projects.py
+++ b/services/web/server/tests/unit/with_dbs/slow/test_projects.py
@@ -15,7 +15,7 @@ import pytest
 import socketio
 from aiohttp import web
 from mock import call
-from socketio.exceptions import ConnectionError
+from socketio.exceptions import ConnectionError as SocketConnectionError
 
 from _helpers import ExpectedResponse, HTTPLocked, standard_role_response
 from pytest_simcore.helpers.utils_assert import assert_status
@@ -933,7 +933,7 @@ async def test_get_active_project(
     try:
         sio = await socketio_client(client_id1)
         assert sio.sid
-    except ConnectionError:
+    except SocketConnectionError:
         if expected == web.HTTPOk:
             pytest.fail("socket io connection should not fail")
 
@@ -966,7 +966,7 @@ async def test_get_active_project(
     try:
         sio = await socketio_client(client_id2)
         assert sio.sid
-    except ConnectionError:
+    except SocketConnectionError:
         if expected == web.HTTPOk:
             pytest.fail("socket io connection should not fail")
     # get active projects -> empty
@@ -1010,7 +1010,7 @@ async def test_delete_multiple_opened_project_forbidden(
     client_session_id1 = client_session_id()
     try:
         sio1 = await socketio_client(client_session_id1)
-    except ConnectionError:
+    except SocketConnectionError:
         if user_role != UserRole.ANONYMOUS:
             pytest.fail("socket io connection should not fail")
     url = client.app.router["open_project"].url_for(project_id=user_project["uuid"])
@@ -1020,7 +1020,7 @@ async def test_delete_multiple_opened_project_forbidden(
     client_session_id2 = client_session_id()
     try:
         sio2 = await socketio_client(client_session_id2)
-    except ConnectionError:
+    except SocketConnectionError:
         if user_role != UserRole.ANONYMOUS:
             pytest.fail("socket io connection should not fail")
     await _delete_project(client, user_project, expected_forbidden)
@@ -1211,7 +1211,7 @@ async def _connect_websocket(
             for event, handler in events.items():
                 sio.on(event, handler=handler)
         return sio
-    except ConnectionError:
+    except SocketConnectionError:
         if check_connection:
             pytest.fail("socket io connection should not fail")
 

--- a/services/web/server/tests/unit/with_dbs/slow/test_projects.py
+++ b/services/web/server/tests/unit/with_dbs/slow/test_projects.py
@@ -17,14 +17,10 @@ from aiohttp import web
 from mock import call
 from socketio.exceptions import ConnectionError
 
-from _helpers import (
-    ExpectedResponse,
-    HTTPLocked,
-    future_with_result,
-    standard_role_response,
-)
+from _helpers import ExpectedResponse, HTTPLocked, standard_role_response
 from pytest_simcore.helpers.utils_assert import assert_status
-from pytest_simcore.helpers.utils_login import LoggedUser, create_user, log_client_in
+from pytest_simcore.helpers.utils_login import LoggedUser, log_client_in
+from pytest_simcore.helpers.utils_mock import future_with_result
 from pytest_simcore.helpers.utils_projects import NewProject, delete_all_projects
 from servicelib.application import create_safe_application
 from simcore_service_webserver.db import setup_db


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Review and cleanup of fixtures in webserver tests :
- reduce redundancy (reuse helpers from pytest-simcore)
- classify fixtures
- share common fixtures

to fulfill needs of  #1724: tests for garbage collector
- a User with more then 2 projects
- a user without projects
- a user with just 1 project

The user can be:
- connected via browser (websocket connection is up)
- disconnected (no websocket connection)


## Related issue number

follows from needs of #1724


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
