### PR TITLE
Fix text filter & Settings to read-only for guest users

### DIFF
--- a/.env-devel
+++ b/.env-devel
@@ -65,6 +65,8 @@ WEBSERVER_FOGBUGZ_NEWCASE_URL=https://z43.manuscript.com/f/cases/new?command=new
 WEBSERVER_S4L_FOGBUGZ_NEWCASE_URL=https://z43.manuscript.com/f/cases/new?command=new&pg=pgEditBug&ixProject=45&ixArea=458
 WEBSERVER_TIS_FOGBUGZ_NEWCASE_URL=https://z43.manuscript.com/f/cases/new?command=new&pg=pgEditBug&ixProject=45&ixArea=459
 WEBSERVER_FEEDBACK_FORM_URL=https://docs.google.com/forms/d/e/1FAIpQLSe232bTigsM2zV97Kjp2OhCenl6o9gNGcDFt2kO_dfkIjtQAQ/viewform?usp=sf_link
+WEBSERVER_VIEWER_RAWGRAPH_VERSION=2.11.1
+WEBSERVER_VIEWER_SIM4LIFE_VERSION=1.0.27
 
 # for debugging
 # PYTHONTRACEMALLOC=1

--- a/services/web/client/source/class/osparc/dashboard/ExploreBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/ExploreBrowser.js
@@ -544,7 +544,7 @@ qx.Class.define("osparc.dashboard.ExploreBrowser", {
     __getPublishOnPortalMenuButton: function() {
       const publishOnPortalButton = new qx.ui.menu.Button(this.tr("Publish on Portal"));
       publishOnPortalButton.addListener("execute", () => {
-        const msg = this.tr("To be implemented");
+        const msg = this.tr("Not yet implemented");
         osparc.component.message.FlashMessenger.getInstance().logAs(msg, "INFO");
       }, this);
       return publishOnPortalButton;

--- a/services/web/client/source/class/osparc/dashboard/ExploreBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/ExploreBrowser.js
@@ -450,6 +450,12 @@ qx.Class.define("osparc.dashboard.ExploreBrowser", {
         menu.add(studyServicesButton);
       }
 
+      const isCurrentUserOwner = osparc.data.model.Study.isOwner(studyData);
+      if (isCurrentUserOwner) {
+        const publishOnPortalButton = this.__getPublishOnPortalMenuButton(studyData);
+        menu.add(publishOnPortalButton);
+      }
+
       const deleteButton = this.__getDeleteTemplateMenuButton(studyData);
       if (deleteButton) {
         menu.addSeparator();
@@ -533,6 +539,15 @@ qx.Class.define("osparc.dashboard.ExploreBrowser", {
         osparc.ui.window.Window.popUpInWindow(servicesInStudy, title, 400, 100);
       }, this);
       return studyServicesButton;
+    },
+
+    __getPublishOnPortalMenuButton: function() {
+      const publishOnPortalButton = new qx.ui.menu.Button(this.tr("Publish on Portal"));
+      publishOnPortalButton.addListener("execute", () => {
+        const msg = this.tr("To be implemented");
+        osparc.component.message.FlashMessenger.getInstance().logAs(msg, "INFO");
+      }, this);
+      return publishOnPortalButton;
     },
 
     __getDeleteTemplateMenuButton: function(studyData) {

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -430,10 +430,6 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         const saveAsTemplateButton = this.__getSaveAsTemplateMenuButton(studyData);
         menu.add(saveAsTemplateButton);
       }
-      if (isCurrentUserOwner && canCreateTemplate) {
-        const publishOnPortalButton = this.__getPublishOnPortalMenuButton(studyData);
-        menu.add(publishOnPortalButton);
-      }
 
       if (osparc.data.model.Study.hasSlideshow(studyData)) {
         const startAsSlideshowButton = this.__getStartAsSlideshowButton(studyData);
@@ -528,15 +524,6 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         }, this);
       }, this);
       return saveAsTemplateButton;
-    },
-
-    __getPublishOnPortalMenuButton: function() {
-      const publishOnPortalButton = new qx.ui.menu.Button(this.tr("Publish on Portal"));
-      publishOnPortalButton.addListener("execute", () => {
-        const msg = this.tr("To be implemented");
-        osparc.component.message.FlashMessenger.getInstance().logAs(msg, "INFO");
-      }, this);
-      return publishOnPortalButton;
     },
 
     __getStartAsSlideshowButton: function(studyData) {

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -430,6 +430,10 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         const saveAsTemplateButton = this.__getSaveAsTemplateMenuButton(studyData);
         menu.add(saveAsTemplateButton);
       }
+      if (isCurrentUserOwner && canCreateTemplate) {
+        const publishOnPortalButton = this.__getPublishOnPortalMenuButton(studyData);
+        menu.add(publishOnPortalButton);
+      }
 
       if (osparc.data.model.Study.hasSlideshow(studyData)) {
         const startAsSlideshowButton = this.__getStartAsSlideshowButton(studyData);
@@ -524,6 +528,15 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         }, this);
       }, this);
       return saveAsTemplateButton;
+    },
+
+    __getPublishOnPortalMenuButton: function() {
+      const publishOnPortalButton = new qx.ui.menu.Button(this.tr("Publish on Portal"));
+      publishOnPortalButton.addListener("execute", () => {
+        const msg = this.tr("To be implemented");
+        osparc.component.message.FlashMessenger.getInstance().logAs(msg, "INFO");
+      }, this);
+      return publishOnPortalButton;
     },
 
     __getStartAsSlideshowButton: function(studyData) {

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
@@ -224,21 +224,21 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonItem", {
       let accessRights = {};
       switch (studyData["resourceType"]) {
         case "study":
-          uuid = studyData.uuid;
-          owner = studyData.prjOwner;
-          accessRights = studyData.accessRights;
+          uuid = studyData.uuid ? studyData.uuid : uuid;
+          owner = studyData.prjOwner ? studyData.prjOwner : owner;
+          accessRights = studyData.accessRights ? studyData.accessRights : accessRights;
           defaultThumbnail = this.self().STUDY_ICON;
           break;
         case "template":
-          uuid = studyData.uuid;
-          owner = studyData.prjOwner;
-          accessRights = studyData.accessRights;
+          uuid = studyData.uuid ? studyData.uuid : uuid;
+          owner = studyData.prjOwner ? studyData.prjOwner : owner;
+          accessRights = studyData.accessRights ? studyData.accessRights : accessRights;
           defaultThumbnail = this.self().TEMPLATE_ICON;
           break;
         case "service":
-          uuid = studyData.key;
-          owner = studyData.owner;
-          accessRights = studyData.access_rights;
+          uuid = studyData.key ? studyData.key : uuid;
+          owner = studyData.owner ? studyData.owner : owner;
+          accessRights = studyData.access_rights ? studyData.access_rights : accessRights;
           defaultThumbnail = this.self().SERVICE_ICON;
           break;
       }

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
@@ -363,8 +363,8 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonItem", {
             this.__setSharedIcon(sharedIcon, value, groups);
           });
 
-        if (this.isResourceType("study") || this.isResourceType("template")) {
-          this._applyStudyPermissions(value);
+        if (this.isResourceType("study")) {
+          this.__setStudyPermissions(value);
         }
       }
     },
@@ -438,7 +438,7 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonItem", {
       }
     },
 
-    _applyStudyPermissions: function(accessRights) {
+    __setStudyPermissions: function(accessRights) {
       const myGroupId = osparc.auth.Data.getInstance().getGroupId();
       const studyPerm = osparc.component.export.StudyPermissions;
       const image = this.getChildControl("permission-icon");

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -606,6 +606,11 @@ qx.Class.define("osparc.data.model.Node", {
         this.getPropsForm().setAccessLevel(inputAccess);
         this.getPropsFormEditor().setAccessLevel(inputAccess);
       }
+
+      const study = osparc.store.Store.getInstance().getCurrentStudy();
+      if (study && study.isReadOnly()) {
+        this.getPropsForm().setEnabled(false);
+      }
     },
 
     setOutputData: function(outputs) {


### PR DESCRIPTION
## What do these changes do?
- [x] Not setting the default values in study/service cards was making the filtering not work properly and, therefore, e2e fail.
- [x] Gray out settings for guest users

### Bonus:
- [x] Show template owners "Publish on Portal" option. A Flash Message will tell you that it is "Not yet implemented" if you click it. This was requested by POs.

## Related issue number
closes https://github.com/ITISFoundation/osparc-simcore/issues/1986
closes https://github.com/ITISFoundation/osparc-simcore/issues/1994
related to https://github.com/ITISFoundation/osparc-issues/issues/345