### PR TITLE
Zero time restart

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -346,6 +346,8 @@ services:
       - "--providers.docker.endpoint=unix:///var/run/docker.sock"
       - "--providers.docker.network=${SWARM_STACK_NAME}_default"
       - "--providers.docker.swarmMode=true"
+      # https://github.com/traefik/traefik/issues/7886
+      - "--providers.docker.swarmModeRefreshSeconds=1"
       - "--providers.docker.exposedByDefault=false"
       - "--providers.docker.constraints=Label(`io.simcore.zone`, `${TRAEFIK_SIMCORE_ZONE}`)"
       - "--tracing=true"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -144,6 +144,9 @@ services:
         - traefik.http.middlewares.${SWARM_STACK_NAME_NO_HYPHEN}_sslheader.headers.customrequestheaders.X-Forwarded-Proto=http
         - traefik.enable=true
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.server.port=8080
+        - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.path=/v0/health
+        - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.interval=1000ms
+        - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.timeout=75ms
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.rule=hostregexp(`{host:.+}`)
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.priority=1

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -324,6 +324,9 @@ services:
     command:
       - "--api=true"
       - "--api.dashboard=true"
+      - "--ping=true"
+      - "--entryPoints.ping.address=:9082"
+      - "--ping.entryPoint=ping"
       - "--log.level=WARNING"
       - "--accesslog=false"
       - "--metrics.prometheus=true"
@@ -365,6 +368,12 @@ services:
     networks:
       - default
       - interactive_services_subnet
+    healthcheck:
+      test: wget --quiet --tries=1 --spider http://localhost:9082/ping || exit 1
+      interval: 3s
+      timeout: 1s
+      retries: 3
+      start_period: 1s
 
 volumes:
   input: {}

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -147,10 +147,11 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.path=/v0/health
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.interval=1000ms
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.timeout=75ms
+        - traefik.http.middlewares.${SWARM_STACK_NAME}_webserver_retry.retry.attempts=3
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.rule=hostregexp(`{host:.+}`)
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.priority=1
-        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.middlewares=${SWARM_STACK_NAME}_gzip@docker, ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader@docker
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.middlewares=${SWARM_STACK_NAME}_gzip@docker, ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader@docker, ${SWARM_STACK_NAME}_webserver_retry
     networks:
       - default
       - interactive_services_subnet


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- add a retry middleware on the webserver: in case of 500 a retry will be done (3x) before returning 500 to the frontend
- add load balancer healthchecking of the webserver as traefik label so that traefik recognize when the webserver is not available anymore. NOTE: the webserver still need to issue a 503 when shutting down, with the header field Retry-After set to something reasonable. the webclient shall read this and retry then before failing.
- set the healthcheck for traefik 
(⚠️ devops) = simcore_traefik commands must be adapted @Surfict , @pcrespov , @GitHK :
```yaml
# this shall be added to the command field
- "--ping=true"
- "--entryPoints.ping.address=:9082"
- "--ping.entryPoint=ping"
- - "--providers.docker.swarmModeRefreshSeconds=1"
```
## Related issue/s

Zero downtime: Connected users should be able to continue working with osparc when osparc micro-services are restarted #2212



## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
1. 
  ```console 
  make build-x up-prod
  ```
2. go to [http://127.0.0.1:9081](http://127.0.0.1:9081)
2. log in
3. go to [http://127.0.0.1:9081/dev/doc#/project/list_projects](http://127.0.0.1:9081/dev/doc#/project/list_projects)
4. try the call --> it should return a 200
5. right-click in google chrom dev module, identify the call to /projects?type=all&state=active, then click in *Copy*, then *Copy as cURL*
6. in the following bash script, replace from the 2nd line till *--compressed* with the obtained copy
7. it should look like something similar as below (let's call it tester.bash).

  ```bash
#!/bin/bash
doit() {
    curl -s -o /dev/null -w "%{http_code} - %{time_total}s\n" 'http://127.0.0.1:9081/v0/projects?type=all&state=active' \
    -H 'Connection: keep-alive' \
    -H 'Pragma: no-cache' \
    -H 'Cache-Control: no-cache' \
    -H 'sec-ch-ua: "Google Chrome";v="89", "Chromium";v="89", ";Not A Brand";v="99"' \
    -H 'accept: application/json' \
    -H 'sec-ch-ua-mobile: ?0' \
    -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.36' \
    -H 'Sec-Fetch-Site: same-origin' \
    -H 'Sec-Fetch-Mode: cors' \
    -H 'Sec-Fetch-Dest: empty' \
    -H 'Referer: http://127.0.0.1:9081/dev/doc' \
    -H 'Accept-Language: en-US,en;q=0.9' \
    -H 'Cookie: adminer_key=f70327f90dbb00a8c697c933a32bbd24; _ga=GA1.1.1164697573.1596089800; _pk_id.1.dc78=3bc4017fe41ce1b3.1598967593.; _xsrf=2|c9c1015c|4cc66909cafefb2882de969e58f09aa4|1613982430; osparc.WEBAPI_SESSION="gAAAAABgTyx35utztzbL4WHmBhDAhjnMOz4FbTBKDiWHcCB97Q6ScucrxGveO39zaoXq4Av4i6iaDKnw1lIXtMTF6gStAZ7_cBTB7pGebXYKfmk7QaeBkEhU1QZjwnQr_kDldrLlROEC_0Ix2ntS2jQK3oHg3qZz_QMHNm5Ri_nwIR-Lwwm7eNY="; user=anderegg@itis.swiss; adminer_sid=f091b10a4383a59dc8593c5de85ecdaa; adminer_permanent=cGdzcWw%3D-cG9zdGdyZXM%3D-YWRtaW4%3D-dGVzdA%3D%3D%3Aa7x8OoLd3eqJCAKu%2BcGdzcWw%3D-cG9zdGdyZXM%3D-c2N1-c2ltY29yZWRi%3AwLJfeCwqtZqCaXHsyuXFxQ%3D%3D%2BcGdzcWw%3D-cG9zdGdyZXM%3D-c2N1-c2ltY29yZWRi%3AwLJfeCwqtZqCaXHsyuXFxQ%3D%3D%2BcGdzcWw%3D-cG9zdGdyZXM%3D-c2N1-c2ltY29yZWRi%3AwLJfeCwqtZqCaXHsyuXFxQ%3D%3D+cGdzcWw%3D-cG9zdGdyZXM%3D-c2N1-c2ltY29yZWRi%3AMPBAMB4Ev%2F998eSTpbMe3A%3D%3D; _pk_ses.1.dc78=1; io=72b46316ea2a4bd2b2b06af5fdccb380' \
    --compressed
}
export -f doit

while true; do
echo $(date +"%H:%M:%S.%N") $(doit)
# seq 10 | parallel --progress -n0 doit
done
  ```
8. go to ```./tester.bash``` this will continuously call /projects endpoint and should output 200s
9. issue ```docker service update --force master-simcore_webserver```, this will simulate an update of the webserver

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
