### PR TITLE
Fixes #2041: adds access-rights layer to storage (⚠️ deploy & upgrade patch)

### DIFF
--- a/api/specs/webserver/openapi.yaml
+++ b/api/specs/webserver/openapi.yaml
@@ -168,7 +168,7 @@ paths:
   /projects/{project_id}/state:
     $ref: "./openapi-projects.yaml#/paths/~1projects~1{project_id}~1state"
 
-  /projects/{project_id}:xport:
+  /projects/{project_id}:export:
     $ref: "./openapi-projects.yaml#/paths/~1projects~1{project_id}~1xport"
 
   /projects/{project_id}:duplicate:

--- a/packages/simcore-sdk/requirements/_test.in
+++ b/packages/simcore-sdk/requirements/_test.in
@@ -25,6 +25,7 @@ aioresponses
 requests
 docker
 python-dotenv
+faker
 
 # tools for CI
 pylint

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -48,6 +48,8 @@ docopt==0.6.2
     # via coveralls
 execnet==1.8.0
     # via pytest-xdist
+faker==6.6.2
+    # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
 idna-ssl==1.1.0
@@ -140,6 +142,7 @@ python-dateutil==2.8.1
     # via
     #   -c requirements/_base.txt
     #   alembic
+    #   faker
 python-dotenv==0.15.0
     # via -r requirements/_test.in
 python-editor==1.0.4
@@ -161,6 +164,8 @@ sqlalchemy[postgresql_psycopg2binary]==1.3.23
     #   alembic
 termcolor==1.1.0
     # via pytest-sugar
+text-unidecode==1.3
+    # via faker
 toml==0.10.2
     # via
     #   pylint

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports/exceptions.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports/exceptions.py
@@ -60,11 +60,11 @@ class InvalidProtocolError(NodeportsException):
 
 
 class StorageInvalidCall(NodeportsException):
-    """S3 transfer error"""
+    """Storage returned an error 400<=status<500"""
 
 
 class StorageServerIssue(NodeportsException):
-    """S3 transfer error"""
+    """Storage returned an error status>=500"""
 
 
 class S3TransferError(NodeportsException):

--- a/packages/simcore-sdk/tests/integration/conftest.py
+++ b/packages/simcore-sdk/tests/integration/conftest.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, Iterable, List, Tuple
 import np_helpers
 import pytest
 import sqlalchemy as sa
-from pytest_simcore.helpers.fakers_rawdata_for_db import random_project, random_user
+from pytest_simcore.helpers.rawdata_fakers import random_project, random_user
 from simcore_postgres_database.storage_models import projects, users
 from simcore_sdk.models.pipeline_models import ComputationalPipeline, ComputationalTask
 from simcore_sdk.node_ports import node_config

--- a/packages/simcore-sdk/tests/integration/conftest.py
+++ b/packages/simcore-sdk/tests/integration/conftest.py
@@ -87,7 +87,7 @@ async def filemanager_cfg(
 
 
 @pytest.fixture
-def file_uuid(project_id: str, node_uuid: str) -> Callable:
+def create_valid_file_uuid(project_id: str, node_uuid: str) -> Callable:
     def create(file_path: Path, project: str = None, node: str = None):
         if project is None:
             project = project_id
@@ -95,7 +95,7 @@ def file_uuid(project_id: str, node_uuid: str) -> Callable:
             node = node_uuid
         return np_helpers.file_uuid(file_path, project, node)
 
-    yield create
+    return create
 
 
 @pytest.fixture()
@@ -130,13 +130,15 @@ def node_link() -> Callable:
 
 
 @pytest.fixture()
-def store_link(minio_service, bucket, file_uuid, s3_simcore_location) -> Callable:
+def store_link(
+    minio_service, bucket, create_valid_file_uuid, s3_simcore_location
+) -> Callable:
     def create_store_link(
         file_path: Path, project_id: str = None, node_id: str = None
     ) -> Dict[str, str]:
         # upload the file to S3
         assert Path(file_path).exists()
-        file_id = file_uuid(file_path, project_id, node_id)
+        file_id = create_valid_file_uuid(file_path, project_id, node_id)
         # using the s3 client the path must be adapted
         # TODO: use the storage sdk instead
         s3_object = Path(project_id, node_id, Path(file_path).name).as_posix()

--- a/packages/simcore-sdk/tests/integration/test_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_filemanager.py
@@ -6,7 +6,9 @@
 import filecmp
 from pathlib import Path
 from typing import Callable
+from uuid import uuid4
 
+import np_helpers
 import pytest
 from simcore_sdk.node_ports import exceptions, filemanager
 
@@ -71,11 +73,12 @@ async def test_invalid_file_path(
         )
 
 
-async def test_invalid_fileid(
+async def test_errors_upon_invalid_file_identifiers(
     tmpdir: Path,
     bucket: str,
     filemanager_cfg: None,
     user_id: str,
+    project_id: str,
     s3_simcore_location: str,
 ):
     file_path = Path(tmpdir) / "test.test"
@@ -87,7 +90,8 @@ async def test_invalid_fileid(
         await filemanager.upload_file(
             store_id=store, s3_object="", local_file_path=file_path
         )
-    with pytest.raises(exceptions.StorageServerIssue):
+
+    with pytest.raises(exceptions.StorageInvalidCall):
         await filemanager.upload_file(
             store_id=store, s3_object="file_id", local_file_path=file_path
         )
@@ -97,9 +101,12 @@ async def test_invalid_fileid(
         await filemanager.download_file_from_s3(
             store_id=store, s3_object="", local_folder=download_folder
         )
+
     with pytest.raises(exceptions.InvalidDownloadLinkError):
         await filemanager.download_file_from_s3(
-            store_id=store, s3_object="file_id", local_folder=download_folder
+            store_id=store,
+            s3_object=np_helpers.file_uuid("invisible.txt", project_id, uuid4()),
+            local_folder=download_folder,
         )
 
 

--- a/packages/simcore-sdk/tests/integration/test_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_filemanager.py
@@ -5,6 +5,7 @@
 
 import filecmp
 from pathlib import Path
+from typing import Callable
 
 import pytest
 from simcore_sdk.node_ports import exceptions, filemanager
@@ -19,14 +20,14 @@ async def test_valid_upload_download(
     bucket: str,
     filemanager_cfg: None,
     user_id: str,
-    file_uuid: str,
+    create_valid_file_uuid: Callable,
     s3_simcore_location: str,
 ):
     file_path = Path(tmpdir) / "test.test"
     file_path.write_text("I am a test file")
     assert file_path.exists()
 
-    file_id = file_uuid(file_path)
+    file_id = create_valid_file_uuid(file_path)
     store_id, e_tag = await filemanager.upload_file(
         store_id=s3_simcore_location, s3_object=file_id, local_file_path=file_path
     )
@@ -47,14 +48,14 @@ async def test_invalid_file_path(
     bucket: str,
     filemanager_cfg: None,
     user_id: str,
-    file_uuid: str,
+    create_valid_file_uuid: Callable,
     s3_simcore_location: str,
 ):
     file_path = Path(tmpdir) / "test.test"
     file_path.write_text("I am a test file")
     assert file_path.exists()
 
-    file_id = file_uuid(file_path)
+    file_id = create_valid_file_uuid(file_path)
     store = s3_simcore_location
     with pytest.raises(FileNotFoundError):
         await filemanager.upload_file(
@@ -107,14 +108,14 @@ async def test_invalid_store(
     bucket: str,
     filemanager_cfg: None,
     user_id: str,
-    file_uuid: str,
+    create_valid_file_uuid: Callable,
     s3_simcore_location: str,
 ):
     file_path = Path(tmpdir) / "test.test"
     file_path.write_text("I am a test file")
     assert file_path.exists()
 
-    file_id = file_uuid(file_path)
+    file_id = create_valid_file_uuid(file_path)
     store = "somefunkystore"
     with pytest.raises(exceptions.S3InvalidStore):
         await filemanager.upload_file(
@@ -133,14 +134,14 @@ async def test_valid_metadata(
     bucket: str,
     filemanager_cfg: None,
     user_id: str,
-    file_uuid: str,
+    create_valid_file_uuid: Callable,
     s3_simcore_location: str,
 ):
     file_path = Path(tmpdir) / "test.test"
     file_path.write_text("I am a test file")
     assert file_path.exists()
 
-    file_id = file_uuid(file_path)
+    file_id = create_valid_file_uuid(file_path)
     store_id, e_tag = await filemanager.upload_file(
         store_id=s3_simcore_location, s3_object=file_id, local_file_path=file_path
     )
@@ -167,11 +168,11 @@ async def test_invalid_metadata(
     bucket: str,
     filemanager_cfg: None,
     user_id: str,
-    file_uuid: str,
+    create_valid_file_uuid: Callable,
     s3_simcore_location: str,
 ):
     file_path = Path(tmpdir) / "test.test"
-    file_id = file_uuid(file_path)
+    file_id = create_valid_file_uuid(file_path)
     assert file_path.exists() is False
 
     with pytest.raises(exceptions.NodeportsException) as exc_info:

--- a/packages/simcore-sdk/tests/integration/test_nodeports2.py
+++ b/packages/simcore-sdk/tests/integration/test_nodeports2.py
@@ -174,12 +174,21 @@ async def test_port_file_accessors(
     item_value: str,
     item_pytype: Type,
     config_value: Dict[str, str],
+    project_id,
+    node_uuid,
     e_tag: str,
 ):  # pylint: disable=W0613, W0621
-    config_dict, project_id, node_uuid = special_configuration(
+
+    config_value["path"] = f"{project_id}/{node_uuid}/{Path(config_value['path']).name}"
+
+    config_dict, _project_id, _node_uuid = special_configuration(
         inputs=[("in_1", item_type, config_value)],
         outputs=[("out_34", item_type, None)],
     )
+
+    assert _project_id == project_id
+    assert _node_uuid == node_uuid
+
     PORTS = await node_ports_v2.ports()
     await check_config_valid(PORTS, config_dict)
     assert await (await PORTS.outputs)["out_34"].get() is None  # check emptyness

--- a/services/sidecar/requirements/_test.in
+++ b/services/sidecar/requirements/_test.in
@@ -25,6 +25,7 @@ pytest-sugar
 aiopg
 docker
 python-dotenv
+faker
 
 # tools for CI
 pylint

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -9,7 +9,7 @@ aiohttp==3.7.3
     #   -c requirements/_base.txt
     #   -c requirements/_packages.txt
     #   pytest-aiohttp
-aiopg[sa]==1.0.0
+aiopg==1.0.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_packages.txt
@@ -50,6 +50,8 @@ docker==4.4.4
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
+faker==6.6.2
+    # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
 idna-ssl==1.1.0
@@ -144,6 +146,7 @@ python-dateutil==2.8.1
     # via
     #   -c requirements/_packages.txt
     #   alembic
+    #   faker
 python-dotenv==0.15.0
     # via -r requirements/_test.in
 python-editor==1.0.4
@@ -169,6 +172,8 @@ sqlalchemy[postgresql_psycopg2binary]==1.3.19
     #   alembic
 termcolor==1.1.0
     # via pytest-sugar
+text-unidecode==1.3
+    # via faker
 toml==0.10.2
     # via
     #   pylint

--- a/services/sidecar/tests/integration/test_sidecar.py
+++ b/services/sidecar/tests/integration/test_sidecar.py
@@ -8,14 +8,15 @@ import json
 from collections import deque
 from pathlib import Path
 from pprint import pformat
-from typing import Any, Dict, List, Tuple
-from uuid import uuid4
+from typing import Any, Dict, Iterable, List, Tuple
 
 import aio_pika
 import pytest
 import sqlalchemy as sa
 from models_library.settings.celery import CeleryConfig
 from models_library.settings.rabbit import RabbitConfig
+from pytest_simcore.helpers.fakers_rawdata_for_db import random_project, random_user
+from simcore_postgres_database.storage_models import projects, users
 from simcore_sdk.models.pipeline_models import ComputationalPipeline, ComputationalTask
 from simcore_service_sidecar import config, utils
 from yarl import URL
@@ -35,13 +36,45 @@ pytest_simcore_ops_services_selection = ["minio", "adminer"]
 
 
 @pytest.fixture
-def project_id() -> str:
-    return str(uuid4())
+def user_id(postgres_engine: sa.engine.Engine) -> Iterable[int]:
+    # inject user in db
+
+    # NOTE: Ideally this (and next fixture) should be done via webserver API but at this point
+    # in time, the webserver service would bring more dependencies to other services
+    # which would turn this test too complex.
+
+    # pylint: disable=no-value-for-parameter
+    stmt = users.insert().values(**random_user(name="test")).returning(users.c.id)
+    print(str(stmt))
+    with postgres_engine.connect() as conn:
+        result = conn.execute(stmt)
+        [usr_id] = result.fetchone()
+
+    yield usr_id
+
+    with postgres_engine.connect() as conn:
+        conn.execute(users.delete().where(users.c.id == usr_id))
 
 
 @pytest.fixture
-def user_id() -> int:
-    return 1
+def project_id(user_id: int, postgres_engine: sa.engine.Engine) -> Iterable[str]:
+    # inject project for user in db. This will give user_id, the full project's ownership
+
+    # pylint: disable=no-value-for-parameter
+    stmt = (
+        projects.insert()
+        .values(**random_project(prj_owner=user_id))
+        .returning(projects.c.uuid)
+    )
+    print(str(stmt))
+    with postgres_engine.connect() as conn:
+        result = conn.execute(stmt)
+        [prj_uuid] = result.fetchone()
+
+    yield prj_uuid
+
+    with postgres_engine.connect() as conn:
+        conn.execute(projects.delete().where(projects.c.uuid == prj_uuid))
 
 
 @pytest.fixture

--- a/services/sidecar/tests/integration/test_sidecar.py
+++ b/services/sidecar/tests/integration/test_sidecar.py
@@ -15,7 +15,7 @@ import pytest
 import sqlalchemy as sa
 from models_library.settings.celery import CeleryConfig
 from models_library.settings.rabbit import RabbitConfig
-from pytest_simcore.helpers.fakers_rawdata_for_db import random_project, random_user
+from pytest_simcore.helpers.rawdata_fakers import random_project, random_user
 from simcore_postgres_database.storage_models import projects, users
 from simcore_sdk.models.pipeline_models import ComputationalPipeline, ComputationalTask
 from simcore_service_sidecar import config, utils

--- a/services/storage/requirements/_test.in
+++ b/services/storage/requirements/_test.in
@@ -22,7 +22,6 @@ pylint
 coverage
 coveralls
 codecov
-fake
 
 # remote debugging
 ptvsd

--- a/services/storage/requirements/_test.in
+++ b/services/storage/requirements/_test.in
@@ -22,6 +22,7 @@ pylint
 coverage
 coveralls
 codecov
+fake
 
 # remote debugging
 ptvsd

--- a/services/storage/requirements/_test.in
+++ b/services/storage/requirements/_test.in
@@ -22,6 +22,7 @@ pylint
 coverage
 coveralls
 codecov
+faker
 
 # remote debugging
 ptvsd

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -68,10 +68,6 @@ docopt==0.6.2
     #   -c requirements/_base.txt
     #   coveralls
     #   docker-compose
-fabric==2.6.0
-    # via fake
-fake==0.8
-    # via -r requirements/_test.in
 idna-ssl==1.1.0
     # via
     #   -c requirements/_base.txt
@@ -91,8 +87,6 @@ importlib-metadata==2.0.0
     #   pytest
 iniconfig==1.1.1
     # via pytest
-invoke==1.5.0
-    # via fabric
 isort==5.7.0
     # via pylint
 jsonschema==3.2.0
@@ -119,11 +113,7 @@ packaging==20.9
 pandas==1.1.5
     # via -r requirements/_test.in
 paramiko==2.7.2
-    # via
-    #   docker
-    #   fabric
-pathlib2==2.3.5
-    # via fabric
+    # via docker
 pluggy==0.13.1
     # via pytest
 ptvsd==4.3.2
@@ -194,7 +184,6 @@ six==1.15.0
     #   docker
     #   dockerpty
     #   jsonschema
-    #   pathlib2
     #   pynacl
     #   python-dateutil
     #   websocket-client

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -68,6 +68,8 @@ docopt==0.6.2
     #   -c requirements/_base.txt
     #   coveralls
     #   docker-compose
+faker==6.6.2
+    # via -r requirements/_test.in
 idna-ssl==1.1.0
     # via
     #   -c requirements/_base.txt
@@ -158,6 +160,7 @@ pytest==6.2.2
 python-dateutil==2.8.1
     # via
     #   -c requirements/_base.txt
+    #   faker
     #   pandas
 python-dotenv==0.15.0
     # via docker-compose
@@ -189,6 +192,8 @@ six==1.15.0
     #   websocket-client
 termcolor==1.1.0
     # via pytest-sugar
+text-unidecode==1.3
+    # via faker
 texttable==1.6.3
     # via docker-compose
 toml==0.10.2

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -68,6 +68,10 @@ docopt==0.6.2
     #   -c requirements/_base.txt
     #   coveralls
     #   docker-compose
+fabric==2.6.0
+    # via fake
+fake==0.8
+    # via -r requirements/_test.in
 idna-ssl==1.1.0
     # via
     #   -c requirements/_base.txt
@@ -87,6 +91,8 @@ importlib-metadata==2.0.0
     #   pytest
 iniconfig==1.1.1
     # via pytest
+invoke==1.5.0
+    # via fabric
 isort==5.7.0
     # via pylint
 jsonschema==3.2.0
@@ -113,7 +119,11 @@ packaging==20.9
 pandas==1.1.5
     # via -r requirements/_test.in
 paramiko==2.7.2
-    # via docker
+    # via
+    #   docker
+    #   fabric
+pathlib2==2.3.5
+    # via fabric
 pluggy==0.13.1
     # via pytest
 ptvsd==4.3.2
@@ -184,6 +194,7 @@ six==1.15.0
     #   docker
     #   dockerpty
     #   jsonschema
+    #   pathlib2
     #   pynacl
     #   python-dateutil
     #   websocket-client

--- a/services/storage/src/simcore_service_storage/access_layer.py
+++ b/services/storage/src/simcore_service_storage/access_layer.py
@@ -89,7 +89,7 @@ async def list_projects_access_rights(
         OR jsonb_exists_any( access_rights, (
                SELECT ARRAY( SELECT gid::TEXT FROM user_to_groups WHERE uid = {user_id} )
             )
-        )sql
+        )
     )
     """
     )
@@ -133,7 +133,7 @@ async def get_project_access_rights(
         SELECT prj_owner, access_rights
         FROM projects
         WHERE (
-            ( uuid = {project_id} ) AND (
+            ( uuid = '{project_id}' ) AND (
                 prj_owner = {user_id}
                 OR jsonb_exists_any( access_rights, (
                     SELECT ARRAY( SELECT gid::TEXT FROM user_to_groups WHERE uid = {user_id} )

--- a/services/storage/src/simcore_service_storage/access_layer.py
+++ b/services/storage/src/simcore_service_storage/access_layer.py
@@ -200,7 +200,7 @@ async def get_file_access_rights(
     row: Optional[RowProxy] = await result.first()
 
     if row:
-        if row.user_id == user_id:
+        if int(row.user_id) == user_id:
             # is owner
             return AccessRights.all()
 

--- a/services/storage/src/simcore_service_storage/access_layer.py
+++ b/services/storage/src/simcore_service_storage/access_layer.py
@@ -237,7 +237,8 @@ async def get_file_access_rights(
                 # ownership still not defined, so we assume it is user_id
                 return AccessRights.all()
 
-            _ = UUID(parent)  # tests parent as UUID
+            # otherwise assert 'parent' string corresponds to a valid UUID
+            UUID(parent)  # raises ValueError
             access_rights = await get_project_access_rights(
                 conn, user_id, project_id=parent
             )

--- a/services/storage/src/simcore_service_storage/access_layer.py
+++ b/services/storage/src/simcore_service_storage/access_layer.py
@@ -94,7 +94,8 @@ def _aggregate_access_rights(
     except KeyError:
         # NOTE: database does NOT include schema for json access_rights column!
         logger.warning(
-            "Invalid entry in projects.access_rights. Revoking all rights [%s]", row
+            "Invalid entry in projects.access_rights. Revoking all rights [%s]",
+            access_rights,
         )
         return AccessRights.none()
 

--- a/services/storage/src/simcore_service_storage/access_layer.py
+++ b/services/storage/src/simcore_service_storage/access_layer.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import Dict, List
+
+import sqlalchemy as sa
+from aiopg.sa.connection import SAConnection
+from aiopg.sa.result import ResultProxy, RowProxy
+from simcore_postgres_database.storage_models import (
+    file_meta_data,
+    projects,
+    user_to_groups,
+)
+from sqlalchemy.sql import text
+
+ProjectID = str
+
+
+@dataclass
+class AccessRights:
+    read: bool
+    write: bool
+    delete: bool
+
+
+async def get_projects_access_rights(
+    conn: SAConnection, user_id: int
+) -> Dict[ProjectID, AccessRights]:
+    """ returns rights that user_id has on projects """
+
+    smt = text(
+        f"""\
+    SELECT uuid, access_rights
+    FROM projects
+    WHERE (
+        jsonb_exists_any( access_rights, (
+               SELECT ARRAY( SELECT gid::TEXT FROM user_to_groups WHERE uid = {user_id} )
+            )
+        )
+        OR prj_owner = {user_id}
+    )
+    """
+    )
+
+    projects_access_rights = {}
+
+    async for row in conn.execute(smt):
+        prj_access = {"read": False, "write": False, "delete": False}
+        for grp_access in row.access_rights.values():
+            for key in grp_access:
+                prj_access[key] |= grp_access[key]
+
+        assert isinstance(row.uuid, ProjectID)
+        projects_access_rights[row.uuid] = AccessRights(**prj_access)
+    return projects_access_rights
+
+
+async def get_readable_project_ids(conn: SAConnection, user_id: int) -> List[ProjectID]:
+    projects_access_rights = await get_projects_access_rights(conn, int(user_id))
+    return [pid for pid, access in projects_access_rights.items() if access.read]

--- a/services/storage/src/simcore_service_storage/access_layer.py
+++ b/services/storage/src/simcore_service_storage/access_layer.py
@@ -1,41 +1,85 @@
+"""
+
+Draft Rationale:
+
+    osparc-simcore defines TWO authorization methods: i.e. a set of rules on what,
+    how and when any resource can be accessed or operated by a user
+
+    ROLE-BASED METHOD:
+    In this method, a user is assigned a role (user/tester/admin) upon registration. Each role is
+    system-wide and defines a set of operations that the user *can* perform
+        - Every operation is named as a resource and an action (e.g. )
+        - Resource is named hierarchically
+        - Roles can inherit permitted operations from other role
+    This method is static because is system-wide and it is defined directly in the
+    code at services/web/server/src/simcore_service_webserver/security_roles.py
+    It is defined on top of every API entrypoint and applied just after authentication of the user.
+
+    GROUP-BASED METHOD:
+    The second method is designed to share a resource among groups of users dynamically. A group
+    defines a set of rules that apply to a resource and users can be added to the group dynamically.
+    So far, there are two resources that define access rights (AR):
+        - one applies to projects (read/write/delete) and
+        - the other to services (execute/write)
+    The project access rights are set in the column "access_rights" of the "projects" table .
+    The service access rights has its own table: service_access_rights
+
+    Access rights apply hierarchically, meaning that the access granted to a project applies
+    to all nodes inside and stored data in nodes.
+
+    How do these two AR coexist?: Access to read, write or delete a project are defined in the project AR but execution
+    will depend on the service AR attached to nodes inside.
+
+
+    What about stored data?
+    - nodes data are stored in s3 hierarchically and inherits the AR from the associated project
+    -
+    - Some s3 data objects are associated with nodes in a project
+    - Access to a project is also regulated via access rights and it is also
+    the case for all data objects under this project
+"""
+
+
 from dataclasses import dataclass
 from typing import Dict, List
 
-import sqlalchemy as sa
 from aiopg.sa.connection import SAConnection
-from aiopg.sa.result import ResultProxy, RowProxy
-from simcore_postgres_database.storage_models import (
-    file_meta_data,
-    projects,
-    user_to_groups,
-)
 from sqlalchemy.sql import text
+
+# import sqlalchemy as sa
+# from aiopg.sa.result import ResultProxy, RowProxy
+# from simcore_postgres_database.storage_models import (
+#    file_meta_data,
+#    projects,
+#    user_to_groups,
+# )
+
 
 ProjectID = str
 
 
 @dataclass
 class AccessRights:
-    read: bool
-    write: bool
-    delete: bool
+    read: bool = False
+    write: bool = False
+    delete: bool = False
 
 
 async def get_projects_access_rights(
     conn: SAConnection, user_id: int
 ) -> Dict[ProjectID, AccessRights]:
-    """ returns rights that user_id has on projects """
+    """ Returns projects included in any user's group and its access rights """
 
     smt = text(
         f"""\
     SELECT uuid, access_rights
     FROM projects
     WHERE (
-        jsonb_exists_any( access_rights, (
+        prj_owner = {user_id}
+        OR jsonb_exists_any( access_rights, (
                SELECT ARRAY( SELECT gid::TEXT FROM user_to_groups WHERE uid = {user_id} )
             )
         )
-        OR prj_owner = {user_id}
     )
     """
     )

--- a/services/storage/src/simcore_service_storage/access_layer.py
+++ b/services/storage/src/simcore_service_storage/access_layer.py
@@ -16,7 +16,7 @@
         It is defined on top of every API entrypoint and applied just after authentication of the user.
 
     ## GROUP-BASED METHOD:
-        The second method is designed to share a resource among groups of users dynamically. A group
+        The second method is designed to dynamically share a resource among groups of users. A group
         defines a set of rules that apply to a resource and users can be added to the group dynamically.
         So far, there are two resources that define access rights (AR):
             - one applies to projects (read/write/delete) and

--- a/services/storage/src/simcore_service_storage/access_layer.py
+++ b/services/storage/src/simcore_service_storage/access_layer.py
@@ -1,58 +1,58 @@
-"""
+""" Helper functions to determin access-rights on stored data
 
-Draft Rationale:
+# DRAFT Rationale:
 
     osparc-simcore defines TWO authorization methods: i.e. a set of rules on what,
     how and when any resource can be accessed or operated by a user
 
-    ROLE-BASED METHOD:
-    In this method, a user is assigned a role (user/tester/admin) upon registration. Each role is
-    system-wide and defines a set of operations that the user *can* perform
-        - Every operation is named as a resource and an action (e.g. )
-        - Resource is named hierarchically
-        - Roles can inherit permitted operations from other role
-    This method is static because is system-wide and it is defined directly in the
-    code at services/web/server/src/simcore_service_webserver/security_roles.py
-    It is defined on top of every API entrypoint and applied just after authentication of the user.
+    ## ROLE-BASED METHOD:
+        In this method, a user is assigned a role (user/tester/admin) upon registration. Each role is
+        system-wide and defines a set of operations that the user *can* perform
+            - Every operation is named as a resource and an action (e.g. )
+            - Resource is named hierarchically
+            - Roles can inherit permitted operations from other role
+        This method is static because is system-wide and it is defined directly in the
+        code at services/web/server/src/simcore_service_webserver/security_roles.py
+        It is defined on top of every API entrypoint and applied just after authentication of the user.
 
-    GROUP-BASED METHOD:
-    The second method is designed to share a resource among groups of users dynamically. A group
-    defines a set of rules that apply to a resource and users can be added to the group dynamically.
-    So far, there are two resources that define access rights (AR):
-        - one applies to projects (read/write/delete) and
-        - the other to services (execute/write)
-    The project access rights are set in the column "access_rights" of the "projects" table .
-    The service access rights has its own table: service_access_rights
+    ## GROUP-BASED METHOD:
+        The second method is designed to share a resource among groups of users dynamically. A group
+        defines a set of rules that apply to a resource and users can be added to the group dynamically.
+        So far, there are two resources that define access rights (AR):
+            - one applies to projects (read/write/delete) and
+            - the other to services (execute/write)
+        The project access rights are set in the column "access_rights" of the "projects" table .
+        The service access rights has its own table: service_access_rights
 
-    Access rights apply hierarchically, meaning that the access granted to a project applies
-    to all nodes inside and stored data in nodes.
+        Access rights apply hierarchically, meaning that the access granted to a project applies
+        to all nodes inside and stored data in nodes.
 
-    How do these two AR coexist?: Access to read, write or delete a project are defined in the project AR but execution
-    will depend on the service AR attached to nodes inside.
+        How do these two AR coexist?: Access to read, write or delete a project are defined in the project AR but execution
+        will depend on the service AR attached to nodes inside.
 
+        What about stored data?
+        - data generated in nodes inherits the AR from the associated project
+        - data generated in API uses full AR provided by ownership (i.e. user_id in files_meta_data table)
 
-    What about stored data?
-    - nodes data are stored in s3 hierarchically and inherits the AR from the associated project
-    -
-    - Some s3 data objects are associated with nodes in a project
-    - Access to a project is also regulated via access rights and it is also
-    the case for all data objects under this project
 """
 
 
+import logging
+from collections import deque
 from dataclasses import dataclass
-from typing import Dict, List
+from pathlib import Path
+from typing import Dict, List, Optional
+from uuid import UUID
 
+import sqlalchemy as sa
 from aiopg.sa.connection import SAConnection
+from aiopg.sa.result import ResultProxy, RowProxy
+from simcore_postgres_database.storage_models import file_meta_data
 from sqlalchemy.sql import text
 
-# import sqlalchemy as sa
-# from aiopg.sa.result import ResultProxy, RowProxy
-# from simcore_postgres_database.storage_models import (
-#    file_meta_data,
-#    projects,
-#    user_to_groups,
-# )
+from .models import FileMetaData, FileMetaDataEx
+
+logger = logging.getLogger(__name__)
 
 
 ProjectID = str
@@ -60,15 +60,29 @@ ProjectID = str
 
 @dataclass
 class AccessRights:
-    read: bool = False
-    write: bool = False
-    delete: bool = False
+    read: bool
+    write: bool
+    delete: bool
+
+    @classmethod
+    def all(cls) -> "AccessRights":
+        return cls(True, True, True)
+
+    @classmethod
+    def none(cls) -> "AccessRights":
+        return cls(False, False, False)
 
 
-async def get_projects_access_rights(
+class NotAllowedError(Exception):
+    ...
+
+
+async def list_projects_access_rights(
     conn: SAConnection, user_id: int
 ) -> Dict[ProjectID, AccessRights]:
-    """ Returns projects included in any user's group and its access rights """
+    """
+    Returns access-rights of user (user_id) over all OWNED or SHARED projects
+    """
 
     smt = text(
         f"""\
@@ -79,7 +93,7 @@ async def get_projects_access_rights(
         OR jsonb_exists_any( access_rights, (
                SELECT ARRAY( SELECT gid::TEXT FROM user_to_groups WHERE uid = {user_id} )
             )
-        )
+        )sql
     )
     """
     )
@@ -87,16 +101,162 @@ async def get_projects_access_rights(
     projects_access_rights = {}
 
     async for row in conn.execute(smt):
-        prj_access = {"read": False, "write": False, "delete": False}
-        for grp_access in row.access_rights.values():
-            for key in grp_access:
-                prj_access[key] |= grp_access[key]
-
+        assert isinstance(row.access_rights, dict)
         assert isinstance(row.uuid, ProjectID)
-        projects_access_rights[row.uuid] = AccessRights(**prj_access)
+
+        if row.access_rights:
+            try:
+                prj_access = {"read": False, "write": False, "delete": False}
+                for grp_access in row.access_rights.values():
+                    for key in grp_access:
+                        prj_access[key] |= grp_access[key]
+
+                projects_access_rights[row.uuid] = AccessRights(**prj_access)
+            except KeyError:
+                # NOTE: database does NOT include schema for json access_rights column!
+                logger.warning("Invalid entry in projects.access_rights: %s", row)
+        else:
+            # backwards compatibility
+            # - no access_rights defined BUT project is owned
+            projects_access_rights[row.uuid] = AccessRights(
+                read=True, write=True, delete=True
+            )
+
     return projects_access_rights
 
 
+async def get_project_access_rights(
+    conn: SAConnection, user_id: int, project_id: UUID
+) -> AccessRights:
+    """
+    Returns access-rights of user (user_id) over a project resource (project_id)
+    """
+
+    stmt = text(
+        f"""\
+        SELECT prj_owner, access_rights
+        FROM projects
+        WHERE (
+            ( uuid = {project_id} ) AND (
+                prj_owner = {user_id}
+                OR jsonb_exists_any( access_rights, (
+                    SELECT ARRAY( SELECT gid::TEXT FROM user_to_groups WHERE uid = {user_id} )
+                    )
+                )
+            )
+        )
+        """
+    )
+
+    result: ResultProxy = await conn.execute(stmt)
+    row: Optional[RowProxy] = await result.first()
+
+    if not row:
+        # Either project does not exists OR user_id has NO access
+        return AccessRights.none()
+
+    assert isinstance(row.prj_owner, int)
+    assert isinstance(row.access_rights, dict)
+
+    if row.prj_owner == user_id:
+        return AccessRights.all()
+    return AccessRights(**dict(row.access_rights))
+
+
+async def get_file_access_rights(
+    conn: SAConnection, user_id: int, file_uuid: str
+) -> AccessRights:
+    """
+    Returns access-rights of user (user_id) over data file resource (file_uuid)
+    """
+
+    stmt = sa.select([file_meta_data.c.project_id, file_meta_data.c.user_id]).where(
+        file_meta_data.c.file_uuid == file_uuid
+    )
+    result: ResultProxy = await conn.execute(stmt)
+    row: Optional[RowProxy] = await result.first()
+
+    if row:
+        if row.user_id == user_id:
+            # is owner
+            return AccessRights.all()
+
+        if not row.project_id:
+            return AccessRights.none()
+
+        # has associated project, then use
+        access_rights = await get_project_access_rights(
+            conn, user_id, project_id=row.project_id
+        )
+        if not access_rights:
+            logger.warning(
+                "File %s references a project %s that does not exists in db",
+                file_uuid,
+                row.project_id,
+            )
+            return AccessRights.none()
+
+        return access_rights
+
+    else:
+        # file is not registered in meta-data table (e.g. is about to be uploaded or it was deleted)
+        try:
+            parent, _, _ = file_uuid.split("/")
+
+            if parent == "api":
+                # ownership still not defined
+                return AccessRights.all()
+
+            else:
+                access_rights = await get_project_access_rights(
+                    conn, user_id, project_id=UUID(parent)
+                )
+                if not access_rights:
+                    logger.warning(
+                        "File %s references a project %s that does not exists in db",
+                        file_uuid,
+                        row.project_id,
+                    )
+                    return AccessRights.none()
+
+                return access_rights
+
+        except (ValueError, AttributeError) as err:
+            raise ValueError(
+                f"Invalid file_uuid. '{file_uuid}' does not follow any known pattern ({err})"
+            ) from err
+
+
+# HELPERS -----------------------------------------------
+
+
 async def get_readable_project_ids(conn: SAConnection, user_id: int) -> List[ProjectID]:
-    projects_access_rights = await get_projects_access_rights(conn, int(user_id))
+    """ Returns a list of projects where user has granted read-access """
+    projects_access_rights = await list_projects_access_rights(conn, int(user_id))
     return [pid for pid, access in projects_access_rights.items() if access.read]
+
+
+# FILEMETADATA repository ----------------------------
+#
+#
+
+
+async def list_files_metadata(conn: SAConnection, user_id: int) -> List[FileMetaDataEx]:
+    files_meta = deque()
+
+    # filter accounting AR
+    can_read_projects = await get_readable_project_ids(conn, int(user_id))
+
+    query = sa.select([file_meta_data]).where(
+        (file_meta_data.c.user_id == user_id)
+        | file_meta_data.c.project_id.in_(can_read_projects)
+    )
+    logger.debug("user %s query: %s", user_id, query)
+
+    # list
+    async for row in conn.execute(query):
+        d = FileMetaData(**dict(row))
+        dex = FileMetaDataEx(fmd=d, parent_id=str(Path(d.object_name).parent))
+        files_meta.append(dex)
+
+    return list(files_meta)

--- a/services/storage/src/simcore_service_storage/access_layer.py
+++ b/services/storage/src/simcore_service_storage/access_layer.py
@@ -252,6 +252,7 @@ async def get_file_access_rights(
             parent, _, _ = file_uuid.split("/")
 
             if parent == "api":
+                # FIXME: this is wrong, all api data must be registered and OWNED
                 # ownership still not defined, so we assume it is user_id
                 return AccessRights.all()
 

--- a/services/storage/src/simcore_service_storage/access_layer.py
+++ b/services/storage/src/simcore_service_storage/access_layer.py
@@ -189,7 +189,7 @@ async def get_project_access_rights(
         # Either project does not exists OR user_id has NO access
         return AccessRights.none()
 
-    assert isinstance(row.prj_owner, int)
+    assert row.prj_owner is None or isinstance(row.prj_owner, int)
     assert isinstance(row.access_rights, dict)
 
     if row.prj_owner == user_id:

--- a/services/storage/src/simcore_service_storage/datcore_wrapper.py
+++ b/services/storage/src/simcore_service_storage/datcore_wrapper.py
@@ -65,7 +65,7 @@ class DatcoreWrapper:
                 api_secret=api_secret,
                 host="https://api.blackfynn.io",
             )
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             self.d_client = None  # Disabled: any call will raise AttributeError
             logger.warning("Failed to setup datcore. Disabling client.", exc_info=True)
 

--- a/services/storage/src/simcore_service_storage/datcore_wrapper.py
+++ b/services/storage/src/simcore_service_storage/datcore_wrapper.py
@@ -4,7 +4,6 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from functools import wraps
-from pathlib import Path
 from typing import List, Optional, Tuple
 
 import attr
@@ -12,13 +11,7 @@ import attr
 from .datcore import DatcoreClient
 from .models import FileMetaData, FileMetaDataEx
 
-FileMetaDataVec = List[FileMetaData]
-FileMetaDataExVec = List[FileMetaDataEx]
-
-CURRENT_DIR = Path(__file__).resolve().parent
 logger = logging.getLogger(__name__)
-
-# pylint: disable=W0703
 
 
 @contextmanager
@@ -49,11 +42,11 @@ def make_async(func):
 
 
 class DatcoreWrapper:
-    """ Wrapper to call the python2 api from datcore
+    """Wrapper to call the python2 api from datcore
 
-        This can go away now. Next cleanup round...
+    This can go away now. Next cleanup round...
 
-        NOTE: Auto-disables client
+    NOTE: Auto-disables client
 
     """
 
@@ -78,7 +71,7 @@ class DatcoreWrapper:
 
     @property
     def is_communication_enabled(self) -> bool:
-        """ Wrapper class auto-disables if client cannot be created
+        """Wrapper class auto-disables if client cannot be created
 
             e.g. if endpoint service is down
 
@@ -88,7 +81,7 @@ class DatcoreWrapper:
         return self.d_client is not None
 
     @make_async
-    def list_files_recursively(self) -> FileMetaDataVec:  # pylint: disable=W0613
+    def list_files_recursively(self) -> List[FileMetaData]:  # pylint: disable=W0613
         files = []
 
         with safe_call(error_msg="Error listing datcore files"):
@@ -97,7 +90,7 @@ class DatcoreWrapper:
         return files
 
     @make_async
-    def list_files_raw(self) -> FileMetaDataExVec:  # pylint: disable=W0613
+    def list_files_raw(self) -> List[FileMetaDataEx]:  # pylint: disable=W0613
         files = []
 
         with safe_call(error_msg="Error listing datcore files"):
@@ -108,7 +101,7 @@ class DatcoreWrapper:
     @make_async
     def list_files_raw_dataset(
         self, dataset_id: str
-    ) -> FileMetaDataExVec:  # pylint: disable=W0613
+    ) -> List[FileMetaDataEx]:  # pylint: disable=W0613
         files = []
         with safe_call(error_msg="Error listing datcore files"):
             files = self.d_client.list_files_raw_dataset(dataset_id)

--- a/services/storage/src/simcore_service_storage/db_tokens.py
+++ b/services/storage/src/simcore_service_storage/db_tokens.py
@@ -4,9 +4,8 @@ from typing import Tuple
 import sqlalchemy as sa
 from aiohttp import web
 from psycopg2 import Error as DbApiError
-from tenacity import retry
-
 from servicelib.aiopg_utils import PostgresRetryPolicyUponOperation
+from tenacity import retry
 
 from .models import tokens
 from .settings import APP_CONFIG_KEY, APP_DB_ENGINE_KEY
@@ -17,20 +16,24 @@ log = logging.getLogger(__name__)
 @retry(**PostgresRetryPolicyUponOperation(log).kwargs)
 async def _get_tokens_from_db(engine, userid):
     async with engine.acquire() as conn:
-        stmt = sa.select([tokens,]).where(tokens.c.user_id == userid)
+        stmt = sa.select(
+            [
+                tokens,
+            ]
+        ).where(tokens.c.user_id == userid)
         result = await conn.execute(stmt)
         row = await result.first()
         data = dict(row) if row else {}
         return data
 
 
-async def get_api_token_and_secret(request: web.Request, userid) -> Tuple[str, str]:
+async def get_api_token_and_secret(app: web.Application, userid) -> Tuple[str, str]:
     # FIXME: this is a temporary solution. This information should be sent in some form
     # from the client side together with the userid?
-    engine = request.app.get(APP_DB_ENGINE_KEY, None)
+    engine = app.get(APP_DB_ENGINE_KEY, None)
 
     # defaults from config if any, othewise None
-    defaults = request.app[APP_CONFIG_KEY].get("test_datcore", {})
+    defaults = app[APP_CONFIG_KEY].get("test_datcore", {})
     api_token, api_secret = defaults.get("api_token"), defaults.get("api_secret")
 
     if engine:

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -956,9 +956,10 @@ class DataStorageManager:
             )
 
             async for row in conn.execute(stmt):
-                meta = FileMetaDataEx(
-                    fmd=FileMetaData(**dict(row)),
+                meta = FileMetaData(**dict(row))
+                meta_extended = FileMetaDataEx(
+                    fmd=meta,
                     parent_id=str(Path(meta.object_name).parent),
                 )
-                files_meta.append(meta)
+                files_meta.append(meta_extended)
         return list(files_meta)

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -207,7 +207,7 @@ class DataStorageManager:
                     conn, int(user_id)
                 )
                 has_read_access = (
-                    file_meta_data.c.user_id == int(user_id)
+                    file_meta_data.c.user_id == user_id
                 ) | file_meta_data.c.project_id.in_(accesible_projects_ids)
 
                 query = sa.select([file_meta_data]).where(has_read_access)

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -26,7 +26,6 @@ from s3wrapper.s3_client import S3Client
 from servicelib.aiopg_utils import DBAPIError, PostgresRetryPolicyUponOperation
 from servicelib.client_session import get_client_session
 from servicelib.utils import fire_and_forget_task
-from sqlalchemy.sql.functions import user
 from tenacity import retry
 from yarl import URL
 
@@ -41,8 +40,8 @@ from .models import (
     DatasetMetaData,
     FileMetaData,
     FileMetaDataEx,
-    _location_from_id,
     file_meta_data,
+    get_location_from_id,
     projects,
 )
 from .s3 import get_config_s3
@@ -163,7 +162,7 @@ class DataStorageManager:
 
     @classmethod
     def location_from_id(cls, location_id: str):
-        return _location_from_id(location_id)
+        return get_location_from_id(location_id)
 
     async def ping_datcore(self, user_id: str) -> bool:
         """Checks whether user account in datcore is accesible

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -406,7 +406,7 @@ class DataStorageManager:
                         "User %s was not allowed to delete file %s", user_id, file_uuid
                     )
                     raise web.HTTPForbidden(
-                        reason=f"{user_id} does not has enough access rights to delete file {file_uuid}"
+                        reason=f"User '{user_id}' does not has enough access rights to delete file {file_uuid}"
                     )
 
                 query = sa.select(
@@ -529,7 +529,7 @@ class DataStorageManager:
                     "User %s was not allowed to upload file %s", user_id, file_uuid
                 )
                 raise web.HTTPForbidden(
-                    reason=f"{user_id} does not has enough access rights to upload file {file_uuid}"
+                    reason=f"User '{user_id}' does not has enough access rights to upload file {file_uuid}"
                 )
 
         @retry(**postgres_service_retry_policy_kwargs)

--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -22,9 +22,6 @@ async def _prepare_storage_manager(
 
     user_id = query.get("user_id")
     location_id = params.get("location_id")
-    import pdb
-
-    pdb.set_trace()
     location = (
         dsm.location_from_id(location_id) if location_id is not None else INIT_STR
     )
@@ -327,9 +324,6 @@ async def delete_file(request: web.Request):
 async def create_folders_from_project(request: web.Request):
     # FIXME: Update openapi-core. Fails with additionalProperties https://github.com/p1c2u/openapi-core/issues/124. Fails with project
     # params, query, body = await extract_and_validate(request)
-    import pdb
-
-    pdb.set_trace()
     user_id = request.query.get("user_id")
 
     body = await request.json()

--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -321,6 +321,7 @@ async def delete_file(request: web.Request):
 # Exclusive for simcore-s3 storage -----------------------
 
 
+# POST /simcore-s3/folders: copy_folders_from_project
 async def create_folders_from_project(request: web.Request):
     # FIXME: Update openapi-core. Fails with additionalProperties https://github.com/p1c2u/openapi-core/issues/124. Fails with project
     # params, query, body = await extract_and_validate(request)

--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -230,7 +230,7 @@ async def download_file(request: web.Request):
     dsm = await _prepare_storage_manager(params, query, request)
     location = dsm.location_from_id(location_id)
     if location == SIMCORE_S3_STR:
-        link = await dsm.download_link_s3(file_uuid=file_uuid)
+        link = await dsm.download_link_s3(file_uuid, user_id)
     else:
         link, _filename = await dsm.download_link_datcore(user_id, file_uuid)
 

--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -48,15 +48,17 @@ async def _prepare_storage_manager(
 
 @contextmanager
 def handle_storage_errors():
-    """
-    Translates low level errors into HTTP
-    """
+    """Basic policies to translate low-level errors into HTTP errors"""
+    # TODO: include _prepare_storage_manager?
+    # TODO: middleware? decorator?
     try:
+
         yield
+
     except InvalidFileIdentifier as err:
         raise web.HTTPUnprocessableEntity(
             reason=f"{err.identifier} is an invalid file identifier"
-        )
+        ) from err
 
 
 # HANDLERS ---------------------------------------------------

--- a/services/storage/src/simcore_service_storage/models.py
+++ b/services/storage/src/simcore_service_storage/models.py
@@ -25,42 +25,26 @@ from simcore_service_storage.settings import DATCORE_STR, SIMCORE_S3_ID, SIMCORE
 # pylint: disable=R0902
 
 
+_LOCATION_ID_TO_TAG_MAP = {0: SIMCORE_S3_STR, 1: DATCORE_STR}
+UNDEFINED_LOCATION_TAG: str = "undefined"
+
+
 def _parse_datcore(file_uuid: str) -> Tuple[str, str]:
     # we should have 12/123123123/111.txt and return (12/123123123, 111.txt)
 
     file_path = Path(file_uuid)
-    destination = file_path.parent
-    file_name = file_path.name
+    destination = str(file_path.parent)
+    file_name = str(file_path.name)
 
     return destination, file_name
 
 
-def _locations():
-    # TODO: so far this is hardcoded
-    simcore_s3 = {"name": SIMCORE_S3_STR, "id": 0}
-    datcore = {"name": DATCORE_STR, "id": 1}
-    return [simcore_s3, datcore]
-
-
-_LOCATION_ID_TO_STR_MAP = {0: SIMCORE_S3_STR, 1: DATCORE_STR}
-
-
-def _location_from_id(location_id: Union[str, int]) -> str:
+def get_location_from_id(location_id: Union[str, int]) -> str:
     try:
         loc_id = int(location_id)
-        return _LOCATION_ID_TO_STR_MAP[loc_id]
+        return _LOCATION_ID_TO_TAG_MAP[loc_id]
     except (ValueError, KeyError):
-        return "undefined"
-
-
-def _location_from_str(location: str) -> str:
-    intstr = "undefined"
-    if location == SIMCORE_S3_STR:
-        intstr = "0"
-    elif location == DATCORE_STR:
-        intstr = "1"
-
-    return intstr
+        return UNDEFINED_LOCATION_TAG
 
 
 @attr.s(auto_attribs=True)

--- a/services/storage/src/simcore_service_storage/models.py
+++ b/services/storage/src/simcore_service_storage/models.py
@@ -3,7 +3,7 @@
 """
 import datetime
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Union
 from uuid import UUID
 
 import attr
@@ -42,15 +42,15 @@ def _locations():
     return [simcore_s3, datcore]
 
 
-def _location_from_id(location_id: str) -> str:
-    # TODO create a map to sync _location_from_id and _location_from_str
-    loc_str = "undefined"
-    if location_id == "0":
-        loc_str = SIMCORE_S3_STR
-    elif location_id == "1":
-        loc_str = DATCORE_STR
+_LOCATION_ID_TO_STR_MAP = {0: SIMCORE_S3_STR, 1: DATCORE_STR}
 
-    return loc_str
+
+def _location_from_id(location_id: Union[str, int]) -> str:
+    try:
+        loc_id = int(location_id)
+        return _LOCATION_ID_TO_STR_MAP[loc_id]
+    except (ValueError, KeyError):
+        return "undefined"
 
 
 def _location_from_str(location: str) -> str:

--- a/services/storage/src/simcore_service_storage/rest_routes.py
+++ b/services/storage/src/simcore_service_storage/rest_routes.py
@@ -87,6 +87,7 @@ def create(specs: OpenApiSpec) -> List[web.RouteDef]:
     operation_id = specs.paths[path].operations["post"].operation_id
     routes.append(web.post(BASEPATH + path, handle, name=operation_id))
 
+    # copy_folders_from_project
     path, handle = "/simcore-s3/folders", handlers.create_folders_from_project
     operation_id = specs.paths[path].operations["post"].operation_id
     routes.append(web.post(BASEPATH + path, handle, name=operation_id))

--- a/services/storage/src/simcore_service_storage/utils.py
+++ b/services/storage/src/simcore_service_storage/utils.py
@@ -1,4 +1,6 @@
 import logging
+from pathlib import Path
+from typing import Union
 
 import aiofiles
 import tenacity
@@ -9,6 +11,7 @@ from yarl import URL
 logger = logging.getLogger(__name__)
 
 
+MAX_CHUNK_SIZE = 1024
 RETRY_WAIT_SECS = 2
 RETRY_COUNT = 20
 CONNECT_TIMEOUT_SECS = 30
@@ -61,11 +64,31 @@ def expo(base=1.2, factor=0.1, max_value=2):
 
 
 async def download_to_file_or_raise(
-    session: ClientSession, url: StrOrURL, destination_path: str
-):
-    # FIXME: stream chunks
+    session: ClientSession,
+    url: StrOrURL,
+    destination_path: Union[str, Path],
+    *,
+    chunk_size=MAX_CHUNK_SIZE,
+) -> int:
+    """
+    Downloads content from url into destination_path
 
-    # raises aiohttp.ClientResponseError
-    async with session.get(url, raise_for_status=True) as resp:
-        async with aiofiles.open(destination_path, mode="wb") as fh:
-            await fh.write(await resp.read())
+    Returns downloaded file size
+
+    May raise aiohttp.ClientErrors:
+     - aiohttp.ClientResponseError if not 2XX
+     - aiohttp.ClientPayloadError while streaming chunks
+    """
+    # SEE Streaming API: https://docs.aiohttp.org/en/stable/streams.html
+
+    dest_file = Path(destination_path)
+
+    total_size = 0
+    async with session.get(url, raise_for_status=True) as response:
+        dest_file.parent.mkdir(parents=True, exist_ok=True)
+        async with aiofiles.open(dest_file, mode="wb") as fh:
+            async for chunk in response.content.iter_chunked(chunk_size):
+                await fh.write(chunk)
+                total_size += len(chunk)
+
+    return total_size

--- a/services/storage/src/simcore_service_storage/utils.py
+++ b/services/storage/src/simcore_service_storage/utils.py
@@ -1,7 +1,9 @@
 import logging
 
+import aiofiles
 import tenacity
 from aiohttp import ClientSession
+from aiohttp.typedefs import StrOrURL
 from yarl import URL
 
 logger = logging.getLogger(__name__)
@@ -20,7 +22,7 @@ CONNECT_TIMEOUT_SECS = 30
 async def assert_enpoint_is_ok(
     session: ClientSession, url: URL, expected_response: int = 200
 ):
-    """ Tenace check to GET given url endpoint
+    """Tenace check to GET given url endpoint
 
     Typically used to check connectivity to a given service
 
@@ -56,3 +58,14 @@ def expo(base=1.2, factor=0.1, max_value=2):
             n += 1
         else:
             yield max_value
+
+
+async def download_to_file_or_raise(
+    session: ClientSession, url: StrOrURL, destination_path: str
+):
+    # FIXME: stream chunks
+
+    # raises aiohttp.ClientResponseError
+    async with session.get(url, raise_for_status=True) as resp:
+        async with aiofiles.open(destination_path, mode="wb") as fh:
+            await fh.write(await resp.read())

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -26,16 +26,26 @@ from simcore_service_storage.datcore_wrapper import DatcoreWrapper
 from simcore_service_storage.dsm import DataStorageManager, DatCoreApiToken
 from simcore_service_storage.models import FileMetaData
 from simcore_service_storage.settings import SIMCORE_S3_STR
-from utils import ACCESS_KEY, BUCKET_NAME, DATABASE, PASS, SECRET_KEY, USER, USER_ID
+from utils import (
+    ACCESS_KEY,
+    BUCKET_NAME,
+    DATA_DIR,
+    DATABASE,
+    PASS,
+    SECRET_KEY,
+    USER,
+    USER_ID,
+)
 
-current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
+CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
+
 # TODO: replace by pytest_simcore
-sys.path.append(str(current_dir / "helpers"))
+sys.path.append(str(CURRENT_DIR / "helpers"))
 
 
 @pytest.fixture(scope="session")
 def here() -> Path:
-    return current_dir
+    return CURRENT_DIR
 
 
 @pytest.fixture(scope="session")
@@ -229,7 +239,7 @@ def dsm_mockup_complete_db(postgres_service_url, s3_client) -> Tuple[str, str]:
         "node_id": "ad9bda7f-1dc5-5480-ab22-5fef4fc53eac",
         "filename": "outputController.dat",
     }
-    f = utils.data_dir() / Path("outputController.dat")
+    f = DATA_DIR / "outputController.dat"
     object_name = "{project_id}/{node_id}/{filename}".format(**file_1)
     s3_client.upload_file(bucket_name, object_name, f)
 
@@ -238,7 +248,7 @@ def dsm_mockup_complete_db(postgres_service_url, s3_client) -> Tuple[str, str]:
         "node_id": "a3941ea0-37c4-5c1d-a7b3-01b5fd8a80c8",
         "filename": "notebooks.zip",
     }
-    f = utils.data_dir() / Path("notebooks.zip")
+    f = DATA_DIR / "notebooks.zip"
     object_name = "{project_id}/{node_id}/{filename}".format(**file_2)
     s3_client.upload_file(bucket_name, object_name, f)
     yield (file_1, file_2)

--- a/services/storage/tests/docker-compose.yml
+++ b/services/storage/tests/docker-compose.yml
@@ -28,3 +28,12 @@ services:
     ports:
       - "9001:9000"
     command: server /data
+  adminer:
+    image: adminer:4.7.6
+    init: true
+    environment:
+      - ADMINER_DEFAULT_SERVER=postgres
+      - ADMINER_DESIGN=nette
+      - ADMINER_PLUGINS=json-column
+    ports:
+      - "18080:8080"

--- a/services/storage/tests/test_access_layer.py
+++ b/services/storage/tests/test_access_layer.py
@@ -1,0 +1,83 @@
+# pylint:disable=unused-variable
+# pylint:disable=unused-argument
+# pylint:disable=redefined-outer-name
+
+
+from typing import Iterable
+from uuid import UUID
+
+import pytest
+from aiopg.sa.engine import Engine
+from pytest_simcore.helpers.fakers_rawdata_for_db import random_project, random_user
+from simcore_postgres_database.storage_models import projects, users
+from simcore_service_storage.access_layer import (
+    AccessRights,
+    get_file_access_rights,
+    get_project_access_rights,
+)
+
+
+@pytest.fixture
+async def user_id(postgres_engine: Engine) -> Iterable[int]:
+    # inject a random user in db
+
+    # NOTE: Ideally this (and next fixture) should be done via webserver API but at this point
+    # in time, the webserver service would bring more dependencies to other services
+    # which would turn this test too complex.
+
+    # pylint: disable=no-value-for-parameter
+    stmt = users.insert().values(**random_user(name="test")).returning(users.c.id)
+    print(str(stmt))
+    async with postgres_engine.acquire() as conn:
+        result = await conn.execute(stmt)
+        row = await result.fetchone()
+
+    assert isinstance(row.id, int)
+    yield row.id
+
+    async with postgres_engine.acquire() as conn:
+        conn.execute(users.delete().where(users.c.id == row.id))
+
+
+@pytest.fixture
+async def project_id(user_id: int, postgres_engine: Engine) -> Iterable[UUID]:
+    # inject a random project for user in db. This will give user_id, the full project's ownership
+
+    # pylint: disable=no-value-for-parameter
+    stmt = (
+        projects.insert()
+        .values(**random_project(prj_owner=user_id))
+        .returning(projects.c.uuid)
+    )
+    print(str(stmt))
+    async with postgres_engine.acquire() as conn:
+        result = await conn.execute(stmt)
+        [prj_uuid] = (await result.fetchone()).as_tuple()
+
+    yield UUID(prj_uuid)
+
+    async with postgres_engine.acquire() as conn:
+        conn.execute(projects.delete().where(projects.c.uuid == prj_uuid))
+
+
+@pytest.fixture
+async def filemeta_id(
+    user_id: int, project_id: str, postgres_engine: Engine
+) -> Iterable[str]:
+    raise NotImplementedError()
+
+
+async def test_access_rights_on_owned_project(
+    user_id: int, project_id: UUID, postgres_engine: Engine
+):
+
+    async with postgres_engine.acquire() as conn:
+
+        access = await get_project_access_rights(conn, user_id, str(project_id))
+        assert access == AccessRights.all()
+
+        # still NOT registered in file_meta_data BUT with prefix {project_id} owned by user
+        access = await get_file_access_rights(
+            conn, user_id, f"{project_id}/node_id/not-in-file-metadata-table.txt"
+        )
+        assert access == AccessRights.all()

--- a/services/storage/tests/test_access_layer.py
+++ b/services/storage/tests/test_access_layer.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import pytest
 from aiopg.sa.engine import Engine
-from pytest_simcore.helpers.fakers_rawdata_for_db import random_project, random_user
+from pytest_simcore.helpers.rawdata_fakers import random_project, random_user
 from simcore_postgres_database.storage_models import projects, users
 from simcore_service_storage.access_layer import (
     AccessRights,

--- a/services/storage/tests/test_dsm.py
+++ b/services/storage/tests/test_dsm.py
@@ -115,10 +115,10 @@ def _create_file_meta_for_s3(postgres_url, s3_client, tmp_file):
 
     # create file and upload
     filename = os.path.basename(tmp_file)
-    project_id = "22"
+    project_id = "api"  # "357879cc-f65d-48b2-ad6c-074e2b9aa1c7"
     project_name = "battlestar"
     node_name = "galactica"
-    node_id = "1006"
+    node_id = "b423b654-686d-4157-b74b-08fa9d90b36e"
     file_name = filename
     file_uuid = os.path.join(str(project_id), str(node_id), str(file_name))
     display_name = os.path.join(str(project_name), str(node_name), str(file_name))
@@ -170,7 +170,7 @@ async def test_links_s3(
 
     tmp_file2 = tmp_file + ".rec"
     user_id = 0
-    down_url = await dsm.download_link_s3(fmd.file_uuid)
+    down_url = await dsm.download_link_s3(fmd.file_uuid, user_id)
 
     urllib.request.urlretrieve(down_url, tmp_file2)
 

--- a/services/storage/tests/test_dsm.py
+++ b/services/storage/tests/test_dsm.py
@@ -109,7 +109,7 @@ async def test_dsm_s3(dsm_mockup_db, dsm_fixture):
 
 
 def _create_file_meta_for_s3(postgres_url, s3_client, tmp_file):
-    utils.create_tables(url=postgres_url)
+
     bucket_name = BUCKET_NAME
     s3_client.create_bucket(bucket_name, delete_contents_if_exists=True)
 
@@ -154,7 +154,6 @@ def _create_file_meta_for_s3(postgres_url, s3_client, tmp_file):
 async def test_links_s3(
     postgres_service_url, s3_client, mock_files_factory, dsm_fixture
 ):
-    utils.create_tables(url=postgres_service_url)
 
     tmp_file = mock_files_factory(1)[0]
     fmd = _create_file_meta_for_s3(postgres_service_url, s3_client, tmp_file)
@@ -180,7 +179,6 @@ async def test_links_s3(
 async def test_copy_s3_s3(
     postgres_service_url, s3_client, mock_files_factory, dsm_fixture
 ):
-    utils.create_tables(url=postgres_service_url)
 
     tmp_file = mock_files_factory(1)[0]
     fmd = _create_file_meta_for_s3(postgres_service_url, s3_client, tmp_file)
@@ -229,8 +227,6 @@ async def test_dsm_datcore(
     if not has_datcore_tokens():
         return
 
-    utils.create_tables(url=postgres_service_url)
-
     dsm = dsm_fixture
     user_id = "0"
     data = await dsm.list_files(
@@ -264,7 +260,7 @@ async def test_dsm_s3_to_datcore(
 ):
     if not has_datcore_tokens():
         return
-    utils.create_tables(url=postgres_service_url)
+
     tmp_file = mock_files_factory(1)[0]
 
     fmd = _create_file_meta_for_s3(postgres_service_url, s3_client, tmp_file)
@@ -314,7 +310,7 @@ async def test_dsm_datcore_to_local(
 ):
     if not has_datcore_tokens():
         return
-    utils.create_tables(url=postgres_service_url)
+
     dsm = dsm_fixture
     user_id = USER_ID
     data = await dsm.list_files(
@@ -343,7 +339,7 @@ async def test_dsm_datcore_to_S3(
 ):
     if not has_datcore_tokens():
         return
-    utils.create_tables(url=postgres_service_url)
+
     # create temporary file
     tmp_file = mock_files_factory(1)[0]
     dest_fmd = _create_file_meta_for_s3(postgres_service_url, s3_client, tmp_file)
@@ -396,7 +392,6 @@ async def test_copy_datcore(
 ):
     if not has_datcore_tokens():
         return
-    utils.create_tables(url=postgres_service_url)
 
     # the fixture should provide 3 files
     dsm = dsm_fixture
@@ -501,7 +496,8 @@ async def test_deep_copy_project_simcore_s3(
     if not has_datcore_tokens():
         return
     dsm = dsm_fixture
-    utils.create_full_tables(url=postgres_service_url)
+
+    utils.fill_tables_from_csv_files(url=postgres_service_url)
 
     path_in_datcore = datcore_structured_testbucket["file_id3"]
     file_name_in_datcore = Path(datcore_structured_testbucket["filename3"]).name

--- a/services/storage/tests/test_utils.py
+++ b/services/storage/tests/test_utils.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from aiohttp import ClientSession
+from simcore_service_storage.utils import MAX_CHUNK_SIZE, download_to_file_or_raise
+
+
+async def test_download_files(tmpdir):
+
+    destination = Path(tmpdir) / "data"
+    expected_size = MAX_CHUNK_SIZE * 3 + 1000
+
+    async with ClientSession() as session:
+        total_size = await download_to_file_or_raise(
+            session, f"https://httpbin.org/bytes/{expected_size}", destination
+        )
+        assert destination.exists()
+        assert expected_size == total_size
+        assert destination.stat().st_size == total_size

--- a/services/storage/tests/utils.py
+++ b/services/storage/tests/utils.py
@@ -37,13 +37,8 @@ PG_TABLES_NEEDED_FOR_STORAGE = [
     groups,
 ]
 
-
-def current_dir() -> Path:
-    return Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
-
-
-def data_dir() -> Path:
-    return current_dir() / Path("data")
+CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
+DATA_DIR = CURRENT_DIR / "data"
 
 
 def has_datcore_tokens() -> bool:
@@ -135,41 +130,12 @@ def insert_metadata(url: str, fmd: FileMetaData):
 def create_full_tables(url):
     engine = create_tables(url)
 
-    for t in ["users", "file_meta_data", "projects"]:
-        filename = t + ".csv"
-        csv_file = str(data_dir() / Path(filename))
-        with open(csv_file, "r") as file:
+    for table in ["users", "file_meta_data", "projects"]:
+        with open(DATA_DIR / f"{table}.csv", "r") as file:
             data_df = pd.read_csv(file)
             data_df.to_sql(
-                t, con=engine, index=False, index_label="id", if_exists="append"
+                table, con=engine, index=False, index_label="id", if_exists="append"
             )
-
-    # NOTE: Leave here as a reference
-    # import psycopg2
-    # conn = psycopg2.connect(url)
-    # cur = conn.cursor()
-    # columns = [["file_uuid","location_id","location","bucket_name","object_name","project_id","project_name","node_id","node_name","file_name","user_id","user_name"],[],[],[]]
-    # if False:
-    #     for t in ["file_meta_data", "projects", "users"]:
-    #         filename = t + ".sql"
-    #         sqlfile = str(data_dir() / Path(filename))
-    #         cur.execute(open(sqlfile, "r").read())
-    # else:
-    #     for t in ["file_meta_data", "projects", "users"]:
-    #         filename = t + ".csv"
-    #         csv_file = str(data_dir() / Path(filename))
-    #         if False:
-    #             with open(csv_file, 'r') as file:
-    #                 next(file)
-    #                 if t == "file_meta_data":
-    #                     cur.copy_from(file, t, sep=',', columns=columns[0])
-    #                 else:
-    #                     cur.copy_from(file, t, sep=',')
-    #                 conn.commit()
-    #         else:
-    #             with open(csv_file, 'r') as file:
-    #                 data_df = pd.read_csv(file)
-    #                 data_df.to_sql(t, con=engine, index=False, index_label="id", if_exists='append')
 
 
 def drop_all_tables(url):

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -10743,7 +10743,7 @@ paths:
                             message: Password is not secure
                             field: pasword
                         status: 400
-  '/projects/{project_id}:xport':
+  '/projects/{project_id}:export':
     parameters:
       - name: project_id
         in: path

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -40,7 +40,6 @@ from ..socketio.events import (
     SOCKET_IO_PROJECT_UPDATED_EVENT,
     post_group_messages,
 )
-from ..storage_api import copy_data_folders_from_project  # mocked in unit-tests
 from ..storage_api import (
     delete_data_folders_of_project,
     delete_data_folders_of_project_node,
@@ -48,7 +47,6 @@ from ..storage_api import (
 from ..users_api import get_user_name
 from .config import CONFIG_SECTION_NAME
 from .projects_db import APP_PROJECT_DBAPI
-from .projects_utils import clone_project_document
 
 log = logging.getLogger(__name__)
 
@@ -97,34 +95,28 @@ async def get_project_for_user(
     return project
 
 
-async def clone_project(
-    request: web.Request, project: Dict, user_id: int, forced_copy_project_id: str = ""
-) -> Dict:
-    """Clones both document and data folders of a project
-
-    - document
-        - get new identifiers for project and nodes
-    - data folders
-        - folder name composes as project_uuid/node_uuid
-        - data is deep-copied to new folder corresponding to new identifiers
-        - managed by storage uservice
-
-    TODO: request to application
-
-    :param request: http request
-    :type request: web.Request
-    :param project: source project document
-    :type project: Dict
-    :return: project document with updated data links
-    :rtype: Dict
-    """
-    cloned_project, nodes_map = clone_project_document(project, forced_copy_project_id)
-
-    updated_project = await copy_data_folders_from_project(
-        request.app, project, cloned_project, nodes_map, user_id
-    )
-
-    return updated_project
+# NOTE: Needs refactoring after access-layer in storage. DO NOT USE but keep
+#       here since it documents well the concept
+#
+# async def clone_project(
+#     request: web.Request, project: Dict, user_id: int, forced_copy_project_id: str = ""
+# ) -> Dict:
+#     """Clones both document and data folders of a project
+#
+#     - document
+#         - get new identifiers for project and nodes
+#     - data folders
+#         - folder name composes as project_uuid/node_uuid
+#         - data is deep-copied to new folder corresponding to new identifiers
+#         - managed by storage uservice
+#     """
+#     cloned_project, nodes_map = clone_project_document(project, forced_copy_project_id)
+#
+#     updated_project = await copy_data_folders_from_project(
+#         request.app, project, cloned_project, nodes_map, user_id
+#     )
+#
+#     return updated_project
 
 
 async def start_project_interactive_services(

--- a/services/web/server/src/simcore_service_webserver/storage_api.py
+++ b/services/web/server/src/simcore_service_webserver/storage_api.py
@@ -5,9 +5,8 @@ import logging
 from pprint import pformat
 
 from aiohttp import web
-from yarl import URL
-
 from servicelib.rest_responses import unwrap_envelope
+from yarl import URL
 
 from .storage_config import get_client_session, get_storage_config
 
@@ -44,6 +43,9 @@ async def copy_data_folders_from_project(
         ssl=False,
     ) as resp:
         payload = await resp.json()
+
+        # FIXME: relying on storage to change the project is not a good idea since
+        # it is not storage responsibility to deal with projects
         updated_project, error = unwrap_envelope(payload)
         if error:
             msg = "Cannot copy project data in storage: %s" % pformat(error)

--- a/services/web/server/src/simcore_service_webserver/studies_access.py
+++ b/services/web/server/src/simcore_service_webserver/studies_access.py
@@ -27,6 +27,7 @@ from .resource_manager.config import (
 )
 from .security_api import is_anonymous, remember
 from .statics import INDEX_RESOURCE_NAME
+from .storage_api import copy_data_folders_from_project
 from .utils import compose_error_msg
 
 log = logging.getLogger(__name__)
@@ -152,7 +153,6 @@ async def copy_study_to_account(
         clone_project_document,
         substitute_parameterized_inputs,
     )
-    from .storage_api import copy_data_folders_from_project
 
     # FIXME: ONLY projects should have access to db since it avoids access layer
     # TODO: move to project_api and add access layer

--- a/services/web/server/tests/integration/test_exporter.py
+++ b/services/web/server/tests/integration/test_exporter.py
@@ -467,7 +467,7 @@ async def test_import_export_import_duplicate(
     url_export = client.app.router["export_project"].url_for(
         project_id=imported_project_uuid
     )
-    assert url_export == URL(API_PREFIX + f"/projects/{imported_project_uuid}:xport")
+    assert url_export == URL(API_PREFIX + f"/projects/{imported_project_uuid}:export")
     async with await client.post(url_export, timeout=10) as export_response:
         assert export_response.status == 200, await export_response.text()
 

--- a/services/web/server/tests/integration/test_project_workflow.py
+++ b/services/web/server/tests/integration/test_project_workflow.py
@@ -132,8 +132,9 @@ async def storage_subsystem_mock(loop, mocker):
     Patched functions are exposed within projects but call storage subsystem
     """
     # requests storage to copy data
+
     mock = mocker.patch(
-        "simcore_service_webserver.projects.projects_api.copy_data_folders_from_project"
+        "simcore_service_webserver.projects.projects_handlers.copy_data_folders_from_project"
     )
 
     async def _mock_copy_data_from_project(*args):

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -208,7 +208,7 @@ async def storage_subsystem_mock(loop, mocker):
     """
     # requests storage to copy data
     mock = mocker.patch(
-        "simcore_service_webserver.projects.projects_api.copy_data_folders_from_project"
+        "simcore_service_webserver.projects.projects_handlers.copy_data_folders_from_project"
     )
 
     async def _mock_copy_data_from_project(*args):

--- a/services/web/server/tests/unit/with_dbs/fast/test_access_to_studies.py
+++ b/services/web/server/tests/unit/with_dbs/fast/test_access_to_studies.py
@@ -187,7 +187,7 @@ async def catalog_subsystem_mock(monkeypatch, published_project):
 
 
 @pytest.fixture
-def mocks_on_projects_api(mocker) -> Dict:
+def mocks_on_projects_api(mocker) -> None:
     """
     All projects in this module are UNLOCKED
     """
@@ -195,6 +195,29 @@ def mocks_on_projects_api(mocker) -> Dict:
         "simcore_service_webserver.projects.projects_api._get_project_lock_state",
         return_value=future_with_result(ProjectLocked(value=False)),
     )
+
+
+@pytest.fixture
+async def storage_subsystem_mock(storage_subsystem_mock, mocker):
+    """
+    Mocks functions that require storage client
+    """
+    # Overrides + extends fixture in services/web/server/tests/unit/with_dbs/conftest.py
+    # SEE https://docs.pytest.org/en/stable/fixture.html#override-a-fixture-on-a-folder-conftest-level
+
+    # Mocks copy_data_folders_from_project BUT under studies_access
+    mock = mocker.patch(
+        "simcore_service_webserver.studies_access.copy_data_folders_from_project"
+    )
+
+    async def _mock_copy_data_from_project(app, src_prj, dst_prj, nodes_map, user_id):
+        print(
+            f"MOCK copying data project {src_prj['uuid']} -> {dst_prj['uuid']} "
+            f"with {len(nodes_map)} s3 objects by user={user_id}"
+        )
+        return dst_prj
+
+    mock.side_effect = _mock_copy_data_from_project
 
 
 # TESTS ----------------------------------------------------------------------------------------------

--- a/services/web/server/tests/unit/with_dbs/slow/test_projects.py
+++ b/services/web/server/tests/unit/with_dbs/slow/test_projects.py
@@ -796,7 +796,6 @@ async def test_new_template_from_project(
                 pytest.fail("Invalid uuid in workbench node {}".format(node_name))
 
 
-@pytest.mark.skip(reason="https://github.com/ITISFoundation/osparc-simcore/issues/2041")
 @pytest.mark.parametrize(*standard_role_response())
 @pytest.mark.parametrize(
     "share_rights",
@@ -1375,7 +1374,6 @@ async def test_tags_to_studies(
     await assert_status(resp, web.HTTPNoContent)
 
 
-@pytest.mark.skip(reason="https://github.com/ITISFoundation/osparc-simcore/issues/2041")
 @pytest.mark.parametrize(*standard_role_response())
 async def test_open_shared_project_2_users_locked(
     client,
@@ -1523,7 +1521,6 @@ async def test_open_shared_project_2_users_locked(
     )
 
 
-@pytest.mark.skip(reason="https://github.com/ITISFoundation/osparc-simcore/issues/2041")
 @pytest.mark.parametrize(*standard_role_response())
 async def test_open_shared_project_at_same_time(
     loop,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

- ADDS access-layer to ``storage`` service
- Cleanup of ``storage`` testing (s
- Patches ``simcore-sdk`` 0.3.1 -> 0.3.2 : 
   -    Tornado raises exception if error message was multiline and simcore-sdk was providing multiline 
   -  ⚠️  UPGRADE jupyter-based dynamic-services (@sanderegg ?)
       -   when tested, move master->staging->deploy
        -   auto upgrade patch in nodes **in all projects** ! 

## Related issue/s

- FIXES: Study collaborators have no access to the Study files #2041
- FIXES: Older study overwrites more recent one ITISFoundation/osparc-issues#435 (when study is shared, the non-owner had no access to stored data, downloaded "nothing" and would upload "nothing", overriding real stored data)
- FIXES: ``simcore-sdk`` multiline error messages

## How to test

#### Manual

Setup:
- ``make up``
- open normal + incognito browser
- register & login with two users
- in one account: create a project with jupyter servcies
- create group and share with other user
Test:
- add/remove files
- both users see files

#### unit tests 
```
cd services/storage
make install-dev
make tests
```

## Checklist
- [x] manual test sharing (#425)
- [x] add ``test_access_layer``
- [x] cleanup ``test_dsm``

