### PR TITLE
Fix (un)grouping

### DIFF
--- a/api/specs/common/schemas/node-meta-v0.0.1-converted.yaml
+++ b/api/specs/common/schemas/node-meta-v0.0.1-converted.yaml
@@ -34,6 +34,7 @@ properties:
     type: string
     description: service type
     enum:
+      - frontend
       - computational
       - dynamic
     example: computational

--- a/api/specs/common/schemas/node-meta-v0.0.1.json
+++ b/api/specs/common/schemas/node-meta-v0.0.1.json
@@ -46,6 +46,7 @@
       "type": "string",
       "description": "service type",
       "enum": [
+        "frontend",
         "computational",
         "dynamic"
       ],

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -24,6 +24,7 @@ GroupId = PositiveInt
 
 
 class ServiceType(str, Enum):
+    frontend = "frontend"
     computational = "computational"
     dynamic = "dynamic"
 

--- a/services/catalog/src/simcore_service_catalog/services/frontend_services.py
+++ b/services/catalog/src/simcore_service_catalog/services/frontend_services.py
@@ -28,7 +28,7 @@ def _node_group_service() -> ServiceDockerData:
     return ServiceDockerData(
         key="simcore/services/frontend/nodes-group",
         version="1.0.0",
-        type="dynamic",
+        type="frontend",
         name="Group",
         description="Group of nodes",
         authors=[{"name": "Odei Maiz", "email": "maiz@itis.swiss"}],

--- a/services/director/src/simcore_service_director/api/v0/openapi.yaml
+++ b/services/director/src/simcore_service_director/api/v0/openapi.yaml
@@ -175,6 +175,7 @@ paths:
                           type: string
                           description: service type
                           enum:
+                            - frontend
                             - computational
                             - dynamic
                           example: computational
@@ -559,6 +560,7 @@ paths:
                           type: string
                           description: service type
                           enum:
+                            - frontend
                             - computational
                             - dynamic
                           example: computational
@@ -2157,6 +2159,7 @@ components:
                 type: string
                 description: service type
                 enum:
+                  - frontend
                   - computational
                   - dynamic
                 example: computational

--- a/services/director/src/simcore_service_director/api/v0/schemas/node-meta-v0.0.1.json
+++ b/services/director/src/simcore_service_director/api/v0/schemas/node-meta-v0.0.1.json
@@ -46,6 +46,7 @@
       "type": "string",
       "description": "service type",
       "enum": [
+        "frontend",
         "computational",
         "dynamic"
       ],

--- a/services/storage/src/simcore_service_storage/api/v0/schemas/node-meta-v0.0.1.json
+++ b/services/storage/src/simcore_service_storage/api/v0/schemas/node-meta-v0.0.1.json
@@ -46,6 +46,7 @@
       "type": "string",
       "description": "service type",
       "enum": [
+        "frontend",
         "computational",
         "dynamic"
       ],

--- a/services/web/client/source/class/osparc/component/export/ExportDAG.js
+++ b/services/web/client/source/class/osparc/component/export/ExportDAG.js
@@ -171,7 +171,11 @@ qx.Class.define("osparc.component.export.ExportDAG", {
       const nodes = Object.values(innerNodes);
       for (const node of nodes) {
         const nodeEntry = nodesGroupService["workbench"][node.getNodeId()];
-        for (let [portId, portValue] of Object.entries(node.getInputEditorValues())) {
+        let editorEntries = {};
+        if (node.isPropertyInitialized("propsFormEditor") && node.getPropsFormEditor()) {
+          editorEntries = node.getPropsFormEditor().getValues();
+        }
+        for (let [portId, portValue] of Object.entries(editorEntries)) {
           nodeEntry.inputs[portId] = portValue;
         }
       }

--- a/services/web/client/source/class/osparc/component/export/ExportDAG.js
+++ b/services/web/client/source/class/osparc/component/export/ExportDAG.js
@@ -171,12 +171,11 @@ qx.Class.define("osparc.component.export.ExportDAG", {
       const nodes = Object.values(innerNodes);
       for (const node of nodes) {
         const nodeEntry = nodesGroupService["workbench"][node.getNodeId()];
-        let editorEntries = {};
         if (node.isPropertyInitialized("propsFormEditor") && node.getPropsFormEditor()) {
-          editorEntries = node.getPropsFormEditor().getValues();
-        }
-        for (let [portId, portValue] of Object.entries(editorEntries)) {
-          nodeEntry.inputs[portId] = portValue;
+          const editorValues = node.getPropsFormEditor().getValues();
+          for (let [portId, portValue] of Object.entries(editorValues)) {
+            nodeEntry.inputs[portId] = portValue;
+          }
         }
       }
       osparc.data.Resources.fetch("dags", "post", {data: nodesGroupService})

--- a/services/web/client/source/class/osparc/component/node/GroupNodeView.js
+++ b/services/web/client/source/class/osparc/component/node/GroupNodeView.js
@@ -51,6 +51,17 @@ qx.Class.define("osparc.component.node.GroupNodeView", {
         }
       });
       return settingsEditorLayout;
+    },
+
+    isSettingsGroupShowable: function(innerNodes) {
+      const innerNodesArray = Object.values(innerNodes);
+      for (let i=0; i<innerNodesArray.length; i++) {
+        const innerNode = innerNodesArray[i];
+        if (osparc.component.node.NodeView.isPropsFormShowable(innerNode)) {
+          return true;
+        }
+      }
+      return false;
     }
   },
 
@@ -66,8 +77,14 @@ qx.Class.define("osparc.component.node.GroupNodeView", {
           const innerSettings = osparc.component.node.BaseNodeView.createSettingsGroupBox();
           innerNode.bind("label", innerSettings, "legend");
           innerSettings.add(propsForm);
+          propsForm.addListener("changeChildVisibility", () => {
+            const isSettingsGroupShowable = osparc.component.node.NodeView.isPropsFormShowable(innerNode);
+            innerSettings.setVisibility(isSettingsGroupShowable ? "visible" : "excluded");
+            this.__checkSettingsVisibility();
+          }, this);
           this._settingsLayout.add(innerSettings);
         }
+        this.__checkSettingsVisibility();
         const mapper = innerNode.getInputsMapper();
         if (mapper) {
           this._mapperLayout.add(mapper, {
@@ -82,17 +99,14 @@ qx.Class.define("osparc.component.node.GroupNodeView", {
       });
     },
 
+    __checkSettingsVisibility: function() {
+      const isSettingsGroupShowable = this.isSettingsGroupShowable();
+      this._settingsLayout.setVisibility(isSettingsGroupShowable ? "visible" : "excluded");
+    },
+
     isSettingsGroupShowable: function() {
       const innerNodes = this.getNode().getInnerNodes(true);
-      const innerNodesArray = Object.values(innerNodes);
-      for (let i=0; i<innerNodesArray.length; i++) {
-        const innerNode = innerNodesArray[i];
-        const propsForm = innerNode.getPropsForm();
-        if (propsForm && propsForm.hasVisibleInputs()) {
-          return true;
-        }
-      }
-      return false;
+      return this.self().isSettingsGroupShowable(innerNodes);
     },
 
     __iFrameChanged: function(innerNode, tabPage) {

--- a/services/web/client/source/class/osparc/component/node/GroupNodeView.js
+++ b/services/web/client/source/class/osparc/component/node/GroupNodeView.js
@@ -83,19 +83,16 @@ qx.Class.define("osparc.component.node.GroupNodeView", {
     },
 
     isSettingsGroupShowable: function() {
-      let anyVisible = false;
       const innerNodes = this.getNode().getInnerNodes(true);
       const innerNodesArray = Object.values(innerNodes);
-      for (let i=0; i<innerNodesArray.length && !anyVisible; i++) {
+      for (let i=0; i<innerNodesArray.length; i++) {
         const innerNode = innerNodesArray[i];
         const propsForm = innerNode.getPropsForm();
-        if (propsForm) {
-          anyVisible = propsForm.hasVisibleInputs();
-        } else {
-          anyVisible = false;
+        if (propsForm && propsForm.hasVisibleInputs()) {
+          return true;
         }
       }
-      return anyVisible;
+      return false;
     },
 
     __iFrameChanged: function(innerNode, tabPage) {

--- a/services/web/client/source/class/osparc/component/node/GroupNodeView.js
+++ b/services/web/client/source/class/osparc/component/node/GroupNodeView.js
@@ -178,7 +178,9 @@ qx.Class.define("osparc.component.node.GroupNodeView", {
     _openEditAccessLevel: function() {
       const settingsEditorLayout = this.self().getSettingsEditorLayout(this.getNode().getInnerNodes());
       const title = this.getNode().getLabel();
-      osparc.ui.window.Window.popUpInWindow(settingsEditorLayout, title, 800, 600);
+      osparc.ui.window.Window.popUpInWindow(settingsEditorLayout, title, 800, 600).set({
+        autoDestroy: false
+      });
     },
 
     _applyNode: function(node) {

--- a/services/web/client/source/class/osparc/component/node/NodeView.js
+++ b/services/web/client/source/class/osparc/component/node/NodeView.js
@@ -37,8 +37,13 @@
 qx.Class.define("osparc.component.node.NodeView", {
   extend: osparc.component.node.BaseNodeView,
 
-  construct: function() {
-    this.base(arguments);
+  statics: {
+    isPropsFormShowable: function(node) {
+      if (node && ("getPropsForm" in node) && node.getPropsForm()) {
+        return node.getPropsForm().hasVisibleInputs();
+      }
+      return false;
+    }
   },
 
   members: {
@@ -75,10 +80,7 @@ qx.Class.define("osparc.component.node.NodeView", {
 
     isSettingsGroupShowable: function() {
       const node = this.getNode();
-      if (node && ("getPropsForm" in node) && node.getPropsForm()) {
-        return node.getPropsForm().hasVisibleInputs();
-      }
-      return false;
+      return this.self().isPropsFormShowable(node);
     },
 
     __iFrameChanged: function() {

--- a/services/web/client/source/class/osparc/component/node/NodeView.js
+++ b/services/web/client/source/class/osparc/component/node/NodeView.js
@@ -138,7 +138,9 @@ qx.Class.define("osparc.component.node.NodeView", {
       const propsFormEditor = this.getNode().getPropsFormEditor();
       settingsEditorLayout.add(propsFormEditor);
       const title = this.getNode().getLabel();
-      osparc.ui.window.Window.popUpInWindow(settingsEditorLayout, title, 800, 600);
+      osparc.ui.window.Window.popUpInWindow(settingsEditorLayout, title, 800, 600).set({
+        autoDestroy: false
+      });
     },
 
     _applyNode: function(node) {

--- a/services/web/client/source/class/osparc/component/node/NodeView.js
+++ b/services/web/client/source/class/osparc/component/node/NodeView.js
@@ -135,7 +135,8 @@ qx.Class.define("osparc.component.node.NodeView", {
 
     _openEditAccessLevel: function() {
       const settingsEditorLayout = osparc.component.node.BaseNodeView.createSettingsGroupBox(this.tr("Settings"));
-      settingsEditorLayout.add(this.getNode().getPropsFormEditor());
+      const propsFormEditor = this.getNode().getPropsFormEditor();
+      settingsEditorLayout.add(propsFormEditor);
       const title = this.getNode().getLabel();
       osparc.ui.window.Window.popUpInWindow(settingsEditorLayout, title, 800, 600);
     },

--- a/services/web/client/source/class/osparc/component/widget/BreadcrumbSplitter.js
+++ b/services/web/client/source/class/osparc/component/widget/BreadcrumbSplitter.js
@@ -91,10 +91,11 @@ qx.Class.define("osparc.component.widget.BreadcrumbSplitter", {
     },
 
     getSlashControls: function(w = 16, h = 32) {
-      const offset = 3;
+      const offsetH = 4;
+      const offsetW = Math.round(offsetH*w/h);
       return [
-        [w-offset, offset],
-        [offset, h-offset]
+        [w-offsetW, offsetH],
+        [offsetW, h-offsetH]
       ];
     },
 

--- a/services/web/client/source/class/osparc/component/widget/NodeSlideTreeItem.js
+++ b/services/web/client/source/class/osparc/component/widget/NodeSlideTreeItem.js
@@ -85,7 +85,7 @@ qx.Class.define("osparc.component.widget.NodeSlideTreeItem", {
       });
       this.addWidget(posLbl);
 
-      const hideBtn = new qx.ui.form.Button(null, "@FontAwesome5Solid/eye-slash/10").set({
+      const hideBtn = new qx.ui.form.Button(null, "@FontAwesome5Solid/eye/10").set({
         marginRight: 5,
         appearance: "no-shadow-button"
       });
@@ -105,7 +105,7 @@ qx.Class.define("osparc.component.widget.NodeSlideTreeItem", {
       });
       this.addWidget(hideBtn);
 
-      const showBtn = new qx.ui.form.Button(null, "@FontAwesome5Solid/eye/10").set({
+      const showBtn = new qx.ui.form.Button(null, "@FontAwesome5Solid/eye-slash/10").set({
         marginRight: 5,
         appearance: "no-shadow-button"
       });

--- a/services/web/client/source/class/osparc/component/widget/NodesSlidesTree.js
+++ b/services/web/client/source/class/osparc/component/widget/NodesSlidesTree.js
@@ -170,20 +170,16 @@ qx.Class.define("osparc.component.widget.NodesSlidesTree", {
         },
         configureItem: item => {
           item.addListener("showNode", () => {
-            this.__show(item.getModel());
-            this.__recalculatePositions();
+            this.__itemActioned(item, "show");
           }, this);
           item.addListener("hideNode", () => {
-            this.__hide(item.getModel());
-            this.__recalculatePositions();
+            this.__itemActioned(item, "hide");
           }, this);
           item.addListener("moveUp", () => {
-            this.__moveUp(item.getModel());
-            this.__recalculatePositions();
+            this.__itemActioned(item, "moveUp");
           }, this);
           item.addListener("moveDown", () => {
-            this.__moveDown(item.getModel());
-            this.__recalculatePositions();
+            this.__itemActioned(item, "moveDown");
           }, this);
         }
       });
@@ -202,6 +198,28 @@ qx.Class.define("osparc.component.widget.NodesSlidesTree", {
             child.setSkipNode(true);
           }
         });
+      }
+    },
+
+    __itemActioned: function(item, action) {
+      let fntc;
+      switch (action) {
+        case "show":
+          fntc = this.__show;
+          break;
+        case "hide":
+          fntc = this.__hide;
+          break;
+        case "moveUp":
+          fntc = this.__moveUp;
+          break;
+        case "moveDown":
+          fntc = this.__moveDown;
+          break;
+      }
+      if (fntc) {
+        fntc.call(this, item.getModel());
+        this.__recalculatePositions();
       }
     },
 

--- a/services/web/client/source/class/osparc/component/widget/NodesSlidesTree.js
+++ b/services/web/client/source/class/osparc/component/widget/NodesSlidesTree.js
@@ -72,6 +72,13 @@ qx.Class.define("osparc.component.widget.NodesSlidesTree", {
       };
     },
 
+    getItemsInTree: function(itemMdl, children = []) {
+      children.push(itemMdl);
+      for (let i=0; itemMdl.getChildren && i<itemMdl.getChildren().length; i++) {
+        this.self().getItemsInTree(itemMdl.getChildren().toArray()[i], children);
+      }
+    },
+
     moveElement: function(input, from, to) {
       let numberOfDeletedElm = 1;
       const elm = input.splice(from, numberOfDeletedElm)[0];
@@ -244,8 +251,10 @@ qx.Class.define("osparc.component.widget.NodesSlidesTree", {
     },
 
     __recalculatePositions: function() {
-      const treeMdl = this.__tree.getModel();
-      const children = treeMdl.getChildren().toArray();
+      const rootModel = this.__tree.getModel();
+      let children = [];
+      this.self().getItemsInTree(rootModel, children);
+      children.shift();
       let pos = 0;
       for (let i=0; i<children.length; i++) {
         const child = children[i];

--- a/services/web/client/source/class/osparc/component/widget/NodesSlidesTree.js
+++ b/services/web/client/source/class/osparc/component/widget/NodesSlidesTree.js
@@ -218,6 +218,7 @@ qx.Class.define("osparc.component.widget.NodesSlidesTree", {
           break;
       }
       if (fntc) {
+        this.__tree.setSelection(new qx.data.Array([item.getModel()]));
         fntc.call(this, item.getModel());
         this.__recalculatePositions();
       }

--- a/services/web/client/source/class/osparc/component/widget/NodesSlidesTree.js
+++ b/services/web/client/source/class/osparc/component/widget/NodesSlidesTree.js
@@ -46,9 +46,9 @@ qx.Class.define("osparc.component.widget.NodesSlidesTree", {
   },
 
   statics: {
-    convertModel: function(nodes) {
+    convertModel: function(nodes, lastPos = -1) {
       let children = [];
-      let i=0;
+      let i = ++lastPos;
       for (let nodeId in nodes) {
         const node = nodes[nodeId];
         let nodeInTree = {
@@ -59,12 +59,17 @@ qx.Class.define("osparc.component.widget.NodesSlidesTree", {
         };
         nodeInTree.label = node.getLabel();
         if (node.isContainer()) {
-          nodeInTree.children = this.convertModel(node.getInnerNodes());
+          const innerChildren = this.convertModel(node.getInnerNodes(), i);
+          nodeInTree.children = innerChildren.children;
+          i = innerChildren.lastPos;
         }
         children.push(nodeInTree);
         i++;
       }
-      return children;
+      return {
+        children,
+        lastPos: i-1
+      };
     },
 
     moveElement: function(input, from, to) {
@@ -132,7 +137,7 @@ qx.Class.define("osparc.component.widget.NodesSlidesTree", {
       const topLevelNodes = study.getWorkbench().getNodes();
       let rootData = {
         label: study.getName(),
-        children: this.self().convertModel(topLevelNodes),
+        children: this.self().convertModel(topLevelNodes).children,
         nodeId: study.getUuid(),
         skipNode: null,
         position: null

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -258,13 +258,6 @@ qx.Class.define("osparc.data.model.Node", {
       return {};
     },
 
-    getInputEditorValues: function() {
-      if (this.isPropertyInitialized("propsFormEditor") && this.getPropsFormEditor()) {
-        return this.getPropsFormEditor().getValues();
-      }
-      return {};
-    },
-
     getInputsDefault: function() {
       return this.__inputsDefault;
     },

--- a/services/web/client/source/class/osparc/data/model/Study.js
+++ b/services/web/client/source/class/osparc/data/model/Study.js
@@ -60,6 +60,7 @@ qx.Class.define("osparc.data.model.Study", {
     this.setUi(new osparc.data.model.StudyUI(studyData.ui));
 
     this.setSweeper(new osparc.data.model.Sweeper(studyData));
+    this.setState(studyData.state);
   },
 
   properties: {
@@ -264,16 +265,19 @@ qx.Class.define("osparc.data.model.Study", {
         if (key === "state") {
           return;
         }
+        if (key === "workbench") {
+          jsonObject[key] = this.getWorkbench().serialize();
+        }
+        if (key === "ui") {
+          jsonObject[key] = this.getUi().serialize();
+          return;
+        }
         if (key === "sweeper") {
           jsonObject["dev"] = {};
           jsonObject["dev"]["sweeper"] = this.getSweeper().serialize();
           return;
         }
-        if (key === "ui") {
-          jsonObject["ui"] = this.getUi().serialize();
-          return;
-        }
-        let value = key === "workbench" ? this.getWorkbench().serialize() : this.get(key);
+        const value = this.get(key);
         if (value !== null) {
           // only put the value in the payload if there is a value
           jsonObject[key] = value;

--- a/services/web/client/source/class/osparc/data/model/Study.js
+++ b/services/web/client/source/class/osparc/data/model/Study.js
@@ -267,6 +267,7 @@ qx.Class.define("osparc.data.model.Study", {
         }
         if (key === "workbench") {
           jsonObject[key] = this.getWorkbench().serialize();
+          return;
         }
         if (key === "ui") {
           jsonObject[key] = this.getUi().serialize();

--- a/services/web/client/source/class/osparc/data/model/StudyUI.js
+++ b/services/web/client/source/class/osparc/data/model/StudyUI.js
@@ -29,9 +29,9 @@ qx.Class.define("osparc.data.model.StudyUI", {
     this.base(arguments);
 
     this.set({
-      workbench: studyDataUI.workbench || {},
-      slideshow: studyDataUI.slideshow || {},
-      currentNodeId: studyDataUI.currentNodeId || null
+      workbench: studyDataUI && studyDataUI.workbench ? studyDataUI.workbench : {},
+      slideshow: studyDataUI && studyDataUI.slideshow ? studyDataUI.slideshow : {},
+      currentNodeId: studyDataUI && studyDataUI.currentNodeId ? studyDataUI.currentNodeId : null
     });
   },
 

--- a/services/web/client/source/class/osparc/desktop/ControlsBar.js
+++ b/services/web/client/source/class/osparc/desktop/ControlsBar.js
@@ -211,16 +211,8 @@ qx.Class.define("osparc.desktop.ControlsBar", {
 
     __updateGroupButtonsVisibility: function(msg) {
       const selectedNodes = msg.getData();
-      let groupBtnVisibility = "excluded";
-      let ungroupBtnVisibility = "excluded";
-      if (selectedNodes.length) {
-        groupBtnVisibility = "visible";
-      }
-      if (selectedNodes.length === 1 && selectedNodes[0].isContainer()) {
-        ungroupBtnVisibility = "visible";
-      }
-      this.__groupButton.setVisibility(groupBtnVisibility);
-      this.__ungroupButton.setVisibility(ungroupBtnVisibility);
+      this.__groupButton.setVisibility(selectedNodes.length ? "visible" : "excluded");
+      this.__ungroupButton.setVisibility((selectedNodes.length === 1 && selectedNodes[0].isContainer()) ? "visible" : "excluded");
     },
 
     __attachEventHandlers: function() {

--- a/services/web/client/source/class/osparc/desktop/ControlsBar.js
+++ b/services/web/client/source/class/osparc/desktop/ControlsBar.js
@@ -129,19 +129,29 @@ qx.Class.define("osparc.desktop.ControlsBar", {
       osparc.store.Store.getInstance().addListener("changeCurrentStudy", e => {
         const study = e.getData();
         if (study && study.getState() && study.getState().state) {
-          switch (study.getState().state.value) {
-            case "PENDING":
-            case "PUBLISHED":
-            case "STARTED":
-              startButton.setFetching(true);
-              stopButton.setEnabled(true);
-              break;
-            default:
-              startButton.setFetching(false);
-              stopButton.setEnabled(false);
-          }
+          this.__updatePipelineState(study.getState().state);
         }
       });
+    },
+
+    __updatePipelineState: function(pipelineState) {
+      const startButton = this.__startButton;
+      const stopButton = this.__stopButton;
+      switch (pipelineState.value) {
+        case "PENDING":
+        case "PUBLISHED":
+        case "STARTED":
+          startButton.setFetching(true);
+          stopButton.setEnabled(true);
+          break;
+        case "NOT_STARTED":
+        case "SUCCESS":
+        case "FAILED":
+        default:
+          startButton.setFetching(false);
+          stopButton.setEnabled(false);
+          break;
+      }
     },
 
     __createShowSweeperButton: function() {

--- a/services/web/client/source/class/osparc/desktop/SlideShowView.js
+++ b/services/web/client/source/class/osparc/desktop/SlideShowView.js
@@ -83,6 +83,7 @@ qx.Class.define("osparc.desktop.SlideShowView", {
           view.getInputsView().exclude();
           view.getOutputsView().exclude();
           this.__showInMainView(view);
+          this.__syncButtons();
         }
       }
       this.getStudy().getUi().setCurrentNodeId(nodeId);
@@ -145,6 +146,23 @@ qx.Class.define("osparc.desktop.SlideShowView", {
       this._addAt(nodeView, 0, {
         flex: 1
       });
+    },
+
+    __syncButtons: function() {
+      const study = this.getStudy();
+      if (study) {
+        const nodes = this.self().getSortedNodes(study);
+        if (nodes.length && nodes[0].nodeId === this.__currentNodeId) {
+          this.__prvsBtn.setEnabled(false);
+        } else {
+          this.__prvsBtn.setEnabled(true);
+        }
+        if (nodes.length && nodes[nodes.length-1].nodeId === this.__currentNodeId) {
+          this.__nextBtn.setEnabled(false);
+        } else {
+          this.__nextBtn.setEnabled(true);
+        }
+      }
     },
 
     __showFirstNode: function() {

--- a/services/web/client/source/class/osparc/desktop/SlideShowView.js
+++ b/services/web/client/source/class/osparc/desktop/SlideShowView.js
@@ -35,6 +35,22 @@ qx.Class.define("osparc.desktop.SlideShowView", {
     }
   },
 
+  statics: {
+    getSortedNodes: function(study) {
+      const slideShow = study.getUi().getSlideshow();
+      const nodes = [];
+      for (let nodeId in slideShow) {
+        const node = slideShow[nodeId];
+        nodes.push({
+          ...node,
+          nodeId
+        });
+      }
+      nodes.sort((a, b) => (a.position > b.position) ? 1 : -1);
+      return nodes;
+    }
+  },
+
   members: {
     __controlsBar: null,
     __prvsBtn: null,
@@ -45,25 +61,6 @@ qx.Class.define("osparc.desktop.SlideShowView", {
       this.__initViews();
 
       this.__showFirstNode();
-    },
-
-    __showFirstNode: function() {
-      const study = this.getStudy();
-      if (study) {
-        const slideShow = study.getUi().getSlideshow();
-        const nodes = [];
-        for (let nodeId in slideShow) {
-          const node = slideShow[nodeId];
-          nodes.push({
-            ...node,
-            nodeId
-          });
-        }
-        if (nodes.length) {
-          nodes.sort((a, b) => (a.position > b.position) ? 1 : -1);
-          this.nodeSelected(nodes[0].nodeId);
-        }
-      }
     },
 
     nodeSelected: function(nodeId) {
@@ -150,20 +147,20 @@ qx.Class.define("osparc.desktop.SlideShowView", {
       });
     },
 
+    __showFirstNode: function() {
+      const study = this.getStudy();
+      if (study) {
+        const nodes = this.self().getSortedNodes(study);
+        if (nodes.length) {
+          this.nodeSelected(nodes[0].nodeId);
+        }
+      }
+    },
+
     __next: function() {
       const study = this.getStudy();
       if (study) {
-        const slideShow = study.getUi().getSlideshow();
-        const nodes = [];
-        for (let nodeId in slideShow) {
-          const node = slideShow[nodeId];
-          nodes.push({
-            ...node,
-            nodeId
-          });
-        }
-        nodes.sort((a, b) => (a.position > b.position) ? 1 : -1);
-
+        const nodes = this.self().getSortedNodes(study);
         const idx = nodes.findIndex(node => node.nodeId === this.__currentNodeId);
         if (idx > -1 && idx+1 < nodes.length) {
           this.nodeSelected(nodes[idx+1].nodeId);
@@ -174,17 +171,7 @@ qx.Class.define("osparc.desktop.SlideShowView", {
     __previous: function() {
       const study = this.getStudy();
       if (study) {
-        const slideShow = study.getUi().getSlideshow();
-        const nodes = [];
-        for (let nodeId in slideShow) {
-          const node = slideShow[nodeId];
-          nodes.push({
-            ...node,
-            nodeId
-          });
-        }
-        nodes.sort((a, b) => (a.position > b.position) ? 1 : -1);
-
+        const nodes = this.self().getSortedNodes(study);
         const idx = nodes.findIndex(node => node.nodeId === this.__currentNodeId);
         if (idx > -1 && idx-1 > -1) {
           this.nodeSelected(nodes[idx-1].nodeId);

--- a/services/web/client/source/class/osparc/desktop/WorkbenchView.js
+++ b/services/web/client/source/class/osparc/desktop/WorkbenchView.js
@@ -294,7 +294,6 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
     __onPipelinesubmitted: function(e) {
       const resp = e.getTarget().getResponse();
       const pipelineId = resp.data["project_id"];
-      const runButton = this.__mainPanel.getControls().getStartButton();
       this.getLogger().debug(null, "Pipeline ID " + pipelineId);
       const notGood = [null, undefined, -1];
       if (notGood.includes(pipelineId)) {
@@ -304,20 +303,7 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
         /* If no projectStateUpdated comes in 60 seconds, client must
         check state of pipeline and update button accordingly. */
         const timer = setTimeout(() => {
-          osparc.data.Resources.fetch("studies", "state", {
-            url: {
-              projectId: pipelineId
-            }
-          })
-            .then(({state}) => {
-              if (state && (
-                state.value === "NOT_STARTED" ||
-                state.value === "SUCCESS" ||
-                state.value === "FAILED"
-              )) {
-                runButton.setFetching(false);
-              }
-            });
+          osparc.store.Store.getInstance().getStudyState(pipelineId);
         }, 60000);
         const socket = osparc.wrapper.WebSocket.getInstance();
         socket.getSocket().once("projectStateUpdated", jsonStr => {

--- a/services/web/client/source/class/osparc/store/Store.js
+++ b/services/web/client/source/class/osparc/store/Store.js
@@ -205,6 +205,17 @@ qx.Class.define("osparc.store.Store", {
       }
     },
 
+    getStudyState: function(pipelineId) {
+      osparc.data.Resources.fetch("studies", "state", {
+        url: {
+          projectId: pipelineId
+        }
+      })
+        .then(({state}) => {
+          this.setStudyState(pipelineId, state);
+        });
+    },
+
     setStudyState: function(studyId, state) {
       const studiesWStateCache = this.getStudies();
       const idx = studiesWStateCache.findIndex(studyWStateCache => studyWStateCache["uuid"] === studyId);

--- a/services/web/server/src/simcore_service_webserver/api/v0/schemas/node-meta-v0.0.1.json
+++ b/services/web/server/src/simcore_service_webserver/api/v0/schemas/node-meta-v0.0.1.json
@@ -46,6 +46,7 @@
       "type": "string",
       "description": "service type",
       "enum": [
+        "frontend",
         "computational",
         "dynamic"
       ],

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -208,6 +208,8 @@ class TutorialBase {
       await utils.sleep(2500);
       if (nodeIds.length === 0) {
         console.log("Services ready in", ((new Date().getTime())-start)/1000);
+        // after the service is responsive we need to a bit until the iframe is rendered
+        await utils.sleep(3000);
         return;
       }
     }

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -208,7 +208,7 @@ class TutorialBase {
       await utils.sleep(2500);
       if (nodeIds.length === 0) {
         console.log("Services ready in", ((new Date().getTime())-start)/1000);
-        // after the service is responsive we need to a bit until the iframe is rendered
+        // after the service is responsive we need to wait a bit until the iframe is rendered
         await utils.sleep(3000);
         return;
       }


### PR DESCRIPTION
## What do these changes do?
- [x] nodes-group service is "frontend" type
- [x] Fix: PropsForm Visibility fixed in GroupNodeView
- [x] Fix: Do not destroy (together with the window) the propsFormEditor when editAccessLevel

#### Bonus
- [x] e2e: Once the dynamic service is responsive, wait 3" for the iframe
- [x] Guided mode: Enable/Disable Previous/Next buttons
- [x] Guided mode: Switch visible/hide buttons
- [x] Guided mode: Positions for groups and its children fixed
- [x] Some refactoring from #1903

![sort slides](https://user-images.githubusercontent.com/33152403/97806517-3b285500-1c5c-11eb-83e1-02f87f16c2ff.gif)


## Related issue number
closes ITISFoundation/osparc-issues#361
closes #1903


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
