### PR TITLE
Bugfix: Disable cache when reloading studies

### DIFF
--- a/services/web/client/source/class/osparc/component/sweeper/Iterations.js
+++ b/services/web/client/source/class/osparc/component/sweeper/Iterations.js
@@ -94,7 +94,7 @@ qx.Class.define("osparc.component.sweeper.Iterations", {
       const combinations = this.__primaryStudy.getSweeper().getCombinations();
       const secondaryStudyIds = this.__primaryStudy.getSweeper().getSecondaryStudyIds();
       if (combinations.length === secondaryStudyIds.length) {
-        osparc.data.Resources.get("studies")
+        osparc.data.Resources.get("studies", null, false)
           .then(studies => {
             const rows = [];
             for (let i=0; i<secondaryStudyIds.length; i++) {

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -105,7 +105,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
      */
     reloadUserStudies: function() {
       if (osparc.data.Permissions.getInstance().canDo("studies.user.read")) {
-        osparc.data.Resources.get("studies")
+        osparc.data.Resources.get("studies", null, false)
           .then(studies => {
             this.__resetStudyList(studies);
             this.resetSelection();


### PR DESCRIPTION
## What do these changes do?
After going back to the Dashboard, frontend requests a fresh list (not cached) of studies.

## Related issue number
closes ITISFoundation/osparc-issues#323