### PR TITLE
Fixed cached classifiers

### DIFF
--- a/services/web/client/source/class/osparc/component/export/Permissions.js
+++ b/services/web/client/source/class/osparc/component/export/Permissions.js
@@ -37,19 +37,19 @@ qx.Class.define("osparc.component.export.Permissions", {
   statics: {
     canDelete: function(accessRights) {
       let canDelete = accessRights.getDelete ? accessRights.getDelete() : false;
-      canDelete = !canDelete && accessRights.getWrite_access ? accessRights.getWrite_access() : false;
+      canDelete = canDelete || (accessRights.getWrite_access ? accessRights.getWrite_access() : false);
       return canDelete;
     },
 
     canWrite: function(accessRights) {
       let canWrite = accessRights.getWrite ? accessRights.getWrite() : false;
-      canWrite = !canWrite && accessRights.getWrite_access ? accessRights.getWrite_access() : false;
+      canWrite = canWrite || (accessRights.getWrite_access ? accessRights.getWrite_access() : false);
       return canWrite;
     },
 
     canView: function(accessRights) {
       let canView = accessRights.getRead ? accessRights.getRead() : false;
-      canView = !canView && accessRights.getExecute_access ? accessRights.getExecute_access() : false;
+      canView = canView || (accessRights.getExecute_access ? accessRights.getExecute_access() : false);
       return canView;
     }
   },

--- a/services/web/client/source/class/osparc/data/Resources.js
+++ b/services/web/client/source/class/osparc/data/Resources.js
@@ -192,7 +192,7 @@ qx.Class.define("osparc.data.Resources", {
        * GROUPS/DAGS
        */
       "dags": {
-        usesCache: true,
+        useCache: true,
         idField: "key",
         endpoints: {
           post: {
@@ -342,7 +342,7 @@ qx.Class.define("osparc.data.Resources", {
        * Gets the json object containing sample classifiers
        */
       "classifiers": {
-        useCache: true,
+        useCache: false,
         idField: "classifiers",
         endpoints: {
           get: {

--- a/services/web/client/source/class/osparc/store/Store.js
+++ b/services/web/client/source/class/osparc/store/Store.js
@@ -473,7 +473,7 @@ qx.Class.define("osparc.store.Store", {
       return new Promise((resolve, reject) => {
         const oldClassifiers = this.getClassifiers();
         if (!reload && oldClassifiers.length) {
-          resolve(this.getClassifiers());
+          resolve(oldClassifiers);
           return;
         }
         osparc.store.Store.getInstance().getGroupsOrganizations()

--- a/services/web/client/source/class/osparc/utils/Classifiers.js
+++ b/services/web/client/source/class/osparc/utils/Classifiers.js
@@ -30,38 +30,16 @@ qx.Class.define("osparc.utils.Classifiers", {
           label: "root",
           children: []
         };
-        osparc.store.Store.getInstance().getGroupsOrganizations()
-          .then(orgs => {
-            if (orgs.length === 0) {
-              reject();
-              return;
+        osparc.store.Store.getInstance().getAllClassifiers()
+          .then(classifiers => {
+            const keys = Object.keys(classifiers);
+            if (keys.length) {
+              // Tree-ify
+              const tree = {};
+              keys.forEach(key => this.__buildTree(classifiers, key, classifiers[key].classifier.split("::"), tree));
+              rootData.children.push(...this.__virtualTree(tree));
             }
-            const classifierPromises = [];
-            orgs.forEach(org => {
-              const params = {
-                url: {
-                  "gid": org["gid"]
-                }
-              };
-              classifierPromises.push(osparc.data.Resources.get("classifiers", params));
-            });
-            Promise.all(classifierPromises)
-              .then(classifierss => {
-                if (classifierss.length === 0) {
-                  reject();
-                  return;
-                }
-                classifierss.forEach(({classifiers}) => {
-                  const keys = Object.keys(classifiers);
-                  if (keys.length) {
-                    // Tree-ify
-                    const tree = {};
-                    keys.forEach(key => this.__buildTree(classifiers, key, classifiers[key].classifier.split("::"), tree));
-                    rootData.children.push(...this.__virtualTree(tree));
-                  }
-                });
-                resolve(rootData);
-              });
+            resolve(rootData);
           });
       });
     },


### PR DESCRIPTION
## What do these changes do?
Fixes replicated classifiers.

The problem we have is that the current frontend cache is not able to handle classifiers coming from different organizations. This PR fixes this specific issue but it would be nice to extend the caching system.

## Related issue number
closes ITISFoundation/osparc-issues#279


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
