### PR TITLE
Is2141/add units in image schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,10 +386,12 @@ nodenv: node_modules ## builds node_modules local environ (TODO)
 .PHONY: pylint
 
 pylint: ## Runs python linter framework's wide
-	# version
-	/bin/bash -c "pylint --version"
-	# run
-	/bin/bash -c "pylint --jobs=0 --rcfile=.pylintrc $(strip $(shell find services packages -iname '*.py' \
+	# pylint version info
+	@/bin/bash -c "pylint --version"
+	# Running linter
+	@/bin/bash -c "pylint --jobs=0 --rcfile=.pylintrc $(strip $(shell find services packages -iname '*.py' \
+											-not -path "*.venv*" \
+											-not -path "*/client/*" \
 											-not -path "*egg*" \
 											-not -path "*migration*" \
 											-not -path "*datcore.py" \

--- a/Makefile
+++ b/Makefile
@@ -386,6 +386,9 @@ nodenv: node_modules ## builds node_modules local environ (TODO)
 .PHONY: pylint
 
 pylint: ## Runs python linter framework's wide
+	# version
+	/bin/bash -c "pylint --version"
+	# run
 	/bin/bash -c "pylint --jobs=0 --rcfile=.pylintrc $(strip $(shell find services packages -iname '*.py' \
 											-not -path "*egg*" \
 											-not -path "*migration*" \

--- a/api/specs/common/schemas/node-meta-v0.0.1-converted.yaml
+++ b/api/specs/common/schemas/node-meta-v0.0.1-converted.yaml
@@ -174,6 +174,10 @@ properties:
             example:
               - Dog
               - true
+          unit:
+            title: Unit
+            description: Units of this input value, if a physical quantity
+            type: string
           widget:
             description: >-
               custom widget to use instead of the default one determined from
@@ -282,4 +286,8 @@ properties:
             example:
               - dir/input1.txt: key_1
                 dir33/input2.txt: key2
+          unit:
+            title: Unit
+            description: Units of the output value, if a physical quantity
+            type: string
     additionalProperties: true

--- a/api/specs/common/schemas/node-meta-v0.0.1.json
+++ b/api/specs/common/schemas/node-meta-v0.0.1.json
@@ -248,6 +248,11 @@
                 true
               ]
             },
+            "unit": {
+              "title": "Unit",
+              "description": "Units of this input value, if a physical quantity",
+              "type": "string"
+            },
             "widget": {
               "description": "custom widget to use instead of the default one determined from the data-type",
               "anyOf": [
@@ -398,6 +403,11 @@
                   "dir33/input2.txt": "key2"
                 }
               ]
+            },
+            "unit": {
+              "title": "Unit",
+              "description": "Units of the output value, if a physical quantity",
+              "type": "string"
             }
           }
         }

--- a/ci/github/unit-testing/python-linting.bash
+++ b/ci/github/unit-testing/python-linting.bash
@@ -9,6 +9,8 @@ install() {
     bash ci/helpers/ensure_python_pip.bash
     bash ci/helpers/install_pylint.bash
     pip list -v
+    echo "Copy paste next to reproduce python environment"
+    pip freeze
 }
 
 test() {

--- a/ci/github/unit-testing/python-linting.bash
+++ b/ci/github/unit-testing/python-linting.bash
@@ -8,8 +8,6 @@ IFS=$'\n\t'
 install() {
     bash ci/helpers/ensure_python_pip.bash
     bash ci/helpers/install_pylint.bash
-    pip list -v
-    echo "Copy paste next to reproduce python environment"
     pip freeze
 }
 

--- a/packages/models-library/requirements/_test.in
+++ b/packages/models-library/requirements/_test.in
@@ -22,3 +22,8 @@ pytest-sugar
 # tools
 pylint  # NOTE: The version in pylint at _text.txt is used as a reference for ci/helpers/install_pylint.bash
 coveralls
+
+
+# to test units tools
+pyyaml
+pint

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -42,8 +42,11 @@ idna==2.10
     #   yarl
 importlib-metadata==3.4.0
     # via
+    #   pint
     #   pluggy
     #   pytest
+importlib-resources==5.1.0
+    # via pint
 iniconfig==1.1.1
     # via pytest
 isort==5.7.0
@@ -58,8 +61,11 @@ multidict==5.1.0
     #   yarl
 packaging==20.9
     # via
+    #   pint
     #   pytest
     #   pytest-sugar
+pint==0.16.1
+    # via -r requirements/_test.in
 pluggy==0.13.1
     # via pytest
 pprintpp==0.4.0
@@ -93,6 +99,10 @@ pytest==6.2.2
     #   pytest-instafail
     #   pytest-mock
     #   pytest-sugar
+pyyaml==5.4.1
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/_test.in
 requests==2.25.1
     # via coveralls
 six==1.15.0
@@ -119,4 +129,6 @@ wrapt==1.12.1
 yarl==1.6.3
     # via aiohttp
 zipp==3.4.0
-    # via importlib-metadata
+    # via
+    #   importlib-metadata
+    #   importlib-resources

--- a/packages/models-library/requirements/_tools.txt
+++ b/packages/models-library/requirements/_tools.txt
@@ -35,6 +35,7 @@ importlib-metadata==3.4.0
     #   virtualenv
 importlib-resources==5.1.0
     # via
+    #   -c requirements/_test.txt
     #   pre-commit
     #   virtualenv
 isort==5.7.0
@@ -54,6 +55,7 @@ pre-commit==2.10.1
 pyyaml==5.4.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_test.txt
     #   pre-commit
 regex==2020.11.13
     # via black

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -174,9 +174,6 @@ class ServiceProperty(BaseModel):
         description="Place the data associated with the named keys in files",
         examples=[{"dir/input1.txt": "key_1", "dir33/input2.txt": "key2"}],
     )
-    default_value: Optional[Union[StrictBool, StrictInt, StrictFloat, str]] = Field(
-        None, alias="defaultValue", examples=["Dog", True]
-    )
 
     # TODO: use discriminators
     unit: Optional[str] = Field(
@@ -192,6 +189,10 @@ class ServiceInput(ServiceProperty):
     """
     Metadata on a service input port
     """
+
+    default_value: Optional[Union[StrictBool, StrictInt, StrictFloat, str]] = Field(
+        None, alias="defaultValue", examples=["Dog", True]
+    )
 
     widget: Optional[Widget] = Field(
         None,
@@ -226,7 +227,6 @@ class ServiceOutput(ServiceProperty):
                 "label": "Time Slept",
                 "description": "Time the service waited before completion",
                 "type": "number",
-                "defaultValue": 0,
                 "unit": "second",
             }
         }

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -228,7 +228,6 @@ class ServiceOutput(ServiceProperty):
                 "type": "number",
                 "defaultValue": 0,
                 "unit": "second",
-                "keyId": "output_2",
             }
         }
 

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -189,6 +189,10 @@ class ServiceProperty(BaseModel):
 
 
 class ServiceInput(ServiceProperty):
+    """
+    Metadata on a service input port
+    """
+
     widget: Optional[Widget] = Field(
         None,
         description="custom widget to use instead of the default one determined from the data-type",

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -222,13 +222,23 @@ class ServiceOutput(ServiceProperty):
 
     class Config(ServiceProperty.Config):
         schema_extra = {
+            "examples": [
+                # version 1
+                {
+                    "displayOrder": 2,
+                    "label": "Time Slept",
+                    "description": "Time the service waited before completion",
+                    "type": "number",
+                },
+            ],
+            # latest
             "example": {
                 "displayOrder": 2,
                 "label": "Time Slept",
                 "description": "Time the service waited before completion",
                 "type": "number",
                 "unit": "second",
-            }
+            },
         }
 
 

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -198,6 +198,19 @@ class ServiceInput(ServiceProperty):
         description="custom widget to use instead of the default one determined from the data-type",
     )
 
+    class Config(ServiceProperty.Config):
+        schema_extra = {
+            "example": {
+                "displayOrder": 2,
+                "label": "Sleep Time",
+                "description": "Time to wait before completion",
+                "type": "number",
+                "defaultValue": 0,
+                "unit": "second",
+                "widget": {"type": "TextArea", "details": {"minHeight": 0}},
+            }
+        }
+
 
 class ServiceOutput(ServiceProperty):
     widget: Optional[Widget] = Field(
@@ -205,6 +218,19 @@ class ServiceOutput(ServiceProperty):
         description="custom widget to use instead of the default one determined from the data-type",
         deprecated=True,
     )
+
+    class Config(ServiceProperty.Config):
+        schema_extra = {
+            "example": {
+                "displayOrder": 2,
+                "label": "Time Slept",
+                "description": "Time the service waited before completion",
+                "type": "number",
+                "defaultValue": 0,
+                "unit": "second",
+                "keyId": "output_2",
+            }
+        }
 
 
 class ServiceKeyVersion(BaseModel):

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -201,15 +201,25 @@ class ServiceInput(ServiceProperty):
 
     class Config(ServiceProperty.Config):
         schema_extra = {
-            "example": {
-                "displayOrder": 2,
-                "label": "Sleep Time",
-                "description": "Time to wait before completion",
-                "type": "number",
-                "defaultValue": 0,
-                "unit": "second",
-                "widget": {"type": "TextArea", "details": {"minHeight": 3}},
-            }
+            "examples": [
+                # file-wo-widget:
+                {
+                    "displayOrder": 1,
+                    "label": "Input files",
+                    "description": "Files downloaded from service connected at the input",
+                    "type": "data:*/*",
+                },
+                # latest:
+                {
+                    "displayOrder": 2,
+                    "label": "Sleep Time",
+                    "description": "Time to wait before completion",
+                    "type": "number",
+                    "defaultValue": 0,
+                    "unit": "second",
+                    "widget": {"type": "TextArea", "details": {"minHeight": 3}},
+                },
+            ],
         }
 
 
@@ -222,21 +232,23 @@ class ServiceOutput(ServiceProperty):
 
     class Config(ServiceProperty.Config):
         schema_extra = {
-            "examples": {
-                "version-1": {
+            "examples": [
+                # previously:
+                {
                     "displayOrder": 2,
                     "label": "Time Slept",
                     "description": "Time the service waited before completion",
                     "type": "number",
                 },
-                "latest": {
+                # latest:
+                {
                     "displayOrder": 2,
                     "label": "Time Slept",
                     "description": "Time the service waited before completion",
                     "type": "number",
                     "unit": "second",
                 },
-            }
+            ]
         }
 
 

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -207,7 +207,7 @@ class ServiceInput(ServiceProperty):
                 "type": "number",
                 "defaultValue": 0,
                 "unit": "second",
-                "widget": {"type": "TextArea", "details": {"minHeight": 0}},
+                "widget": {"type": "TextArea", "details": {"minHeight": 3}},
             }
         }
 

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -222,23 +222,21 @@ class ServiceOutput(ServiceProperty):
 
     class Config(ServiceProperty.Config):
         schema_extra = {
-            "examples": [
-                # version 1
-                {
+            "examples": {
+                "version-1": {
                     "displayOrder": 2,
                     "label": "Time Slept",
                     "description": "Time the service waited before completion",
                     "type": "number",
                 },
-            ],
-            # latest
-            "example": {
-                "displayOrder": 2,
-                "label": "Time Slept",
-                "description": "Time the service waited before completion",
-                "type": "number",
-                "unit": "second",
-            },
+                "latest": {
+                    "displayOrder": 2,
+                    "label": "Time Slept",
+                    "description": "Time the service waited before completion",
+                    "type": "number",
+                    "unit": "second",
+                },
+            }
         }
 
 

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -127,6 +127,13 @@ class Widget(BaseModel):
 
 
 class ServiceProperty(BaseModel):
+    """
+    Metadata on a service input or output port
+    """
+
+    ## management
+
+    ### human readable descriptors
     display_order: float = Field(
         ...,
         alias="displayOrder",
@@ -139,6 +146,8 @@ class ServiceProperty(BaseModel):
         description="description of the property",
         example="Age in seconds since 1970",
     )
+
+    # mathematical and physics descriptors
     property_type: constr(regex=PROPERTY_TYPE_RE) = Field(
         ...,
         alias="type",
@@ -157,6 +166,8 @@ class ServiceProperty(BaseModel):
             "data:application/edu.ucdavis@ceclancy.xyz",
         ],
     )
+
+    # value
     file_to_key_map: Optional[Dict[FileName, PropertyName]] = Field(
         None,
         alias="fileToKeyMap",
@@ -167,8 +178,14 @@ class ServiceProperty(BaseModel):
         None, alias="defaultValue", examples=["Dog", True]
     )
 
+    # TODO: use discriminators
+    unit: Optional[str] = Field(
+        None, description="Units, when it refers to a physical quantity"
+    )
+
     class Config:
         extra = Extra.forbid
+        # TODO: all alias with camecase
 
 
 class ServiceInput(ServiceProperty):

--- a/packages/models-library/tests/conftest.py
+++ b/packages/models-library/tests/conftest.py
@@ -14,6 +14,7 @@ import models_library
 pytest_plugins = [
     "pytest_simcore.repository_paths",
     "pytest_simcore.schemas",
+    "pytest_simcore.pydantic_models",
 ]
 
 

--- a/packages/models-library/tests/image-meta.yaml
+++ b/packages/models-library/tests/image-meta.yaml
@@ -1,0 +1,51 @@
+name: sleeper
+key: simcore/services/comp/itis/sleeper
+type: computational
+integration-version: 1.0.0
+version: 2.0.2
+description: A service which awaits for time to pass.
+contact: neagu@itis.swiss
+authors:
+  - name: "Manuel Guidon"
+    email: guidon@itis.swiss
+    affiliation: "IT'IS Foundation"
+  - name: "Odei Maiz"
+    email: maiz@itis.swiss
+    affiliation: "IT'IS Foundation"
+  - name: "Andrei Neagu"
+    email: neagu@itis.swiss
+    affiliation: "IT'IS Foundation"
+inputs:
+  input_1:
+    displayOrder: 1
+    label: File with int number
+    description: Pick a file containing only one integer
+    type: "data:text/plain"
+    fileToKeyMap:
+      single_number.txt: input_1
+  input_2:
+    displayOrder: 2
+    label: Sleep interval
+    description: Choose an amount of time to sleep
+    type: integer
+    defaultValue: 2
+  input_3:
+    displayOrder: 3
+    label: Fail after sleep
+    description: If set to true will cause service to fail after it sleeps
+    type: boolean
+    defaultValue: false
+
+outputs:
+  output_1:
+    displayOrder: 1
+    label: File containing one random integer
+    description: Integer is generated in range [1-9]
+    type: "data:text/plain"
+    fileToKeyMap:
+      single_number.txt: output_1
+  output_2:
+    displayOrder: 2
+    label: Random sleep interval
+    description: Interval is generated in range [1-9]
+    type: integer

--- a/packages/models-library/tests/test_models_fit_schemas.py
+++ b/packages/models-library/tests/test_models_fit_schemas.py
@@ -6,10 +6,9 @@ import json
 from typing import Callable
 
 import pytest
-from pydantic.main import BaseModel
-
 from models_library.projects import Project
 from models_library.services import ServiceDockerData
+from pydantic.main import BaseModel
 
 
 @pytest.mark.parametrize(
@@ -22,6 +21,9 @@ def test_generated_schema_same_as_original(
     diff_json_schemas: Callable,
     json_schema_dict: Callable,
 ):
+    # TODO: create instead a fixture that returns a Callable and do these checks
+    # on separate test_* files that follow the same package submodule's hierarchy
+    #
     generated_schema = json.loads(pydantic_model.schema_json(indent=2))
     original_schema = json_schema_dict(original_json_schema)
 

--- a/packages/models-library/tests/test_services.py
+++ b/packages/models-library/tests/test_services.py
@@ -2,7 +2,7 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-from pprint import pprint
+from pprint import pformat
 from typing import Any, Dict
 
 import pytest
@@ -92,7 +92,7 @@ def test_service_port_units(osparc_simcore_root_dir):
     ),
 )
 def test_service_models_examples(model_cls, model_cls_examples):
-    for example in model_cls_examples:
-        pprint(example)
+    for name, example in model_cls_examples.items():
+        print(name, ":", pformat(example))
         model_instance = model_cls(**example)
-        assert model_instance
+        assert model_instance, f"Failed with {name}"

--- a/packages/models-library/tests/test_services.py
+++ b/packages/models-library/tests/test_services.py
@@ -2,11 +2,17 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
+from pprint import pprint
 from typing import Any, Dict
 
 import pytest
 import yaml
-from models_library.services import ServiceCommonData, ServiceDockerData
+from models_library.services import (
+    ServiceCommonData,
+    ServiceDockerData,
+    ServiceInput,
+    ServiceOutput,
+)
 from pint import Unit, UnitRegistry
 
 
@@ -76,3 +82,17 @@ def test_service_port_units(osparc_simcore_root_dir):
         assert isinstance(valid_unit, Unit)
 
         assert valid_unit.dimensionless
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    (
+        ServiceInput,
+        ServiceOutput,
+    ),
+)
+def test_service_models_examples(model_cls, model_cls_examples):
+    for example in model_cls_examples:
+        pprint(example)
+        model_instance = model_cls(**example)
+        assert model_instance

--- a/packages/models-library/tests/test_services.py
+++ b/packages/models-library/tests/test_services.py
@@ -5,7 +5,9 @@
 from typing import Any, Dict
 
 import pytest
-from models_library.services import ServiceCommonData
+import yaml
+from models_library.services import ServiceCommonData, ServiceDockerData
+from pint import Unit, UnitRegistry
 
 
 @pytest.fixture()
@@ -53,3 +55,23 @@ def test_node_with_thumbnail(minimal_service_common_data: Dict[str, Any]):
         service.thumbnail
         == "https://www.google.com/imgres?imgurl=http%3A%2F%2Fclipart-library.com%2Fimages%2FpT5ra4Xgc.jpg&imgrefurl=http%3A%2F%2Fclipart-library.com%2Fcool-pictures.html&tbnid=6Cgc0X9Jo24p3M&vet=12ahUKEwiW3Kbd8KruAhUHzaQKHbvtApwQMygAegUIARCaAQ..i&docid=QuGKBFIIEGuLhM&w=1920&h=1080&q=some%20cool%20images&ved=2ahUKEwiW3Kbd8KruAhUHzaQKHbvtApwQMygAegUIARCaAQ"
     )
+
+
+def test_service_port_units(osparc_simcore_root_dir):
+    ureg = UnitRegistry()
+
+    data = yaml.safe_load(
+        (
+            osparc_simcore_root_dir / "packages/models-library/tests/image-meta.yaml"
+        ).read_text()
+    )
+
+    service_meta = ServiceDockerData.parse_obj(data)
+    for input_nameid, input_meta in service_meta.inputs.items():
+        assert input_nameid
+
+        # validation
+        valid_unit: Unit = ureg.parse_units(input_meta.unit)
+        assert isinstance(valid_unit, Unit)
+
+        assert valid_unit.dimensionless

--- a/packages/models-library/tests/test_services.py
+++ b/packages/models-library/tests/test_services.py
@@ -65,6 +65,7 @@ def test_service_port_units(osparc_simcore_root_dir):
             osparc_simcore_root_dir / "packages/models-library/tests/image-meta.yaml"
         ).read_text()
     )
+    print(ServiceDockerData.schema_json(indent=2))
 
     service_meta = ServiceDockerData.parse_obj(data)
     for input_nameid, input_meta in service_meta.inputs.items():

--- a/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
+++ b/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict, List, Type
+
+import pytest
+from pydantic import BaseModel
+
+## PYDANTIC MODELS & SCHEMAS -----------------------------------------------------
+
+
+@pytest.fixture
+def model_cls_examples(model_cls: Type[BaseModel]) -> List[Dict[str, Any]]:
+    """
+    Extracts examples from pydantic model class Config
+    """
+    # Use by defining model_cls as test parametrization
+    # SEE https://pydantic-docs.helpmanual.io/usage/schema/#schema-customization
+    examples = model_cls.Config.schema_extra.get("examples", [])
+    example = model_cls.Config.schema_extra.get("example")
+    if example:
+        examples.append(example)
+
+    assert model_cls_examples, (
+        f"{model_cls} has NO examples. Add them in Config class."
+        "These are useful to test backwards compatibility and doc."
+    )
+
+    return examples

--- a/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
+++ b/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, Type
 
 import pytest
 from pydantic import BaseModel

--- a/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
+++ b/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
@@ -7,20 +7,34 @@ from pydantic import BaseModel
 
 
 @pytest.fixture
-def model_cls_examples(model_cls: Type[BaseModel]) -> List[Dict[str, Any]]:
+def model_cls_examples(model_cls: Type[BaseModel]) -> Dict[str, Dict[str, Any]]:
     """
     Extracts examples from pydantic model class Config
     """
     # Use by defining model_cls as test parametrization
-    # SEE https://pydantic-docs.helpmanual.io/usage/schema/#schema-customization
-    examples = model_cls.Config.schema_extra.get("examples", [])
-    example = model_cls.Config.schema_extra.get("example")
-    if example:
-        examples.append(example)
 
     assert model_cls_examples, (
-        f"{model_cls} has NO examples. Add them in Config class."
-        "These are useful to test backwards compatibility and doc."
+        f"Testing against a {model_cls} model that has NO examples. Add them in Config class. "
+        "These are useful to test backwards compatibility and doc. "
+        "SEE https://pydantic-docs.helpmanual.io/usage/schema/#schema-customization"
     )
+
+    # checks exampleS setup in schema_extra
+    examples_dict = model_cls.Config.schema_extra.get("examples", {})
+    assert isinstance(examples_dict, dict), (
+        "OpenAPI expects examples: {example-name: example-body, ...}. "
+        "SEE https://swagger.io/docs/specification/adding-examples/"
+    )
+
+    # check example in schema_extra
+    example = model_cls.Config.schema_extra.get("example")
+
+    # collect all examples and creates fixture -> {example-name: example, ...}
+    examples = {
+        f"{model_cls.__name__}.example[{name}]": example
+        for name, example in examples_dict.items()
+    }
+    if example:
+        examples[f"{model_cls.__name__}.example"] = example
 
     return examples

--- a/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
+++ b/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
@@ -20,9 +20,12 @@ def model_cls_examples(model_cls: Type[BaseModel]) -> Dict[str, Dict[str, Any]]:
     )
 
     # checks exampleS setup in schema_extra
-    examples_dict = model_cls.Config.schema_extra.get("examples", {})
-    assert isinstance(examples_dict, dict), (
-        "OpenAPI expects examples: {example-name: example-body, ...}. "
+    examples_list = model_cls.Config.schema_extra.get("examples", [])
+    assert isinstance(examples_list, list), (
+        "OpenAPI and json-schema differ regarding the format for exampleS."
+        "The former is a dict and the latter an array. "
+        "We follow json-schema here"
+        "SEE https://json-schema.org/understanding-json-schema/reference/generic.html"
         "SEE https://swagger.io/docs/specification/adding-examples/"
     )
 
@@ -31,8 +34,8 @@ def model_cls_examples(model_cls: Type[BaseModel]) -> Dict[str, Dict[str, Any]]:
 
     # collect all examples and creates fixture -> {example-name: example, ...}
     examples = {
-        f"{model_cls.__name__}.example[{name}]": example
-        for name, example in examples_dict.items()
+        f"{model_cls.__name__}.example[{index}]": example
+        for index, example in enumerate(examples_list)
     }
     if example:
         examples[f"{model_cls.__name__}.example"] = example

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -67,10 +67,10 @@ DEFAULT_FORMATTING = "%(levelname)s: [%(asctime)s/%(processName)s] [%(name)s:%(f
 
 
 def config_all_loggers():
-    manager: logging.Manager = logging.Logger.manager
+    the_manager: logging.Manager = logging.Logger.manager
 
     loggers = [logging.getLogger()] + [
-        logging.getLogger(name) for name in manager.loggerDict
+        logging.getLogger(name) for name in the_manager.loggerDict
     ]
     for logger in loggers:
         set_logging_handler(logger)

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -67,8 +67,10 @@ DEFAULT_FORMATTING = "%(levelname)s: [%(asctime)s/%(processName)s] [%(name)s:%(f
 
 
 def config_all_loggers():
+    manager: logging.Manager = logging.Logger.manager
+
     loggers = [logging.getLogger()] + [
-        logging.getLogger(name) for name in logging.root.manager.loggerDict
+        logging.getLogger(name) for name in manager.loggerDict
     ]
     for logger in loggers:
         set_logging_handler(logger)

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
@@ -25,6 +25,7 @@ class Port(ServiceProperty):
     key: str = Field(..., regex=PROPERTY_KEY_RE)
     widget: Optional[Dict[str, Any]] = None
 
+    default_value: Optional[DataItemValue] = None
     value: Optional[DataItemValue]
 
     _py_value_type: Tuple[Type[ItemConcreteValue]] = PrivateAttr()
@@ -102,7 +103,7 @@ class Port(ServiceProperty):
         # don't atempt conversion of None it fails
         if value is None:
             return None
-        
+
         return self._py_value_converter(value)
 
     async def set(self, new_value: ItemConcreteValue) -> None:

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
@@ -25,7 +25,7 @@ class Port(ServiceProperty):
     key: str = Field(..., regex=PROPERTY_KEY_RE)
     widget: Optional[Dict[str, Any]] = None
 
-    default_value: Optional[DataItemValue] = None
+    default_value: Optional[DataItemValue] = Field(None, alias="defaultValue")
     value: Optional[DataItemValue]
 
     _py_value_type: Tuple[Type[ItemConcreteValue]] = PrivateAttr()

--- a/services/api-server/tests/unit/conftest.py
+++ b/services/api-server/tests/unit/conftest.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Type, Union
+from typing import Callable, Dict, Iterator, Union
 
 import aiopg.sa
 import aiopg.sa.engine as aiopg_sa_engine
@@ -23,7 +23,6 @@ from dotenv import dotenv_values
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
-from pydantic import BaseModel
 from simcore_postgres_database.models.base import metadata
 from simcore_service_api_server.models.domain.api_keys import ApiKeyInDB
 
@@ -33,6 +32,7 @@ pytestmark = pytest.mark.asyncio
 
 pytest_plugins = [
     "pytest_simcore.repository_paths",
+    "pytest_simcore.pydantic_models",
 ]
 
 
@@ -266,21 +266,3 @@ async def test_api_key(loop, initialized_app, test_user_id) -> ApiKeyInDB:
             "test-api-key", api_key="key", api_secret="secret", user_id=test_user_id
         )
         return apikey
-
-
-## PYDANTIC MODELS & SCHEMAS -----------------------------------------------------
-
-
-@pytest.fixture
-def model_cls_examples(model_cls: Type[BaseModel]) -> List[Dict[str, Any]]:
-    # Extracts examples from pydantic model class
-    # Use by defining model_cls as test parametrization
-    # SEE https://pydantic-docs.helpmanual.io/usage/schema/#schema-customization
-    examples = model_cls.Config.schema_extra.get("examples", [])
-    example = model_cls.Config.schema_extra.get("example")
-    if example:
-        examples.append(example)
-
-    assert model_cls_examples, f"{model_cls} has NO examples. Add them in Config class"
-
-    return examples

--- a/services/api-server/tests/unit/test_model_schemas_files.py
+++ b/services/api-server/tests/unit/test_model_schemas_files.py
@@ -5,7 +5,7 @@
 import hashlib
 import tempfile
 from pathlib import Path
-from pprint import pprint
+from pprint import pformat
 from uuid import uuid4
 
 import pytest
@@ -96,7 +96,7 @@ def test_convert_filemetadata():
 
 @pytest.mark.parametrize("model_cls", (FileMetadata,))
 def test_file_model_examples(model_cls, model_cls_examples):
-    for example in model_cls_examples:
-        pprint(example)
+    for name, example in model_cls_examples.items():
+        print(name, ":", pformat(example))
         model_instance = model_cls(**example)
-        assert model_instance
+        assert model_instance, f"Failed with {name}"

--- a/services/api-server/tests/unit/test_model_schemas_meta.py
+++ b/services/api-server/tests/unit/test_model_schemas_meta.py
@@ -1,7 +1,7 @@
 # pylint:disable=unused-variable
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
-from pprint import pprint
+from pprint import pformat
 
 import pytest
 from simcore_service_api_server.models.schemas.meta import Meta
@@ -9,7 +9,7 @@ from simcore_service_api_server.models.schemas.meta import Meta
 
 @pytest.mark.parametrize("model_cls", (Meta,))
 def test_meta_model_examples(model_cls, model_cls_examples):
-    for example in model_cls_examples:
-        pprint(example)
+    for name, example in model_cls_examples.items():
+        print(name, ":", pformat(example))
         model_instance = model_cls(**example)
-        assert model_instance
+        assert model_instance, f"Failed with {name}"

--- a/services/api-server/tests/unit/test_model_schemas_profiles.py
+++ b/services/api-server/tests/unit/test_model_schemas_profiles.py
@@ -1,7 +1,7 @@
 # pylint:disable=unused-variable
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
-from pprint import pprint
+from pprint import pformat
 
 import pytest
 from simcore_service_api_server.models.schemas.profiles import Profile
@@ -9,7 +9,7 @@ from simcore_service_api_server.models.schemas.profiles import Profile
 
 @pytest.mark.parametrize("model_cls", (Profile,))
 def test_profiles_model_examples(model_cls, model_cls_examples):
-    for example in model_cls_examples:
-        pprint(example)
+    for name, example in model_cls_examples.items():
+        print(name, ":", pformat(example))
         model_instance = model_cls(**example)
-        assert model_instance
+        assert model_instance, f"Failed with {name}"

--- a/services/api-server/tests/unit/test_model_schemas_solvers.py
+++ b/services/api-server/tests/unit/test_model_schemas_solvers.py
@@ -4,7 +4,7 @@
 
 import sys
 from operator import attrgetter
-from pprint import pprint
+from pprint import pformat
 from uuid import uuid4
 
 import pytest
@@ -21,10 +21,10 @@ from simcore_service_api_server.models.schemas.solvers import (
 
 @pytest.mark.parametrize("model_cls", (Job, Solver, JobInput, JobOutput))
 def test_solvers_model_examples(model_cls, model_cls_examples):
-    for example in model_cls_examples:
-        pprint(example)
+    for name, example in model_cls_examples.items():
+        print(name, ":", pformat(example))
         model_instance = model_cls(**example)
-        assert model_instance
+        assert model_instance, f"Failed with {name}"
 
 
 def test_create_solver_from_image_metadata():

--- a/services/director-v2/src/simcore_service_director_v2/utils/logging_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/logging_utils.py
@@ -70,8 +70,10 @@ DEFAULT_FORMATTING = "%(levelname)s: [%(asctime)s/%(processName)s] [%(name)s:%(f
 
 
 def config_all_loggers():
+    the_manager: logging.Manager = logging.Logger.manager
+
     loggers = [logging.getLogger()] + [
-        logging.getLogger(name) for name in logging.root.manager.loggerDict
+        logging.getLogger(name) for name in the_manager.loggerDict
     ]
     for logger in loggers:
         set_logging_handler(logger)

--- a/services/director-v2/tests/mocks/fake_service.json
+++ b/services/director-v2/tests/mocks/fake_service.json
@@ -47,7 +47,6 @@
       "label": "voluptate cupidatat dolore nulla fugiat",
       "description": "Excepteur culpa pariatur labore laborum",
       "type": "string",
-      "defaultValue": -61271885,
       "widget": {
         "type": "SelectBox",
         "details": {

--- a/services/director-v2/tests/mocks/fake_task.json
+++ b/services/director-v2/tests/mocks/fake_task.json
@@ -39,11 +39,7 @@
         "displayOrder": 12125782.735056356,
         "label": "in non ea eu commodo",
         "description": "eu et ex",
-        "type": "boolean",
-        "fileToKeyMap": {
-          "9f~\\|": "BdrosoP3mj"
-        },
-        "defaultValue": 97221400
+        "type": "boolean"
       }
     }
   },

--- a/services/director/src/simcore_service_director/api/v0/openapi.yaml
+++ b/services/director/src/simcore_service_director/api/v0/openapi.yaml
@@ -307,6 +307,10 @@ paths:
                                   example:
                                     - Dog
                                     - true
+                                unit:
+                                  title: Unit
+                                  description: 'Units of this input value, if a physical quantity'
+                                  type: string
                                 widget:
                                   description: custom widget to use instead of the default one determined from the data-type
                                   anyOf:
@@ -411,6 +415,10 @@ paths:
                                   example:
                                     - dir/input1.txt: key_1
                                       dir33/input2.txt: key2
+                                unit:
+                                  title: Unit
+                                  description: 'Units of the output value, if a physical quantity'
+                                  type: string
                           additionalProperties: true
                   error:
                     nullable: true
@@ -692,6 +700,10 @@ paths:
                                   example:
                                     - Dog
                                     - true
+                                unit:
+                                  title: Unit
+                                  description: 'Units of this input value, if a physical quantity'
+                                  type: string
                                 widget:
                                   description: custom widget to use instead of the default one determined from the data-type
                                   anyOf:
@@ -796,6 +808,10 @@ paths:
                                   example:
                                     - dir/input1.txt: key_1
                                       dir33/input2.txt: key2
+                                unit:
+                                  title: Unit
+                                  description: 'Units of the output value, if a physical quantity'
+                                  type: string
                           additionalProperties: true
                   error:
                     nullable: true
@@ -2291,6 +2307,10 @@ components:
                         example:
                           - Dog
                           - true
+                      unit:
+                        title: Unit
+                        description: 'Units of this input value, if a physical quantity'
+                        type: string
                       widget:
                         description: custom widget to use instead of the default one determined from the data-type
                         anyOf:
@@ -2395,6 +2415,10 @@ components:
                         example:
                           - dir/input1.txt: key_1
                             dir33/input2.txt: key2
+                      unit:
+                        title: Unit
+                        description: 'Units of the output value, if a physical quantity'
+                        type: string
                 additionalProperties: true
         error:
           nullable: true

--- a/services/director/src/simcore_service_director/api/v0/schemas/node-meta-v0.0.1.json
+++ b/services/director/src/simcore_service_director/api/v0/schemas/node-meta-v0.0.1.json
@@ -248,6 +248,11 @@
                 true
               ]
             },
+            "unit": {
+              "title": "Unit",
+              "description": "Units of this input value, if a physical quantity",
+              "type": "string"
+            },
             "widget": {
               "description": "custom widget to use instead of the default one determined from the data-type",
               "anyOf": [
@@ -398,6 +403,11 @@
                   "dir33/input2.txt": "key2"
                 }
               ]
+            },
+            "unit": {
+              "title": "Unit",
+              "description": "Units of the output value, if a physical quantity",
+              "type": "string"
             }
           }
         }

--- a/services/storage/src/simcore_service_storage/api/v0/schemas/node-meta-v0.0.1.json
+++ b/services/storage/src/simcore_service_storage/api/v0/schemas/node-meta-v0.0.1.json
@@ -248,6 +248,11 @@
                 true
               ]
             },
+            "unit": {
+              "title": "Unit",
+              "description": "Units of this input value, if a physical quantity",
+              "type": "string"
+            },
             "widget": {
               "description": "custom widget to use instead of the default one determined from the data-type",
               "anyOf": [
@@ -398,6 +403,11 @@
                   "dir33/input2.txt": "key2"
                 }
               ]
+            },
+            "unit": {
+              "title": "Unit",
+              "description": "Units of the output value, if a physical quantity",
+              "type": "string"
             }
           }
         }

--- a/services/web/server/src/simcore_service_webserver/api/v0/schemas/node-meta-v0.0.1.json
+++ b/services/web/server/src/simcore_service_webserver/api/v0/schemas/node-meta-v0.0.1.json
@@ -248,6 +248,11 @@
                 true
               ]
             },
+            "unit": {
+              "title": "Unit",
+              "description": "Units of this input value, if a physical quantity",
+              "type": "string"
+            },
             "widget": {
               "description": "custom widget to use instead of the default one determined from the data-type",
               "anyOf": [
@@ -398,6 +403,11 @@
                   "dir33/input2.txt": "key2"
                 }
               ]
+            },
+            "unit": {
+              "title": "Unit",
+              "description": "Units of the output value, if a physical quantity",
+              "type": "string"
             }
           }
         }


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

- ADDED: Adds unit field in static service metadata schemas (i.e. metadata injected in docker images labels). 
     -  Adds examples and new fixture in simcore_pytest to collect and compare them
     -  NOTE: This PR is a part of PR - ``Is2141/compatible units`` #2145  to **unblock** PR ITISFoundation/osparc-services#88
- FIX: error in ``ServiceOutput`` model
- FIX: sudden ``python-linting`` error. Dumps more version info on ``python-linting`` test to diagnose environment

## Related issue/s

#2141 Processing of metadata in pipelines: units


## How to test

Tests backwards compatibility against example

```cmd
make devenv
source .venv/bin/activate
cd package/models-library
make install-dev
make tests
```



## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
