### PR TITLE
getting states of all nodes

### DIFF
--- a/packages/models-library/src/models_library/projects_pipeline.py
+++ b/packages/models-library/src/models_library/projects_pipeline.py
@@ -9,10 +9,11 @@ from .projects_state import RunningState
 
 class PipelineDetails(BaseModel):
     adjacency_list: Dict[NodeID, List[NodeID]] = Field(
-        ..., description="The adjacency list in terms of {NodeID: [successor NodeID]}"
+        ...,
+        description="The adjacency list of the current pipeline in terms of {NodeID: [successor NodeID]}",
     )
     node_states: Dict[NodeID, NodeState] = Field(
-        ..., description="The states of each of the pipeline node"
+        ..., description="The states of each of the computational nodes in the pipeline"
     )
 
 

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -132,7 +132,7 @@ async def create_computation(
         await computation_pipelines.upsert_pipeline(
             project.uuid, computational_dag, job.start_pipeline
         )
-        await computation_tasks.upsert_tasks_from_project(
+        inserted_comp_tasks = await computation_tasks.upsert_tasks_from_project(
             project,
             director_client,
             list(computational_dag.nodes()) if job.start_pipeline else [],
@@ -161,7 +161,7 @@ async def create_computation(
             if job.start_pipeline
             else RunningState.NOT_STARTED,
             pipeline_details=await compute_pipeline_details(
-                complete_dag, computational_dag, comp_tasks
+                complete_dag, computational_dag, inserted_comp_tasks
             ),
             url=f"{request.url}/{job.project_id}",
             stop_url=f"{request.url}/{job.project_id}:stop"

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -161,7 +161,7 @@ async def create_computation(
             if job.start_pipeline
             else RunningState.NOT_STARTED,
             pipeline_details=await compute_pipeline_details(
-                complete_dag, computational_dag
+                complete_dag, computational_dag, comp_tasks
             ),
             url=f"{request.url}/{job.project_id}",
             stop_url=f"{request.url}/{job.project_id}:stop"
@@ -231,7 +231,9 @@ async def get_computation(
         task_out = ComputationTaskOut(
             id=project_id,
             state=pipeline_state,
-            pipeline_details=await compute_pipeline_details(complete_dag, pipeline_dag),
+            pipeline_details=await compute_pipeline_details(
+                complete_dag, pipeline_dag, all_comp_tasks
+            ),
             url=f"{request.url.remove_query_params('user_id')}",
             stop_url=f"{request.url.remove_query_params('user_id')}:stop"
             if is_pipeline_running(pipeline_state)
@@ -308,7 +310,9 @@ async def stop_computation_project(
         return ComputationTaskOut(
             id=project_id,
             state=pipeline_state,
-            pipeline_details=await compute_pipeline_details(complete_dag, pipeline_dag),
+            pipeline_details=await compute_pipeline_details(
+                complete_dag, pipeline_dag, tasks
+            ),
             url=f"{str(request.url).rstrip(':stop')}",
         )
 

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -207,13 +207,15 @@ async def get_computation(
         )
 
         # get the project task states
-        tasks: List[CompTaskAtDB] = await computation_tasks.get_all_tasks(project_id)
+        all_comp_tasks: List[CompTaskAtDB] = await computation_tasks.get_all_tasks(
+            project_id
+        )
         # create the complete DAG graph
-        complete_dag = create_complete_dag_from_tasks(tasks)
+        complete_dag = create_complete_dag_from_tasks(all_comp_tasks)
 
         # filter the tasks by the effective pipeline
         filtered_tasks = [
-            t for t in tasks if str(t.node_id) in list(pipeline_dag.nodes())
+            t for t in all_comp_tasks if str(t.node_id) in list(pipeline_dag.nodes())
         ]
         pipeline_state = get_pipeline_state_from_task_states(
             filtered_tasks, celery_client.settings.publication_timeout

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -100,6 +100,10 @@ async def _generate_tasks_list_from_project(
             requires_mpi=requires_mpi,
         )
 
+        task_state = node.state.current_status
+        if node_id in published_nodes and node_class == NodeClass.COMPUTATIONAL:
+            task_state = RunningState.PUBLISHED
+
         task_db = CompTaskAtDB(
             project_id=project.uuid,
             node_id=node_id,
@@ -108,11 +112,7 @@ async def _generate_tasks_list_from_project(
             outputs=node.outputs,
             image=image,
             submit=datetime.utcnow(),
-            state=(
-                RunningState.PUBLISHED
-                if node_id in published_nodes and node_class == NodeClass.COMPUTATIONAL
-                else RunningState.NOT_STARTED
-            ),
+            state=task_state,
             internal_id=internal_id,
             node_class=node_class,
         )

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -199,7 +199,9 @@ class CompTasksRepository(BaseRepository):
                 **comp_task_db.dict(by_alias=True, exclude_unset=True)
             )
 
-            exclusion_rule = {"state"}
+            exclusion_rule = (
+                {"state"} if str(comp_task_db.node_id) not in published_nodes else set()
+            )
             if to_node_class(comp_task_db.image.name) != NodeClass.FRONTEND:
                 exclusion_rule.add("outputs")
             on_update_stmt = insert_stmt.on_conflict_do_update(

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -14,6 +14,7 @@ from models_library.services import (
     ServiceKeyVersion,
     ServiceType,
 )
+from sqlalchemy import literal_column
 from sqlalchemy.dialects.postgresql import insert
 
 from ....models.domains.comp_tasks import CompTaskAtDB, Image, NodeSchema
@@ -160,10 +161,12 @@ class CompTasksRepository(BaseRepository):
         director_client: DirectorV0Client,
         published_nodes: List[NodeID],
         str_project_uuid: str,
-    ) -> None:
+    ) -> List[CompTaskAtDB]:
 
         # NOTE: really do an upsert here because of issue https://github.com/ITISFoundation/osparc-simcore/issues/2125
-        list_of_comp_tasks_in_project = await _generate_tasks_list_from_project(
+        list_of_comp_tasks_in_project: List[
+            CompTaskAtDB
+        ] = await _generate_tasks_list_from_project(
             project, director_client, published_nodes
         )
         # get current tasks
@@ -189,6 +192,7 @@ class CompTasksRepository(BaseRepository):
         # insert or update the remaining tasks
         # NOTE: comp_tasks DB only trigger a notification to the webserver if an UPDATE on comp_tasks.outputs or comp_tasks.state is done
         # NOTE: an exception to this is when a frontend service changes its output since there is no node_ports, the UPDATE must be done here.
+        inserted_comp_tasks_db: List[CompTaskAtDB] = []
         for comp_task_db in list_of_comp_tasks_in_project:
 
             insert_stmt = insert(comp_tasks).values(
@@ -203,8 +207,11 @@ class CompTasksRepository(BaseRepository):
                 set_=comp_task_db.dict(
                     by_alias=True, exclude_unset=True, exclude=exclusion_rule
                 ),
-            )
-            await self.connection.execute(on_update_stmt)
+            ).returning(literal_column("*"))
+            result = await self.connection.execute(on_update_stmt)
+            row: RowProxy = await result.fetchone()
+            inserted_comp_tasks_db.append(CompTaskAtDB.from_orm(row))
+        return inserted_comp_tasks_db
 
     @log_decorator(logger=logger)
     async def upsert_tasks_from_project(
@@ -212,7 +219,7 @@ class CompTasksRepository(BaseRepository):
         project: ProjectAtDB,
         director_client: DirectorV0Client,
         published_nodes: List[NodeID],
-    ) -> None:
+    ) -> List[CompTaskAtDB]:
 
         # only used by the decorator on the "_sequentially_upsert_tasks_from_project"
         str_project_uuid: str = str(project.uuid)
@@ -223,7 +230,7 @@ class CompTasksRepository(BaseRepository):
         # If we need to scale this service or the same comp_task entry is used in
         # a different service an implementation of "therun_sequentially_in_context"
         # based on redis queues needs to be put in place.
-        await self._sequentially_upsert_tasks_from_project(
+        return await self._sequentially_upsert_tasks_from_project(
             project=project,
             director_client=director_client,
             published_nodes=published_nodes,

--- a/services/director-v2/src/simcore_service_director_v2/utils/dags.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dags.py
@@ -176,11 +176,11 @@ async def compute_pipeline_details(
         adjacency_list=nx.to_dict_of_lists(pipeline_dag),
         node_states={
             node_id: NodeState(
-                modified=node_data.get(kNODE_MODIFIED_STATE),
-                dependencies=node_data.get(kNODE_DEPENDENCIES_TO_COMPUTE),
+                modified=node_data.get(kNODE_MODIFIED_STATE, False),
+                dependencies=node_data.get(kNODE_DEPENDENCIES_TO_COMPUTE, set()),
             )
             for node_id, node_data in complete_dag.nodes.data()
-            if node_id in pipeline_dag.nodes
+            if _is_node_computational(node_data["key"])
         },
     )
 

--- a/services/director-v2/src/simcore_service_director_v2/utils/db.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/db.py
@@ -10,3 +10,5 @@ DB_TO_RUNNING_STATE = {
     StateType.RUNNING: RunningState.STARTED,
     StateType.ABORTED: RunningState.ABORTED,
 }
+
+RUNNING_STATE_TO_DB = {v: k for k, v in DB_TO_RUNNING_STATE.items()}

--- a/services/director-v2/tests/integration/test_computation_api.py
+++ b/services/director-v2/tests/integration/test_computation_api.py
@@ -347,6 +347,7 @@ PartialComputationParams = namedtuple(
                     1: {
                         "modified": True,
                         "dependencies": [],
+                        "currentStatus": RunningState.PUBLISHED,
                     },
                     2: {
                         "modified": True,
@@ -365,6 +366,7 @@ PartialComputationParams = namedtuple(
                     1: {
                         "modified": False,
                         "dependencies": [],
+                        "currentStatus": RunningState.SUCCESS,
                     },
                     2: {
                         "modified": True,
@@ -390,36 +392,44 @@ PartialComputationParams = namedtuple(
                     1: {
                         "modified": True,
                         "dependencies": [],
+                        "currentStatus": RunningState.PUBLISHED,
                     },
                     2: {
                         "modified": True,
                         "dependencies": [1],
+                        "currentStatus": RunningState.PUBLISHED,
                     },
                     3: {
                         "modified": True,
                         "dependencies": [],
+                        "currentStatus": RunningState.PUBLISHED,
                     },
                     4: {
                         "modified": True,
                         "dependencies": [2, 3],
+                        "currentStatus": RunningState.PUBLISHED,
                     },
                 },
                 exp_node_states_after_run={
                     1: {
                         "modified": False,
                         "dependencies": [],
+                        "currentStatus": RunningState.SUCCESS,
                     },
                     2: {
                         "modified": False,
                         "dependencies": [],
+                        "currentStatus": RunningState.SUCCESS,
                     },
                     3: {
                         "modified": False,
                         "dependencies": [],
+                        "currentStatus": RunningState.SUCCESS,
                     },
                     4: {
                         "modified": False,
                         "dependencies": [],
+                        "currentStatus": RunningState.SUCCESS,
                     },
                 },
             ),
@@ -457,6 +467,7 @@ def test_run_partial_computation(
                 dependencies={
                     workbench_node_uuids[dep_n] for dep_n in s["dependencies"]
                 },
+                currentStatus=s.get("currentStatus", RunningState.NOT_STARTED),
             )
             for n, s in exp_node_states.items()
         }

--- a/services/director-v2/tests/integration/test_computation_api.py
+++ b/services/director-v2/tests/integration/test_computation_api.py
@@ -284,6 +284,17 @@ def fake_workbench_computational_pipeline_details_completed(
     return completed_pipeline_details
 
 
+@pytest.fixture(scope="session")
+def fake_workbench_computational_pipeline_details_not_started(
+    fake_workbench_computational_pipeline_details: PipelineDetails,
+) -> PipelineDetails:
+    completed_pipeline_details = deepcopy(fake_workbench_computational_pipeline_details)
+    for node_state in completed_pipeline_details.node_states.values():
+        node_state.modified = True
+        node_state.current_status = RunningState.NOT_STARTED
+    return completed_pipeline_details
+
+
 # TESTS ---------------------------------------
 
 
@@ -723,6 +734,7 @@ def test_update_and_delete_computation(
     user_id: PositiveInt,
     project: Callable,
     fake_workbench_without_outputs: Dict[str, Any],
+    fake_workbench_computational_pipeline_details_not_started: PipelineDetails,
     fake_workbench_computational_pipeline_details: PipelineDetails,
 ):
     sleepers_project = project(workbench=fake_workbench_without_outputs)
@@ -742,7 +754,7 @@ def test_update_and_delete_computation(
         task_out,
         project=sleepers_project,
         exp_task_state=RunningState.NOT_STARTED,
-        exp_pipeline_details=fake_workbench_computational_pipeline_details,
+        exp_pipeline_details=fake_workbench_computational_pipeline_details_not_started,
     )
 
     # update the pipeline
@@ -761,7 +773,7 @@ def test_update_and_delete_computation(
         task_out,
         project=sleepers_project,
         exp_task_state=RunningState.NOT_STARTED,
-        exp_pipeline_details=fake_workbench_computational_pipeline_details,
+        exp_pipeline_details=fake_workbench_computational_pipeline_details_not_started,
     )
 
     # update the pipeline
@@ -780,7 +792,7 @@ def test_update_and_delete_computation(
         task_out,
         project=sleepers_project,
         exp_task_state=RunningState.NOT_STARTED,
-        exp_pipeline_details=fake_workbench_computational_pipeline_details,
+        exp_pipeline_details=fake_workbench_computational_pipeline_details_not_started,
     )
 
     # start it now

--- a/services/director-v2/tests/integration/test_computation_api.py
+++ b/services/director-v2/tests/integration/test_computation_api.py
@@ -280,6 +280,7 @@ def fake_workbench_computational_pipeline_details_completed(
     for node_state in completed_pipeline_details.node_states.values():
         node_state.modified = False
         node_state.dependencies = set()
+        node_state.current_status = RunningState.SUCCESS
     return completed_pipeline_details
 
 

--- a/services/director-v2/tests/mocks/fake_workbench_computational_node_states.json
+++ b/services/director-v2/tests/mocks/fake_workbench_computational_node_states.json
@@ -1,23 +1,27 @@
 {
   "3a710d8b-565c-5f46-870b-b45ebe195fc7": {
     "modified": true,
-    "dependencies": []
+    "dependencies": [],
+    "currentStatus": "PUBLISHED"
   },
   "e1e2ea96-ce8f-5abc-8712-b8ed312a782c": {
     "modified": true,
-    "dependencies": []
+    "dependencies": [],
+    "currentStatus": "PUBLISHED"
   },
   "415fefd1-d08b-53c1-adb0-16bed3a687ef": {
     "modified": true,
     "dependencies": [
       "3a710d8b-565c-5f46-870b-b45ebe195fc7"
-    ]
+    ],
+    "currentStatus": "PUBLISHED"
   },
   "6ede1209-b459-5735-91fc-761aa584808d": {
     "modified": true,
     "dependencies": [
       "e1e2ea96-ce8f-5abc-8712-b8ed312a782c",
       "415fefd1-d08b-53c1-adb0-16bed3a687ef"
-    ]
+    ],
+    "currentStatus": "PUBLISHED"
   }
 }

--- a/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
@@ -17,8 +17,13 @@ from models_library.projects_state import RunningState
 from pydantic.types import PositiveInt
 from servicelib.application_keys import APP_DB_ENGINE_KEY
 from servicelib.logging_utils import log_decorator
+from servicelib.utils import logged_gather
 from simcore_postgres_database.webserver_models import DB_CHANNEL_NAME, projects
 from sqlalchemy.sql import select
+
+from services.web.server.src.simcore_service_webserver.projects.projects_utils import (
+    project_get_depending_nodes,
+)
 
 from .computation_api import convert_state_from_db
 from .projects import projects_api, projects_exceptions
@@ -73,6 +78,15 @@ async def _update_project_outputs(
     )
 
     await projects_api.notify_project_node_update(app, project, node_uuid)
+    # get depending node and notify for these ones as well
+    depending_node_uuids = await project_get_depending_nodes(project, node_uuid)
+    await logged_gather(
+        *[
+            projects_api.notify_project_node_update(app, project, n)
+            for n in depending_node_uuids
+        ]
+    )
+    # notifiy
     await projects_api.post_trigger_connected_service_retrieve(
         app=app, project=project, updated_node_uuid=node_uuid, changed_keys=changed_keys
     )

--- a/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
@@ -21,12 +21,9 @@ from servicelib.utils import logged_gather
 from simcore_postgres_database.webserver_models import DB_CHANNEL_NAME, projects
 from sqlalchemy.sql import select
 
-from services.web.server.src.simcore_service_webserver.projects.projects_utils import (
-    project_get_depending_nodes,
-)
-
 from .computation_api import convert_state_from_db
 from .projects import projects_api, projects_exceptions
+from .projects.projects_utils import project_get_depending_nodes
 
 log = logging.getLogger(__name__)
 

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -529,9 +529,7 @@ async def add_project_states_for_user(
                 if prj_node is None:
                     continue
                 node_state_dict = json.loads(
-                    node_state.json(
-                        by_alias=True, exclude_unset=True, exclude={"current_status"}
-                    )
+                    node_state.json(by_alias=True, exclude_unset=True)
                 )
                 prj_node.setdefault("state", {}).update(node_state_dict)
 

--- a/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
@@ -2,7 +2,7 @@ import logging
 import re
 import uuid as uuidlib
 from copy import deepcopy
-from typing import AnyStr, Dict, List, Match, Optional, Set, Tuple
+from typing import Any, AnyStr, Dict, List, Match, Optional, Set, Tuple
 
 from servicelib.decorators import safe_return
 
@@ -118,7 +118,9 @@ def substitute_parameterized_inputs(
     return project
 
 
-def is_graph_equal(lhs_workbench: Dict, rhs_workbench: Dict) -> bool:
+def is_graph_equal(
+    lhs_workbench: Dict[str, Any], rhs_workbench: Dict[str, Any]
+) -> bool:
     """Checks whether both workbench contain the same graph
 
     Two graphs are the same when the same topology (i.e. nodes and edges)
@@ -152,7 +154,7 @@ def is_graph_equal(lhs_workbench: Dict, rhs_workbench: Dict) -> bool:
 
 
 async def project_uses_available_services(
-    project: Dict, available_services: List[Dict]
+    project: Dict[str, Any], available_services: List[Dict[str, Any]]
 ) -> bool:
     if not project["workbench"]:
         # empty project
@@ -168,3 +170,18 @@ async def project_uses_available_services(
     }
 
     return needed_services.issubset(available_services)
+
+
+async def project_get_depending_nodes(
+    project: Dict[str, Any], node_uuid: str
+) -> Set[str]:
+    depending_node_uuids = set()
+    for dep_node_uuid, dep_node_data in project.get("workbench", {}).items():
+        for dep_node_inputs_key_data in dep_node_data.get("inputs", {}).values():
+            if (
+                isinstance(dep_node_inputs_key_data, dict)
+                and dep_node_inputs_key_data.get("nodeUuid") == node_uuid
+            ):
+                depending_node_uuids.add(dep_node_uuid)
+
+    return depending_node_uuids

--- a/services/web/server/tests/unit/isolated/test_projects_utils.py
+++ b/services/web/server/tests/unit/isolated/test_projects_utils.py
@@ -4,16 +4,20 @@
 
 import json
 from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, Set
 
 import jsonschema
 import pytest
 from jsonschema import ValidationError
-
-from simcore_service_webserver.projects.projects_utils import clone_project_document
+from simcore_service_webserver.projects.projects_utils import (
+    clone_project_document,
+    project_get_dependent_nodes,
+)
 from simcore_service_webserver.resources import resources
 
 
-def load_template_projects():
+def load_template_projects() -> Dict[str, Any]:
     projects = []
     projects_names = [
         name for name in resources.listdir("data") if "template-projects" in name
@@ -25,7 +29,7 @@ def load_template_projects():
 
 
 @pytest.fixture
-def project_schema(project_schema_file):
+def project_schema(project_schema_file: Path) -> Dict[str, Any]:
     with open(project_schema_file) as fh:
         schema = json.load(fh)
     return schema
@@ -34,7 +38,9 @@ def project_schema(project_schema_file):
 @pytest.mark.parametrize(
     "name,project", [(p["name"], p) for p in load_template_projects()]
 )
-def test_clone_project_document(name, project, project_schema):
+def test_clone_project_document(
+    name: str, project: Dict[str, Any], project_schema: Dict[str, Any]
+):
 
     source = deepcopy(project)
     clone, _ = clone_project_document(source)
@@ -53,3 +59,31 @@ def test_clone_project_document(name, project, project_schema):
         jsonschema.validate(instance=clone, schema=project_schema)
     except ValidationError as err:
         pytest.fail(f"Invalid clone of '{name}': {err.message}")
+
+
+@pytest.fixture(scope="session")
+def fake_project_data(fake_data_dir: Path) -> Dict[str, Any]:
+    with (fake_data_dir / "fake-project.json").open() as fp:
+        return json.load(fp)
+
+
+@pytest.mark.parametrize(
+    "node_uuid, expected_dependencies",
+    [
+        (
+            "b4b20476-e7c0-47c2-8cc4-f66ac21a13bf",
+            {
+                "5739e377-17f7-4f09-a6ad-62659fb7fdec",
+            },
+        ),
+        ("5739e377-17f7-4f09-a6ad-62659fb7fdec", set()),
+        ("351fd505-1ee3-466d-ad6c-ea2915ffd364", set()),
+    ],
+)
+async def test_project_get_depending_nodes(
+    fake_project_data: Dict[str, Any], node_uuid: str, expected_dependencies: Set[str]
+):
+    set_of_depending_nodes = await project_get_dependent_nodes(
+        fake_project_data, node_uuid
+    )
+    assert set_of_depending_nodes == expected_dependencies

--- a/services/web/server/tests/unit/isolated/test_projects_utils.py
+++ b/services/web/server/tests/unit/isolated/test_projects_utils.py
@@ -12,7 +12,7 @@ import pytest
 from jsonschema import ValidationError
 from simcore_service_webserver.projects.projects_utils import (
     clone_project_document,
-    project_get_dependent_nodes,
+    project_get_depending_nodes,
 )
 from simcore_service_webserver.resources import resources
 
@@ -83,7 +83,7 @@ def fake_project_data(fake_data_dir: Path) -> Dict[str, Any]:
 async def test_project_get_depending_nodes(
     fake_project_data: Dict[str, Any], node_uuid: str, expected_dependencies: Set[str]
 ):
-    set_of_depending_nodes = await project_get_dependent_nodes(
+    set_of_depending_nodes = await project_get_depending_nodes(
         fake_project_data, node_uuid
     )
     assert set_of_depending_nodes == expected_dependencies

--- a/services/web/server/tests/unit/with_dbs/slow/test_projects.py
+++ b/services/web/server/tests/unit/with_dbs/slow/test_projects.py
@@ -6,11 +6,12 @@ import json
 import time
 import unittest.mock as mock
 import uuid as uuidlib
-from asyncio import Future, sleep
+from asyncio import Future
 from copy import deepcopy
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from unittest.mock import call
 
+import aiohttp
 import pytest
 import socketio
 from _helpers import ExpectedResponse, HTTPLocked, standard_role_response
@@ -209,7 +210,9 @@ async def project_db_cleaner(client):
 
 
 @pytest.fixture
-async def catalog_subsystem_mock(monkeypatch):
+async def catalog_subsystem_mock(
+    monkeypatch,
+) -> Callable[[Optional[Union[List[Dict], Dict]]], None]:
     services_in_project = []
 
     def creator(projects: Optional[Union[List[Dict], Dict]] = None) -> None:
@@ -520,13 +523,13 @@ async def _delete_project(client, project: Dict, expected: web.Response) -> None
     ],
 )
 async def test_list_projects(
-    client,
-    logged_user,
-    user_project,
-    template_project,
-    expected,
-    catalog_subsystem_mock,
-    director_v2_service_mock,
+    client: aiohttp.test_utils.TestClient,
+    logged_user: Dict[str, Any],
+    user_project: Dict[str, Any],
+    template_project: Dict[str, Any],
+    expected: aiohttp.web.HTTPException,
+    catalog_subsystem_mock: Callable[[Optional[Union[List[Dict], Dict]]], None],
+    director_v2_service_mock: aioresponses,
 ):
     catalog_subsystem_mock([user_project, template_project])
     data = await _list_projects(client, expected)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- director-v2 was only retrieving the states of the running pipeline
- also notify frontend on possible state changes on nodes directly following the node which completed its run

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
