### PR TITLE
Allow a direct connection to postgres from webserver for LISTEN/NOTIFY channel

### DIFF
--- a/.env-devel
+++ b/.env-devel
@@ -17,6 +17,7 @@ POSTGRES_HOST=pgbouncer
 POSTGRES_PASSWORD=adminadmin
 POSTGRES_PORT=5432
 POSTGRES_USER=scu
+POSTGRES_LISTENING_ENDPOINT=postgres:5432
 
 RABBIT_CHANNELS={"log": "comp.backend.channels.log", "instrumentation": "comp.backend.channels.instrumentation"}
 RABBIT_HOST=rabbit

--- a/.env-devel
+++ b/.env-devel
@@ -17,7 +17,7 @@ POSTGRES_HOST=pgbouncer
 POSTGRES_PASSWORD=adminadmin
 POSTGRES_PORT=5432
 POSTGRES_USER=scu
-POSTGRES_LISTENING_HOST=postgres
+POSTGRES_LONG_RUNNING_SESSION_HOST=postgres
 
 RABBIT_CHANNELS={"log": "comp.backend.channels.log", "instrumentation": "comp.backend.channels.instrumentation"}
 RABBIT_HOST=rabbit

--- a/.env-devel
+++ b/.env-devel
@@ -17,7 +17,7 @@ POSTGRES_HOST=pgbouncer
 POSTGRES_PASSWORD=adminadmin
 POSTGRES_PORT=5432
 POSTGRES_USER=scu
-POSTGRES_LISTENING_ENDPOINT=postgres:5432
+POSTGRES_LISTENING_HOST=postgres
 
 RABBIT_CHANNELS={"log": "comp.backend.channels.log", "instrumentation": "comp.backend.channels.instrumentation"}
 RABBIT_HOST=rabbit

--- a/packages/models-library/src/models_library/settings/postgres.py
+++ b/packages/models-library/src/models_library/settings/postgres.py
@@ -17,6 +17,10 @@ class PostgresSettings(BaseSettings):
     # entrypoint
     host: str
     port: PortInt = 5432
+    long_running_session_host: Optional[str] = Field(
+        None,
+        description="host for long running sessions (e.g. listen/notify, prepared statements, etc...)",
+    )
 
     # auth
     user: str

--- a/packages/postgres-database/tests/docker-compose.yml
+++ b/packages/postgres-database/tests/docker-compose.yml
@@ -1,18 +1,21 @@
 version: "3.7"
 services:
   pgbouncer:
-    image: pgbouncer/pgbouncer:1.15.0
+    image: "edoburu/pgbouncer:1.15.0@sha256:2f47bf272fa9fdf25c100d11f1972b23af61a351a136d3721bfa6bdb52630426"
     init: true
     environment:
-      - DATABASES_HOST=postgres
-      - DATABASES_PORT=5432
-      - DATABASES_USER=test
-      - DATABASES_PASSWORD=test
-      - DATABASES_DBNAME=test
-      - PGBOUNCER_LISTEN_PORT=5432
-      - PGBOUNCER_LISTEN_ADDE=*
-      - PGBOUNCER_POOL_MODE=transaction
-      - PGBOUNCER_ADMIN_USERS=${POSTGRES_USER}
+      - DB_HOST=postgres
+      - DB_PORT=5432
+      - DB_USER=test
+      - DB_PASSWORD=test
+      - DB_NAME=test
+      # pgbouncer.ini variables
+      - LISTEN_ADDR=*
+      - LISTEN_PORT=5432
+      - POOL_MODE=transaction
+      - MAX_CLIENT_CONN=90 # we keep some for other OPS higher level services
+      - APPLICATION_NAME_ADD_HOST=1
+      - ADMIN_USERS=${POSTGRES_USER}
 
     ports:
       - "6432:5432"

--- a/packages/simcore-sdk/src/simcore_sdk/config/db.py
+++ b/packages/simcore-sdk/src/simcore_sdk/config/db.py
@@ -15,6 +15,9 @@ CONFIG_SCHEMA = T.Dict(
         "host": T.Or(T.String, T.Null),
         "port": T.Or(T.ToInt, T.Null),
         "endpoint": T.Or(T.String, T.Null),
+        T.Key("long_running_session_host", default=None, optional=True): T.Or(
+            T.String, T.Null
+        ),
     }
 )
 

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -265,18 +265,21 @@ services:
       - default
 
   pgbouncer:
-    image: "pgbouncer/pgbouncer:1.15.0@sha256:aa8a38b7b33e5fe70c679053f97a8e55c74d52b00c195f0880845e52b50ce516"
+    image: "edoburu/pgbouncer:1.15.0@sha256:2f47bf272fa9fdf25c100d11f1972b23af61a351a136d3721bfa6bdb52630426"
     init: true
     environment:
-      - DATABASES_HOST=postgres
-      - DATABASES_PORT=${POSTGRES_PORT}
-      - DATABASES_USER=${POSTGRES_USER}
-      - DATABASES_PASSWORD=${POSTGRES_PASSWORD}
-      - DATABASES_DBNAME=${POSTGRES_DB}
-      - PGBOUNCER_LISTEN_ADDE=*
-      - PGBOUNCER_LISTEN_PORT=${POSTGRES_PORT}
-      - PGBOUNCER_POOL_MODE=transaction
-      - PGBOUNCER_ADMIN_USERS=${POSTGRES_USER}
+      - DB_HOST=postgres
+      - DB_PORT=${POSTGRES_PORT}
+      - DB_USER=${POSTGRES_USER}
+      - DB_PASSWORD=${POSTGRES_PASSWORD}
+      - DB_NAME=${POSTGRES_DB}
+      # pgbouncer.ini variables
+      - LISTEN_ADDR=*
+      - LISTEN_PORT=${POSTGRES_PORT}
+      - POOL_MODE=transaction
+      - MAX_CLIENT_CONN=90 # we keep some for other OPS higher level services
+      - APPLICATION_NAME_ADD_HOST=1
+      - ADMIN_USERS=${POSTGRES_USER}
     networks:
       - default
       - interactive_services_subnet

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -277,7 +277,9 @@ services:
       - LISTEN_ADDR=*
       - LISTEN_PORT=${POSTGRES_PORT}
       - POOL_MODE=transaction
-      - MAX_CLIENT_CONN=90 # we keep some for other OPS higher level services
+      - MAX_CLIENT_CONN=10000 # we keep some for other OPS higher level services
+      - DEFAULT_POOL_SIZE=20
+      - MAX_DB_CONNECTIONS=90
       - APPLICATION_NAME_ADD_HOST=1
       - ADMIN_USERS=${POSTGRES_USER}
     networks:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -154,6 +154,7 @@ services:
     networks:
       - default
       - interactive_services_subnet
+      - postgres_network # for access to listen/notify channel
 
   sidecar:
     image: ${DOCKER_REGISTRY:-itisfoundation}/sidecar:${DOCKER_IMAGE_TAG:-latest}

--- a/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
@@ -201,6 +201,7 @@ async def listening_channel_pg_engine(app: web.Application) -> Engine:
 async def comp_tasks_listening_task(app: web.Application) -> None:
     log.info("starting comp_task db listening task...")
     while True:
+        db_engine: Engine = None
         try:
             # create a special connection here
             db_engine = await listening_channel_pg_engine(app)

--- a/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
@@ -15,21 +15,13 @@ from models_library.projects import ProjectID
 from models_library.projects_nodes import NodeID
 from models_library.projects_state import RunningState
 from pydantic.types import PositiveInt
-from servicelib.aiopg_utils import (
-    DataSourceName,
-    PostgresRetryPolicyUponInitialization,
-    create_pg_engine,
-    raise_if_not_responsive,
-)
-from servicelib.application_keys import APP_CONFIG_KEY
 from servicelib.logging_utils import log_decorator
 from servicelib.utils import logged_gather
 from simcore_postgres_database.webserver_models import DB_CHANNEL_NAME, projects
 from sqlalchemy.sql import select
-from tenacity import Retrying
 
 from .computation_api import convert_state_from_db
-from .db_config import CONFIG_SECTION_NAME
+from .db import APP_LONG_RUNNING_DB_ENGINE_KEY
 from .projects import projects_api, projects_exceptions
 from .projects.projects_utils import project_get_depending_nodes
 
@@ -173,38 +165,12 @@ async def listen(app: web.Application, db_engine: Engine):
                 continue
 
 
-async def listening_channel_pg_engine(app: web.Application) -> Engine:
-    cfg = app[APP_CONFIG_KEY][CONFIG_SECTION_NAME]
-    pg_cfg = cfg["postgres"]
-
-    dsn = DataSourceName(
-        application_name=f"{__name__}_{id(app)}",
-        database=pg_cfg["database"],
-        user=pg_cfg["user"],
-        password=pg_cfg["password"],
-        host=pg_cfg["long_running_session_host"],
-        port=pg_cfg["port"],
-    )
-    MIN_SIZE = 1
-    MAX_SIZE = 1
-    log.info("Creating listening pg engine for %s", dsn)
-    for attempt in Retrying(**PostgresRetryPolicyUponInitialization(log).kwargs):
-        with attempt:
-            engine = await create_pg_engine(dsn, minsize=MIN_SIZE, maxsize=MAX_SIZE)
-            await raise_if_not_responsive(engine)
-
-    assert engine  # nosec
-
-    return engine  # -------------------
-
-
 async def comp_tasks_listening_task(app: web.Application) -> None:
     log.info("starting comp_task db listening task...")
     while True:
-        db_engine: Engine = None
         try:
             # create a special connection here
-            db_engine = await listening_channel_pg_engine(app)
+            db_engine = app[APP_LONG_RUNNING_DB_ENGINE_KEY]
             log.info("listening to comp_task events...")
             await listen(app, db_engine)
         except asyncio.CancelledError:
@@ -215,10 +181,6 @@ async def comp_tasks_listening_task(app: web.Application) -> None:
                 "caught unhandled comp_task db listening task exception, restarting...",
                 exc_info=True,
             )
-        finally:
-            if db_engine:
-                db_engine.close()
-                await db_engine.wait_closed()
 
 
 async def setup_comp_tasks_listening_task(app: web.Application):

--- a/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
@@ -215,8 +215,9 @@ async def comp_tasks_listening_task(app: web.Application) -> None:
                 exc_info=True,
             )
         finally:
-            db_engine.close()
-            await db_engine.wait_closed()
+            if db_engine:
+                db_engine.close()
+                await db_engine.wait_closed()
 
 
 async def setup_comp_tasks_listening_task(app: web.Application):

--- a/services/web/server/src/simcore_service_webserver/config/server-defaults.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-defaults.yaml
@@ -22,6 +22,7 @@ db:
     database: simcoredb
     endpoint: postgres:5432
     host: postgres
+    long_running_session_host: postgres
     maxsize: 5
     minsize: 1
     password: simcore

--- a/services/web/server/src/simcore_service_webserver/config/server-docker-dev.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-docker-dev.yaml
@@ -28,6 +28,7 @@ db:
     user: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
     host: ${POSTGRES_HOST}
+    long_running_session_host: ${POSTGRES_LONG_RUNNING_SESSION_HOST}
     port: ${POSTGRES_PORT}
     minsize: 10
     maxsize: 40

--- a/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
@@ -28,6 +28,7 @@ db:
     user: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
     host: ${POSTGRES_HOST}
+    long_running_session_host: ${POSTGRES_LONG_RUNNING_SESSION_HOST}
     port: ${POSTGRES_PORT}
     minsize: 10
     maxsize: 40

--- a/services/web/server/src/simcore_service_webserver/db.py
+++ b/services/web/server/src/simcore_service_webserver/db.py
@@ -5,8 +5,7 @@
 import logging
 
 from aiohttp import web
-from tenacity import Retrying
-
+from aiopg.sa import Engine
 from servicelib.aiopg_utils import (
     DataSourceName,
     PostgresRetryPolicyUponInitialization,
@@ -16,11 +15,13 @@ from servicelib.aiopg_utils import (
 )
 from servicelib.application_keys import APP_CONFIG_KEY, APP_DB_ENGINE_KEY
 from servicelib.application_setup import ModuleCategory, app_module_setup
+from tenacity import Retrying
 
 from .db_config import CONFIG_SECTION_NAME, assert_valid_config
 
 THIS_MODULE_NAME = __name__.split(".")[-1]
 THIS_SERVICE_NAME = "postgres"
+APP_LONG_RUNNING_DB_ENGINE_KEY = f"{__name__ }.long_running_db_engine"
 
 log = logging.getLogger(__name__)
 
@@ -64,6 +65,65 @@ async def pg_engine(app: web.Application):
     )
 
 
+async def _create_pg_engine(
+    dsn: DataSourceName, min_size: int, max_size: int
+) -> Engine:
+    log.info("Creating pg engine for %s", dsn)
+    for attempt in Retrying(**PostgresRetryPolicyUponInitialization(log).kwargs):
+        with attempt:
+            engine = await create_pg_engine(dsn, minsize=min_size, maxsize=max_size)
+            await raise_if_not_responsive(engine)
+
+    assert engine  # nosec
+    return engine
+
+
+async def pg_engines(app: web.Application) -> None:
+    # create the "normal" engine that connects through pgbouncer
+    cfg = app[APP_CONFIG_KEY][CONFIG_SECTION_NAME]
+    pg_cfg = cfg["postgres"]
+
+    dsn = DataSourceName(
+        application_name=f"{__name__}_{id(app)}",
+        database=pg_cfg["database"],
+        user=pg_cfg["user"],
+        password=pg_cfg["password"],
+        host=pg_cfg["host"],
+        port=pg_cfg["port"],
+    )
+    normal_engine = await _create_pg_engine(dsn, pg_cfg["minsize"], pg_cfg["maxsize"])
+    app[APP_DB_ENGINE_KEY] = normal_engine
+    # create the long running session engine that connects directly to postgres
+    dsn = DataSourceName(
+        application_name=f"{__name__}_{id(app)}",
+        database=pg_cfg["database"],
+        user=pg_cfg["user"],
+        password=pg_cfg["password"],
+        host=pg_cfg["long_running_session_host"],
+        port=pg_cfg["port"],
+    )
+    long_running_session_engine = await _create_pg_engine(dsn, min_size=1, max_size=1)
+    app[APP_LONG_RUNNING_DB_ENGINE_KEY] = long_running_session_engine
+
+    yield  # -------------------
+
+    # clean-up
+    if normal_engine is not app.get(APP_DB_ENGINE_KEY):
+        log.critical("app does not hold right db engine. Somebody has changed it??")
+    if long_running_session_engine is not app.get(APP_LONG_RUNNING_DB_ENGINE_KEY):
+        log.critical("app does not hold right db engine. Somebody has changed it??")
+
+    for engine in [normal_engine, long_running_session_engine]:
+        engine.close()
+        await engine.wait_closed()
+        log.debug(
+            "engine '%s' after shutdown: closed=%s, size=%d",
+            engine.dsn,
+            engine.closed,
+            engine.size,
+        )
+
+
 def is_service_enabled(app: web.Application):
     return app.get(APP_DB_ENGINE_KEY) is not None
 
@@ -86,10 +146,11 @@ def setup(app: web.Application):
 
     # ensures keys exist
     app[APP_DB_ENGINE_KEY] = None
+    app[APP_LONG_RUNNING_DB_ENGINE_KEY] = None
 
     # async connection to db
     # app.on_startup.append(_init_db) # TODO: review how is this disposed
-    app.cleanup_ctx.append(pg_engine)
+    app.cleanup_ctx.append(pg_engines)
 
 
 # alias ---

--- a/services/web/server/tests/integration/conftest.py
+++ b/services/web/server/tests/integration/conftest.py
@@ -113,6 +113,12 @@ def webserver_environ(
         published_port = get_service_published_port(name, int(environ.get(port_key)))
         environ[host_key] = "127.0.0.1"
         environ[port_key] = published_port
+        if name == "postgres":
+            # special case for postgres
+            assert (
+                "POSTGRES_LONG_RUNNING_SESSION_HOST" in environ
+            ), "POSTGRES_LONG_RUNNING_SESSION_HOST is missing from .env"
+            environ["POSTGRES_LONG_RUNNING_SESSION_HOST"] = "127.0.0.1"
 
     pprint(environ)  # NOTE: displayed only if error
     return environ
@@ -169,6 +175,7 @@ def app_config(_webserver_dev_config: Dict, aiohttp_unused_port) -> Dict:
     """
     cfg = deepcopy(_webserver_dev_config)
     cfg["main"]["port"] = aiohttp_unused_port()
+
     return cfg
 
 

--- a/services/web/server/tests/unit/with_dbs/config-devel.yml
+++ b/services/web/server/tests/unit/with_dbs/config-devel.yml
@@ -14,6 +14,7 @@ db:
     database: test
     endpoint: 127.0.0.1:5432
     host: 127.0.0.1
+    long_running_session_host: 127.0.0.1
     maxsize: 5
     minsize: 1
     password: admin

--- a/services/web/server/tests/unit/with_dbs/config.yaml
+++ b/services/web/server/tests/unit/with_dbs/config.yaml
@@ -20,6 +20,7 @@ db:
     user: admin
     password: admin
     host: 127.0.0.1
+    long_running_session_host: postgres
     port: 5432
     maxsize: 5
     minsize: 1

--- a/services/web/server/tests/unit/with_dbs/config.yaml
+++ b/services/web/server/tests/unit/with_dbs/config.yaml
@@ -20,11 +20,11 @@ db:
     user: admin
     password: admin
     host: 127.0.0.1
-    long_running_session_host: postgres
+    long_running_session_host: 127.0.0.1
     port: 5432
     maxsize: 5
     minsize: 1
-    endpoint: postgres:5432
+    endpoint: 127.0.0.1:5432
 resource_manager:
   enabled: True
   redis:

--- a/tests/e2e/utils/wait_for_services.py
+++ b/tests/e2e/utils/wait_for_services.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
 WAIT_BEFORE_RETRY = 10
-MAX_RETRY_COUNT = 10
+MAX_RETRY_COUNT = 20
 MAX_WAIT_TIME = 240
 
 # SEE https://docs.docker.com/engine/swarm/how-swarm-mode-works/swarm-task-states/


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
pgBouncer works best in Transaction pooling mode with our aiopg backend. BUT, this mode does not allow for listening to postgres notifications see [here](https://www.pgbouncer.org/features.html)

therefore, a direct connection to postgres is allowed for the webserver service ONLY to this end. everything else seems to work as expected until now.

- changed the docker container used for pgbouncer as it was deprecated... now using edoburu/pgbouncer:1.15.0@sha256:2f47bf272fa9fdf25c100d11f1972b23af61a351a136d3721bfa6bdb52630426
- increase max_client_conn to 10000 on pgbouncer to allow for err... 10000 clients... not the default 100...
- POSTGRES_LONG_RUNNING_SESSION_HOST env variable added to .env-devel for direct connections with postgres DB
-   (⚠️ devops) due to change of docker image container: please change ENVs to DB_HOST

NOTE:
To access pgbouncer statistics:
```console
docker exec -it PGBOUNCER_ID sh
psql postgres://127.0.0.1/pgbouncer -U scu
# enter postgres password
show help;
```

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
