### PR TITLE
Maintenance/weekly upgrades

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,11 @@
 # root
-.*/
 ancillary/
 docs/
 ops/
 
-# Docker
-**/Dockerfile
-**/docker-compose*
-
 # Byte-compiled / optimized / DLL files
 **/__pycache__
 *.py[cod]
+
+# virtualenv
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ prof/
 services/**/.codeclimate.yml
 # WSL
 .fake_hostname_file
+.bash_history

--- a/ci/github/helpers/setup_docker_compose.bash
+++ b/ci/github/helpers/setup_docker_compose.bash
@@ -6,8 +6,8 @@ set -o pipefail  # don't hide errors within pipes
 IFS=$'\n\t'
 
 # when changing the DOCKER_COMPOSE_VERSION please compute the sha256sum on an ubuntu box (macOS has different checksum)
-DOCKER_COMPOSE_VERSION="1.27.3"
-DOCKER_COMPOSE_SHA256SUM="92055c48e1514c0377b76ed3df87f505c50099145d86835b06fa5109811b6a83"
+DOCKER_COMPOSE_VERSION="1.27.4"
+DOCKER_COMPOSE_SHA256SUM="04216d65ce0cd3c27223eab035abfeb20a8bef20259398e3b9d9aa8de633286d"
 DOCKER_COMPOSE_BIN=/usr/local/bin/docker-compose
 curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o $DOCKER_COMPOSE_BIN
 chmod +x $DOCKER_COMPOSE_BIN

--- a/packages/postgres-database/requirements/_base.txt
+++ b/packages/postgres-database/requirements/_base.txt
@@ -9,4 +9,4 @@ multidict==4.7.6          # via yarl
 psycopg2-binary==2.8.6    # via sqlalchemy
 sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.in
 typing-extensions==3.7.4.3  # via yarl
-yarl==1.5.1               # via -r requirements/_base.in
+yarl==1.6.0               # via -r requirements/_base.in

--- a/packages/postgres-database/requirements/_migration.txt
+++ b/packages/postgres-database/requirements/_migration.txt
@@ -23,4 +23,4 @@ tenacity==6.2.0           # via -r requirements/_migration.in
 typing-extensions==3.7.4.3  # via -r requirements/_base.txt, yarl
 urllib3==1.25.10          # via -r requirements/_migration.in, requests
 websocket-client==0.57.0  # via docker
-yarl==1.5.1               # via -r requirements/_base.txt
+yarl==1.6.0               # via -r requirements/_base.txt

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -9,25 +9,25 @@ aiopg[sa]==1.0.0          # via -r requirements/_test.in
 alembic==1.4.3            # via -r requirements/_migration.txt
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via aiohttp
-attrs==19.3.0             # via aiohttp, jsonschema, pytest, pytest-docker
+attrs==20.2.0             # via aiohttp, jsonschema, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
-cached-property==1.5.1    # via docker-compose
+cached-property==1.5.2    # via docker-compose
 certifi==2020.6.20        # via -r requirements/_migration.txt, requests
 cffi==1.14.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via -r requirements/_migration.txt, aiohttp, requests
 click==7.1.2              # via -r requirements/_migration.txt
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
-cryptography==3.1         # via paramiko
+cryptography==3.1.1       # via paramiko
 distro==1.5.0             # via docker-compose
-docker-compose==1.27.3    # via pytest-docker
+docker-compose==1.27.4    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_migration.txt, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 faker==4.1.3              # via -r requirements/_test.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via -r requirements/_migration.txt, idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via jsonschema, pluggy, pytest
+importlib-metadata==2.0.0  # via jsonschema, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==5.5.3              # via pylint
 jsonschema==3.2.0         # via docker-compose
@@ -35,7 +35,6 @@ lazy-object-proxy==1.4.3  # via astroid
 mako==1.1.3               # via -r requirements/_migration.txt, alembic
 markupsafe==1.1.1         # via -r requirements/_migration.txt, mako
 mccabe==0.6.1             # via pylint
-more-itertools==8.5.0     # via pytest
 multidict==4.7.6          # via -r requirements/_migration.txt, aiohttp, yarl
 packaging==20.4           # via pytest
 paramiko==2.7.2           # via docker
@@ -49,10 +48,10 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.10.0     # via -r requirements/_test.in
+pytest-docker==0.10.1     # via -r requirements/_test.in
 pytest-instafail==0.4.2   # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
-pytest==6.0.2             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail
+pytest==6.1.0             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail
 python-dateutil==2.8.1    # via -r requirements/_migration.txt, alembic, faker
 python-dotenv==0.14.0     # via docker-compose
 python-editor==1.0.4      # via -r requirements/_migration.txt, alembic
@@ -69,8 +68,8 @@ typing-extensions==3.7.4.3  # via -r requirements/_migration.txt, aiohttp, yarl
 urllib3==1.25.10          # via -r requirements/_migration.txt, requests
 websocket-client==0.57.0  # via -r requirements/_migration.txt, docker, docker-compose
 wrapt==1.12.1             # via astroid
-yarl==1.5.1               # via -r requirements/_migration.txt, aiohttp
-zipp==3.1.0               # via importlib-metadata
+yarl==1.6.0               # via -r requirements/_migration.txt, aiohttp
+zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/packages/s3wrapper/requirements/_test.txt
+++ b/packages/s3wrapper/requirements/_test.txt
@@ -5,30 +5,29 @@
 #    pip-compile --output-file=requirements/_test.txt requirements/_test.in
 #
 astroid==2.4.2            # via pylint
-attrs==19.3.0             # via jsonschema, pytest, pytest-docker
+attrs==20.2.0             # via jsonschema, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
-cached-property==1.5.1    # via docker-compose
+cached-property==1.5.2    # via docker-compose
 certifi==2020.6.20        # via -r requirements/_base.txt, minio, requests
 cffi==1.14.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 configparser==5.0.0       # via -r requirements/_base.txt, minio
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
-cryptography==3.1         # via paramiko
+cryptography==3.1.1       # via paramiko
 distro==1.5.0             # via docker-compose
-docker-compose==1.27.3    # via pytest-docker
+docker-compose==1.27.4    # via pytest-docker
 docker[ssh]==4.3.1        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via jsonschema, pluggy, pytest
+importlib-metadata==2.0.0  # via jsonschema, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==5.5.3              # via pylint
 jsonschema==3.2.0         # via docker-compose
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 minio==6.0.0              # via -r requirements/_base.txt
-more-itertools==8.5.0     # via pytest
 packaging==20.4           # via pytest
 paramiko==2.7.2           # via docker
 pluggy==0.13.1            # via pytest
@@ -39,9 +38,9 @@ pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.10.0     # via -r requirements/_test.in
+pytest-docker==0.10.1     # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
-pytest==6.0.2             # via -r requirements/_test.in, pytest-cov, pytest-docker
+pytest==6.1.0             # via -r requirements/_test.in, pytest-cov, pytest-docker
 python-dateutil==2.8.1    # via -r requirements/_base.txt, minio
 python-dotenv==0.14.0     # via docker-compose
 pytz==2020.1              # via -r requirements/_base.txt, minio
@@ -54,7 +53,7 @@ typed-ast==1.4.1          # via astroid
 urllib3==1.25.10          # via -r requirements/_base.txt, minio, requests
 websocket-client==0.57.0  # via docker, docker-compose
 wrapt==1.12.1             # via astroid
-zipp==3.1.0               # via importlib-metadata
+zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/packages/service-library/requirements/_base.in
+++ b/packages/service-library/requirements/_base.in
@@ -16,6 +16,6 @@ werkzeug
 jsonschema
 prometheus_client
 tenacity
-attrs<20,>=19   # from pytest-docker==0.8.0
+attrs
 trafaret
 aiodebug

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -9,7 +9,7 @@ aiohttp==3.6.2            # via -r requirements/_base.in, aiozipkin
 aiopg[sa]==1.0.0          # via -r requirements/_base.in
 aiozipkin==0.7.1          # via -r requirements/_base.in
 async-timeout==3.0.1      # via aiohttp
-attrs==19.3.0             # via -r requirements/_base.in, aiohttp, jsonschema, openapi-core
+attrs==20.2.0             # via -r requirements/_base.in, aiohttp, jsonschema, openapi-core
 chardet==3.0.4            # via aiohttp
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via idna-ssl, yarl

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -11,7 +11,9 @@ aiozipkin==0.7.1          # via -r requirements/_base.in
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via -r requirements/_base.in, aiohttp, jsonschema, openapi-core
 chardet==3.0.4            # via aiohttp
-idna==2.10                # via yarl
+idna-ssl==1.1.0           # via aiohttp
+idna==2.10                # via idna-ssl, yarl
+importlib-metadata==2.0.0  # via jsonschema
 isodate==0.6.0            # via openapi-core
 jsonschema==3.2.0         # via -r requirements/_base.in, openapi-spec-validator
 lazy-object-proxy==1.4.3  # via -r requirements/_base.in, openapi-core
@@ -30,7 +32,8 @@ trafaret==2.1.0           # via -r requirements/_base.in
 typing-extensions==3.7.4.3  # via aiohttp, yarl
 ujson==3.2.0              # via -r requirements/_base.in
 werkzeug==1.0.1           # via -r requirements/_base.in
-yarl==1.5.1               # via aiohttp
+yarl==1.6.0               # via aiohttp
+zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -12,28 +12,27 @@ astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp
 attrs==19.3.0             # via -r requirements/_base.txt, aiohttp, jsonschema, openapi-core, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
-cached-property==1.5.1    # via docker-compose
+cached-property==1.5.2    # via docker-compose
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via -r requirements/_base.txt, aiohttp, requests
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
-cryptography==3.1         # via paramiko
+cryptography==3.1.1       # via paramiko
 distro==1.5.0             # via docker-compose
-docker-compose==1.27.3    # via pytest-docker
+docker-compose==1.27.4    # via pytest-docker
 docker[ssh]==4.3.1        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 idna-ssl==1.1.0           # via -r requirements/_base.txt, aiohttp
 idna==2.10                # via -r requirements/_base.txt, idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via -r requirements/_base.txt, jsonschema, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/_base.txt, jsonschema, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isodate==0.6.0            # via -r requirements/_base.txt, openapi-core
 isort==5.5.3              # via pylint
 jsonschema==3.2.0         # via -r requirements/_base.txt, docker-compose, openapi-spec-validator
 lazy-object-proxy==1.4.3  # via -r requirements/_base.txt, astroid, openapi-core
 mccabe==0.6.1             # via pylint
-more-itertools==8.5.0     # via pytest
 multidict==4.7.6          # via -r requirements/_base.txt, aiohttp, yarl
 openapi-core==0.12.0      # via -r requirements/_base.txt
 openapi-spec-validator==0.2.9  # via -r requirements/_base.txt, openapi-core
@@ -50,12 +49,12 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via -r requirements/_base.txt, jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.10.0     # via -r requirements/_test.in
+pytest-docker==0.10.1     # via -r requirements/_test.in
 pytest-instafail==0.4.2   # via -r requirements/_test.in
 pytest-mock==3.3.1        # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
 pytest-sugar==0.9.4       # via -r requirements/_test.in
-pytest==6.0.2             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail, pytest-mock, pytest-sugar
+pytest==6.1.0             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail, pytest-mock, pytest-sugar
 python-dotenv==0.14.0     # via docker-compose
 pyyaml==5.3.1             # via -r requirements/_base.txt, docker-compose, openapi-spec-validator
 requests==2.24.0          # via coveralls, docker, docker-compose
@@ -74,7 +73,8 @@ urllib3==1.25.10          # via requests
 websocket-client==0.57.0  # via docker, docker-compose
 werkzeug==1.0.1           # via -r requirements/_base.txt
 wrapt==1.12.1             # via astroid
-yarl==1.5.1               # via -r requirements/_base.txt, aiohttp
+yarl==1.6.0               # via -r requirements/_base.txt, aiohttp
+zipp==3.2.0               # via -r requirements/_base.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -10,7 +10,7 @@ aiopg[sa]==1.0.0          # via -r requirements/_base.txt
 aiozipkin==0.7.1          # via -r requirements/_base.txt
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp
-attrs==19.3.0             # via -r requirements/_base.txt, aiohttp, jsonschema, openapi-core, pytest, pytest-docker
+attrs==20.2.0             # via -r requirements/_base.txt, aiohttp, jsonschema, openapi-core, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
 cached-property==1.5.2    # via docker-compose
 certifi==2020.6.20        # via requests

--- a/packages/simcore-sdk/requirements/_base.in
+++ b/packages/simcore-sdk/requirements/_base.in
@@ -10,4 +10,4 @@ pydantic
 tenacity
 trafaret-config
 
-attrs<20,>=19 # from pytest-docker==0.8.0
+attrs

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -25,4 +25,4 @@ tenacity==6.2.0           # via -r requirements/_base.in
 trafaret-config==2.0.2    # via -r requirements/_base.in
 trafaret==2.1.0           # via trafaret-config
 typing-extensions==3.7.4.3  # via aiohttp, yarl
-yarl==1.5.1               # via aiohttp
+yarl==1.6.0               # via aiohttp

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -11,30 +11,29 @@ astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp
 attrs==19.3.0             # via -r requirements/_base.txt, aiohttp, jsonschema, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
-cached-property==1.5.1    # via docker-compose
+cached-property==1.5.2    # via docker-compose
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via -r requirements/_base.txt, aiohttp, requests
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
-cryptography==3.1         # via paramiko
+cryptography==3.1.1       # via paramiko
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 decorator==4.4.2          # via -r requirements/_base.txt, networkx
 distro==1.5.0             # via docker-compose
-docker-compose==1.27.3    # via pytest-docker
+docker-compose==1.27.4    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 idna-ssl==1.1.0           # via -r requirements/_base.txt, aiohttp
 idna==2.10                # via -r requirements/_base.txt, idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via jsonschema, pluggy, pytest
+importlib-metadata==2.0.0  # via jsonschema, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==5.5.3              # via pylint
 jsonschema==3.2.0         # via docker-compose
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==4.0.2               # via -r requirements/_test.in
-more-itertools==8.5.0     # via pytest
 multidict==4.7.6          # via -r requirements/_base.txt, aiohttp, yarl
 networkx==2.5             # via -r requirements/_base.txt
 packaging==20.4           # via pytest, pytest-sugar
@@ -50,12 +49,12 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.3        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.10.0     # via -r requirements/_test.in
+pytest-docker==0.10.1     # via -r requirements/_test.in
 pytest-instafail==0.4.2   # via -r requirements/_test.in
 pytest-mock==3.3.1        # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
 pytest-sugar==0.9.4       # via -r requirements/_test.in
-pytest==6.0.2             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail, pytest-mock, pytest-sugar
+pytest==6.1.0             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-instafail, pytest-mock, pytest-sugar
 python-dotenv==0.14.0     # via -r requirements/_test.in, docker-compose
 pyyaml==5.3.1             # via -r requirements/_base.txt, docker-compose, trafaret-config
 requests==2.24.0          # via -r requirements/_test.in, coveralls, docker, docker-compose
@@ -72,8 +71,8 @@ typing-extensions==3.7.4.3  # via -r requirements/_base.txt, aiohttp, yarl
 urllib3==1.25.10          # via requests
 websocket-client==0.57.0  # via docker, docker-compose
 wrapt==1.12.1             # via astroid
-yarl==1.5.1               # via -r requirements/_base.txt, aiohttp
-zipp==3.1.0               # via importlib-metadata
+yarl==1.6.0               # via -r requirements/_base.txt, aiohttp
+zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/scripts/requirements/Dockerfile
+++ b/scripts/requirements/Dockerfile
@@ -2,6 +2,10 @@ ARG PYTHON_VERSION="3.6.10"
 FROM python:${PYTHON_VERSION}-slim-buster as base
 
 
+RUN apt-get update && apt-get install \
+  make
+
+
 RUN pip --no-cache-dir install --upgrade \
   pip~=20.2.2  \
   wheel \
@@ -9,13 +13,9 @@ RUN pip --no-cache-dir install --upgrade \
 
 
 # devenv
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
-
-WORKDIR /work
-
-# .dockerignore to include only target folders
-# mount osparc-simcore -> /work
-# cd script
-# make reqs
+RUN pip install \
+  black \
+  isort \
+  pip-tools \
+  bump2version \
+  rope

--- a/scripts/requirements/Dockerfile
+++ b/scripts/requirements/Dockerfile
@@ -1,9 +1,16 @@
+# NOTE: This is a first step towards a devcontainer
+#       to perform operations like pip-compile or auto-formatting
+#       that preserves identical environment across developer machines
+#
 ARG PYTHON_VERSION="3.6.10"
 FROM python:${PYTHON_VERSION}-slim-buster as base
 
 
-RUN apt-get update && apt-get install \
-  make
+RUN apt-get update \
+  && apt-get -y install --no-install-recommends\
+  make \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 
 RUN pip --no-cache-dir install --upgrade \

--- a/scripts/requirements/Dockerfile
+++ b/scripts/requirements/Dockerfile
@@ -9,6 +9,7 @@ FROM python:${PYTHON_VERSION}-slim-buster as base
 RUN apt-get update \
   && apt-get -y install --no-install-recommends\
   make \
+  git \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
 

--- a/scripts/requirements/Makefile
+++ b/scripts/requirements/Makefile
@@ -48,6 +48,25 @@ reqs: _check_py36_version ## updates requirements of all package libraries
 	$(foreach p,${_input-requirements},touch $(p); $(MAKE_C) $(dir $(p)) reqs $(UPGRADE_OPTION);)
 
 
+# SEE https://medium.com/faun/set-current-host-user-for-docker-container-4e521cef9ffc
+.PHONY: build
+build:
+	docker build --tag local/python-devkit:latest .
+
+.PHONY: run
+run: build ## Runs upgrade in a container
+	docker run -it \
+		--workdir="/home/$(USER)" \
+    --volume="/etc/group:/etc/group:ro" \
+    --volume="/etc/passwd:/etc/passwd:ro" \
+    --volume="/etc/shadow:/etc/shadow:ro" \
+		--volume=$(REPODIR):/home/$(USER) \
+		--user=$(shell id -u):$(shell id -g) \
+		--entrypoint=/bin/bash \
+		local/python-devkit:latest \
+		-c "cd scripts/requirements; make reqs $(if $(upgrade),upgrade=$(upgrade),)"
+
+
 .PHONY: help
 # thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help: ## this colorful help

--- a/scripts/requirements/Makefile
+++ b/scripts/requirements/Makefile
@@ -66,6 +66,18 @@ run: build ## Runs upgrade in a container
 		local/python-devkit:latest \
 		-c "cd scripts/requirements; make reqs $(if $(upgrade),upgrade=$(upgrade),)"
 
+.PHONY: shell
+shell:
+	docker run -it \
+		--workdir="/home/$(USER)" \
+    --volume="/etc/group:/etc/group:ro" \
+    --volume="/etc/passwd:/etc/passwd:ro" \
+    --volume="/etc/shadow:/etc/shadow:ro" \
+		--volume=$(REPODIR):/home/$(USER) \
+		--user=$(shell id -u):$(shell id -g) \
+		--entrypoint=/bin/bash \
+		local/python-devkit:latest
+
 
 .PHONY: help
 # thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html

--- a/services/api-server/requirements/_base.in
+++ b/services/api-server/requirements/_base.in
@@ -20,6 +20,6 @@ aiopg[sa]
 httpx
 
 #
-attrs<20,>=19 # from pytest-docker==0.8.0
+attrs
 tenacity
 cryptography

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -9,7 +9,7 @@ aiopg[sa]==1.0.0          # via -r requirements/_base.in
 aniso8601==7.0.0          # via graphene
 async-exit-stack==1.0.1   # via -r requirements/_base.in, fastapi
 async-generator==1.10     # via -r requirements/_base.in, fastapi
-attrs==19.3.0             # via -r requirements/_base.in
+attrs==20.2.0             # via -r requirements/_base.in
 certifi==2020.6.20        # via httpx, requests
 cffi==1.14.2              # via cryptography
 chardet==3.0.4            # via httpx, requests

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -30,7 +30,7 @@ cryptography==3.1         # via -r requirements/_base.txt, paramiko
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 distro==1.5.0             # via docker-compose
 dnspython==2.0.0          # via -r requirements/_base.txt, email-validator
-docker-compose==1.27.3    # via pytest-docker
+docker-compose==1.27.4    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -14,7 +14,7 @@ astroid==2.4.2            # via pylint
 async-exit-stack==1.0.1   # via -r requirements/_base.txt, asgi-lifespan, fastapi
 async-generator==1.10     # via -r requirements/_base.txt, fastapi
 async-timeout==3.0.1      # via aiohttp
-attrs==19.3.0             # via -r requirements/_base.txt, aiohttp, jsonschema, pytest, pytest-docker
+attrs==20.2.0             # via -r requirements/_base.txt, aiohttp, jsonschema, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko, passlib
 cached-property==1.5.1    # via docker-compose
 certifi==2020.6.20        # via -r requirements/_base.txt, httpx, requests
@@ -75,7 +75,7 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.10.0     # via -r requirements/_test.in
+pytest-docker==0.10.1     # via -r requirements/_test.in
 pytest-mock==3.3.1        # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
 pytest==5.4.3             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-mock

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -73,7 +73,7 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.10.0     # via -r requirements/_test.in
+pytest-docker==0.10.1     # via -r requirements/_test.in
 pytest-mock==3.3.1        # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in
 pytest==5.4.3             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-docker, pytest-mock

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -28,7 +28,7 @@ cryptography==3.1         # via paramiko
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 distro==1.5.0             # via docker-compose
 dnspython==2.0.0          # via -r requirements/_base.txt, email-validator
-docker-compose==1.27.3    # via pytest-docker
+docker-compose==1.27.4    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose

--- a/services/director/requirements/_base.txt
+++ b/services/director/requirements/_base.txt
@@ -10,7 +10,7 @@ git+https://github.com/ITISFoundation/aiohttp_apiset.git@fixes_4_osparc#egg=aioh
 async-generator==1.10     # via asyncio-extras
 async-timeout==3.0.1      # via aiohttp
 asyncio-extras==1.3.2     # via -r requirements/_base.in
-attrs==19.1.0             # via aiohttp
+attrs==20.2.0             # via aiohttp
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via aiohttp, requests
 idna-ssl==1.1.0           # via aiohttp

--- a/services/director/requirements/_test.txt
+++ b/services/director/requirements/_test.txt
@@ -11,7 +11,7 @@ astroid==2.4.2            # via pylint
 async-generator==1.10     # via -r requirements/_base.txt, asyncio-extras
 async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp
 asyncio-extras==1.3.2     # via -r requirements/_base.txt
-attrs==19.1.0             # via -r requirements/_base.txt, aiohttp, pytest
+attrs==20.2.0             # via -r requirements/_base.txt, aiohttp, pytest
 certifi==2019.3.9         # via -r requirements/_base.txt, requests
 chardet==3.0.4            # via -r requirements/_base.txt, aiohttp, requests
 codecov==2.1.7            # via -r requirements/_test.in
@@ -25,8 +25,6 @@ importlib-metadata==1.7.0  # via pluggy, pytest
 isort==4.3.21             # via pylint
 jsonschema==2.6.0         # via -r requirements/_base.txt, aiohttp-apiset, openapi-spec-validator
 lazy-object-proxy==1.4.3  # via astroid
-mako==1.1.3               # via alembic
-markupsafe==1.1.1         # via mako
 mccabe==0.6.1             # via pylint
 more-itertools==8.4.0     # via pytest
 multidict==4.5.2          # via -r requirements/_base.txt, aiohttp, yarl
@@ -47,7 +45,7 @@ pytest==5.4.3             # via -r requirements/_test.in, pytest-aiohttp, pytest
 python-dotenv==0.14.0     # via -r requirements/_test.in
 pyyaml==5.3               # via -r requirements/_base.txt, aiohttp-apiset, openapi-spec-validator
 requests==2.22.0          # via -r requirements/_base.txt, codecov, coveralls, docker
-six==1.12.0               # via -r requirements/_base.txt, astroid, docker, openapi-spec-validator, packaging, python-dateutil, tenacity, websocket-client
+six==1.12.0               # via -r requirements/_base.txt, astroid, docker, openapi-spec-validator, packaging, tenacity, websocket-client
 tenacity==6.0.0           # via -r requirements/_base.txt
 termcolor==1.1.0          # via pytest-sugar
 toml==0.10.1              # via pylint

--- a/services/sidecar/requirements/_base.txt
+++ b/services/sidecar/requirements/_base.txt
@@ -15,7 +15,7 @@ aioredlock==0.5.2         # via -r requirements/_base.in
 aiormq==3.2.3             # via aio-pika
 amqp==2.6.1               # via kombu
 async-timeout==3.0.1      # via aiohttp, aioredis
-attrs==19.3.0             # via -c requirements/../../../packages/service-library/requirements/_base.in, aiohttp, aioredlock
+attrs==20.2.0             # via -c requirements/../../../packages/service-library/requirements/_base.in, aiohttp, aioredlock
 billiard==3.6.3.0         # via celery
 caio==0.6.1               # via aiofile
 celery[redis]==4.4.7      # via -r requirements/_base.in

--- a/services/sidecar/requirements/_packages.txt
+++ b/services/sidecar/requirements/_packages.txt
@@ -9,7 +9,7 @@ aiohttp==3.6.2            # via -c requirements/_base.txt, -r requirements/../..
 aiopg[sa]==1.0.0          # via -c requirements/_base.txt, -r requirements/../../../packages/service-library/requirements/_base.in
 aiozipkin==0.7.1          # via -r requirements/../../../packages/service-library/requirements/_base.in
 async-timeout==3.0.1      # via -c requirements/_base.txt, aiohttp
-attrs==19.3.0             # via -c requirements/_base.txt, -r requirements/../../../packages/service-library/requirements/_base.in, aiohttp, jsonschema, openapi-core
+attrs==20.2.0             # via -c requirements/_base.txt, -r requirements/../../../packages/service-library/requirements/_base.in, aiohttp, jsonschema, openapi-core
 certifi==2020.6.20        # via minio
 chardet==3.0.4            # via -c requirements/_base.txt, aiohttp
 configparser==5.0.0       # via minio

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -5,24 +5,27 @@
 #    pip-compile --output-file=requirements/_test.txt requirements/_test.in
 #
 aio-pika==6.7.0           # via -r requirements/_base.txt
+aiodebug==1.1.2           # via -r requirements/_packages.txt
 aiodocker==0.19.1         # via -r requirements/_base.txt
 aiofile==3.1.0            # via -r requirements/_base.txt
 aiofiles==0.5.0           # via -r requirements/_base.txt
-aiohttp==3.6.2            # via -r requirements/_base.txt, aiodocker, pytest-aiohttp
-aiopg[sa]==1.0.0          # via -r requirements/_base.txt, -r requirements/_test.in
+aiohttp==3.6.2            # via -r requirements/_base.txt, -r requirements/_packages.txt, aiodocker, aiozipkin, pytest-aiohttp
+aiopg[sa]==1.0.0          # via -r requirements/_base.txt, -r requirements/_packages.txt, -r requirements/_test.in
 aioredis==1.3.1           # via -r requirements/_base.txt, aioredlock
 aioredlock==0.5.2         # via -r requirements/_base.txt
 aiormq==3.2.3             # via -r requirements/_base.txt, aio-pika
+aiozipkin==0.7.1          # via -r requirements/_packages.txt
 amqp==2.6.1               # via -r requirements/_base.txt, kombu
 astroid==2.4.2            # via pylint
-async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp, aioredis
-attrs==19.3.0             # via -r requirements/_base.txt, aiohttp, aioredlock, pytest
+async-timeout==3.0.1      # via -r requirements/_base.txt, -r requirements/_packages.txt, aiohttp, aioredis
+attrs==20.2.0             # via -r requirements/_base.txt, -r requirements/_packages.txt, aiohttp, aioredlock, jsonschema, openapi-core, pytest
 billiard==3.6.3.0         # via -r requirements/_base.txt, celery
 caio==0.6.1               # via -r requirements/_base.txt, aiofile
 celery[redis]==4.4.7      # via -r requirements/_base.txt
-certifi==2020.6.20        # via requests
-chardet==3.0.4            # via -r requirements/_base.txt, aiohttp, requests
+certifi==2020.6.20        # via -r requirements/_packages.txt, minio, requests
+chardet==3.0.4            # via -r requirements/_base.txt, -r requirements/_packages.txt, aiohttp, requests
 click==7.1.2              # via -r requirements/_base.txt
+configparser==5.0.0       # via -r requirements/_packages.txt, minio
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
@@ -30,26 +33,33 @@ decorator==4.4.2          # via -r requirements/_base.txt, networkx
 docker==4.3.1             # via -r requirements/_test.in
 docopt==0.6.2             # via coveralls
 hiredis==1.1.0            # via -r requirements/_base.txt, aioredis
-idna-ssl==1.1.0           # via -r requirements/_base.txt, aiohttp
-idna==2.10                # via -r requirements/_base.txt, idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via -r requirements/_base.txt, kombu, pluggy, pytest
+idna-ssl==1.1.0           # via -r requirements/_base.txt, -r requirements/_packages.txt, aiohttp
+idna==2.10                # via -r requirements/_base.txt, -r requirements/_packages.txt, idna-ssl, requests, yarl
+importlib-metadata==2.0.0  # via -r requirements/_base.txt, -r requirements/_packages.txt, jsonschema, kombu, pluggy, pytest
 iniconfig==1.0.1          # via pytest
+isodate==0.6.0            # via -r requirements/_packages.txt, openapi-core
 isort==5.5.3              # via pylint
+jsonschema==3.2.0         # via -r requirements/_packages.txt, openapi-spec-validator
 kombu==4.6.11             # via -r requirements/_base.txt, celery
-lazy-object-proxy==1.4.3  # via astroid
+lazy-object-proxy==1.4.3  # via -r requirements/_packages.txt, astroid, openapi-core
 mccabe==0.6.1             # via pylint
+minio==6.0.0              # via -r requirements/_packages.txt
 more-itertools==8.5.0     # via pytest
-multidict==4.7.6          # via -r requirements/_base.txt, aiohttp, yarl
+multidict==4.7.6          # via -r requirements/_base.txt, -r requirements/_packages.txt, aiohttp, yarl
 networkx==2.5             # via -r requirements/_base.txt
+openapi-core==0.12.0      # via -r requirements/_packages.txt
+openapi-spec-validator==0.2.9  # via -r requirements/_packages.txt, openapi-core
 packaging==20.4           # via -r requirements/_base.txt, pytest, pytest-sugar
 pamqp==2.3.0              # via -r requirements/_base.txt, aiormq
 pluggy==0.13.1            # via pytest
-psycopg2-binary==2.8.6    # via -r requirements/_base.txt, aiopg, sqlalchemy
+prometheus-client==0.8.0  # via -r requirements/_packages.txt
+psycopg2-binary==2.8.6    # via -r requirements/_base.txt, -r requirements/_packages.txt, aiopg, sqlalchemy
 ptvsd==4.3.2              # via -r requirements/_test.in
 py==1.9.0                 # via pytest
 pydantic==1.6.1           # via -r requirements/_base.txt
 pylint==2.6.0             # via -r requirements/_test.in
 pyparsing==2.4.7          # via -r requirements/_base.txt, packaging
+pyrsistent==0.17.3        # via -r requirements/_packages.txt, jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
 pytest-instafail==0.4.2   # via -r requirements/_test.in
@@ -57,20 +67,29 @@ pytest-lazy-fixture==0.6.3  # via -r requirements/_test.in
 pytest-mock==3.3.1        # via -r requirements/_test.in
 pytest-sugar==0.9.4       # via -r requirements/_test.in
 pytest==6.0.2             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-lazy-fixture, pytest-mock, pytest-sugar
+python-dateutil==2.8.1    # via -r requirements/_packages.txt, minio
 python-dotenv==0.14.0     # via -r requirements/_test.in
-pytz==2020.1              # via -r requirements/_base.txt, celery
+pytz==2020.1              # via -r requirements/_base.txt, -r requirements/_packages.txt, celery, minio
+pyyaml==5.3.1             # via -r requirements/_packages.txt, openapi-spec-validator
 redis==3.5.3              # via -r requirements/_base.txt, celery
 requests==2.24.0          # via coveralls, docker
-six==1.15.0               # via -r requirements/_base.txt, astroid, docker, packaging, tenacity, websocket-client
-sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.txt, aiopg
-tenacity==6.2.0           # via -r requirements/_base.txt
+six==1.15.0               # via -r requirements/_base.txt, -r requirements/_packages.txt, astroid, docker, isodate, jsonschema, openapi-core, openapi-spec-validator, packaging, python-dateutil, tenacity, websocket-client
+sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.txt, -r requirements/_packages.txt, aiopg
+strict-rfc3339==0.7       # via -r requirements/_packages.txt, openapi-core
+tenacity==6.2.0           # via -r requirements/_base.txt, -r requirements/_packages.txt
 termcolor==1.1.0          # via pytest-sugar
 toml==0.10.1              # via pylint, pytest
+trafaret==2.1.0           # via -r requirements/_packages.txt
 typed-ast==1.4.1          # via astroid
-typing-extensions==3.7.4.3  # via -r requirements/_base.txt, aiodocker, aiohttp, yarl
-urllib3==1.25.10          # via -r requirements/_base.txt, requests
+typing-extensions==3.7.4.3  # via -r requirements/_base.txt, -r requirements/_packages.txt, aiodocker, aiohttp, yarl
+ujson==3.2.0              # via -r requirements/_packages.txt
+urllib3==1.25.10          # via -r requirements/_base.txt, -r requirements/_packages.txt, minio, requests
 vine==1.3.0               # via -r requirements/_base.txt, amqp, celery
 websocket-client==0.57.0  # via docker
+werkzeug==1.0.1           # via -r requirements/_packages.txt
 wrapt==1.12.1             # via astroid
-yarl==1.5.1               # via -r requirements/_base.txt, aio-pika, aiohttp, aiormq
-zipp==3.2.0               # via -r requirements/_base.txt, importlib-metadata
+yarl==1.5.1               # via -r requirements/_base.txt, -r requirements/_packages.txt, aio-pika, aiohttp, aiormq
+zipp==3.2.0               # via -r requirements/_base.txt, -r requirements/_packages.txt, importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -47,7 +47,7 @@ s3transfer==0.3.3         # via boto3
 semantic-version==2.8.5   # via -r requirements/_base.in
 semver==2.10.2            # via blackfynn
 six==1.15.0               # via isodate, jsonschema, openapi-core, openapi-spec-validator, protobuf, pyrsistent, python-dateutil, tenacity, websocket-client
-sqlalchemy[postgresql_psycopg2binary]==1.3.18  # via -r requirements/../../../packages/postgres-database/requirements/_base.in, -r requirements/../../../packages/service-library/requirements/_base.in, aiopg
+sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/../../../packages/postgres-database/requirements/_base.in, -r requirements/../../../packages/service-library/requirements/_base.in, aiopg
 strict-rfc3339==0.7       # via openapi-core
 tenacity==6.2.0           # via -r requirements/../../../packages/service-library/requirements/_base.in, -r requirements/_base.in
 trafaret-config==2.0.2    # via -r requirements/_base.in

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -12,7 +12,7 @@ aioitertools==0.7.0       # via aiobotocore
 aiopg[sa]==1.0.0          # via -r requirements/../../../packages/service-library/requirements/_base.in, -r requirements/_base.in
 aiozipkin==0.7.0          # via -r requirements/../../../packages/service-library/requirements/_base.in
 async-timeout==3.0.1      # via aiohttp
-attrs==19.3.0             # via -r requirements/../../../packages/service-library/requirements/_base.in, aiohttp, jsonschema, openapi-core
+attrs==20.2.0             # via -r requirements/../../../packages/service-library/requirements/_base.in, aiohttp, jsonschema, openapi-core
 blackfynn==4.0.0          # via -r requirements/_base.in
 boto3==1.12.32            # via -r requirements/_base.in, blackfynn
 botocore==1.15.32         # via aiobotocore, boto3, s3transfer

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -29,7 +29,7 @@ coveralls==2.1.2          # via -r requirements/_test.in
 cryptography==3.0         # via paramiko
 deprecated==1.2.10        # via -r requirements/_base.txt, blackfynn
 distro==1.5.0             # via docker-compose
-docker-compose==1.27.3    # via pytest-docker
+docker-compose==1.27.4    # via pytest-docker
 docker[ssh]==4.3.1        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via -r requirements/_base.txt, blackfynn, coveralls, docker-compose

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -13,7 +13,7 @@ aiopg[sa]==1.0.0          # via -r requirements/_base.txt
 aiozipkin==0.7.0          # via -r requirements/_base.txt
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp
-attrs==19.3.0             # via -r requirements/_base.txt, aiohttp, jsonschema, openapi-core, pytest, pytest-docker
+attrs==20.2.0             # via -r requirements/_base.txt, aiohttp, jsonschema, openapi-core, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
 blackfynn==4.0.0          # via -r requirements/_base.txt
 boto3==1.12.32            # via -r requirements/_base.txt, blackfynn
@@ -67,7 +67,7 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via -r requirements/_base.txt, jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.10.0     # via -r requirements/_test.in
+pytest-docker==0.10.1     # via -r requirements/_test.in
 pytest-instafail==0.4.2   # via -r requirements/_test.in
 pytest-mock==3.2.0        # via -r requirements/_test.in
 pytest-runner==5.2        # via -r requirements/_test.in

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -82,7 +82,7 @@ s3transfer==0.3.3         # via -r requirements/_base.txt, boto3
 semantic-version==2.8.5   # via -r requirements/_base.txt
 semver==2.10.2            # via -r requirements/_base.txt, blackfynn
 six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, dockerpty, isodate, jsonschema, openapi-core, openapi-spec-validator, packaging, protobuf, pynacl, pyrsistent, python-dateutil, tenacity, websocket-client
-sqlalchemy[postgresql_psycopg2binary]==1.3.18  # via -r requirements/_base.txt, aiopg
+sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.txt, aiopg
 strict-rfc3339==0.7       # via -r requirements/_base.txt, openapi-core
 tenacity==6.2.0           # via -r requirements/_base.txt
 termcolor==1.1.0          # via pytest-sugar

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -20,7 +20,7 @@ aiozipkin==0.7.0          # via -r requirements/../../../../packages/service-lib
 amqp==2.6.1               # via kombu
 async-timeout==3.0.1      # via aiohttp, aioredis
 asyncpg==0.21.0           # via -r requirements/_base.in
-attrs==19.3.0             # via -r requirements/../../../../packages/service-library/requirements/_base.in, aiohttp, aioredlock, jsonschema, openapi-core
+attrs==20.2.0             # via -r requirements/../../../../packages/service-library/requirements/_base.in, aiohttp, aioredlock, jsonschema, openapi-core
 billiard==3.6.3.0         # via celery
 celery==4.4.7             # via -r requirements/_base.in
 cffi==1.14.2              # via cryptography

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -39,7 +39,7 @@ cryptography==3.0         # via -r requirements/_base.txt, aiohttp-session, para
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 distro==1.5.0             # via docker-compose
 dnspython==2.0.0          # via -r requirements/_base.txt, email-validator
-docker-compose==1.27.3    # via pytest-docker
+docker-compose==1.27.4    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -22,7 +22,7 @@ amqp==2.6.1               # via -r requirements/_base.txt, kombu
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp, aioredis
 asyncpg==0.21.0           # via -r requirements/_base.txt
-attrs==19.3.0             # via -r requirements/_base.txt, aiohttp, aioredlock, jsonschema, openapi-core, pytest, pytest-docker
+attrs==20.2.0             # via -r requirements/_base.txt, aiohttp, aioredlock, jsonschema, openapi-core, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
 billiard==3.6.3.0         # via -r requirements/_base.txt, celery
 cached-property==1.5.1    # via docker-compose
@@ -86,7 +86,7 @@ pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via -r requirements/_base.txt, jsonschema
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
 pytest-cov==2.10.1        # via -r requirements/_test.in
-pytest-docker==0.10.0     # via -r requirements/_test.in
+pytest-docker==0.10.1     # via -r requirements/_test.in
 pytest-icdiff==0.5        # via -r requirements/_test.in
 pytest-instafail==0.4.2   # via -r requirements/_test.in
 pytest-mock==3.2.0        # via -r requirements/_test.in

--- a/tests/environment-setup/requirements/requirements.txt
+++ b/tests/environment-setup/requirements/requirements.txt
@@ -10,9 +10,8 @@ attrs==20.2.0             # via aiohttp, pytest
 chardet==3.0.4            # via aiohttp
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via idna-ssl, yarl
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==2.0.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
-more-itertools==8.5.0     # via pytest
 multidict==4.7.6          # via aiohttp, yarl
 packaging==20.4           # via pytest, pytest-sugar
 pluggy==0.13.1            # via pytest
@@ -22,10 +21,10 @@ pytest-aiohttp==0.3.0     # via -r requirements/requirements.in
 pytest-instafail==0.4.2   # via -r requirements/requirements.in
 pytest-runner==5.2        # via -r requirements/requirements.in
 pytest-sugar==0.9.4       # via -r requirements/requirements.in
-pytest==6.0.2             # via -r requirements/requirements.in, pytest-aiohttp, pytest-instafail, pytest-sugar
+pytest==6.1.0             # via -r requirements/requirements.in, pytest-aiohttp, pytest-instafail, pytest-sugar
 six==1.15.0               # via packaging
 termcolor==1.1.0          # via pytest-sugar
 toml==0.10.1              # via pytest
 typing-extensions==3.7.4.3  # via aiohttp, yarl
-yarl==1.5.1               # via aiohttp
-zipp==3.1.0               # via importlib-metadata
+yarl==1.6.0               # via aiohttp
+zipp==3.2.0               # via importlib-metadata

--- a/tests/swarm-deploy/requirements/requirements.txt
+++ b/tests/swarm-deploy/requirements/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/requirements.txt requirements/requirements.in
 #
-aio-pika==6.7.0           # via -r requirements/requirements.in
+aio-pika==6.7.1           # via -r requirements/requirements.in
 aiohttp==3.6.2            # via pytest-aiohttp
 aiormq==3.2.3             # via aio-pika
 alembic==1.4.3            # via -r requirements/requirements.in
@@ -17,11 +17,10 @@ coverage==5.3             # via -r requirements/requirements.in, pytest-cov
 docker==4.3.1             # via -r requirements/requirements.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via requests, yarl
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==2.0.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
 mako==1.1.3               # via alembic
 markupsafe==1.1.1         # via mako
-more-itertools==8.5.0     # via pytest
 multidict==4.7.6          # via aiohttp, yarl
 packaging==20.4           # via pytest, pytest-sugar
 pamqp==2.3.0              # via aiormq
@@ -34,7 +33,7 @@ pytest-instafail==0.4.2   # via -r requirements/requirements.in
 pytest-mock==3.3.1        # via -r requirements/requirements.in
 pytest-runner==5.2        # via -r requirements/requirements.in
 pytest-sugar==0.9.4       # via -r requirements/requirements.in
-pytest==6.0.2             # via -r requirements/requirements.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-mock, pytest-sugar
+pytest==6.1.0             # via -r requirements/requirements.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-mock, pytest-sugar
 python-dateutil==2.8.1    # via alembic
 python-dotenv==0.14.0     # via -r requirements/requirements.in
 python-editor==1.0.4      # via alembic
@@ -48,5 +47,5 @@ toml==0.10.1              # via pytest
 typing-extensions==3.7.4.3  # via aiohttp, yarl
 urllib3==1.25.10          # via requests
 websocket-client==0.57.0  # via docker
-yarl==1.5.1               # via aio-pika, aiohttp, aiormq
-zipp==3.1.0               # via importlib-metadata
+yarl==1.6.0               # via aio-pika, aiohttp, aiormq
+zipp==3.2.0               # via importlib-metadata


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
- weekly requirement upgrades for ``packages``:
  - ``yarl`` PR#1836
  - ``pytest`` PR #1835
  - ``pytest-docker`` PR #1834 : removes constraints on ``attrs``. Both upgraded in all services as well!
  - ``docker-compose`` to 1.27.4
 
- Now pip-compile is done from a docker container instead of the developer host. Added draft of dev-container and used to pip-compile reqs: 
```cmd
cd scripts/requirements
make shell
# enters in container shell
$ cd scripts/requirements
$ make reqs
```

