### PR TITLE
BugFix: New fix for access_studies using redlocks

### DIFF
--- a/services/web/server/src/simcore_service_webserver/cli.py
+++ b/services/web/server/src/simcore_service_webserver/cli.py
@@ -99,7 +99,10 @@ def main(args: Optional[List] = None):
     config = parse(args, parser)
 
     # service log level
-    setup_logging(level=config["main"]["log_level"])
+    slow_duration = float(
+        os.environ.get("AIODEBUG_SLOW_DURATION_SECS", 0)
+    )  # TODO: move to settings.py::ApplicationSettings
+    setup_logging(level=config["main"]["log_level"], slow_duration=slow_duration)
 
     # run
     run_service(config)

--- a/services/web/server/src/simcore_service_webserver/log.py
+++ b/services/web/server/src/simcore_service_webserver/log.py
@@ -2,8 +2,7 @@
 
 """
 import logging
-import os
-from typing import Union
+from typing import Optional, Union
 
 from aiodebug import log_slow_callbacks
 from aiohttp.log import access_logger
@@ -13,7 +12,7 @@ from servicelib.logging_utils import set_logging_handler
 LOG_LEVEL_STEP = logging.CRITICAL - logging.ERROR
 
 
-def setup_logging(*, level: Union[str, int]):
+def setup_logging(*, level: Union[str, int], slow_duration: Optional[float] = None):
     # service log level
     logging.basicConfig(level=level)
 
@@ -25,15 +24,17 @@ def setup_logging(*, level: Union[str, int]):
     access_logger.setLevel(level)
 
     # keep mostly quiet noisy loggers
-    quiet_level: int = max(min(logging.root.level + LOG_LEVEL_STEP, logging.CRITICAL), logging.WARNING)
+    quiet_level: int = max(
+        min(logging.root.level + LOG_LEVEL_STEP, logging.CRITICAL), logging.WARNING
+    )
     logging.getLogger("engineio").setLevel(quiet_level)
     logging.getLogger("openapi_spec_validator").setLevel(quiet_level)
     logging.getLogger("sqlalchemy").setLevel(quiet_level)
     logging.getLogger("sqlalchemy.engine").setLevel(quiet_level)
 
-    # NOTE: Every task blocking > AIODEBUG_SLOW_DURATION_SECS secs is considered slow and logged as warning
-    slow_duration = float(os.environ.get("AIODEBUG_SLOW_DURATION_SECS", 0.1))
-    log_slow_callbacks.enable(slow_duration)
+    if slow_duration:
+        # NOTE: Every task blocking > AIODEBUG_SLOW_DURATION_SECS secs is considered slow and logged as warning
+        log_slow_callbacks.enable(abs(slow_duration))
 
 
 def test_logger_propagation(logger: logging.Logger):

--- a/services/web/server/src/simcore_service_webserver/resource_manager/config.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/config.py
@@ -21,7 +21,6 @@ APP_GARBAGE_COLLECTOR_KEY = __name__ + ".resource_manager.garbage_collector_key"
 
 
 # lock names and format strings
-GC_EXECUTION_LOCK = f"{__name__}:redlock:garbage_collector_execution"
 GUEST_USER_RC_LOCK_FORMAT = f"{__name__}:redlock:garbage_collect_user:{{user_id}}"
 
 schema = T.Dict(

--- a/services/web/server/src/simcore_service_webserver/resource_manager/config.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/config.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 
 import trafaret as T
 from aiohttp.web import Application
-from pydantic import BaseSettings, PositiveInt, Field
+from pydantic import BaseSettings, Field, PositiveInt
 
 from models_library.settings.redis import RedisConfig
 from servicelib.application_keys import APP_CONFIG_KEY
@@ -18,6 +18,11 @@ APP_CLIENT_REDIS_LOCK_KEY = __name__ + ".resource_manager.redis_lock"
 APP_CLIENT_SOCKET_REGISTRY_KEY = __name__ + ".resource_manager.registry"
 APP_RESOURCE_MANAGER_TASKS_KEY = __name__ + ".resource_manager.tasks.key"
 APP_GARBAGE_COLLECTOR_KEY = __name__ + ".resource_manager.garbage_collector_key"
+
+
+# lock names and format strings
+GC_EXECUTION_LOCK = f"{__name__}:redlock:garbage_collector_execution"
+GUEST_USER_RC_LOCK_FORMAT = f"{__name__}:redlock:garbage_collect_user:{{user_id}}"
 
 schema = T.Dict(
     {
@@ -47,7 +52,8 @@ class ResourceManagerSettings(BaseSettings):
     enabled: bool = True
 
     resource_deletion_timeout_seconds: Optional[PositiveInt] = Field(
-        900, description="Expiration time (or Time to live (TTL) in redis jargon) for a registered resource"
+        900,
+        description="Expiration time (or Time to live (TTL) in redis jargon) for a registered resource",
     )
     garbage_collection_interval_seconds: Optional[PositiveInt] = Field(
         30, description="Waiting time between consecutive runs of the garbage-colector"

--- a/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from itertools import chain
-from typing import Dict
+from typing import Dict, List, Tuple
 
 from aiohttp import web
 from aiopg.sa.result import RowProxy
@@ -267,7 +267,7 @@ async def remove_users_manually_marked_as_guests(
         user_ids_to_ignore.add(int(entry["user_id"]))
 
     # Prevent creating this list if a guest user
-    guest_users = await get_guest_user_ids_and_names(app)
+    guest_users: List[Tuple[int, str]] = await get_guest_user_ids_and_names(app)
     logger.info("GUEST user candidates to clean %s", guest_users)
 
     for guest_user_id, guest_user_name in guest_users:

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -136,11 +136,6 @@ class WebsocketRegistry:
             key,
             value,
         )
-        assert key in (  # nosec
-            "project_id",  # nosec
-            SOCKET_ID_KEY,  # nosec
-        ), "Notice that these names were used somewhere else!"  # nosec
-
         registry = get_registry(self.app)
         await registry.set_resource(self._resource_key(), (key, value))
 

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -33,6 +33,16 @@ SOCKET_ID_KEY = "socket_id"
 
 @attr.s(auto_attribs=True)
 class WebsocketRegistry:
+    """
+    Keeps track of resources allocated for a user's session
+
+    A session is started when a socket resource is allocated (via set_socket_id)
+    A session can allocate multiple resources
+
+    """
+    # TODO: find a more descriptive name ... too many registries!
+    #
+
     user_id: int
     client_session_id: Optional[str]
     app: web.Application
@@ -45,7 +55,7 @@ class WebsocketRegistry:
             else "*",
         }
 
-    async def set_socket_id(self, socket_id: str, *, extra_tll: int = 0) -> None:
+    async def set_socket_id(self, socket_id: str) -> None:
         log.debug(
             "user %s/tab %s adding socket %s in registry...",
             self.user_id,
@@ -56,7 +66,7 @@ class WebsocketRegistry:
         await registry.set_resource(self._resource_key(), (SOCKET_ID_KEY, socket_id))
         # NOTE: hearthbeat is not emulated in tests, make sure that with very small GC intervals
         # the resources do not expire; this value is usually in the order of minutes
-        timeout = max(3, get_service_deletion_timeout(self.app)) + abs(extra_tll)
+        timeout = max(3, get_service_deletion_timeout(self.app))
         await registry.set_key_alive(self._resource_key(), timeout)
 
     async def get_socket_id(self) -> Optional[str]:
@@ -88,7 +98,7 @@ class WebsocketRegistry:
         )
 
     async def set_heartbeat(self) -> None:
-        """Refreshes heartbeat """
+        """Extends TTL to avoid expiration of all resources under this session """
         registry = get_registry(self.app)
         await registry.set_key_alive(
             self._resource_key(), get_service_deletion_timeout(self.app)
@@ -126,6 +136,11 @@ class WebsocketRegistry:
             key,
             value,
         )
+        assert key in (  # nosec
+            "project_id",  # nosec
+            SOCKET_ID_KEY,  # nosec
+        ), "Notice that these names were used somewhere else!"  # nosec
+
         registry = get_registry(self.app)
         await registry.set_resource(self._resource_key(), (key, value))
 

--- a/services/web/server/src/simcore_service_webserver/studies_access.py
+++ b/services/web/server/src/simcore_service_webserver/studies_access.py
@@ -209,7 +209,7 @@ async def access_study(request: web.Request) -> web.Response:
 
     if not user:
         log.debug("Creating temporary user ...")
-        wait_if_creating_user: asyncio.Semaphore = request.app[f"{__name__}.semaphone"]
+        wait_if_creating_user: asyncio.Semaphore = request.app[f"{__name__}.semaphore"]
 
         await wait_if_creating_user.acquire()
         try:
@@ -284,7 +284,7 @@ def setup(app: web.Application):
         ]
     )
 
-    app[f"{__name__}.semaphone"] = asyncio.Semaphore(value=1)
+    app[f"{__name__}.semaphore"] = asyncio.Semaphore(value=1)
 
     return True
 

--- a/services/web/server/src/simcore_service_webserver/users_api.py
+++ b/services/web/server/src/simcore_service_webserver/users_api.py
@@ -118,7 +118,7 @@ async def get_guest_user_ids_and_names(app: web.Application) -> List[Tuple[int, 
         async for row in conn.execute(
             sa.select([users.c.id, users.c.name]).where(users.c.role == UserRole.GUEST)
         ):
-            result.append(row)
+            result.append(row.as_tuple())
         return list(result)
 
 

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -326,7 +326,7 @@ def postgres_db(postgres_dsn: Dict, postgres_service: str) -> sa.engine.Engine:
 
 
 @pytest.fixture(scope="session")
-def redis_service(docker_services, docker_ip):
+def redis_service(docker_services, docker_ip) -> URL:
 
     host = docker_ip
     port = docker_services.port_for("redis", 6379)

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -25,6 +25,7 @@ import socketio
 import sqlalchemy as sa
 import trafaret_config
 from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
 from pydantic import BaseSettings
 from yarl import URL
 
@@ -125,9 +126,11 @@ class _BaseSettingEncoder(json.JSONEncoder):
 
 
 @pytest.fixture
-def web_server(loop, aiohttp_server, app_cfg, monkeypatch, postgres_db):
+def web_server(
+    loop, aiohttp_server, app_cfg: Dict, monkeypatch, postgres_db
+) -> TestServer:
     print(
-        "Inits webserver with config",
+        "Inits webserver with app_cfg",
         json.dumps(app_cfg, indent=2, cls=_BaseSettingEncoder),
     )
     # original APP
@@ -143,9 +146,9 @@ def web_server(loop, aiohttp_server, app_cfg, monkeypatch, postgres_db):
 
 
 @pytest.fixture
-def client(loop, aiohttp_client, web_server, mock_orphaned_services):
-    client = loop.run_until_complete(aiohttp_client(web_server))
-    return client
+def client(loop, aiohttp_client, web_server, mock_orphaned_services) -> TestClient:
+    cli = loop.run_until_complete(aiohttp_client(web_server))
+    return cli
 
 
 # SUBSYSTEM MOCKS FIXTURES ------------------------------------------------
@@ -301,7 +304,7 @@ def postgres_service(docker_services, postgres_dsn):
 
 
 @pytest.fixture
-def postgres_db( postgres_dsn: Dict, postgres_service: str ) -> sa.engine.Engine:
+def postgres_db(postgres_dsn: Dict, postgres_service: str) -> sa.engine.Engine:
     url = postgres_service
 
     # Configures db and initializes tables
@@ -357,7 +360,7 @@ def _is_redis_responsive(host: str, port: int) -> bool:
 
 @pytest.fixture()
 def socketio_url(client) -> Callable:
-    def create_url(client_override: Optional = None) -> str:
+    def create_url(client_override: Optional[TestClient] = None) -> str:
         SOCKET_IO_PATH = "/socket.io/"
         return str((client_override or client).make_url(SOCKET_IO_PATH))
 
@@ -366,7 +369,7 @@ def socketio_url(client) -> Callable:
 
 @pytest.fixture()
 async def security_cookie_factory(client) -> Callable:
-    async def creator(client_override: Optional = None) -> str:
+    async def creator(client_override: Optional[TestClient] = None) -> str:
         # get the cookie by calling the root entrypoint
         resp = await (client_override or client).get("/v0/")
         data, error = await assert_status(resp, web.HTTPOk)
@@ -390,7 +393,7 @@ async def socketio_client(
     clients = []
 
     async def connect(
-        client_session_id: str, client: Optional = None
+        client_session_id: str, client: Optional[TestClient] = None
     ) -> socketio.AsyncClient:
         sio = socketio.AsyncClient(ssl_verify=False)
         # enginio 3.10.0 introduced ssl verification

--- a/services/web/server/tests/unit/with_dbs/fast/test_access_to_studies.py
+++ b/services/web/server/tests/unit/with_dbs/fast/test_access_to_studies.py
@@ -34,7 +34,6 @@ from servicelib.rest_responses import unwrap_envelope
 from simcore_service_webserver import catalog
 from simcore_service_webserver.log import setup_logging
 from simcore_service_webserver.projects.projects_api import delete_project_from_db
-from simcore_service_webserver.resource_manager.garbage_collector import collect_garbage
 from simcore_service_webserver.statics import STATIC_DIRNAMES
 from simcore_service_webserver.users_api import delete_user, is_user_guest
 
@@ -393,7 +392,7 @@ async def test_access_cookie_of_expired_user(
     assert data["login"] != user_email
 
 
-@pytest.mark.parametrize("number_of_simultaneous_requests", [1, 2, 4, 8, 16, 32])
+@pytest.mark.parametrize("number_of_simultaneous_requests", [1, 2, 16, 32, 64])
 async def test_guest_user_is_not_garbage_collected(
     number_of_simultaneous_requests,
     web_server,
@@ -407,6 +406,9 @@ async def test_guest_user_is_not_garbage_collected(
 
     async def _test_guest_user_workflow(request_index):
         print("request #", request_index, "-" * 10)
+
+        # TODO: heartbeat is missing here!
+        # TODO: reduce GC activation period to 0.1 secs
 
         # every guest uses different client to preserve it's own authorization/authentication cookies
         client: TestClient = await aiohttp_client(web_server)

--- a/services/web/server/tests/unit/with_dbs/fast/test_redis.py
+++ b/services/web/server/tests/unit/with_dbs/fast/test_redis.py
@@ -2,10 +2,74 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-import aioredis
+import pytest
+from aioredis import Redis
+from aioredlock import Aioredlock, LockError
+from yarl import URL
 
 
-async def test_aioredis(loop, redis_client):
+@pytest.fixture
+async def lock_manager(loop, redis_service: URL):
+    lm = Aioredlock(
+        [
+            str(redis_service),
+        ]
+    )
+
+    yield lm
+
+    # Clear the connections with Redis:
+    await lm.destroy()
+
+
+
+async def test_redlocks_features(lock_manager: Aioredlock):
+    # Originally https://github.com/joanvila/aioredlock#readme
+
+    # Check wether a resourece acquired by any other redlock instance:
+    assert not await lock_manager.is_locked("resource_name")
+
+    # Try to acquire the lock:
+    try:
+        lock = await lock_manager.lock("resource_name", lock_timeout=10)
+    except LockError:
+        print("Lock not acquired")
+        raise
+
+    # Now the lock is acquired:
+    assert lock.valid
+    assert await lock_manager.is_locked("resource_name")
+
+    # Extend lifetime of the lock:
+    await lock_manager.extend(lock, lock_timeout=10)
+    # Raises LockError if the lock manager can not extend the lock lifetime
+    # on more then half of the Redis instances.
+
+    # Release the lock:
+    await lock_manager.unlock(lock)
+    # Raises LockError if the lock manager can not release the lock
+    # on more then half of redis instances.
+
+    # The released lock become invalid:
+    assert not lock.valid
+    assert not await lock_manager.is_locked("resource_name")
+
+    # Or you can use the lock as async context manager:
+    try:
+        async with await lock_manager.lock("resource_name") as lock:
+            assert lock.valid is True
+            # Do your stuff having the lock
+            await lock.extend()  # alias for lock_manager.extend(lock)
+            # Do more stuff having the lock
+        assert lock.valid is False  # lock will be released by context manager
+    except LockError:
+        print("Lock not acquired")
+        raise
+
+    await lock_manager.destroy()
+
+
+async def test_aioredis(loop, redis_client: Redis):
     await redis_client.set("my-key", "value")
     val = await redis_client.get("my-key")
     assert val == "value"


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

- It reimplements the fix using locks to protect construction and initialization of the GUEST user from an eager GC! :-)
- This PR replaces PR#1928  (bugfix for #1853: garbage collector deletes guest users  bug). This implementation avoid setting fictitious resources or anonymous users as in PR #1928. Those proved to be very error prone.
- EXTRA: resources are removed from registry when GC actually executes the clean. This way, the share-lock mechanism will prevent  a user from opening a resource that is being removed [upon request from @odeimaiz and @sanderegg]


## Related issue number

<!-- Please add #issues -->
 Fixes #1853


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->
```
make devenv
cd services/web/server
make install-dev
make test-dev-unit
```

## Checklist

- [x] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
