### PR TITLE
Freezes director reqs

### DIFF
--- a/services/director/requirements/_base.in
+++ b/services/director/requirements/_base.in
@@ -1,13 +1,69 @@
 #
 # Specifies third-party dependencies for 'director'
 #
-urllib3>=1.25.8     # Vulnerability
-pyyaml>=5.3         # Vulnerable
 
-aiohttp
-aiodocker
-asyncio_extras
-requests
-tenacity
+#  IMPORTANT: All requirements (including the packages in this repository) as FROZEN to those in itisfoundation/director:master-2020-11-05--14-45.c8669fb52659b684514fefa4f3b4599f57f276a0
+#    - current service is going to be replaced by director-v2
+#
+#
 
-git+https://github.com/ITISFoundation/aiohttp_apiset.git@fixes_4_osparc#egg=aiohttp_apiset # TODO: constaints aiohttp >=1.2,<3.4
+# This list was obtained as follows
+#
+# $ docker pull itisfoundation/director:master-2020-11-05--14-45.c8669fb52659b684514fefa4f3b4599f57f276a0
+#    master-2020-11-05--14-45.c8669fb52659b684514fefa4f3b4599f57f276a0: Pulling from itisfoundation/director
+#    Digest: sha256:84ba999ca348bf9d56d9ef0af2e3494ede0cd06d357d289e2a09a4191e7a56d3
+#    Status: Image is up to date for itisfoundation/director:master-2020-11-05--14-45.c8669fb52659b684514fefa4f3b4599f57f276a0
+#    docker.io/itisfoundation/director:master-2020-11-05--14-45.c8669fb52659b684514fefa4f3b4599f57f276a0
+#
+# $ docker inspect itisfoundation/director:master-2020-11-05--14-45.c8669fb52659b684514fefa4f3b4599f57f276a0| jq '.[0] | .RepoTags, .ContainerConfig.Labels'
+#    [
+#      "itisfoundation/director:master-2020-11-05--14-45.c8669fb52659b684514fefa4f3b4599f57f276a0"
+#    ]
+#    {
+#      "io.osparc.api-version": "0.1.0",
+#      "maintainer": "sanderegg",
+#      "org.label-schema.build-date": "2020-11-05T14:02:31Z",
+#      "org.label-schema.schema-version": "1.0",
+#      "org.label-schema.vcs-ref": "c8669fb",
+#      "org.label-schema.vcs-url": "https://github.com/ITISFoundation/osparc-simcore.git"
+#    }
+#
+# $ docker run -it itisfoundation/director:master-2020-11-05--14-45.c8669fb52659b684514fefa4f3b4599f57f276a0 pip freeze
+#
+
+aiodebug==1.1.2
+aiodocker==0.14.0
+aiohttp==3.3.2
+aiohttp-apiset @ git+https://github.com/ITISFoundation/aiohttp_apiset.git@5c8a61ceb6de7ed9e09db5b4609b458a0d3773df
+aiopg==1.0.0
+aiozipkin==0.7.1
+async-generator==1.10
+async-timeout==3.0.1
+asyncio-extras==1.3.2
+attrs==20.2.0
+certifi==2019.3.9
+chardet==3.0.4
+dataclasses==0.7
+idna==2.8
+idna-ssl==1.1.0
+isodate==0.6.0
+jsonschema==2.6.0
+lazy-object-proxy==1.4.3
+multidict==4.5.2
+openapi-core==0.12.0
+openapi-spec-validator==0.2.9
+prometheus-client==0.8.0
+psycopg2-binary==2.8.6
+pydantic==1.7.2
+PyYAML==5.3
+requests==2.22.0
+simcore-service-library @ git+https://github.com/ITISFoundation/osparc-simcore.git@c8669fb52659b684514fefa4f3b4599f57f276a0#egg=simcore-service-library&subdirectory=packages/service-library
+six==1.12.0
+SQLAlchemy==1.3.20
+strict-rfc3339==0.7
+tenacity==6.0.0
+trafaret==2.1.0
+ujson==4.0.1
+urllib3==1.25.11
+Werkzeug==1.0.1
+yarl==1.3.0

--- a/services/director/requirements/_base.txt
+++ b/services/director/requirements/_base.txt
@@ -4,22 +4,39 @@
 #
 #    pip-compile --output-file=requirements/_base.txt requirements/_base.in
 #
+aiodebug==1.1.2           # via -r requirements/_base.in, simcore-service-library
 aiodocker==0.14.0         # via -r requirements/_base.in
-aiohttp==3.3.2            # via -r requirements/_base.in, aiodocker, aiohttp-apiset
-git+https://github.com/ITISFoundation/aiohttp_apiset.git@fixes_4_osparc#egg=aiohttp_apiset  # via -r requirements/_base.in
-async-generator==1.10     # via asyncio-extras
-async-timeout==3.0.1      # via aiohttp
+git+https://github.com/ITISFoundation/aiohttp_apiset.git@5c8a61ceb6de7ed9e09db5b4609b458a0d3773df  # via -r requirements/_base.in
+aiohttp==3.3.2            # via -r requirements/_base.in, aiodocker, aiohttp-apiset, aiozipkin, simcore-service-library
+aiopg==1.0.0              # via -r requirements/_base.in, simcore-service-library
+aiozipkin==0.7.1          # via -r requirements/_base.in, simcore-service-library
+async-generator==1.10     # via -r requirements/_base.in, asyncio-extras
+async-timeout==3.0.1      # via -r requirements/_base.in, aiohttp
 asyncio-extras==1.3.2     # via -r requirements/_base.in
-attrs==20.2.0             # via aiohttp
-certifi==2019.3.9         # via requests
-chardet==3.0.4            # via aiohttp, requests
-idna-ssl==1.1.0           # via aiohttp
-idna==2.8                 # via idna-ssl, requests, yarl
-jsonschema==2.6.0         # via aiohttp-apiset
-multidict==4.5.2          # via aiohttp, yarl
-pyyaml==5.3               # via -r requirements/_base.in, aiohttp-apiset
+attrs==20.2.0             # via -r requirements/_base.in, aiohttp, openapi-core, simcore-service-library
+certifi==2019.3.9         # via -r requirements/_base.in, requests
+chardet==3.0.4            # via -r requirements/_base.in, aiohttp, requests
+dataclasses==0.7          # via -r requirements/_base.in, pydantic
+idna-ssl==1.1.0           # via -r requirements/_base.in, aiohttp
+idna==2.8                 # via -r requirements/_base.in, idna-ssl, requests, yarl
+isodate==0.6.0            # via -r requirements/_base.in, openapi-core
+jsonschema==2.6.0         # via -r requirements/_base.in, aiohttp-apiset, openapi-spec-validator, simcore-service-library
+lazy-object-proxy==1.4.3  # via -r requirements/_base.in, openapi-core, simcore-service-library
+multidict==4.5.2          # via -r requirements/_base.in, aiohttp, yarl
+openapi-core==0.12.0      # via -r requirements/_base.in, simcore-service-library
+openapi-spec-validator==0.2.9  # via -r requirements/_base.in, openapi-core
+prometheus-client==0.8.0  # via -r requirements/_base.in, simcore-service-library
+psycopg2-binary==2.8.6    # via -r requirements/_base.in, aiopg, simcore-service-library
+pydantic==1.7.2           # via -r requirements/_base.in, simcore-service-library
+pyyaml==5.3               # via -r requirements/_base.in, aiohttp-apiset, openapi-spec-validator, simcore-service-library
 requests==2.22.0          # via -r requirements/_base.in
-six==1.12.0               # via tenacity
-tenacity==6.0.0           # via -r requirements/_base.in
+git+https://github.com/ITISFoundation/osparc-simcore.git@c8669fb52659b684514fefa4f3b4599f57f276a0#egg=simcore-service-library&subdirectory=packages/service-library  # via -r requirements/_base.in
+six==1.12.0               # via -r requirements/_base.in, isodate, openapi-core, openapi-spec-validator, tenacity
+sqlalchemy==1.3.20        # via -r requirements/_base.in, simcore-service-library
+strict-rfc3339==0.7       # via -r requirements/_base.in, openapi-core
+tenacity==6.0.0           # via -r requirements/_base.in, simcore-service-library
+trafaret==2.1.0           # via -r requirements/_base.in, simcore-service-library
+ujson==4.0.1              # via -r requirements/_base.in, simcore-service-library
 urllib3==1.25.11          # via -r requirements/_base.in, requests
-yarl==1.3.0               # via aiodocker, aiohttp
+werkzeug==1.0.1           # via -r requirements/_base.in, simcore-service-library
+yarl==1.3.0               # via -r requirements/_base.in, aiodocker, aiohttp

--- a/services/director/requirements/_test.txt
+++ b/services/director/requirements/_test.txt
@@ -4,35 +4,44 @@
 #
 #    pip-compile --output-file=requirements/_test.txt requirements/_test.in
 #
+aiodebug==1.1.2           # via -r requirements/_base.txt, simcore-service-library
 aiodocker==0.14.0         # via -r requirements/_base.txt
-aiohttp==3.3.2            # via -r requirements/_base.txt, aiodocker, aiohttp-apiset, pytest-aiohttp
-git+https://github.com/ITISFoundation/aiohttp_apiset.git@fixes_4_osparc#egg=aiohttp_apiset  # via -r requirements/_base.txt
+git+https://github.com/ITISFoundation/aiohttp_apiset.git@5c8a61ceb6de7ed9e09db5b4609b458a0d3773df  # via -r requirements/_base.txt
+aiohttp==3.3.2            # via -r requirements/_base.txt, aiodocker, aiohttp-apiset, aiozipkin, pytest-aiohttp, simcore-service-library
+aiopg==1.0.0              # via -r requirements/_base.txt, simcore-service-library
+aiozipkin==0.7.1          # via -r requirements/_base.txt, simcore-service-library
 astroid==2.4.2            # via pylint
 async-generator==1.10     # via -r requirements/_base.txt, asyncio-extras
 async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp
 asyncio-extras==1.3.2     # via -r requirements/_base.txt
-attrs==20.2.0             # via -r requirements/_base.txt, aiohttp, pytest
+attrs==20.2.0             # via -r requirements/_base.txt, aiohttp, openapi-core, pytest, simcore-service-library
 certifi==2019.3.9         # via -r requirements/_base.txt, requests
 chardet==3.0.4            # via -r requirements/_base.txt, aiohttp, requests
 codecov==2.1.10           # via -r requirements/_test.in
 coverage==4.5.1           # via -r requirements/_test.in, codecov, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
+dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 docker==4.3.1             # via -r requirements/_test.in
 docopt==0.6.2             # via coveralls
 idna-ssl==1.1.0           # via -r requirements/_base.txt, aiohttp
 idna==2.8                 # via -r requirements/_base.txt, idna-ssl, requests, yarl
 importlib-metadata==2.0.0  # via pluggy, pytest
 iniconfig==1.1.1          # via pytest
+isodate==0.6.0            # via -r requirements/_base.txt, openapi-core
 isort==5.6.4              # via pylint
-jsonschema==2.6.0         # via -r requirements/_base.txt, aiohttp-apiset, openapi-spec-validator
-lazy-object-proxy==1.4.3  # via astroid
+jsonschema==2.6.0         # via -r requirements/_base.txt, aiohttp-apiset, openapi-spec-validator, simcore-service-library
+lazy-object-proxy==1.4.3  # via -r requirements/_base.txt, astroid, openapi-core, simcore-service-library
 mccabe==0.6.1             # via pylint
 multidict==4.5.2          # via -r requirements/_base.txt, aiohttp, yarl
-openapi-spec-validator==0.2.9  # via -r requirements/_test.in
+openapi-core==0.12.0      # via -r requirements/_base.txt, simcore-service-library
+openapi-spec-validator==0.2.9  # via -r requirements/_base.txt, -r requirements/_test.in, openapi-core
 packaging==20.4           # via pytest, pytest-sugar
 pluggy==0.13.1            # via pytest
+prometheus-client==0.8.0  # via -r requirements/_base.txt, simcore-service-library
+psycopg2-binary==2.8.6    # via -r requirements/_base.txt, aiopg, simcore-service-library
 ptvsd==4.3.2              # via -r requirements/_test.in
 py==1.9.0                 # via pytest
+pydantic==1.7.2           # via -r requirements/_base.txt, simcore-service-library
 pylint==2.6.0             # via -r requirements/_test.in
 pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
@@ -43,15 +52,21 @@ pytest-runner==5.2        # via -r requirements/_test.in
 pytest-sugar==0.9.4       # via -r requirements/_test.in
 pytest==6.1.2             # via -r requirements/_test.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-mock, pytest-sugar
 python-dotenv==0.15.0     # via -r requirements/_test.in
-pyyaml==5.3               # via -r requirements/_base.txt, aiohttp-apiset, openapi-spec-validator
+pyyaml==5.3               # via -r requirements/_base.txt, aiohttp-apiset, openapi-spec-validator, simcore-service-library
 requests==2.22.0          # via -r requirements/_base.txt, codecov, coveralls, docker
-six==1.12.0               # via -r requirements/_base.txt, astroid, docker, openapi-spec-validator, packaging, tenacity, websocket-client
-tenacity==6.0.0           # via -r requirements/_base.txt
+git+https://github.com/ITISFoundation/osparc-simcore.git@c8669fb52659b684514fefa4f3b4599f57f276a0#egg=simcore-service-library&subdirectory=packages/service-library  # via -r requirements/_base.txt
+six==1.12.0               # via -r requirements/_base.txt, astroid, docker, isodate, openapi-core, openapi-spec-validator, packaging, tenacity, websocket-client
+sqlalchemy==1.3.20        # via -r requirements/_base.txt, simcore-service-library
+strict-rfc3339==0.7       # via -r requirements/_base.txt, openapi-core
+tenacity==6.0.0           # via -r requirements/_base.txt, simcore-service-library
 termcolor==1.1.0          # via pytest-sugar
-toml==0.10.1              # via pylint, pytest
+toml==0.10.2              # via pylint, pytest
+trafaret==2.1.0           # via -r requirements/_base.txt, simcore-service-library
 typed-ast==1.4.1          # via astroid
+ujson==4.0.1              # via -r requirements/_base.txt, simcore-service-library
 urllib3==1.25.11          # via -r requirements/_base.txt, requests
 websocket-client==0.57.0  # via docker
+werkzeug==1.0.1           # via -r requirements/_base.txt, simcore-service-library
 wrapt==1.12.1             # via astroid
 yarl==1.3.0               # via -r requirements/_base.txt, aiodocker, aiohttp
 zipp==3.4.0               # via importlib-metadata

--- a/services/director/requirements/ci.txt
+++ b/services/director/requirements/ci.txt
@@ -9,8 +9,6 @@
 # installs base + tests requirements
 -r _test.txt
 ../../packages/pytest-simcore/
-# installs this repo's packages
-../../packages/service-library/
 
 # installs current package
 .

--- a/services/director/requirements/dev.txt
+++ b/services/director/requirements/dev.txt
@@ -11,7 +11,6 @@
 -r _test.txt
 
 # installs this repo's packages
--e ../../packages/service-library/
 -e ../../packages/pytest-simcore/
 
 # installs current package

--- a/services/director/setup.py
+++ b/services/director/setup.py
@@ -21,8 +21,8 @@ def read_reqs(reqs_path: Path):
 
 
 install_requirements = read_reqs(here / "requirements" / "_base.txt") + [
-    "aiohttp-apiset==0.0.0.dev0",
-    "simcore-service-library==0.1.0",
+    "aiohttp-apiset",
+    "simcore-service-library",
 ]
 
 test_requirements = read_reqs(here / "requirements" / "_test.txt")


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

Fixes versions errors due to missing unpinned versions in ``director/requirements/_base.txt`` 

<!-- Please give a short brief about these changes. -->
Requirements in ``director`` ``_base.txt`` where not **deep frozen** since  the dependencies of ``servicelib`` (a package in the same repository) were not included (by mistake!)

Since the service will be replaced by ``director-v2`` we took this opportunity to **freeze the reqs** of this service to the latest working image (see procedure in ``_base.txt`` documentation). 

All reqs are frozen to match those of [itisfoundation/director:master-2020-11-05--14-45.c8669fb52659b684514fefa4f3b4599f57f276a0](https://hub.docker.com/layers/itisfoundation/director/master-2020-11-05--14-45.c8669fb52659b684514fefa4f3b4599f57f276a0/images/sha256-84ba999ca348bf9d56d9ef0af2e3494ede0cd06d357d289e2a09a4191e7a56d3?context=repo)

## How to test

```
$ make devenv
$ cd services/director
$ make build
$ docker run -it local/director:production pip freeze
```
should give the same list as in ``_base.txt`` PLUS ``simcore-service-director @ file:///build/services/director``
