### PR TITLE
FastAPI services: remove limitation of 1 connection per request

### DIFF
--- a/ci/github/system-testing/e2e.bash
+++ b/ci/github/system-testing/e2e.bash
@@ -1,15 +1,14 @@
 #!/bin/bash
 # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-on-travis-ci
-set -o errexit   # abort on nonzero exitstatus
-set -o nounset   # abort on unbound variable
-set -o pipefail  # don't hide errors within pipes
+set -o errexit  # abort on nonzero exitstatus
+set -o nounset  # abort on unbound variable
+set -o pipefail # don't hide errors within pipes
 IFS=$'\n\t'
 
 # in case it's a Pull request, the env are never available, default to itisfoundation to get a maybe not too old version for caching
 DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag.bash)
 export DOCKER_IMAGE_TAG
-
 
 install() {
   pushd tests/e2e
@@ -23,7 +22,6 @@ test() {
   popd
 }
 
-
 setup_images() {
   echo "--------------- preparing docker images..."
   make pull-version || ( (make pull-cache || true) && make build-x tag-version)
@@ -35,7 +33,7 @@ clean_up() {
   echo "--------------- listing services running..."
   docker service ls
   echo "--------------- listing service details..."
-  docker service ps --no-trunc $(docker service ls --quiet)
+  docker service ps --no-trunc "$(docker service ls --quiet)"
   echo "--------------- listing container details..."
   docker container ps -a
   echo "--------------- listing images available..."
@@ -50,16 +48,16 @@ dump_docker_logs() {
   # get docker logs
   # NOTE: Timeout avoids issue with dumping logs that hang!
   mkdir --parents simcore_logs
-  (timeout 30 docker service logs --timestamps --tail=300 --details ${SWARM_STACK_NAME}_webserver >simcore_logs/webserver.log 2>&1) || true
+  (timeout 30 docker service logs --timestamps --tail=300 --details "${SWARM_STACK_NAME:-test}"_webserver >simcore_logs/webserver.log 2>&1) || true
   # then the rest (alphabetically)
-  (timeout 30 docker service logs --timestamps --tail=100 --details ${SWARM_STACK_NAME}_api-server  >simcore_logs/api-server.log 2>&1) || true
-  (timeout 30 docker service logs --timestamps --tail=200 --details ${SWARM_STACK_NAME}_catalog     >simcore_logs/catalog.log 2>&1) || true
-  (timeout 30 docker service logs --timestamps --tail=200 --details ${SWARM_STACK_NAME}_director    >simcore_logs/director.log 2>&1) || true
-  (timeout 30 docker service logs --timestamps --tail=200 --details ${SWARM_STACK_NAME}_director-v2 >simcore_logs/director-v2.log 2>&1) || true
-  (timeout 30 docker service logs --timestamps --tail=200 --details ${SWARM_STACK_NAME}_sidecar     >simcore_logs/sidecar.log 2>&1) || true
-  (timeout 30 docker service logs --timestamps --tail=200 --details ${SWARM_STACK_NAME}_storage     >simcore_logs/storage.log 2>&1) || true
-  (timeout 30 docker service logs --timestamps --tail=200 --details ${SWARM_STACK_NAME}_migration   >simcore_logs/migration.log 2>&1) || true
-  (timeout 30 docker service logs --timestamps --tail=200 --details ${SWARM_STACK_NAME}_postgres    >simcore_logs/postgres.log 2>&1) || true
+  (timeout 30 docker service logs --timestamps --tail=100 --details "${SWARM_STACK_NAME:-test}"_api-server >simcore_logs/api-server.log 2>&1) || true
+  (timeout 30 docker service logs --timestamps --tail=200 --details "${SWARM_STACK_NAME:-test}"_catalog >simcore_logs/catalog.log 2>&1) || true
+  (timeout 30 docker service logs --timestamps --tail=200 --details "${SWARM_STACK_NAME:-test}"_director >simcore_logs/director.log 2>&1) || true
+  (timeout 30 docker service logs --timestamps --tail=200 --details "${SWARM_STACK_NAME:-test}"_director-v2 >simcore_logs/director-v2.log 2>&1) || true
+  (timeout 30 docker service logs --timestamps --tail=200 --details "${SWARM_STACK_NAME:-test}"_sidecar >simcore_logs/sidecar.log 2>&1) || true
+  (timeout 30 docker service logs --timestamps --tail=200 --details "${SWARM_STACK_NAME:-test}"_storage >simcore_logs/storage.log 2>&1) || true
+  (timeout 30 docker service logs --timestamps --tail=200 --details "${SWARM_STACK_NAME:-test}"_migration >simcore_logs/migration.log 2>&1) || true
+  (timeout 30 docker service logs --timestamps --tail=200 --details "${SWARM_STACK_NAME:-test}"_postgres >simcore_logs/postgres.log 2>&1) || true
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/system-testing/e2e.bash
+++ b/ci/github/system-testing/e2e.bash
@@ -33,7 +33,8 @@ clean_up() {
   echo "--------------- listing services running..."
   docker service ls
   echo "--------------- listing service details..."
-  docker service ps --no-trunc "$(docker service ls --quiet)"
+  # shellcheck disable=SC2046
+  docker service ps --no-trunc $(docker service ls --quiet)
   echo "--------------- listing container details..."
   docker container ps -a
   echo "--------------- listing images available..."

--- a/services/api-server/src/simcore_service_api_server/api/dependencies/database.py
+++ b/services/api-server/src/simcore_service_api_server/api/dependencies/database.py
@@ -1,7 +1,7 @@
 import logging
 from typing import AsyncGenerator, Callable, Type
 
-from aiopg.sa import Engine, SAConnection
+from aiopg.sa import Engine
 from fastapi import Depends
 from fastapi.requests import Request
 
@@ -14,44 +14,25 @@ def get_db_engine(request: Request) -> Engine:
     return request.app.state.engine
 
 
-async def _acquire_connection(engine: Engine = Depends(get_db_engine)) -> SAConnection:
-    logger.debug(
-        "Acquiring pg connection from pool: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
-        engine.size,
-        engine.size - engine.freesize,
-        engine.freesize,
-        engine.minsize,
-        engine.maxsize,
-    )
-    if engine.freesize <= 1:
-        logger.warning(
-            "Last or no pg connection in pool: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
-            engine.size,
-            engine.size - engine.freesize,
-            engine.freesize,
-            engine.minsize,
-            engine.maxsize,
-        )
-
-    async with engine.acquire() as conn:
-        yield conn
-
-    logger.debug(
-        "Released pg connection: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
-        engine.size,
-        engine.size - engine.freesize,
-        engine.freesize,
-        engine.minsize,
-        engine.maxsize,
-    )
-
-
 def get_repository(repo_type: Type[BaseRepository]) -> Callable:
-    async def _acquire_connection_and_get_repo(
-        db_connection: SAConnection = Depends(_acquire_connection),
+    async def _get_repo(
+        engine: Engine = Depends(get_db_engine),
     ) -> AsyncGenerator[BaseRepository, None]:
-        # NOTE: Since _acquire_connection is a dependency, it is a cached by FastApi and is only called once per request
-        # Be very careful if you change this!!! or we will end up in the problem described in https://github.com/ITISFoundation/osparc-simcore/pull/1966
-        yield repo_type(db_connection)
+        # NOTE: 2 different ideas were tried here with not so good
+        # 1st one was acquiring a connection per repository which lead to the following issue https://github.com/ITISFoundation/osparc-simcore/pull/1966
+        # 2nd one was acquiring a connection per request which works but blocks the director-v2 responsiveness once
+        # the max amount of connections is reached
+        # now the current solution is to acquire connection when needed.
 
-    return _acquire_connection_and_get_repo
+        if engine.freesize <= 1:
+            logger.warning(
+                "Low pg connections available in pool: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
+                engine.size,
+                engine.size - engine.freesize,
+                engine.freesize,
+                engine.minsize,
+                engine.maxsize,
+            )
+        yield repo_type(db_engine=engine)
+
+    return _get_repo

--- a/services/api-server/src/simcore_service_api_server/db/repositories/_base.py
+++ b/services/api-server/src/simcore_service_api_server/db/repositories/_base.py
@@ -1,15 +1,12 @@
-from aiopg.sa.connection import SAConnection
+from dataclasses import dataclass
+
+from aiopg.sa import Engine
 
 
+@dataclass
 class BaseRepository:
     """
-        Repositories are pulled at every request
-        All queries to db within that request use same connection
+    Repositories are pulled at every request
     """
 
-    def __init__(self, conn: SAConnection) -> None:
-        self._conn = conn
-
-    @property
-    def connection(self) -> SAConnection:
-        return self._conn
+    db_engine: Engine = None

--- a/services/api-server/src/simcore_service_api_server/db/repositories/users.py
+++ b/services/api-server/src/simcore_service_api_server/db/repositories/users.py
@@ -9,16 +9,30 @@ from ._base import BaseRepository
 class UsersRepository(BaseRepository):
     async def get_user_id(self, api_key: str, api_secret: str) -> Optional[int]:
         stmt = sa.select([api_keys.c.user_id,]).where(
-            sa.and_(api_keys.c.api_key == api_key, api_keys.c.api_secret == api_secret,)
+            sa.and_(
+                api_keys.c.api_key == api_key,
+                api_keys.c.api_secret == api_secret,
+            )
         )
-        user_id: Optional[int] = await self.connection.scalar(stmt)
+        async with self.db_engine.acquire() as conn:
+            user_id: Optional[int] = await conn.scalar(stmt)
         return user_id
 
     async def any_user_with_id(self, user_id: int) -> bool:
-        stmt = sa.select([api_keys.c.user_id,]).where(api_keys.c.user_id == user_id)
-        return (await self.connection.scalar(stmt)) is not None
+        stmt = sa.select(
+            [
+                api_keys.c.user_id,
+            ]
+        ).where(api_keys.c.user_id == user_id)
+        async with self.db_engine.acquire() as conn:
+            return (await conn.scalar(stmt)) is not None
 
     async def get_email_from_user_id(self, user_id: int) -> Optional[str]:
-        stmt = sa.select([users.c.email,]).where(users.c.id == user_id)
-        email: Optional[str] = await self.connection.scalar(stmt)
+        stmt = sa.select(
+            [
+                users.c.email,
+            ]
+        ).where(users.c.id == user_id)
+        async with self.db_engine.acquire() as conn:
+            email: Optional[str] = await conn.scalar(stmt)
         return email

--- a/services/catalog/src/simcore_service_catalog/api/dependencies/database.py
+++ b/services/catalog/src/simcore_service_catalog/api/dependencies/database.py
@@ -1,7 +1,7 @@
 import logging
 from typing import AsyncGenerator, Callable, Type
 
-from aiopg.sa import Engine, SAConnection
+from aiopg.sa import Engine
 from fastapi import Depends
 from fastapi.requests import Request
 
@@ -14,44 +14,25 @@ def _get_db_engine(request: Request) -> Engine:
     return request.app.state.engine
 
 
-async def _acquire_connection(engine: Engine = Depends(_get_db_engine)) -> SAConnection:
-    logger.debug(
-        "Acquiring pg connection from pool: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
-        engine.size,
-        engine.size - engine.freesize,
-        engine.freesize,
-        engine.minsize,
-        engine.maxsize,
-    )
-    if engine.freesize <= 1:
-        logger.warning(
-            "Last or no pg connection in pool: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
-            engine.size,
-            engine.size - engine.freesize,
-            engine.freesize,
-            engine.minsize,
-            engine.maxsize,
-        )
-
-    async with engine.acquire() as conn:
-        yield conn
-
-    logger.debug(
-        "Released pg connection: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
-        engine.size,
-        engine.size - engine.freesize,
-        engine.freesize,
-        engine.minsize,
-        engine.maxsize,
-    )
-
-
 def get_repository(repo_type: Type[BaseRepository]) -> Callable:
     async def _get_repo(
-        db_connection: SAConnection = Depends(_acquire_connection),
+        engine: Engine = Depends(_get_db_engine),
     ) -> AsyncGenerator[BaseRepository, None]:
-        # NOTE: Since _acquire_connection is a dependency, it is a cached by FastApi and is only called once per request
-        # Be very careful if you change this!!! or we will end up in the problem described in https://github.com/ITISFoundation/osparc-simcore/pull/1966
-        yield repo_type(db_connection)
+        # NOTE: 2 different ideas were tried here with not so good
+        # 1st one was acquiring a connection per repository which lead to the following issue https://github.com/ITISFoundation/osparc-simcore/pull/1966
+        # 2nd one was acquiring a connection per request which works but blocks the director-v2 responsiveness once
+        # the max amount of connections is reached
+        # now the current solution is to acquire connection when needed.
+
+        if engine.freesize <= 1:
+            logger.warning(
+                "Low pg connections available in pool: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
+                engine.size,
+                engine.size - engine.freesize,
+                engine.freesize,
+                engine.minsize,
+                engine.maxsize,
+            )
+        yield repo_type(db_engine=engine)
 
     return _get_repo

--- a/services/catalog/src/simcore_service_catalog/db/repositories/_base.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/_base.py
@@ -1,15 +1,12 @@
-from aiopg.sa.connection import SAConnection
+from dataclasses import dataclass
+
+from aiopg.sa import Engine
 
 
+@dataclass
 class BaseRepository:
     """
     Repositories are pulled at every request
-    All queries to db within that request use same connection
     """
 
-    def __init__(self, conn: SAConnection) -> None:
-        self._conn = conn
-
-    @property
-    def connection(self) -> SAConnection:
-        return self._conn
+    db_engine: Engine = None

--- a/services/catalog/src/simcore_service_catalog/db/repositories/dags.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/dags.py
@@ -23,8 +23,8 @@ class DAGsRepository(BaseRepository):
             row: RowProxy = await (
                 await conn.execute(dags.select().where(dags.c.id == dag_id))
             ).first()
-            if row:
-                return DAGAtDB(**row)
+        if row:
+            return DAGAtDB(**row)
 
     async def create_dag(self, dag: DAGIn) -> int:
         async with self.db_engine.acquire() as conn:

--- a/services/catalog/src/simcore_service_catalog/db/repositories/dags.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/dags.py
@@ -13,48 +13,55 @@ from ._base import BaseRepository
 class DAGsRepository(BaseRepository):
     async def list_dags(self) -> List[DAGAtDB]:
         dagraphs = []
-        async for row in self.connection.execute(dags.select()):
-            if row:
-                dagraphs.append(DAGAtDB(**row))
+        async with self.db_engine.acquire() as conn:
+            async for row in conn.execute(dags.select()):
+                if row:
+                    dagraphs.append(DAGAtDB(**row))
         return dagraphs
 
     async def get_dag(self, dag_id: int) -> Optional[DAGAtDB]:
-        stmt = dags.select().where(dags.c.id == dag_id)
-        row: RowProxy = await (await self.connection.execute(stmt)).first()
-        if row:
-            return DAGAtDB(**row)
-        return None
+        async with self.db_engine.acquire() as conn:
+            row: RowProxy = await (
+                await conn.execute(dags.select().where(dags.c.id == dag_id))
+            ).first()
+            if row:
+                return DAGAtDB(**row)
 
     async def create_dag(self, dag: DAGIn) -> int:
-        stmt = dags.insert().values(
-            workbench=json.dumps(dag.dict()["workbench"]),
-            **dag.dict(exclude={"workbench"})
-        )
-        new_id: int = await (await self.connection.execute(stmt)).scalar()
-        return new_id
+        async with self.db_engine.acquire() as conn:
+            new_id: int = await (
+                await conn.execute(
+                    dags.insert().values(
+                        workbench=json.dumps(dag.dict()["workbench"]),
+                        **dag.dict(exclude={"workbench"})
+                    )
+                )
+            ).scalar()
+            return new_id
 
     async def replace_dag(self, dag_id: int, dag: DAGIn):
-        stmt = (
-            dags.update()
-            .values(
-                workbench=json.dumps(dag.dict()["workbench"]),
-                **dag.dict(exclude={"workbench"})
+        async with self.db_engine.acquire() as conn:
+            await conn.execute(
+                dags.update()
+                .values(
+                    workbench=json.dumps(dag.dict()["workbench"]),
+                    **dag.dict(exclude={"workbench"})
+                )
+                .where(dags.c.id == dag_id)
             )
-            .where(dags.c.id == dag_id)
-        )
-        await self.connection.execute(stmt)
 
     async def update_dag(self, dag_id: int, dag: DAGIn):
         patch = dag.dict(exclude_unset=True, exclude={"workbench"})
         if "workbench" in dag.__fields_set__:
             patch["workbench"] = json.dumps(patch["workbench"])
+        async with self.db_engine.acquire() as conn:
+            res = await conn.execute(
+                sa.update(dags).values(**patch).where(dags.c.id == dag_id)
+            )
 
-        stmt = sa.update(dags).values(**patch).where(dags.c.id == dag_id)
-        res = await self.connection.execute(stmt)
-
-        # TODO: dev asserts
-        assert res.returns_rows == False  # nosec
+            # TODO: dev asserts
+            assert res.returns_rows == False  # nosec
 
     async def delete_dag(self, dag_id: int):
-        stmt = sa.delete(dags).where(dags.c.id == dag_id)
-        await self.connection.execute(stmt)
+        async with self.db_engine.acquire() as conn:
+            await conn.execute(sa.delete(dags).where(dags.c.id == dag_id))

--- a/services/catalog/src/simcore_service_catalog/db/repositories/dags.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/dags.py
@@ -15,8 +15,7 @@ class DAGsRepository(BaseRepository):
         dagraphs = []
         async with self.db_engine.acquire() as conn:
             async for row in conn.execute(dags.select()):
-                if row:
-                    dagraphs.append(DAGAtDB(**row))
+                dagraphs.append(DAGAtDB(**row))
         return dagraphs
 
     async def get_dag(self, dag_id: int) -> Optional[DAGAtDB]:

--- a/services/catalog/src/simcore_service_catalog/db/repositories/groups.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/groups.py
@@ -31,6 +31,7 @@ class GroupsRepository(BaseRepository):
                     sa.select([groups]).where(groups.c.type == GroupType.EVERYONE)
                 )
             ).first()
+        if row:
             return GroupAtDB(**row)
 
     async def get_user_gid_from_email(

--- a/services/catalog/src/simcore_service_catalog/db/repositories/groups.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/groups.py
@@ -13,38 +13,42 @@ from ._base import BaseRepository
 class GroupsRepository(BaseRepository):
     async def list_user_groups(self, user_id: int) -> List[GroupAtDB]:
         groups_in_db = []
-        async for row in self.connection.execute(
-            sa.select([groups])
-            .select_from(
-                user_to_groups.join(groups, user_to_groups.c.gid == groups.c.gid),
-            )
-            .where(user_to_groups.c.uid == user_id)
-        ):
-            if row:
+        async with self.db_engine.acquire() as conn:
+            async for row in conn.execute(
+                sa.select([groups])
+                .select_from(
+                    user_to_groups.join(groups, user_to_groups.c.gid == groups.c.gid),
+                )
+                .where(user_to_groups.c.uid == user_id)
+            ):
                 groups_in_db.append(GroupAtDB(**row))
         return groups_in_db
 
     async def get_everyone_group(self) -> GroupAtDB:
-        row: RowProxy = await (
-            await self.connection.execute(
-                sa.select([groups]).where(groups.c.type == GroupType.EVERYONE)
-            )
-        ).first()
-        return GroupAtDB(**row)
+        async with self.db_engine.acquire() as conn:
+            row: RowProxy = await (
+                await conn.execute(
+                    sa.select([groups]).where(groups.c.type == GroupType.EVERYONE)
+                )
+            ).first()
+            return GroupAtDB(**row)
 
     async def get_user_gid_from_email(
         self, user_email: EmailStr
     ) -> Optional[PositiveInt]:
-        return await self.connection.scalar(
-            sa.select([users.c.primary_gid]).where(users.c.email == user_email)
-        )
+        async with self.db_engine.acquire() as conn:
+            return await conn.scalar(
+                sa.select([users.c.primary_gid]).where(users.c.email == user_email)
+            )
 
     async def get_gid_from_affiliation(self, affiliation: str) -> Optional[PositiveInt]:
-        return await self.connection.scalar(
-            sa.select([groups.c.gid]).where(groups.c.name == affiliation)
-        )
+        async with self.db_engine.acquire() as conn:
+            return await conn.scalar(
+                sa.select([groups.c.gid]).where(groups.c.name == affiliation)
+            )
 
     async def get_user_email_from_gid(self, gid: PositiveInt) -> Optional[EmailStr]:
-        return await self.connection.scalar(
-            sa.select([users.c.email]).where(users.c.primary_gid == gid)
-        )
+        async with self.db_engine.acquire() as conn:
+            return await conn.scalar(
+                sa.select([users.c.email]).where(users.c.primary_gid == gid)
+            )

--- a/services/catalog/src/simcore_service_catalog/db/repositories/projects.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/projects.py
@@ -14,27 +14,28 @@ logger = logging.getLogger(__name__)
 class ProjectsRepository(BaseRepository):
     async def list_services_from_published_templates(self) -> List[ServiceKeyVersion]:
         list_of_published_services: List[ServiceKeyVersion] = []
-        async for row in self.connection.execute(
-            sa.select([projects]).where(
-                (projects.c.type == ProjectType.TEMPLATE)
-                & (projects.c.published == True)
-            )
-        ):
-            project_workbench = row.workbench
-            for node in project_workbench:
-                service = project_workbench[node]
-                try:
-                    if (
-                        "file-picker" in service["key"]
-                        or "nodes-group" in service["key"]
-                    ):
-                        # these 2 are not going to pass the validation tests, they are frontend only nodes.
+        async with self.db_engine.acquire() as conn:
+            async for row in conn.execute(
+                sa.select([projects]).where(
+                    (projects.c.type == ProjectType.TEMPLATE)
+                    & (projects.c.published == True)
+                )
+            ):
+                project_workbench = row.workbench
+                for node in project_workbench:
+                    service = project_workbench[node]
+                    try:
+                        if (
+                            "file-picker" in service["key"]
+                            or "nodes-group" in service["key"]
+                        ):
+                            # these 2 are not going to pass the validation tests, they are frontend only nodes.
+                            continue
+                        list_of_published_services.append(ServiceKeyVersion(**service))
+                    except ValidationError:
+                        logger.warning(
+                            "service %s could not be validated", service, exc_info=True
+                        )
                         continue
-                    list_of_published_services.append(ServiceKeyVersion(**service))
-                except ValidationError:
-                    logger.warning(
-                        "service %s could not be validated", service, exc_info=True
-                    )
-                    continue
 
         return list_of_published_services

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -87,6 +87,7 @@ class ServicesRepository(BaseRepository):
             )
         async with self.db_engine.acquire() as conn:
             row: RowProxy = await (await conn.execute(query)).first()
+        if row:
             return ServiceMetaDataAtDB(**row)
 
     async def create_service(
@@ -129,8 +130,8 @@ class ServicesRepository(BaseRepository):
                     .returning(literal_column("*"))
                 )
             ).first()
-            updated_service = ServiceMetaDataAtDB(**row)
-            return updated_service
+        updated_service = ServiceMetaDataAtDB(**row)
+        return updated_service
 
     async def get_service_access_rights(
         self,

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -45,9 +45,8 @@ class ServicesRepository(BaseRepository):
                     )
                 )
             )
-
-        async for row in self.connection.execute(query):
-            if row:
+        async with self.db_engine.acquire() as conn:
+            async for row in conn.execute(query):
                 services_in_db.append(ServiceMetaDataAtDB(**row))
         return services_in_db
 
@@ -86,8 +85,8 @@ class ServicesRepository(BaseRepository):
                     )
                 )
             )
-        row: RowProxy = await (await self.connection.execute(query)).first()
-        if row:
+        async with self.db_engine.acquire() as conn:
+            row: RowProxy = await (await conn.execute(query)).first()
             return ServiceMetaDataAtDB(**row)
 
     async def create_service(
@@ -95,40 +94,43 @@ class ServicesRepository(BaseRepository):
         new_service: ServiceMetaDataAtDB,
         new_service_access_rights: List[ServiceAccessRightsAtDB],
     ) -> ServiceMetaDataAtDB:
-        row: RowProxy = await (
-            await self.connection.execute(
-                # pylint: disable=no-value-for-parameter
-                services_meta_data.insert()
-                .values(**new_service.dict(by_alias=True))
-                .returning(literal_column("*"))
-            )
-        ).first()
-        created_service = ServiceMetaDataAtDB(**row)
-        for rights in new_service_access_rights:
-            insert_stmt = insert(services_access_rights).values(
-                **rights.dict(by_alias=True)
-            )
-            await self.connection.execute(insert_stmt)
+        async with self.db_engine.acquire() as conn:
+            async with conn.begin() as _transaction:  # NOTE: this ensure proper rollback in case of issue
+                row: RowProxy = await (
+                    await conn.execute(
+                        # pylint: disable=no-value-for-parameter
+                        services_meta_data.insert()
+                        .values(**new_service.dict(by_alias=True))
+                        .returning(literal_column("*"))
+                    )
+                ).first()
+                created_service = ServiceMetaDataAtDB(**row)
+                for rights in new_service_access_rights:
+                    insert_stmt = insert(services_access_rights).values(
+                        **rights.dict(by_alias=True)
+                    )
+                    await conn.execute(insert_stmt)
         return created_service
 
     async def update_service(
         self, patched_service: ServiceMetaDataAtDB
     ) -> ServiceMetaDataAtDB:
         # update the services_meta_data table
-        row: RowProxy = await (
-            await self.connection.execute(
-                # pylint: disable=no-value-for-parameter
-                services_meta_data.update()
-                .where(
-                    (services_meta_data.c.key == patched_service.key)
-                    & (services_meta_data.c.version == patched_service.version)
+        async with self.db_engine.acquire() as conn:
+            row: RowProxy = await (
+                await conn.execute(
+                    # pylint: disable=no-value-for-parameter
+                    services_meta_data.update()
+                    .where(
+                        (services_meta_data.c.key == patched_service.key)
+                        & (services_meta_data.c.version == patched_service.version)
+                    )
+                    .values(**patched_service.dict(by_alias=True, exclude_unset=True))
+                    .returning(literal_column("*"))
                 )
-                .values(**patched_service.dict(by_alias=True, exclude_unset=True))
-                .returning(literal_column("*"))
-            )
-        ).first()
-        updated_service = ServiceMetaDataAtDB(**row)
-        return updated_service
+            ).first()
+            updated_service = ServiceMetaDataAtDB(**row)
+            return updated_service
 
     async def get_service_access_rights(
         self,
@@ -142,8 +144,8 @@ class ServicesRepository(BaseRepository):
             & (services_access_rights.c.version == version)
             & (services_access_rights.c.product_name == product_name)
         )
-        async for row in self.connection.execute(query):
-            if row:
+        async with self.db_engine.acquire() as conn:
+            async for row in conn.execute(query):
                 services_in_db.append(ServiceAccessRightsAtDB(**row))
         return services_in_db
 
@@ -165,10 +167,11 @@ class ServicesRepository(BaseRepository):
                 set_=rights.dict(by_alias=True, exclude_unset=True),
             )
             try:
-                await self.connection.execute(
-                    # pylint: disable=no-value-for-parameter
-                    on_update_stmt
-                )
+                async with self.db_engine.acquire() as conn:
+                    await conn.execute(
+                        # pylint: disable=no-value-for-parameter
+                        on_update_stmt
+                    )
             except ForeignKeyViolation:
                 logger.warning(
                     "The service %s:%s is missing from services_meta_data",
@@ -179,13 +182,14 @@ class ServicesRepository(BaseRepository):
     async def delete_service_access_rights(
         self, delete_access_rights: List[ServiceAccessRightsAtDB]
     ) -> None:
-        for rights in delete_access_rights:
-            await self.connection.execute(
-                # pylint: disable=no-value-for-parameter
-                services_access_rights.delete().where(
-                    (services_access_rights.c.key == rights.key)
-                    & (services_access_rights.c.version == rights.version)
-                    & (services_access_rights.c.gid == rights.gid)
-                    & (services_access_rights.c.product_name == rights.product_name)
+        async with self.db_engine.acquire() as conn:
+            for rights in delete_access_rights:
+                await conn.execute(
+                    # pylint: disable=no-value-for-parameter
+                    services_access_rights.delete().where(
+                        (services_access_rights.c.key == rights.key)
+                        & (services_access_rights.c.version == rights.version)
+                        & (services_access_rights.c.gid == rights.gid)
+                        & (services_access_rights.c.product_name == rights.product_name)
+                    )
                 )
-            )

--- a/services/director-v2/src/simcore_service_director_v2/api/dependencies/database.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/dependencies/database.py
@@ -1,7 +1,7 @@
 import logging
 from typing import AsyncGenerator, Callable, Type
 
-from aiopg.sa import Engine, SAConnection
+from aiopg.sa import Engine
 from fastapi import Depends
 from fastapi.requests import Request
 

--- a/services/director-v2/src/simcore_service_director_v2/api/dependencies/database.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/dependencies/database.py
@@ -14,44 +14,25 @@ def _get_db_engine(request: Request) -> Engine:
     return request.app.state.engine
 
 
-async def _acquire_connection(engine: Engine = Depends(_get_db_engine)) -> SAConnection:
-    logger.debug(
-        "Acquiring pg connection from pool: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
-        engine.size,
-        engine.size - engine.freesize,
-        engine.freesize,
-        engine.minsize,
-        engine.maxsize,
-    )
-    if engine.freesize <= 1:
-        logger.warning(
-            "Last or no pg connection in pool: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
-            engine.size,
-            engine.size - engine.freesize,
-            engine.freesize,
-            engine.minsize,
-            engine.maxsize,
-        )
-
-    async with engine.acquire() as conn:
-        yield conn
-
-    logger.debug(
-        "Released pg connection: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
-        engine.size,
-        engine.size - engine.freesize,
-        engine.freesize,
-        engine.minsize,
-        engine.maxsize,
-    )
-
-
 def get_repository(repo_type: Type[BaseRepository]) -> Callable:
     async def _get_repo(
-        db_connection: SAConnection = Depends(_acquire_connection),
+        engine: Engine = Depends(_get_db_engine),
     ) -> AsyncGenerator[BaseRepository, None]:
-        # NOTE: Since _acquire_connection is a dependency, it is a cached by FastApi and is only called once per request
-        # Be very careful if you change this!!! or we will end up in the problem described in https://github.com/ITISFoundation/osparc-simcore/pull/1966
-        yield repo_type(db_connection)
+        # NOTE: 2 different ideas were tried here with not so good
+        # 1st one was acquiring a connection per repository which lead to the following issue https://github.com/ITISFoundation/osparc-simcore/pull/1966
+        # 2nd one was acquiring a connection per request which works but blocks the director-v2 responsiveness once
+        # the max amount of connections is reached
+        # now the current solution is to acquire connection when needed.
+
+        if engine.freesize <= 1:
+            logger.warning(
+                "Low pg connections available in pool: pool size=%d, acquired=%d, free=%d, reserved=[%d, %d]",
+                engine.size,
+                engine.size - engine.freesize,
+                engine.freesize,
+                engine.minsize,
+                engine.maxsize,
+            )
+        yield repo_type(db_engine=engine)
 
     return _get_repo

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/_base.py
@@ -1,15 +1,12 @@
-from aiopg.sa.connection import SAConnection
+from dataclasses import dataclass
+
+from aiopg.sa import Engine
 
 
+@dataclass
 class BaseRepository:
     """
     Repositories are pulled at every request
-    All queries to db within that request use same connection
     """
 
-    def __init__(self, conn: SAConnection) -> None:
-        self._conn = conn
-
-    @property
-    def connection(self) -> SAConnection:
-        return self._conn
+    db_engine: Engine = None

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
@@ -19,15 +19,16 @@ logger = logging.getLogger(__name__)
 class CompPipelinesRepository(BaseRepository):
     @log_decorator(logger=logger)
     async def get_pipeline(self, project_id: ProjectID) -> CompPipelineAtDB:
-        result = await self.connection.execute(
-            sa.select([comp_pipeline]).where(
-                comp_pipeline.c.project_id == str(project_id)
+        async with self.db_engine.acquire() as conn:
+            result = await conn.execute(
+                sa.select([comp_pipeline]).where(
+                    comp_pipeline.c.project_id == str(project_id)
+                )
             )
-        )
-        row: RowProxy = await result.fetchone()
-        if not row:
-            raise PipelineNotFoundError(str(project_id))
-        return CompPipelineAtDB.from_orm(row)
+            row: RowProxy = await result.fetchone()
+            if not row:
+                raise PipelineNotFoundError(str(project_id))
+            return CompPipelineAtDB.from_orm(row)
 
     @log_decorator(logger=logger)
     async def upsert_pipeline(
@@ -44,12 +45,14 @@ class CompPipelinesRepository(BaseRepository):
             index_elements=[comp_pipeline.c.project_id],
             set_=pipeline_at_db.dict(by_alias=True, exclude_unset=True),
         )
-        await self.connection.execute(on_update_stmt)
+        async with self.db_engine.acquire() as conn:
+            await conn.execute(on_update_stmt)
 
     @log_decorator(logger=logger)
     async def delete_pipeline(self, project_id: ProjectID) -> None:
-        await self.connection.execute(
-            sa.delete(comp_pipeline).where(
-                comp_pipeline.c.project_id == str(project_id)
+        async with self.db_engine.acquire() as conn:
+            await conn.execute(
+                sa.delete(comp_pipeline).where(
+                    comp_pipeline.c.project_id == str(project_id)
+                )
             )
-        )

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
@@ -26,9 +26,9 @@ class CompPipelinesRepository(BaseRepository):
                 )
             )
             row: RowProxy = await result.fetchone()
-            if not row:
-                raise PipelineNotFoundError(str(project_id))
-            return CompPipelineAtDB.from_orm(row)
+        if not row:
+            raise PipelineNotFoundError(str(project_id))
+        return CompPipelineAtDB.from_orm(row)
 
     @log_decorator(logger=logger)
     async def upsert_pipeline(

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -132,11 +132,14 @@ class CompTasksRepository(BaseRepository):
         project_id: ProjectID,
     ) -> List[CompTaskAtDB]:
         tasks: List[CompTaskAtDB] = []
-        async for row in self.connection.execute(
-            sa.select([comp_tasks]).where((comp_tasks.c.project_id == str(project_id)))
-        ):
-            task_db = CompTaskAtDB.from_orm(row)
-            tasks.append(task_db)
+        async with self.db_engine.acquire() as conn:
+            async for row in conn.execute(
+                sa.select([comp_tasks]).where(
+                    (comp_tasks.c.project_id == str(project_id))
+                )
+            ):
+                task_db = CompTaskAtDB.from_orm(row)
+                tasks.append(task_db)
 
         return tasks
 
@@ -146,14 +149,15 @@ class CompTasksRepository(BaseRepository):
         project_id: ProjectID,
     ) -> List[CompTaskAtDB]:
         tasks: List[CompTaskAtDB] = []
-        async for row in self.connection.execute(
-            sa.select([comp_tasks]).where(
-                (comp_tasks.c.project_id == str(project_id))
-                & (comp_tasks.c.node_class == NodeClass.COMPUTATIONAL)
-            )
-        ):
-            task_db = CompTaskAtDB.from_orm(row)
-            tasks.append(task_db)
+        async with self.db_engine.acquire() as conn:
+            async for row in conn.execute(
+                sa.select([comp_tasks]).where(
+                    (comp_tasks.c.project_id == str(project_id))
+                    & (comp_tasks.c.node_class == NodeClass.COMPUTATIONAL)
+                )
+            ):
+                task_db = CompTaskAtDB.from_orm(row)
+                tasks.append(task_db)
 
         return tasks
 
@@ -173,47 +177,50 @@ class CompTasksRepository(BaseRepository):
         ] = await _generate_tasks_list_from_project(
             project, director_client, published_nodes
         )
-        # get current tasks
-        result: RowProxy = await self.connection.execute(
-            sa.select([comp_tasks.c.node_id]).where(
-                comp_tasks.c.project_id == str(project.uuid)
-            )
-        )
-        # remove the tasks that were removed from project workbench
-        node_ids_to_delete = [
-            t.node_id
-            for t in await result.fetchall()
-            if t.node_id not in project.workbench
-        ]
-        for node_id in node_ids_to_delete:
-            await self.connection.execute(
-                sa.delete(comp_tasks).where(
-                    (comp_tasks.c.project_id == str(project.uuid))
-                    & (comp_tasks.c.node_id == node_id)
+        async with self.db_engine.acquire() as conn:
+            # get current tasks
+            result: RowProxy = await conn.execute(
+                sa.select([comp_tasks.c.node_id]).where(
+                    comp_tasks.c.project_id == str(project.uuid)
                 )
             )
+            # remove the tasks that were removed from project workbench
+            node_ids_to_delete = [
+                t.node_id
+                for t in await result.fetchall()
+                if t.node_id not in project.workbench
+            ]
+            for node_id in node_ids_to_delete:
+                await conn.execute(
+                    sa.delete(comp_tasks).where(
+                        (comp_tasks.c.project_id == str(project.uuid))
+                        & (comp_tasks.c.node_id == node_id)
+                    )
+                )
 
-        # insert or update the remaining tasks
-        # NOTE: comp_tasks DB only trigger a notification to the webserver if an UPDATE on comp_tasks.outputs or comp_tasks.state is done
-        # NOTE: an exception to this is when a frontend service changes its output since there is no node_ports, the UPDATE must be done here.
-        inserted_comp_tasks_db: List[CompTaskAtDB] = []
-        for comp_task_db in list_of_comp_tasks_in_project:
+            # insert or update the remaining tasks
+            # NOTE: comp_tasks DB only trigger a notification to the webserver if an UPDATE on comp_tasks.outputs or comp_tasks.state is done
+            # NOTE: an exception to this is when a frontend service changes its output since there is no node_ports, the UPDATE must be done here.
+            inserted_comp_tasks_db: List[CompTaskAtDB] = []
+            for comp_task_db in list_of_comp_tasks_in_project:
 
-            insert_stmt = insert(comp_tasks).values(**comp_task_db.to_db_model())
+                insert_stmt = insert(comp_tasks).values(**comp_task_db.to_db_model())
 
-            exclusion_rule = (
-                {"state"} if str(comp_task_db.node_id) not in published_nodes else set()
-            )
-            if to_node_class(comp_task_db.image.name) != NodeClass.FRONTEND:
-                exclusion_rule.add("outputs")
-            on_update_stmt = insert_stmt.on_conflict_do_update(
-                index_elements=[comp_tasks.c.project_id, comp_tasks.c.node_id],
-                set_=comp_task_db.to_db_model(exclude=exclusion_rule),
-            ).returning(literal_column("*"))
-            result = await self.connection.execute(on_update_stmt)
-            row: RowProxy = await result.fetchone()
-            inserted_comp_tasks_db.append(CompTaskAtDB.from_orm(row))
-        return inserted_comp_tasks_db
+                exclusion_rule = (
+                    {"state"}
+                    if str(comp_task_db.node_id) not in published_nodes
+                    else set()
+                )
+                if to_node_class(comp_task_db.image.name) != NodeClass.FRONTEND:
+                    exclusion_rule.add("outputs")
+                on_update_stmt = insert_stmt.on_conflict_do_update(
+                    index_elements=[comp_tasks.c.project_id, comp_tasks.c.node_id],
+                    set_=comp_task_db.to_db_model(exclude=exclusion_rule),
+                ).returning(literal_column("*"))
+                result = await conn.execute(on_update_stmt)
+                row: RowProxy = await result.fetchone()
+                inserted_comp_tasks_db.append(CompTaskAtDB.from_orm(row))
+            return inserted_comp_tasks_db
 
     @log_decorator(logger=logger)
     async def upsert_tasks_from_project(
@@ -242,21 +249,25 @@ class CompTasksRepository(BaseRepository):
     @log_decorator(logger=logger)
     async def mark_project_tasks_as_aborted(self, project: ProjectAtDB) -> None:
         # block all pending tasks, so the sidecars stop taking them
-        await self.connection.execute(
-            sa.update(comp_tasks)
-            .where(
-                (comp_tasks.c.project_id == str(project.uuid))
-                & (comp_tasks.c.node_class == NodeClass.COMPUTATIONAL)
-                & (
-                    (comp_tasks.c.state == StateType.PUBLISHED)
-                    | (comp_tasks.c.state == StateType.PENDING)
+        async with self.db_engine.acquire() as conn:
+            await conn.execute(
+                sa.update(comp_tasks)
+                .where(
+                    (comp_tasks.c.project_id == str(project.uuid))
+                    & (comp_tasks.c.node_class == NodeClass.COMPUTATIONAL)
+                    & (
+                        (comp_tasks.c.state == StateType.PUBLISHED)
+                        | (comp_tasks.c.state == StateType.PENDING)
+                    )
                 )
+                .values(state=StateType.ABORTED)
             )
-            .values(state=StateType.ABORTED)
-        )
 
     @log_decorator(logger=logger)
     async def delete_tasks_from_project(self, project: ProjectAtDB) -> None:
-        await self.connection.execute(
-            sa.delete(comp_tasks).where(comp_tasks.c.project_id == str(project.uuid))
-        )
+        async with self.db_engine.acquire() as conn:
+            await conn.execute(
+                sa.delete(comp_tasks).where(
+                    comp_tasks.c.project_id == str(project.uuid)
+                )
+            )

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
@@ -13,11 +13,12 @@ logger = logging.getLogger(__name__)
 
 class ProjectsRepository(BaseRepository):
     async def get_project(self, project_id: ProjectID) -> ProjectAtDB:
-        row: RowProxy = await (
-            await self.connection.execute(
-                sa.select([projects]).where(projects.c.uuid == str(project_id))
-            )
-        ).first()
-        if not row:
-            raise ProjectNotFoundError(project_id)
-        return ProjectAtDB.from_orm(row)
+        async with self.db_engine.acquire() as conn:
+            row: RowProxy = await (
+                await conn.execute(
+                    sa.select([projects]).where(projects.c.uuid == str(project_id))
+                )
+            ).first()
+            if not row:
+                raise ProjectNotFoundError(project_id)
+            return ProjectAtDB.from_orm(row)

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
@@ -19,6 +19,6 @@ class ProjectsRepository(BaseRepository):
                     sa.select([projects]).where(projects.c.uuid == str(project_id))
                 )
             ).first()
-            if not row:
-                raise ProjectNotFoundError(project_id)
-            return ProjectAtDB.from_orm(row)
+        if not row:
+            raise ProjectNotFoundError(project_id)
+        return ProjectAtDB.from_orm(row)

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -99,7 +99,6 @@ services:
       - SIMCORE_SERVICES_NETWORK_NAME=interactive_services_subnet
       - MONITORING_ENABLED=${MONITORING_ENABLED:-True}
       - LOG_LEVEL=${LOG_LEVEL:-WARNING}
-      - POSTGRES_MAXSIZE=30
     env_file:
       - ../.env
     volumes:

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -188,7 +188,7 @@ async def list_projects(request: web.Request):
             user_id=user_id, filter_by_services=user_available_services
         )
         projects_list += user_projects
-        project_types_list += [False for i in range(len(template_projects))]
+        project_types_list += [False for i in range(len(user_projects))]
 
     start = int(request.query.get("start", 0))
     count = int(request.query.get("count", len(projects_list)))


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?
- [x] director-v2 now acquires connection when executing transactions
- [x] director-v2 max number of connections set back to default of 10 
- [x] catalog now acquires connection when executing transactions
- [x] api-server

Bonus:
- [x] webserver/list_projects gets the study states AFTER splicing (e.g. if call with *count=1* only ask for 1 state not all of them and then splice)
- [x] fix missing docker logs in e2e CI testing   
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
