### PR TITLE
if metadata file did not exist it would crash

### DIFF
--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -181,6 +181,9 @@ async def get_file_metadata(request: web.Request):
     location = dsm.location_from_id(location_id)
 
     data = await dsm.list_file(user_id=user_id, location=location, file_uuid=file_uuid)
+    # when no metadata is found
+    if data is None:
+        return {"error": "No result found", "data": {}}
 
     envelope = {
         "error": None,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

When requesting metadata for a file which dose not exist storage would be crashing. This is now avoided.

**Note:** without this fix deployed to staging and production the fixed jupyter-labs will not work.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
