### PR TITLE
bugfix: director-v2 is implicitely converting float values to int, preventing kember from running

### DIFF
--- a/packages/models-library/src/models_library/projects_nodes.py
+++ b/packages/models-library/src/models_library/projects_nodes.py
@@ -4,7 +4,17 @@
 
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, Extra, Field, HttpUrl, constr, validator
+from pydantic import (
+    BaseModel,
+    Extra,
+    Field,
+    HttpUrl,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    constr,
+    validator,
+)
 
 from .basic_regex import VERSION_RE
 from .projects_access import AccessEnum
@@ -20,10 +30,23 @@ from .projects_state import RunningState
 from .services import PROPERTY_KEY_RE, SERVICE_KEY_RE
 
 InputTypes = Union[
-    int, bool, str, float, PortLink, SimCoreFileLink, DatCoreFileLink, DownloadLink
+    StrictBool,
+    StrictInt,
+    StrictFloat,
+    str,
+    PortLink,
+    SimCoreFileLink,
+    DatCoreFileLink,
+    DownloadLink,
 ]
 OutputTypes = Union[
-    int, bool, str, float, SimCoreFileLink, DatCoreFileLink, DownloadLink
+    StrictBool,
+    StrictInt,
+    StrictFloat,
+    str,
+    SimCoreFileLink,
+    DatCoreFileLink,
+    DownloadLink,
 ]
 
 InputID = OutputID = constr(regex=PROPERTY_KEY_RE)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Kember tutorial was failing because a wrong value of 0 is passed as deltaT to the kember service

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
