### PR TITLE
Fixes registry step in e2e-CI 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,11 +452,12 @@ info: ## displays setup information
 	@echo ' DIRECTOR_API_VERSION  : ${DIRECTOR_API_VERSION}'
 	@echo ' STORAGE_API_VERSION   : ${STORAGE_API_VERSION}'
 	@echo ' WEBSERVER_API_VERSION : ${WEBSERVER_API_VERSION}'
-	# tools version
+	# dev tools version
 	@echo ' make   : $(shell make --version 2>&1 | head -n 1)'
 	@echo ' jq     : $(shell jq --version)'
 	@echo ' awk    : $(shell awk -W version 2>&1 | head -n 1)'
 	@echo ' python : $(shell python3 --version)'
+	@echo ' node   : $(shell node --version 2> /dev/null || echo ERROR nodejs missing)'
 
 
 define show-meta

--- a/Makefile
+++ b/Makefile
@@ -498,7 +498,7 @@ endif
 
 .PHONY: clean clean-images clean-venv clean-all clean-more
 
-_git_clean_args := -dxf -e .vscode -e TODO.md -e .venv
+_git_clean_args := -dxf -e .vscode -e TODO.md -e .venv -e .python-version
 _running_containers = $(shell docker ps -aq)
 
 .check-clean:

--- a/scripts/install_nodejs_14.bash
+++ b/scripts/install_nodejs_14.bash
@@ -1,0 +1,21 @@
+#
+# Install Node.js 14 on Ubuntu
+#
+# Requirements for development machines
+#
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+IFS=$'\n\t'
+
+sudo apt update
+
+# Script to install the NodeSource Node.js 14.x repo onto a Debian or Ubuntu system
+curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
+
+# Verify new source
+cat /etc/apt/sources.list.d/nodesource.list
+
+# Installs node-js
+apt-get install -y nodejs

--- a/services/docker-compose-ops.yml
+++ b/services/docker-compose-ops.yml
@@ -71,7 +71,9 @@ services:
       - simcore_default
 
   flower:
-    image: mher/flower:latest
+    # NOTE: latest with DIGEST 9bcc31818a1c7 is broken!
+    # SEE https://github.com/mher/flower/issues/1029
+    image: mher/flower:0.9.5
     init: true
     restart: always
     environment:

--- a/tests/e2e/utils/wait_for_services.py
+++ b/tests/e2e/utils/wait_for_services.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import sys
 import time
 from datetime import datetime
@@ -7,17 +8,22 @@ from pathlib import Path
 from pdb import Pdb
 from pprint import pformat
 from typing import Dict, List
-import os
 
 import docker
 import yaml
-from tenacity import Retrying, before_sleep_log, stop_after_attempt, wait_fixed
+from tenacity import (
+    RetryError,
+    Retrying,
+    before_sleep_log,
+    stop_after_attempt,
+    wait_fixed,
+)
 
 logger = logging.getLogger(__name__)
 
 current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
-WAIT_BEFORE_RETRY = 5
+WAIT_BEFORE_RETRY = 10
 MAX_RETRY_COUNT = 10
 MAX_WAIT_TIME = 240
 
@@ -48,7 +54,7 @@ def get_tasks_summary(service_tasks):
     msg = ""
     for task in service_tasks:
         status: Dict = task["Status"]
-        msg += f"- task ID:{task['ID']}, CREATED: {task['CreatedAt']}, UPDATED: {task['UpdatedAt']}, DESIREDSTATE: {task['DesiredState']}, STATE: {status['State']}"
+        msg += f"- task ID:{task['ID']}, CREATED: {task['CreatedAt']}, UPDATED: {task['UpdatedAt']}, DESIRED_STATE: {task['DesiredState']}, STATE: {status['State']}"
         error = status.get("Err")
         if error:
             msg += f", ERROR: {error}"

--- a/tests/e2e/utils/wait_for_services.py
+++ b/tests/e2e/utils/wait_for_services.py
@@ -136,7 +136,6 @@ def wait_for_services() -> None:
             stop=stop_after_attempt(MAX_RETRY_COUNT),
             wait=wait_fixed(WAIT_BEFORE_RETRY),
             reraise=True,
-            before_sleep=before_sleep_log(logger, logging.WARNING),
         ):
             with attempt:
                 service_tasks: List[Dict] = service.tasks()  #  freeze
@@ -152,7 +151,7 @@ def wait_for_services() -> None:
                 )
                 assert (
                     valid_replicas == expected_replicas
-                ), f"Service {service.name} failed to start\n { json.dumps(service.attrs, indent=2) }"
+                ), f"Service {service.name} failed to start\n { json.dumps(service.attrs, indent=1) }"
 
 
 if __name__ == "__main__":

--- a/tests/e2e/utils/wait_for_services.py
+++ b/tests/e2e/utils/wait_for_services.py
@@ -47,7 +47,7 @@ def get_tasks_summary(service_tasks):
     msg = ""
     for task in service_tasks:
         status: Dict = task["Status"]
-        msg += f"- task ID:{task['ID']}, CREATED: {task['CreatedAt']}, UPDATED: {task['UpdatedAt']}, DESIREDSTATE: {task["DesiredState"]}, STATE: {status['State']}"
+        msg += f"- task ID:{task['ID']}, CREATED: {task['CreatedAt']}, UPDATED: {task['UpdatedAt']}, DESIREDSTATE: {task['DesiredState']}, STATE: {status['State']}"
         error = status.get("Err")
         if error:
             msg += f", ERROR: {error}"


### PR DESCRIPTION
Fixes sudden CI failure in registry step during the e2e workflow.
The problem was that the latest release of ``flower`` was actually broken. The image tag was not frozen so the step ``wait_for_sercices.py`` would constantly fail. 

- Froze flower service in ops to latest working version
- Improved logging and checks reliability in ``tests/e2e/utils/wait_for_services.py``
- Small convenience improvements to help running in newly development machines
