### PR TITLE
Bring back dynamic services retrieve/push

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/services_api_mocks_for_aiohttp_clients.py
+++ b/packages/pytest-simcore/src/pytest_simcore/services_api_mocks_for_aiohttp_clients.py
@@ -11,8 +11,15 @@ def creation_cb(url, **kwargs):
     body = kwargs["json"]
     for param in ["user_id", "project_id"]:
         assert param in body, f"{param} is missing from body: {body}"
+    state = (
+        RunningState.PUBLISHED
+        if "start_pipeline" in body and body["start_pipeline"]
+        else RunningState.NOT_STARTED
+    )
 
-    return CallbackResult(status=201, payload={"id": kwargs["json"]["project_id"]})
+    return CallbackResult(
+        status=201, payload={"id": kwargs["json"]["project_id"], "state": state}
+    )
 
 
 @pytest.fixture

--- a/services/director-v2/Makefile
+++ b/services/director-v2/Makefile
@@ -11,10 +11,13 @@ requirements reqs: ## (or reqs) compiles pip requirements (.in -> .txt)
 	@$(MAKE_C) requirements reqs
 
 
-.PHONY: openapi-specs
+.PHONY: openapi.json
 openapi-specs: openapi.json
-openapi.json:
-	# generating openapi specs file
+openapi.json: .env
+	# generating openapi specs file (need to have the environment set for this)
+	@set -o allexport; \
+	source .env; \
+	set +o allexport; \
 	python3 -c "import json; from $(APP_PACKAGE_NAME).__main__ import *; print( json.dumps(the_app.openapi(), indent=2) )" > $@
 
 

--- a/services/director-v2/openapi.json
+++ b/services/director-v2/openapi.json
@@ -53,68 +53,15 @@
             "description": "The service type:\n   - computational - a computational service\n   - interactive - an interactive service\n",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/ServiceType"
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ServiceType"
+                }
+              ],
+              "description": "The service type:\n   - computational - a computational service\n   - interactive - an interactive service\n"
             },
             "name": "service_type",
             "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServicesArrayEnveloped"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v0/services/{service_key}/{service_version}": {
-      "get": {
-        "tags": [
-          "services"
-        ],
-        "summary": "Get Service Versioned",
-        "description": "Returns details of the selected service if available in the platform",
-        "operationId": "get_service_versioned_v0_services__service_key___service_version__get",
-        "parameters": [
-          {
-            "description": "Distinctive name for the node based on the docker registry path",
-            "required": true,
-            "schema": {
-              "title": "Service Key",
-              "pattern": "^(simcore)/(services)/(comp|dynamic)(/[^\\s/]+)+$",
-              "type": "string",
-              "description": "Distinctive name for the node based on the docker registry path"
-            },
-            "name": "service_key",
-            "in": "path"
-          },
-          {
-            "description": "The tag/version of the service",
-            "required": true,
-            "schema": {
-              "title": "Service Version",
-              "pattern": "^(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)){2}(-(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*)(\\.(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*))*)?(\\+[-\\da-zA-Z]+(\\.[-\\da-zA-Z-]+)*)?$",
-              "type": "string",
-              "description": "The tag/version of the service"
-            },
-            "name": "service_version",
-            "in": "path"
           }
         ],
         "responses": {
@@ -155,7 +102,7 @@
             "required": true,
             "schema": {
               "title": "Service Key",
-              "pattern": "^(simcore)/(services)/(comp|dynamic)(/[^\\s/]+)+$",
+              "pattern": "^(simcore)/(services)/(comp|dynamic|frontend)(/[^\\s/]+)+$",
               "type": "string",
               "description": "Distinctive name for the node based on the docker registry path"
             },
@@ -182,6 +129,64 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ServiceExtrasEnveloped"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/services/{service_key}/{service_version}": {
+      "get": {
+        "tags": [
+          "services"
+        ],
+        "summary": "Get Service Versioned",
+        "description": "Returns details of the selected service if available in the platform",
+        "operationId": "get_service_versioned_v0_services__service_key___service_version__get",
+        "parameters": [
+          {
+            "description": "Distinctive name for the node based on the docker registry path",
+            "required": true,
+            "schema": {
+              "title": "Service Key",
+              "pattern": "^(simcore)/(services)/(comp|dynamic|frontend)(/[^\\s/]+)+$",
+              "type": "string",
+              "description": "Distinctive name for the node based on the docker registry path"
+            },
+            "name": "service_key",
+            "in": "path"
+          },
+          {
+            "description": "The tag/version of the service",
+            "required": true,
+            "schema": {
+              "title": "Service Version",
+              "pattern": "^(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)){2}(-(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*)(\\.(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*))*)?(\\+[-\\da-zA-Z]+(\\.[-\\da-zA-Z-]+)*)?$",
+              "type": "string",
+              "description": "The tag/version of the service"
+            },
+            "name": "service_version",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServicesArrayEnveloped"
                 }
               }
             }
@@ -289,7 +294,7 @@
             "required": true,
             "schema": {
               "title": "Service Key",
-              "pattern": "^(simcore)/(services)/(comp|dynamic)(/[^\\s/]+)+$",
+              "pattern": "^(simcore)/(services)/(comp|dynamic|frontend)(/[^\\s/]+)+$",
               "type": "string",
               "description": "distinctive name for the node based on the docker registry path",
               "example": [
@@ -380,6 +385,195 @@
           }
         }
       }
+    },
+    "/v2/computations": {
+      "post": {
+        "tags": [
+          "computations"
+        ],
+        "summary": "Create and optionaly Start a new computation",
+        "operationId": "create_computation_v2_computations_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ComputationTaskCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ComputationTaskOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/computations/{project_id}": {
+      "get": {
+        "tags": [
+          "computations"
+        ],
+        "summary": "Returns a computation pipeline state",
+        "operationId": "get_computation_v2_computations__project_id__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string",
+              "format": "uuid"
+            },
+            "name": "project_id",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "exclusiveMinimum": 0.0,
+              "type": "integer"
+            },
+            "name": "user_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ComputationTaskOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "computations"
+        ],
+        "summary": "Deletes a computation pipeline",
+        "operationId": "delete_pipeline_v2_computations__project_id__delete",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string",
+              "format": "uuid"
+            },
+            "name": "project_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ComputationTaskDelete"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/computations/{project_id}:stop": {
+      "post": {
+        "tags": [
+          "computations"
+        ],
+        "summary": "Stops a computation pipeline",
+        "operationId": "stop_computation_project_v2_computations__project_id__stop_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string",
+              "format": "uuid"
+            },
+            "name": "project_id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ComputationTaskStop"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -396,25 +590,29 @@
             "title": "Name",
             "type": "string",
             "description": "Name of the author",
-            "example": [
-              "Sun Bak",
-              "Delenn"
-            ]
+            "example": "Jim Knopf"
           },
           "email": {
             "title": "Email",
             "type": "string",
             "description": "Email address",
             "format": "email",
-            "example": "sun@sense.eight"
+            "example": [
+              "sun@sense.eight",
+              "deleen@minbar.bab"
+            ]
           },
           "affiliation": {
             "title": "Affiliation",
             "type": "string",
             "description": "Affiliation of the author",
-            "example": "Sense8"
+            "example": [
+              "Sense8",
+              "Babylon 5"
+            ]
           }
-        }
+        },
+        "additionalProperties": false
       },
       "Badge": {
         "title": "Badge",
@@ -437,8 +635,11 @@
           },
           "image": {
             "title": "Image",
+            "maxLength": 2083,
+            "minLength": 1,
             "type": "string",
-            "description": "Url to the shield",
+            "description": "Url to the badge",
+            "format": "uri",
             "example": [
               "https://travis-ci.org/ITISFoundation/osparc-simcore.svg?branch=master",
               "https://coveralls.io/repos/github/ITISFoundation/osparc-simcore/badge.svg?branch=master",
@@ -447,13 +648,123 @@
           },
           "url": {
             "title": "Url",
+            "maxLength": 2083,
+            "minLength": 1,
             "type": "string",
-            "description": "Link to status",
+            "description": "Link to the status",
+            "format": "uri",
             "example": [
               "https://travis-ci.org/ITISFoundation/osparc-simcore 'State of CI: build, test and pushing images'",
               "https://coveralls.io/github/ITISFoundation/osparc-simcore?branch=master 'Test coverage'",
               "https://itisfoundation.github.io/"
             ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "ComputationTaskCreate": {
+        "title": "ComputationTaskCreate",
+        "required": [
+          "user_id",
+          "project_id"
+        ],
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "title": "User Id",
+            "exclusiveMinimum": 0.0,
+            "type": "integer"
+          },
+          "project_id": {
+            "title": "Project Id",
+            "type": "string",
+            "format": "uuid"
+          },
+          "start_pipeline": {
+            "title": "Start Pipeline",
+            "type": "boolean",
+            "description": "if True the computation pipeline will start right away",
+            "default": false
+          }
+        }
+      },
+      "ComputationTaskDelete": {
+        "title": "ComputationTaskDelete",
+        "required": [
+          "user_id"
+        ],
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "title": "User Id",
+            "exclusiveMinimum": 0.0,
+            "type": "integer"
+          },
+          "force": {
+            "title": "Force",
+            "type": "boolean",
+            "description": "if True then the pipeline will be removed even if it is running",
+            "default": false
+          }
+        }
+      },
+      "ComputationTaskOut": {
+        "title": "ComputationTaskOut",
+        "required": [
+          "id",
+          "state",
+          "url"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "the id of the computation task",
+            "format": "uuid"
+          },
+          "state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RunningState"
+              }
+            ],
+            "description": "the state of the computational task"
+          },
+          "result": {
+            "title": "Result",
+            "type": "string",
+            "description": "the result of the computational task"
+          },
+          "url": {
+            "title": "Url",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "the link where to get the status of the task",
+            "format": "uri"
+          },
+          "stop_url": {
+            "title": "Stop Url",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "the link where to stop the task",
+            "format": "uri"
+          }
+        }
+      },
+      "ComputationTaskStop": {
+        "title": "ComputationTaskStop",
+        "required": [
+          "user_id"
+        ],
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "title": "User Id",
+            "exclusiveMinimum": 0.0,
+            "type": "integer"
           }
         }
       },
@@ -467,95 +778,6 @@
             "items": {
               "$ref": "#/components/schemas/ValidationError"
             }
-          }
-        }
-      },
-      "ImageMetaData": {
-        "title": "ImageMetaData",
-        "required": [
-          "key",
-          "version",
-          "name",
-          "description",
-          "authors",
-          "contact",
-          "inputs",
-          "outputs"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "title": "Key",
-            "pattern": "^(simcore)/(services)/(comp|dynamic)(/[^\\s/]+)+$",
-            "type": "string",
-            "description": "distinctive name for the node based on the docker registry path",
-            "example": [
-              "simcore/services/comp/itis/sleeper",
-              "simcore/services/dynamic/3dviewer"
-            ]
-          },
-          "integration-version": {
-            "title": "Integration-Version",
-            "pattern": "^(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)){2}(-(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*)(\\.(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*))*)?(\\+[-\\da-zA-Z]+(\\.[-\\da-zA-Z-]+)*)?$",
-            "type": "string",
-            "description": "integration version number",
-            "example": "1.0.0"
-          },
-          "version": {
-            "title": "Version",
-            "pattern": "^(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)){2}(-(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*)(\\.(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*))*)?(\\+[-\\da-zA-Z]+(\\.[-\\da-zA-Z-]+)*)?$",
-            "type": "string",
-            "description": "service version number",
-            "example": "0.0.1"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string",
-            "description": "short, human readable name for the node",
-            "example": "Fast Counter"
-          },
-          "thumbnail": {
-            "title": "Thumbnail",
-            "type": "string",
-            "description": "url to the thumbnail",
-            "example": "https://user-images.githubusercontent.com/32800795/61083844-ff48fb00-a42c-11e9-8e63-fa2d709c8baf.png"
-          },
-          "badges": {
-            "title": "Badges",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Badge"
-            }
-          },
-          "description": {
-            "title": "Description",
-            "type": "string",
-            "description": "human readable description of the purpose of the node",
-            "example": "The mother of all nodes, makes your numbers shine!"
-          },
-          "authors": {
-            "title": "Authors",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Author"
-            }
-          },
-          "contact": {
-            "title": "Contact",
-            "type": "string",
-            "description": "email to correspond to the authors about the node",
-            "format": "email",
-            "example": "lab@net.flix"
-          },
-          "inputs": {
-            "title": "Inputs",
-            "type": "object",
-            "description": "definition of the inputs of this node"
-          },
-          "outputs": {
-            "title": "Outputs",
-            "type": "object",
-            "description": "definition of the outputs of this node"
           }
         }
       },
@@ -599,7 +821,8 @@
         "title": "NodeRequirement",
         "enum": [
           "CPU",
-          "GPU"
+          "GPU",
+          "MPI"
         ],
         "type": "string",
         "description": "An enumeration."
@@ -619,7 +842,7 @@
         "properties": {
           "published_port": {
             "title": "Published Port",
-            "minimum": 1.0,
+            "exclusiveMinimum": 0.0,
             "type": "integer",
             "description": "The ports where the service provides its interface"
           },
@@ -631,19 +854,28 @@
           "service_uuid": {
             "title": "Service Uuid",
             "type": "string",
-            "description": "The UUID attached to this service"
+            "description": "The UUID attached to this service",
+            "format": "uuid4"
           },
           "service_key": {
             "title": "Service Key",
-            "pattern": "^(simcore)/(services)/(comp|dynamic)(/[^\\s/]+)+$",
+            "pattern": "^(simcore)/(services)/(comp|dynamic|frontend)(/[^\\s/]+)+$",
             "type": "string",
-            "description": "distinctive name for the node based on the docker registry path"
+            "description": "distinctive name for the node based on the docker registry path",
+            "example": [
+              "simcore/services/comp/itis/sleeper",
+              "simcore/services/dynamic/3dviewer"
+            ]
           },
           "service_version": {
             "title": "Service Version",
             "pattern": "^(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)){2}(-(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*)(\\.(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*))*)?(\\+[-\\da-zA-Z]+(\\.[-\\da-zA-Z-]+)*)?$",
             "type": "string",
-            "description": "semantic version number"
+            "description": "service version number",
+            "example": [
+              "1.0.0",
+              "0.0.1"
+            ]
           },
           "service_host": {
             "title": "Service Host",
@@ -652,7 +884,7 @@
           },
           "service_port": {
             "title": "Service Port",
-            "minimum": 1.0,
+            "exclusiveMinimum": 0.0,
             "type": "integer",
             "description": "port to access the service within the network"
           },
@@ -663,7 +895,12 @@
             "default": ""
           },
           "service_state": {
-            "$ref": "#/components/schemas/ServiceState"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ServiceState"
+              }
+            ],
+            "description": "the service state * 'pending' - The service is waiting for resources to start * 'pulling' - The service is being pulled from the registry * 'starting' - The service is starting * 'running' - The service is running * 'complete' - The service completed * 'failed' - The service failed to start\n"
           },
           "service_message": {
             "title": "Service Message",
@@ -691,8 +928,47 @@
           }
         }
       },
+      "RunningState": {
+        "title": "RunningState",
+        "enum": [
+          "UNKNOWN",
+          "PUBLISHED",
+          "NOT_STARTED",
+          "PENDING",
+          "STARTED",
+          "RETRY",
+          "SUCCESS",
+          "FAILED",
+          "ABORTED"
+        ],
+        "type": "string",
+        "description": "An enumeration."
+      },
+      "SelectBox": {
+        "title": "SelectBox",
+        "required": [
+          "structure"
+        ],
+        "type": "object",
+        "properties": {
+          "structure": {
+            "title": "Structure",
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Structure"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "ServiceBuildDetails": {
         "title": "ServiceBuildDetails",
+        "required": [
+          "build_date",
+          "vcs_ref",
+          "vcs_url"
+        ],
         "type": "object",
         "properties": {
           "build_date": {
@@ -709,6 +985,117 @@
           }
         }
       },
+      "ServiceDockerData": {
+        "title": "simcore node",
+        "required": [
+          "name",
+          "description",
+          "key",
+          "version",
+          "type",
+          "authors",
+          "contact",
+          "inputs",
+          "outputs"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "short, human readable name for the node",
+            "example": "Fast Counter"
+          },
+          "thumbnail": {
+            "title": "Thumbnail",
+            "maxLength": 2083,
+            "minLength": 1,
+            "type": "string",
+            "description": "url to the thumbnail",
+            "format": "uri",
+            "example": "https://user-images.githubusercontent.com/32800795/61083844-ff48fb00-a42c-11e9-8e63-fa2d709c8baf.png"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "human readable description of the purpose of the node",
+            "example": [
+              "Our best node type",
+              "The mother of all nodes, makes your numbers shine!"
+            ]
+          },
+          "key": {
+            "title": "Key",
+            "pattern": "^(simcore)/(services)/(comp|dynamic|frontend)(/[^\\s/]+)+$",
+            "type": "string",
+            "description": "distinctive name for the node based on the docker registry path",
+            "example": [
+              "simcore/services/comp/itis/sleeper",
+              "simcore/services/dynamic/3dviewer"
+            ]
+          },
+          "version": {
+            "title": "Version",
+            "pattern": "^(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)){2}(-(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*)(\\.(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*))*)?(\\+[-\\da-zA-Z]+(\\.[-\\da-zA-Z-]+)*)?$",
+            "type": "string",
+            "description": "service version number",
+            "example": [
+              "1.0.0",
+              "0.0.1"
+            ]
+          },
+          "integration-version": {
+            "title": "Integration-Version",
+            "pattern": "^(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)){2}(-(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*)(\\.(0|[1-9]\\d*|\\d*[-a-zA-Z][-\\da-zA-Z]*))*)?(\\+[-\\da-zA-Z]+(\\.[-\\da-zA-Z-]+)*)?$",
+            "type": "string",
+            "description": "integration version number",
+            "example": "1.0.0"
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ServiceType"
+              }
+            ],
+            "description": "service type"
+          },
+          "badges": {
+            "title": "Badges",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Badge"
+            }
+          },
+          "authors": {
+            "title": "Authors",
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Author"
+            }
+          },
+          "contact": {
+            "title": "Contact",
+            "type": "string",
+            "description": "email to correspond to the authors about the node",
+            "format": "email",
+            "example": [
+              "lab@net.flix"
+            ]
+          },
+          "inputs": {
+            "title": "Inputs",
+            "type": "object",
+            "description": "definition of the inputs of this node"
+          },
+          "outputs": {
+            "title": "Outputs",
+            "type": "object",
+            "description": "definition of the outputs of this node"
+          }
+        },
+        "additionalProperties": false
+      },
       "ServiceExtras": {
         "title": "ServiceExtras",
         "required": [
@@ -717,7 +1104,6 @@
         "type": "object",
         "properties": {
           "node_requirements": {
-            "title": "Node Requirements",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/NodeRequirement"
@@ -740,6 +1126,189 @@
           }
         }
       },
+      "ServiceInput": {
+        "title": "ServiceInput",
+        "required": [
+          "displayOrder",
+          "label",
+          "description",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "displayOrder": {
+            "title": "Displayorder",
+            "type": "number",
+            "description": "use this to numerically sort the properties for display",
+            "example": [
+              1,
+              -0.2
+            ]
+          },
+          "label": {
+            "title": "Label",
+            "type": "string",
+            "description": "short name for the property",
+            "example": "Age"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "description of the property",
+            "example": "Age in seconds since 1970"
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^(number|integer|boolean|string|data:([^/\\s,]+/[^/\\s,]+|\\[[^/\\s,]+/[^/\\s,]+(,[^/\\s]+/[^/,\\s]+)*\\]))$",
+            "type": "string",
+            "description": "data type expected on this input glob matching for data type is allowed",
+            "example": [
+              "number",
+              "boolean",
+              "data:*/*",
+              "data:text/*",
+              "data:[image/jpeg,image/png]",
+              "data:application/json",
+              "data:application/json;schema=https://my-schema/not/really/schema.json",
+              "data:application/vnd.ms-excel",
+              "data:text/plain",
+              "data:application/hdf5",
+              "data:application/edu.ucdavis@ceclancy.xyz"
+            ]
+          },
+          "fileToKeyMap": {
+            "title": "Filetokeymap",
+            "type": "object",
+            "description": "Place the data associated with the named keys in files",
+            "example": [
+              {
+                "dir/input1.txt": "key_1",
+                "dir33/input2.txt": "key2"
+              }
+            ]
+          },
+          "defaultValue": {
+            "title": "Defaultvalue",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "example": [
+              "Dog",
+              true
+            ]
+          },
+          "widget": {
+            "title": "Widget",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Widget"
+              }
+            ],
+            "description": "custom widget to use instead of the default one determined from the data-type"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ServiceOutput": {
+        "title": "ServiceOutput",
+        "required": [
+          "displayOrder",
+          "label",
+          "description",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "displayOrder": {
+            "title": "Displayorder",
+            "type": "number",
+            "description": "use this to numerically sort the properties for display",
+            "example": [
+              1,
+              -0.2
+            ]
+          },
+          "label": {
+            "title": "Label",
+            "type": "string",
+            "description": "short name for the property",
+            "example": "Age"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "description of the property",
+            "example": "Age in seconds since 1970"
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^(number|integer|boolean|string|data:([^/\\s,]+/[^/\\s,]+|\\[[^/\\s,]+/[^/\\s,]+(,[^/\\s]+/[^/,\\s]+)*\\]))$",
+            "type": "string",
+            "description": "data type expected on this input glob matching for data type is allowed",
+            "example": [
+              "number",
+              "boolean",
+              "data:*/*",
+              "data:text/*",
+              "data:[image/jpeg,image/png]",
+              "data:application/json",
+              "data:application/json;schema=https://my-schema/not/really/schema.json",
+              "data:application/vnd.ms-excel",
+              "data:text/plain",
+              "data:application/hdf5",
+              "data:application/edu.ucdavis@ceclancy.xyz"
+            ]
+          },
+          "fileToKeyMap": {
+            "title": "Filetokeymap",
+            "type": "object",
+            "description": "Place the data associated with the named keys in files",
+            "example": [
+              {
+                "dir/input1.txt": "key_1",
+                "dir33/input2.txt": "key2"
+              }
+            ]
+          },
+          "defaultValue": {
+            "title": "Defaultvalue",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "example": [
+              "Dog",
+              true
+            ]
+          },
+          "widget": {
+            "title": "Widget",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Widget"
+              }
+            ],
+            "description": "custom widget to use instead of the default one determined from the data-type",
+            "deprecated": true
+          }
+        },
+        "additionalProperties": false
+      },
       "ServiceState": {
         "title": "ServiceState",
         "enum": [
@@ -757,7 +1326,8 @@
         "title": "ServiceType",
         "enum": [
           "computational",
-          "interactive"
+          "dynamic",
+          "frontend"
         ],
         "type": "string",
         "description": "An enumeration."
@@ -773,10 +1343,55 @@
             "title": "Data",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ImageMetaData"
+              "$ref": "#/components/schemas/ServiceDockerData"
             }
           }
         }
+      },
+      "Structure": {
+        "title": "Structure",
+        "required": [
+          "key",
+          "label"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "title": "Key",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TextArea": {
+        "title": "TextArea",
+        "required": [
+          "minHeight"
+        ],
+        "type": "object",
+        "properties": {
+          "minHeight": {
+            "title": "Minheight",
+            "exclusiveMinimum": 0.0,
+            "type": "integer",
+            "description": "minimum Height of the textarea"
+          }
+        },
+        "additionalProperties": false
       },
       "ValidationError": {
         "title": "ValidationError",
@@ -803,6 +1418,45 @@
             "type": "string"
           }
         }
+      },
+      "Widget": {
+        "title": "Widget",
+        "required": [
+          "type",
+          "details"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WidgetType"
+              }
+            ],
+            "description": "type of the property"
+          },
+          "details": {
+            "title": "Details",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TextArea"
+              },
+              {
+                "$ref": "#/components/schemas/SelectBox"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "WidgetType": {
+        "title": "WidgetType",
+        "enum": [
+          "TextArea",
+          "SelectBox"
+        ],
+        "type": "string",
+        "description": "An enumeration."
       }
     }
   }

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List
+from models_library.project_nodes import RunningState
 
 import networkx as nx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
@@ -69,7 +70,7 @@ async def _abort_pipeline_tasks(
 
 @router.post(
     "",
-    summary="Create and Start a new computation",
+    summary="Create and optionaly Start a new computation",
     response_model=ComputationTaskOut,
     status_code=status.HTTP_201_CREATED,
 )
@@ -97,7 +98,8 @@ async def create_computation(
         # get the project
         project: ProjectAtDB = await project_repo.get_project(job.project_id)
 
-        # check if current state allow to start the computation
+        # FIXME: this could not be valid anymore if the user deletes the project in between right?
+        # check if current state allow to modify the computation
         comp_tasks: List[CompTaskAtDB] = await computation_tasks.get_comp_tasks(
             job.project_id
         )
@@ -110,7 +112,7 @@ async def create_computation(
                 detail=f"Projet {job.project_id} already started, current state is {pipeline_state}",
             )
 
-        # create the DAG
+        # create the computational DAG
         dag_graph = create_dag_graph(project.workbench)
         # validate DAG
         if not nx.is_directed_acyclic_graph(dag_graph):
@@ -118,30 +120,44 @@ async def create_computation(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Project {job.project_id} is not a valid directed acyclic graph!",
             )
-        # find the entrypoints
-        entrypoints = find_entrypoints(dag_graph)
-        if not entrypoints:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Project {job.project_id} has no services to compute",
-            )
-        # FIXME: directly pass the tasks to celery instead of the current recursive way
-        # ok so publish the tasks
-        await computation_pipelines.publish_pipeline(project.uuid, dag_graph)
-        await computation_tasks.publish_tasks_from_project(project, director_client)
-        # trigger celery
-        task = celery_client.send_computation_task(job.user_id, job.project_id)
-        background_tasks.add_task(background_on_message, task)
-        log.debug(
-            "Started computational task %s for user %s based on project %s",
-            task.id,
-            job.user_id,
-            job.project_id,
+
+        if job.start_pipeline:
+            # find the entrypoints, if not the pipeline cannot be started
+            entrypoints = find_entrypoints(dag_graph)
+            if not entrypoints:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Project {job.project_id} has no services to compute",
+                )
+
+        # ok so put the tasks in the db
+        await computation_pipelines.upsert_pipeline(
+            project.uuid, dag_graph, job.start_pipeline
         )
+        await computation_tasks.upsert_tasks_from_project(
+            project, director_client, job.start_pipeline
+        )
+
+        if job.start_pipeline:
+            # trigger celery
+            task = celery_client.send_computation_task(job.user_id, job.project_id)
+            background_tasks.add_task(background_on_message, task)
+            log.debug(
+                "Started computational task %s for user %s based on project %s",
+                task.id,
+                job.user_id,
+                job.project_id,
+            )
+
         return ComputationTaskOut(
             id=job.project_id,
-            state=task.state,
+            state=RunningState.PUBLISHED
+            if job.start_pipeline
+            else RunningState.NOT_STARTED,
             url=f"{request.url}/{job.project_id}",
+            stop_url=f"{request.url}/{job.project_id}:stop"
+            if job.start_pipeline
+            else None,
         )
 
     except ProjectNotFoundError as e:
@@ -187,6 +203,9 @@ async def get_computation(
             id=project_id,
             state=pipeline_state,
             url=f"{request.url.remove_query_params('user_id')}",
+            stop_url=f"{request.url.remove_query_params('user_id')}:stop"
+            if is_pipeline_running(pipeline_state)
+            else None,
         )
         return task_out
 
@@ -210,11 +229,12 @@ async def get_computation(
     "/{project_id}:stop",
     summary="Stops a computation pipeline",
     response_model=None,
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_202_ACCEPTED,
 )
 async def stop_computation_project(
     comp_task_stop: ComputationTaskStop,
     project_id: ProjectID,
+    request: Request,
     project_repo: ProjectsRepository = Depends(get_repository(ProjectsRepository)),
     computation_tasks: CompTasksRepository = Depends(
         get_repository(CompTasksRepository)
@@ -241,6 +261,11 @@ async def stop_computation_project(
             await _abort_pipeline_tasks(
                 project, comp_tasks, computation_tasks, celery_client
             )
+        return ComputationTaskOut(
+            id=project_id,
+            state=pipeline_state,
+            url=f"{str(request.url).rstrip(':stop')}",
+        )
 
     except ProjectNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
@@ -303,7 +328,7 @@ async def delete_pipeline(
                 return is_pipeline_stopped(pipeline_state)
 
             # wait for the pipeline to be stopped
-            if not check_pipeline_stopped():
+            if not await check_pipeline_stopped():
                 log.error(
                     "pipeline %s could not be stopped properly after %ss",
                     project_id,

--- a/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
@@ -18,6 +18,9 @@ TaskID = UUID
 class ComputationTaskCreate(BaseModel):
     user_id: UserID
     project_id: ProjectID
+    start_pipeline: Optional[bool] = Field(
+        False, description="if True the computation pipeline will start right away"
+    )
 
 
 class ComputationTaskStop(BaseModel):
@@ -42,6 +45,9 @@ class ComputationTask(BaseModel):
 class ComputationTaskOut(ComputationTask):
     url: AnyHttpUrl = Field(
         ..., description="the link where to get the status of the task"
+    )
+    stop_url: Optional[AnyHttpUrl] = Field(
+        None, description="the link where to stop the task"
     )
 
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
@@ -16,14 +16,14 @@ logger = logging.getLogger(__name__)
 
 class CompPipelinesRepository(BaseRepository):
     @log_decorator(logger=logger)
-    async def publish_pipeline(
-        self, project_id: ProjectID, dag_graph: nx.DiGraph
+    async def upsert_pipeline(
+        self, project_id: ProjectID, dag_graph: nx.DiGraph, publish: bool
     ) -> None:
 
         pipeline_at_db = CompPipelineAtDB(
             project_id=project_id,
             dag_adjacency_list=nx.to_dict_of_lists(dag_graph),
-            state=RunningState.PUBLISHED,
+            state=RunningState.PUBLISHED if publish else RunningState.NOT_STARTED,
         )
         insert_stmt = insert(comp_pipeline).values(**pipeline_at_db.dict(by_alias=True))
         on_update_stmt = insert_stmt.on_conflict_do_update(

--- a/services/web/server/src/simcore_service_webserver/director_v2.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2.py
@@ -164,7 +164,14 @@ async def stop_pipeline(request: web.Request) -> web.Response:
             request.app, "POST", backend_url, data=body
         )
         data = {}
-        return web.json_response(data=wrap_as_envelope(data=data), status=resp_status)
+        # director responds with a 202
+        if resp_status != web.HTTPAccepted.status_code:
+            raise ForwardedException(
+                resp_status, "Unexpected response from director-v2"
+            )
+        return web.json_response(
+            data=wrap_as_envelope(data=data), status=web.HTTPNoContent.status_code
+        )
     except ForwardedException as exc:
         return web.json_response(
             data=wrap_as_envelope(error=exc.reason), status=exc.status

--- a/services/web/server/src/simcore_service_webserver/director_v2.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2.py
@@ -61,6 +61,25 @@ async def _request_director_v2(
 
 
 @log_decorator(logger=log)
+async def create_or_update_pipeline(
+    app: web.Application, user_id: PositiveInt, project_id: UUID
+) -> Dict:
+    director2_settings: Directorv2Settings = get_settings(app)
+
+    backend_url = URL(f"{director2_settings.endpoint}/computations")
+    body = {"user_id": user_id, "project_id": str(project_id)}
+    # request to director-v2
+    try:
+        computation_task_out, _ = await _request_director_v2(
+            app, "POST", backend_url, data=body
+        )
+        return computation_task_out
+
+    except ForwardedException:
+        log.error("could not create pipeline from project %s", project_id)
+
+
+@log_decorator(logger=log)
 async def get_pipeline_state(
     app: web.Application, user_id: PositiveInt, project_id: UUID
 ) -> RunningState:
@@ -109,7 +128,7 @@ async def start_pipeline(request: web.Request) -> web.Response:
 
     backend_url = URL(f"{director2_settings.endpoint}/computations")
     log.debug("Redirecting '%s' -> '%s'", request.url, backend_url)
-    body = {"user_id": user_id, "project_id": project_id}
+    body = {"user_id": user_id, "project_id": project_id, "start_pipeline": True}
 
     # request to director-v2
     try:

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -3,16 +3,16 @@
 """
 import json
 import logging
-
 from typing import Dict, List, Optional, Set
 
 import aioredlock
 from aiohttp import web
 from jsonschema import ValidationError
+
 from models_library.projects import ProjectState
 from servicelib.utils import fire_and_forget_task, logged_gather
 
-from .. import catalog
+from .. import catalog, director_v2
 from ..constants import RQ_PRODUCT_KEY
 from ..login.decorators import RQT_USERID_KEY, login_required
 from ..resource_manager.websocket_manager import managed_resource
@@ -38,6 +38,7 @@ log = logging.getLogger(__name__)
 
 @login_required
 @permission_required("project.create")
+@permission_required("services.pipeline.*")  # due to update_pipeline_db
 async def create_projects(request: web.Request):
     # pylint: disable=too-many-branches
     # TODO: keep here since is async and parser thinks it is a handler
@@ -92,6 +93,10 @@ async def create_projects(request: web.Request):
         # update metadata (uuid, timestamps, ownership) and save
         project = await db.add_project(
             project, user_id, force_as_template=as_template is not None
+        )
+        # This is a new project and every new graph needs to be reflected in the pipeline db
+        await director_v2.create_or_update_pipeline(
+            request.app, user_id, project["uuid"]
         )
 
         # Appends state
@@ -200,6 +205,7 @@ async def get_project(request: web.Request):
 
 @login_required
 @permission_required("project.update")
+@permission_required("services.pipeline.*")  # due to update_pipeline_db
 async def replace_project(request: web.Request):
     """Implements PUT /projects
 
@@ -251,7 +257,7 @@ async def replace_project(request: web.Request):
         new_project = await db.update_user_project(
             new_project, user_id, project_uuid, include_templates=True
         )
-
+        await director_v2.create_or_update_pipeline(request.app, user_id, project_uuid)
         # Appends state
         new_project["state"] = await projects_api.get_project_state_for_user(
             user_id, project_uuid, request.app

--- a/services/web/server/tests/unit/with_dbs/fast/test_director_v2.py
+++ b/services/web/server/tests/unit/with_dbs/fast/test_director_v2.py
@@ -95,6 +95,14 @@ async def test_stop_pipeline(
     )
 
 
+async def test_create_pipeline(client, user_id: PositiveInt, project_id: UUID):
+    task_out = await director_v2.create_or_update_pipeline(
+        client.app, user_id, project_id
+    )
+    assert "state" in task_out
+    assert task_out["state"] == RunningState.NOT_STARTED
+
+
 async def test_get_pipeline_state(
     client,
     user_id: PositiveInt,


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
With the director-v2 #1877 some things were too much simplified...

the dynamic services currently need the comp_tasks table to be filled continuously with something similar to the project (until the dynamic sidecar is available and this may become simpler)

**changes**
- director-v2: POST computations now has an additional parameter "start_pipeline" defaulted to False
- director-v2: POST/GET also return a stop_url for convenience
- director-v2: only start the pipeline if "start_pipeline" is set to True
- director-v2: return 422 on POST computations if there is no computational services in the pipeline only when start_pipeline is True
- webserver: brought back calls to update the pipeline when creating/replacing projects

**NOTE:** the outputs of the project are copied into comp_tasks. hopefully this fixes some issues.




## Related issue number
#1877 
<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
