### PR TITLE
Disabling GC service removal

### DIFF
--- a/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
@@ -118,7 +118,11 @@ async def collect_garbage(registry: RedisResourceRegistry, app: web.Application)
     # the projects are closed or the user was disconencted.
     # This will close and remove all these services from
     # the cluster, thus freeing important resources.
-    await remove_orphaned_services(registry, app)
+
+    # Temporary disabling GC to until the dynamic service
+    # safe function is invoked by the GC. This will avoid
+    # data loss for current users.
+    # await remove_orphaned_services(registry, app)
 
 
 async def remove_disconnected_user_resources(


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
The last step of the GC, after removing everything is to also delete raining dynamic services.

Currently, some dynamic services (notebooks), require longer time than usual to be closed. This will be addressed in a separate PR.

Leaving this in place may cause users, which have big amounts of data to loose their data because partially saved.

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
