### PR TITLE
Maintenance week 46

### DIFF
--- a/packages/models-library/requirements/_base.txt
+++ b/packages/models-library/requirements/_base.txt
@@ -6,6 +6,6 @@
 #
 dataclasses==0.7          # via pydantic
 dnspython==2.0.0          # via email-validator
-email-validator==1.1.1    # via pydantic
+email-validator==1.1.2    # via pydantic
 idna==2.10                # via email-validator
-pydantic[email]==1.6.1    # via -r requirements/_base.in
+pydantic[email]==1.7.2    # via -r requirements/_base.in

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -7,15 +7,15 @@
 aiohttp==3.7.2            # via pytest-aiohttp
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via aiohttp
-attrs==20.2.0             # via aiohttp, pytest
-certifi==2020.6.20        # via requests
+attrs==20.3.0             # via aiohttp, pytest
+certifi==2020.11.8        # via requests
 chardet==3.0.4            # via aiohttp, requests
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 dnspython==2.0.0          # via -r requirements/_base.txt, email-validator
 docopt==0.6.2             # via coveralls
-email-validator==1.1.1    # via -r requirements/_base.txt, pydantic
+email-validator==1.1.2    # via -r requirements/_base.txt, pydantic
 icdiff==1.9.1             # via pytest-icdiff
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via -r requirements/_base.txt, email-validator, idna-ssl, requests, yarl
@@ -29,7 +29,7 @@ packaging==20.4           # via pytest, pytest-sugar
 pluggy==0.13.1            # via pytest
 pprintpp==0.4.0           # via pytest-icdiff
 py==1.9.0                 # via pytest
-pydantic[email]==1.6.1    # via -r requirements/_base.txt
+pydantic[email]==1.7.2    # via -r requirements/_base.txt
 pylint==2.6.0             # via -r requirements/_test.in
 pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via -r requirements/_test.in
@@ -43,7 +43,7 @@ pytest==6.1.2             # via -r requirements/_test.in, pytest-aiohttp, pytest
 requests==2.24.0          # via coveralls
 six==1.15.0               # via astroid, packaging
 termcolor==1.1.0          # via pytest-sugar
-toml==0.10.1              # via pylint, pytest
+toml==0.10.2              # via pylint, pytest
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via aiohttp, yarl
 urllib3==1.25.11          # via requests

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -9,7 +9,7 @@ aiopg[sa]==1.0.0          # via -r requirements/_test.in
 alembic==1.4.3            # via -r requirements/_migration.txt
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via aiohttp
-attrs==20.2.0             # via aiohttp, jsonschema, pytest, pytest-docker
+attrs==20.3.0             # via aiohttp, jsonschema, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
 cached-property==1.5.2    # via docker-compose
 certifi==2020.6.20        # via -r requirements/_migration.txt, requests

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -24,7 +24,7 @@ docker-compose==1.27.4    # via pytest-docker
 docker[ssh]==4.3.1        # via -r requirements/_migration.txt, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
-faker==4.14.0             # via -r requirements/_test.in
+faker==4.14.2             # via -r requirements/_test.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via -r requirements/_migration.txt, idna-ssl, requests, yarl
 importlib-metadata==2.0.0  # via jsonschema, pluggy, pytest

--- a/packages/s3wrapper/requirements/_base.txt
+++ b/packages/s3wrapper/requirements/_base.txt
@@ -4,10 +4,10 @@
 #
 #    pip-compile --output-file=requirements/_base.txt requirements/_base.in
 #
-certifi==2020.6.20        # via minio
-configparser==5.0.0       # via minio
+certifi==2020.11.8        # via minio
+configparser==5.0.1       # via minio
 minio==6.0.0              # via -r requirements/_base.in
 python-dateutil==2.8.1    # via minio
-pytz==2020.1              # via minio
+pytz==2020.4              # via minio
 six==1.15.0               # via python-dateutil
 urllib3==1.25.11          # via -r requirements/_base.in, minio

--- a/packages/s3wrapper/requirements/_test.txt
+++ b/packages/s3wrapper/requirements/_test.txt
@@ -5,13 +5,13 @@
 #    pip-compile --output-file=requirements/_test.txt requirements/_test.in
 #
 astroid==2.4.2            # via pylint
-attrs==20.2.0             # via jsonschema, pytest, pytest-docker
+attrs==20.3.0             # via jsonschema, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
 cached-property==1.5.2    # via docker-compose
-certifi==2020.6.20        # via -r requirements/_base.txt, minio, requests
+certifi==2020.11.8        # via -r requirements/_base.txt, minio, requests
 cffi==1.14.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
-configparser==5.0.0       # via -r requirements/_base.txt, minio
+configparser==5.0.1       # via -r requirements/_base.txt, minio
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 cryptography==3.2.1       # via paramiko
@@ -43,12 +43,12 @@ pytest-runner==5.2        # via -r requirements/_test.in
 pytest==6.1.2             # via -r requirements/_test.in, pytest-cov, pytest-docker
 python-dateutil==2.8.1    # via -r requirements/_base.txt, minio
 python-dotenv==0.15.0     # via docker-compose
-pytz==2020.1              # via -r requirements/_base.txt, minio
+pytz==2020.4              # via -r requirements/_base.txt, minio
 pyyaml==5.3.1             # via docker-compose
 requests==2.24.0          # via -r requirements/_test.in, coveralls, docker, docker-compose
 six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, dockerpty, jsonschema, packaging, pynacl, python-dateutil, websocket-client
 texttable==1.6.3          # via docker-compose
-toml==0.10.1              # via pylint, pytest
+toml==0.10.2              # via pylint, pytest
 typed-ast==1.4.1          # via astroid
 urllib3==1.25.11          # via -r requirements/_base.txt, minio, requests
 websocket-client==0.57.0  # via docker, docker-compose

--- a/packages/service-library/requirements/_base.in
+++ b/packages/service-library/requirements/_base.in
@@ -7,7 +7,7 @@ pyyaml>=5.3              # Vulnerable
 psycopg2-binary          # enforces binary version - http://initd.org/psycopg/docs/install.html#binary-install-from-pypi
 openapi-core==0.12.0     # frozen until https://github.com/ITISFoundation/osparc-simcore/pull/1396 is CLOSED
 lazy-object-proxy~=1.4.3 # cannot upgrade due to contraints in openapi-core
-aiozipkin==0.7.1         # not compatible with new released version 1.0.0
+aiozipkin==0.7.1         # breaking changes with new released version 1.0.0 (https://github.com/aio-libs/aiozipkin/releases)
 
 aiohttp
 aiopg[sa]

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -9,7 +9,7 @@ aiohttp==3.7.2            # via -r requirements/_base.in, aiozipkin
 aiopg[sa]==1.0.0          # via -r requirements/_base.in
 aiozipkin==1.0.0          # via -r requirements/_base.in
 async-timeout==3.0.1      # via aiohttp
-attrs==20.2.0             # via -r requirements/_base.in, aiohttp, jsonschema, openapi-core
+attrs==20.3.0             # via -r requirements/_base.in, aiohttp, jsonschema, openapi-core
 chardet==3.0.4            # via aiohttp
 dataclasses==0.7          # via pydantic
 idna-ssl==1.1.0           # via aiohttp

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -7,7 +7,7 @@
 aiodebug==1.1.2           # via -r requirements/_base.in
 aiohttp==3.7.2            # via -r requirements/_base.in, aiozipkin
 aiopg[sa]==1.0.0          # via -r requirements/_base.in
-aiozipkin==1.0.0          # via -r requirements/_base.in
+aiozipkin==0.7.1          # via -r requirements/_base.in
 async-timeout==3.0.1      # via aiohttp
 attrs==20.3.0             # via -r requirements/_base.in, aiohttp, jsonschema, openapi-core
 chardet==3.0.4            # via aiohttp

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -11,7 +11,10 @@ aiozipkin==1.0.0          # via -r requirements/_base.in
 async-timeout==3.0.1      # via aiohttp
 attrs==20.2.0             # via -r requirements/_base.in, aiohttp, jsonschema, openapi-core
 chardet==3.0.4            # via aiohttp
-idna==2.10                # via yarl
+dataclasses==0.7          # via pydantic
+idna-ssl==1.1.0           # via aiohttp
+idna==2.10                # via idna-ssl, yarl
+importlib-metadata==2.0.0  # via jsonschema
 isodate==0.6.0            # via openapi-core
 jsonschema==3.2.0         # via -r requirements/_base.in, openapi-spec-validator
 lazy-object-proxy==1.4.3  # via -r requirements/_base.in, openapi-core
@@ -20,7 +23,7 @@ openapi-core==0.12.0      # via -r requirements/_base.in
 openapi-spec-validator==0.2.9  # via openapi-core
 prometheus-client==0.8.0  # via -r requirements/_base.in
 psycopg2-binary==2.8.6    # via -r requirements/_base.in, aiopg, sqlalchemy
-pydantic==1.6.1           # via -r requirements/_base.in
+pydantic==1.7.2           # via -r requirements/_base.in
 pyrsistent==0.17.3        # via jsonschema
 pyyaml==5.3.1             # via -r requirements/_base.in, openapi-spec-validator
 six==1.15.0               # via isodate, jsonschema, openapi-core, openapi-spec-validator, tenacity
@@ -28,10 +31,11 @@ sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.in, a
 strict-rfc3339==0.7       # via openapi-core
 tenacity==6.2.0           # via -r requirements/_base.in
 trafaret==2.1.0           # via -r requirements/_base.in
-typing-extensions==3.7.4.3  # via aiohttp
+typing-extensions==3.7.4.3  # via aiohttp, yarl
 ujson==4.0.1              # via -r requirements/_base.in
 werkzeug==1.0.1           # via -r requirements/_base.in
 yarl==1.5.1               # via aiohttp
+zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -10,7 +10,7 @@ aiopg[sa]==1.0.0          # via -r requirements/_base.txt
 aiozipkin==1.0.0          # via -r requirements/_base.txt
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp
-attrs==20.2.0             # via -r requirements/_base.txt, aiohttp, jsonschema, openapi-core, pytest, pytest-docker
+attrs==20.3.0             # via -r requirements/_base.txt, aiohttp, jsonschema, openapi-core, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
 cached-property==1.5.2    # via docker-compose
 certifi==2020.6.20        # via requests

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -19,12 +19,15 @@ chardet==3.0.4            # via -r requirements/_base.txt, aiohttp, requests
 coverage==5.3             # via -r requirements/_test.in, coveralls, pytest-cov
 coveralls==2.1.2          # via -r requirements/_test.in
 cryptography==3.2.1       # via paramiko
+dataclasses==0.7          # via -r requirements/_base.txt, pydantic
 distro==1.5.0             # via docker-compose
 docker-compose==1.27.4    # via pytest-docker
 docker[ssh]==4.3.1        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
-idna==2.10                # via -r requirements/_base.txt, requests, yarl
+idna-ssl==1.1.0           # via -r requirements/_base.txt, aiohttp
+idna==2.10                # via -r requirements/_base.txt, idna-ssl, requests, yarl
+importlib-metadata==2.0.0  # via -r requirements/_base.txt, jsonschema, pluggy, pytest
 iniconfig==1.1.1          # via pytest
 isodate==0.6.0            # via -r requirements/_base.txt, openapi-core
 isort==5.6.4              # via pylint
@@ -41,7 +44,7 @@ prometheus-client==0.8.0  # via -r requirements/_base.txt
 psycopg2-binary==2.8.6    # via -r requirements/_base.txt, aiopg, sqlalchemy
 py==1.9.0                 # via pytest
 pycparser==2.20           # via cffi
-pydantic==1.6.1           # via -r requirements/_base.txt
+pydantic==1.7.2           # via -r requirements/_base.txt
 pylint==2.6.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging
@@ -65,13 +68,15 @@ termcolor==1.1.0          # via pytest-sugar
 texttable==1.6.3          # via docker-compose
 toml==0.10.1              # via pylint, pytest
 trafaret==2.1.0           # via -r requirements/_base.txt
-typing-extensions==3.7.4.3  # via -r requirements/_base.txt, aiohttp
+typed-ast==1.4.1          # via astroid
+typing-extensions==3.7.4.3  # via -r requirements/_base.txt, aiohttp, yarl
 ujson==4.0.1              # via -r requirements/_base.txt
 urllib3==1.25.11          # via requests
 websocket-client==0.57.0  # via docker, docker-compose
 werkzeug==1.0.1           # via -r requirements/_base.txt
 wrapt==1.12.1             # via astroid
 yarl==1.5.1               # via -r requirements/_base.txt, aiohttp
+zipp==3.4.0               # via -r requirements/_base.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -7,7 +7,7 @@
 aiodebug==1.1.2           # via -r requirements/_base.txt
 aiohttp==3.7.2            # via -r requirements/_base.txt, aiozipkin, pytest-aiohttp
 aiopg[sa]==1.0.0          # via -r requirements/_base.txt
-aiozipkin==1.0.0          # via -r requirements/_base.txt
+aiozipkin==0.7.1          # via -r requirements/_base.txt
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp
 attrs==20.3.0             # via -r requirements/_base.txt, aiohttp, jsonschema, openapi-core, pytest, pytest-docker

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -8,7 +8,7 @@ aiofiles==0.5.0           # via -r requirements/_base.in
 aiohttp==3.6.3            # via -r requirements/_base.in
 aiopg[sa]==1.0.0          # via -r requirements/_base.in
 async-timeout==3.0.1      # via aiohttp
-attrs==19.3.0             # via -r requirements/_base.in, aiohttp
+attrs==20.3.0             # via -r requirements/_base.in, aiohttp
 chardet==3.0.4            # via aiohttp
 dataclasses==0.7          # via pydantic
 decorator==4.4.2          # via networkx

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -17,7 +17,7 @@ idna==2.10                # via idna-ssl, yarl
 multidict==4.7.6          # via aiohttp, yarl
 networkx==2.5             # via -r requirements/_base.in
 psycopg2-binary==2.8.6    # via -r requirements/_base.in, aiopg, sqlalchemy
-pydantic==1.6.1           # via -r requirements/_base.in
+pydantic==1.7.2           # via -r requirements/_base.in
 pyyaml==5.3.1             # via trafaret-config
 six==1.15.0               # via tenacity
 sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via aiopg

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -9,7 +9,7 @@ aiohttp==3.6.3            # via -r requirements/_base.txt, pytest-aiohttp
 aiopg[sa]==1.0.0          # via -r requirements/_base.txt
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp
-attrs==19.3.0             # via -r requirements/_base.txt, aiohttp, jsonschema, pytest, pytest-docker
+attrs==20.3.0             # via -r requirements/_base.txt, aiohttp, jsonschema, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
 cached-property==1.5.2    # via docker-compose
 certifi==2020.6.20        # via requests

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -42,7 +42,7 @@ pluggy==0.13.1            # via pytest
 psycopg2-binary==2.8.6    # via -r requirements/_base.txt, aiopg, sqlalchemy
 py==1.9.0                 # via pytest
 pycparser==2.20           # via cffi
-pydantic==1.6.1           # via -r requirements/_base.txt
+pydantic==1.7.2           # via -r requirements/_base.txt
 pylint==2.6.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging

--- a/scripts/requirements/Dockerfile
+++ b/scripts/requirements/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
   && apt-get -y install --no-install-recommends\
   make \
   git \
+  gawk \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
 

--- a/scripts/requirements/Makefile
+++ b/scripts/requirements/Makefile
@@ -32,8 +32,8 @@ _input-requirements = $(shell find ${PACKAGES_DIR} -type f -name _base.in)
 _input-requirements += $(shell find $(REPODIR)/api/tests/ -type f -name "*.in")
 # system tests
 _input-requirements += $(shell find $(REPODIR)/tests/ -type f -name "*.in")
-# services/*/_*.in
-_input-requirements += $(shell find ${SERVICES_DIR} -type f -name "_*.in")
+# services tests libraries, tools and fixtures
+_input-requirements += $(shell find ${SERVICES_DIR} -type f -name "_test.in")
 
 $(info Found $(_input-requirements))
 

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -37,7 +37,7 @@ orjson==3.3.1             # via fastapi
 promise==2.3              # via graphql-core, graphql-relay
 psycopg2-binary==2.8.6    # via aiopg, sqlalchemy
 pycparser==2.20           # via cffi
-pydantic[dotenv]==1.6.1   # via -r requirements/_base.in, fastapi
+pydantic[dotenv]==1.7.2   # via -r requirements/_base.in, fastapi
 python-dotenv==0.14.0     # via pydantic
 python-multipart==0.0.5   # via fastapi
 pyyaml==5.3.1             # via fastapi

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -35,7 +35,7 @@ docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 email-validator==1.1.1    # via -r requirements/_base.txt, fastapi
-faker==4.14.0             # via -r requirements/_test.in
+faker==4.14.2             # via -r requirements/_test.in
 fastapi[all]==0.61.1      # via -r requirements/_base.txt
 graphene==2.1.8           # via -r requirements/_base.txt, fastapi
 graphql-core==2.3.2       # via -r requirements/_base.txt, graphene, graphql-relay
@@ -94,7 +94,7 @@ starlette==0.13.6         # via -r requirements/_base.txt, fastapi
 tenacity==6.2.0           # via -r requirements/_base.txt
 text-unidecode==1.3       # via faker
 texttable==1.6.3          # via docker-compose
-toml==0.10.1              # via pylint, pytest
+toml==0.10.2              # via pylint, pytest
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/_base.txt, aiohttp, yarl
 ujson==3.2.0              # via -r requirements/_base.txt, fastapi

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -68,7 +68,7 @@ psycopg2-binary==2.8.6    # via -r requirements/_base.txt, aiopg, sqlalchemy
 ptvsd==4.3.2              # via -r requirements/_test.in
 py==1.9.0                 # via pytest
 pycparser==2.20           # via -r requirements/_base.txt, cffi
-pydantic[dotenv]==1.6.1   # via -r requirements/_base.txt, fastapi
+pydantic[dotenv]==1.7.2   # via -r requirements/_base.txt, fastapi
 pylint==2.6.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -33,7 +33,7 @@ multidict==4.7.6          # via yarl
 orjson==3.3.1             # via fastapi
 promise==2.3              # via graphql-core, graphql-relay
 psycopg2-binary==2.8.6    # via aiopg, sqlalchemy
-pydantic[dotenv,email]==1.6.1  # via -r requirements/../../../packages/models-library/requirements/_base.in, -r requirements/_base.in, fastapi
+pydantic[dotenv,email]==1.7.2  # via -r requirements/../../../packages/models-library/requirements/_base.in, -r requirements/_base.in, fastapi
 python-dotenv==0.14.0     # via pydantic
 python-multipart==0.0.5   # via fastapi
 pyyaml==5.3.1             # via -r requirements/_base.in, fastapi

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -66,7 +66,7 @@ psycopg2-binary==2.8.6    # via -r requirements/_base.txt, aiopg, sqlalchemy
 ptvsd==4.3.2              # via -r requirements/_test.in
 py==1.9.0                 # via pytest
 pycparser==2.20           # via cffi
-pydantic[dotenv,email]==1.6.1  # via -r requirements/_base.txt, fastapi
+pydantic[dotenv,email]==1.7.2  # via -r requirements/_base.txt, fastapi
 pylint==2.6.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -33,7 +33,7 @@ docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 email-validator==1.1.1    # via -r requirements/_base.txt, fastapi, pydantic
-faker==4.14.0             # via -r requirements/_test.in
+faker==4.14.2             # via -r requirements/_test.in
 fastapi[all]==0.61.1      # via -r requirements/_base.txt
 graphene==2.1.8           # via -r requirements/_base.txt, fastapi
 graphql-core==2.3.2       # via -r requirements/_base.txt, graphene, graphql-relay

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -13,7 +13,7 @@ astroid==2.4.2            # via pylint
 async-exit-stack==1.0.1   # via -r requirements/_base.txt, fastapi
 async-generator==1.10     # via -r requirements/_base.txt, fastapi
 async-timeout==3.0.1      # via aiohttp
-attrs==19.3.0             # via aiohttp, jsonschema, pytest, pytest-docker
+attrs==20.3.0             # via aiohttp, jsonschema, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
 cached-property==1.5.1    # via docker-compose
 certifi==2020.6.20        # via -r requirements/_base.txt, httpx, requests

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -32,7 +32,7 @@ markupsafe==1.1.1         # via jinja2
 multidict==4.7.6          # via aiohttp, yarl
 orjson==3.4.0             # via fastapi
 promise==2.3              # via graphql-core, graphql-relay
-pydantic[dotenv]==1.6.1   # via -r requirements/_base.in, fastapi
+pydantic[dotenv]==1.7.2   # via -r requirements/_base.in, fastapi
 python-dotenv==0.14.0     # via pydantic
 python-multipart==0.0.5   # via fastapi
 pyyaml==5.3.1             # via fastapi

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -33,13 +33,13 @@ docker[ssh]==4.3.1        # via -r requirements/_test.in, docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 email-validator==1.1.1    # via -r requirements/_base.txt, fastapi
-faker==4.14.0             # via -r requirements/_test.in
+faker==4.14.2             # via -r requirements/_test.in
 fastapi[all]==0.61.1      # via -r requirements/_base.txt
 graphene==2.1.8           # via -r requirements/_base.txt, fastapi
 graphql-core==2.3.2       # via -r requirements/_base.txt, graphene, graphql-relay
 graphql-relay==2.0.1      # via -r requirements/_base.txt, graphene
 h11==0.9.0                # via -r requirements/_base.txt, httpcore, uvicorn
-httpcore==0.12.0          # via httpx
+httpcore==0.12.1          # via httpx
 httptools==0.1.1          # via -r requirements/_base.txt, uvicorn
 httpx==0.16.1             # via respx
 idna-ssl==1.1.0           # via -r requirements/_base.txt, aiohttp
@@ -81,7 +81,7 @@ python-editor==1.0.4      # via alembic
 python-multipart==0.0.5   # via -r requirements/_base.txt, fastapi
 pyyaml==5.3.1             # via -r requirements/_base.txt, docker-compose, fastapi
 requests==2.24.0          # via -r requirements/_base.txt, codecov, coveralls, docker, docker-compose, fastapi
-respx==0.14.0             # via -r requirements/_test.in
+respx==0.15.0             # via -r requirements/_test.in
 rfc3986[idna2008]==1.4.0  # via httpx
 rx==1.6.1                 # via -r requirements/_base.txt, graphql-core
 six==1.15.0               # via -r requirements/_base.txt, astroid, bcrypt, cryptography, docker, dockerpty, graphene, graphql-core, graphql-relay, jsonschema, packaging, promise, pynacl, python-dateutil, python-multipart, tenacity, websocket-client
@@ -91,7 +91,7 @@ starlette==0.13.6         # via -r requirements/_base.txt, fastapi
 tenacity==6.2.0           # via -r requirements/_base.txt
 text-unidecode==1.3       # via faker
 texttable==1.6.3          # via docker-compose
-toml==0.10.1              # via pylint, pytest
+toml==0.10.2              # via pylint, pytest
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/_base.txt, aiodocker, aiohttp, yarl
 ujson==3.2.0              # via -r requirements/_base.txt, fastapi

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -64,7 +64,7 @@ promise==2.3              # via -r requirements/_base.txt, graphql-core, graphql
 ptvsd==4.3.2              # via -r requirements/_test.in
 py==1.9.0                 # via pytest
 pycparser==2.20           # via cffi
-pydantic[dotenv]==1.6.1   # via -r requirements/_base.txt, fastapi
+pydantic[dotenv]==1.7.2   # via -r requirements/_base.txt, fastapi
 pylint==2.6.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging

--- a/services/director/requirements/Makefile
+++ b/services/director/requirements/Makefile
@@ -4,3 +4,7 @@
 include ../../../scripts/requirements.Makefile
 
 # Add here any extra explicit dependency: e.g. _migration.txt: _base.txt
+
+
+_test.txt: _base.txt _test.in
+	@echo INFO: test.txt is frozen. Skipping upgrade.

--- a/services/director/requirements/_test.in
+++ b/services/director/requirements/_test.in
@@ -5,6 +5,12 @@
 # frozen specs
 -r _base.txt
 
+# NOTE:
+# FROZEN  (see notes in _base.in)
+# DO NOT CHANGE ANYTHING HERE.
+# IT WON'T HAVE ANY EFFECT
+#
+
 # testing
 coverage==4.5.1 # TODO: Downgraded because of a bug https://github.com/nedbat/coveragepy/issues/716
 pytest

--- a/services/sidecar/requirements/Makefile
+++ b/services/sidecar/requirements/Makefile
@@ -5,4 +5,4 @@ include ../../../scripts/requirements.Makefile
 
 # Add here any extra explicit dependency: e.g. _migration.txt: _base.txt
 
-_packages.txt: _base.txt
+_packages.in: _base.txt

--- a/services/sidecar/requirements/_base.txt
+++ b/services/sidecar/requirements/_base.txt
@@ -35,7 +35,7 @@ networkx==2.5             # via -r requirements/_base.in
 packaging==20.4           # via -r requirements/_base.in
 pamqp==2.3.0              # via aiormq
 psycopg2-binary==2.8.6    # via -c requirements/../../../packages/service-library/requirements/_base.in, aiopg, sqlalchemy
-pydantic[email]==1.6.1    # via -c requirements/../../../packages/models-library/requirements/_base.in, -r requirements/_base.in
+pydantic[email]==1.7.2    # via -c requirements/../../../packages/models-library/requirements/_base.in, -c requirements/../../../packages/service-library/requirements/_base.in, -r requirements/_base.in
 pyparsing==2.4.7          # via packaging
 pytz==2020.1              # via celery
 redis==3.5.3              # via celery

--- a/services/sidecar/requirements/_packages.txt
+++ b/services/sidecar/requirements/_packages.txt
@@ -28,7 +28,7 @@ openapi-core==0.12.0      # via -r requirements/../../../packages/service-librar
 openapi-spec-validator==0.2.9  # via openapi-core
 prometheus-client==0.8.0  # via -r requirements/../../../packages/service-library/requirements/_base.in
 psycopg2-binary==2.8.6    # via -c requirements/_base.txt, -r requirements/../../../packages/service-library/requirements/_base.in, aiopg, sqlalchemy
-pydantic[email]==1.6.1    # via -c requirements/_base.txt, -r requirements/../../../packages/models-library/requirements/_base.in
+pydantic[email]==1.7.2           # via -c requirements/_base.txt, -r requirements/../../../packages/models-library/requirements/_base.in, -r requirements/../../../packages/service-library/requirements/_base.in
 pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via minio
 pytz==2020.1              # via -c requirements/_base.txt, minio

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -86,7 +86,7 @@ sqlalchemy[postgresql_psycopg2binary]==1.3.19  # via -r requirements/_base.txt, 
 strict-rfc3339==0.7       # via -r requirements/_packages.txt, openapi-core
 tenacity==6.2.0           # via -r requirements/_base.txt, -r requirements/_packages.txt
 termcolor==1.1.0          # via pytest-sugar
-toml==0.10.1              # via pylint, pytest
+toml==0.10.2              # via pylint, pytest
 trafaret==2.1.0           # via -r requirements/_packages.txt
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/_base.txt, -r requirements/_packages.txt, aiodocker, aiohttp, yarl

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -10,7 +10,7 @@ aiodocker==0.19.1         # via -r requirements/_base.txt
 aiofile==3.1.0            # via -r requirements/_base.txt
 aiofiles==0.5.0           # via -r requirements/_base.txt
 aiohttp==3.6.3            # via -r requirements/_base.txt, -r requirements/_packages.txt, aiodocker, aiozipkin, pytest-aiohttp
-aiopg[sa]==1.0.0              # via -r requirements/_base.txt, -r requirements/_packages.txt, -r requirements/_test.in
+aiopg[sa]==1.0.0          # via -r requirements/_base.txt, -r requirements/_packages.txt, -r requirements/_test.in
 aioredis==1.3.1           # via -r requirements/_base.txt, aioredlock
 aioredlock==0.5.2         # via -r requirements/_base.txt
 aiormq==3.2.3             # via -r requirements/_base.txt, aio-pika
@@ -62,7 +62,7 @@ prometheus-client==0.8.0  # via -r requirements/_packages.txt
 psycopg2-binary==2.8.6    # via -r requirements/_base.txt, -r requirements/_packages.txt, aiopg, sqlalchemy
 ptvsd==4.3.2              # via -r requirements/_test.in
 py==1.9.0                 # via pytest
-pydantic[email]==1.7.2           # via -r requirements/_base.txt, -r requirements/_packages.txt
+pydantic[email]==1.7.2    # via -r requirements/_base.txt, -r requirements/_packages.txt
 pylint==2.6.0             # via -r requirements/_test.in
 pyparsing==2.4.7          # via -r requirements/_base.txt, packaging
 pyrsistent==0.17.3        # via -r requirements/_packages.txt, jsonschema

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -10,7 +10,7 @@ aiodocker==0.19.1         # via -r requirements/_base.txt
 aiofile==3.1.0            # via -r requirements/_base.txt
 aiofiles==0.5.0           # via -r requirements/_base.txt
 aiohttp==3.6.3            # via -r requirements/_base.txt, -r requirements/_packages.txt, aiodocker, aiozipkin, pytest-aiohttp
-aiopg[sa]==1.0.0          # via -r requirements/_base.txt, -r requirements/_packages.txt, -r requirements/_test.in
+aiopg[sa]==1.0.0              # via -r requirements/_base.txt, -r requirements/_packages.txt, -r requirements/_test.in
 aioredis==1.3.1           # via -r requirements/_base.txt, aioredlock
 aioredlock==0.5.2         # via -r requirements/_base.txt
 aiormq==3.2.3             # via -r requirements/_base.txt, aio-pika
@@ -62,7 +62,7 @@ prometheus-client==0.8.0  # via -r requirements/_packages.txt
 psycopg2-binary==2.8.6    # via -r requirements/_base.txt, -r requirements/_packages.txt, aiopg, sqlalchemy
 ptvsd==4.3.2              # via -r requirements/_test.in
 py==1.9.0                 # via pytest
-pydantic[email]==1.6.1    # via -r requirements/_base.txt, -r requirements/_packages.txt
+pydantic[email]==1.7.2           # via -r requirements/_base.txt, -r requirements/_packages.txt
 pylint==2.6.0             # via -r requirements/_test.in
 pyparsing==2.4.7          # via -r requirements/_base.txt, packaging
 pyrsistent==0.17.3        # via -r requirements/_packages.txt, jsonschema

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -45,7 +45,7 @@ prometheus-client==0.8.0  # via -r requirements/../../../packages/service-librar
 protobuf==3.13.0          # via blackfynn
 psutil==5.7.3             # via blackfynn
 psycopg2-binary==2.8.6    # via -r requirements/../../../packages/service-library/requirements/_base.in, aiopg, sqlalchemy
-pydantic[email]==1.7.1    # via -r requirements/../../../packages/models-library/requirements/_base.in, -r requirements/../../../packages/service-library/requirements/_base.in
+pydantic[email]==1.7.2    # via -r requirements/../../../packages/models-library/requirements/_base.in, -r requirements/../../../packages/service-library/requirements/_base.in
 pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via blackfynn, botocore, minio
 pytz==2020.1              # via blackfynn, minio

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -7,7 +7,7 @@
 aiobotocore==1.0.7        # via -r requirements/_base.txt
 aiodebug==1.1.2           # via -r requirements/_base.txt
 aiofiles==0.6.0           # via -r requirements/_base.txt
-aiohttp-swagger==1.0.15   # via -r requirements/_base.txt
+aiohttp-swagger[performance]==1.0.15  # via -r requirements/_base.txt
 aiohttp==3.7.2            # via -r requirements/_base.txt, aiobotocore, aiohttp-swagger, aiozipkin, pytest-aiohttp
 aioitertools==0.7.0       # via -r requirements/_base.txt, aiobotocore
 aiopg[sa]==1.0.0          # via -r requirements/_base.txt
@@ -54,11 +54,11 @@ markupsafe==1.1.1         # via -r requirements/_base.txt, aiohttp-swagger, jinj
 mccabe==0.6.1             # via pylint
 minio==6.0.0              # via -r requirements/_base.txt
 multidict==5.0.0          # via -r requirements/_base.txt, aiohttp, yarl
-numpy==1.19.3             # via pandas
+numpy==1.19.4             # via pandas
 openapi-core==0.12.0      # via -r requirements/_base.txt
 openapi-spec-validator==0.2.9  # via -r requirements/_base.txt, openapi-core
 packaging==20.4           # via pytest, pytest-sugar
-pandas==1.1.3             # via -r requirements/_test.in
+pandas==1.1.4             # via -r requirements/_test.in
 paramiko==2.7.2           # via docker
 pluggy==0.13.1            # via pytest
 prometheus-client==0.8.0  # via -r requirements/_base.txt
@@ -95,7 +95,7 @@ strict-rfc3339==0.7       # via -r requirements/_base.txt, openapi-core
 tenacity==6.2.0           # via -r requirements/_base.txt
 termcolor==1.1.0          # via pytest-sugar
 texttable==1.6.3          # via docker-compose
-toml==0.10.1              # via pylint, pytest
+toml==0.10.2              # via pylint, pytest
 trafaret==2.1.0           # via -r requirements/_base.txt
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/_base.txt, aiohttp, aioitertools, yarl

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -68,7 +68,7 @@ psycopg2-binary==2.8.6    # via -r requirements/_base.txt, aiopg, sqlalchemy
 ptvsd==4.3.2              # via -r requirements/_test.in
 py==1.9.0                 # via pytest
 pycparser==2.20           # via cffi
-pydantic[email]==1.7.1    # via -r requirements/_base.txt
+pydantic[email]==1.7.2    # via -r requirements/_base.txt
 pylint==2.6.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -20,7 +20,7 @@ aiozipkin==0.7.0          # via -r requirements/../../../../packages/service-lib
 amqp==5.0.1               # via kombu
 async-timeout==3.0.1      # via aiohttp, aioredis
 asyncpg==0.21.0           # via -r requirements/_base.in
-attrs==20.2.0             # via -r requirements/../../../../packages/service-library/requirements/_base.in, aiohttp, aioredlock, jsonschema, openapi-core
+attrs==20.3.0             # via -r requirements/../../../../packages/service-library/requirements/_base.in, aiohttp, aioredlock, jsonschema, openapi-core
 billiard==3.6.3.0         # via celery
 celery[redis]==5.0.1      # via -r requirements/_base.in
 cffi==1.14.2              # via cryptography

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -56,7 +56,7 @@ prometheus-client==0.8.0  # via -r requirements/../../../../packages/service-lib
 prompt-toolkit==3.0.8     # via click-repl
 psycopg2-binary==2.8.5    # via -r requirements/../../../../packages/service-library/requirements/_base.in, aiopg, sqlalchemy
 pycparser==2.20           # via cffi
-pydantic[email]==1.6.1    # via -r requirements/../../../../packages/models-library/requirements/_base.in, -r requirements/_base.in
+pydantic[email]==1.7.2    # via -r requirements/../../../../packages/models-library/requirements/_base.in, -r requirements/../../../../packages/service-library/requirements/_base.in, -r requirements/_base.in
 pyrsistent==0.16.0        # via jsonschema
 python-engineio==3.13.2   # via python-socketio
 python-socketio==4.6.0    # via -r requirements/_base.in

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -16,7 +16,7 @@ aioredis==1.3.1           # via -r requirements/_base.in, aioredlock
 aioredlock==0.5.2         # via -r requirements/_base.in
 aiormq==3.2.3             # via aio-pika
 aiosmtplib==1.1.3         # via -r requirements/_base.in
-aiozipkin==0.7.0          # via -r requirements/../../../../packages/service-library/requirements/_base.in
+aiozipkin==0.7.1          # via -r requirements/../../../../packages/service-library/requirements/_base.in
 amqp==5.0.1               # via kombu
 async-timeout==3.0.1      # via aiohttp, aioredis
 asyncpg==0.21.0           # via -r requirements/_base.in

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -16,7 +16,7 @@ aioredis==1.3.1           # via -r requirements/_base.txt, aioredlock
 aioredlock==0.5.2         # via -r requirements/_base.txt
 aiormq==3.2.3             # via -r requirements/_base.txt, aio-pika
 aiosmtplib==1.1.3         # via -r requirements/_base.txt
-aiozipkin==0.7.0          # via -r requirements/_base.txt
+aiozipkin==0.7.1          # via -r requirements/_base.txt
 alembic==1.4.2            # via -r requirements/_test.in
 amqp==5.0.1               # via -r requirements/_base.txt, kombu
 astroid==2.4.2            # via pylint

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -22,7 +22,7 @@ amqp==5.0.1               # via -r requirements/_base.txt, kombu
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via -r requirements/_base.txt, aiohttp, aioredis
 asyncpg==0.21.0           # via -r requirements/_base.txt
-attrs==20.2.0             # via -r requirements/_base.txt, aiohttp, aioredlock, jsonschema, openapi-core, pytest, pytest-docker
+attrs==20.3.0             # via -r requirements/_base.txt, aiohttp, aioredlock, jsonschema, openapi-core, pytest, pytest-docker
 bcrypt==3.2.0             # via paramiko
 billiard==3.6.3.0         # via -r requirements/_base.txt, celery
 cached-property==1.5.1    # via docker-compose

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -82,7 +82,7 @@ psycopg2-binary==2.8.5    # via -r requirements/_base.txt, aiopg, sqlalchemy
 ptvsd==4.3.2              # via -r requirements/_test.in
 py==1.9.0                 # via pytest
 pycparser==2.20           # via -r requirements/_base.txt, cffi
-pydantic[email]==1.6.1    # via -r requirements/_base.txt
+pydantic==1.7.2           # via -r requirements/_base.txt
 pylint==2.5.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -47,7 +47,7 @@ dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via coveralls, docker-compose
 email-validator==1.1.1    # via -r requirements/_base.txt, pydantic
 expiringdict==1.2.1       # via -r requirements/_base.txt
-faker==4.14.0             # via -r requirements/_test.in
+faker==4.14.2             # via -r requirements/_test.in
 hiredis==1.1.0            # via -r requirements/_base.txt, aioredis
 icdiff==1.9.1             # via pytest-icdiff
 idna-ssl==1.1.0           # via -r requirements/_base.txt, aiohttp

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -82,7 +82,7 @@ psycopg2-binary==2.8.5    # via -r requirements/_base.txt, aiopg, sqlalchemy
 ptvsd==4.3.2              # via -r requirements/_test.in
 py==1.9.0                 # via pytest
 pycparser==2.20           # via -r requirements/_base.txt, cffi
-pydantic==1.7.2           # via -r requirements/_base.txt
+pydantic[email]==1.7.2    # via -r requirements/_base.txt
 pylint==2.5.0             # via -r requirements/_test.in
 pynacl==1.4.0             # via paramiko
 pyparsing==2.4.7          # via packaging

--- a/tests/environment-setup/requirements/requirements.txt
+++ b/tests/environment-setup/requirements/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiohttp==3.7.2            # via pytest-aiohttp
 async-timeout==3.0.1      # via aiohttp
-attrs==20.2.0             # via aiohttp, pytest
+attrs==20.3.0             # via aiohttp, pytest
 chardet==3.0.4            # via aiohttp
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via idna-ssl, yarl
@@ -24,7 +24,7 @@ pytest-sugar==0.9.4       # via -r requirements/requirements.in
 pytest==6.1.2             # via -r requirements/requirements.in, pytest-aiohttp, pytest-instafail, pytest-sugar
 six==1.15.0               # via packaging
 termcolor==1.1.0          # via pytest-sugar
-toml==0.10.1              # via pytest
+toml==0.10.2              # via pytest
 typing-extensions==3.7.4.3  # via aiohttp, yarl
 yarl==1.6.2               # via aiohttp
 zipp==3.4.0               # via importlib-metadata

--- a/tests/swarm-deploy/requirements/requirements.txt
+++ b/tests/swarm-deploy/requirements/requirements.txt
@@ -9,8 +9,8 @@ aiohttp==3.7.2            # via pytest-aiohttp
 aiormq==3.3.1             # via aio-pika
 alembic==1.4.3            # via -r requirements/requirements.in
 async-timeout==3.0.1      # via aiohttp
-attrs==20.2.0             # via aiohttp, pytest
-certifi==2020.6.20        # via requests
+attrs==20.3.0             # via aiohttp, pytest
+certifi==2020.11.8        # via requests
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via -r requirements/requirements.in
 coverage==5.3             # via -r requirements/requirements.in, pytest-cov
@@ -43,7 +43,7 @@ six==1.15.0               # via docker, packaging, python-dateutil, tenacity, we
 sqlalchemy==1.3.20        # via alembic
 tenacity==6.2.0           # via -r requirements/requirements.in
 termcolor==1.1.0          # via pytest-sugar
-toml==0.10.1              # via pytest
+toml==0.10.2              # via pytest
 typing-extensions==3.7.4.3  # via aiohttp, yarl
 urllib3==1.25.11          # via requests
 websocket-client==0.57.0  # via docker


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

Weekly upgrade of python dependencies.

- Main library upgrades (see links to Bump PR below):
   - pydantic (minor)
   - attrs (patch)
   - faker (patch)
   - aiozipkin frozen to 0.7.1 due to incompatibilities
- Some test libraries and tools in packages as well (not in services)
- Tuning in Makefile recipes and Dockerfile (adds awk to display help)