### PR TITLE
Reverted :export to :xport 

### DIFF
--- a/api/specs/webserver/openapi.yaml
+++ b/api/specs/webserver/openapi.yaml
@@ -168,7 +168,7 @@ paths:
   /projects/{project_id}/state:
     $ref: "./openapi-projects.yaml#/paths/~1projects~1{project_id}~1state"
 
-  /projects/{project_id}:export:
+  /projects/{project_id}:xport:
     $ref: "./openapi-projects.yaml#/paths/~1projects~1{project_id}~1xport"
 
   /projects/{project_id}:duplicate:

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -10743,7 +10743,7 @@ paths:
                             message: Password is not secure
                             field: pasword
                         status: 400
-  '/projects/{project_id}:export':
+  '/projects/{project_id}:xport':
     parameters:
       - name: project_id
         in: path

--- a/services/web/server/tests/integration/test_exporter.py
+++ b/services/web/server/tests/integration/test_exporter.py
@@ -467,7 +467,7 @@ async def test_import_export_import_duplicate(
     url_export = client.app.router["export_project"].url_for(
         project_id=imported_project_uuid
     )
-    assert url_export == URL(API_PREFIX + f"/projects/{imported_project_uuid}:export")
+    assert url_export == URL(API_PREFIX + f"/projects/{imported_project_uuid}:xport")
     async with await client.post(url_export, timeout=10) as export_response:
         assert export_response.status == 200, await export_response.text()
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

after talking to @odeimaiz I changed export entrypoint to the original path. I thought it was a typo but apparently @GitHK had some reason to set it up that way. For the moment it is best to revert it so the front-end can export


@GitHK could you please add extra input on this issue?

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
