### PR TITLE
Hide DownloadLink in File Picker

### DIFF
--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -111,6 +111,8 @@ qx.Class.define("osparc.file.FilePicker", {
           });
           control = new osparc.file.FileDownloadLink();
           groupBox.add(control);
+          // SAn: Remove the following line as soon as the node-ports support the download link
+          groupBox.exclude();
           this._add(groupBox);
           break;
         }


### PR DESCRIPTION
This PR hides the DownloadLink section in the File Picker.

Once the node-ports support the download link @sanderegg will bring it back.