### PR TITLE
Bugfix/allow removing outputs from services

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -34,7 +34,7 @@ from ...utils.computations import (
     is_pipeline_stopped,
 )
 from ...utils.dags import create_dag_graph, create_minimal_graph_based_on_selection
-from ...utils.exceptions import ProjectNotFoundError
+from ...utils.exceptions import PipelineNotFoundError, ProjectNotFoundError
 from ..dependencies.celery import CeleryClient, get_celery_client
 from ..dependencies.database import get_repository
 from ..dependencies.director_v0 import DirectorV0Client, get_director_v0_client
@@ -228,7 +228,7 @@ async def get_computation(
         )
         return task_out
 
-    except ProjectNotFoundError as e:
+    except (ProjectNotFoundError, PipelineNotFoundError) as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
     # NOTE: this will be re-used for the prep2go API stuff... don't worry...

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
@@ -8,6 +8,7 @@ from models_library.projects_state import RunningState
 from sqlalchemy.dialects.postgresql import insert
 
 from ....models.domains.comp_pipelines import CompPipelineAtDB
+from ....utils.exceptions import PipelineNotFoundError
 from ....utils.logging_utils import log_decorator
 from ..tables import comp_pipeline
 from ._base import BaseRepository
@@ -24,6 +25,8 @@ class CompPipelinesRepository(BaseRepository):
             )
         )
         row: RowProxy = await result.fetchone()
+        if not row:
+            raise PipelineNotFoundError(str(project_id))
         return CompPipelineAtDB.from_orm(row)
 
     @log_decorator(logger=logger)

--- a/services/director-v2/src/simcore_service_director_v2/utils/exceptions.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/exceptions.py
@@ -11,7 +11,14 @@ class DirectorException(Exception):
 
 
 class ProjectNotFoundError(DirectorException):
-    """Service was not found in swarm"""
+    """Project not found error"""
 
     def __init__(self, project_id: ProjectID):
         super().__init__(f"project {project_id} not found")
+
+
+class PipelineNotFoundError(DirectorException):
+    """Pipeline not found error"""
+
+    def __init__(self, pipeline_id: str):
+        super().__init__(f"pipeline {pipeline_id} not found")

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -609,12 +609,16 @@ qx.Class.define("osparc.data.model.Node", {
     },
 
     setOutputData: function(outputs) {
-      if (outputs) {
-        for (const outputKey in outputs) {
+      if (outputs){
+        for (const outputKey in this.__outputs) {
           if (!Object.prototype.hasOwnProperty.call(this.__outputs, outputKey)) {
             this.__outputs[outputKey] = {};
           }
-          this.__outputs[outputKey]["value"] = outputs[outputKey];
+          if (!outputs.hasOwnProperty(outputKey)) {
+            this.__outputs[outputKey]["value"] = "";
+          } else {
+            this.__outputs[outputKey]["value"] = outputs[outputKey];
+          }
           this.fireDataEvent("outputChanged", outputKey);
         }
       }

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -614,10 +614,10 @@ qx.Class.define("osparc.data.model.Node", {
           if (!Object.prototype.hasOwnProperty.call(this.__outputs, outputKey)) {
             this.__outputs[outputKey] = {};
           }
-          if (!outputs.hasOwnProperty(outputKey)) {
-            this.__outputs[outputKey]["value"] = "";
-          } else {
+          if (Object.prototype.hasOwnProperty.call(outputs, outputKey)) {
             this.__outputs[outputKey]["value"] = outputs[outputKey];
+          } else {
+            this.__outputs[outputKey]["value"] = "";
           }
           this.fireDataEvent("outputChanged", outputKey);
         }

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -609,7 +609,7 @@ qx.Class.define("osparc.data.model.Node", {
     },
 
     setOutputData: function(outputs) {
-      if (outputs){
+      if (outputs) {
         for (const outputKey in this.__outputs) {
           if (!Object.prototype.hasOwnProperty.call(this.__outputs, outputKey)) {
             this.__outputs[outputKey] = {};

--- a/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 from pprint import pformat
-from typing import Dict, List
+from typing import Dict
 
 from aiohttp import web
 from aiopg.sa import Engine

--- a/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
@@ -61,11 +61,8 @@ async def _update_project_outputs(
     node_uuid: NodeID,
     outputs: Dict,
 ) -> None:
-    changed_keys: List[str] = list(outputs.keys())
-    if not changed_keys:
-        return
-
-    project = await projects_api.update_project_node_outputs(
+    # the new outputs might be {}, or {key_name: payload}
+    project, changed_keys = await projects_api.update_project_node_outputs(
         app,
         user_id,
         project_uuid,

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -11,7 +11,7 @@
 import logging
 from collections import defaultdict
 from pprint import pformat
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 from uuid import uuid4
 
 from aiohttp import web
@@ -344,7 +344,7 @@ async def update_project_node_outputs(
     project_id: str,
     node_id: str,
     data: Optional[Dict],
-) -> Dict:
+) -> Tuple[Dict, List[str]]:
     """
     Updates outputs of a given node in a project with 'data'
     """
@@ -363,25 +363,34 @@ async def update_project_node_outputs(
 
     # NOTE: update outputs (not required) if necessary as the UI expects a
     # dataset/label field that is missing
-    outputs: Dict[str, Any] = project["workbench"][node_id].setdefault("outputs", {})
-    outputs.update(data)
+    current_outputs = project["workbench"][node_id].setdefault("outputs", {})
+    new_outputs = data
+    project["workbench"][node_id]["outputs"] = new_outputs
 
-    for output_key in outputs.keys():
-        if not isinstance(outputs[output_key], dict):
+    # find changed keys (the ones that appear or disapppear for sure)
+    changed_keys = list(current_outputs.keys() ^ new_outputs.keys())
+    # now check the ones that are in both object
+    for key in current_outputs.keys() & new_outputs.keys():
+        if current_outputs[key] != new_outputs[key]:
+            changed_keys.append(key)
+
+    # FIXME: this should be reviewed @maiz. how is an output file defined. I think we have several flavours.
+    for output_key in new_outputs.keys():
+        if not isinstance(new_outputs[output_key], dict):
             continue
-        if "path" in outputs[output_key]:
+        if "path" in new_outputs[output_key]:
             # file_id is of type study_id/node_id/file.ext
-            file_id = outputs[output_key]["path"]
+            file_id = new_outputs[output_key]["path"]
             study_id, _, file_ext = file_id.split("/")
-            outputs[output_key]["dataset"] = study_id
-            outputs[output_key]["label"] = file_ext
+            new_outputs[output_key]["dataset"] = study_id
+            new_outputs[output_key]["label"] = file_ext
 
     db = app[APP_PROJECT_DBAPI]
     updated_project = await db.update_user_project(project, user_id, project_id)
     updated_project["state"] = await get_project_state_for_user(
         user_id, project_id, app
     )
-    return updated_project
+    return updated_project, changed_keys
 
 
 async def get_workbench_node_ids_from_project_uuid(


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
- backend correctly updates the project DB table when a service removes an output (e.g. jupyter lab empty the outputs folder, -> propagates to comp_tasks table, then propagates to projects table)
- frontend correctly updates the UI (please @odeimaiz , @ignapas check that part, it does not pass the linter)

**NOTE:** the files are still in S3 and they stay there forever unless overwritten (this did not change)

![removing_files](https://user-images.githubusercontent.com/35365065/102633261-7ae5c600-4150-11eb-91fd-a886befab81e.gif)

## Related issue number

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state whether this PR needs a full rebuild, database changes, etc. -->
```
make up-devel
```
- fire up a jupyter-lab 1.5.2
- put some stuff in the outputs folder, the frontend shows the files correctly
- delete that stuff, the frontend removes the files correctly

## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)

