### PR TITLE
BugFix: Get service entrypoint also account for front-end

### DIFF
--- a/services/catalog/src/simcore_service_catalog/api/routes/services.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services.py
@@ -186,7 +186,10 @@ async def get_service(
             key=service_key, version=service_version
         )
         # FIXME: Should not convert back to front-end service because of alias
-        service = ServiceOut.parse_obj(frontend_service.dict(by_alias=True))
+        # FIXME: set the same policy for f/e and director datasets!
+        service = ServiceOut.parse_obj(
+            frontend_service.dict(by_alias=True, exclude_unset=True)
+        )
     else:
         services_in_registry = await director_client.get(
             f"/services/{urllib.parse.quote_plus(service_key)}/{service_version}"

--- a/services/catalog/src/simcore_service_catalog/api/routes/services.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services.py
@@ -1,3 +1,6 @@
+# pylint: disable=too-many-arguments
+
+
 import logging
 import urllib.parse
 from typing import List, Optional, Set, Tuple
@@ -17,7 +20,11 @@ from pydantic.types import PositiveInt
 from ...db.repositories.groups import GroupsRepository
 from ...db.repositories.services import ServicesRepository
 from ...models.schemas.services import ServiceOut, ServiceUpdate
-from ...services.frontend_services import get_services as get_frontend_services
+from ...services.frontend_services import (
+    get_frontend_service,
+    is_frontend_service,
+    iter_frontend_services,
+)
 from ..dependencies.database import get_repository
 from ..dependencies.director import DirectorApi, get_director_api
 
@@ -39,7 +46,6 @@ RESPONSE_MODEL_POLICY = {
 
 @router.get("", response_model=List[ServiceOut], **RESPONSE_MODEL_POLICY)
 async def list_services(
-    # pylint: disable=too-many-arguments
     user_id: PositiveInt,
     details: Optional[bool] = True,
     director_client: DirectorApi = Depends(get_director_api),
@@ -101,7 +107,7 @@ async def list_services(
     # Detailed view re-directing to
 
     # get the services from the registry and filter them out
-    frontend_services = [s.dict(by_alias=True) for s in get_frontend_services()]
+    frontend_services = [s.dict(by_alias=True) for s in iter_frontend_services()]
     registry_services = await director_client.get("/services")
     detailed_services_metadata = frontend_services + registry_services
     detailed_services: List[ServiceOut] = []
@@ -166,7 +172,6 @@ async def list_services(
     **RESPONSE_MODEL_POLICY,
 )
 async def get_service(
-    # pylint: disable=too-many-arguments
     user_id: int,
     service_key: constr(regex=KEY_RE),
     service_version: constr(regex=VERSION_RE),
@@ -175,12 +180,18 @@ async def get_service(
     services_repo: ServicesRepository = Depends(get_repository(ServicesRepository)),
     x_simcore_products_name: str = Header(None),
 ):
-    # check the service exists
-    services_in_registry = await director_client.get(
-        f"/services/{urllib.parse.quote_plus(service_key)}/{service_version}"
-    )
-    service = ServiceOut.parse_obj(services_in_registry[0])
-    # the director client already raises an exception if not found
+    # check the service exists (raise HTTP_404_NOT_FOUND)
+    if is_frontend_service(service_key):
+        frontend_service = get_frontend_service(
+            key=service_key, version=service_version
+        )
+        # FIXME: Should not convert back to front-end service because of alias
+        service = ServiceOut.parse_obj(frontend_service.dict(by_alias=True))
+    else:
+        services_in_registry = await director_client.get(
+            f"/services/{urllib.parse.quote_plus(service_key)}/{service_version}"
+        )
+        service = ServiceOut.parse_obj(services_in_registry[0])
 
     # get the user groups
     user_groups = await groups_repository.list_user_groups(user_id)

--- a/services/catalog/src/simcore_service_catalog/core/background_tasks.py
+++ b/services/catalog/src/simcore_service_catalog/core/background_tasks.py
@@ -30,7 +30,7 @@ from ..api.dependencies.director import get_director_api
 from ..db.repositories.groups import GroupsRepository
 from ..db.repositories.projects import ProjectsRepository
 from ..db.repositories.services import ServicesRepository
-from ..services.frontend_services import get_services as get_frontend_services
+from ..services.frontend_services import list_frontend_services
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ async def _list_registry_services(
     client = get_director_api(app)
     data = await client.get("/services")
     services: Dict[Tuple[ServiceKey, ServiceVersion], ServiceDockerData] = {
-        (s.key, s.version): s for s in get_frontend_services()
+        (s.key, s.version): s for s in list_frontend_services()
     }
     for x in data:
         try:

--- a/services/catalog/src/simcore_service_catalog/core/background_tasks.py
+++ b/services/catalog/src/simcore_service_catalog/core/background_tasks.py
@@ -30,7 +30,7 @@ from ..api.dependencies.director import get_director_api
 from ..db.repositories.groups import GroupsRepository
 from ..db.repositories.projects import ProjectsRepository
 from ..db.repositories.services import ServicesRepository
-from ..services.frontend_services import list_frontend_services
+from ..services.frontend_services import iter_service_docker_data
 
 logger = logging.getLogger(__name__)
 
@@ -39,14 +39,16 @@ ServiceVersion = str
 
 OLD_SERVICES_DATE: datetime = datetime(2020, 8, 19)
 
+ServiceDockerDataMap = Dict[Tuple[ServiceKey, ServiceVersion], ServiceDockerData]
+
 
 async def _list_registry_services(
     app: FastAPI,
-) -> Dict[Tuple[ServiceKey, ServiceVersion], ServiceDockerData]:
+) -> ServiceDockerDataMap:
     client = get_director_api(app)
     data = await client.get("/services")
-    services: Dict[Tuple[ServiceKey, ServiceVersion], ServiceDockerData] = {
-        (s.key, s.version): s for s in list_frontend_services()
+    services: ServiceDockerDataMap = {
+        (s.key, s.version): s for s in iter_service_docker_data()
     }
     for x in data:
         try:

--- a/services/catalog/src/simcore_service_catalog/services/director.py
+++ b/services/catalog/src/simcore_service_catalog/services/director.py
@@ -1,10 +1,10 @@
 import functools
 import logging
 from contextlib import suppress
-from typing import Coroutine, Dict, Optional
+from typing import Coroutine, Dict, List, Optional, Union
 
 from fastapi import FastAPI, HTTPException
-from httpx import AsyncClient, codes, Response
+from httpx import AsyncClient, Response, codes
 from starlette import status
 
 from ..core.settings import DirectorSettings
@@ -106,7 +106,7 @@ class DirectorApi:
     # TODO: add ping to healthcheck
 
     @safe_request
-    async def get(self, path: str) -> Optional[Dict]:
+    async def get(self, path: str) -> Optional[Union[Dict, List]]:
         # temp solution: default timeout increased to 20"
         return await self.client.get(path, timeout=20.0)
 

--- a/services/catalog/src/simcore_service_catalog/services/frontend_services.py
+++ b/services/catalog/src/simcore_service_catalog/services/frontend_services.py
@@ -11,8 +11,7 @@ def create_file_picker_service() -> ServiceDockerData:
     return ServiceDockerData(
         key=f"{FRONTEND_SERVICE_KEY_PREFIX}/file-picker",
         version="1.0.0",
-        # FIXME: ask Odei?? ServiceType.FRONTEND
-        type="dynamic",
+        type=ServiceType.FRONTEND,
         name="File Picker",
         description="File Picker",
         authors=[{"name": "Odei Maiz", "email": "maiz@itis.swiss"}],

--- a/services/catalog/src/simcore_service_catalog/services/frontend_services.py
+++ b/services/catalog/src/simcore_service_catalog/services/frontend_services.py
@@ -1,13 +1,17 @@
-from typing import List
+from typing import Iterator, List
 
-from models_library.services import ServiceDockerData
+from fastapi import status
+from fastapi.exceptions import HTTPException
+from models_library.services import ServiceDockerData, ServiceType
+
+FRONTEND_SERVICE_KEY_PREFIX = "simcore/services/frontend"
 
 
-def _file_picker_service() -> ServiceDockerData:
-    # TODO: create once and just create copies here
+def create_file_picker_service() -> ServiceDockerData:
     return ServiceDockerData(
-        key="simcore/services/frontend/file-picker",
+        key=f"{FRONTEND_SERVICE_KEY_PREFIX}/file-picker",
         version="1.0.0",
+        # FIXME: ask Odei?? ServiceType.FRONTEND
         type="dynamic",
         name="File Picker",
         description="File Picker",
@@ -25,11 +29,11 @@ def _file_picker_service() -> ServiceDockerData:
     )
 
 
-def _node_group_service() -> ServiceDockerData:
+def create_node_group_service() -> ServiceDockerData:
     return ServiceDockerData(
-        key="simcore/services/frontend/nodes-group",
+        key=f"{FRONTEND_SERVICE_KEY_PREFIX}/nodes-group",
         version="1.0.0",
-        type="frontend",
+        type=ServiceType.FRONTEND,
         name="Group",
         description="Group of nodes",
         authors=[{"name": "Odei Maiz", "email": "maiz@itis.swiss"}],
@@ -46,5 +50,27 @@ def _node_group_service() -> ServiceDockerData:
     )
 
 
-def get_services() -> List[ServiceDockerData]:
-    return [_file_picker_service(), _node_group_service()]
+def is_frontend_service(service_key) -> bool:
+    return service_key.startswith(FRONTEND_SERVICE_KEY_PREFIX + "/")
+
+
+def list_frontend_services() -> List[ServiceDockerData]:
+    return list(iter_frontend_services())
+
+
+def iter_frontend_services() -> Iterator[ServiceDockerData]:
+    for factory in [create_file_picker_service, create_node_group_service]:
+        model_instance = factory()
+        yield model_instance
+
+
+def get_frontend_service(key, version) -> ServiceDockerData:
+    try:
+        return next(
+            s for s in iter_frontend_services() if s.key == key and s.version == version
+        )
+    except StopIteration as err:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Frontend service '{key}:{version}' not found",
+        ) from err

--- a/services/catalog/tests/unit/test_services_frontend_services.py
+++ b/services/catalog/tests/unit/test_services_frontend_services.py
@@ -3,27 +3,34 @@
 # pylint:disable=redefined-outer-name
 # pylint:disable=protected-access
 
-from simcore_service_catalog.models.schemas.services import ServiceDockerData
+from simcore_service_catalog.models.schemas.services import (
+    ServiceDockerData,
+    ServiceOut,
+)
 from simcore_service_catalog.services.frontend_services import (
-    _file_picker_service,
-    _node_group_service,
+    create_file_picker_service,
+    create_node_group_service,
 )
 
 
 def test_create_file_picker():
 
-    image_metadata = _file_picker_service()
+    image_metadata = create_file_picker_service()
     assert isinstance(image_metadata, ServiceDockerData)
 
     assert (
         not image_metadata.inputs and image_metadata.outputs
     ), "Expected a source node"
+
+    service = ServiceOut.parse_obj(image_metadata.dict(by_alias=True))
 
 
 def tests_create_node_group():
-    image_metadata = _node_group_service()
+    image_metadata = create_node_group_service()
     assert isinstance(image_metadata, ServiceDockerData)
 
     assert (
         not image_metadata.inputs and image_metadata.outputs
     ), "Expected a source node"
+
+    service = ServiceOut.parse_obj(image_metadata.dict(by_alias=True))


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- FIX: ``GET v0/catalog/services/simcore%2Fservices%2Ffrontend%2Ffile-picker/1.0.0`` for any front-end service failed



## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
