### PR TITLE
bugfix: access port type using proper attribute

### DIFF
--- a/services/sidecar/src/simcore_service_sidecar/executor.py
+++ b/services/sidecar/src/simcore_service_sidecar/executor.py
@@ -159,7 +159,7 @@ class Executor:
             )
             # check if the file is a zip, in that case extract all if the service does not expect a zip file
             if zipfile.is_zipfile(final_path) and (
-                str(port.type) != "data:application/zip"
+                str(port.property_type) != "data:application/zip"
             ):
                 with zipfile.ZipFile(final_path, "r") as zip_obj:
                     zip_obj.extractall(final_path.parents[0])


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
fixes the access to the port type by using the correct attribute name (pydantic side effect)

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
