### PR TITLE
bugfix: correct project jsonschema regarding runHash field

### DIFF
--- a/api/specs/common/schemas/project-v0.0.1-converted.yaml
+++ b/api/specs/common/schemas/project-v0.0.1-converted.yaml
@@ -123,7 +123,9 @@ properties:
             description: >-
               the hex digest of the resolved inputs +outputs hash at the time
               when the last outputs were generated
-            type: string
+            type:
+              - string
+              - 'null'
             example:
               - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
           inputs:

--- a/api/specs/common/schemas/project-v0.0.1.json
+++ b/api/specs/common/schemas/project-v0.0.1.json
@@ -157,7 +157,10 @@
             },
             "runHash": {
               "description": "the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated",
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "examples": [
                 "a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2"
               ]

--- a/packages/models-library/src/models_library/projects_nodes.py
+++ b/packages/models-library/src/models_library/projects_nodes.py
@@ -148,3 +148,12 @@ class Node(BaseModel):
 
     class Config:
         extra = Extra.forbid
+
+        # NOTE: exporting without this trick does not make runHash as nullabel.
+        # It is a Pydantic issue see https://github.com/samuelcolvin/pydantic/issues/1270
+        @staticmethod
+        def schema_extra(schema, _):
+            for prop, value in schema.get("properties", {}).items():
+                if prop in ["runHash"]:  # Your actual nullable fields go in this list.
+                    was = value["type"]
+                    value["type"] = [was, "null"]

--- a/services/director/src/simcore_service_director/api/v0/schemas/project-v0.0.1.json
+++ b/services/director/src/simcore_service_director/api/v0/schemas/project-v0.0.1.json
@@ -157,7 +157,10 @@
             },
             "runHash": {
               "description": "the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated",
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "examples": [
                 "a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2"
               ]

--- a/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
+++ b/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
@@ -1848,7 +1848,9 @@ paths:
                                 - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                             runHash:
                               description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                              type: string
+                              type:
+                                - string
+                                - 'null'
                               example:
                                 - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                             inputs:
@@ -2290,7 +2292,9 @@ paths:
                                 - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                             runHash:
                               description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                              type: string
+                              type:
+                                - string
+                                - 'null'
                               example:
                                 - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                             inputs:
@@ -2742,7 +2746,9 @@ paths:
                               - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                           runHash:
                             description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                            type: string
+                            type:
+                              - string
+                              - 'null'
                             example:
                               - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                           inputs:
@@ -3294,7 +3300,9 @@ components:
                     - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                 runHash:
                   description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                  type: string
+                  type:
+                    - string
+                    - 'null'
                   example:
                     - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                 inputs:

--- a/services/storage/src/simcore_service_storage/api/v0/schemas/project-v0.0.1.json
+++ b/services/storage/src/simcore_service_storage/api/v0/schemas/project-v0.0.1.json
@@ -157,7 +157,10 @@
             },
             "runHash": {
               "description": "the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated",
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "examples": [
                 "a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2"
               ]

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -6212,7 +6212,9 @@ paths:
                                         - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                                     runHash:
                                       description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                                      type: string
+                                      type:
+                                        - string
+                                        - 'null'
                                       example:
                                         - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                                     inputs:
@@ -6785,7 +6787,9 @@ paths:
                             - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                         runHash:
                           description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                          type: string
+                          type:
+                            - string
+                            - 'null'
                           example:
                             - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                         inputs:
@@ -7238,7 +7242,9 @@ paths:
                                       - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                                   runHash:
                                     description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                                    type: string
+                                    type:
+                                      - string
+                                      - 'null'
                                     example:
                                       - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                                   inputs:
@@ -7809,7 +7815,9 @@ paths:
                                       - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                                   runHash:
                                     description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                                    type: string
+                                    type:
+                                      - string
+                                      - 'null'
                                     example:
                                       - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                                   inputs:
@@ -8386,7 +8394,9 @@ paths:
                                       - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                                   runHash:
                                     description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                                    type: string
+                                    type:
+                                      - string
+                                      - 'null'
                                     example:
                                       - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                                   inputs:
@@ -8954,7 +8964,9 @@ paths:
                             - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                         runHash:
                           description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                          type: string
+                          type:
+                            - string
+                            - 'null'
                           example:
                             - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                         inputs:
@@ -9407,7 +9419,9 @@ paths:
                                       - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                                   runHash:
                                     description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                                    type: string
+                                    type:
+                                      - string
+                                      - 'null'
                                     example:
                                       - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                                   inputs:
@@ -10000,7 +10014,9 @@ paths:
                                       - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                                   runHash:
                                     description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                                    type: string
+                                    type:
+                                      - string
+                                      - 'null'
                                     example:
                                       - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                                   inputs:
@@ -10820,7 +10836,9 @@ paths:
                                       - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                                   runHash:
                                     description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                                    type: string
+                                    type:
+                                      - string
+                                      - 'null'
                                     example:
                                       - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                                   inputs:
@@ -12093,7 +12111,9 @@ paths:
                                       - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
                                   runHash:
                                     description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
-                                    type: string
+                                    type:
+                                      - string
+                                      - 'null'
                                     example:
                                       - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                                   inputs:
@@ -12661,6 +12681,13 @@ paths:
                                     description: url of the latest screenshot of the node
                                     example:
                                       - 'https://placeimg.com/171/96/tech/grayscale/?0.jpg'
+                                  runHash:
+                                    description: the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated
+                                    type:
+                                      - string
+                                      - 'null'
+                                    example:
+                                      - a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2
                                   inputs:
                                     type: object
                                     description: values of input properties

--- a/services/web/server/src/simcore_service_webserver/api/v0/schemas/project-v0.0.1.json
+++ b/services/web/server/src/simcore_service_webserver/api/v0/schemas/project-v0.0.1.json
@@ -157,7 +157,10 @@
             },
             "runHash": {
               "description": "the hex digest of the resolved inputs +outputs hash at the time when the last outputs were generated",
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "examples": [
                 "a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2"
               ]


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
runHash can be NULL, as defined in pydantic but not picked up by the test comparing the jsonschemas...

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
