### PR TITLE
BugFix: re-allow for control loops

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/utils/dags.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dags.py
@@ -173,9 +173,13 @@ async def create_minimal_computational_graph_based_on_selection(
 async def compute_pipeline_details(
     complete_dag: nx.DiGraph, pipeline_dag: nx.DiGraph, comp_tasks: List[CompTaskAtDB]
 ) -> PipelineDetails:
-
-    # first pass, traversing in topological order to correctly get the dependencies, set the nodes states
-    await _set_computational_nodes_states(complete_dag)
+    try:
+        # FIXME: this problem of cyclic graphs for control loops create all kinds of issues that must be fixed
+        # first pass, traversing in topological order to correctly get the dependencies, set the nodes states
+        await _set_computational_nodes_states(complete_dag)
+    except nx.NetworkXUnfeasible:
+        # not acyclic
+        pass
     return PipelineDetails(
         adjacency_list=nx.to_dict_of_lists(pipeline_dag),
         node_states={


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?
fixes in the director-v2 for retrieving states of all nodes prevent saving from control loops which are not acyclic graphs.


<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
