### PR TITLE
Fixes project validation of FileLinks

### DIFF
--- a/packages/models-library/src/models_library/projects_nodes.py
+++ b/packages/models-library/src/models_library/projects_nodes.py
@@ -30,6 +30,7 @@ from .projects_nodes_ui import Position
 from .projects_state import RunningState
 from .services import PROPERTY_KEY_RE, SERVICE_KEY_RE
 
+# NOTE: WARNING the order here matters
 InputTypes = Union[
     StrictBool,
     StrictInt,

--- a/packages/models-library/src/models_library/projects_nodes_io.py
+++ b/packages/models-library/src/models_library/projects_nodes_io.py
@@ -119,7 +119,13 @@ class SimCoreFileLink(BaseFileLink):
                 "path": "api/0a3b2c56-dbcd-4871-b93b-d454b7883f9f/input.txt",
                 "eTag": "859fda0cb82fc4acb4686510a172d9a9-1",
                 "label": "input.txt",
-            }
+            },
+            "examples": [
+                # minimal
+                {
+                    "path": "api/0a3b2c56-dbcd-4871-b93b-d454b7883f9f/input.txt",
+                }
+            ],
         }
 
 
@@ -133,6 +139,7 @@ class DatCoreFileLink(BaseFileLink):
         description="The real file name",
         examples=["MyFile.txt"],
     )
+
     dataset: str = Field(
         ...,
         description="Unique identifier to access the dataset on datcore (REQUIRED for datcore)",
@@ -157,5 +164,13 @@ class DatCoreFileLink(BaseFileLink):
                 "eTag": "28394b3e806aca87776a6bef9be23fd4-1",
                 "label": "single_number.txt",
                 "dataset": "N:dataset:f9f5ac51-33ea-4861-8e08-5b4faf655041",
-            }
+            },
+            "examples": [
+                # minimal
+                {
+                    "path": "f551278e-54ee-11eb-bf88-02420a00005a/377059c7-27c1-4428-943e-52d91bb9311f/input.txt",
+                    "label": "input.txt",
+                    "dataset": "N:dataset:f9f5ac51-33ea-4861-8e08-5b4faf655041",
+                }
+            ],
         }

--- a/packages/models-library/src/models_library/projects_nodes_io.py
+++ b/packages/models-library/src/models_library/projects_nodes_io.py
@@ -61,6 +61,7 @@ class BaseFileLink(BaseModel):
         description="The store identifier, '0' or 0 for simcore S3, '1' or 1 for datcore",
         examples=["0", 1],
     )
+
     path: str = Field(
         ...,
         regex=r"^.+$",
@@ -70,15 +71,22 @@ class BaseFileLink(BaseModel):
             "94453a6a-c8d4-52b3-a22d-ccbf81f8d636/d4442ca4-23fd-5b6b-ba6d-0b75f711c109/y_1D.txt",
         ],
     )
-    e_tag: Optional[str] = Field(
+
+    dataset: Optional[str] = Field(
         None,
-        description="Entity tag that uniquely represents the file. The method to generate the tag is not specified (black box).",
-        alias="eTag",
+        description="Unique identifier to access the dataset on datcore (only REQUIRED for datcore)",
     )
+
     label: Optional[str] = Field(
         None,
         description="The real file name",
         examples=["MyFile.txt"],
+    )
+
+    e_tag: Optional[str] = Field(
+        None,
+        description="Entity tag that uniquely represents the file. The method to generate the tag is not specified (black box).",
+        alias="eTag",
     )
 
 
@@ -142,3 +150,12 @@ class DatCoreFileLink(BaseFileLink):
 
     class Config:
         extra = Extra.forbid
+        schema_extra = {
+            "example": {
+                "store": "1",
+                "path": "f551278e-54ee-11eb-bf88-02420a00005a/377059c7-27c1-4428-943e-52d91bb9311f/single_number.txt",
+                "eTag": "28394b3e806aca87776a6bef9be23fd4-1",
+                "label": "single_number.txt",
+                "dataset": "N:dataset:f9f5ac51-33ea-4861-8e08-5b4faf655041",
+            }
+        }

--- a/packages/models-library/src/models_library/projects_nodes_io.py
+++ b/packages/models-library/src/models_library/projects_nodes_io.py
@@ -58,7 +58,7 @@ class BaseFileLink(BaseModel):
     # Recall lru_cache options regarding types!!
     store: Union[str, int] = Field(
         ...,
-        description="The store identifier, '0' or 0 for simcore S3, '1' or 1 for datcore",
+        description="The store identifier: '0' or 0 for simcore S3, '1' or 1 for datcore",
         examples=["0", 1],
     )
 
@@ -70,11 +70,6 @@ class BaseFileLink(BaseModel):
             "N:package:b05739ef-260c-4038-b47d-0240d04b0599",
             "94453a6a-c8d4-52b3-a22d-ccbf81f8d636/d4442ca4-23fd-5b6b-ba6d-0b75f711c109/y_1D.txt",
         ],
-    )
-
-    dataset: Optional[str] = Field(
-        None,
-        description="Unique identifier to access the dataset on datcore (only REQUIRED for datcore)",
     )
 
     label: Optional[str] = Field(
@@ -93,15 +88,18 @@ class BaseFileLink(BaseModel):
 class SimCoreFileLink(BaseFileLink):
     """ I/O port type to hold a link to a file in simcore S3 storage """
 
-    store: str = "0"
+    dataset: Optional[str] = Field(
+        None,
+        deprecated=True
+        # TODO: Remove with storage refactoring
+    )
 
     @validator("store", always=True)
     @classmethod
-    def must_be_simcore_s3(cls, v):
-        if v is None:
-            v = "0"
+    def check_discriminator(cls, v):
+        """ Used as discriminator to cast to this class """
         if v != "0":
-            raise ValueError(f"SimCore store must be set to 0, got {v}")
+            raise ValueError(f"SimCore store identifier must be set to 0, got {v}")
         return "0"
 
     @validator("label", always=True, pre=True)
@@ -109,13 +107,13 @@ class SimCoreFileLink(BaseFileLink):
     def pre_fill_label_with_filename_ext(cls, v, values):
         if v is None and "path" in values:
             return Path(values["path"]).name
-
         return v
 
     class Config:
         extra = Extra.forbid
         schema_extra = {
             "example": {
+                "store": "0",
                 "path": "api/0a3b2c56-dbcd-4871-b93b-d454b7883f9f/input.txt",
                 "eTag": "859fda0cb82fc4acb4686510a172d9a9-1",
                 "label": "input.txt",
@@ -123,6 +121,7 @@ class SimCoreFileLink(BaseFileLink):
             "examples": [
                 # minimal
                 {
+                    "store": "0",
                     "path": "api/0a3b2c56-dbcd-4871-b93b-d454b7883f9f/input.txt",
                 }
             ],
@@ -131,8 +130,6 @@ class SimCoreFileLink(BaseFileLink):
 
 class DatCoreFileLink(BaseFileLink):
     """ I/O port type to hold a link to a file in DATCORE storage """
-
-    store: str = "1"
 
     label: str = Field(
         ...,
@@ -148,29 +145,21 @@ class DatCoreFileLink(BaseFileLink):
 
     @validator("store", always=True)
     @classmethod
-    def must_be_datcore(cls, v):
-        if v is None:
-            v = "1"
+    def check_discriminator(cls, v):
+        """ Used as discriminator to cast to this class """
+
         if v != "1":
-            raise ValueError(f"Datcore store must be set to 1, got {v}")
+            raise ValueError(f"DatCore store must be set to 1, got {v}")
         return "1"
 
     class Config:
         extra = Extra.forbid
         schema_extra = {
             "example": {
-                "store": "1",
-                "path": "f551278e-54ee-11eb-bf88-02420a00005a/377059c7-27c1-4428-943e-52d91bb9311f/single_number.txt",
-                "eTag": "28394b3e806aca87776a6bef9be23fd4-1",
-                "label": "single_number.txt",
-                "dataset": "N:dataset:f9f5ac51-33ea-4861-8e08-5b4faf655041",
-            },
-            "examples": [
                 # minimal
-                {
-                    "path": "f551278e-54ee-11eb-bf88-02420a00005a/377059c7-27c1-4428-943e-52d91bb9311f/input.txt",
-                    "label": "input.txt",
-                    "dataset": "N:dataset:f9f5ac51-33ea-4861-8e08-5b4faf655041",
-                }
-            ],
+                "store": 1,
+                "dataset": "N:dataset:ea2325d8-46d7-4fbd-a644-30f6433070b4",
+                "path": "N:package:32df09ba-e8d6-46da-bd54-f696157de6ce",
+                "label": "initial_WTstates",
+            },
         }

--- a/packages/models-library/tests/test_project_nodes_io.py
+++ b/packages/models-library/tests/test_project_nodes_io.py
@@ -6,7 +6,7 @@ from pprint import pformat
 from typing import Any, Dict
 
 import pytest
-from models_library.projects_nodes_io import SimCoreFileLink
+from models_library.projects_nodes_io import DatCoreFileLink, SimCoreFileLink
 
 
 @pytest.fixture()
@@ -37,7 +37,7 @@ def test_simcore_file_link_with_label(minimal_simcore_file_link: Dict[str, Any])
     assert simcore_file_link.e_tag == None
 
 
-@pytest.mark.parametrize("model_cls", (SimCoreFileLink,))
+@pytest.mark.parametrize("model_cls", (SimCoreFileLink, DatCoreFileLink))
 def test_project_nodes_io_model_examples(model_cls, model_cls_examples):
     for name, example in model_cls_examples.items():
         print(name, ":", pformat(example))

--- a/packages/models-library/tests/test_project_nodes_io.py
+++ b/packages/models-library/tests/test_project_nodes_io.py
@@ -2,10 +2,12 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
+import sys
 from pprint import pformat
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 import pytest
+from models_library.projects_nodes import Node, PortLink
 from models_library.projects_nodes_io import DatCoreFileLink, SimCoreFileLink
 
 
@@ -46,3 +48,77 @@ def test_project_nodes_io_model_examples(model_cls, model_cls_examples):
 
         assert model_instance, f"Failed with {name}"
         print(name, ":", model_instance)
+
+
+def get_args(annotation) -> Tuple:
+    assert (  # nosec
+        sys.version_info.major == 3 and sys.version_info.minor < 8  # nosec
+    ), "TODO: py3.8 replace __args__ with typings.get_args"
+    return annotation.__args__
+
+
+def test_store_discriminator():
+    workbench = {
+        "89f95b67-a2a3-4215-a794-2356684deb61": {
+            "key": "simcore/services/frontend/file-picker",
+            "version": "1.0.0",
+            "label": "File Picker",
+            "inputs": {},
+            "inputNodes": [],
+            "parent": None,
+            "thumbnail": "",
+            "outputs": {
+                "outFile": {
+                    "store": 1,
+                    "dataset": "N:dataset:ea2325d8-46d7-4fbd-a644-30f6433070b4",
+                    "path": "N:package:32df09ba-e8d6-46da-bd54-f696157de6ce",
+                    "label": "initial_WTstates",
+                }
+            },
+            "progress": 100,
+            "runHash": None,
+        },
+        "88119776-e869-4df2-a529-4aae9d9fa35c": {
+            "key": "simcore/services/dynamic/raw-graphs",
+            "version": "2.10.6",
+            "label": "2D plot",
+            "inputs": {
+                "input_1": {
+                    "nodeUuid": "89f95b67-a2a3-4215-a794-2356684deb61",
+                    "output": "outFile",
+                }
+            },
+            "inputNodes": ["89f95b67-a2a3-4215-a794-2356684deb61"],
+            "parent": None,
+            "thumbnail": "",
+        },
+        "75c1707c-ec1c-49ac-a7bf-af6af9088f38": {
+            "key": "simcore/services/frontend/file-picker",
+            "version": "1.0.0",
+            "label": "File Picker_2",
+            "inputs": {},
+            "inputNodes": [],
+            "parent": None,
+            "thumbnail": "",
+            "outputs": {
+                "outFile": {
+                    "store": "0",
+                    "dataset": "05e9404a-acb4-11e9-bf0f-02420aff77ac",
+                    "path": "05e9404a-acb4-11e9-bf0f-02420aff77ac/4b3ac665-f692-5f7f-8b27-dadcb3f77260/output.csv",
+                    "label": "output.csv",
+                }
+            },
+            "progress": 100,
+            "runHash": None,
+        },
+    }
+
+    datacore_node = Node.parse_obj(workbench["89f95b67-a2a3-4215-a794-2356684deb61"])
+    rawgraph_node = Node.parse_obj(workbench["88119776-e869-4df2-a529-4aae9d9fa35c"])
+    simcore_node = Node.parse_obj(workbench["75c1707c-ec1c-49ac-a7bf-af6af9088f38"])
+
+    # must cast to the right subclass within project_nodes.py's InputTypes and OutputTypes unions
+    assert isinstance(datacore_node.outputs["outFile"], DatCoreFileLink)
+    assert isinstance(simcore_node.outputs["outFile"], SimCoreFileLink)
+
+    assert isinstance(rawgraph_node.inputs["input_1"], PortLink)

--- a/services/api-server/src/simcore_service_api_server/utils/solver_job_models_converters.py
+++ b/services/api-server/src/simcore_service_api_server/utils/solver_job_models_converters.py
@@ -82,6 +82,7 @@ def create_node_inputs_from_job_inputs(inputs: JobInputs) -> Dict[InputID, Input
         if isinstance(value, File):
             # FIXME: ensure this aligns with storage policy
             node_inputs[name] = SimCoreFileLink(
+                store=0,
                 path=f"api/{value.id}/{value.filename}",
                 label=value.filename,
                 eTag=value.checksum,

--- a/services/api-server/tests/unit/test_utils_solver_job_models_converters.py
+++ b/services/api-server/tests/unit/test_utils_solver_job_models_converters.py
@@ -86,6 +86,7 @@ def test_job_to_node_inputs_conversion():
         "title": "Temperature",
         "enabled": True,
         "input_file": SimCoreFileLink(
+            store=0,
             path="api/0a3b2c56-dbcd-4871-b93b-d454b7883f9f/input.txt",
             eTag="859fda0cb82fc4acb4686510a172d9a9-1",
             label="input.txt",

--- a/services/web/server/tests/integration/test_exporter.py
+++ b/services/web/server/tests/integration/test_exporter.py
@@ -497,9 +497,8 @@ async def import_study_from_file(client, file_path: Path) -> str:
     return imported_project_uuid
 
 
-@pytest.mark.skip(
-    reason="FIXME: validation errors. SEE https://github.com/ITISFoundation/osparc-simcore/pull/2220/checks?check_run_id=2244051004. Fix in next PR"
-)
+
+# TODO: Fix this https://github.com/ITISFoundation/osparc-simcore/pull/2220/checks?check_run_id=2244051004
 @pytest.mark.parametrize("export_version", get_exported_projects())
 async def test_import_export_import_duplicate(
     loop,

--- a/services/web/server/tests/integration/test_exporter.py
+++ b/services/web/server/tests/integration/test_exporter.py
@@ -191,6 +191,7 @@ async def login_user(client):
 
 
 def get_exported_projects() -> List[Path]:
+    # TODO: explain how to re-generate these files?
     exporter_dir = CURRENT_DIR / ".." / "data" / "exporter"
     return [x for x in exporter_dir.glob("*.osparc")]
 
@@ -497,8 +498,6 @@ async def import_study_from_file(client, file_path: Path) -> str:
     return imported_project_uuid
 
 
-
-# TODO: Fix this https://github.com/ITISFoundation/osparc-simcore/pull/2220/checks?check_run_id=2244051004
 @pytest.mark.parametrize("export_version", get_exported_projects())
 async def test_import_export_import_duplicate(
     loop,

--- a/services/web/server/tests/integration/test_exporter.py
+++ b/services/web/server/tests/integration/test_exporter.py
@@ -17,7 +17,6 @@ import aiofiles
 import aiohttp
 import aiopg
 import aioredis
-import psycopg2
 import pytest
 from models_library.settings.redis import RedisConfig
 from pytest_simcore.docker_registry import _pull_push_service
@@ -66,6 +65,8 @@ pytest_simcore_core_services_selection = [
     "storage",
 ]
 pytest_simcore_ops_services_selection = ["minio"]
+
+CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
 
 API_VERSION = "v0"
@@ -189,10 +190,10 @@ async def login_user(client):
     return await log_client_in(client=client, user_data={"role": UserRole.USER.name})
 
 
-def get_exported_projects(project_tests_dir) -> List[Path]:
+def get_exported_projects() -> List[Path]:
     # These files are generated from the front-end
     # when the formatter be finished
-    exporter_dir = project_tests_dir / "data" / "exporter"
+    exporter_dir = CURRENT_DIR.parent / "data" / "exporter"
     return [x for x in exporter_dir.glob("*.osparc")]
 
 
@@ -473,7 +474,7 @@ async def download_files_and_get_checksums(
         return checksums
 
 
-async def get_checksums_for_files_in_storage(
+async def get_checksmus_for_files_in_storage(
     app: aiohttp.web.Application,
     project: Dict[str, Any],
     normalized_project: Dict[str, Any],
@@ -619,19 +620,19 @@ async def test_import_export_import_duplicate(
     )
 
     # check files in storage fingerprint matches
-    imported_files_checksums = await get_checksums_for_files_in_storage(
+    imported_files_checksums = await get_checksmus_for_files_in_storage(
         app=client.app,
         project=imported_project,
         normalized_project=normalized_imported_project,
         user_id=user["id"],
     )
-    reimported_files_checksums = await get_checksums_for_files_in_storage(
+    reimported_files_checksums = await get_checksmus_for_files_in_storage(
         app=client.app,
         project=reimported_project,
         normalized_project=normalized_reimported_project,
         user_id=user["id"],
     )
-    duplicated_files_checksums = await get_checksums_for_files_in_storage(
+    duplicated_files_checksums = await get_checksmus_for_files_in_storage(
         app=client.app,
         project=duplicated_project,
         normalized_project=normalized_duplicated_project,

--- a/services/web/server/tests/integration/test_exporter.py
+++ b/services/web/server/tests/integration/test_exporter.py
@@ -193,7 +193,7 @@ async def login_user(client):
 def get_exported_projects() -> List[Path]:
     # TODO: explain how to re-generate these files?
     exporter_dir = CURRENT_DIR / ".." / "data" / "exporter"
-    return [x for x in exporter_dir.glob("*.osparc")]
+    return sorted([x for x in exporter_dir.glob("*.osparc")])
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

- Fixes [test failure](https://github.com/ITISFoundation/osparc-simcore/pull/2220/checks?check_run_id=2244051004) of ``services/web/server/tests/integration/test_exporter.py::test_import_export_import_duplicate[export_version0]`` caused by a ``ValidationError`` after changes in the constraints of ``BaseFileLink`` models in ``packages/models-library/src/models_library/projects_nodes_io.py``

This issue detected that ``BaseFileLink`` had some inconsistencies when compared with ``api/specs/common/schemas/project-v0.0.1.json``, specifically in the ``dataset`` field. THIS NEEDS review when storage is refactored.

NOTE: This test was temporary disabled in [PR#2220](https://github.com/ITISFoundation/osparc-simcore/pull/2220) so it could be resolved separately for clarity.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```cmd
make devenv
source .venv/bin/activate
cd services/web/server
make install-dev
pytest -vv --pdb tests/integration/test_exporter.py
```

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
