### PR TITLE
e2e: split remove study

### DIFF
--- a/tests/e2e/tutorials/jupyters.js
+++ b/tests/e2e/tutorials/jupyters.js
@@ -102,6 +102,7 @@ async function runTutorial() {
     ];
     await tutorial.checkResults(outFiles2.length);
 
+    await tutorial.closeStudy();
 
     await tutorial.removeStudy();
   }

--- a/tests/e2e/tutorials/mattward.js
+++ b/tests/e2e/tutorials/mattward.js
@@ -43,6 +43,8 @@ async function runTutorial() {
     ];
     await tutorial.checkResults(outFiles.length);
 
+    await tutorial.closeStudy();
+
     await tutorial.removeStudy();
   }
   catch(err) {

--- a/tests/e2e/tutorials/sim4life.js
+++ b/tests/e2e/tutorials/sim4life.js
@@ -29,6 +29,8 @@ async function runTutorial() {
     // Wait for some time
     await tutorial.waitFor(12000);
 
+    await tutorial.closeStudy();
+
     await tutorial.removeStudy();
   }
   catch(err) {

--- a/tests/e2e/tutorials/sleepers.js
+++ b/tests/e2e/tutorials/sleepers.js
@@ -40,6 +40,8 @@ async function runTutorial() {
     await tutorial.openNodeFiles(4);
     await tutorial.checkResults(outFiles.length);
 
+    await tutorial.closeStudy();
+
     await tutorial.removeStudy();
   }
   catch(err) {

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -291,17 +291,17 @@ class TutorialBase {
 
   async removeStudy() {
     await auto.toDashboard(this.__page);
-    await this.takeScreenshot("dashboardDeleteFirstStudy_before");
+    await this.takeScreenshot("deleteFirstStudy_before");
     this.__responsesQueue.addResponseListener("projects/");
     try {
-      await auto.dashboardDeleteFirstStudy(this.__page, this.__templateName);
+      await auto.deleteFirstStudy(this.__page, this.__templateName);
       await this.__responsesQueue.waitUntilResponse("projects/");
     }
     catch(err) {
       console.error("Failed deleting study", err);
       throw(err);
     }
-    await this.takeScreenshot("dashboardDeleteFirstStudy_after");
+    await this.takeScreenshot("deleteFirstStudy_after");
   }
 
   async logOut() {

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -289,8 +289,21 @@ class TutorialBase {
     await this.takeScreenshot("checkResults_after");
   }
 
+  async closeStudy() {
+    await this.takeScreenshot("closeStudy_before");
+    this.__responsesQueue.addResponseListener(":close");
+    try {
+      await auto.toDashboard(this.__page);
+      await this.__responsesQueue.waitUntilResponse(":close");
+    }
+    catch(err) {
+      console.error("Failed closing study", err);
+      throw(err);
+    }
+    await this.takeScreenshot("closeStudy_after");
+  }
+
   async removeStudy() {
-    await auto.toDashboard(this.__page);
     await this.takeScreenshot("deleteFirstStudy_before");
     this.__responsesQueue.addResponseListener("projects/");
     try {

--- a/tests/e2e/utils/auto.js
+++ b/tests/e2e/utils/auto.js
@@ -130,19 +130,7 @@ async function dashboardNewStudy(page) {
 async function toDashboard(page) {
   console.log("To Dashboard");
 
-  console.log("close study");
-  const responsesQueue = new responses.ResponsesQueue(page);
-  responsesQueue.addResponseListener(":close");
-
   await utils.waitAndClick(page, '[osparc-test-id="dashboardBtn"]');
-
-  try {
-    await responsesQueue.waitUntilResponse(":close");
-  }
-  catch (err) {
-    console.error(err);
-    throw (err);
-  }
 }
 
 async function dashboardOpenFirstTemplate(page, templateName) {

--- a/tests/e2e/utils/auto.js
+++ b/tests/e2e/utils/auto.js
@@ -241,7 +241,7 @@ async function runStudy(page) {
   }
 }
 
-async function dashboardDeleteFirstStudy(page, studyName) {
+async function deleteFirstStudy(page, studyName) {
   console.log("Deleting first study")
 
   await utils.waitAndClick(page, '[osparc-test-id="studiesTabBtn"]')
@@ -373,7 +373,7 @@ module.exports = {
   dashboardOpenFirstService,
   clickLoggerTitle,
   runStudy,
-  dashboardDeleteFirstStudy,
+  deleteFirstStudy,
   toDashboard,
   openNode,
   openLastNode,


### PR DESCRIPTION
## What do these changes do?

The last step in the e2e testing is to remove the created study. This PR splits that step into two different steps: closeStudy (back to Dashboard) and delete the study.

Sometimes the old merged function was running into troubles because an expected answer was received before starting to listen to it.