### PR TITLE
Bugfix/use aio pika connect

### DIFF
--- a/services/sidecar/src/simcore_service_sidecar/cli.py
+++ b/services/sidecar/src/simcore_service_sidecar/cli.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from typing import List, Optional, Tuple
-from aiormq.base import task
 
 import click
 

--- a/services/sidecar/src/simcore_service_sidecar/cli.py
+++ b/services/sidecar/src/simcore_service_sidecar/cli.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from typing import List, Optional, Tuple
+from aiormq.base import task
 
 import click
 
@@ -22,21 +23,9 @@ def main(
     job_id: str, user_id: str, project_id: str, node_id: str
 ) -> Optional[List[str]]:
 
-    log.info(
-        "STARTING task processing for user %s, project %s, node %s",
-        user_id,
-        project_id,
-        node_id,
-    )
     try:
         next_task_nodes, _ = wrap_async_call(
             run_sidecar(job_id, user_id, project_id, node_id=node_id)
-        )
-        log.info(
-            "COMPLETED task processing for user %s, project %s, node %s",
-            user_id,
-            project_id,
-            node_id,
         )
         return next_task_nodes
     except Exception:  # pylint: disable=broad-except
@@ -47,13 +36,21 @@ async def run_sidecar(
     job_id: str, user_id: str, project_id: str, node_id: Optional[str]
 ) -> Tuple[Optional[List[str]], Optional[str]]:
     try:
+        log.info(
+            "STARTING task %s processing for user %s, project %s, node %s",
+            job_id,
+            user_id,
+            project_id,
+            node_id,
+        )
         async with DBContextManager() as db_engine:
             async with RabbitMQ(config=RABBIT_CONFIG) as rabbit_mq:
                 next_task_nodes: Optional[List[str]] = await inspect(
                     db_engine, rabbit_mq, job_id, user_id, project_id, node_id=node_id
                 )
                 log.info(
-                    "COMPLETED task processing for user %s, project %s, node %s",
+                    "COMPLETED task %s processing for user %s, project %s, node %s",
+                    job_id,
                     user_id,
                     project_id,
                     node_id,

--- a/services/sidecar/src/simcore_service_sidecar/rabbitmq.py
+++ b/services/sidecar/src/simcore_service_sidecar/rabbitmq.py
@@ -28,10 +28,6 @@ def _close_callback(sender: Any, exc: Optional[BaseException]):
         log.info("Rabbit connection closed from %s", sender)
 
 
-def _reconnect_callback():
-    log.warning("Rabbit connection reconnected")
-
-
 def _channel_close_callback(sender: Any, exc: Optional[BaseException]):
     if exc:
         log.error(
@@ -59,12 +55,11 @@ class RabbitMQ(BaseModel):
         await _wait_till_rabbit_responsive(url)
 
         # NOTE: to show the connection name in the rabbitMQ UI see there [https://www.bountysource.com/issues/89342433-setting-custom-connection-name-via-client_properties-doesn-t-work-when-connecting-using-an-amqp-url]
-        self.connection = await aio_pika.connect_robust(
+        self.connection = await aio_pika.connect(
             url + f"?name={__name__}_{id(socket.gethostname())}",
             client_properties={"connection_name": "sidecar connection"},
         )
         self.connection.add_close_callback(_close_callback)
-        self.connection.add_reconnect_callback(_reconnect_callback)
 
         log.debug("Creating channel")
         self.channel = await self.connection.channel(publisher_confirms=False)
@@ -76,12 +71,14 @@ class RabbitMQ(BaseModel):
         )
         log.debug("Declaring %s exchange", self.config.channels["progress"])
         self.progress_exchange = await self.channel.declare_exchange(
-            self.config.channels["progress"], aio_pika.ExchangeType.FANOUT,
+            self.config.channels["progress"],
+            aio_pika.ExchangeType.FANOUT,
         )
 
         log.debug("Declaring %s exchange", self.config.channels["instrumentation"])
         self.instrumentation_exchange = await self.channel.declare_exchange(
-            self.config.channels["instrumentation"], aio_pika.ExchangeType.FANOUT,
+            self.config.channels["instrumentation"],
+            aio_pika.ExchangeType.FANOUT,
         )
 
     async def close(self):
@@ -130,10 +127,12 @@ class RabbitMQ(BaseModel):
         )
 
     async def post_instrumentation_message(
-        self, instrumentation_data: Dict,
+        self,
+        instrumentation_data: Dict,
     ):
         await self._post_message(
-            self.instrumentation_exchange, data=instrumentation_data,
+            self.instrumentation_exchange,
+            data=instrumentation_data,
         )
 
     async def __aenter__(self):

--- a/services/sidecar/tests/unit/test_rabbitmq.py
+++ b/services/sidecar/tests/unit/test_rabbitmq.py
@@ -24,9 +24,6 @@ async def test_rabbitmq(
     mock_close_channel_cb = mocker.patch(
         "simcore_service_sidecar.rabbitmq._channel_close_callback"
     )
-    mock_reconnect_cb = mocker.patch(
-        "simcore_service_sidecar.rabbitmq._reconnect_callback"
-    )
 
     user_id: str = "some user id"
     project_id: str = "some project id"
@@ -56,7 +53,6 @@ async def test_rabbitmq(
 
     mock_close_channel_cb.assert_called_once()
     mock_close_connection_cb.assert_called_once()
-    mock_reconnect_cb.assert_not_called()
 
     # if this fails the above sleep did not work
     assert len(incoming_data) == 3


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
- use aio_pika connection.connect() instead of connect_robust()

connect_robust as I understand it is used in case we need to reconnect which we could do. but as we are using a context manager already and connecting manually to the channels I think this is an overkill.
Also it seems like the reconnect feature creates a lot of unnecessary error messages that pollute the logs.

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [x] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
