### PR TITLE
Enhancement/improve e2e usage

### DIFF
--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -489,7 +489,6 @@ jobs:
           name: unit_service_integration_coverage
           path: codeclimate.unit_service_integration_coverage.json
 
-
   unit-test-service-library:
     name: "[unit] service-library"
     runs-on: ${{ matrix.os }}
@@ -1271,17 +1270,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: setup images
-        run: ./ci/github/system-testing/e2e.bash setup_images
-      - name: setup and start swarm
-        run: ./ci/github/system-testing/e2e.bash setup_and_run_stack
-      - name: setup environment
-        run: ./ci/github/system-testing/e2e.bash setup_environment
-      - name: setup registry
-        run: ./ci/github/system-testing/e2e.bash setup_registry
-      - name: setup database
-        timeout-minutes: 2
-        run: ./ci/github/system-testing/e2e.bash setup_database
+      - name: setup
+        run: ./ci/github/system-testing/e2e.bash install
       - name: test
         run: ./ci/github/system-testing/e2e.bash test
       - name: recover docker logs

--- a/Makefile
+++ b/Makefile
@@ -423,10 +423,10 @@ get_my_ip := $(shell hostname --all-ip-addresses | cut --delimiter=" " --fields=
 local-registry: .env ## creates a local docker registry and configure simcore to use it (NOTE: needs admin rights)
 	@$(if $(shell grep "127.0.0.1 $(local_registry)" /etc/hosts),,\
 					echo setting host file to redirect $(etc_host_entry); \
-					echo 127.0.0.1 $(local_registry) >> /etc/hosts)
+					sudo echo 127.0.0.1 $(local_registry) | sudo tee -a /etc/hosts
 	@$(if $(shell grep "{\"insecure-registries\": \[\"registry:5000\"\]}" /etc/docker/daemon.json),,\
 					echo allowing docker engine to use insecure local registry and restarting engine...; \
-					echo {\"insecure-registries\": [\"$(local_registry):5000\"]} >> /etc/docker/daemon.json; service docker restart)
+					sudo echo {\"insecure-registries\": [\"$(local_registry):5000\"]} | sudo tee -a /etc/docker/daemon.json; service docker restart)
 	@$(if $(shell docker ps --format="{{.Names}}" | grep registry),,\
 					echo starting registry on $(local_registry):5000...; \
 					docker run --detach \

--- a/Makefile
+++ b/Makefile
@@ -419,7 +419,7 @@ postgres-upgrade: ## initalize or upgrade postgres db to latest state
 
 local_registry=registry
 get_my_ip := $(shell hostname --all-ip-addresses | cut --delimiter=" " --fields=1)
-.PHONY: local-registry
+.PHONY: local-registry rm-local-registry
 local-registry: .env ## creates a local docker registry and configure simcore to use it (NOTE: needs admin rights)
 	@$(if $(shell grep "127.0.0.1 $(local_registry)" /etc/hosts),,\
 					echo setting host file to redirect $(etc_host_entry); \
@@ -446,6 +446,11 @@ local-registry: .env ## creates a local docker registry and configure simcore to
 	# local registry set in $(local_registry):5000
 	# images currently in registry:
 	curl --silent $(local_registry):5000/v2/_catalog | jq
+
+rm-local-registry:
+	$(if $(shell grep "127.0.0.1 $(local_registry) /etc/hosts"),\
+	echo removing host file to redirect $(etc_host_entry); \
+	sed -i "/127.0.0.1 $(local_registry)/d" /etc/hosts;,)
 
 ## INFO -------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ get_my_ip := $(shell hostname --all-ip-addresses | cut --delimiter=" " --fields=
 local-registry: .env ## creates a local docker registry and configure simcore to use it (NOTE: needs admin rights)
 	@$(if $(shell grep "127.0.0.1 $(local_registry)" /etc/hosts),,\
 					echo setting host file to redirect $(etc_host_entry); \
-					sudo echo 127.0.0.1 $(local_registry) | sudo tee -a /etc/hosts
+					sudo echo 127.0.0.1 $(local_registry) | sudo tee -a /etc/hosts)
 	@$(if $(shell grep "{\"insecure-registries\": \[\"registry:5000\"\]}" /etc/docker/daemon.json),,\
 					echo allowing docker engine to use insecure local registry and restarting engine...; \
 					sudo echo {\"insecure-registries\": [\"$(local_registry):5000\"]} | sudo tee -a /etc/docker/daemon.json; service docker restart)

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ leave: ## Forces to stop all services, networks, etc by the node leaving the swa
 .PHONY: .init-swarm
 .init-swarm:
 	# Ensures swarm is initialized
-	$(if $(SWARM_HOSTS),,docker swarm init)
+	$(if $(SWARM_HOSTS),,docker swarm init --advertise-addr=$(get_my_ip))
 
 
 ## DOCKER TAGS  -------------------------------

--- a/ci/github/system-testing/e2e.bash
+++ b/ci/github/system-testing/e2e.bash
@@ -21,10 +21,6 @@ test() {
   popd
 }
 
-clean_up() {
-  make down
-  make leave
-}
 
 
 SWARM_STACK_NAME=e2e_test_stack
@@ -155,21 +151,6 @@ setup_database() {
   popd
 }
 
-install() {
-  ## shortcut
-  setup_images
-  setup_and_run_stack
-  setup_environment
-  setup_registry
-  setup_database
-}
-
-test() {
-  sleep 5
-  pushd tests/e2e
-  make test
-  popd
-}
 
 dump_docker_logs() {
   # get docker logs

--- a/ci/github/system-testing/e2e.bash
+++ b/ci/github/system-testing/e2e.bash
@@ -8,6 +8,25 @@ IFS=$'\n\t'
 DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag.bash)
 export DOCKER_IMAGE_TAG
 
+
+install() {
+  pushd tests/e2e
+  make install
+  popd
+}
+
+test() {
+  pushd tests/e2e
+  make test
+  popd
+}
+
+clean_up() {
+  make down
+  make leave
+}
+
+
 SWARM_STACK_NAME=e2e_test_stack
 export SWARM_STACK_NAME
 

--- a/ci/github/system-testing/e2e.bash
+++ b/ci/github/system-testing/e2e.bash
@@ -22,27 +22,6 @@ test() {
 }
 
 
-
-
-uninstall_insecure_registry() {
-  echo "------------------ reverting .env"
-  if [[ -f .env.bak ]]; then
-    mv .env.bak .env
-  fi
-
-  echo "------------------ reverting /etc/hosts"
-  if [[ -f .hosts.bak ]]; then
-    sudo mv .hosts.bak /etc/hosts
-  fi
-
-  if [[ -f .daemon.bak ]]; then
-    echo "------------------ reverting /etc/docker/daemon.json"
-    sudo mv .daemon.bak /etc/docker/daemon.json
-    echo "------------------ restarting daemon [takes some time]"
-    sudo service docker restart
-  fi
-}
-
 setup_images() {
   echo "--------------- preparing docker images..."
   make pull-version || ( (make pull-cache || true) && make build-x tag-version)
@@ -50,6 +29,20 @@ setup_images() {
 
 }
 
+clean_up() {
+  echo "--------------- listing services running..."
+  docker service ls
+  echo "--------------- listing service details..."
+  docker service ps --no-trunc $(docker service ls --quiet)
+  echo "--------------- listing container details..."
+  docker container ps -a
+  echo "--------------- listing images available..."
+  docker images
+  echo "--------------- switching off..."
+  pushd tests/e2e
+  make clean-up
+  popd
+}
 
 dump_docker_logs() {
   # get docker logs
@@ -65,21 +58,6 @@ dump_docker_logs() {
   (timeout 30 docker service logs --timestamps --tail=200 --details ${SWARM_STACK_NAME}_storage     >simcore_logs/storage.log 2>&1) || true
   (timeout 30 docker service logs --timestamps --tail=200 --details ${SWARM_STACK_NAME}_migration   >simcore_logs/migration.log 2>&1) || true
   (timeout 30 docker service logs --timestamps --tail=200 --details ${SWARM_STACK_NAME}_postgres    >simcore_logs/postgres.log 2>&1) || true
-}
-
-clean_up() {
-  echo "--------------- listing services running..."
-  docker service ls
-  echo "--------------- listing service details..."
-  docker service ps --no-trunc $(docker service ls --quiet)
-  echo "--------------- listing container details..."
-  docker container ps -a
-  echo "--------------- listing images available..."
-  docker images
-  echo "--------------- switching off..."
-  make leave
-  echo "--------------- uninstalling insecure registry"
-  uninstall_insecure_registry
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/system-testing/e2e.bash
+++ b/ci/github/system-testing/e2e.bash
@@ -11,7 +11,7 @@ export DOCKER_IMAGE_TAG
 
 install() {
   pushd tests/e2e
-  make install
+  make install-ci
   popd
 }
 

--- a/services/director/src/simcore_service_director/config.py
+++ b/services/director/src/simcore_service_director/config.py
@@ -63,6 +63,9 @@ REGISTRY_AUTH: bool = strtobool(os.environ.get("REGISTRY_AUTH", "False"))
 REGISTRY_USER: str = os.environ.get("REGISTRY_USER", "")
 REGISTRY_PW: str = os.environ.get("REGISTRY_PW", "")
 REGISTRY_URL: str = os.environ.get("REGISTRY_URL", "")
+REGISTRY_PATH: str = os.environ.get("REGISTRY_PATH", None) or os.environ.get(
+    "REGISTRY_URL", ""
+)  # This is useful in case of a local registry, where the registry url (path) is relative to the host docker engine
 REGISTRY_SSL: bool = strtobool(os.environ.get("REGISTRY_SSL", "True"))
 
 EXTRA_HOSTS_SUFFIX: str = os.environ.get("EXTRA_HOSTS_SUFFIX", "undefined")

--- a/services/director/tests/conftest.py
+++ b/services/director/tests/conftest.py
@@ -58,6 +58,7 @@ def configure_schemas_location(package_dir, common_schemas_specs_dir):
 @pytest.fixture
 def configure_registry_access(docker_registry):
     config.REGISTRY_URL = docker_registry
+    config.REGISTRY_PATH = docker_registry
     config.REGISTRY_SSL = False
     config.DIRECTOR_REGISTRY_CACHING = False
 

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     init: true
     environment:
       - REGISTRY_URL=${REGISTRY_URL}
+      - REGISTRY_PATH=${REGISTRY_PATH}
       - REGISTRY_AUTH=${REGISTRY_AUTH}
       - REGISTRY_USER=${REGISTRY_USER}
       - REGISTRY_PW=${REGISTRY_PW}

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -1,33 +1,44 @@
-.DEFAULT_GOAL := help
+include ../../scripts/common.Makefile
 
-# Operating system
-ifeq ($(filter Windows_NT,$(OS)),)
-IS_WSL  := $(if $(findstring Microsoft,$(shell uname -a)),WSL,)
-IS_OSX  := $(filter Darwin,$(shell uname -a))
-IS_LINUX:= $(if $(or $(IS_WSL),$(IS_OSX)),,$(filter Linux,$(shell uname -a)))
-endif
+SIMCORE_DOT_ENV = $(abspath $(CURDIR)/../../.env)
+DOT_ENV_BACKUP = $(SIMCORE_DOT_ENV).bak
 
-IS_WIN  := $(strip $(if $(or $(IS_LINUX),$(IS_OSX),$(IS_WSL)),,$(OS)))
-$(if $(IS_WIN),$(error Windows is not supported in all recipes. Use WSL instead. Follow instructions in README.md),)
+$(DOT_ENV_BACKUP): $(SIMCORE_DOT_ENV)
+	$(if $(wildcard $@), \
+	@echo "WARNING #####  $< is newer than $@ ####"; diff -uN $@ $<; false;,\
+	@echo "WARNING ##### $@ does not exist, cloning $< as $@ ############"; cp $< $@)
 
-SHELL := /bin/bash
 
-.PHONY: help
-help: ## help on rule's targets
-ifeq ($(IS_WIN),)
-	@awk --posix 'BEGIN {FS = ":.*?## "} /^[[:alpha:][:space:]_-]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
-else
-	@awk --posix 'BEGIN {FS = ":.*?## "} /^[[:alpha:][:space:]_-]+:.*?## / {printf "%-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
-endif
+_build-simcore-images:
+	@$(MAKE_C) $(REPO_BASE_DIR) pull-version tag-local || $(MAKE_C) ../.. build-x
+	@$(MAKE_C) $(REPO_BASE_DIR) info-images
+
+_setup-registry:
+	@$(MAKE_C) $(REPO_BASE_DIR) local-registry
+
+_setup-simcore:
+	@echo WEBSERVER_LOGIN_REGISTRATION_INVITATION_REQUIRED=0 >> $(SIMCORE_DOT_ENV)
+	@echo WEBSERVER_LOGIN_REGISTRATION_CONFIRMATION_REQUIRED=0 >> $(SIMCORE_DOT_ENV)
+	@echo SERVICES_MAX_NANO_CPUS=2000000000 >> $(SIMCORE_DOT_ENV)
+	@echo SIDECAR_FORCE_CPU_NODE=1 >> $(SIMCORE_DOT_ENV)
+	@$(MAKE_C) $(REPO_BASE_DIR) up-prod
+
+_setup_python:
+	@$(MAKE_C) $(REPO_BASE_DIR) devenv
+	# install python dependencies
+	@$(VENV_DIR)/bin/pip install -r requirements/requirements.txt
+	# install node dependencies (puppeteer...)
+	@npm install
 
 
 .PHONY: install
-install: ## install testing framework
-	# install puppeteer
-	@npm install
-	@pip install -r requirements/requirements.txt
-	# installing postgres-db
-	@pushd "$(abspath $(CURDIR)/../../packages/postgres-database)"; pip install -r requirements/prod.txt; popd
+install: _build-simcore-images _setup-registry _setup-simcore ## install testing framework
+
+
+
+clean-up:
+	@$(MAKE_C) $(REPO_BASE_DIR) down
+	@$(MAKE_C) $(REPO_BASE_DIR) leave
 
 
 registry-up: ## deploys the insecure docker registry in the simcore network
@@ -38,7 +49,7 @@ registry-down: ## bring the docker registry down
 
 
 .PHONY: wait-for-services
-wait-for-services: ## wait for simcore services to be up
+wait-for-services:  _check_venv_active ## wait for simcore services to be up
 	@python utils/wait_for_services.py
 
 
@@ -66,7 +77,7 @@ inject-templates-in-db: ## inject project templates
 
 
 .PHONY: test
-test: ## test the platformå
+test: ## test the platform
 	# tests
 	npm test
 	# tests whether tutorial run

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -4,58 +4,60 @@ SIMCORE_DOT_ENV = $(abspath $(CURDIR)/../../.env)
 
 
 # UTILS ############
-.PHONY: _simcore-images _local-registry _simcore-up _test_environment _wait-for-services _transfer-images-to-registry _inject-templates-in-db
-_simcore-images:
-	@$(MAKE_C) $(REPO_BASE_DIR) pull-version tag-local || $(MAKE_C) ../.. build-x
-	@$(MAKE_C) $(REPO_BASE_DIR) info-images
+define _build_simcore_images
+# build simcore images using the selected flavor
+$(if $(findstring -ci,$@),$(MAKE_C) $(REPO_BASE_DIR) pull-version tag-local ||,) $(MAKE_C) $(REPO_BASE_DIR) build$(if $(findstring -dev,$@),-devel,)-x
+$(MAKE_C) $(REPO_BASE_DIR) info-images
+endef
 
-_local-registry:
-	@$(MAKE_C) $(REPO_BASE_DIR) local-registry
+define _up_simcore
+# set some parameters to allow for e2e to run
+echo WEBSERVER_LOGIN_REGISTRATION_INVITATION_REQUIRED=0 >> $(SIMCORE_DOT_ENV)
+echo WEBSERVER_LOGIN_REGISTRATION_CONFIRMATION_REQUIRED=0 >> $(SIMCORE_DOT_ENV)
+echo SERVICES_MAX_NANO_CPUS=2000000000 >> $(SIMCORE_DOT_ENV)
+echo SIDECAR_FORCE_CPU_NODE=1 >> $(SIMCORE_DOT_ENV)
+# NOTE: in devel mode the stack is started as a separate process and we wait so the stack files are created
+$(MAKE_C) $(REPO_BASE_DIR) up$(if $(findstring -dev,$@),-devel &,-prod)
+$(if $(findstring -dev,$@),sleep 30,)
+endef
 
-_simcore-up:
-	@echo WEBSERVER_LOGIN_REGISTRATION_INVITATION_REQUIRED=0 >> $(SIMCORE_DOT_ENV)
-	@echo WEBSERVER_LOGIN_REGISTRATION_CONFIRMATION_REQUIRED=0 >> $(SIMCORE_DOT_ENV)
-	@echo SERVICES_MAX_NANO_CPUS=2000000000 >> $(SIMCORE_DOT_ENV)
-	@echo SIDECAR_FORCE_CPU_NODE=1 >> $(SIMCORE_DOT_ENV)
-	@$(MAKE_C) $(REPO_BASE_DIR) up-prod
+define _setup_test_environment
+# setup the python environment
+$(MAKE_C) $(REPO_BASE_DIR) devenv
+$(VENV_DIR)/bin/pip install -r requirements/requirements.txt
+# setup node environment for puppeteer
+npm install
+endef
 
-_test_environment:
-	@$(MAKE_C) $(REPO_BASE_DIR) devenv
-	# install python dependencies
-	@$(VENV_DIR)/bin/pip install -r requirements/requirements.txt
-	# install node dependencies (puppeteer...)
-	@npm install
-	# wait for services being ready
-	@$(VENV_DIR)/bin/python utils/wait_for_services.py
-
-_wait-for-services:  _check_venv_active
-	@python utils/wait_for_services.py
-
-_transfer-images-to-registry:
-	# pushing sleeper image
-	@docker pull itisfoundation/sleeper:1.0.0
-	@docker tag itisfoundation/sleeper:1.0.0 registry:5000/simcore/services/comp/itis/sleeper:1.0.0
-	@docker push registry:5000/simcore/services/comp/itis/sleeper:1.0.0
-	# completed transfer of images
-	@curl -s registry:5000/v2/_catalog | jq '.repositories'
-	@curl -s http://registry:5000/v2/simcore/services/comp/itis/sleeper/tags/list?n=50 | jq '.'
+define _transfer-images-to-registry
+# pushing sleeper image
+@docker pull itisfoundation/sleeper:1.0.0
+@docker tag itisfoundation/sleeper:1.0.0 registry:5000/simcore/services/comp/itis/sleeper:1.0.0
+@docker push registry:5000/simcore/services/comp/itis/sleeper:1.0.0
+# completed transfer of images
+@curl -s registry:5000/v2/_catalog | jq '.repositories'
+@curl -s http://registry:5000/v2/simcore/services/comp/itis/sleeper/tags/list?n=50 | jq '.'
+endef
 
 
-_inject-templates-in-db:
-	@docker cp tutorials/sleepers_project_template_sql.csv $$(docker ps -q --filter="name=postgres"):/template_projects_sleepers_project_template_sql.csv
-	@docker exec $$(docker ps -q --filter="name=postgres") psql --user scu --dbname simcoredb --command "\copy projects from '/template_projects_sleepers_project_template_sql.csv' csv header;"
-
+define _inject-templates-in-db
+# inject the sleepers template
+@docker cp tutorials/sleepers_project_template_sql.csv $$(docker ps -q --filter="name=postgres"):/template_projects_sleepers_project_template_sql.csv
+# template is copied into the postgres container and then injected
+@docker exec $$(docker ps -q --filter="name=postgres") psql --user scu --dbname simcoredb --command "\copy projects from '/template_projects_sleepers_project_template_sql.csv' csv header;"
+endef
 
 # SETUP ##################
 
-.PHONY: install clean-up
-install: _simcore-images _local-registry _simcore-up _test_environment ## install e2e testing framework and start simcore/registry
-	@$(MAKE) _simcore-images
-	@$(MAKE) _local-registry
-	@$(MAKE) _simcore-up
-	@$(MAKE) _test_environment
-	@$(MAKE) _transfer-images-to-registry
-	@$(MAKE) _inject-templates-in-db
+.PHONY: install-ci install-dev install-prod clean-up
+install-ci install-dev install-prod: ## install e2e testing framework and start simcore/registry
+	@$(_build_simcore_images)
+	@$(MAKE_C) $(REPO_BASE_DIR) local-registry
+	@$(_up_simcore)
+	@$(_setup_test_environment)
+	@$(VENV_DIR)/bin/python utils/wait_for_services.py
+	@$(_transfer-images-to-registry)
+	@$(_inject-templates-in-db)
 
 clean-up: ## remove everything
 	# switch simcore stack down
@@ -63,7 +65,7 @@ clean-up: ## remove everything
 	# leave docker swarm
 	@$(MAKE_C) $(REPO_BASE_DIR) leave
 	# remove local registry
-	@$(MAKE_C) $(REPO_BASE_DIR) rm-local-registry
+	@$(MAKE_C) $(REPO_BASE_DIR) rm-registry
 
 
 

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -16,9 +16,7 @@ echo WEBSERVER_LOGIN_REGISTRATION_INVITATION_REQUIRED=0 >> $(SIMCORE_DOT_ENV)
 echo WEBSERVER_LOGIN_REGISTRATION_CONFIRMATION_REQUIRED=0 >> $(SIMCORE_DOT_ENV)
 echo SERVICES_MAX_NANO_CPUS=2000000000 >> $(SIMCORE_DOT_ENV)
 echo SIDECAR_FORCE_CPU_NODE=1 >> $(SIMCORE_DOT_ENV)
-# NOTE: in devel mode the stack is started as a separate process and we wait so the stack files are created
-$(MAKE_C) $(REPO_BASE_DIR) up$(if $(findstring -dev,$@),-devel &,-prod)
-$(if $(findstring -dev,$@),sleep 30,)
+$(MAKE_C) $(REPO_BASE_DIR) up-prod
 endef
 
 define _setup_test_environment
@@ -49,8 +47,8 @@ endef
 
 # SETUP ##################
 
-.PHONY: install-ci install-dev install-prod clean-up
-install-ci install-dev install-prod: ## install e2e testing framework and start simcore/registry
+.PHONY: install-ci install-prod clean-up
+install-ci install-prod: ## install e2e testing framework and start simcore/registry
 	@$(_build_simcore_images)
 	@$(MAKE_C) $(REPO_BASE_DIR) local-registry
 	@$(_up_simcore)

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -1,14 +1,10 @@
 include ../../scripts/common.Makefile
 
 SIMCORE_DOT_ENV = $(abspath $(CURDIR)/../../.env)
-DOT_ENV_BACKUP = $(SIMCORE_DOT_ENV).bak
-
-$(DOT_ENV_BACKUP): $(SIMCORE_DOT_ENV)
-	$(if $(wildcard $@), \
-	@echo "WARNING #####  $< is newer than $@ ####"; diff -uN $@ $<; false;,\
-	@echo "WARNING ##### $@ does not exist, cloning $< as $@ ############"; cp $< $@)
 
 
+# UTILS ############
+.PHONY: _simcore-images _local-registry _simcore-up _test_environment _wait-for-services _transfer-images-to-registry _inject-templates-in-db
 _simcore-images:
 	@$(MAKE_C) $(REPO_BASE_DIR) pull-version tag-local || $(MAKE_C) ../.. build-x
 	@$(MAKE_C) $(REPO_BASE_DIR) info-images
@@ -32,35 +28,10 @@ _test_environment:
 	# wait for services being ready
 	@$(VENV_DIR)/bin/python utils/wait_for_services.py
 
-.PHONY: install
-install: _simcore-images _local-registry _simcore-up _test_environment ## install testing framework
-	@$(MAKE) _simcore-images
-	@$(MAKE) _local-registry
-	@$(MAKE) _simcore-up
-	@$(MAKE) _test_environment
-	@$(MAKE) transfer-images-to-registry
-	@$(MAKE) inject-templates-in-db
-
-clean-up: ## remove everything
-	@$(MAKE_C) $(REPO_BASE_DIR) down
-	@$(MAKE_C) $(REPO_BASE_DIR) leave
-	@$(MAKE_C) $(REPO_BASE_DIR) rm-local-registry
-
-
-registry-up: ## deploys the insecure docker registry in the simcore network
-	docker stack deploy -c docker-compose.yml registry
-
-registry-down: ## bring the docker registry down
-	docker stack rm registry
-
-
-.PHONY: wait-for-services
-wait-for-services:  _check_venv_active ## wait for simcore services to be up
+_wait-for-services:  _check_venv_active
 	@python utils/wait_for_services.py
 
-
-.PHONY: transfer-images-to-registry
-transfer-images-to-registry: ## transfer images to registry
+_transfer-images-to-registry:
 	# pushing sleeper image
 	@docker pull itisfoundation/sleeper:1.0.0
 	@docker tag itisfoundation/sleeper:1.0.0 registry:5000/simcore/services/comp/itis/sleeper:1.0.0
@@ -70,12 +41,33 @@ transfer-images-to-registry: ## transfer images to registry
 	@curl -s http://registry:5000/v2/simcore/services/comp/itis/sleeper/tags/list?n=50 | jq '.'
 
 
-.PHONY: inject-templates-in-db
-inject-templates-in-db: ## inject project templates
+_inject-templates-in-db:
 	@docker cp tutorials/sleepers_project_template_sql.csv $$(docker ps -q --filter="name=postgres"):/template_projects_sleepers_project_template_sql.csv
 	@docker exec $$(docker ps -q --filter="name=postgres") psql --user scu --dbname simcoredb --command "\copy projects from '/template_projects_sleepers_project_template_sql.csv' csv header;"
 
 
+# SETUP ##################
+
+.PHONY: install clean-up
+install: _simcore-images _local-registry _simcore-up _test_environment ## install e2e testing framework and start simcore/registry
+	@$(MAKE) _simcore-images
+	@$(MAKE) _local-registry
+	@$(MAKE) _simcore-up
+	@$(MAKE) _test_environment
+	@$(MAKE) _transfer-images-to-registry
+	@$(MAKE) _inject-templates-in-db
+
+clean-up: ## remove everything
+	# switch simcore stack down
+	@$(MAKE_C) $(REPO_BASE_DIR) down
+	# leave docker swarm
+	@$(MAKE_C) $(REPO_BASE_DIR) leave
+	# remove local registry
+	@$(MAKE_C) $(REPO_BASE_DIR) rm-local-registry
+
+
+
+# TEST ###############
 .PHONY: test
 test: ## test the platform
 	# tests

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -9,34 +9,39 @@ $(DOT_ENV_BACKUP): $(SIMCORE_DOT_ENV)
 	@echo "WARNING ##### $@ does not exist, cloning $< as $@ ############"; cp $< $@)
 
 
-_build-simcore-images:
+_simcore-images:
 	@$(MAKE_C) $(REPO_BASE_DIR) pull-version tag-local || $(MAKE_C) ../.. build-x
 	@$(MAKE_C) $(REPO_BASE_DIR) info-images
 
-_setup-registry:
+_local-registry:
 	@$(MAKE_C) $(REPO_BASE_DIR) local-registry
 
-_setup-simcore:
+_simcore-up:
 	@echo WEBSERVER_LOGIN_REGISTRATION_INVITATION_REQUIRED=0 >> $(SIMCORE_DOT_ENV)
 	@echo WEBSERVER_LOGIN_REGISTRATION_CONFIRMATION_REQUIRED=0 >> $(SIMCORE_DOT_ENV)
 	@echo SERVICES_MAX_NANO_CPUS=2000000000 >> $(SIMCORE_DOT_ENV)
 	@echo SIDECAR_FORCE_CPU_NODE=1 >> $(SIMCORE_DOT_ENV)
 	@$(MAKE_C) $(REPO_BASE_DIR) up-prod
 
-_setup_python:
+_test_environment:
 	@$(MAKE_C) $(REPO_BASE_DIR) devenv
 	# install python dependencies
 	@$(VENV_DIR)/bin/pip install -r requirements/requirements.txt
 	# install node dependencies (puppeteer...)
 	@npm install
-
+	# wait for services being ready
+	@$(VENV_DIR)/bin/python utils/wait_for_services.py
 
 .PHONY: install
-install: _build-simcore-images _setup-registry _setup-simcore ## install testing framework
+install: _simcore-images _local-registry _simcore-up _test_environment ## install testing framework
+	@$(MAKE) _simcore-images
+	@$(MAKE) _local-registry
+	@$(MAKE) _simcore-up
+	@$(MAKE) _test_environment
+	@$(MAKE) transfer-images-to-registry
+	@$(MAKE) inject-templates-in-db
 
-
-
-clean-up:
+clean-up: ## remove everything
 	@$(MAKE_C) $(REPO_BASE_DIR) down
 	@$(MAKE_C) $(REPO_BASE_DIR) leave
 
@@ -60,20 +65,14 @@ transfer-images-to-registry: ## transfer images to registry
 	@docker tag itisfoundation/sleeper:1.0.0 registry:5000/simcore/services/comp/itis/sleeper:1.0.0
 	@docker push registry:5000/simcore/services/comp/itis/sleeper:1.0.0
 	# completed transfer of images
-	curl -s registry:5000/v2/_catalog | jq '.repositories'
-	curl -s http://registry:5000/v2/simcore/services/comp/itis/sleeper/tags/list?n=50 | jq '.'
+	@curl -s registry:5000/v2/_catalog | jq '.repositories'
+	@curl -s http://registry:5000/v2/simcore/services/comp/itis/sleeper/tags/list?n=50 | jq '.'
 
 
-PUBLISHED_PORT = $(shell docker inspect $(shell docker service ls --format "{{ .Name }}" | grep postgres) --format "{{(index .Endpoint.Ports 0).PublishedPort}}")
 .PHONY: inject-templates-in-db
 inject-templates-in-db: ## inject project templates
-	# Injecting fixture tables in database via port $(PUBLISHED_PORT)
-	PGPASSWORD=adminadmin psql \
-		--host 127.0.0.1 \
-		--port $(PUBLISHED_PORT) \
-		--user scu \
-		--dbname simcoredb \
-		--command "\copy projects from 'tutorials/sleepers_project_template_sql.csv' csv header;";
+	@docker cp tutorials/sleepers_project_template_sql.csv $$(docker ps -q --filter="name=postgres"):/template_projects_sleepers_project_template_sql.csv
+	@docker exec $$(docker ps -q --filter="name=postgres") psql --user scu --dbname simcoredb --command "\copy projects from '/template_projects_sleepers_project_template_sql.csv' csv header;"
 
 
 .PHONY: test

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -44,6 +44,7 @@ install: _simcore-images _local-registry _simcore-up _test_environment ## instal
 clean-up: ## remove everything
 	@$(MAKE_C) $(REPO_BASE_DIR) down
 	@$(MAKE_C) $(REPO_BASE_DIR) leave
+	@$(MAKE_C) $(REPO_BASE_DIR) rm-local-registry
 
 
 registry-up: ## deploys the insecure docker registry in the simcore network

--- a/tests/e2e/utils/wait_for_services.py
+++ b/tests/e2e/utils/wait_for_services.py
@@ -143,7 +143,7 @@ def wait_for_services() -> int:
                 )
     except RetryError:
         print(
-            f"found these services: {started_services}\nexpected services: {expected_services}"
+            f"found these services: {len(started_services)} {[s.name for s in started_services]}\nexpected services: {len(expected_services)} {expected_services}"
         )
         return os.EX_SOFTWARE
 

--- a/tests/e2e/utils/wait_for_services.py
+++ b/tests/e2e/utils/wait_for_services.py
@@ -79,7 +79,7 @@ def osparc_simcore_root_dir() -> Path:
 
 
 def core_docker_compose_file() -> Path:
-    return osparc_simcore_root_dir() / ".stack-simcore-version.yml"
+    return osparc_simcore_root_dir() / ".stack-simcore-production.yml"
 
 
 def core_services() -> List[str]:


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Running the e2e as is done in the CI is cumbersome locally.
Much of the complexity of the e2e bash scripts were moved into the Makefile and optimized (less changes in host system are necessary)

The CI does:
```console
cd tests/e2e
make install-ci
make test
make clean-up
```
The developer can do:
```console
cd tests/e2e
make install-prod # or -ci if she/he wants to do the exact same thing
make test
make clean-up
```

The Makefile installation recipe does in order:
- pull the simcore stack from Dockerhub (if install-ci is used, it will try to find the branch name)
- build the simcore stack (if install-ci is used, this is a fallback)
- modify the host file/docker engine to allow usage of a local registry
- start a local registry
- setup python/node environment for puppeteer/python test infrastructure
- wait for the stack to be up
- transfer the sleeper 1.0.0 from Dockerhub to the local registry
- inject the sleepers template into the local postgres DB

The Makefile test procedure:
- runs the small tests
- runs the sleepers tutorial

The Makefile clean-up procedure:
- leaves the swarm (thus killing all services)
- stops the local registry
- cleans the host file and the docker engine configuration

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state whether this PR needs a full rebuild, database changes, etc. -->

```console
# ensure the host is clean
make clean-all
# go to e2e
cd tests/e2e
make install-prod
make test
```

**Note for people testing 3rd party services locally:**
- the main Makefile allow to do ```make local-registry``` which will setup the simcore stack to use a local registry in ```registry:5000``` and you can push whatever service there (e.g. ```registry:5000/simcore/services/dynamic/my/awesom/service/that/fix/everything:2.3.4```)


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
