### PR TITLE
Partial pipelines: Handle retries in sidecar, and failures

### DIFF
--- a/services/sidecar/src/simcore_service_sidecar/celery_configurator.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery_configurator.py
@@ -56,7 +56,7 @@ def define_celery_task(app: Celery, name: str) -> None:
         base=AbortableTask,
         bind=True,
         autoretry_for=(Exception,),
-        retry_kwargs={"max_retries": 3, "countdown": 2},
+        retry_kwargs={"max_retries": 2, "countdown": 2},
         on_failure=on_task_failure_handler,
         on_success=on_task_success_handler,
         track_started=True,

--- a/services/sidecar/src/simcore_service_sidecar/celery_task.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery_task.py
@@ -35,13 +35,13 @@ def _shared_task_dispatch(
     try:
         next_task_nodes = wrap_async_call(
             run_sidecar(
-                celery_request.request.retries,
-                celery_request.max_retries,
                 celery_request.request.id,
                 user_id,
                 project_id,
                 node_id,
                 celery_request.is_aborted,
+                retry=celery_request.request.retries,
+                max_retries=celery_request.max_retries,
             )
         )
     except CancelledError:

--- a/services/sidecar/src/simcore_service_sidecar/celery_task.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery_task.py
@@ -25,14 +25,18 @@ def _shared_task_dispatch(
     celery_request, app: Celery, user_id: str, project_id: str, node_id: Optional[str]
 ) -> None:
     log.info(
-        "Run sidecar for user %s, project %s, node %s",
+        "Run sidecar for user %s, project %s, node %s retry [%s/%s]",
         user_id,
         project_id,
         node_id,
+        celery_request.request.retries,
+        celery_request.max_retries,
     )
     try:
         next_task_nodes = wrap_async_call(
             run_sidecar(
+                celery_request.request.retries,
+                celery_request.max_retries,
                 celery_request.request.id,
                 user_id,
                 project_id,

--- a/services/sidecar/src/simcore_service_sidecar/cli.py
+++ b/services/sidecar/src/simcore_service_sidecar/cli.py
@@ -48,13 +48,13 @@ async def perdiodicaly_check_if_aborted(is_aborted_cb: Callable[[], bool]) -> No
 
 @log_decorator(logger=log, level=logging.INFO)
 async def run_sidecar(
-    retry: int,
-    max_retries: int,
     job_id: str,
     user_id: str,
     project_id: str,
     node_id: Optional[str] = None,
     is_aborted_cb: Optional[Callable[[], bool]] = None,
+    retry: int = 1,
+    max_retries: int = 1,
 ) -> Optional[List[str]]:
     abortion_task = (
         asyncio.get_event_loop().create_task(

--- a/services/sidecar/src/simcore_service_sidecar/core.py
+++ b/services/sidecar/src/simcore_service_sidecar/core.py
@@ -127,40 +127,33 @@ async def _get_pipeline_from_db(
     return pipeline
 
 
-async def _set_task_status(
-    db_engine: Engine, project_id: str, node_id: str, run_result: StateType
+async def _set_task_state(
+    conn: SAConnection, project_id: str, node_id: str, state: StateType
 ):
-    log.debug("setting task status of %s:%s to %s", project_id, node_id, run_result)
-    async with db_engine.acquire() as connection:
-        await connection.execute(
-            # FIXME: E1120:No value for argument 'dml' in method call
-            # pylint: disable=E1120
-            comp_tasks.update()
-            .where(
-                and_(
-                    comp_tasks.c.node_id == node_id,
-                    comp_tasks.c.project_id == project_id,
-                )
+    log.debug("setting task status of %s:%s to %s", project_id, node_id, state)
+    await conn.execute(
+        # pylint: disable=E1120
+        comp_tasks.update()
+        .where(
+            and_(
+                comp_tasks.c.node_id == node_id,
+                comp_tasks.c.project_id == project_id,
             )
-            .values(state=run_result, end=datetime.utcnow())
         )
+        .values(state=state, end=datetime.utcnow())
+    )
 
 
-async def _set_pipeline_tasks_as_pending(
-    conn: SAConnection, graph: nx.DiGraph, project_id: str
+async def _set_tasks_state(
+    conn: SAConnection,
+    project_id: str,
+    graph: nx.DiGraph,
+    state: StateType,
+    offset: int = 0,
 ):
-    node_ids = list(graph.nodes)
-    for node_id in node_ids:
-        await conn.execute(
-            # pylint: disable=no-value-for-parameter
-            comp_tasks.update()
-            .where(
-                (comp_tasks.c.node_id == node_id)
-                & (comp_tasks.c.project_id == project_id)
-                & (comp_tasks.c.state != StateType.ABORTED)
-            )
-            .values(state=StateType.PENDING)
-        )
+    log.debug("setting tasks state from %s to %s", graph, state)
+    for node_id in list(graph.nodes())[offset:]:
+        await _set_task_state(conn, project_id, node_id, state)
 
 
 async def inspect(
@@ -175,82 +168,90 @@ async def inspect(
     max_retries: int,
 ) -> Optional[List[str]]:
 
-    task: Optional[RowProxy] = None
-    graph: Optional[nx.DiGraph] = None
-    try:
-        log.debug(
-            "ENTERING inspect with user %s pipeline:node %s: %s",
-            user_id,
-            project_id,
-            node_id,
-        )
+    async with db_engine.acquire() as connection:
+        task: Optional[RowProxy] = None
+        graph: Optional[nx.DiGraph] = None
+        try:
+            log.debug(
+                "ENTERING inspect with user %s pipeline:node %s: %s",
+                user_id,
+                project_id,
+                node_id,
+            )
 
-        async with db_engine.acquire() as connection:
             pipeline: RowProxy = await _get_pipeline_from_db(connection, project_id)
             graph = execution_graph(pipeline)
             if not node_id:
                 log.debug("NODE id was zero, this was the entry node id")
-                await _set_pipeline_tasks_as_pending(connection, graph, project_id)
+                await _set_tasks_state(connection, project_id, graph, StateType.PENDING)
                 return find_entry_point(graph)
             log.debug("NODE id is %s, getting the task from DB...", node_id)
             task = await _try_get_task_from_db(
                 connection, graph, job_request_id, project_id, node_id
             )
 
-        if not task:
-            log.debug("no task at hand, let's rest...")
-            return
-    except asyncio.CancelledError:
-        log.warning("Task has been cancelled")
-        if node_id:
-            await _set_task_status(db_engine, project_id, node_id, StateType.ABORTED)
-        raise
+            if not task:
+                log.debug("no task at hand, let's rest...")
+                return
+        except asyncio.CancelledError:
+            log.warning("Task has been cancelled")
+            if node_id:
+                await _set_task_state(
+                    connection, project_id, node_id, StateType.ABORTED
+                )
+            raise
 
-    run_result = StateType.FAILED
-    try:
-        await rabbit_mq.post_log_message(
-            user_id,
-            project_id,
-            node_id,
-            "[sidecar]Task found: starting...",
-        )
-
-        # config nodeports
-        node_ports_v2.node_config.USER_ID = user_id
-        node_ports_v2.node_config.NODE_UUID = task.node_id
-        node_ports_v2.node_config.PROJECT_ID = task.project_id
-
-        # now proceed actually running the task (we do that after the db session has been closed)
-        # try to run the task, return empyt list of next nodes if anything goes wrong
-
+        run_result = StateType.FAILED
         next_task_nodes = []
-
-        executor = Executor(
-            db_engine=db_engine,
-            rabbit_mq=rabbit_mq,
-            task=task,
-            user_id=user_id,
-        )
-        await executor.run()
-        next_task_nodes = list(graph.successors(node_id))
-        run_result = StateType.SUCCESS
-    except asyncio.CancelledError:
-        log.warning("Task has been cancelled")
-        run_result = StateType.ABORTED
-        await _set_task_status(db_engine, project_id, node_id, run_result)
-        raise
-
-    finally:
-        if node_id:
+        try:
             await rabbit_mq.post_log_message(
                 user_id,
                 project_id,
                 node_id,
-                f"[sidecar]Task completed with result: {run_result.name} [Trial {retry+1}/{max_retries}]",
+                "[sidecar]Task found: starting...",
             )
-            if (retry + 1) < max_retries and run_result == StateType.FAILED:
-                # try again!
-                run_result = StateType.PENDING
-            await _set_task_status(db_engine, project_id, node_id, run_result)
+
+            # config nodeports
+            node_ports_v2.node_config.USER_ID = user_id
+            node_ports_v2.node_config.NODE_UUID = task.node_id
+            node_ports_v2.node_config.PROJECT_ID = task.project_id
+
+            # now proceed actually running the task (we do that after the db session has been closed)
+            # try to run the task, return empyt list of next nodes if anything goes wrong
+            executor = Executor(
+                db_engine=db_engine,
+                rabbit_mq=rabbit_mq,
+                task=task,
+                user_id=user_id,
+            )
+            await executor.run()
+            next_task_nodes = list(graph.successors(node_id))
+            run_result = StateType.SUCCESS
+        except asyncio.CancelledError:
+            log.warning("Task has been cancelled")
+            run_result = StateType.ABORTED
+            raise
+
+        finally:
+            if node_id:
+                await rabbit_mq.post_log_message(
+                    user_id,
+                    project_id,
+                    node_id,
+                    f"[sidecar]Task completed with result: {run_result.name} [Trial {retry+1}/{max_retries}]",
+                )
+                if (retry + 1) < max_retries and run_result == StateType.FAILED:
+                    # try again!
+                    run_result = StateType.PENDING
+                await _set_task_state(connection, project_id, node_id, run_result)
+                if run_result == StateType.FAILED:
+                    # set the successive tasks as ABORTED
+                    await _set_tasks_state(
+                        connection,
+                        project_id,
+                        nx.bfs_tree(graph, node_id),
+                        StateType.ABORTED,
+                        offset=1,
+                    )
 
     return next_task_nodes

--- a/services/sidecar/src/simcore_service_sidecar/utils.py
+++ b/services/sidecar/src/simcore_service_sidecar/utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import uuid
-from typing import Awaitable, List
+from typing import Awaitable, List, Optional
 
 import aiodocker
 import networkx as nx
@@ -25,7 +25,7 @@ def wrap_async_call(fct: Awaitable):
 
 def find_entry_point(g: nx.DiGraph) -> List:
     result = []
-    for node in g.nodes:
+    for node in g.nodes():
         if len(list(g.predecessors(node))) == 0:
             result.append(node)
     return result
@@ -62,17 +62,9 @@ async def is_node_ready(
     return True
 
 
-def execution_graph(pipeline: RowProxy) -> nx.DiGraph:
+def execution_graph(pipeline: RowProxy) -> Optional[nx.DiGraph]:
     d = pipeline.dag_adjacency_list
-    G = nx.DiGraph()
-
-    for node in d.keys():
-        nodes = d[node]
-        if len(nodes) == 0:
-            G.add_node(node)
-            continue
-        G.add_edges_from([(node, n) for n in nodes])
-    return G
+    return nx.from_dict_of_lists(d, create_using=nx.DiGraph)
 
 
 def is_gpu_node() -> bool:

--- a/services/web/server/src/simcore_service_webserver/computation_subscribe.py
+++ b/services/web/server/src/simcore_service_webserver/computation_subscribe.py
@@ -16,11 +16,11 @@ from servicelib.monitor_services import (
 from servicelib.rabbitmq_utils import RabbitMQRetryPolicyUponInitialization
 from tenacity import retry
 
-from .computation_config import get_settings as get_computation_settings
 from .computation_config import (
     APP_CLIENT_RABBIT_DECORATED_HANDLERS_KEY,
     ComputationSettings,
 )
+from .computation_config import get_settings as get_computation_settings
 from .projects import projects_api
 from .projects.projects_exceptions import NodeNotFoundError, ProjectNotFoundError
 from .socketio.events import post_messages
@@ -60,7 +60,7 @@ async def parse_rabbit_message_data(app: web.Application, data: Dict) -> None:
             )
             messages["nodeUpdated"] = {
                 "Node": node_id,
-                "Data": project["workbench"][node_id],
+                "data": project["workbench"][node_id],
             }
         elif data["Channel"] == "Log":
             messages["logger"] = data


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
- When a computational task fails, the sidecar retries 2 times. setting the task back to PENDING so another sidecar might take it and run it.
- When the task fails 3 times, the task is set to FAILED
- Show the number of retries in the logs
- When a node fails, it then set the successors of that node to ABORTED

*see GIF below: The chip come from this [PR](https://github.com/ITISFoundation/osparc-simcore/pull/2057)
![propagating failure](https://user-images.githubusercontent.com/35365065/102405982-2d4f4900-3fea-11eb-98ed-489f03f69a1f.gif)


## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state whether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
