### PR TITLE
BugFix: handling empty list of services in catalog services and module-app

### DIFF
--- a/scripts/demo/create_portal_markdown.py
+++ b/scripts/demo/create_portal_markdown.py
@@ -15,10 +15,9 @@ from datetime import datetime
 from pathlib import Path
 from string import ascii_uppercase
 
-from yarl import URL
-
 from simcore_service_webserver.login.registration import get_invitation_url
 from simcore_service_webserver.login.utils import get_random_string
+from yarl import URL
 
 current_path = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve()
 current_dir = current_path.parent
@@ -79,7 +78,7 @@ def write_list(hostname, url, data, fh):
     print("", file=fh)
 
 
-def main(mock_codes):
+def main(mock_codes, *, uid: int = 1):
     data = {}
 
     with open(current_dir / "template-projects/templates_in_master.json") as fp:
@@ -126,8 +125,11 @@ def main(mock_codes):
     with _open(file_path) as fh:
         print("code,user_id,action,data,created_at", file=fh)
         for n, code in enumerate(mock_codes, start=1):
-            print('%s,1,INVITATION,"{' % code, file=fh)
-            print(f'""guest"": ""invitation-{today.year:04d}{today.month:02d}{today.day:02d}-{n}"" ,', file=fh)
+            print(f'{code},{uid},INVITATION,"{{', file=fh)
+            print(
+                f'""guest"": ""invitation-{today.year:04d}{today.month:02d}{today.day:02d}-{n}"" ,',
+                file=fh,
+            )
             print('""issuer"" : ""support@osparc.io""', file=fh)
             print('}",%s' % datetime.now().isoformat(sep=" "), file=fh)
 
@@ -140,6 +142,7 @@ if __name__ == "__main__":
         action="store_true",
         help="Regenerates codes for invitations",
     )
+    parser.add_argument("--user-id", "-u", default=1)
 
     args = parser.parse_args()
 
@@ -147,4 +150,4 @@ if __name__ == "__main__":
     if args.renew_invitation_codes:
         codes = [get_random_string(len(c)) for c in default_mock_codes]
 
-    main(codes)
+    main(codes, uid=args.user_id)

--- a/services/web/server/src/simcore_service_webserver/catalog_client.py
+++ b/services/web/server/src/simcore_service_webserver/catalog_client.py
@@ -95,7 +95,7 @@ async def make_request_and_envelope_response(
 
 async def get_services_for_user_in_product(
     app: web.Application, user_id: int, product_name: str, *, only_key_versions: bool
-) -> Optional[List[Dict]]:
+) -> List[Dict]:
     url = (
         URL(app[KCATALOG_ORIGIN])
         .with_path(app[KCATALOG_VERSION_PREFIX] + "/services")
@@ -104,8 +104,11 @@ async def get_services_for_user_in_product(
     session = get_client_session(app)
     async with session.get(url, headers={X_PRODUCT_NAME_HEADER: product_name}) as resp:
         if resp.status >= 400:
-            logger.error("Error while retrieving services for user %s", user_id)
-            return
+            logger.warning(
+                "Error while retrieving services for user %s. Returning an empty list",
+                user_id,
+            )
+            return []
         return await resp.json()
 
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

FIX: While reviewing failures on e2e, I found that the catalog failed when requests had to return empty lists. 
CHANGED: added extra options to script to produce invitations

## Related issue/s



## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
