### PR TITLE
bugfix:Fixes/stop services

### DIFF
--- a/ci/github/unit-testing/api-server.bash
+++ b/ci/github/unit-testing/api-server.bash
@@ -11,7 +11,7 @@ install() {
 
 test() {
     pytest --cov=simcore_service_api_server --durations=10 --cov-append \
-          --color=yes --cov-report=term-missing --cov-report=xml \
+          --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
           -v -m "not travis" services/api-server/tests/unit
 }
 

--- a/packages/pytest-simcore/src/pytest_simcore/schemas.py
+++ b/packages/pytest-simcore/src/pytest_simcore/schemas.py
@@ -4,7 +4,7 @@ import json
 import logging
 import subprocess
 from pathlib import Path
-from typing import Callable, Dict, Iterable
+from typing import Any, Callable, Dict, Iterable
 
 import pytest
 
@@ -54,9 +54,11 @@ def json_faker_script(script_dir: Path) -> Path:
 
 @pytest.fixture(scope="session")
 def random_json_from_schema(
-    json_faker_script: Path, tmp_path_factory: Path
-) -> Iterable[Callable]:
-    def _generator(json_schema: str) -> Dict:
+    json_faker_script: Path, tmp_path_factory
+) -> Iterable[Callable[[str], Dict[str, Any]]]:
+    # tmp_path_factory fixture: https://docs.pytest.org/en/stable/tmpdir.html
+
+    def _generator(json_schema: str) -> Dict[str, Any]:
         tmp_path = tmp_path_factory.mktemp(__name__)
         schema_path = tmp_path / "schema.json"
 

--- a/packages/pytest-simcore/src/pytest_simcore/schemas.py
+++ b/packages/pytest-simcore/src/pytest_simcore/schemas.py
@@ -4,7 +4,7 @@ import json
 import logging
 import subprocess
 from pathlib import Path
-from typing import Callable, Dict
+from typing import Callable, Dict, Iterable
 
 import pytest
 
@@ -33,7 +33,7 @@ def node_meta_schema(node_meta_schema_file: Path) -> Dict:
 
 
 @pytest.fixture(scope="session")
-def json_schema_dict(common_schemas_specs_dir: Path) -> Callable:
+def json_schema_dict(common_schemas_specs_dir: Path) -> Iterable[Callable]:
     def schema_getter(schema_name: str) -> Dict:
         json_file = common_schemas_specs_dir / schema_name
         assert (
@@ -55,12 +55,15 @@ def json_faker_script(script_dir: Path) -> Path:
 @pytest.fixture(scope="session")
 def random_json_from_schema(
     json_faker_script: Path, tmp_path_factory: Path
-) -> Callable:
-    def _generator(schema: Dict) -> Dict:
+) -> Iterable[Callable]:
+    def _generator(json_schema: str) -> Dict:
         tmp_path = tmp_path_factory.mktemp(__name__)
         schema_path = tmp_path / "schema.json"
-        schema_path.write_text(schema)
+
+        schema_path.write_text(json_schema)
         assert schema_path.exists()
+
+        print("Faking schema\n", schema_path.read_text(), "\n")
 
         generated_json_path = tmp_path / "random_example.json"
         assert not generated_json_path.exists()
@@ -74,9 +77,10 @@ def random_json_from_schema(
             check=False,
             cwd=tmp_path,
         )
+
         assert (
             result.returncode == 0
-        ), f"Issue running {result.args}, gives following errors:\n{result.stdout}"
+        ), f"Issue running {result.args}, gives following errors:\n{result.stdout.decode('utf-8')}"
 
         assert generated_json_path.exists()
         return json.loads(generated_json_path.read_text())

--- a/packages/service-library/tests/with_postgres/test_aiopg_utils.py
+++ b/packages/service-library/tests/with_postgres/test_aiopg_utils.py
@@ -139,7 +139,7 @@ async def test_engine_when_idle_for_some_time():
     # import pdb; pdb.set_trace()
 
 
-async def test_engine_when_pg_not_reachable():
+async def test_engine_when_pg_not_reachable(loop):
     dsn = DataSourceName(
         database="db", user="foo", password="foo", host="localhost", port=123
     )

--- a/scripts/common.Makefile
+++ b/scripts/common.Makefile
@@ -83,6 +83,12 @@ inf%: ## displays basic info
 	@echo ' NOW_TIMESTAMP    : ${NOW_TIMESTAMP}'
 	@echo ' VCS_URL          : ${VCS_URL}'
 	@echo ' VCS_REF          : ${VCS_REF}'
+	# dev tools version
+	@echo ' make   : $(shell make --version 2>&1 | head -n 1)'
+	@echo ' jq     : $(shell jq --version)'
+	@echo ' awk    : $(shell awk -W version 2>&1 | head -n 1)'
+	@echo ' node   : $(shell node --version 2> /dev/null || echo ERROR nodejs missing)'
+	@echo ' python : $(shell python3 --version)'
 	# installed in .venv
 	@pip list
 	# package

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     init: true
     environment:
       - WEBSERVER_HOST=${WEBSERVER_HOST:-webserver}
-      - LOGLEVEL=${LOG_LEVEL:-INFO}
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
     env_file:
       - ../.env
     deploy:

--- a/services/web/server/src/simcore_service_webserver/director/config.py
+++ b/services/web/server/src/simcore_service_webserver/director/config.py
@@ -6,17 +6,16 @@
 from typing import Dict, Optional, Tuple
 
 import trafaret as T
-from aiohttp import ClientSession
 from aiohttp.web import Application
-from pydantic import AnyHttpUrl, BaseSettings, Field, validator
-
 from models_library.basic_types import PortInt, VersionTag
-from servicelib.application_keys import APP_CLIENT_SESSION_KEY, APP_CONFIG_KEY
+from pydantic import AnyHttpUrl, BaseSettings, Field, validator
+from servicelib.application_keys import APP_CONFIG_KEY
 
 APP_DIRECTOR_API_KEY = __name__ + ".director_api"
 
 CONFIG_SECTION_NAME = "director"
 
+# TODO: deprecate trafaret schema
 schema = T.Dict(
     {
         T.Key("enabled", default=True, optional=True): T.Bool(),
@@ -27,7 +26,7 @@ schema = T.Dict(
         T.Key("port", default=8001): T.ToInt(),
         T.Key("version", default="v0"): T.Regexp(
             regexp=r"^v\d+"
-        ),  # storage API version basepath
+        ),  # director API version basepath
     }
 )
 
@@ -57,10 +56,6 @@ class DirectorSettings(BaseSettings):
 
 def get_config(app: Application) -> Dict:
     return app[APP_CONFIG_KEY][CONFIG_SECTION_NAME]
-
-
-def get_client_session(app: Application) -> ClientSession:
-    return app[APP_CLIENT_SESSION_KEY]
 
 
 def assert_valid_config(app: Application) -> Tuple[Dict, DirectorSettings]:

--- a/services/web/server/src/simcore_service_webserver/director/director_api.py
+++ b/services/web/server/src/simcore_service_webserver/director/director_api.py
@@ -4,22 +4,19 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from aiohttp import ClientSession, web
 from models_library.settings.services_common import ServicesCommonSettings
+from servicelib.client_session import get_client_session
 from servicelib.utils import logged_gather
 from yarl import URL
 
 from . import director_exceptions
-from .config import get_client_session, get_config
+from .config import get_config
 
 log = logging.getLogger(__name__)
 
 
 def _get_director_client(app: web.Application) -> Tuple[ClientSession, URL]:
-    cfg = get_config(app)
+    cfg: Dict[str, Any] = get_config(app)
 
-    # director service API endpoint
-    # TODO: service API endpoint could be deduced and checked upon setup (e.g. health check on startup)
-    # Use director.
-    # TODO: this is also in app[APP_DIRECTOR_API_KEY] upon startup
     api_endpoint = URL.build(
         scheme="http", host=cfg["host"], port=cfg["port"]
     ).with_path(cfg["version"])

--- a/services/web/server/src/simcore_service_webserver/director/director_api.py
+++ b/services/web/server/src/simcore_service_webserver/director/director_api.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-many-arguments
-
 import logging
 import urllib.parse
 from typing import Any, Dict, List, Optional, Tuple

--- a/services/web/server/src/simcore_service_webserver/director/director_api.py
+++ b/services/web/server/src/simcore_service_webserver/director/director_api.py
@@ -1,3 +1,8 @@
+"""
+    Facade to DIRECTOR service:
+        - collection of functions to perform requests to the DIRECTOR services
+"""
+
 import logging
 import urllib.parse
 from typing import Any, Dict, List, Optional, Tuple
@@ -100,8 +105,11 @@ async def stop_services(
     services = await get_running_interactive_services(
         app, user_id=user_id, project_id=project_id
     )
+
     stop_tasks = [stop_service(app, s["service_uuid"]) for s in services]
-    await logged_gather(*stop_tasks, reraise=False)
+
+    # FIXME: if stop_service is cancelled, it will and is running stop_tasks, it will never cancel!
+    await logged_gather(*stop_tasks, reraise=True)
 
 
 async def get_service_by_key_version(

--- a/services/web/server/src/simcore_service_webserver/director/module_setup.py
+++ b/services/web/server/src/simcore_service_webserver/director/module_setup.py
@@ -6,12 +6,8 @@
 import logging
 
 from aiohttp import web
-
 from servicelib.application_setup import ModuleCategory, app_module_setup
-from servicelib.rest_routing import (
-    iter_path_operations,
-    map_handlers_with_operations,
-)
+from servicelib.rest_routing import iter_path_operations, map_handlers_with_operations
 
 from ..rest_config import APP_OPENAPI_SPECS_KEY
 from .config import APP_DIRECTOR_API_KEY, assert_valid_config
@@ -36,7 +32,7 @@ def setup_director(app: web.Application, *, disable_login=False):
     # ----------------------------------------------
     # TODO: temporary, just to check compatibility between
     # trafaret and pydantic schemas
-    _ , settings = assert_valid_config(app)
+    _, settings = assert_valid_config(app)
     # ---------------------------------------------
 
     # director service API base url, e.g. http://director:8081/v0
@@ -61,6 +57,3 @@ def setup_director(app: web.Application, *, disable_login=False):
         handlers_dict, filter(include_path, iter_path_operations(specs)), strict=True
     )
     app.router.add_routes(routes)
-
-
-__all__ = "setup_director"

--- a/services/web/server/tests/unit/conftest.py
+++ b/services/web/server/tests/unit/conftest.py
@@ -29,6 +29,7 @@ pytest_plugins = [
     "pytest_simcore.repository_paths",
     "pytest_simcore.environment_configs",
     "pytest_simcore.services_api_mocks_for_aiohttp_clients",
+    "pytest_simcore.schemas",
 ]
 
 

--- a/services/web/server/tests/unit/isolated/test_director_api.py
+++ b/services/web/server/tests/unit/isolated/test_director_api.py
@@ -1,0 +1,17 @@
+# pylint:disable=unused-argument
+# pylint:disable=redefined-outer-name
+# pylint:disable=no-name-in-module
+
+
+import pytest
+from simcore_service_webserver.director.director_api import (
+    get_service_by_key_version,
+    get_services_extras,
+    start_service,
+    stop_service,
+    stop_services,
+)
+
+# director API mock based on openapi specs
+
+#

--- a/services/web/server/tests/unit/isolated/test_director_api.py
+++ b/services/web/server/tests/unit/isolated/test_director_api.py
@@ -3,8 +3,23 @@
 # pylint:disable=no-name-in-module
 
 
+import json
+import re
+from typing import Dict
+
 import pytest
+from aiohttp.client import ClientSession
+from aiohttp.web_routedef import static
+from aioresponses.core import CallbackResult, aioresponses
+from faker import Faker
+from models_library.services import ServiceDockerData
+from servicelib.client_session import get_client_session
+from simcore_service_webserver.director.config import (
+    APP_DIRECTOR_API_KEY,
+    DirectorSettings,
+)
 from simcore_service_webserver.director.director_api import (
+    get_running_interactive_services,
     get_service_by_key_version,
     get_services_extras,
     start_service,
@@ -12,6 +27,126 @@ from simcore_service_webserver.director.director_api import (
     stop_services,
 )
 
-# director API mock based on openapi specs
 
-#
+@pytest.fixture
+async def director_service_api_mock(loop, faker: Faker) -> aioresponses:
+    #
+    # Mocks director's service API api/specs/director/openapi.yaml
+    #
+    #
+
+    # GET /running_interactive_services
+    class get_running_interactive_services:
+        pattern = re.compile(
+            r"^http://[a-z\-_]*director:[0-9]+/v0/running_interactive_services$"
+        )
+
+        @staticmethod
+        def handler(url, **kwargs):
+            def _create(n):
+                return dict(
+                    published_port=faker.unique.random_int(),
+                    entry_point="/the/entry/point/is/here",
+                    service_uuid=faker.unique.uuid4(cast_to=str),
+                    service_key=f"simcore/services/comp/itis/{faker.unique.word()}",
+                    service_version=".".join(str(faker.random_int()) for _ in range(3)),
+                    service_host="jupyter_E1O2E-LAH",
+                    service_port=faker.unique.random_int(80, 10000),
+                    service_basepath="/x/E1O2E-LAH",
+                    service_state=faker.random_choices(["pending", "starting"]),
+                    service_message=faker.unique.sentence(),
+                )
+
+            return CallbackResult(payload={"data": [_create(n) for n in range(3)]})
+
+    # POST /running_interactive_services
+    start_service = re.compile(
+        r"^http://[a-z\-_]*director:[0-9]+/v0/running_interactive_services$"
+    )
+
+    # DELETE /running_interactive_services/{service_uuid}
+    stop_service = re.compile(
+        r"^http://[a-z\-_]*director:[0-9]+/v0/running_interactive_services/.+$"
+    )
+
+    # GET /service_extras/{service_key}/{service_version}
+    get_service_by_key_version = re.compile(
+        r"^http://[a-z\-_]*director:[0-9]+/v0/services/\w+/.+$"
+    )
+
+    # GET /services/{service_key}/{service_version}
+    get_service_extras = re.compile(
+        r"^http://[a-z\-_]*director:[0-9]+/v0/service_extras/\w+/.+$"
+    )
+
+    with aioresponses() as mock:
+        mock.get(
+            get_running_interactive_services.pattern,
+            status=200,
+            callback=get_running_interactive_services.handler,
+        )
+        mock.post(start_service, status=200, payload={"data": {}})
+        mock.delete(
+            stop_service,
+            status=204,
+        )
+
+        mock.get(get_service_by_key_version, status=200, payload={"data": {}})
+        mock.get(get_service_extras, status=200, payload={"data": {}})
+
+        yield mock
+
+
+@pytest.mark.skip(reason="dev")
+async def test_mocks(director_service_api_mock):
+    async with ClientSession() as session:
+        async with session.get(
+            "http://director:8000/v0/running_interactive_services"
+        ) as resp:
+            assert resp.status == 200
+            print(await resp.json())
+
+
+@pytest.fixture
+def app_mock(director_service_api_mock):
+    # we only need the app as a container of the aiohttp client session and
+    # the director entrypoint
+    #
+    settings = DirectorSettings()
+
+    app = {}
+    app[APP_DIRECTOR_API_KEY] = str(settings.url)
+    single_client_in_app = get_client_session(app)
+    assert single_client_in_app
+    assert single_client_in_app is get_client_session(app)
+
+    return app
+
+
+async def test_director_api_client_calls(app):
+
+    # check services running in my study
+    services = await get_running_interactive_services(
+        app, user_id="1", project_id="dc7d6847-a3b7-4905-bbfb-777e3bd433c8"
+    )
+
+    service = await get_service_by_key_version(
+        app, service_key="simcore/comp/isolve", service_version="1.0.3"
+    )
+
+    extras = await get_services_extras(
+        app, service_key="simcore/comp/isolve", service_version="1.0.3"
+    )
+
+    started = await start_service(
+        app,
+        user_id="1",
+        project_id="dc7d6847-a3b7-4905-bbfb-777e3bd433c8",
+        service_key="simcore/comp/isolve",
+        service_version="1.0.3",
+        service_uuid="43946ec4-fb14-4667-a81b-df6e8375282d",
+    )
+
+    await stop_service(app, started["uuid"])
+
+    await stop_services(app, project_id="dc7d6847-a3b7-4905-bbfb-777e3bd433c8")

--- a/services/web/server/tests/unit/isolated/test_director_api.py
+++ b/services/web/server/tests/unit/isolated/test_director_api.py
@@ -3,15 +3,9 @@
 # pylint:disable=no-name-in-module
 """
     Tests services/web/server/src/simcore_service_webserver/director/director_api.py which ...
-    - is a ubmodule part of the 'director' app module at the webserver
+    - is a submodule part of the 'director' app module at the webserver
     - provides function interface that simplifies requests to the 'director service'
     - NOTE: was deprecated and  shall use instead 'director-v2' service
-
-
-    - Tests that all requests to director's API comply with openapi specs at api/specs/director/openapi.yaml
-        - paths are correct
-        - i/o are correct
-    - Any changes in the director API interface should make this test fail
 
 """
 import json
@@ -46,7 +40,7 @@ def director_openapi_dir(osparc_simcore_root_dir: Path) -> Path:
 
 @pytest.fixture(scope="session")
 def director_openapi_specs(director_openapi_dir: Path) -> Dict[str, Any]:
-    openapi_path = director_openapi_dir / "openapi.yml"
+    openapi_path = director_openapi_dir / "openapi.yaml"
     openapi_specs = yaml.safe_load(openapi_path.read_text())
     return openapi_specs
 
@@ -86,6 +80,10 @@ def registry_service_model_schema(osparc_simcore_root_dir: Path) -> Dict:
 
 @pytest.fixture(scope="session")
 def model_fake_factory(random_json_from_schema: Callable) -> Callable:
+    """
+    Adapter to create fake data instances of a mo
+    """
+
     def _create(schema: Dict, **override_attrs):
         model_instance = random_json_from_schema(json.dumps(schema))
         model_instance.update(override_attrs)
@@ -124,9 +122,6 @@ def project_nodes():
             ":"
         ),
     ].copy()
-
-
-# -------------------
 
 
 @pytest.fixture
@@ -344,8 +339,20 @@ def test_director_openapi_specs(director_openapi_specs):
     # do it so we resign ourselves to doing it by hand
     #
     assert "get" in director_openapi_specs["paths"]["/running_interactive_services"]
-    assert "delete" in director_openapi_specs["paths"]["/running_interactive_services"]
     assert "post" in director_openapi_specs["paths"]["/running_interactive_services"]
+
+    assert (
+        "delete"
+        in director_openapi_specs["paths"][
+            "/running_interactive_services/{service_uuid}"
+        ]
+    )
+    assert (
+        "get"
+        in director_openapi_specs["paths"][
+            "/running_interactive_services/{service_uuid}"
+        ]
+    )
 
 
 async def test_director_workflow(

--- a/services/web/server/tests/unit/isolated/test_director_api.py
+++ b/services/web/server/tests/unit/isolated/test_director_api.py
@@ -314,25 +314,6 @@ def app_mock():
     return app
 
 
-@pytest.mark.skip(reason="dev")
-async def test_aioresponse_mocks(mock_director_service):
-    # NOTE: keep this to tune mock_director_service fixture
-
-    for match in mock_director_service._matches.values():
-        print(
-            match.method,
-            match.url_or_pattern,
-        )
-
-    async with ClientSession() as session:
-        async with session.get(
-            # "http://director:8000/v0/running_interactive_services"
-            "http://director:8001/v0/running_interactive_services?project_id=dc7d6847-a3b7-4905-bbfb-777e3bd433c8&user_id=1"
-        ) as resp:
-            assert resp.status == 200
-            print(await resp.json())
-
-
 def test_director_openapi_specs(director_openapi_specs):
     #
     # At this point in time we cannot afford a more sophisticated way to

--- a/services/web/server/tests/unit/isolated/test_director_api.py
+++ b/services/web/server/tests/unit/isolated/test_director_api.py
@@ -1,152 +1,418 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 # pylint:disable=no-name-in-module
+"""
+    Tests services/web/server/src/simcore_service_webserver/director/director_api.py which ...
+    - is a ubmodule part of the 'director' app module at the webserver
+    - provides function interface that simplifies requests to the 'director service'
+    - NOTE: was deprecated and  shall use instead 'director-v2' service
 
 
+    - Tests that all requests to director's API comply with openapi specs at api/specs/director/openapi.yaml
+        - paths are correct
+        - i/o are correct
+    - Any changes in the director API interface should make this test fail
+
+"""
 import json
 import re
-from typing import Dict
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Tuple
 
 import pytest
+import simcore_service_webserver.director.config as director_config
+import yaml
+from aiohttp import web
 from aiohttp.client import ClientSession
-from aiohttp.web_routedef import static
 from aioresponses.core import CallbackResult, aioresponses
-from faker import Faker
-from models_library.services import ServiceDockerData
 from servicelib.client_session import get_client_session
-from simcore_service_webserver.director.config import (
-    APP_DIRECTOR_API_KEY,
-    DirectorSettings,
-)
+from simcore_service_webserver.director.config import DirectorSettings
 from simcore_service_webserver.director.director_api import (
     get_running_interactive_services,
     get_service_by_key_version,
-    get_services_extras,
     start_service,
-    stop_service,
     stop_services,
 )
+from simcore_service_webserver.director.module_setup import setup_director
+from yarl import URL
+
+
+@pytest.fixture(scope="session")
+def director_openapi_dir(osparc_simcore_root_dir: Path) -> Path:
+    base_dir = osparc_simcore_root_dir / "api" / "specs" / "director"
+    assert base_dir.exists()
+    return base_dir
+
+
+@pytest.fixture(scope="session")
+def director_openapi_specs(director_openapi_dir: Path) -> Dict[str, Any]:
+    openapi_path = director_openapi_dir / "openapi.yml"
+    openapi_specs = yaml.safe_load(openapi_path.read_text())
+    return openapi_specs
+
+
+@pytest.fixture(scope="session")
+def running_service_model_schema(osparc_simcore_root_dir: Path) -> Dict:
+    # SEE: https://github.com/ITISFoundation/osparc-simcore/tree/master/api/specs/common/schemas/running_service.yaml#L30
+    content = yaml.safe_load(
+        (
+            osparc_simcore_root_dir / "api/specs/common/schemas/running_service.yaml"
+        ).read_text()
+    )
+    schema = content["components"]["schemas"]["RunningServiceType"]
+
+    # Creates fake instances of RunningServiceType model
+    # Check dump manually in https://json-schema-faker.js.org/
+    print(json.dumps(schema))
+
+    return schema
+
+
+@pytest.fixture(scope="session")
+def registry_service_model_schema(osparc_simcore_root_dir: Path) -> Dict:
+    # SEE: https://github.com/ITISFoundation/osparc-simcore/tree/master/api/specs/common/schemas/services.yaml#L11
+    #      https://github.com/ITISFoundation/osparc-simcore/tree/master/api/specs/common/schemas/node-meta-v0.0.1.json
+    schema = json.loads(
+        (
+            osparc_simcore_root_dir / "api/specs/common/schemas/node-meta-v0.0.1.json"
+        ).read_text()
+    )
+
+    # Check dump manually in https://json-schema-faker.js.org/
+    print(json.dumps(schema))
+
+    return schema
+
+
+@pytest.fixture(scope="session")
+def model_fake_factory(random_json_from_schema: Callable) -> Callable:
+    def _create(schema: Dict, **override_attrs):
+        model_instance = random_json_from_schema(json.dumps(schema))
+        model_instance.update(override_attrs)
+
+        # TODO: validate model instance including overrides?
+
+        return model_instance
+
+    return _create
+
+
+# SCENARIO / TEST CONTEXT -----------------
+#
+# For the sake of simplicity, the director service is
+# mocked assuming a concrete context/scenario:
+#
+
+
+@pytest.fixture(scope="module")
+def user_id():
+    return 1
+
+
+@pytest.fixture(scope="module")
+def project_id():
+    return "dc7d6847-a3b7-4905-bbfb-777e3bd433c8"
+
+
+@pytest.fixture(scope="module")
+def project_nodes():
+    return [
+        "simcore/services/dynamic/smash:1.0.3:4fc8d1e6-a06c-451a-8eb8-2f64b8f93efa".split(
+            ":"
+        ),
+        "simcore/services/dynamic/jupyter:3.4.2:503c0ab8-133f-455f-b07d-53364dbfead5".split(
+            ":"
+        ),
+    ].copy()
+
+
+# -------------------
 
 
 @pytest.fixture
-async def director_service_api_mock(loop, faker: Faker) -> aioresponses:
-    #
-    # Mocks director's service API api/specs/director/openapi.yaml
-    #
-    #
+def mock_director_service(
+    model_fake_factory,
+    running_service_model_schema,
+    registry_service_model_schema,
+    user_id: int,
+    project_id: str,
+    project_nodes: List[Tuple[str, ...]],
+):
 
-    # GET /running_interactive_services
-    class get_running_interactive_services:
-        pattern = re.compile(
-            r"^http://[a-z\-_]*director:[0-9]+/v0/running_interactive_services$"
+    # helpers
+    def fake_registry_service_model(**overrides):
+        return model_fake_factory(registry_service_model_schema, **overrides)
+
+    def fake_running_service_model(**overrides):
+        return model_fake_factory(running_service_model_schema, **overrides)
+
+    # fake director service "state" variables
+    _fake_project_services = [
+        fake_registry_service_model(key=s[0], version=s[1]) for s in project_nodes
+    ]
+
+    _fake_running_services = []
+
+    def _get_running():
+        return [
+            s
+            for s in _fake_running_services
+            if s["service_state"] not in "complete failed".split()
+        ]
+
+    #
+    # Mocks director's service API  api/specs/director/openapi.yaml
+    #
+    with aioresponses() as mock:
+
+        # GET /running_interactive_services -------------------------------------------------
+        url_pattern = (
+            r"^http://[a-z\-_]*director:[0-9]+/v0/running_interactive_services\?.*$"
         )
 
-        @staticmethod
-        def handler(url, **kwargs):
-            def _create(n):
-                return dict(
-                    published_port=faker.unique.random_int(),
-                    entry_point="/the/entry/point/is/here",
-                    service_uuid=faker.unique.uuid4(cast_to=str),
-                    service_key=f"simcore/services/comp/itis/{faker.unique.word()}",
-                    service_version=".".join(str(faker.random_int()) for _ in range(3)),
-                    service_host="jupyter_E1O2E-LAH",
-                    service_port=faker.unique.random_int(80, 10000),
-                    service_basepath="/x/E1O2E-LAH",
-                    service_state=faker.random_choices(["pending", "starting"]),
-                    service_message=faker.unique.sentence(),
+        def get_running_interactive_services_handler(url: URL, **kwargs):
+            assert int(url.query.get("user_id", 0)) in (user_id, 0)
+            assert url.query.get("project_id") in (project_id, None)
+
+            return CallbackResult(payload={"data": _get_running()}, status=200)
+
+        mock.get(
+            re.compile(url_pattern),
+            callback=get_running_interactive_services_handler,
+            repeat=True,
+        )
+
+        # POST /running_interactive_services -------------------------------------------------
+
+        url_pattern = (
+            r"^http://[a-z\-_]*director:[0-9]+/v0/running_interactive_services\?.*$"
+        )
+
+        def start_service_handler(url: URL, **kwargs):
+            assert int(url.query["user_id"]) == user_id
+            assert url.query["project_id"] == project_id
+
+            service_uuid = url.query["service_uuid"]
+
+            if any(s["service_uuid"] == service_uuid for s in _get_running()):
+                return CallbackResult(
+                    payload={
+                        "error": f"A service with the same uuid {service_uuid} already running exists"
+                    },
+                    status=409,
                 )
 
-            return CallbackResult(payload={"data": [_create(n) for n in range(3)]})
+            service_key = url.query["service_key"]
+            service_tag = url.query.get("service_tag")
 
-    # POST /running_interactive_services
-    start_service = re.compile(
-        r"^http://[a-z\-_]*director:[0-9]+/v0/running_interactive_services$"
-    )
+            try:
+                service = next(
+                    s
+                    for s in _fake_project_services
+                    if s["key"] == service_key and s["version"] == service_tag
+                )
+            except StopIteration:
+                return CallbackResult(
+                    payload={
+                        "error": f"Service {service_key}:{service_tag} not found in project"
+                    },
+                    status=404,
+                )
 
-    # DELETE /running_interactive_services/{service_uuid}
-    stop_service = re.compile(
-        r"^http://[a-z\-_]*director:[0-9]+/v0/running_interactive_services/.+$"
-    )
+            starting_service = fake_running_service_model(
+                service_key=service["key"],
+                service_version=service["version"],
+                service_basepath=url.query.get(
+                    "service_basepath", ""
+                ),  # predefined basepath for the backend service otherwise uses root
+                service_state="starting",  # let's assume it pulls very fast :-)
+            )
 
-    # GET /service_extras/{service_key}/{service_version}
-    get_service_by_key_version = re.compile(
-        r"^http://[a-z\-_]*director:[0-9]+/v0/services/\w+/.+$"
-    )
+            _fake_running_services.append(starting_service)
+            return CallbackResult(payload={"data": starting_service}, status=201)
 
-    # GET /services/{service_key}/{service_version}
-    get_service_extras = re.compile(
-        r"^http://[a-z\-_]*director:[0-9]+/v0/service_extras/\w+/.+$"
-    )
+        mock.post(re.compile(url_pattern), callback=start_service_handler, repeat=True)
 
-    with aioresponses() as mock:
+        # DELETE /running_interactive_services/{service_uuid}-------------------------------------------------
+        url_pattern = (
+            r"^http://[a-z\-_]*director:[0-9]+/v0/running_interactive_services/.+$"
+        )
+
+        def stop_service_handler(url: URL, **kwargs):
+            service_uuid = url.parts[-1]
+
+            try:
+                service = next(
+                    s
+                    for s in _fake_running_services
+                    if s["service_uuid"] == service_uuid
+                )
+                service["service_state"] = "complete"
+
+            except StopIteration:
+                return CallbackResult(
+                    payload={"error": "service not found"}, status=404
+                )
+
+            return CallbackResult(status=204)
+
+        mock.delete(re.compile(url_pattern), callback=stop_service_handler, repeat=True)
+
+        # GET /services/{service_key}/{service_version}-------------------------------------------------
+        url_pattern = r"^http://[a-z\-_]*director:[0-9]+/v0/services/.+/.+$"
+
+        def get_service_by_key_version_handler(url: URL, **kwargs):
+            service_key, service_version = url.parts[-2:]
+            # TODO: validate against schema?
+            # TODO: improve API: does it make sense to return multiple services
+            services = [
+                s
+                for s in _fake_project_services
+                if s["key"] == service_key and s["version"] == service_version
+            ]
+            if services:
+                return CallbackResult(payload={"data": services}, status=200)
+
+            return CallbackResult(
+                payload={
+                    "error": f"Service {service_key}:{service_version} not found in project"
+                },
+                status=404,
+            )
+
         mock.get(
-            get_running_interactive_services.pattern,
-            status=200,
-            callback=get_running_interactive_services.handler,
-        )
-        mock.post(start_service, status=200, payload={"data": {}})
-        mock.delete(
-            stop_service,
-            status=204,
+            re.compile(url_pattern),
+            callback=get_service_by_key_version_handler,
+            repeat=True,
         )
 
-        mock.get(get_service_by_key_version, status=200, payload={"data": {}})
-        mock.get(get_service_extras, status=200, payload={"data": {}})
+        # GET /service_extras/{service_key}/{service_version}
+        # get_service_extras = re.compile(
+        #    r"^http://[a-z\-_]*director:[0-9]+/v0/service_extras/\w+/.+$"
+        # )
 
+        ## mock.get(get_service_extras, status=200, payload={"data": {}})
         yield mock
 
 
+@pytest.fixture
+def app_mock():
+    # we only need the app as a container of the aiohttp client session and the director entrypoint
+
+    app = web.Application()
+
+    # mocks client session (normally included as upon startup)
+    single_client_in_app = get_client_session(app)
+    assert single_client_in_app
+    assert single_client_in_app is get_client_session(app)
+
+    # mocks loading config
+    settings = DirectorSettings()
+    app[director_config.APP_CONFIG_KEY] = {
+        director_config.CONFIG_SECTION_NAME: json.loads(
+            settings.json(exclude={"url"}, by_alias=True)
+        )
+    }
+
+    assert setup_director(app, disable_routes=True)
+
+    return app
+
+
 @pytest.mark.skip(reason="dev")
-async def test_mocks(director_service_api_mock):
+async def test_aioresponse_mocks(mock_director_service):
+    # NOTE: keep this to tune mock_director_service fixture
+
+    for match in mock_director_service._matches.values():
+        print(
+            match.method,
+            match.url_or_pattern,
+        )
+
     async with ClientSession() as session:
         async with session.get(
-            "http://director:8000/v0/running_interactive_services"
+            # "http://director:8000/v0/running_interactive_services"
+            "http://director:8001/v0/running_interactive_services?project_id=dc7d6847-a3b7-4905-bbfb-777e3bd433c8&user_id=1"
         ) as resp:
             assert resp.status == 200
             print(await resp.json())
 
 
-@pytest.fixture
-def app_mock(director_service_api_mock):
-    # we only need the app as a container of the aiohttp client session and
-    # the director entrypoint
+def test_director_openapi_specs(director_openapi_specs):
     #
-    settings = DirectorSettings()
-
-    app = {}
-    app[APP_DIRECTOR_API_KEY] = str(settings.url)
-    single_client_in_app = get_client_session(app)
-    assert single_client_in_app
-    assert single_client_in_app is get_client_session(app)
-
-    return app
+    # At this point in time we cannot afford a more sophisticated way to
+    # do it so we resign ourselves to doing it by hand
+    #
+    assert "get" in director_openapi_specs["paths"]["/running_interactive_services"]
+    assert "delete" in director_openapi_specs["paths"]["/running_interactive_services"]
+    assert "post" in director_openapi_specs["paths"]["/running_interactive_services"]
 
 
-async def test_director_api_client_calls(app):
+async def test_director_workflow(
+    loop,
+    mock_director_service,
+    app_mock,
+    user_id: int,
+    project_id: str,
+    project_nodes: List[Tuple[str, ...]],
+):
 
-    # check services running in my study
-    services = await get_running_interactive_services(
-        app, user_id="1", project_id="dc7d6847-a3b7-4905-bbfb-777e3bd433c8"
+    app = app_mock
+
+    # After app's setup, the director config should be in place
+    # and all these function should trigger requests correclty
+    # to the director service
+    #
+    # These tests will capture those requests in the back at the transport
+    # layer and make sure they comply with OpenApi specifications of the
+    # director's API
+    #
+
+    # nothing is running
+    running_services = await get_running_interactive_services(
+        app, str(user_id), project_id
     )
+    assert not running_services
 
-    service = await get_service_by_key_version(
-        app, service_key="simcore/comp/isolve", service_version="1.0.3"
+    for service_key, service_version, service_uuid in project_nodes:
+
+        # service is in registry
+        service = await get_service_by_key_version(app, service_key, service_version)
+        assert service
+
+        # not running
+        running_services = await get_running_interactive_services(
+            app, str(user_id), project_id
+        )
+        assert not any(s["service_uuid"] == service_uuid for s in running_services)
+
+        # start
+        started = await start_service(
+            app,
+            str(user_id),
+            project_id,
+            service_key,
+            service_version,
+            service_uuid,
+        )
+
+        # now is running
+        running_services = await get_running_interactive_services(
+            app, str(user_id), project_id
+        )
+        assert started in running_services
+
+    # so two of them are running
+    running_services = await get_running_interactive_services(
+        app, str(user_id), project_id
     )
+    assert len(running_services) == 2
 
-    extras = await get_services_extras(
-        app, service_key="simcore/comp/isolve", service_version="1.0.3"
+    # stop all
+    await stop_services(app, user_id=str(user_id))  # also calls stop_service
+
+    # nothing running
+    running_services = await get_running_interactive_services(
+        app, str(user_id), project_id
     )
-
-    started = await start_service(
-        app,
-        user_id="1",
-        project_id="dc7d6847-a3b7-4905-bbfb-777e3bd433c8",
-        service_key="simcore/comp/isolve",
-        service_version="1.0.3",
-        service_uuid="43946ec4-fb14-4667-a81b-df6e8375282d",
-    )
-
-    await stop_service(app, started["uuid"])
-
-    await stop_services(app, project_id="dc7d6847-a3b7-4905-bbfb-777e3bd433c8")
+    assert not running_services

--- a/services/web/server/tests/unit/with_dbs/slow/test_projects.py
+++ b/services/web/server/tests/unit/with_dbs/slow/test_projects.py
@@ -1004,7 +1004,7 @@ async def test_delete_project(
         calls = [call(client.server.app, service["service_uuid"]) for service in fakes]
         mocked_director_subsystem["stop_service"].has_calls(calls)
         # wait for the fire&forget to run
-        await sleep(2)
+        await asyncio.sleep(2)
         await _assert_get_same_project(client, user_project, web.HTTPNotFound)
 
 
@@ -1392,7 +1392,6 @@ async def test_open_shared_project_2_users_locked(
     logged_user: Dict,
     shared_project: Dict,
     socketio_client: Callable,
-    # mocked_director_subsystem,
     client_session_id: Callable,
     user_role: UserRole,
     expected: ExpectedResponse,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

 Fixes an error in the implementation of ``stop_services`` in ``services/web/server/src/simcore_service_webserver/director/director_api.py`` prevents from stopping services.

#### Other minor fixes
   - api-server: 
        - FIX: typo in ``LOG_LEVEL`` environment variable prevented setting log level
        - FIX: missing coverage argument in ci bash script
   - FIX: missing namespace in ``test_projects``
   - FIX: loop fixture missing in ``test_aiopg_utils`` would produce constant ``FileNotFoundError`` messages upon cleanup
   

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

Added a new test ``services/web/server/tests/unit/isolated/test_director_api.py`` that mocks director service API and
runs all functions in ``services/web/server/src/simcore_service_webserver/director/director_api.py`` in a workflow

```
cd osparc-simcore
make devenv
source .venv/bin/activate
cd services/web/server
make install-dev
pytest tests/unit/isolated/test_director_api.py
```





