### PR TITLE
Changes unarchive_dir and tests unarchive+prune algorithm

### DIFF
--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -147,7 +147,7 @@ async def archive_dir(
         )
 
 
-def is_leaf_path(p: Path):
+def is_leaf_path(p: Path) -> bool:
     """Tests whether a path corresponds to a file or empty folder, i.e.
     some leaf item in a file-system tree structure
     """
@@ -172,7 +172,7 @@ class PrunableFolder:
         self.before_relpaths = set()
         self.capture()
 
-    def capture(self):
+    def capture(self) -> None:
         # captures leaf paths in folder at this moment
         self.before_relpaths = set(
             p.relative_to(self.basedir)
@@ -180,7 +180,7 @@ class PrunableFolder:
             if is_leaf_path(p)
         )
 
-    def prune(self, exclude: Set[Path]):
+    def prune(self, exclude: Set[Path]) -> None:
         """
         Deletes all paths in folder skipping the exclude set
         """

--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -69,7 +69,7 @@ def ensure_destination_subdirectories_exist(
 async def unarchive_dir(
     archive_to_extract: Path, destination_folder: Path
 ) -> Set[Path]:
-    """Extracts zipped file archive_to_extract in destination_folder,
+    """Extracts zipped file archive_to_extract to destination_folder,
     preserving all relative files and folders inside the archive
 
     Returns a set of paths extracted from archive (NOTE: that these are both files and folders)

--- a/packages/service-library/tests/test_archiving_utils.py
+++ b/packages/service-library/tests/test_archiving_utils.py
@@ -1,32 +1,19 @@
 # pylint:disable=redefined-outer-name,unused-argument
 
-import os
-import tempfile
-import hashlib
-import random
-from pathlib import Path
 import asyncio
-from typing import Set, List, Dict, Iterator, Tuple
-from concurrent.futures import ProcessPoolExecutor
-import string
+import hashlib
+import itertools
+import os
+import random
 import secrets
-
+import string
+import tempfile
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
 
 import pytest
-
 from servicelib.archiving_utils import archive_dir, unarchive_dir
-
-
-@pytest.fixture
-def temp_dir_one() -> Path:
-    with tempfile.TemporaryDirectory() as temp_dir:
-        yield Path(temp_dir)
-
-
-@pytest.fixture
-def temp_dir_two(tmpdir) -> Path:
-    with tempfile.TemporaryDirectory() as temp_dir:
-        yield Path(temp_dir)
 
 
 @pytest.fixture
@@ -61,7 +48,7 @@ def dir_with_random_content() -> Path:
                 max_file_count=max_file_count,
             )
 
-    def get_dirs_and_subdris_in_path(path_to_scan: Path) -> Iterator[Path]:
+    def get_dirs_and_subdris_in_path(path_to_scan: Path) -> List[Path]:
         return [path for path in path_to_scan.rglob("*") if path.is_dir()]
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -86,8 +73,7 @@ def dir_with_random_content() -> Path:
 
 
 def strip_directory_from_path(input_path: Path, to_strip: Path) -> Path:
-    to_strip = f"{str(to_strip)}/"
-    return Path(str(input_path).replace(to_strip, ""))
+    return Path(str(input_path).replace(str(to_strip) + "/", ""))
 
 
 def get_all_files_in_dir(dir_path: Path) -> Set[Path]:
@@ -171,20 +157,45 @@ async def assert_same_directory_content(
         )
 
 
-# end utils
+def assert_unarchived_paths(
+    unarchived_paths, src_dir: Path, dst_dir: Path, store_relative_path: bool
+):
+    # all are under dst_dir
+    assert all(dst_dir in f.parents for f in unarchived_paths)
+
+    # can be also checked with strings
+    assert all(str(f).startswith(str(dst_dir)) for f in unarchived_paths)
+
+    # trim basedir and compare relative paths (alias 'tails') against src_dir
+    basedir = str(dst_dir)
+    if not store_relative_path:
+        basedir += str(src_dir)
+
+    got_tails = set(
+        os.path.relpath(f, basedir) for f in unarchived_paths if f.is_file()
+    )
+    expected_tails = set(
+        os.path.relpath(f, src_dir) for f in src_dir.rglob("*") if f.is_file()
+    )
+    assert got_tails == expected_tails
 
 
 @pytest.mark.parametrize(
     "compress,store_relative_path",
-    [[True, True], [True, False], [False, True], [False, False]],
+    itertools.product([True, False], repeat=2),
 )
 async def test_archive_unarchive_same_structure_dir(
     dir_with_random_content: Path,
-    temp_dir_one: Path,
-    temp_dir_two: Path,
+    tmp_path: Path,
     compress: bool,
     store_relative_path: bool,
 ):
+    temp_dir_one = tmp_path / "one"
+    temp_dir_two = tmp_path / "two"
+
+    temp_dir_one.mkdir()
+    temp_dir_two.mkdir()
+
     archive_file = temp_dir_one / "archive.zip"
 
     archive_result = await archive_dir(
@@ -195,8 +206,15 @@ async def test_archive_unarchive_same_structure_dir(
     )
     assert archive_result is True
 
-    await unarchive_dir(
+    unarchived_paths: Set[Path] = await unarchive_dir(
         archive_to_extract=archive_file, destination_folder=temp_dir_two
+    )
+
+    assert_unarchived_paths(
+        unarchived_paths,
+        src_dir=dir_with_random_content,
+        dst_dir=temp_dir_two,
+        store_relative_path=store_relative_path,
     )
 
     await assert_same_directory_content(
@@ -208,15 +226,15 @@ async def test_archive_unarchive_same_structure_dir(
 
 @pytest.mark.parametrize(
     "compress,store_relative_path",
-    [[True, True], [True, False], [False, True], [False, False]],
+    itertools.product([True, False], repeat=2),
 )
 async def test_unarchive_in_same_dir_as_archive(
     dir_with_random_content: Path,
-    temp_dir_one: Path,
+    tmp_path: Path,
     compress: bool,
     store_relative_path: bool,
 ):
-    archive_file = temp_dir_one / "archive.zip"
+    archive_file = tmp_path / "archive.zip"
 
     archive_result = await archive_dir(
         dir_to_compress=dir_with_random_content,
@@ -226,12 +244,21 @@ async def test_unarchive_in_same_dir_as_archive(
     )
     assert archive_result is True
 
-    await unarchive_dir(
-        archive_to_extract=archive_file, destination_folder=temp_dir_one
+    unarchived_paths = await unarchive_dir(
+        archive_to_extract=archive_file, destination_folder=tmp_path
     )
-    archive_file.unlink()
+
+    archive_file.unlink()  # delete before comparing contents
+
+    assert_unarchived_paths(
+        unarchived_paths,
+        src_dir=dir_with_random_content,
+        dst_dir=tmp_path,
+        store_relative_path=store_relative_path,
+    )
+
     await assert_same_directory_content(
         dir_with_random_content,
-        temp_dir_one,
+        tmp_path,
         None if store_relative_path else dir_with_random_content,
     )

--- a/packages/service-library/tests/test_archiving_utils.py
+++ b/packages/service-library/tests/test_archiving_utils.py
@@ -6,6 +6,7 @@ import itertools
 import os
 import random
 import secrets
+import shutil
 import string
 import tempfile
 from concurrent.futures import ProcessPoolExecutor
@@ -262,3 +263,72 @@ async def test_unarchive_in_same_dir_as_archive(
         tmp_path,
         None if store_relative_path else dir_with_random_content,
     )
+
+
+def test_override_and_prune_folder(tmp_path: Path):
+
+    # original
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    (target_dir / "d1").mkdir()
+    (target_dir / "d1" / "f1").write_text("o" * 100)
+    (target_dir / "d1" / "f2").write_text("o" * 100)
+    (target_dir / "empty").mkdir()
+    (target_dir / "d1" / "d1_1" / "d1_2").mkdir(parents=True, exist_ok=True)
+    (target_dir / "d1" / "d1_1" / "f3").touch()
+    (target_dir / "d1" / "d1_1" / "d1_2" / "f4").touch()
+
+    print("before ----")
+    for p in target_dir.rglob("*"):
+        print(f"{p.stat().st_size:>12.2f} {p}")
+
+    # download
+    download_dir = tmp_path / "download"
+    download_dir.mkdir()
+    (download_dir / "d1").mkdir()
+    (download_dir / "d1" / "f1").write_text("x")  # override
+    (download_dir / "d1" / "f2").write_text("x")  # override
+    # empty dir deleted
+    (download_dir / "d1" / "d1_1" / "d1_2").mkdir(parents=True, exist_ok=True)
+    # f3 and f4 are deleted
+    (download_dir / "d1" / "d1_1" / "d1_2" / "f5").touch()  # new
+    (download_dir / "d1" / "empty").mkdir()  # new
+
+    print("downloaded ----")
+    expected_paths = set(p.relative_to(download_dir) for p in download_dir.rglob("*"))
+    for p in download_dir.rglob("*"):
+        print(f"{p.stat().st_size:>12.2f} {p}")
+
+    # --------
+    # 1) evaluate prune
+    file_or_emptydir = lambda p: p.is_file() or (p.is_dir() and not any(p.glob("*")))
+
+    old_paths = set(p for p in target_dir.rglob("*") if file_or_emptydir(p))
+    new_paths = set(
+        target_dir / p.relative_to(download_dir)
+        for p in download_dir.rglob("*")
+        if file_or_emptydir(p)
+    )
+    to_delete = old_paths.difference(new_paths)
+
+    # 2) override download_dir -> target_dir
+    for p in download_dir.rglob("*"):
+        if file_or_emptydir(p):
+            shutil.move(str(p), str(target_dir / p.relative_to(download_dir)))
+
+    # 3) prune
+    for path in to_delete:
+        if path.is_file():
+            path.unlink()
+        elif path.is_dir():
+            path.rmdir()
+
+    # -------
+    got_paths = set(p.relative_to(target_dir) for p in target_dir.rglob("*"))
+
+    assert expected_paths == got_paths
+    assert old_paths != got_paths
+
+    print("after ----")
+    for p in target_dir.rglob("*"):
+        print(f"{p.stat().st_size:>12.2f} {p}")

--- a/packages/service-library/tests/test_archiving_utils_extra.py
+++ b/packages/service-library/tests/test_archiving_utils_extra.py
@@ -4,18 +4,21 @@
 
 import shutil
 from pathlib import Path
+from typing import Set
 
 import pytest
-from servicelib.archiving_utils import archive_dir, unarchive_dir
-
-# tests for leaf nodes in a paths tree
-is_leaf_path = lambda p: p.is_file() or (p.is_dir() and not any(p.glob("*")))
+from servicelib.archiving_utils import (
+    PrunableFolder,
+    archive_dir,
+    is_leaf_path,
+    unarchive_dir,
+)
 
 
 def print_tree(path: Path, level=0):
     tab = " " * level
-    print(f"{tab}- {path}")
-    for p in path.rglob("*"):
+    print(f"{tab}{'+' if path.is_dir() else '-'} {path if level==0 else path.name}")
+    for p in path.glob("*"):
         print_tree(p, level + 1)
 
 
@@ -24,16 +27,29 @@ def state_dir(tmp_path) -> Path:
     """ Folder with some data, representing a given state"""
     base_dir = tmp_path / "original"
     base_dir.mkdir()
+    (base_dir / "empty").mkdir()
     (base_dir / "d1").mkdir()
     (base_dir / "d1" / "f1").write_text("o" * 100)
     (base_dir / "d1" / "f2").write_text("o" * 100)
-    (base_dir / "empty").mkdir()
     (base_dir / "d1" / "d1_1" / "d1_2").mkdir(parents=True, exist_ok=True)
     (base_dir / "d1" / "d1_1" / "f3").touch()
     (base_dir / "d1" / "d1_1" / "d1_2" / "f4").touch()
+    (base_dir / "d1" / "d1_1" / "d1_1_1").mkdir(parents=True, exist_ok=True)
+    (base_dir / "d1" / "d1_1" / "d1_1_1" / "f6").touch()
 
     print("state-dir ---")
     print_tree(base_dir)
+    # + /tmp/pytest-of-crespo/pytest-95/test_override_and_prune_from_a1/original
+    #  + empty
+    #  + d1
+    #   + d1_1
+    #    + d2_2
+    #     - f6
+    #    - f3
+    #    + d1_2
+    #     - f4
+    #   - f2
+    #   - f1
 
     return base_dir
 
@@ -51,9 +67,18 @@ def new_state_dir(tmp_path) -> Path:
     # f3 and f4 are deleted
     (base_dir / "d1" / "d1_1" / "d1_2" / "f5").touch()  # new
     (base_dir / "d1" / "empty").mkdir()  # new
+    # f6 deleted -> d1/d1_1/d2_2 remains empty and should be pruned
 
     print("new-state-dir ---")
     print_tree(base_dir)
+    # + /tmp/pytest-of-crespo/pytest-95/test_override_and_prune_from_a1/updated
+    #  + d1
+    #   + d1_1
+    #    + d1_2
+    #     - f5
+    #   - f2
+    #   - f1
+    #   + empty
 
     return base_dir
 
@@ -90,6 +115,10 @@ def test_override_and_prune_folder(state_dir: Path, new_state_dir: Path):
         elif path.is_dir():
             path.rmdir()
 
+    for p in state_dir.rglob("*"):
+        if p.is_dir() and p not in new_paths and not any(p.glob("*")):
+            p.rmdir()
+
     # -------
     got_paths = set(p.relative_to(state_dir) for p in state_dir.rglob("*"))
 
@@ -110,7 +139,6 @@ async def test_override_and_prune_from_archive(
     new_state_dir: Path,
     compress: bool,
 ):
-
     download_file = tmp_path / "download.zip"
     expected_paths = set(
         p.relative_to(new_state_dir)
@@ -126,30 +154,19 @@ async def test_override_and_prune_from_archive(
         store_relative_path=True,  # <=== relative!
     )
 
-    before_relpaths = set(
-        p.relative_to(state_dir) for p in state_dir.rglob("*") if is_leaf_path(p)
-    )
+    folder = PrunableFolder(state_dir)
+    folder.capture_status()
 
     # unarchive download.zip into state_dir
     unarchived = await unarchive_dir(
         archive_to_extract=download_file, destination_folder=state_dir
     )
 
-    # prune outdated leaf paths
-    unarchived_relpaths = set(p.relative_to(state_dir) for p in unarchived)
-    to_delete = before_relpaths.difference(unarchived_relpaths)
-    for p in to_delete:
-        path = state_dir / p
-        assert path.exists()
-
-        if path.is_file():
-            path.unlink()
-        elif path.is_dir():
-            path.rmdir()
+    folder.prune_to_match(unarchived)
 
     after_relpaths = set(
         p.relative_to(state_dir) for p in state_dir.rglob("*") if is_leaf_path(p)
     )
 
-    assert after_relpaths != before_relpaths
-    assert after_relpaths == unarchived_relpaths
+    assert after_relpaths != folder.before_relpaths
+    assert after_relpaths == set(p.relative_to(state_dir) for p in unarchived)

--- a/packages/service-library/tests/test_archiving_utils_extra.py
+++ b/packages/service-library/tests/test_archiving_utils_extra.py
@@ -155,14 +155,13 @@ async def test_override_and_prune_from_archive(
     )
 
     folder = PrunableFolder(state_dir)
-    folder.capture_status()
 
     # unarchive download.zip into state_dir
     unarchived = await unarchive_dir(
         archive_to_extract=download_file, destination_folder=state_dir
     )
 
-    folder.prune_to_match(unarchived)
+    folder.prune(unarchived)
 
     after_relpaths = set(
         p.relative_to(state_dir) for p in state_dir.rglob("*") if is_leaf_path(p)

--- a/packages/service-library/tests/test_archiving_utils_extra.py
+++ b/packages/service-library/tests/test_archiving_utils_extra.py
@@ -4,7 +4,6 @@
 
 import shutil
 from pathlib import Path
-from typing import Set
 
 import pytest
 from servicelib.archiving_utils import (

--- a/packages/service-library/tests/test_archiving_utils_extra.py
+++ b/packages/service-library/tests/test_archiving_utils_extra.py
@@ -1,0 +1,102 @@
+# pylint:disable=unused-variable
+# pylint:disable=unused-argument
+# pylint:disable=redefined-outer-name
+
+import shutil
+from pathlib import Path
+
+import pytest
+from servicelib.archiving_utils import archive_dir, unarchive_dir
+
+# tests for leaf nodes in a paths tree
+is_leaf_path = lambda p: p.is_file() or (p.is_dir() and not any(p.glob("*")))
+
+
+def print_tree(path: Path, level=0):
+    tab = " " * level
+    print(f"{tab}- {path}")
+    for p in path.rglob("*"):
+        print_tree(p, level + 1)
+
+
+@pytest.fixture
+def state_dir(tmp_path) -> Path:
+    """ Folder with some data """
+    base_dir = tmp_path / "original"
+    base_dir.mkdir()
+    (base_dir / "d1").mkdir()
+    (base_dir / "d1" / "f1").write_text("o" * 100)
+    (base_dir / "d1" / "f2").write_text("o" * 100)
+    (base_dir / "empty").mkdir()
+    (base_dir / "d1" / "d1_1" / "d1_2").mkdir(parents=True, exist_ok=True)
+    (base_dir / "d1" / "d1_1" / "f3").touch()
+    (base_dir / "d1" / "d1_1" / "d1_2" / "f4").touch()
+
+    print("state-dir ---")
+    print_tree(base_dir)
+
+    return base_dir
+
+
+@pytest.fixture
+def new_state_dir(tmp_path) -> Path:
+    """ Folder AFTER updated with new data """
+    base_dir = tmp_path / "updated"
+    base_dir.mkdir()
+    (base_dir / "d1").mkdir()
+    (base_dir / "d1" / "f1").write_text("x")  # override
+    (base_dir / "d1" / "f2").write_text("x")  # override
+    # empty dir deleted
+    (base_dir / "d1" / "d1_1" / "d1_2").mkdir(parents=True, exist_ok=True)
+    # f3 and f4 are deleted
+    (base_dir / "d1" / "d1_1" / "d1_2" / "f5").touch()  # new
+    (base_dir / "d1" / "empty").mkdir()  # new
+
+    print("new-state-dir ---")
+    print_tree(base_dir)
+
+    return base_dir
+
+
+def test_override_and_prune_folder(
+    tmp_path: Path, state_dir: Path, new_state_dir: Path
+):
+    """
+    Test a concept that will be implemented in jupyter-commons
+    Added here since in the latter there is no testing infrastructure and
+    so it can be reused when code is moved into the new sidecar
+    """
+
+    expected_paths = set(p.relative_to(new_state_dir) for p in new_state_dir.rglob("*"))
+
+    # --------
+    # 1) evaluate leafs to prune in paths tree
+
+    old_paths = set(p for p in state_dir.rglob("*") if is_leaf_path(p))
+    new_paths = set(
+        state_dir / p.relative_to(new_state_dir)
+        for p in new_state_dir.rglob("*")
+        if is_leaf_path(p)
+    )
+    to_delete = old_paths.difference(new_paths)
+
+    # 2) override leafs from new_state_dir -> state_dir
+    for p in new_state_dir.rglob("*"):
+        if is_leaf_path(p):
+            shutil.move(str(p), str(state_dir / p.relative_to(new_state_dir)))
+
+    # 3) prune leafs that were not overriden
+    for path in to_delete:
+        if path.is_file():
+            path.unlink()
+        elif path.is_dir():
+            path.rmdir()
+
+    # -------
+    got_paths = set(p.relative_to(state_dir) for p in state_dir.rglob("*"))
+
+    assert expected_paths == got_paths
+    assert old_paths != got_paths
+
+    print("after ----")
+    print_tree(state_dir)

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports/filemanager.py
@@ -139,7 +139,8 @@ async def _download_link_to_file(session: ClientSession, url: URL, file_path: Pa
         if response.status > 299:
             raise exceptions.TransferError(url)
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_size = int(response.headers.get("content-length", 0)) or None
+        # SEE https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length
+        file_size = int(response.headers.get("Content-Length", 0)) or None
         try:
             with tqdm(
                 desc=f"downloading {file_path} [{file_size} bytes]",


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

- ``unarchive_dir`` returns set of paths extracted from archive 
- tests unarchive+prune algorithm will be used in the jupyter-commons library to fix #2256
   - ADDS ``PrunableFolder`` class to gather capture+prune operations

NOTE: These changes will be imported into jupyter-common next.

## Related issue/s

- FIXES: Avoid empty state while updating work directory in dynamic services #2256 
- Might FIX: Jupyter displays "Directory not found" menu permanently ITISFoundation/osparc-issues#412



## How to test

```
make devenv
source .venv/bin/activate
cd packages/service-library
make install-dev
make tests
```

## Checklist

- [ ] Use in jupyter-commons instead of copy&paste
- [ ] 

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
