### PR TITLE
Webserver: handle 500s from director-v2 gracefully

### DIFF
--- a/services/web/server/src/simcore_service_webserver/director_v2.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from uuid import UUID
 
-from aiohttp import ClientTimeout, web
+from aiohttp import ClientError, ClientTimeout, web
 from models_library.projects_pipeline import ComputationTask
 from pydantic.types import PositiveInt
 from servicelib.application_setup import ModuleCategory, app_module_setup
@@ -60,9 +60,10 @@ async def _request_director_v2(
             payload: Dict = await resp.json()
             return payload
 
-    except TimeoutError as err:
-        raise web.HTTPServiceUnavailable(
-            reason="director service is currently unavailable"
+    except (ClientError, TimeoutError) as err:
+        raise _DirectorServiceError(
+            web.HTTPServiceUnavailable.status_code,
+            reason="director-v2 service is unavailable",
         ) from err
 
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
when some network glitch happens when webserver talks with director-v2 to get the pipeline status a 500 could come back to the frontend. Now this should be catched and an UNKNOWN status is returned.


partially fixes #2155 
## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
