### PR TITLE
Fix: Avoid setting null on file File Picker's output label

### DIFF
--- a/services/web/client/source/class/osparc/file/FileDownloadLink.js
+++ b/services/web/client/source/class/osparc/file/FileDownloadLink.js
@@ -59,7 +59,7 @@ qx.Class.define("osparc.file.FileDownloadLink", {
           return osparc.file.FileDownloadLink.extractLabelFromLink(outInfo.downloadLink);
         }
       }
-      return null;
+      return "";
     },
 
     extractLabelFromLink: function(downloadLink) {
@@ -70,7 +70,7 @@ qx.Class.define("osparc.file.FileDownloadLink", {
         const parts = found[1].split("/");
         return parts[parts.length - 1];
       }
-      return null;
+      return "";
     },
 
     checkFileExists: function(urlToFile) {

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -228,7 +228,7 @@ qx.Class.define("osparc.file.FilePicker", {
         const outputs = this.__getOutputFile();
         outputs["value"] = {
           downloadLink,
-          label
+          label: label ? label : ""
         };
         this.getNode().getStatus().setProgress(100);
         this.getNode().repopulateOutputPortData();


### PR DESCRIPTION
## What do these changes do?
While trying to figure out what the filename behind a download link is, sometimes null was set. Making project's validation fail.

This PR makes sure that if the deduced value is null an empty string is set.