### PR TITLE
weekly maintenance and changes on makefile recipes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ jobs:
 
     # test python, webserver ----------------------------------------------------------------------
     - stage: build / unit-testing
-      name: webserver
+      name: webserver-isolated
       language: python
       python:
         - "3.6"
@@ -101,7 +101,67 @@ jobs:
       before_script:
         - unbuffer bash ci/travis/unit-testing/webserver.bash before_script
       script:
-        - unbuffer bash ci/travis/unit-testing/webserver.bash script
+        - unbuffer bash ci/travis/unit-testing/webserver.bash test_isolated
+      after_success:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash after_success
+      after_failure:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash after_failure
+
+    - stage: build / unit-testing
+      name: webserver-with-db-slow
+      language: python
+      python:
+        - "3.6"
+      sudo: required
+      cache: pip
+      before_install:
+        - sudo bash ci/travis/unit-testing/webserver.bash before_install
+      install:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash install
+      before_script:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash before_script
+      script:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash test_with_db_slow
+      after_success:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash after_success
+      after_failure:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash after_failure
+
+    - stage: build / unit-testing
+      name: webserver-with-db-medium
+      language: python
+      python:
+        - "3.6"
+      sudo: required
+      cache: pip
+      before_install:
+        - sudo bash ci/travis/unit-testing/webserver.bash before_install
+      install:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash install
+      before_script:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash before_script
+      script:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash test_with_db_medium
+      after_success:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash after_success
+      after_failure:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash after_failure
+
+    - stage: build / unit-testing
+      name: webserver-with-db-fast
+      language: python
+      python:
+        - "3.6"
+      sudo: required
+      cache: pip
+      before_install:
+        - sudo bash ci/travis/unit-testing/webserver.bash before_install
+      install:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash install
+      before_script:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash before_script
+      script:
+        - unbuffer bash ci/travis/unit-testing/webserver.bash test_with_db_fast
       after_success:
         - unbuffer bash ci/travis/unit-testing/webserver.bash after_success
       after_failure:

--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -8,7 +8,7 @@ aiohttp==3.6.2            # via -r requirements.in, pytest-aiohttp
 async-timeout==3.0.1      # via aiohttp
 attrs==20.2.0             # via aiohttp, jsonschema, openapi-core, pytest
 chardet==3.0.4            # via aiohttp
-coverage==5.2.1           # via -r requirements.in, pytest-cov
+coverage==5.3             # via -r requirements.in, pytest-cov
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via idna-ssl, yarl
 importlib-metadata==1.7.0  # via jsonschema, pluggy, pytest
@@ -22,16 +22,16 @@ openapi-core==0.13.4      # via -r requirements.in
 openapi-schema-validator==0.1.1  # via openapi-core
 openapi-spec-validator==0.2.9  # via openapi-core
 packaging==20.4           # via pytest, pytest-sugar
-parse==1.17.0             # via openapi-core
+parse==1.18.0             # via openapi-core
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
 pyparsing==2.4.7          # via packaging
-pyrsistent==0.16.0        # via jsonschema
+pyrsistent==0.17.3        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements.in
 pytest-cov==2.10.1        # via -r requirements.in
 pytest-instafail==0.4.2   # via -r requirements.in
 pytest-sugar==0.9.4       # via -r requirements.in
-pytest==6.0.1             # via -r requirements.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-sugar
+pytest==6.0.2             # via -r requirements.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-sugar
 pyyaml==5.3.1             # via openapi-spec-validator
 six==1.15.0               # via isodate, jsonschema, openapi-core, openapi-schema-validator, openapi-spec-validator, packaging
 strict-rfc3339==0.7       # via openapi-schema-validator

--- a/ci/github/helpers/setup_docker_compose.bash
+++ b/ci/github/helpers/setup_docker_compose.bash
@@ -6,8 +6,8 @@ set -o pipefail  # don't hide errors within pipes
 IFS=$'\n\t'
 
 # when changing the DOCKER_COMPOSE_VERSION please compute the sha256sum on an ubuntu box (macOS has different checksum)
-DOCKER_COMPOSE_VERSION="1.26.2"
-DOCKER_COMPOSE_SHA256SUM="13e50875393decdb047993c3c0192b0a3825613e6dfc0fa271efed4f5dbdd6eb"
+DOCKER_COMPOSE_VERSION="1.27.3"
+DOCKER_COMPOSE_SHA256SUM="92055c48e1514c0377b76ed3df87f505c50099145d86835b06fa5109811b6a83"
 DOCKER_COMPOSE_BIN=/usr/local/bin/docker-compose
 curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o $DOCKER_COMPOSE_BIN
 chmod +x $DOCKER_COMPOSE_BIN

--- a/ci/travis/unit-testing/webserver.bash
+++ b/ci/travis/unit-testing/webserver.bash
@@ -6,54 +6,88 @@ IFS=$'\n\t'
 FOLDER_CHECKS=(api/ webserver packages/ services/web .travis.yml)
 
 before_install() {
-    if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}";
-    then
-        bash ci/travis/helpers/update-docker.bash
-        bash ci/travis/helpers/install-docker-compose.bash
-        bash ci/helpers/show_system_versions.bash
-    fi
+  if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}"; then
+    bash ci/travis/helpers/update-docker.bash
+    bash ci/travis/helpers/install-docker-compose.bash
+    bash ci/helpers/show_system_versions.bash
+  fi
 }
 
 install() {
-    if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}";
-    then
-        bash ci/helpers/ensure_python_pip.bash
-        pushd services/web/server; pip3 install -r requirements/ci.txt; popd;
-    fi
+  if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}"; then
+    bash ci/helpers/ensure_python_pip.bash
+    pushd services/web/server
+    pip3 install -r requirements/ci.txt
+    popd
+  fi
 }
 
 before_script() {
-    if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}";
-    then
-        pip list -v
-    fi
+  if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}"; then
+    pip list -v
+  fi
 }
 
-script() {
-    if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}";
-    then
-        pytest --cov=simcore_service_webserver --durations=10 --cov-append \
-                --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
-                -v -m "not travis" services/web/server/tests/unit
-    else
-        echo "No changes detected. Skipping unit-testing of webserver."
-    fi
+test_isolated() {
+  if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}"; then
+
+    pytest --cov=simcore_service_webserver --durations=10 --cov-append \
+      --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+      -v -m "not travis" services/web/server/tests/unit/isolated
+  else
+    echo "No changes detected. Skipping unit-testing of webserver."
+  fi
+
+}
+
+test_with_db_slow() {
+  if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}"; then
+
+    pytest --cov=simcore_service_webserver --durations=10 --cov-append \
+      --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+      -v -m "not travis" services/web/server/tests/unit/with_dbs/slow
+  else
+    echo "No changes detected. Skipping unit-testing of webserver."
+  fi
+
+}
+
+test_with_db_medium() {
+  if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}"; then
+
+    pytest --cov=simcore_service_webserver --durations=10 --cov-append \
+      --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+      -v -m "not travis" services/web/server/tests/unit/with_dbs/medium
+  else
+    echo "No changes detected. Skipping unit-testing of webserver."
+  fi
+
+}
+
+test_with_db_fast() {
+  if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}"; then
+
+    pytest --cov=simcore_service_webserver --durations=10 --cov-append \
+      --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+      -v -m "not travis" services/web/server/tests/unit/with_dbs/fast
+  else
+    echo "No changes detected. Skipping unit-testing of webserver."
+  fi
+
 }
 
 after_success() {
-    if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}";
-    then
-        coveralls
-    fi
+  if bash ci/travis/helpers/test-for-changes.bash "${FOLDER_CHECKS[@]}"; then
+    coveralls
+  fi
 }
 
 after_failure() {
-    echo "failure... you can always write something more interesting here..."
+  echo "failure... you can always write something more interesting here..."
 }
 
 # Check if the function exists (bash specific)
-if declare -f "$1" > /dev/null
-then
+if declare -f "$1" >/dev/null; then
   # call arguments verbatim
   "$@"
 else

--- a/packages/postgres-database/Makefile
+++ b/packages/postgres-database/Makefile
@@ -2,6 +2,7 @@
 # Targets for DEVELOPMENT of postgres-database
 #
 include ../../scripts/common.Makefile
+include ../../scripts/common-package.Makefile
 
 
 .PHONY: requirements

--- a/packages/postgres-database/requirements/_migration.txt
+++ b/packages/postgres-database/requirements/_migration.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_migration.txt requirements/_migration.in
 #
-alembic==1.4.2            # via -r requirements/_migration.in
+alembic==1.4.3            # via -r requirements/_migration.in
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r requirements/_migration.in

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -13,14 +13,14 @@ attrs==19.3.0             # via aiohttp, jsonschema, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
 cached-property==1.5.1    # via docker-compose
 certifi==2020.6.20        # via -r requirements/_migration.txt, requests
-cffi==1.14.2              # via bcrypt, cryptography, pynacl
+cffi==1.14.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via -r requirements/_migration.txt, aiohttp, requests
 click==7.1.2              # via -r requirements/_migration.txt
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 cryptography==3.1         # via paramiko
 distro==1.5.0             # via docker-compose
-docker-compose==1.27.2    # via pytest-docker
+docker-compose==1.27.3    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_migration.txt, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
@@ -28,7 +28,8 @@ faker==4.1.3              # via -r requirements/_test.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via -r requirements/_migration.txt, idna-ssl, requests, yarl
 importlib-metadata==1.7.0  # via jsonschema, pluggy, pytest
-isort==5.5.2              # via pylint
+iniconfig==1.0.1          # via pytest
+isort==5.5.3              # via pylint
 jsonschema==3.2.0         # via docker-compose
 lazy-object-proxy==1.4.3  # via astroid
 mako==1.1.3               # via -r requirements/_migration.txt, alembic
@@ -48,10 +49,10 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.8.0      # via -r requirements/_test.in
+pytest-docker==0.10.0     # via -r requirements/_test.in
 pytest-instafail==0.4.2   # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
-pytest==5.4.3             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail
+pytest==6.0.2             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail
 python-dateutil==2.8.1    # via -r requirements/_migration.txt, alembic, faker
 python-dotenv==0.14.0     # via docker-compose
 python-editor==1.0.4      # via -r requirements/_migration.txt, alembic
@@ -62,11 +63,10 @@ sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_migration.
 tenacity==6.2.0           # via -r requirements/_migration.txt
 text-unidecode==1.3       # via faker
 texttable==1.6.3          # via docker-compose
-toml==0.10.1              # via pylint
+toml==0.10.1              # via pylint, pytest
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/_migration.txt, aiohttp, yarl
 urllib3==1.25.10          # via -r requirements/_migration.txt, requests
-wcwidth==0.2.5            # via pytest
 websocket-client==0.57.0  # via -r requirements/_migration.txt, docker, docker-compose
 wrapt==1.12.1             # via astroid
 yarl==1.5.1               # via -r requirements/_migration.txt, aiohttp

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -6,7 +6,7 @@
 #
 aiohttp==3.6.2            # via pytest-aiohttp
 aiopg[sa]==1.0.0          # via -r requirements/_test.in
-alembic==1.4.2            # via -r requirements/_migration.txt
+alembic==1.4.3            # via -r requirements/_migration.txt
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, jsonschema, pytest, pytest-docker
@@ -16,19 +16,19 @@ certifi==2020.6.20        # via -r requirements/_migration.txt, requests
 cffi==1.14.2              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via -r requirements/_migration.txt, aiohttp, requests
 click==7.1.2              # via -r requirements/_migration.txt
-coverage==5.2.1           # via -r requirements/_test.in, coveralls, pytest-cov
+coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 cryptography==3.1         # via paramiko
 distro==1.5.0             # via docker-compose
-docker-compose==1.26.2    # via pytest-docker
+docker-compose==1.27.2    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_migration.txt, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
-faker==4.1.2              # via -r requirements/_test.in
+faker==4.1.3              # via -r requirements/_test.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via -r requirements/_migration.txt, idna-ssl, requests, yarl
 importlib-metadata==1.7.0  # via jsonschema, pluggy, pytest
-isort==5.5.1              # via pylint
+isort==5.5.2              # via pylint
 jsonschema==3.2.0         # via docker-compose
 lazy-object-proxy==1.4.3  # via astroid
 mako==1.1.3               # via -r requirements/_migration.txt, alembic
@@ -45,7 +45,7 @@ pycparser==2.20           # via cffi
 pylint==2.6.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging
-pyrsistent==0.16.0        # via jsonschema
+pyrsistent==0.17.3        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
 pytest-docker==0.8.0      # via -r requirements/_test.in
@@ -57,7 +57,7 @@ python-dotenv==0.14.0     # via docker-compose
 python-editor==1.0.4      # via -r requirements/_migration.txt, alembic
 pyyaml==5.3.1             # via -r requirements/_test.in, docker-compose
 requests==2.24.0          # via -r requirements/_migration.txt, coveralls, docker, docker-compose
-six==1.15.0               # via -r requirements/_migration.txt, astroid, bcrypt, cryptography, docker, docker-compose, dockerpty, jsonschema, packaging, pynacl, pyrsistent, python-dateutil, tenacity, websocket-client
+six==1.15.0               # via -r requirements/_migration.txt, astroid, bcrypt, cryptography, docker, dockerpty, jsonschema, packaging, pynacl, python-dateutil, tenacity, websocket-client
 sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_migration.txt, aiopg, alembic
 tenacity==6.2.0           # via -r requirements/_migration.txt
 text-unidecode==1.3       # via faker

--- a/packages/s3wrapper/requirements/_test.txt
+++ b/packages/s3wrapper/requirements/_test.txt
@@ -12,17 +12,17 @@ certifi==2020.6.20        # via -r requirements/_base.txt, minio, requests
 cffi==1.14.2              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 configparser==5.0.0       # via -r requirements/_base.txt, minio
-coverage==5.2.1           # via -r requirements/_test.in, coveralls, pytest-cov
+coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 cryptography==3.1         # via paramiko
 distro==1.5.0             # via docker-compose
-docker-compose==1.26.2    # via pytest-docker
+docker-compose==1.27.2    # via pytest-docker
 docker[ssh]==4.3.1        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 idna==2.10                # via requests
 importlib-metadata==1.7.0  # via jsonschema, pluggy, pytest
-isort==5.5.1              # via pylint
+isort==5.5.2              # via pylint
 jsonschema==3.2.0         # via docker-compose
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
@@ -36,7 +36,7 @@ pycparser==2.20           # via cffi
 pylint==2.6.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging
-pyrsistent==0.16.0        # via jsonschema
+pyrsistent==0.17.3        # via jsonschema
 pytest-cov==2.10.1        # via -r requirements/_test.in
 pytest-docker==0.8.0      # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
@@ -46,7 +46,7 @@ python-dotenv==0.14.0     # via docker-compose
 pytz==2020.1              # via -r requirements/_base.txt, minio
 pyyaml==5.3.1             # via docker-compose
 requests==2.24.0          # via -r requirements/_test.in, coveralls, docker, docker-compose
-six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, docker-compose, dockerpty, jsonschema, packaging, pynacl, pyrsistent, python-dateutil, websocket-client
+six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, dockerpty, jsonschema, packaging, pynacl, python-dateutil, websocket-client
 texttable==1.6.3          # via docker-compose
 toml==0.10.1              # via pylint
 typed-ast==1.4.1          # via astroid

--- a/packages/s3wrapper/requirements/_test.txt
+++ b/packages/s3wrapper/requirements/_test.txt
@@ -9,20 +9,21 @@ attrs==19.3.0             # via jsonschema, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
 cached-property==1.5.1    # via docker-compose
 certifi==2020.6.20        # via -r requirements/_base.txt, minio, requests
-cffi==1.14.2              # via bcrypt, cryptography, pynacl
+cffi==1.14.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 configparser==5.0.0       # via -r requirements/_base.txt, minio
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 cryptography==3.1         # via paramiko
 distro==1.5.0             # via docker-compose
-docker-compose==1.27.2    # via pytest-docker
+docker-compose==1.27.3    # via pytest-docker
 docker[ssh]==4.3.1        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 idna==2.10                # via requests
 importlib-metadata==1.7.0  # via jsonschema, pluggy, pytest
-isort==5.5.2              # via pylint
+iniconfig==1.0.1          # via pytest
+isort==5.5.3              # via pylint
 jsonschema==3.2.0         # via docker-compose
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
@@ -38,9 +39,9 @@ pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.8.0      # via -r requirements/_test.in
+pytest-docker==0.10.0     # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
-pytest==5.4.3             # via -r requirements/_test.in, pytest-cov, pytest-docker
+pytest==6.0.2             # via -r requirements/_test.in, pytest-cov, pytest-docker
 python-dateutil==2.8.1    # via -r requirements/_base.txt, minio
 python-dotenv==0.14.0     # via docker-compose
 pytz==2020.1              # via -r requirements/_base.txt, minio
@@ -48,10 +49,9 @@ pyyaml==5.3.1             # via docker-compose
 requests==2.24.0          # via -r requirements/_test.in, coveralls, docker, docker-compose
 six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, dockerpty, jsonschema, packaging, pynacl, python-dateutil, websocket-client
 texttable==1.6.3          # via docker-compose
-toml==0.10.1              # via pylint
+toml==0.10.1              # via pylint, pytest
 typed-ast==1.4.1          # via astroid
 urllib3==1.25.10          # via -r requirements/_base.txt, minio, requests
-wcwidth==0.2.5            # via pytest
 websocket-client==0.57.0  # via docker, docker-compose
 wrapt==1.12.1             # via astroid
 zipp==3.1.0               # via importlib-metadata

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -20,14 +20,15 @@ openapi-core==0.12.0      # via -r requirements/_base.in
 openapi-spec-validator==0.2.9  # via openapi-core
 prometheus-client==0.8.0  # via -r requirements/_base.in
 psycopg2-binary==2.8.6    # via -r requirements/_base.in, aiopg, sqlalchemy
-pyrsistent==0.16.0        # via jsonschema
+pyrsistent==0.17.3        # via jsonschema
 pyyaml==5.3.1             # via -r requirements/_base.in, openapi-spec-validator
-six==1.15.0               # via isodate, jsonschema, openapi-core, openapi-spec-validator, pyrsistent, tenacity
+six==1.15.0               # via isodate, jsonschema, openapi-core, openapi-spec-validator, tenacity
 sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.in, aiopg
 strict-rfc3339==0.7       # via openapi-core
 tenacity==6.2.0           # via -r requirements/_base.in
-trafaret==2.0.2           # via -r requirements/_base.in
-ujson==3.1.0              # via -r requirements/_base.in
+trafaret==2.1.0           # via -r requirements/_base.in
+typing-extensions==3.7.4.3  # via aiohttp, yarl
+ujson==3.2.0              # via -r requirements/_base.in
 werkzeug==1.0.1           # via -r requirements/_base.in
 yarl==1.5.1               # via aiohttp
 

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -16,17 +16,17 @@ cached-property==1.5.1    # via docker-compose
 certifi==2020.6.20        # via requests
 cffi==1.14.2              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via -r requirements/_base.txt, aiohttp, requests
-coverage==5.2.1           # via -r requirements/_test.in, coveralls, pytest-cov
+coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 cryptography==3.1         # via paramiko
 distro==1.5.0             # via docker-compose
-docker-compose==1.26.2    # via pytest-docker
+docker-compose==1.27.2    # via pytest-docker
 docker[ssh]==4.3.1        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 idna==2.10                # via -r requirements/_base.txt, requests, yarl
 isodate==0.6.0            # via -r requirements/_base.txt, openapi-core
-isort==5.5.1              # via pylint
+isort==5.5.2              # via pylint
 jsonschema==3.2.0         # via -r requirements/_base.txt, docker-compose, openapi-spec-validator
 lazy-object-proxy==1.4.3  # via -r requirements/_base.txt, astroid, openapi-core
 mccabe==0.6.1             # via pylint
@@ -44,7 +44,7 @@ pycparser==2.20           # via cffi
 pylint==2.6.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging
-pyrsistent==0.16.0        # via -r requirements/_base.txt, jsonschema
+pyrsistent==0.17.3        # via -r requirements/_base.txt, jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
 pytest-docker==0.8.0      # via -r requirements/_test.in
@@ -56,15 +56,17 @@ pytest==5.4.3             # via -r requirements/_test.in, pytest-aiohttp, pytest
 python-dotenv==0.14.0     # via docker-compose
 pyyaml==5.3.1             # via -r requirements/_base.txt, docker-compose, openapi-spec-validator
 requests==2.24.0          # via coveralls, docker, docker-compose
-six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, docker-compose, dockerpty, isodate, jsonschema, openapi-core, openapi-spec-validator, packaging, pynacl, pyrsistent, tenacity, websocket-client
+six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, dockerpty, isodate, jsonschema, openapi-core, openapi-spec-validator, packaging, pynacl, tenacity, websocket-client
 sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.txt, aiopg
 strict-rfc3339==0.7       # via -r requirements/_base.txt, openapi-core
 tenacity==6.2.0           # via -r requirements/_base.txt
 termcolor==1.1.0          # via pytest-sugar
 texttable==1.6.3          # via docker-compose
 toml==0.10.1              # via pylint
-trafaret==2.0.2           # via -r requirements/_base.txt
-ujson==3.1.0              # via -r requirements/_base.txt
+trafaret==2.1.0           # via -r requirements/_base.txt
+typed-ast==1.4.1          # via astroid
+typing-extensions==3.7.4.3  # via -r requirements/_base.txt, aiohttp, yarl
+ujson==3.2.0              # via -r requirements/_base.txt
 urllib3==1.25.10          # via requests
 wcwidth==0.2.5            # via pytest
 websocket-client==0.57.0  # via docker, docker-compose

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -14,19 +14,22 @@ attrs==19.3.0             # via -r requirements/_base.txt, aiohttp, jsonschema, 
 bcrypt==3.2.0             # via paramiko
 cached-property==1.5.1    # via docker-compose
 certifi==2020.6.20        # via requests
-cffi==1.14.2              # via bcrypt, cryptography, pynacl
+cffi==1.14.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via -r requirements/_base.txt, aiohttp, requests
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 cryptography==3.1         # via paramiko
 distro==1.5.0             # via docker-compose
-docker-compose==1.27.2    # via pytest-docker
+docker-compose==1.27.3    # via pytest-docker
 docker[ssh]==4.3.1        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
-idna==2.10                # via -r requirements/_base.txt, requests, yarl
+idna-ssl==1.1.0           # via -r requirements/_base.txt, aiohttp
+idna==2.10                # via -r requirements/_base.txt, idna-ssl, requests, yarl
+importlib-metadata==1.7.0  # via -r requirements/_base.txt, jsonschema, pluggy, pytest
+iniconfig==1.0.1          # via pytest
 isodate==0.6.0            # via -r requirements/_base.txt, openapi-core
-isort==5.5.2              # via pylint
+isort==5.5.3              # via pylint
 jsonschema==3.2.0         # via -r requirements/_base.txt, docker-compose, openapi-spec-validator
 lazy-object-proxy==1.4.3  # via -r requirements/_base.txt, astroid, openapi-core
 mccabe==0.6.1             # via pylint
@@ -47,12 +50,12 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via -r requirements/_base.txt, jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.8.0      # via -r requirements/_test.in
+pytest-docker==0.10.0     # via -r requirements/_test.in
 pytest-instafail==0.4.2   # via -r requirements/_test.in
 pytest-mock==3.3.1        # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
 pytest-sugar==0.9.4       # via -r requirements/_test.in
-pytest==5.4.3             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail, pytest-mock, pytest-sugar
+pytest==6.0.2             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail, pytest-mock, pytest-sugar
 python-dotenv==0.14.0     # via docker-compose
 pyyaml==5.3.1             # via -r requirements/_base.txt, docker-compose, openapi-spec-validator
 requests==2.24.0          # via coveralls, docker, docker-compose
@@ -62,13 +65,12 @@ strict-rfc3339==0.7       # via -r requirements/_base.txt, openapi-core
 tenacity==6.2.0           # via -r requirements/_base.txt
 termcolor==1.1.0          # via pytest-sugar
 texttable==1.6.3          # via docker-compose
-toml==0.10.1              # via pylint
+toml==0.10.1              # via pylint, pytest
 trafaret==2.1.0           # via -r requirements/_base.txt
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/_base.txt, aiohttp, yarl
 ujson==3.2.0              # via -r requirements/_base.txt
 urllib3==1.25.10          # via requests
-wcwidth==0.2.5            # via pytest
 websocket-client==0.57.0  # via docker, docker-compose
 werkzeug==1.0.1           # via -r requirements/_base.txt
 wrapt==1.12.1             # via astroid

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -23,6 +23,6 @@ six==1.15.0               # via tenacity
 sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via aiopg
 tenacity==6.2.0           # via -r requirements/_base.in
 trafaret-config==2.0.2    # via -r requirements/_base.in
-trafaret==2.0.2           # via trafaret-config
+trafaret==2.1.0           # via trafaret-config
 typing-extensions==3.7.4.3  # via aiohttp, yarl
 yarl==1.5.1               # via aiohttp

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -13,7 +13,7 @@ attrs==19.3.0             # via -r requirements/_base.txt, aiohttp, jsonschema, 
 bcrypt==3.2.0             # via paramiko
 cached-property==1.5.1    # via docker-compose
 certifi==2020.6.20        # via requests
-cffi==1.14.2              # via bcrypt, cryptography, pynacl
+cffi==1.14.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via -r requirements/_base.txt, aiohttp, requests
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
@@ -21,14 +21,15 @@ cryptography==3.1         # via paramiko
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 decorator==4.4.2          # via -r requirements/_base.txt, networkx
 distro==1.5.0             # via docker-compose
-docker-compose==1.27.2    # via pytest-docker
+docker-compose==1.27.3    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 idna-ssl==1.1.0           # via -r requirements/_base.txt, aiohttp
 idna==2.10                # via -r requirements/_base.txt, idna-ssl, requests, yarl
 importlib-metadata==1.7.0  # via jsonschema, pluggy, pytest
-isort==5.5.2              # via pylint
+iniconfig==1.0.1          # via pytest
+isort==5.5.3              # via pylint
 jsonschema==3.2.0         # via docker-compose
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
@@ -49,12 +50,12 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.8.0      # via -r requirements/_test.in
+pytest-docker==0.10.0     # via -r requirements/_test.in
 pytest-instafail==0.4.2   # via -r requirements/_test.in
 pytest-mock==3.3.1        # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
 pytest-sugar==0.9.4       # via -r requirements/_test.in
-pytest==5.4.3             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail, pytest-mock, pytest-sugar
+pytest==6.0.2             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail, pytest-mock, pytest-sugar
 python-dotenv==0.14.0     # via -r requirements/_test.in, docker-compose
 pyyaml==5.3.1             # via -r requirements/_base.txt, docker-compose, trafaret-config
 requests==2.24.0          # via -r requirements/_test.in, coveralls, docker, docker-compose
@@ -63,13 +64,12 @@ sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.txt, 
 tenacity==6.2.0           # via -r requirements/_base.txt
 termcolor==1.1.0          # via pytest-sugar
 texttable==1.6.3          # via docker-compose
-toml==0.10.1              # via pylint
+toml==0.10.1              # via pylint, pytest
 trafaret-config==2.0.2    # via -r requirements/_base.txt
 trafaret==2.1.0           # via -r requirements/_base.txt, trafaret-config
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/_base.txt, aiohttp, yarl
 urllib3==1.25.10          # via requests
-wcwidth==0.2.5            # via pytest
 websocket-client==0.57.0  # via docker, docker-compose
 wrapt==1.12.1             # via astroid
 yarl==1.5.1               # via -r requirements/_base.txt, aiohttp

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -15,20 +15,20 @@ cached-property==1.5.1    # via docker-compose
 certifi==2020.6.20        # via requests
 cffi==1.14.2              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via -r requirements/_base.txt, aiohttp, requests
-coverage==5.2.1           # via -r requirements/_test.in, coveralls, pytest-cov
+coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 cryptography==3.1         # via paramiko
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 decorator==4.4.2          # via -r requirements/_base.txt, networkx
 distro==1.5.0             # via docker-compose
-docker-compose==1.26.2    # via pytest-docker
+docker-compose==1.27.2    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 idna-ssl==1.1.0           # via -r requirements/_base.txt, aiohttp
 idna==2.10                # via -r requirements/_base.txt, idna-ssl, requests, yarl
 importlib-metadata==1.7.0  # via jsonschema, pluggy, pytest
-isort==5.5.1              # via pylint
+isort==5.5.2              # via pylint
 jsonschema==3.2.0         # via docker-compose
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
@@ -46,7 +46,7 @@ pydantic==1.6.1           # via -r requirements/_base.txt
 pylint==2.6.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging
-pyrsistent==0.16.0        # via jsonschema
+pyrsistent==0.17.3        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
 pytest-docker==0.8.0      # via -r requirements/_test.in
@@ -58,14 +58,14 @@ pytest==5.4.3             # via -r requirements/_test.in, pytest-aiohttp, pytest
 python-dotenv==0.14.0     # via -r requirements/_test.in, docker-compose
 pyyaml==5.3.1             # via -r requirements/_base.txt, docker-compose, trafaret-config
 requests==2.24.0          # via -r requirements/_test.in, coveralls, docker, docker-compose
-six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, docker-compose, dockerpty, jsonschema, packaging, pynacl, pyrsistent, tenacity, websocket-client
+six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, dockerpty, jsonschema, packaging, pynacl, tenacity, websocket-client
 sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.txt, aiopg
 tenacity==6.2.0           # via -r requirements/_base.txt
 termcolor==1.1.0          # via pytest-sugar
 texttable==1.6.3          # via docker-compose
 toml==0.10.1              # via pylint
 trafaret-config==2.0.2    # via -r requirements/_base.txt
-trafaret==2.0.2           # via -r requirements/_base.txt, trafaret-config
+trafaret==2.1.0           # via -r requirements/_base.txt, trafaret-config
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/_base.txt, aiohttp, yarl
 urllib3==1.25.10          # via requests

--- a/scripts/common-package.Makefile
+++ b/scripts/common-package.Makefile
@@ -1,0 +1,41 @@
+#
+# These are common target and recipes to Makefiles for packages/
+#
+# USAGE: Add this in the top of package's Makefile
+#
+#   include ../../scripts/common.Makefile
+#   include ../../scripts/common-package.Makefile
+#
+
+#
+# GLOBALS
+#
+
+# NOTE $(CURDIR) in this file refers to the directory where this file is included
+
+# Variable based on conventions (override if they do not apply)
+PACKAGE_VERSION  := $(shell cat VERSION)
+
+export PACKAGE_VERSION
+
+
+#
+# SHORTCUTS
+#
+
+
+#
+# COMMON TASKS
+#
+
+.PHONY: info
+info: ## displays package info
+	@make --no-print-directory info-super
+	# package setup
+	@echo ' PACKAGE_VERSION      : ${PACKAGE_VERSION}'
+
+
+
+#
+# SUBTASKS
+#

--- a/scripts/common-service.Makefile
+++ b/scripts/common-service.Makefile
@@ -32,6 +32,16 @@ export APP_VERSION
 # COMMON TASKS
 #
 
+
+## FIXME: pip-sync --quiet requirements/$(subst install-,,$@).txt
+
+.PHONY: install-dev install-prod install-ci
+install-dev install-prod install-ci: _check_venv_active ## install app in development/production or CI mode
+	# installing in $(subst install-,,$@) mode
+	pip-sync requirements/$(subst install-,,$@).txt
+
+
+
 .PHONY: build build-nc build-devel build-devel-nc build-cache build-cache-nc
 build build-nc build-devel build-devel-nc build-cache build-cache-nc: ## builds docker image in many flavours
 	# building docker image for ${APP_NAME} ...

--- a/scripts/common-service.Makefile
+++ b/scripts/common-service.Makefile
@@ -1,0 +1,66 @@
+#
+# These are common target and recipes to Makefiles for services/
+#
+# USAGE: Add this in the top of service's Makefile
+#
+#   include ../../scripts/common.Makefile
+#   include ../../scripts/common-service.Makefile
+#
+
+#
+# GLOBALS
+#
+
+# NOTE $(CURDIR) in this file refers to the directory where this file is included
+
+# Variable based on conventions (override if they do not apply)
+APP_NAME          = $(notdir $(CURDIR))
+APP_CLI_NAME      = simcore-service-$(APP_NAME)
+APP_PACKAGE_NAME  = $(subst -,_,$(APP_CLI_NAME))
+APP_VERSION      := $(shell cat VERSION)
+SRC_DIR           = $(abspath $(CURDIR)/src/$(APP_PACKAGE_NAME))
+
+export APP_VERSION
+
+
+#
+# SHORTCUTS
+#
+
+
+#
+# COMMON TASKS
+#
+
+.PHONY: build build-nc build-devel build-devel-nc build-cache build-cache-nc
+build build-nc build-devel build-devel-nc build-cache build-cache-nc: ## builds docker image in many flavours
+	# building docker image for ${APP_NAME} ...
+	@$(MAKE_C) ${REPO_BASE_DIR} $@ target=${APP_NAME}
+
+
+.PHONY: shell
+shell: ## runs shell in production container
+	# runs ${APP_NAME}:production shell
+	docker run -it --name="${APP_NAME}_${APP_VERSION}_shell" local/${APP_NAME}:production /bin/bash
+
+
+.PHONY: tail
+tail: ## tails log of $(APP_NAME) container
+	docker logs --follow $(shell docker ps -f "name=$(APP_NAME)*" --format {{.ID}}) > $(APP_NAME).log 2>&1
+
+
+.PHONY: info
+info: ## displays service info
+	@make --no-print-directory info-super
+	# service setup
+	@echo ' APP_NAME         : $(APP_NAME)'
+	@echo ' APP_CLI_NAME     : ${APP_CLI_NAME}'
+	@echo ' APP_PACKAGE_NAME : ${APP_PACKAGE_NAME}'
+	@echo ' APP_VERSION      : ${APP_VERSION}'
+	@echo ' SRC_DIR          : ${SRC_DIR}'
+
+
+
+#
+# SUBTASKS
+#

--- a/scripts/common.Makefile
+++ b/scripts/common.Makefile
@@ -1,5 +1,5 @@
 #
-# These are common target and recipes to Makefiles of packages/ and services/
+# These are COMMON target and recipes to Makefiles for **packages/ and services/**
 #
 # This file is included at the top of every Makefile
 #
@@ -76,7 +76,7 @@ clean: ## cleans all unversioned files in project and temp files create by this 
 
 
 .PHONY: info
-info: ## displays basic info
+inf%: ## displays basic info
 	# system
 	@echo ' OS               : $(IS_LINUX)$(IS_OSX)$(IS_WSL)$(IS_WIN)'
 	@echo ' CURDIR           : ${CURDIR}'
@@ -88,7 +88,6 @@ info: ## displays basic info
 	# package
 	-@echo ' name         : ' $(shell python ${CURDIR}/setup.py --name)
 	-@echo ' version      : ' $(shell python ${CURDIR}/setup.py --version)
-
 
 
 .PHONY: autoformat
@@ -105,9 +104,11 @@ autoformat: ## runs black python formatter on this service's code. Use AFTER mak
 		--exclude "/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|buck-out|build|dist|migration|client-sdk|generated_code)/" \
 		$(CURDIR)
 
+
 .PHONY: mypy
 mypy: $(REPO_BASE_DIR)/scripts/mypy.bash $(REPO_BASE_DIR)/mypy.ini ## runs mypy python static type checker on this services's code. Use AFTER make install-*
 	@$(REPO_BASE_DIR)/scripts/mypy.bash src
+
 
 .PHONY: code-analysis
 code-analysis: $(REPO_BASE_DIR)/.codeclimate.yml ## runs code-climate analysis
@@ -129,20 +130,6 @@ version-minor: ## commits version with backwards-compatible API addition or chan
 version-major: ## commits version with backwards-INcompatible addition or changes
 	$(_bumpversion)
 
-
-buil%: ## builds docker image (using main services/docker-compose-build.yml)
-	# building docker image for ${APP_NAME}
-	@$(MAKE_C) ${REPO_BASE_DIR} build target=${APP_NAME}
-
-# FIXME:
-#.PHONY: build build-nc build-devel build-devel-nc build-cache build-cache-nc
-#build build-nc build-devel build-devel-nc build-cache build-cache-nc: ## docker image build in many flavours
-#	# building docker image for ${APP_NAME} ...
-#	@$(MAKE_C) ${REPO_BASE_DIR} $@ target=${APP_NAME}
-
-.PHONY: shell
-shell: ## runs shell in production container
-	@$(MAKE_C) ${REPO_BASE_DIR} shell target=${APP_NAME}
 
 #
 # SUBTASKS

--- a/scripts/requirements/Dockerfile
+++ b/scripts/requirements/Dockerfile
@@ -1,0 +1,21 @@
+ARG PYTHON_VERSION="3.6.10"
+FROM python:${PYTHON_VERSION}-slim-buster as base
+
+
+RUN pip --no-cache-dir install --upgrade \
+  pip~=20.2.2  \
+  wheel \
+  setuptools
+
+
+# devenv
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+
+WORKDIR /work
+
+# .dockerignore to include only target folders
+# mount osparc-simcore -> /work
+# cd script
+# make reqs

--- a/services/api-server/Makefile
+++ b/services/api-server/Makefile
@@ -10,18 +10,6 @@ reqs: ## compiles pip requirements (.in -> .txt)
 	@$(MAKE_C) requirements reqs
 
 
-PHONY: tests-unit tests-integration tests
-tests: tests-unit tests-integration
-
-tests-unit: ## runs unit tests
-	# running unit tests
-	@pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests/unit
-
-tests-integration: ## runs integration tests against local+production images
-	# running integration tests local/(service):production images ...
-	@export DOCKER_REGISTRY=local; \
-	export DOCKER_IMAGE_TAG=production; \
-	pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests/integration
 
 
 # DEVELOPMENT TOOLS ########

--- a/services/api-server/Makefile
+++ b/services/api-server/Makefile
@@ -2,15 +2,8 @@
 # Targets for DEVELOPMENT of Public API Server
 #
 include ../../scripts/common.Makefile
+include ../../scripts/common-service.Makefile
 
-# Custom variables
-APP_NAME         := $(notdir $(CURDIR))
-APP_CLI_NAME     := simcore-service-$(APP_NAME)
-APP_PACKAGE_NAME := $(subst -,_,$(APP_CLI_NAME))
-APP_VERSION      := $(shell cat VERSION)
-SRC_DIR          := $(abspath $(CURDIR)/src/$(APP_PACKAGE_NAME))
-
-export APP_VERSION
 
 .PHONY: reqs
 reqs: ## compiles pip requirements (.in -> .txt)
@@ -77,12 +70,6 @@ down: docker-compose.yml ## stops pg fixture
 
 
 # BUILD ########
-
-
-.PHONY: build build-nc build-devel build-devel-nc build-cache build-cache-nc
-build build-nc build-devel build-devel-nc build-cache build-cache-nc: ## builds docker image (using main services/docker-compose-build.yml)
-	@$(MAKE_C) ${REPO_BASE_DIR} $@ target=${APP_NAME}
-
 
 .PHONY: openapi-specs openapi.json
 openapi-specs: openapi.json

--- a/services/api-server/Makefile
+++ b/services/api-server/Makefile
@@ -10,12 +10,6 @@ reqs: ## compiles pip requirements (.in -> .txt)
 	@$(MAKE_C) requirements reqs
 
 
-.PHONY: install-dev install-prod install-ci
-install-dev install-prod install-ci: _check_venv_active ## install app in development/production or CI mode
-	# installing in $(subst install-,,$@) mode
-	pip-sync requirements/$(subst install-,,$@).txt
-
-
 PHONY: tests-unit tests-integration tests
 tests: tests-unit tests-integration
 

--- a/services/api-server/requirements/_test.in
+++ b/services/api-server/requirements/_test.in
@@ -13,7 +13,6 @@ pytest
 pytest-aiohttp  # incompatible with pytest-asyncio. See https://github.com/pytest-dev/pytest-asyncio/issues/76
 pytest-cov
 pytest-docker
-docker-compose==1.26.2 # avoids increasing via pytest-docker
 pytest-mock
 pytest-runner
 asgi_lifespan

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -30,7 +30,7 @@ cryptography==3.1         # via -r requirements/_base.txt, paramiko
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 distro==1.5.0             # via docker-compose
 dnspython==2.0.0          # via -r requirements/_base.txt, email-validator
-docker-compose==1.26.2    # via -r requirements/_test.in, pytest-docker
+docker-compose==1.27.3    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
@@ -75,7 +75,7 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.8.0      # via -r requirements/_test.in
+pytest-docker==0.10.0     # via -r requirements/_test.in
 pytest-mock==3.3.1        # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
 pytest==5.4.3             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-mock
@@ -87,7 +87,7 @@ pyyaml==5.3.1             # via -r requirements/_base.txt, docker-compose, fasta
 requests==2.24.0          # via -r requirements/_base.txt, codecov, coveralls, docker, docker-compose, fastapi
 rfc3986[idna2008]==1.4.0  # via -r requirements/_base.txt, httpx
 rx==1.6.1                 # via -r requirements/_base.txt, graphql-core
-six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, docker-compose, dockerpty, graphene, graphql-core, graphql-relay, jsonschema, packaging, promise, pynacl, pyrsistent, python-dateutil, python-multipart, tenacity, websocket-client
+six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, dockerpty, graphene, graphql-core, graphql-relay, jsonschema, packaging, promise, pynacl, pyrsistent, python-dateutil, python-multipart, tenacity, websocket-client
 sniffio==1.1.0            # via -r requirements/_base.txt, asgi-lifespan, httpcore, httpx
 sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.txt, aiopg, alembic
 starlette==0.13.6         # via -r requirements/_base.txt, fastapi

--- a/services/catalog/Makefile
+++ b/services/catalog/Makefile
@@ -2,15 +2,8 @@
 # Targets for DEVELOPMENT of Components Catalog Service
 #
 include ../../scripts/common.Makefile
+include ../../scripts/common-service.Makefile
 
-# Custom variables
-APP_NAME         := $(notdir $(CURDIR))
-APP_CLI_NAME     := simcore-service-catalog
-APP_PACKAGE_NAME := $(subst -,_,$(APP_CLI_NAME))
-APP_VERSION      := $(shell cat VERSION)
-SRC_DIR          := $(abspath $(CURDIR)/src/$(APP_PACKAGE_NAME))
-
-export APP_VERSION
 
 .PHONY: requirements reqs
 requirements reqs: ## (or reqs) compiles pip requirements (.in -> .txt)
@@ -75,12 +68,6 @@ run-devel run-prod: .env up-adjacent ## runs app with services defined in docker
 
 
 # BUILD #####################
-
-.PHONY: build build-nc build-devel build-devel-nc build-cache build-cache-nc
-build build-nc build-devel build-devel-nc build-cache build-cache-nc: ## docker image build in many flavours
-	# building ${APP_NAME} ...
-	@$(MAKE_C) ${REPO_BASE_DIR} $@ target=${APP_NAME}
-
 
 .PHONY: openapi-specs openapi.json
 openapi-specs: openapi.json .env

--- a/services/catalog/Makefile
+++ b/services/catalog/Makefile
@@ -10,12 +10,6 @@ requirements reqs: ## (or reqs) compiles pip requirements (.in -> .txt)
 	@$(MAKE_C) requirements reqs
 
 
-.PHONY: install-dev install-prod install-ci
-install-dev install-prod install-ci: requirements _check_venv_active ## install app in development/production or CI mode
-	# installing in $(subst install-,,$@) mode
-	pip-sync --quiet requirements/$(subst install-,,$@).txt
-
-
 PHONY: tests-unit tests-integration tests
 tests: tests-unit tests-integration
 

--- a/services/catalog/Makefile
+++ b/services/catalog/Makefile
@@ -10,18 +10,7 @@ requirements reqs: ## (or reqs) compiles pip requirements (.in -> .txt)
 	@$(MAKE_C) requirements reqs
 
 
-PHONY: tests-unit tests-integration tests
-tests: tests-unit tests-integration
 
-tests-unit: ## runs unit tests
-	# running unit tests
-	@pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests/unit
-
-tests-integration: ## runs integration tests against local+production images
-	# running integration tests local/(service):production images ...
-	@export DOCKER_REGISTRY=local; \
-	export DOCKER_IMAGE_TAG=production; \
-	pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests/integration
 
 
 # DEVELOPMENT ########

--- a/services/catalog/requirements/_test.in
+++ b/services/catalog/requirements/_test.in
@@ -17,7 +17,6 @@ pytest-cov
 pytest-mock
 pytest-runner
 pytest-docker
-docker-compose==1.26.2 # avoids increasing via pytest-docker
 
 # fixtures
 Faker

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -28,7 +28,7 @@ cryptography==3.1         # via paramiko
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 distro==1.5.0             # via docker-compose
 dnspython==2.0.0          # via -r requirements/_base.txt, email-validator
-docker-compose==1.26.2    # via -r requirements/_test.in, pytest-docker
+docker-compose==1.27.3    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
@@ -73,7 +73,7 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.8.0      # via -r requirements/_test.in
+pytest-docker==0.10.0     # via -r requirements/_test.in
 pytest-mock==3.3.1        # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
 pytest==5.4.3             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-mock
@@ -86,7 +86,7 @@ requests==2.24.0          # via -r requirements/_base.txt, codecov, coveralls, d
 respx==0.12.1             # via -r requirements/_test.in
 rfc3986[idna2008]==1.4.0  # via -r requirements/_base.txt, httpx
 rx==1.6.1                 # via -r requirements/_base.txt, graphql-core
-six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, docker-compose, dockerpty, graphene, graphql-core, graphql-relay, jsonschema, packaging, promise, pynacl, pyrsistent, python-dateutil, python-multipart, tenacity, websocket-client
+six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, dockerpty, graphene, graphql-core, graphql-relay, jsonschema, packaging, promise, pynacl, pyrsistent, python-dateutil, python-multipart, tenacity, websocket-client
 sniffio==1.1.0            # via -r requirements/_base.txt, httpcore, httpx
 sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.txt, aiopg, alembic
 starlette==0.13.6         # via -r requirements/_base.txt, fastapi

--- a/services/director/Makefile
+++ b/services/director/Makefile
@@ -10,12 +10,6 @@ openapi-specs: ## updates and validates openapi specifications
 	$(MAKE) -C $(CURDIR)/src/simcore_service_${APP_NAME}/api $@
 
 
-.PHONY: install-dev install-prod install-ci
-install-dev install-prod install-ci: openapi-specs _check_venv_active ## install app in development/production or CI mode
-	# installing in $(subst install-,,$@) mode
-	python -m pip install -r requirements/$(subst install-,,$@).txt
-
-
 .PHONY: tests
 tests: ## runs unit tests
 	# running unit tests

--- a/services/director/Makefile
+++ b/services/director/Makefile
@@ -8,9 +8,3 @@ include ../../scripts/common-service.Makefile
 .PHONY: openapi-specs
 openapi-specs: ## updates and validates openapi specifications
 	$(MAKE) -C $(CURDIR)/src/simcore_service_${APP_NAME}/api $@
-
-
-.PHONY: tests
-tests: ## runs unit tests
-	# running unit tests
-	@pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests

--- a/services/director/Makefile
+++ b/services/director/Makefile
@@ -2,8 +2,8 @@
 # Targets for DEVELOPMENT for Director service
 #
 include ../../scripts/common.Makefile
+include ../../scripts/common-service.Makefile
 
-APP_NAME := $(notdir $(CURDIR))
 
 .PHONY: openapi-specs
 openapi-specs: ## updates and validates openapi specifications
@@ -20,8 +20,3 @@ install-dev install-prod install-ci: openapi-specs _check_venv_active ## install
 tests: ## runs unit tests
 	# running unit tests
 	@pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests
-
-
-.PHONY: build
-build: openapi-specs ## builds docker image (using main services/docker-compose-build.yml)
-	@make --no-print-directory build-super

--- a/services/docker-compose.devel.yml
+++ b/services/docker-compose.devel.yml
@@ -109,9 +109,6 @@ services:
       - REGISTRY_USER=${REGISTRY_USER}
       - REGISTRY_PW=${REGISTRY_PW}
       - SWARM_STACK_NAME=${SWARM_STACK_NAME:-simcore}
-    depends_on:
-      - rabbit
-      - postgres
     networks:
       - computational_services_subnet
 
@@ -165,9 +162,6 @@ services:
       - REGISTRY_PW=${REGISTRY_PW}
       - SWARM_STACK_NAME=${SWARM_STACK_NAME:-simcore}
       - TARGET_MPI_NODE_CPU_COUNT=${DEV_PC_CPU_COUNT:-0} # development computer CPU count, if env var is missing put to 0 to disable
-    depends_on:
-      - rabbit
-      - postgres
     networks:
       - computational_services_subnet
 

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -8,9 +8,6 @@ services:
       - LOGLEVEL=${LOG_LEVEL:-INFO}
     env_file:
       - ../.env
-    depends_on:
-      - postgres
-      - webserver
     deploy:
       labels:
         - io.simcore.zone=${TRAEFIK_SIMCORE_ZONE}
@@ -39,9 +36,6 @@ services:
       - POSTGRES_PORT=${POSTGRES_PORT}
       - LOG_LEVEL=${LOG_LEVEL:-WARNING}
       - BACKGROUND_TASK_REST_TIME=${CATALOG_BACKGROUND_TASK_REST_TIME:-60}
-    depends_on:
-      - postgres
-      - director
     networks:
       - default
 
@@ -105,13 +99,6 @@ services:
       - DIAGNOSTICS_MAX_AVG_LATENCY=10
     env_file:
       - ../.env
-    depends_on:
-      - storage
-      - catalog
-      - director
-      - postgres
-      - rabbit
-      - redis
     deploy:
       placement:
         constraints:
@@ -175,10 +162,6 @@ services:
       - START_AS_MODE_CPU=${SIDECAR_FORCE_CPU_NODE:-0}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PORT=${REDIS_PORT}
-    depends_on:
-      - rabbit
-      - postgres
-      - redis
     networks:
       - computational_services_subnet
 
@@ -203,8 +186,6 @@ services:
       - BF_API_KEY=${BF_API_KEY}
       - TRACING_ENABLED=${TRACING_ENABLED:-True}
       - TRACING_ZIPKIN_ENDPOINT=${TRACING_ZIPKIN_ENDPOINT:-http://jaeger:9411}
-    depends_on:
-      - postgres
     deploy:
       placement:
         constraints:
@@ -234,8 +215,6 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_HOST=${POSTGRES_HOST}
       - POSTGRES_PORT=${POSTGRES_PORT}
-    depends_on:
-      - postgres
     networks:
       - default
 
@@ -308,11 +287,9 @@ services:
       - "--tracing.jaeger=true"
       - "--tracing.jaeger.samplingServerURL=http://jaeger:5778/sampling"
       - "--tracing.jaeger.localAgentHostPort=jaeger:6831"
-
     volumes:
       # So that Traefik can listen to the Docker events
       - /var/run/docker.sock:/var/run/docker.sock
-
     deploy:
       placement:
         constraints:

--- a/services/sidecar/Makefile
+++ b/services/sidecar/Makefile
@@ -2,14 +2,8 @@
 # Targets for DEVELOPMENT of Components Catalog Service
 #
 include ../../scripts/common.Makefile
+include ../../scripts/common-service.Makefile
 
-
-APP_NAME     := sidecar
-APP_CLI_NAME := simcore-service-sidecar
-export APP_VERSION = $(shell cat VERSION)
-
-REPO_BASE_DIR  = $(abspath $(CURDIR)/../../)
-VENV_DIR      ?= $(abspath $(REPO_BASE_DIR)/.venv)
 
 
 .PHONY: requirements
@@ -37,9 +31,3 @@ tests-integration: ## runs integration tests against local+production images
 	@export DOCKER_REGISTRY=local; \
 	export DOCKER_IMAGE_TAG=production; \
 	pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests/integration
-
-
-.PHONY: build build-nc build-devel build-devel-nc build-cache build-cache-nc
-build build-nc build-devel build-devel-nc build-cache build-cache-nc: ## docker image build in many flavours
-	# building ${APP_NAME} ...
-	@$(MAKE_C) ${REPO_BASE_DIR} $@ target=${APP_NAME}

--- a/services/sidecar/Makefile
+++ b/services/sidecar/Makefile
@@ -9,17 +9,3 @@ include ../../scripts/common-service.Makefile
 .PHONY: requirements
 requirements: ## compiles pip requirements (.in -> .txt)
 	@$(MAKE_C) requirements reqs
-
-
-.PHONY: tests-unit tests-integration tests
-tests: tests-unit tests-integration
-
-tests-unit: ## runs unit tests
-	# running unit tests
-	@pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests/unit
-
-tests-integration: ## runs integration tests against local+production images
-	# running integration tests local/(service):production images ...
-	@export DOCKER_REGISTRY=local; \
-	export DOCKER_IMAGE_TAG=production; \
-	pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests/integration

--- a/services/sidecar/Makefile
+++ b/services/sidecar/Makefile
@@ -11,14 +11,6 @@ requirements: ## compiles pip requirements (.in -> .txt)
 	@$(MAKE_C) requirements reqs
 
 
-.PHONY: install-dev install-prod install-ci
-install-dev install-prod install-ci: requirements _check_venv_active ## install app in development/production or CI mode
-	# installing in $(subst install-,,$@) mode
-	# FIXME: pip-sync does not manage to install storage-sdk
-	# pip-sync requirements/$(subst install-,,$@).txt
-	pip install -r requirements/$(subst install-,,$@).txt
-
-
 .PHONY: tests-unit tests-integration tests
 tests: tests-unit tests-integration
 

--- a/services/sidecar/requirements/_test.in
+++ b/services/sidecar/requirements/_test.in
@@ -6,7 +6,7 @@
 -r _base.txt
 
 # testing
-coverage==4.5.1 # TODO: Downgraded because of a bug https://github.com/nedbat/coveragepy/issues/716
+coverage
 pytest
 pytest-aiohttp  # incompatible with pytest-asyncio. See https://github.com/pytest-dev/pytest-asyncio/issues/76
 pytest-cov

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -23,7 +23,7 @@ celery[redis]==4.4.7      # via -r requirements/_base.txt
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via -r requirements/_base.txt, aiohttp, requests
 click==7.1.2              # via -r requirements/_base.txt
-coverage==4.5.1           # via -r requirements/_test.in, coveralls, pytest-cov
+coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 decorator==4.4.2          # via -r requirements/_base.txt, networkx

--- a/services/sidecar/setup.py
+++ b/services/sidecar/setup.py
@@ -24,7 +24,6 @@ install_requirements = read_reqs(current_dir / "requirements" / "_base.txt") + [
     "s3wrapper==0.1.0",
     "simcore-postgres-database",
     "simcore-sdk==0.1.0",
-    "simcore-service-storage-sdk==0.1.0",
     "simcore-service-library",
 ]
 

--- a/services/storage/Makefile
+++ b/services/storage/Makefile
@@ -2,8 +2,8 @@
 # Targets for DEVELOPMENT for Storage service
 #
 include ../../scripts/common.Makefile
+include ../../scripts/common-service.Makefile
 
-APP_NAME := $(notdir $(CURDIR))
 
 .PHONY: openapi-specs
 openapi-specs: ## updates and validates openapi specifications
@@ -20,8 +20,3 @@ install-dev install-prod install-ci: openapi-specs _check_venv_active ## install
 tests: ## runs unit tests
 	# running unit tests
 	@pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests
-
-
-.PHONY: build build-devel
-build build-devel: openapi-specs ## builds docker image (using main services/docker-compose-build.yml)
-	@$(MAKE) -C ${REPO_BASE_DIR} $@ target=${APP_NAME}

--- a/services/storage/Makefile
+++ b/services/storage/Makefile
@@ -10,12 +10,6 @@ openapi-specs: ## updates and validates openapi specifications
 	$(MAKE) -C $(CURDIR)/src/simcore_service_${APP_NAME}/api $@
 
 
-.PHONY: install-dev install-prod install-ci
-install-dev install-prod install-ci: openapi-specs _check_venv_active ## install app in development/production or CI mode
-	# installing in $(subst install-,,$@) mode
-	python -m pip install -r requirements/$(subst install-,,$@).txt
-
-
 .PHONY: tests
 tests: ## runs unit tests
 	# running unit tests

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -29,7 +29,7 @@ coveralls==2.1.2          # via -r requirements/_test.in
 cryptography==3.0         # via paramiko
 deprecated==1.2.10        # via -r requirements/_base.txt, blackfynn
 distro==1.5.0             # via docker-compose
-docker-compose==1.26.2    # via pytest-docker
+docker-compose==1.27.3    # via pytest-docker
 docker[ssh]==4.3.1        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via -r requirements/_base.txt, blackfynn, coveralls, docker-compose
@@ -67,7 +67,7 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via -r requirements/_base.txt, jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.8.0      # via -r requirements/_test.in
+pytest-docker==0.10.0     # via -r requirements/_test.in
 pytest-instafail==0.4.2   # via -r requirements/_test.in
 pytest-mock==3.2.0        # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
@@ -81,7 +81,7 @@ requests==2.24.0          # via -r requirements/_base.txt, blackfynn, codecov, c
 s3transfer==0.3.3         # via -r requirements/_base.txt, boto3
 semantic-version==2.8.5   # via -r requirements/_base.txt
 semver==2.10.2            # via -r requirements/_base.txt, blackfynn
-six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, docker-compose, dockerpty, isodate, jsonschema, openapi-core, openapi-spec-validator, packaging, protobuf, pynacl, pyrsistent, python-dateutil, tenacity, websocket-client
+six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, dockerpty, isodate, jsonschema, openapi-core, openapi-spec-validator, packaging, protobuf, pynacl, pyrsistent, python-dateutil, tenacity, websocket-client
 sqlalchemy[postgresql_psycopg2binary]==1.3.18  # via -r requirements/_base.txt, aiopg
 strict-rfc3339==0.7       # via -r requirements/_base.txt, openapi-core
 tenacity==6.2.0           # via -r requirements/_base.txt

--- a/services/storage/tests/docker-compose.yml
+++ b/services/storage/tests/docker-compose.yml
@@ -20,13 +20,6 @@ services:
     #   - net.ipv4.tcp_keepalive_probes=9
     #   - net.ipv4.tcp_keepalive_time=600
     command: postgres -c tcp_keepalives_idle=600 -c tcp_keepalives_interval=600 -c tcp_keepalives_count=5
-  # adminer:
-  #   image: adminer
-  #   restart: always
-  #   ports:
-  #     - 18080:8080
-  #   depends_on:
-  #     - postgres
   minio:
     image: minio/minio
     environment:

--- a/services/web/server/Makefile
+++ b/services/web/server/Makefile
@@ -18,11 +18,6 @@ openapi-specs: ## updates and validates openapi specifications
 	$(MAKE_C) $(CURDIR)/src/simcore_service_${APP_NAME}/api $@
 
 
-.PHONY: install-dev install-prod install-ci
-install-dev install-prod install-ci: openapi-specs requirements _check_venv_active ## install app in development/production or CI mode
-	# installing in $(subst install-,,$@) mode
-	python -m pip --quiet install -r requirements/$(subst install-,,$@).txt
-
 
 .PHONY: tests-unit tests-integration tests
 

--- a/services/web/server/Makefile
+++ b/services/web/server/Makefile
@@ -5,7 +5,7 @@ include ../../../scripts/common.Makefile
 include ../../../scripts/common-service.Makefile
 
 # overrides since it does not has same directory name
-APP_NAME     := webserver
+APP_NAME := webserver
 
 
 .PHONY: requirements
@@ -17,21 +17,6 @@ requirements: ## compiles pip requirements (.in -> .txt)
 openapi-specs: ## updates and validates openapi specifications
 	$(MAKE_C) $(CURDIR)/src/simcore_service_${APP_NAME}/api $@
 
-
-
-.PHONY: tests-unit tests-integration tests
-
-tests: tests-unit tests-integration
-
-tests-unit: ## runs unit tests
-	# running unit tests
-	@pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests/unit
-
-tests-integration: ## runs integration tests against local+production images
-	# running integration tests local/(service):production images ...
-	@export DOCKER_REGISTRY=local; \
-	export DOCKER_IMAGE_TAG=production; \
-	pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests/integration
 
 
 .PHONY: run-devel

--- a/services/web/server/Makefile
+++ b/services/web/server/Makefile
@@ -2,10 +2,10 @@
 # Targets for DEVELOPMENT for Webserver service
 #
 include ../../../scripts/common.Makefile
+include ../../../scripts/common-service.Makefile
 
+# overrides since it does not has same directory name
 APP_NAME     := webserver
-APP_CLI_NAME := simcore-service-catalog
-export APP_VERSION = $(shell cat VERSION)
 
 
 .PHONY: requirements
@@ -47,14 +47,3 @@ run-devel: ## runs app with pg service
 	# Running $(APP_CLI_NAME)
 	## $(APP_CLI_NAME) --print-config > config.yaml | sed enable: true enable: false
 	$(APP_CLI_NAME)  -c  tests/unit/with_dbs/config-devel.yml
-
-
-.PHONY: build build-nc build-devel build-devel-nc build-cache build-cache-nc
-build build-nc build-devel build-devel-nc build-cache build-cache-nc: openapi-specs ## docker image build in many flavours
-	# building ${APP_NAME} ...
-	@$(MAKE_C) ${REPO_BASE_DIR} $@ target=${APP_NAME}
-
-
-.PHONY: tail
-tail: ## tails log of $(APP_NAME) container
-	docker logs -f $(shell docker ps -f "name=$(APP_NAME)*" --format {{.ID}}) > $(APP_NAME).log 2>&1

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -39,8 +39,8 @@ cryptography==3.0         # via -r requirements/_base.txt, aiohttp-session, para
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 distro==1.5.0             # via docker-compose
 dnspython==2.0.0          # via -r requirements/_base.txt, email-validator
-docker-compose==1.26.2    # via pytest-docker
-docker[ssh]==4.3.0        # via -r requirements/_test.in, docker-compose
+docker-compose==1.27.3    # via pytest-docker
+docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 email-validator==1.1.1    # via -r requirements/_base.txt, pydantic
@@ -86,7 +86,7 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via -r requirements/_base.txt, jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.8.0      # via -r requirements/_test.in
+pytest-docker==0.10.0     # via -r requirements/_test.in
 pytest-icdiff==0.5        # via -r requirements/_test.in
 pytest-instafail==0.4.2   # via -r requirements/_test.in
 pytest-mock==3.2.0        # via -r requirements/_test.in
@@ -103,7 +103,7 @@ pyyaml==5.3.1             # via -r requirements/_base.txt, aiohttp-swagger, dock
 redis==3.5.3              # via -r requirements/_test.in
 requests==2.24.0          # via codecov, coveralls, docker, docker-compose
 semantic-version==2.8.5   # via -r requirements/_base.txt
-six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, docker-compose, dockerpty, isodate, jsonschema, openapi-core, openapi-spec-validator, packaging, pynacl, pyrsistent, python-dateutil, python-engineio, python-socketio, tenacity, websocket-client
+six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, dockerpty, isodate, jsonschema, openapi-core, openapi-spec-validator, packaging, pynacl, pyrsistent, python-dateutil, python-engineio, python-socketio, tenacity, websocket-client
 sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.txt, aiopg, alembic
 strict-rfc3339==0.7       # via -r requirements/_base.txt, openapi-core
 tenacity==6.2.0           # via -r requirements/_base.txt, -r requirements/_test.in

--- a/services/web/server/src/simcore_service_webserver/groups_api.py
+++ b/services/web/server/src/simcore_service_webserver/groups_api.py
@@ -222,7 +222,11 @@ async def add_user_in_group(
     new_user_email: Optional[str] = None,
     access_rights: Optional[Dict[str, bool]] = None,
 ) -> None:
+    """
+        adds new_user (either by id or email) in group (with gid) owned by user_id
+    """
     if not new_user_id and not new_user_email:
+        # TODO: I would return ValueError here since is a problem with the arguments
         raise GroupsException("Invalid method call, missing user id or user email")
 
     if new_user_email:

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -436,16 +436,21 @@ async def standard_groups(client, logged_user: Dict) -> List[Dict[str, str]]:
     async with NewUser(
         {"name": f"{logged_user['name']}_admin", "role": "USER"}, client.app
     ) as admin_user:
+        # creates two groups
         sparc_group = await create_user_group(client.app, admin_user["id"], sparc_group)
         team_black_group = await create_user_group(
             client.app, admin_user["id"], team_black_group
         )
+
+        # adds logged_user  to sparc group
         await add_user_in_group(
             client.app,
             admin_user["id"],
             sparc_group["gid"],
             new_user_id=logged_user["id"],
         )
+
+        # adds logged_user  to team-black group
         await add_user_in_group(
             client.app,
             admin_user["id"],

--- a/tests/environment-setup/requirements/requirements.txt
+++ b/tests/environment-setup/requirements/requirements.txt
@@ -22,7 +22,7 @@ pytest-aiohttp==0.3.0     # via -r requirements/requirements.in
 pytest-instafail==0.4.2   # via -r requirements/requirements.in
 pytest-runner==5.2        # via -r requirements/requirements.in
 pytest-sugar==0.9.4       # via -r requirements/requirements.in
-pytest==6.0.1             # via -r requirements/requirements.in, pytest-aiohttp, pytest-instafail, pytest-sugar
+pytest==6.0.2             # via -r requirements/requirements.in, pytest-aiohttp, pytest-instafail, pytest-sugar
 six==1.15.0               # via packaging
 termcolor==1.1.0          # via pytest-sugar
 toml==0.10.1              # via pytest

--- a/tests/swarm-deploy/requirements/requirements.txt
+++ b/tests/swarm-deploy/requirements/requirements.txt
@@ -7,13 +7,13 @@
 aio-pika==6.7.0           # via -r requirements/requirements.in
 aiohttp==3.6.2            # via pytest-aiohttp
 aiormq==3.2.3             # via aio-pika
-alembic==1.4.2            # via -r requirements/requirements.in
+alembic==1.4.3            # via -r requirements/requirements.in
 async-timeout==3.0.1      # via aiohttp
 attrs==20.2.0             # via aiohttp, pytest
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via -r requirements/requirements.in
-coverage==5.2.1           # via -r requirements/requirements.in, pytest-cov
+coverage==5.3             # via -r requirements/requirements.in, pytest-cov
 docker==4.3.1             # via -r requirements/requirements.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via requests, yarl
@@ -34,7 +34,7 @@ pytest-instafail==0.4.2   # via -r requirements/requirements.in
 pytest-mock==3.3.1        # via -r requirements/requirements.in
 pytest-runner==5.2        # via -r requirements/requirements.in
 pytest-sugar==0.9.4       # via -r requirements/requirements.in
-pytest==6.0.1             # via -r requirements/requirements.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-mock, pytest-sugar
+pytest==6.0.2             # via -r requirements/requirements.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-mock, pytest-sugar
 python-dateutil==2.8.1    # via alembic
 python-dotenv==0.14.0     # via -r requirements/requirements.in
 python-editor==1.0.4      # via alembic


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

- [x] weekly package dips upgrades:
   - patch ``alembic 1.4.2 -> 1.4.3``
   - testing tooling: minor on ``coverage 5.2.1->5.3``, patch on ``pytest 6.0.1->6.0.2`` , ``isort==5.5.2``
-  ~~remove ``docker-compose`` dependencies~~  -> needs further discussion
- [x] Removed ``depends_on`` since [not used when deployed in swarm](https://docs.docker.com/compose/compose-file/#depends_on) and was causing problems with latest ``docker-compose config``:
![image](https://user-images.githubusercontent.com/32402063/93753467-7b79c980-fc00-11ea-87c4-3e576dfbda80.png)
- [x] updates travis: webserver unit-test is split as in github-actions
- [x] improves ``common.Makefile`` amd  include ``make test-dev, test-ci``
  ```cmd
  cd services/any-name
  make build # builds specific service in production mode. And variants: -nc, -devel, -devel-nc, ...
  make shell # runs and opens service
  make tail # tails logs of running service container (only if one)
  make info
  make install-dev # and -prod, -ci variants

  # new 
  make test-dev # test-dev target=unit/foo
  make test-ci  
  ```

## Related issue number

<!-- Please add #issues -->
Weekly maintenance


## Checklist

- [x] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Unit tests for the changes exist
- [ ] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
