### PR TITLE
Fix resource manger alive keys always have a TTL

### DIFF
--- a/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
@@ -30,10 +30,10 @@ ALIVE_SUFFIX = "alive"
 
 @attr.s(auto_attribs=True)
 class RedisResourceRegistry:
-    """ Keeps a record of connected sockets per user
+    """Keeps a record of connected sockets per user
 
-        redis structure is following
-        Redis Hash: key=user_id:client_session_id values={server_id socket_id project_id}
+    redis structure is following
+    Redis Hash: key=user_id:client_session_id values={server_id socket_id project_id}
     """
 
     app: web.Application
@@ -92,12 +92,12 @@ class RedisResourceRegistry:
                 keys.append(self._decode_hash_key(hash_key))
         return keys
 
-    async def set_key_alive(
-        self, key: Dict[str, str], alive: bool, timeout: int = 0
-    ) -> None:
+    async def set_key_alive(self, key: Dict[str, str], timeout: int) -> None:
+        # setting the timeout to always expire, timeout > 0
+        timeout = int(max(1, timeout))
         client = get_redis_client(self.app)
         hash_key = f"{self._hash_key(key)}:{ALIVE_SUFFIX}"
-        await client.set(hash_key, 1, expire=0 if alive else timeout)
+        await client.set(hash_key, 1, expire=timeout)
 
     async def is_key_alive(self, key: Dict[str, str]) -> bool:
         client = get_redis_client(self.app)

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -54,7 +54,9 @@ class WebsocketRegistry:
         )
         registry = get_registry(self.app)
         await registry.set_resource(self._resource_key(), (SOCKET_ID_KEY, socket_id))
-        await registry.set_key_alive(self._resource_key(), True)
+        await registry.set_key_alive(
+            self._resource_key(), get_service_deletion_timeout(self.app)
+        )
 
     async def get_socket_id(self) -> Optional[str]:
         log.debug(
@@ -70,7 +72,7 @@ class WebsocketRegistry:
         """When the user disconnects expire as soon as possible the alive key
         to ensure garbage collection will trigger in the next 2 cycles."""
         registry = get_registry(self.app)
-        await registry.set_key_alive(self._resource_key(), False, 1)
+        await registry.set_key_alive(self._resource_key(), 1)
 
     async def remove_socket_id(self) -> None:
         log.debug(

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -54,9 +54,10 @@ class WebsocketRegistry:
         )
         registry = get_registry(self.app)
         await registry.set_resource(self._resource_key(), (SOCKET_ID_KEY, socket_id))
-        await registry.set_key_alive(
-            self._resource_key(), get_service_deletion_timeout(self.app)
-        )
+        # hearthbeat is not emulated in tests, make sure that with very small GC intervals
+        # the resources do not result as timeout; this value is usually in the order of minutes
+        timeout = max(3, get_service_deletion_timeout(self.app))
+        await registry.set_key_alive(self._resource_key(), timeout)
 
     async def get_socket_id(self) -> Optional[str]:
         log.debug(

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -83,14 +83,14 @@ class WebsocketRegistry:
         registry = get_registry(self.app)
         await registry.remove_resource(self._resource_key(), SOCKET_ID_KEY)
         await registry.set_key_alive(
-            self._resource_key(), False, get_service_deletion_timeout(self.app)
+            self._resource_key(), get_service_deletion_timeout(self.app)
         )
 
     async def set_heartbeat(self) -> None:
         """Refreshes heartbeat """
         registry = get_registry(self.app)
         await registry.set_key_alive(
-            self._resource_key(), False, get_service_deletion_timeout(self.app)
+            self._resource_key(), get_service_deletion_timeout(self.app)
         )
 
     async def find_socket_ids(self) -> List[str]:


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Resources will always have an alive key which will make them expire and get garbage collected by the system.

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
