### PR TITLE
Feature/open download output

### DIFF
--- a/services/web/client/source/class/osparc/component/node/BaseNodeView.js
+++ b/services/web/client/source/class/osparc/component/node/BaseNodeView.js
@@ -108,7 +108,7 @@ qx.Class.define("osparc.component.node.BaseNodeView", {
     __buildSideView: function(isInput) {
       const collapsedWidth = 35;
       const sidePanel = new osparc.desktop.SidePanel().set({
-        minWidth: 200,
+        minWidth: 220,
         collapsedMinWidth: collapsedWidth,
         collapsedWidth: collapsedWidth
       });

--- a/services/web/client/source/class/osparc/component/widget/CollapsibleView.js
+++ b/services/web/client/source/class/osparc/component/widget/CollapsibleView.js
@@ -29,13 +29,7 @@ qx.Class.define("osparc.component.widget.CollapsibleView", {
     // Layout
     this._setLayout(new qx.ui.layout.VBox());
 
-    // Title bar
-    this.__titleBar = new qx.ui.container.Composite(new qx.ui.layout.HBox(5).set({
-      alignY: "middle"
-    }));
-    this._add(this.__titleBar);
-
-    this.__caret = this.getChildControl("caret");
+    this.getChildControl("caret");
 
     // Set if coming in the constructor arguments
     if (title) {
@@ -79,9 +73,6 @@ qx.Class.define("osparc.component.widget.CollapsibleView", {
   },
 
   members: {
-    __titleBar: null,
-    __titleLabel: null,
-    __caret: null,
     _innerContainer: null,
     __containerHeight: null,
     __layoutFlex: null,
@@ -91,20 +82,30 @@ qx.Class.define("osparc.component.widget.CollapsibleView", {
     _createChildControlImpl: function(id) {
       let control;
       switch (id) {
-        case "caret":
+        case "header":
+          control = new qx.ui.container.Composite(new qx.ui.layout.HBox(5).set({
+            alignY: "middle"
+          }));
+          this._add(control);
+          break;
+        case "caret": {
+          const header = this.getChildControl("header");
           control = new qx.ui.basic.Image(this.__getCaretId(this.getCollapsed())).set({
             visibility: "excluded"
           });
-          this.__titleBar.addAt(control, 0);
+          header.addAt(control, 0);
           // Attach handler
           this.__attachToggler(control);
           break;
-        case "title":
+        }
+        case "title": {
+          const header = this.getChildControl("header");
           control = new qx.ui.basic.Atom(this.getTitle());
-          this.__titleBar.addAt(control, 1);
+          header.addAt(control, 1);
           // Attach handler
           this.__attachToggler(control);
           break;
+        }
       }
       return control || this.base(arguments, id);
     },
@@ -114,16 +115,16 @@ qx.Class.define("osparc.component.widget.CollapsibleView", {
     },
 
     getTitleBar: function() {
-      return this.__titleBar;
+      return this.getChildControl("header");
     },
 
     getTitleLabel: function() {
-      return this.__titleLabel;
+      return this.getChildControl("title");
     },
 
     _applyCollapsed: function(collapsed) {
       if (this.getContent()) {
-        this.__caret.setSource(this.__getCaretId(collapsed));
+        this.getChildControl("caret").setSource(this.__getCaretId(collapsed));
         if (collapsed) {
           this.__minHeight = this.getMinHeight();
           if (this.getContent()) {
@@ -178,20 +179,20 @@ qx.Class.define("osparc.component.widget.CollapsibleView", {
       this._innerContainer.add(content);
       this._innerContainer.setHeight(this.getCollapsed() ? 0 : this.__containerHeight);
 
+      const caret = this.getChildControl("caret");
       if (content) {
-        this.__caret.show();
+        caret.show();
       } else {
-        this.__caret.exclude();
+        caret.exclude();
       }
     },
 
     _applyTitle: function(title) {
-      this.__titleLabel = this.getChildControl("title");
-      this.__titleLabel.setLabel(title);
+      this.getChildControl("title").setLabel(title);
     },
 
     _applyCaretSize: function(size) {
-      this.__caret.setSource(this.__getCaretId(this.getCollapsed()));
+      this.getChildControl("caret").setSource(this.__getCaretId(this.getCollapsed()));
     },
 
     __getCaretId: function(collapsed) {

--- a/services/web/client/source/class/osparc/component/widget/inputs/NodeOutputTreeItem.js
+++ b/services/web/client/source/class/osparc/component/widget/inputs/NodeOutputTreeItem.js
@@ -85,7 +85,9 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
     __label: null,
 
     _addWidgets : function() {
-      this.addHint();
+      this.addHint().set({
+        alignY: "middle"
+      });
       this._add(new qx.ui.core.Spacer(5));
 
       this.addIcon();
@@ -97,7 +99,9 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
         converter: val => typeof val === "string" ? "visible" : "excluded"
       });
 
-      const labelLink = this.__labelLink = new osparc.ui.basic.LinkLabel("", null);
+      const labelLink = this.__labelLink = new osparc.ui.basic.LinkLabel("", null).set({
+        alignY: "middle"
+      });
       this.addWidget(labelLink);
       this.bind("value", labelLink, "visibility", {
         converter: val => typeof val === "string" ? "excluded" : "visible"

--- a/services/web/client/source/class/osparc/component/widget/inputs/NodeOutputTreeItem.js
+++ b/services/web/client/source/class/osparc/component/widget/inputs/NodeOutputTreeItem.js
@@ -70,6 +70,7 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
 
     value: {
       nullable: true,
+      event: "changeValue",
       apply: "_applyValue",
       transform: "_transformValue"
     },
@@ -81,7 +82,7 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
   },
 
   members : {
-    __valueLabel: null,
+    __label: null,
 
     _addWidgets : function() {
       this.addHint();
@@ -89,9 +90,9 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
 
       this.addIcon();
 
-      // Add the port value
-      this.__valueLabel = new qx.ui.basic.Label();
-      this.addWidget(this.__valueLabel);
+      // Add the port label
+      const label = this.__label = new qx.ui.basic.Label();
+      this.addWidget(label);
 
       // All else should be right justified
       this.addWidget(new qx.ui.core.Spacer(), {
@@ -108,14 +109,14 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
     },
 
     _transformValue: function(value) {
-      if (value.getLabel) {
-        return value.getLabel();
-      }
       if (value.getPath) {
         const fileName = value.getPath().split("/");
         if (fileName.length) {
           return fileName[fileName.length-1];
         }
+      }
+      if (value.getLabel) {
+        return value.getLabel();
       }
       if (this.__isNumber(value)) {
         return value.toString();

--- a/services/web/client/source/class/osparc/component/widget/inputs/NodeOutputTreeItem.js
+++ b/services/web/client/source/class/osparc/component/widget/inputs/NodeOutputTreeItem.js
@@ -115,6 +115,7 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
 
     _applyValue: async function(value) {
       if (typeof value === "object" && "store" in value) {
+        // it's a file
         const download = true;
         const locationId = value.store;
         const fileId = value.path;
@@ -126,6 +127,12 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
             url: presignedLinkData.presignedLink.link
           });
         }
+      } else if (typeof value === "object" && "donwloadLink" in value) {
+        // it's a link
+        this.__labelLink.set({
+          value: value.filename,
+          url: value.donwloadLink
+        });
       } else {
         this.__label.setValue(value);
       }
@@ -147,6 +154,13 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
             filename: fn
           };
         }
+      }
+      if (value.getDownloadLink) {
+        // it's a link
+        return {
+          donwloadLink: value.getDownloadLink(),
+          filename: value.getLabel()
+        };
       }
       if (value.getLabel) {
         return value.getLabel();

--- a/services/web/client/source/class/osparc/file/FilePicker.js
+++ b/services/web/client/source/class/osparc/file/FilePicker.js
@@ -152,7 +152,7 @@ qx.Class.define("osparc.file.FilePicker", {
       const reloadButton = this.getChildControl("reload-button");
       reloadButton.addListener("execute", () => {
         this.__filesTree.resetCache();
-        this.__filesTree.populateTree();
+        this.__recreateFilesTree();
       }, this);
 
       this.__recreateFilesTree();
@@ -171,7 +171,7 @@ qx.Class.define("osparc.file.FilePicker", {
 
       const selectBtn = this.getChildControl("selectButton");
       selectBtn.setEnabled(false);
-      selectBtn.addListener("execute", function() {
+      selectBtn.addListener("execute", () => {
         this.__itemSelectedFromStore();
       }, this);
 

--- a/services/web/client/source/class/osparc/ui/basic/LinkLabel.js
+++ b/services/web/client/source/class/osparc/ui/basic/LinkLabel.js
@@ -41,7 +41,7 @@ qx.Class.define("osparc.ui.basic.LinkLabel", {
       font: "link-label"
     });
 
-    this.addListener("click", this._onClick);
+    this.addListener("click", this.__onClick);
   },
 
   properties: {
@@ -52,8 +52,11 @@ qx.Class.define("osparc.ui.basic.LinkLabel", {
   },
 
   members: {
-    _onClick: function(e) {
-      window.open(this.getUrl());
+    __onClick: function() {
+      const link = this.getUrl();
+      if (link) {
+        window.open(link);
+      }
     }
   }
 });


### PR DESCRIPTION
## What do these changes do?

This PR changes the way files are represented in the inputs/outputs ports.

If it's a file (or a download link) it will be shown as a link. This means that when the user clicks on it, if the browser's [fileReader](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) is able to read, it's content will be shown in a new tab, if not the download process will start.

![readfiles](https://user-images.githubusercontent.com/33152403/107509048-2ab04080-6ba2-11eb-8c19-39374b1de566.gif)
![readfiles2](https://user-images.githubusercontent.com/33152403/107509051-2c7a0400-6ba2-11eb-868b-31b84a6d328a.gif)


## Related issue/s
related to https://github.com/ITISFoundation/osparc-issues/issues/409

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
