### PR TITLE
BugFix: fixes awaitables and broad-exceptions in garbage-collector

### DIFF
--- a/services/sidecar/src/simcore_service_sidecar/log_parser.py
+++ b/services/sidecar/src/simcore_service_sidecar/log_parser.py
@@ -121,7 +121,7 @@ async def _monitor_log_file(
             # try to read line
             line = await file_pointer.readline()
             if not line:
-                asyncio.sleep(1)
+                await asyncio.sleep(1)
                 continue
             log_type, parsed_line = await parse_line(line)
 

--- a/services/web/server/src/simcore_service_webserver/resource_manager/config.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/config.py
@@ -7,9 +7,8 @@ from typing import Dict, Optional
 
 import trafaret as T
 from aiohttp.web import Application
-from pydantic import BaseSettings, Field, PositiveInt
-
 from models_library.settings.redis import RedisConfig
+from pydantic import BaseSettings, Field, PositiveInt
 from servicelib.application_keys import APP_CONFIG_KEY
 
 CONFIG_SECTION_NAME = "resource_manager"
@@ -17,7 +16,6 @@ APP_CLIENT_REDIS_CLIENT_KEY = __name__ + ".resource_manager.redis_client"
 APP_CLIENT_REDIS_LOCK_KEY = __name__ + ".resource_manager.redis_lock"
 APP_CLIENT_SOCKET_REGISTRY_KEY = __name__ + ".resource_manager.registry"
 APP_RESOURCE_MANAGER_TASKS_KEY = __name__ + ".resource_manager.tasks.key"
-APP_GARBAGE_COLLECTOR_KEY = __name__ + ".resource_manager.garbage_collector_key"
 
 
 # lock names and format strings

--- a/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
@@ -86,7 +86,7 @@ async def collect_garbage_periodically(app: web.Application):
             # do not catch Cancellation errors
             raise
 
-        except Exception as err:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             logger.warning(
                 "There was an error during garbage collection, restarting...",
                 exc_info=True,

--- a/services/web/server/src/simcore_service_webserver/users_api.py
+++ b/services/web/server/src/simcore_service_webserver/users_api.py
@@ -11,14 +11,14 @@ from typing import Any, Dict, List, Tuple
 import sqlalchemy as sa
 from aiohttp import web
 from aiopg.sa.result import RowProxy
-from sqlalchemy import and_, literal_column
-
 from servicelib.application_keys import APP_DB_ENGINE_KEY
 from simcore_postgres_database.models.users import UserRole
 from simcore_service_webserver.login.cfg import get_storage
+from sqlalchemy import and_, literal_column
 
 from .db_models import GroupType, groups, tokens, user_to_groups, users
 from .groups_api import convert_groups_db_to_schema
+from .login.storage import AsyncpgStorage
 from .security_api import clean_auth_policy_cache
 from .users_exceptions import UserNotFoundError
 from .users_utils import convert_user_db_to_schema
@@ -137,8 +137,7 @@ async def delete_user(app: web.Application, user_id: int) -> None:
     # otherwise this function will raise asyncpg.exceptions.ForeignKeyViolationError
     # Consider "marking" users as deleted and havning a background job that
     # cleans it up
-
-    db = get_storage(app)
+    db: AsyncpgStorage = get_storage(app)
     user = await db.get_user({"id": user_id})
     if not user:
         logger.warning(

--- a/services/web/server/tests/sandbox/app.py
+++ b/services/web/server/tests/sandbox/app.py
@@ -6,7 +6,6 @@ from typing import Optional
 from aiohttp import web
 from aiohttp.web import middleware
 from multidict import MultiDict
-
 from simcore_service_webserver._meta import api_vtag
 
 # FRONT_END ####################################
@@ -91,7 +90,7 @@ async def discover_product_middleware(request, handler):
         request[RQ_PRODUCT_NAME_KEY] = frontend_app
 
     else:
-        #/s4/boot.js is called with 'Referer': 'http://localhost:9081/s4l/index.html'
+        # /s4/boot.js is called with 'Referer': 'http://localhost:9081/s4l/index.html'
 
         # if path to index
         match = PRODUCT_PATH_RE.match(request.path)
@@ -102,7 +101,7 @@ async def discover_product_middleware(request, handler):
     response = await handler(request)
 
     # FIXME: notice that if raised error, it will not be attached
-    #if RQ_PRODUCT_NAME_KEY in request:
+    # if RQ_PRODUCT_NAME_KEY in request:
     #    response.headers[PRODUCT_NAME_HEADER] = request[RQ_PRODUCT_NAME_KEY]
 
     return response
@@ -113,8 +112,6 @@ async def discover_product_middleware(request, handler):
 async def serve_default_app(request):
     # TODO: check url and defined what is the default??
     print("Request from", request.headers["Host"])
-    import pdb; pdb.set_trace()
-
     target_product = request.get(RQ_PRODUCT_NAME_KEY, default_frontend_app)
 
     print("Serving front-end for product", target_product)


### PR DESCRIPTION


## What do these changes do?

Another group of fixes from PR #2079 associated with issues in the garbage collector.

- broad exceptions catches were suppressing ``CancelledError`` which avoided the gc. Since the gc is a periodic background task it could never be cancelled
- some extra fixes in garbage_collector.py
- some coroutines were not awaited


## How to test

```cmd
make devenv
cd packages/postgres-database
make install-dev
make tests
cd ...
cd services/web/server
make install-dev
make test-dev-unit
```
cover this bugfix

