### PR TITLE
Fix libmagic install via Docker

### DIFF
--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -73,7 +73,7 @@ ENV SC_BUILD_TARGET build
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     build-essential \
-    libmagic-dev \
+    libmagic1 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -138,6 +138,13 @@ WORKDIR /home/scu
 
 # bring installed package without build tools
 COPY --from=cache --chown=scu:scu ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+
+# libmagic is requried by the exporter
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    libmagic1 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # copy docker entrypoint and boot scripts
 COPY --chown=scu:scu services/web/server/docker services/web/server/docker

--- a/services/web/server/src/simcore_service_webserver/exporter/formatters/sds/xlsx/templates/directory_manifest.py
+++ b/services/web/server/src/simcore_service_webserver/exporter/formatters/sds/xlsx/templates/directory_manifest.py
@@ -4,6 +4,7 @@ from collections import deque
 from typing import List, Tuple, Dict
 from pathlib import Path
 
+import magic
 from pydantic import BaseModel, Field, StrictStr, validator
 
 from ..xlsx_base import BaseXLSXCellData, BaseXLSXSheet, BaseXLSXDocument
@@ -49,7 +50,6 @@ class DirectoryManifestParams(BaseModel):
     def compose_from_directory(
         cls, start_path: Path
     ) -> List["DirectoryManifestParams"]:
-        import magic  # avoids an issue with a dependency in all [sys] testing cases
 
         file_entries = deque()
         for file_entry in get_files_in_dir(start_path):

--- a/tests/swarm-deploy/test_service_images.py
+++ b/tests/swarm-deploy/test_service_images.py
@@ -24,11 +24,11 @@ async def test_python_package_installation(
     simcore_docker_compose: Dict,
     osparc_simcore_root_dir: Path,
 ):
-    def _extract_from_dockerfile():
+    def _extract_from_dockerfile(service_name: str) -> None:
         dockerfile_path: Path = (
             osparc_simcore_root_dir
             / "services"
-            / ("web" if service == "webserver" else service)
+            / ("web" if service_name == "webserver" else service_name)
             / "Dockerfile"
         )
 
@@ -37,9 +37,8 @@ async def test_python_package_installation(
         assert m, f"{dockerfile_path} has no 'base' alias!?"
         return m.group(0)
 
-    docker_base_name = _extract_from_dockerfile()
-
     for service in services:
+        docker_base_name = _extract_from_dockerfile(service)
         print("Service", service, "has a base image from", docker_base_name)
 
         # tests failing installation undetected


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- fixes how libmagic is installed and the version which is installed
- adds a test to check that libmagic is present int he webserver

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
