### PR TITLE
FilePicker supports download links

### DIFF
--- a/api/specs/common/schemas/project-v0.0.1-converted.yaml
+++ b/api/specs/common/schemas/project-v0.0.1-converted.yaml
@@ -155,6 +155,7 @@ properties:
                     properties:
                       downloadLink:
                         type: string
+                        format: uri
                       label:
                         type: string
           inputAccess:
@@ -213,6 +214,7 @@ properties:
                     properties:
                       downloadLink:
                         type: string
+                        format: uri
                       label:
                         type: string
           outputNode:

--- a/api/specs/common/schemas/project-v0.0.1-converted.yaml
+++ b/api/specs/common/schemas/project-v0.0.1-converted.yaml
@@ -197,6 +197,15 @@ properties:
                         type: string
                       label:
                         type: string
+                  - type: object
+                    additionalProperties: false
+                    required:
+                      - downloadLink
+                    properties:
+                      downloadLink:
+                        type: string
+                      label:
+                        type: string
           outputNode:
             type: boolean
             deprecated: true

--- a/api/specs/common/schemas/project-v0.0.1-converted.yaml
+++ b/api/specs/common/schemas/project-v0.0.1-converted.yaml
@@ -148,6 +148,15 @@ properties:
                         type: string
                       label:
                         type: string
+                  - type: object
+                    additionalProperties: false
+                    required:
+                      - downloadLink
+                    properties:
+                      downloadLink:
+                        type: string
+                      label:
+                        type: string
           inputAccess:
             description: map with key - access level pairs
             type: object

--- a/api/specs/common/schemas/project-v0.0.1.json
+++ b/api/specs/common/schemas/project-v0.0.1.json
@@ -200,6 +200,21 @@
                           "type": "string"
                         }
                       }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "downloadLink"
+                      ],
+                      "properties": {
+                        "downloadLink": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
                     }
                   ]
                 }

--- a/api/specs/common/schemas/project-v0.0.1.json
+++ b/api/specs/common/schemas/project-v0.0.1.json
@@ -273,6 +273,21 @@
                           "type": "string"
                         }
                       }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "downloadLink"
+                      ],
+                      "properties": {
+                        "downloadLink": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
                     }
                   ]
                 }

--- a/api/specs/common/schemas/project-v0.0.1.json
+++ b/api/specs/common/schemas/project-v0.0.1.json
@@ -298,7 +298,8 @@
                       ],
                       "properties": {
                         "downloadLink": {
-                          "type": "string"
+                          "type": "string",
+                          "format": "uri"
                         },
                         "label": {
                           "type": "string"

--- a/api/specs/common/schemas/project-v0.0.1.json
+++ b/api/specs/common/schemas/project-v0.0.1.json
@@ -209,7 +209,8 @@
                       ],
                       "properties": {
                         "downloadLink": {
-                          "type": "string"
+                          "type": "string",
+                          "format": "uri"
                         },
                         "label": {
                           "type": "string"

--- a/services/director/src/simcore_service_director/api/v0/schemas/project-v0.0.1.json
+++ b/services/director/src/simcore_service_director/api/v0/schemas/project-v0.0.1.json
@@ -209,7 +209,8 @@
                       ],
                       "properties": {
                         "downloadLink": {
-                          "type": "string"
+                          "type": "string",
+                          "format": "uri"
                         },
                         "label": {
                           "type": "string"
@@ -297,7 +298,8 @@
                       ],
                       "properties": {
                         "downloadLink": {
-                          "type": "string"
+                          "type": "string",
+                          "format": "uri"
                         },
                         "label": {
                           "type": "string"

--- a/services/director/src/simcore_service_director/api/v0/schemas/project-v0.0.1.json
+++ b/services/director/src/simcore_service_director/api/v0/schemas/project-v0.0.1.json
@@ -200,6 +200,21 @@
                           "type": "string"
                         }
                       }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "downloadLink"
+                      ],
+                      "properties": {
+                        "downloadLink": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
                     }
                   ]
                 }

--- a/services/director/src/simcore_service_director/api/v0/schemas/project-v0.0.1.json
+++ b/services/director/src/simcore_service_director/api/v0/schemas/project-v0.0.1.json
@@ -273,6 +273,21 @@
                           "type": "string"
                         }
                       }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "downloadLink"
+                      ],
+                      "properties": {
+                        "downloadLink": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
                     }
                   ]
                 }

--- a/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
+++ b/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
@@ -1881,6 +1881,7 @@ paths:
                                       properties:
                                         downloadLink:
                                           type: string
+                                          format: uri
                                         label:
                                           type: string
                             inputAccess:
@@ -1939,6 +1940,7 @@ paths:
                                       properties:
                                         downloadLink:
                                           type: string
+                                          format: uri
                                         label:
                                           type: string
                             outputNode:
@@ -2282,6 +2284,7 @@ paths:
                                       properties:
                                         downloadLink:
                                           type: string
+                                          format: uri
                                         label:
                                           type: string
                             inputAccess:
@@ -2340,6 +2343,7 @@ paths:
                                       properties:
                                         downloadLink:
                                           type: string
+                                          format: uri
                                         label:
                                           type: string
                             outputNode:
@@ -2693,6 +2697,7 @@ paths:
                                     properties:
                                       downloadLink:
                                         type: string
+                                        format: uri
                                       label:
                                         type: string
                           inputAccess:
@@ -2751,6 +2756,7 @@ paths:
                                     properties:
                                       downloadLink:
                                         type: string
+                                        format: uri
                                       label:
                                         type: string
                           outputNode:
@@ -3204,6 +3210,7 @@ components:
                           properties:
                             downloadLink:
                               type: string
+                              format: uri
                             label:
                               type: string
                 inputAccess:
@@ -3262,6 +3269,7 @@ components:
                           properties:
                             downloadLink:
                               type: string
+                              format: uri
                             label:
                               type: string
                 outputNode:

--- a/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
+++ b/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
@@ -1923,6 +1923,15 @@ paths:
                                           type: string
                                         label:
                                           type: string
+                                    - type: object
+                                      additionalProperties: false
+                                      required:
+                                        - downloadLink
+                                      properties:
+                                        downloadLink:
+                                          type: string
+                                        label:
+                                          type: string
                             outputNode:
                               type: boolean
                               deprecated: true
@@ -2296,6 +2305,15 @@ paths:
                                         dataset:
                                           type: string
                                         path:
+                                          type: string
+                                        label:
+                                          type: string
+                                    - type: object
+                                      additionalProperties: false
+                                      required:
+                                        - downloadLink
+                                      properties:
+                                        downloadLink:
                                           type: string
                                         label:
                                           type: string
@@ -2682,6 +2700,15 @@ paths:
                                       dataset:
                                         type: string
                                       path:
+                                        type: string
+                                      label:
+                                        type: string
+                                  - type: object
+                                    additionalProperties: false
+                                    required:
+                                      - downloadLink
+                                    properties:
+                                      downloadLink:
                                         type: string
                                       label:
                                         type: string
@@ -3168,6 +3195,15 @@ components:
                             dataset:
                               type: string
                             path:
+                              type: string
+                            label:
+                              type: string
+                        - type: object
+                          additionalProperties: false
+                          required:
+                            - downloadLink
+                          properties:
+                            downloadLink:
                               type: string
                             label:
                               type: string

--- a/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
+++ b/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
@@ -1874,6 +1874,15 @@ paths:
                                           type: string
                                         label:
                                           type: string
+                                    - type: object
+                                      additionalProperties: false
+                                      required:
+                                        - downloadLink
+                                      properties:
+                                        downloadLink:
+                                          type: string
+                                        label:
+                                          type: string
                             inputAccess:
                               description: map with key - access level pairs
                               type: object
@@ -2256,6 +2265,15 @@ paths:
                                         dataset:
                                           type: string
                                         path:
+                                          type: string
+                                        label:
+                                          type: string
+                                    - type: object
+                                      additionalProperties: false
+                                      required:
+                                        - downloadLink
+                                      properties:
+                                        downloadLink:
                                           type: string
                                         label:
                                           type: string
@@ -2651,6 +2669,15 @@ paths:
                                       dataset:
                                         type: string
                                       path:
+                                        type: string
+                                      label:
+                                        type: string
+                                  - type: object
+                                    additionalProperties: false
+                                    required:
+                                      - downloadLink
+                                    properties:
+                                      downloadLink:
                                         type: string
                                       label:
                                         type: string
@@ -3146,6 +3173,15 @@ components:
                             dataset:
                               type: string
                             path:
+                              type: string
+                            label:
+                              type: string
+                        - type: object
+                          additionalProperties: false
+                          required:
+                            - downloadLink
+                          properties:
+                            downloadLink:
                               type: string
                             label:
                               type: string

--- a/services/storage/src/simcore_service_storage/api/v0/schemas/project-v0.0.1.json
+++ b/services/storage/src/simcore_service_storage/api/v0/schemas/project-v0.0.1.json
@@ -209,7 +209,8 @@
                       ],
                       "properties": {
                         "downloadLink": {
-                          "type": "string"
+                          "type": "string",
+                          "format": "uri"
                         },
                         "label": {
                           "type": "string"
@@ -297,7 +298,8 @@
                       ],
                       "properties": {
                         "downloadLink": {
-                          "type": "string"
+                          "type": "string",
+                          "format": "uri"
                         },
                         "label": {
                           "type": "string"

--- a/services/storage/src/simcore_service_storage/api/v0/schemas/project-v0.0.1.json
+++ b/services/storage/src/simcore_service_storage/api/v0/schemas/project-v0.0.1.json
@@ -200,6 +200,21 @@
                           "type": "string"
                         }
                       }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "downloadLink"
+                      ],
+                      "properties": {
+                        "downloadLink": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
                     }
                   ]
                 }

--- a/services/storage/src/simcore_service_storage/api/v0/schemas/project-v0.0.1.json
+++ b/services/storage/src/simcore_service_storage/api/v0/schemas/project-v0.0.1.json
@@ -273,6 +273,21 @@
                           "type": "string"
                         }
                       }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "downloadLink"
+                      ],
+                      "properties": {
+                        "downloadLink": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
                     }
                   ]
                 }

--- a/services/web/client/source/class/osparc/data/model/Workbench.js
+++ b/services/web/client/source/class/osparc/data/model/Workbench.js
@@ -111,12 +111,14 @@ qx.Class.define("osparc.data.model.Workbench", {
       const nodePath = [];
       nodePath.unshift(nodeId);
       const node = this.getNode(nodeId);
-      let parentNodeId = node.getParentNodeId();
-      while (parentNodeId) {
-        const checkThisNode = this.getNode(parentNodeId);
-        if (checkThisNode) {
-          nodePath.unshift(parentNodeId);
-          parentNodeId = checkThisNode.getParentNodeId();
+      if (node) {
+        let parentNodeId = node.getParentNodeId();
+        while (parentNodeId) {
+          const checkThisNode = this.getNode(parentNodeId);
+          if (checkThisNode) {
+            nodePath.unshift(parentNodeId);
+            parentNodeId = checkThisNode.getParentNodeId();
+          }
         }
       }
       nodePath.unshift(studyId);

--- a/services/web/client/source/class/osparc/desktop/WorkbenchView.js
+++ b/services/web/client/source/class/osparc/desktop/WorkbenchView.js
@@ -77,7 +77,7 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
 
     nodeSelected: function(nodeId) {
       if (!nodeId) {
-        this.__loggerView.setCurrentNodeId();
+        this.__loggerView.setCurrentNodeId("");
         return;
       }
       if (this.__nodesTree) {

--- a/services/web/client/source/class/osparc/file/FileDownloadLink.js
+++ b/services/web/client/source/class/osparc/file/FileDownloadLink.js
@@ -35,7 +35,7 @@ qx.Class.define("osparc.file.FileDownloadLink", {
     this.base(arguments);
 
     this._setLayout(new qx.ui.layout.HBox(5));
-    const downloadLinkField = this._createChildControlImpl("downloadLink");
+    const downloadLinkField = this.__downloadLinkField = this._createChildControlImpl("downloadLink");
 
     const selectButton = this._createChildControlImpl("selectButton");
     selectButton.addListener("execute", () => {
@@ -90,6 +90,8 @@ qx.Class.define("osparc.file.FileDownloadLink", {
   },
 
   members: {
+    __downloadLinkField: null,
+
     _createChildControlImpl: function(id) {
       let control;
       switch (id) {
@@ -118,6 +120,14 @@ qx.Class.define("osparc.file.FileDownloadLink", {
           break;
       }
       return control || this.base(arguments, id);
+    },
+
+    getValue: function() {
+      return this.__downloadLinkField.getValue();
+    },
+
+    setValue: function(value) {
+      this.__downloadLinkField.setValue(value);
     }
   }
 });

--- a/services/web/client/source/class/osparc/file/FileDownloadLink.js
+++ b/services/web/client/source/class/osparc/file/FileDownloadLink.js
@@ -1,0 +1,102 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2020 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+/**
+ * Widget that provides a way to use a download link
+ *
+ * *Example*
+ *
+ * Here is a little example of how to use the widget.
+ *
+ * <pre class='javascript'>
+ *   let filesAdd = new osparc.file.FileDownloadLink();
+ *   this.getRoot().add(filesAdd);
+ * </pre>
+ */
+
+qx.Class.define("osparc.file.FileDownloadLink", {
+  extend: qx.ui.core.Widget,
+
+  construct: function() {
+    this.base(arguments);
+
+    this._setLayout(new qx.ui.layout.HBox(5));
+    const downloadLinkField = this._createChildControlImpl("downloadLink");
+    const checkButton = this._createChildControlImpl("checkButton");
+    const checkLink = this._createChildControlImpl("checkLink");
+    const selectButton = this._createChildControlImpl("selectButton");
+
+    checkButton.addListener("execute", () => {
+      const downloadLink = downloadLinkField.getValue();
+      if (this.self().checkFileExists(downloadLink)) {
+        checkLink.setSource("@FontAwesome5Solid/check-circle/14");
+      } else {
+        checkLink.setSource("@FontAwesome5Solid/times-circle/14");
+      }
+    }, this);
+
+    selectButton.addListener("execute", () => {
+      const downloadLink = downloadLinkField.getValue();
+      this.fireDataEvent("fileLinkAdded", downloadLink);
+    }, this);
+  },
+
+  events: {
+    "fileLinkAdded": "qx.event.type.Data"
+  },
+
+  statics: {
+    checkFileExists: function(urlToFile) {
+      const xhr = new XMLHttpRequest();
+      xhr.open("HEAD", urlToFile, false);
+      xhr.send();
+      return xhr.status != "404";
+    }
+  },
+
+  members: {
+    _createChildControlImpl: function(id) {
+      let control;
+      switch (id) {
+        case "downloadLink":
+          control = new qx.ui.form.TextField().set({
+            placeholder: this.tr("Type a Download Link")
+          });
+          this._add(control, {
+            flex: 1
+          });
+          break;
+        case "checkButton":
+          control = new qx.ui.toolbar.Button(this.tr("Validate"));
+          this._add(control);
+          break;
+        case "checkLink":
+          control = new qx.ui.basic.Image();
+          control.set({
+            source: "@FontAwesome5Solid/question-circle/14"
+          });
+          this._add(control);
+          break;
+        case "selectButton":
+          control = new qx.ui.toolbar.Button(this.tr("Select"));
+          this._add(control);
+          break;
+      }
+      return control || this.base(arguments, id);
+    }
+  }
+});

--- a/services/web/client/source/class/osparc/file/FileDownloadLink.js
+++ b/services/web/client/source/class/osparc/file/FileDownloadLink.js
@@ -36,8 +36,8 @@ qx.Class.define("osparc.file.FileDownloadLink", {
 
     this._setLayout(new qx.ui.layout.HBox(5));
     const downloadLinkField = this._createChildControlImpl("downloadLink");
-    const selectButton = this._createChildControlImpl("selectButton");
 
+    const selectButton = this._createChildControlImpl("selectButton");
     selectButton.addListener("execute", () => {
       const downloadLink = downloadLinkField.getValue();
       this.fireDataEvent("fileLinkAdded", downloadLink);
@@ -49,6 +49,26 @@ qx.Class.define("osparc.file.FileDownloadLink", {
   },
 
   statics: {
+    getOutputLabel: function(outputValue) {
+      if ("outFile" in outputValue) {
+        const outInfo = outputValue["outFile"];
+        if ("label" in outInfo) {
+          return outInfo.label;
+        }
+        if ("downloadLink" in outInfo) {
+          // until question mark
+          const downloadLink = outInfo.downloadLink;
+          const regex = "(^.*)(?=\\?)";
+          const found = downloadLink.match(regex);
+          if (found && found.length > 1) {
+            const parts = found[1].split("/");
+            return parts[parts.length - 1];
+          }
+        }
+      }
+      return null;
+    },
+
     checkFileExists: function(urlToFile) {
       return new Promise(resolve => {
         const xhr = new XMLHttpRequest();

--- a/services/web/client/source/class/osparc/file/FileDownloadLink.js
+++ b/services/web/client/source/class/osparc/file/FileDownloadLink.js
@@ -36,21 +36,7 @@ qx.Class.define("osparc.file.FileDownloadLink", {
 
     this._setLayout(new qx.ui.layout.HBox(5));
     const downloadLinkField = this._createChildControlImpl("downloadLink");
-    const checkButton = this._createChildControlImpl("checkButton");
-    const checkLink = this._createChildControlImpl("checkLink");
     const selectButton = this._createChildControlImpl("selectButton");
-
-    checkButton.addListener("execute", () => {
-      const downloadLink = downloadLinkField.getValue();
-      this.self().checkFileExists(downloadLink)
-        .then(exists => {
-          if (exists) {
-            checkLink.setSource("@FontAwesome5Solid/check-circle/14");
-          } else {
-            checkLink.setSource("@FontAwesome5Solid/times-circle/14");
-          }
-        });
-    }, this);
 
     selectButton.addListener("execute", () => {
       const downloadLink = downloadLinkField.getValue();

--- a/services/web/client/source/class/osparc/file/FileDownloadLink.js
+++ b/services/web/client/source/class/osparc/file/FileDownloadLink.js
@@ -51,16 +51,16 @@ qx.Class.define("osparc.file.FileDownloadLink", {
   statics: {
     checkFileExists: function(urlToFile) {
       return new Promise(resolve => {
-        const http = new XMLHttpRequest();
-        http.open("HEAD", urlToFile, true);
-        http.onreadystatechange = function() {
-          if (this.readyState === this.DONE) {
+        const xhr = new XMLHttpRequest();
+        xhr.open("HEAD", urlToFile, true);
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState === 4) { // 4=this.DONE
             resolve(true);
           } else {
             resolve(false);
           }
         };
-        http.send();
+        xhr.send();
       });
     }
   },

--- a/services/web/client/source/class/osparc/file/FileDownloadLink.js
+++ b/services/web/client/source/class/osparc/file/FileDownloadLink.js
@@ -42,11 +42,14 @@ qx.Class.define("osparc.file.FileDownloadLink", {
 
     checkButton.addListener("execute", () => {
       const downloadLink = downloadLinkField.getValue();
-      if (this.self().checkFileExists(downloadLink)) {
-        checkLink.setSource("@FontAwesome5Solid/check-circle/14");
-      } else {
-        checkLink.setSource("@FontAwesome5Solid/times-circle/14");
-      }
+      this.self().checkFileExists(downloadLink)
+        .then(exists => {
+          if (exists) {
+            checkLink.setSource("@FontAwesome5Solid/check-circle/14");
+          } else {
+            checkLink.setSource("@FontAwesome5Solid/times-circle/14");
+          }
+        });
     }, this);
 
     selectButton.addListener("execute", () => {
@@ -61,10 +64,18 @@ qx.Class.define("osparc.file.FileDownloadLink", {
 
   statics: {
     checkFileExists: function(urlToFile) {
-      const xhr = new XMLHttpRequest();
-      xhr.open("HEAD", urlToFile, false);
-      xhr.send();
-      return xhr.status != "404";
+      return new Promise(resolve => {
+        const http = new XMLHttpRequest();
+        http.open("HEAD", urlToFile, true);
+        http.onreadystatechange = function() {
+          if (this.readyState === this.DONE) {
+            resolve(true);
+          } else {
+            resolve(false);
+          }
+        };
+        http.send();
+      });
     }
   },
 

--- a/services/web/client/source/class/osparc/file/FileDownloadLink.js
+++ b/services/web/client/source/class/osparc/file/FileDownloadLink.js
@@ -56,15 +56,19 @@ qx.Class.define("osparc.file.FileDownloadLink", {
           return outInfo.label;
         }
         if ("downloadLink" in outInfo) {
-          // until question mark
-          const downloadLink = outInfo.downloadLink;
-          const regex = "(^.*)(?=\\?)";
-          const found = downloadLink.match(regex);
-          if (found && found.length > 1) {
-            const parts = found[1].split("/");
-            return parts[parts.length - 1];
-          }
+          return osparc.file.FileDownloadLink.extractLabelFromLink(outInfo.downloadLink);
         }
+      }
+      return null;
+    },
+
+    extractLabelFromLink: function(downloadLink) {
+      // until question mark
+      const regex = "(^.*)(?=\\?)";
+      const found = downloadLink.match(regex);
+      if (found && found.length > 1) {
+        const parts = found[1].split("/");
+        return parts[parts.length - 1];
       }
       return null;
     },

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -109,7 +109,6 @@ qx.Class.define("osparc.file.FilePicker", {
           break;
         case "downloadLink": {
           const groupBox = new qx.ui.groupbox.GroupBox(this.tr("Or provide a Download Link")).set({
-            // appearance: "settings-groupbox",
             layout: new qx.ui.layout.VBox(5)
           });
           control = new osparc.file.FileDownloadLink();
@@ -133,7 +132,7 @@ qx.Class.define("osparc.file.FilePicker", {
 
       const filesTree = this.__filesTree = this._createChildControlImpl("filesTree");
       filesTree.addListener("selectionChanged", this.__selectionChanged, this);
-      filesTree.addListener("itemSelected", this.__itemSelected, this);
+      filesTree.addListener("itemSelected", this.__itemSelectedFromStore, this);
       filesTree.addListener("filesAddedToTree", this.__checkSelectedFileIsListed, this);
 
       const toolbar = new qx.ui.toolbar.ToolBar();
@@ -158,7 +157,7 @@ qx.Class.define("osparc.file.FilePicker", {
       const selectBtn = this.__selectBtn = this._createChildControlImpl("selectButton");
       selectBtn.setEnabled(false);
       selectBtn.addListener("execute", function() {
-        this.__itemSelected();
+        this.__itemSelectedFromStore();
       }, this);
     },
 
@@ -189,7 +188,7 @@ qx.Class.define("osparc.file.FilePicker", {
       this.__selectBtn.setEnabled(data ? data["isFile"] : false);
     },
 
-    __itemSelected: function() {
+    __itemSelectedFromStore: function() {
       const data = this.__filesTree.getSelectedFile();
       if (data && data["isFile"]) {
         const selectedItem = data["selectedItem"];

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -65,8 +65,10 @@ qx.Class.define("osparc.file.FilePicker", {
         if ("label" in outInfo) {
           return outInfo.label;
         }
-        const splitFilename = outInfo.path.split("/");
-        return splitFilename[splitFilename.length-1];
+        if ("path" in outInfo) {
+          const splitFilename = outInfo.path.split("/");
+          return splitFilename[splitFilename.length-1];
+        }
       }
       return null;
     }

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -170,7 +170,7 @@ qx.Class.define("osparc.file.FilePicker", {
     },
 
     init: function() {
-      if (this.__isOutputFileSelected()) {
+      if (this.__isOutputFileSelectedFromStore()) {
         const outFile = this.__getOutputFile();
         this.__filesTree.loadFilePath(outFile.value);
       } else {
@@ -235,7 +235,7 @@ qx.Class.define("osparc.file.FilePicker", {
       }
     },
 
-    __isOutputFileSelected: function() {
+    __isOutputFileSelectedFromStore: function() {
       const outFile = this.__getOutputFile();
       if (outFile && "value" in outFile && "path" in outFile.value) {
         return true;
@@ -244,7 +244,7 @@ qx.Class.define("osparc.file.FilePicker", {
     },
 
     __checkSelectedFileIsListed: function() {
-      if (this.__isOutputFileSelected()) {
+      if (this.__isOutputFileSelectedFromStore()) {
         const outFile = this.__getOutputFile();
         this.__filesTree.setSelectedFile(outFile.value.path);
         this.__filesTree.fireEvent("selectionChanged");

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -158,7 +158,8 @@ qx.Class.define("osparc.file.FilePicker", {
       const fileDownloadLink = this.__downloadLink = this._createChildControlImpl("downloadLink");
       fileDownloadLink.addListener("fileLinkAdded", e => {
         const downloadLink = e.getData();
-        this.__setOutputFileFromLink(downloadLink);
+        const label = osparc.file.FileDownloadLink.extractLabelFromLink(downloadLink);
+        this.__setOutputFileFromLink(downloadLink, label);
       }, this);
 
       const selectBtn = this.__selectBtn = this._createChildControlImpl("selectButton");

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -137,7 +137,7 @@ qx.Class.define("osparc.file.FilePicker", {
       filesAdd.addListener("fileAdded", e => {
         const fileMetadata = e.getData();
         if ("location" in fileMetadata && "dataset" in fileMetadata && "path" in fileMetadata && "name" in fileMetadata) {
-          this.__setOutputFile(fileMetadata["location"], fileMetadata["dataset"], fileMetadata["path"], fileMetadata["name"]);
+          this.__setOutputFileFromStore(fileMetadata["location"], fileMetadata["dataset"], fileMetadata["path"], fileMetadata["name"]);
         }
         this.__filesTree.resetCache();
         this.__initResources();
@@ -181,7 +181,7 @@ qx.Class.define("osparc.file.FilePicker", {
       const data = this.__filesTree.getSelectedFile();
       if (data && data["isFile"]) {
         const selectedItem = data["selectedItem"];
-        this.__setOutputFile(selectedItem.getLocation(), selectedItem.getDatasetId(), selectedItem.getFileId(), selectedItem.getLabel());
+        this.__setOutputFileFromStore(selectedItem.getLocation(), selectedItem.getDatasetId(), selectedItem.getFileId(), selectedItem.getLabel());
         this.getNode().repopulateOutputPortData();
         this.fireEvent("finished");
       }
@@ -192,7 +192,7 @@ qx.Class.define("osparc.file.FilePicker", {
       return outputs["outFile"];
     },
 
-    __setOutputFile: function(store, dataset, path, label) {
+    __setOutputFileFromStore: function(store, dataset, path, label) {
       if (store !== undefined && path) {
         const outputs = this.__getOutputFile();
         outputs["value"] = {

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -152,7 +152,11 @@ qx.Class.define("osparc.file.FilePicker", {
         this.__initResources();
       }, this);
 
-      this.__downloadLink = this._createChildControlImpl("downloadLink");
+      const fileDownloadLink = this.__downloadLink = this._createChildControlImpl("downloadLink");
+      fileDownloadLink.addListener("fileLinkAdded", e => {
+        const downloadLink = e.getData();
+        this.__setOutputFileFromLink(downloadLink);
+      }, this);
 
       const selectBtn = this.__selectBtn = this._createChildControlImpl("selectButton");
       selectBtn.setEnabled(false);

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -69,6 +69,9 @@ qx.Class.define("osparc.file.FilePicker", {
           const splitFilename = outInfo.path.split("/");
           return splitFilename[splitFilename.length-1];
         }
+        if ("downloadLink" in outInfo) {
+          return osparc.file.FileDownloadLink.getOutputLabel(outputValue);
+        }
       }
       return null;
     }

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -107,10 +107,16 @@ qx.Class.define("osparc.file.FilePicker", {
           control = new qx.ui.toolbar.Button(this.tr("Select"));
           this.__mainButtons.add(control);
           break;
-        case "downloadLink":
+        case "downloadLink": {
+          const groupBox = new qx.ui.groupbox.GroupBox(this.tr("Or provide a Download Link")).set({
+            // appearance: "settings-groupbox",
+            layout: new qx.ui.layout.VBox(5)
+          });
           control = new osparc.file.FileDownloadLink();
-          this._add(control);
+          groupBox.add(control);
+          this._add(groupBox);
           break;
+        }
       }
 
       return control || this.base(arguments, id);

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -22,7 +22,6 @@
  * - FilesTree will be populated with data provided by storage service (simcore.S3 and datcore)
  * - Add button will open a dialogue where the selected file will be upload to S3
  * - Select button puts the file in the output of the FilePicker node so that connected nodes can access it.
- * When the selection is made "finished" event will be fired
  *
  * *Example*
  *
@@ -52,10 +51,6 @@ qx.Class.define("osparc.file.FilePicker", {
     node: {
       check: "osparc.data.model.Node"
     }
-  },
-
-  events: {
-    "finished": "qx.event.type.Event"
   },
 
   statics: {
@@ -207,7 +202,6 @@ qx.Class.define("osparc.file.FilePicker", {
         const selectedItem = data["selectedItem"];
         this.__setOutputFileFromStore(selectedItem.getLocation(), selectedItem.getDatasetId(), selectedItem.getFileId(), selectedItem.getLabel());
         this.getNode().repopulateOutputPortData();
-        this.fireEvent("finished");
       }
     },
 
@@ -237,6 +231,7 @@ qx.Class.define("osparc.file.FilePicker", {
           label
         };
         this.getNode().getStatus().setProgress(100);
+        this.getNode().repopulateOutputPortData();
       }
     },
 

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -176,6 +176,11 @@ qx.Class.define("osparc.file.FilePicker", {
       } else {
         this.__initResources();
       }
+
+      if (this.__isOutputFileSelectedFromLink()) {
+        const outFile = this.__getOutputFile();
+        this.__downloadLink.setValue(outFile.value["downloadLink"]);
+      }
     },
 
     uploadPendingFiles: function(files) {
@@ -238,6 +243,14 @@ qx.Class.define("osparc.file.FilePicker", {
     __isOutputFileSelectedFromStore: function() {
       const outFile = this.__getOutputFile();
       if (outFile && "value" in outFile && "path" in outFile.value) {
+        return true;
+      }
+      return false;
+    },
+
+    __isOutputFileSelectedFromLink: function() {
+      const outFile = this.__getOutputFile();
+      if (outFile && "value" in outFile && "downloadLink" in outFile.value) {
         return true;
       }
       return false;

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -107,6 +107,10 @@ qx.Class.define("osparc.file.FilePicker", {
           control = new qx.ui.toolbar.Button(this.tr("Select"));
           this.__mainButtons.add(control);
           break;
+        case "downloadLink":
+          control = new osparc.file.FileDownloadLink();
+          this._add(control);
+          break;
       }
 
       return control || this.base(arguments, id);
@@ -142,6 +146,8 @@ qx.Class.define("osparc.file.FilePicker", {
         this.__filesTree.resetCache();
         this.__initResources();
       }, this);
+
+      this.__downloadLink = this._createChildControlImpl("downloadLink");
 
       const selectBtn = this.__selectBtn = this._createChildControlImpl("selectButton");
       selectBtn.setEnabled(false);
@@ -199,6 +205,17 @@ qx.Class.define("osparc.file.FilePicker", {
           store,
           dataset,
           path,
+          label
+        };
+        this.getNode().getStatus().setProgress(100);
+      }
+    },
+
+    __setOutputFileFromLink: function(downloadLink, label) {
+      if (downloadLink) {
+        const outputs = this.__getOutputFile();
+        outputs["value"] = {
+          downloadLink,
           label
         };
         this.getNode().getStatus().setProgress(100);

--- a/services/web/client/source/class/osparc/ui/basic/NodeStatusUI.js
+++ b/services/web/client/source/class/osparc/ui/basic/NodeStatusUI.js
@@ -127,14 +127,7 @@ qx.Class.define("osparc.ui.basic.NodeStatusUI", {
       this.__node.getStatus().bind("progress", this.__label, "value", {
         converter: progress => {
           if (progress === 100) {
-            const outInfo = node.getOutputValues().outFile;
-            if (outInfo) {
-              if ("label" in outInfo) {
-                return outInfo.label;
-              }
-              const splitFilename = outInfo.path.split("/");
-              return splitFilename[splitFilename.length-1];
-            }
+            return osparc.file.FilePicker.getOutputLabel(node.getOutputValues());
           }
           return this.tr("Select a file");
         }

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -5924,6 +5924,7 @@ paths:
                                               properties:
                                                 downloadLink:
                                                   type: string
+                                                  format: uri
                                                 label:
                                                   type: string
                                     inputAccess:
@@ -5982,6 +5983,7 @@ paths:
                                               properties:
                                                 downloadLink:
                                                   type: string
+                                                  format: uri
                                                 label:
                                                   type: string
                                     outputNode:
@@ -6456,6 +6458,7 @@ paths:
                                   properties:
                                     downloadLink:
                                       type: string
+                                      format: uri
                                     label:
                                       type: string
                         inputAccess:
@@ -6514,6 +6517,7 @@ paths:
                                   properties:
                                     downloadLink:
                                       type: string
+                                      format: uri
                                     label:
                                       type: string
                         outputNode:
@@ -6868,6 +6872,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   inputAccess:
@@ -6926,6 +6931,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   outputNode:
@@ -7398,6 +7404,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   inputAccess:
@@ -7456,6 +7463,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   outputNode:
@@ -7934,6 +7942,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   inputAccess:
@@ -7992,6 +8001,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   outputNode:
@@ -8461,6 +8471,7 @@ paths:
                                   properties:
                                     downloadLink:
                                       type: string
+                                      format: uri
                                     label:
                                       type: string
                         inputAccess:
@@ -8519,6 +8530,7 @@ paths:
                                   properties:
                                     downloadLink:
                                       type: string
+                                      format: uri
                                     label:
                                       type: string
                         outputNode:
@@ -8873,6 +8885,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   inputAccess:
@@ -8931,6 +8944,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   outputNode:
@@ -9425,6 +9439,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   inputAccess:
@@ -9483,6 +9498,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   outputNode:
@@ -10789,6 +10805,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   inputAccess:
@@ -10847,6 +10864,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   outputNode:
@@ -11318,6 +11336,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   inputAccess:
@@ -11376,6 +11395,7 @@ paths:
                                             properties:
                                               downloadLink:
                                                 type: string
+                                                format: uri
                                               label:
                                                 type: string
                                   outputNode:

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -5966,6 +5966,15 @@ paths:
                                                   type: string
                                                 label:
                                                   type: string
+                                            - type: object
+                                              additionalProperties: false
+                                              required:
+                                                - downloadLink
+                                              properties:
+                                                downloadLink:
+                                                  type: string
+                                                label:
+                                                  type: string
                                     outputNode:
                                       type: boolean
                                       deprecated: true
@@ -6473,6 +6482,15 @@ paths:
                                       type: string
                                     label:
                                       type: string
+                                - type: object
+                                  additionalProperties: false
+                                  required:
+                                    - downloadLink
+                                  properties:
+                                    downloadLink:
+                                      type: string
+                                    label:
+                                      type: string
                         outputNode:
                           type: boolean
                           deprecated: true
@@ -6857,6 +6875,15 @@ paths:
                                               dataset:
                                                 type: string
                                               path:
+                                                type: string
+                                              label:
+                                                type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
                                                 type: string
                                               label:
                                                 type: string
@@ -7362,6 +7389,15 @@ paths:
                                               dataset:
                                                 type: string
                                               path:
+                                                type: string
+                                              label:
+                                                type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
                                                 type: string
                                               label:
                                                 type: string
@@ -7876,6 +7912,15 @@ paths:
                                                 type: string
                                               label:
                                                 type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
+                                                type: string
+                                              label:
+                                                type: string
                                   outputNode:
                                     type: boolean
                                     deprecated: true
@@ -8378,6 +8423,15 @@ paths:
                                       type: string
                                     label:
                                       type: string
+                                - type: object
+                                  additionalProperties: false
+                                  required:
+                                    - downloadLink
+                                  properties:
+                                    downloadLink:
+                                      type: string
+                                    label:
+                                      type: string
                         outputNode:
                           type: boolean
                           deprecated: true
@@ -8762,6 +8816,15 @@ paths:
                                               dataset:
                                                 type: string
                                               path:
+                                                type: string
+                                              label:
+                                                type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
                                                 type: string
                                               label:
                                                 type: string
@@ -9289,6 +9352,15 @@ paths:
                                               dataset:
                                                 type: string
                                               path:
+                                                type: string
+                                              label:
+                                                type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
                                                 type: string
                                               label:
                                                 type: string
@@ -10631,6 +10703,15 @@ paths:
                                                 type: string
                                               label:
                                                 type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
+                                                type: string
+                                              label:
+                                                type: string
                                   outputNode:
                                     type: boolean
                                     deprecated: true
@@ -11132,6 +11213,15 @@ paths:
                                               dataset:
                                                 type: string
                                               path:
+                                                type: string
+                                              label:
+                                                type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
                                                 type: string
                                               label:
                                                 type: string

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -5917,6 +5917,15 @@ paths:
                                                   type: string
                                                 label:
                                                   type: string
+                                            - type: object
+                                              additionalProperties: false
+                                              required:
+                                                - downloadLink
+                                              properties:
+                                                downloadLink:
+                                                  type: string
+                                                label:
+                                                  type: string
                                     inputAccess:
                                       description: map with key - access level pairs
                                       type: object
@@ -6433,6 +6442,15 @@ paths:
                                       type: string
                                     label:
                                       type: string
+                                - type: object
+                                  additionalProperties: false
+                                  required:
+                                    - downloadLink
+                                  properties:
+                                    downloadLink:
+                                      type: string
+                                    label:
+                                      type: string
                         inputAccess:
                           description: map with key - access level pairs
                           type: object
@@ -6826,6 +6844,15 @@ paths:
                                               dataset:
                                                 type: string
                                               path:
+                                                type: string
+                                              label:
+                                                type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
                                                 type: string
                                               label:
                                                 type: string
@@ -7340,6 +7367,15 @@ paths:
                                               dataset:
                                                 type: string
                                               path:
+                                                type: string
+                                              label:
+                                                type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
                                                 type: string
                                               label:
                                                 type: string
@@ -7863,6 +7899,15 @@ paths:
                                                 type: string
                                               label:
                                                 type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
+                                                type: string
+                                              label:
+                                                type: string
                                   inputAccess:
                                     description: map with key - access level pairs
                                     type: object
@@ -8374,6 +8419,15 @@ paths:
                                       type: string
                                     label:
                                       type: string
+                                - type: object
+                                  additionalProperties: false
+                                  required:
+                                    - downloadLink
+                                  properties:
+                                    downloadLink:
+                                      type: string
+                                    label:
+                                      type: string
                         inputAccess:
                           description: map with key - access level pairs
                           type: object
@@ -8767,6 +8821,15 @@ paths:
                                               dataset:
                                                 type: string
                                               path:
+                                                type: string
+                                              label:
+                                                type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
                                                 type: string
                                               label:
                                                 type: string
@@ -9303,6 +9366,15 @@ paths:
                                               dataset:
                                                 type: string
                                               path:
+                                                type: string
+                                              label:
+                                                type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
                                                 type: string
                                               label:
                                                 type: string
@@ -10654,6 +10726,15 @@ paths:
                                                 type: string
                                               label:
                                                 type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
+                                                type: string
+                                              label:
+                                                type: string
                                   inputAccess:
                                     description: map with key - access level pairs
                                     type: object
@@ -11164,6 +11245,15 @@ paths:
                                               dataset:
                                                 type: string
                                               path:
+                                                type: string
+                                              label:
+                                                type: string
+                                          - type: object
+                                            additionalProperties: false
+                                            required:
+                                              - downloadLink
+                                            properties:
+                                              downloadLink:
                                                 type: string
                                               label:
                                                 type: string

--- a/services/web/server/src/simcore_service_webserver/api/v0/schemas/project-v0.0.1.json
+++ b/services/web/server/src/simcore_service_webserver/api/v0/schemas/project-v0.0.1.json
@@ -209,7 +209,8 @@
                       ],
                       "properties": {
                         "downloadLink": {
-                          "type": "string"
+                          "type": "string",
+                          "format": "uri"
                         },
                         "label": {
                           "type": "string"
@@ -297,7 +298,8 @@
                       ],
                       "properties": {
                         "downloadLink": {
-                          "type": "string"
+                          "type": "string",
+                          "format": "uri"
                         },
                         "label": {
                           "type": "string"

--- a/services/web/server/src/simcore_service_webserver/api/v0/schemas/project-v0.0.1.json
+++ b/services/web/server/src/simcore_service_webserver/api/v0/schemas/project-v0.0.1.json
@@ -200,6 +200,21 @@
                           "type": "string"
                         }
                       }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "downloadLink"
+                      ],
+                      "properties": {
+                        "downloadLink": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
                     }
                   ]
                 }

--- a/services/web/server/src/simcore_service_webserver/api/v0/schemas/project-v0.0.1.json
+++ b/services/web/server/src/simcore_service_webserver/api/v0/schemas/project-v0.0.1.json
@@ -273,6 +273,21 @@
                           "type": "string"
                         }
                       }
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "downloadLink"
+                      ],
+                      "properties": {
+                        "downloadLink": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
                     }
                   ]
                 }


### PR DESCRIPTION
## What do these changes do?
- [x] Update schemas to support downloadLink in node input/output
- [x] FilePicker also renders a text box to support downloadLink. This is serialized/deserialized.

## Related issue number
related to ITISFoundation/osparc-issues#343

![DL](https://user-images.githubusercontent.com/33152403/98568938-edda6200-22b1-11eb-9b3b-d720e6e941d6.gif)


## How to test


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
