### PR TITLE
fix redis version to version 5.0.9-alpine

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -255,7 +255,7 @@ services:
       ]
 
   redis:
-    image: redis:5.0-alpine
+    image: redis:5.0.9-alpine
     init: true
     networks:
       - default


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
fixed the redis version to the last digit.

if you want to fix to the SHA of all the versions. please feel free to create a PR.

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
