### PR TITLE
remove pgbouncer and increase pg clients

### DIFF
--- a/.env-devel
+++ b/.env-devel
@@ -12,12 +12,11 @@ DIRECTOR_REGISTRY_CACHING_TTL=900
 DIRECTOR_REGISTRY_CACHING=True
 
 POSTGRES_DB=simcoredb
-POSTGRES_ENDPOINT=pgbouncer:5432
-POSTGRES_HOST=pgbouncer
+POSTGRES_ENDPOINT=postgres:5432
+POSTGRES_HOST=postgres
 POSTGRES_PASSWORD=adminadmin
 POSTGRES_PORT=5432
 POSTGRES_USER=scu
-POSTGRES_LONG_RUNNING_SESSION_HOST=postgres
 
 RABBIT_CHANNELS={"log": "comp.backend.channels.log", "instrumentation": "comp.backend.channels.instrumentation"}
 RABBIT_HOST=rabbit

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ endif
 define _show_endpoints
 # The following endpoints are available
 echo "http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):9081                                                                 - oSparc platform"
-echo "http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):18080/?pgsql=pgbouncer&username=scu&db=simcoredb&ns=public  - Postgres DB"
+echo "http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):18080/?pgsql=postgres&username=scu&db=simcoredb&ns=public  - Postgres DB"
 echo "http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):9000                                                                 - Portainer"
 endef
 

--- a/packages/models-library/src/models_library/settings/postgres.py
+++ b/packages/models-library/src/models_library/settings/postgres.py
@@ -17,10 +17,6 @@ class PostgresSettings(BaseSettings):
     # entrypoint
     host: str
     port: PortInt = 5432
-    long_running_session_host: Optional[str] = Field(
-        None,
-        description="host for long running sessions (e.g. listen/notify, prepared statements, etc...)",
-    )
 
     # auth
     user: str

--- a/packages/models-library/src/models_library/settings/postgres.py
+++ b/packages/models-library/src/models_library/settings/postgres.py
@@ -26,8 +26,8 @@ class PostgresSettings(BaseSettings):
     db: str
 
     # pool connection limits
-    minsize: conint(ge=1) = 10
-    maxsize: conint(ge=1) = 100
+    minsize: conint(ge=1) = 1
+    maxsize: conint(ge=1) = 50
 
     dsn: Optional[PostgresDsn] = Field(None, description="Database Source Name")
 

--- a/packages/postgres-database/tests/docker-compose.yml
+++ b/packages/postgres-database/tests/docker-compose.yml
@@ -1,27 +1,5 @@
 version: "3.7"
 services:
-  pgbouncer:
-    image: "edoburu/pgbouncer:1.15.0@sha256:2f47bf272fa9fdf25c100d11f1972b23af61a351a136d3721bfa6bdb52630426"
-    init: true
-    environment:
-      - DB_HOST=postgres
-      - DB_PORT=5432
-      - DB_USER=test
-      - DB_PASSWORD=test
-      - DB_NAME=test
-      # pgbouncer.ini variables
-      - LISTEN_ADDR=*
-      - LISTEN_PORT=5432
-      - POOL_MODE=transaction
-      - MAX_CLIENT_CONN=90 # we keep some for other OPS higher level services
-      - APPLICATION_NAME_ADD_HOST=1
-      - ADMIN_USERS=${POSTGRES_USER}
-
-    ports:
-      - "6432:5432"
-    depends_on:
-      - postgres
-
   postgres:
     image: "postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f"
     init: true
@@ -73,4 +51,4 @@ services:
     ports:
       - 18080:8080
     depends_on:
-      - pgbouncer
+      - postgres

--- a/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
@@ -158,10 +158,6 @@ def core_services_selection(request) -> List[str]:
     """ Selection of services from the simcore stack """
     core_services = getattr(request.module, FIXTURE_CONFIG_CORE_SERVICES_SELECTION, [])
 
-    if "postgres" in core_services:
-        assert (
-            "pgbouncer" in core_services
-        ), f"WARNING: the test is missing pgbouncer service in '{FIXTURE_CONFIG_CORE_SERVICES_SELECTION}' within '{request.module.__name__}'. postgres alone is not accessible!!"
     assert (
         core_services
     ), f"Expected at least one service in '{FIXTURE_CONFIG_CORE_SERVICES_SELECTION}' within '{request.module.__name__}'"

--- a/packages/pytest-simcore/src/pytest_simcore/simcore_services.py
+++ b/packages/pytest-simcore/src/pytest_simcore/simcore_services.py
@@ -15,7 +15,7 @@ from .helpers.utils_docker import get_service_published_port
 
 log = logging.getLogger(__name__)
 
-SERVICES_TO_SKIP = ["sidecar", "postgres", "pgbouncer", "redis", "rabbit"]
+SERVICES_TO_SKIP = ["sidecar", "postgres", "redis", "rabbit"]
 SERVICE_HEALTHCHECK_ENTRYPOINT = {"director-v2": "/"}
 
 

--- a/packages/simcore-sdk/src/simcore_sdk/config/db.py
+++ b/packages/simcore-sdk/src/simcore_sdk/config/db.py
@@ -15,9 +15,6 @@ CONFIG_SCHEMA = T.Dict(
         "host": T.Or(T.String, T.Null),
         "port": T.Or(T.ToInt, T.Null),
         "endpoint": T.Or(T.String, T.Null),
-        T.Key("long_running_session_host", default=None, optional=True): T.Or(
-            T.String, T.Null
-        ),
     }
 )
 

--- a/packages/simcore-sdk/tests/integration/test_dbmanager.py
+++ b/packages/simcore-sdk/tests/integration/test_dbmanager.py
@@ -10,7 +10,7 @@ from typing import Callable, Dict
 from simcore_sdk.node_ports import config
 from simcore_sdk.node_ports.dbmanager import DBManager
 
-pytest_simcore_core_services_selection = ["postgres", "pgbouncer"]
+pytest_simcore_core_services_selection = ["postgres"]
 
 pytest_simcore_ops_services_selection = ["minio"]
 

--- a/packages/simcore-sdk/tests/integration/test_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_filemanager.py
@@ -12,7 +12,7 @@ import np_helpers
 import pytest
 from simcore_sdk.node_ports import exceptions, filemanager
 
-pytest_simcore_core_services_selection = ["postgres", "pgbouncer", "storage"]
+pytest_simcore_core_services_selection = ["postgres", "storage"]
 
 pytest_simcore_ops_services_selection = ["minio"]
 

--- a/packages/simcore-sdk/tests/integration/test_nodeports.py
+++ b/packages/simcore-sdk/tests/integration/test_nodeports.py
@@ -17,7 +17,7 @@ from simcore_sdk.node_ports import exceptions
 from simcore_sdk.node_ports._item import ItemConcreteValue
 from simcore_sdk.node_ports.nodeports import Nodeports
 
-pytest_simcore_core_services_selection = ["postgres", "pgbouncer", "storage"]
+pytest_simcore_core_services_selection = ["postgres", "storage"]
 
 pytest_simcore_ops_services_selection = ["minio"]
 

--- a/packages/simcore-sdk/tests/integration/test_nodeports2.py
+++ b/packages/simcore-sdk/tests/integration/test_nodeports2.py
@@ -17,7 +17,7 @@ from simcore_sdk.node_ports_v2 import exceptions
 from simcore_sdk.node_ports_v2.links import ItemConcreteValue
 from simcore_sdk.node_ports_v2.nodeports_v2 import Nodeports
 
-pytest_simcore_core_services_selection = ["postgres", "pgbouncer", "storage"]
+pytest_simcore_core_services_selection = ["postgres", "storage"]
 
 pytest_simcore_ops_services_selection = ["minio"]
 

--- a/services/catalog/tests/unit/with_dbs/test_entrypoint_dags.py
+++ b/services/catalog/tests/unit/with_dbs/test_entrypoint_dags.py
@@ -9,7 +9,7 @@ from simcore_service_catalog.meta import api_version
 from simcore_service_catalog.models.schemas.meta import Meta
 from starlette.testclient import TestClient
 
-pytest_simcore_core_services_selection = ["postgres", "pgbouncer"]
+pytest_simcore_core_services_selection = ["postgres"]
 pytest_simcore_ops_services_selection = ["adminer"]
 
 

--- a/services/catalog/tests/unit/with_dbs/test_entrypoint_services.py
+++ b/services/catalog/tests/unit/with_dbs/test_entrypoint_services.py
@@ -27,7 +27,6 @@ from yarl import URL
 
 pytest_simcore_core_services_selection = [
     "postgres",
-    "pgbouncer",
 ]
 pytest_simcore_ops_services_selection = ["adminer"]
 

--- a/services/director-v2/tests/integration/test_computation_api.py
+++ b/services/director-v2/tests/integration/test_computation_api.py
@@ -42,7 +42,6 @@ pytest_simcore_core_services_selection = [
     "sidecar",
     "storage",
     "postgres",
-    "pgbouncer",
 ]
 pytest_simcore_ops_services_selection = ["minio", "adminer"]
 

--- a/services/docker-compose-ops.yml
+++ b/services/docker-compose-ops.yml
@@ -30,9 +30,7 @@ services:
     ports:
       - "18080:8080"
     networks:
-      # NOTE: simcore_default allows access to postgres through pgbouncer, postgres_network allows access directly to postgres
       - simcore_default
-      - postgres_network
 
   portainer:
     image: portainer/portainer-ce
@@ -103,7 +101,4 @@ networks:
     external: true
   computational_services_subnet:
     name: ${SWARM_STACK_NAME:-simcore}_computational_services_subnet
-    external: true
-  postgres_network:
-    name: ${SWARM_STACK_NAME:-simcore}_postgres_network
     external: true

--- a/services/docker-compose.local.yml
+++ b/services/docker-compose.local.yml
@@ -55,10 +55,6 @@ services:
       - "8080"
       - "3001:3000"
 
-  pgbouncer:
-    ports:
-      - "6432:5432"
-
   postgres:
     ports:
       - "5432:5432"

--- a/services/docker-compose.local.yml
+++ b/services/docker-compose.local.yml
@@ -80,6 +80,10 @@ services:
         "log_line_prefix=%m [%p] %q%u@%d/%a ",
         "-c",
         'listen_addresses="*"',
+        "-c",
+        "max_connections=413",
+        "-c",
+        "shared_buffers=256MB"
       ]
 
   rabbit:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -264,30 +264,6 @@ services:
     networks:
       - default
 
-  pgbouncer:
-    image: "edoburu/pgbouncer:1.15.0@sha256:2f47bf272fa9fdf25c100d11f1972b23af61a351a136d3721bfa6bdb52630426"
-    init: true
-    environment:
-      - DB_HOST=postgres
-      - DB_PORT=${POSTGRES_PORT}
-      - DB_USER=${POSTGRES_USER}
-      - DB_PASSWORD=${POSTGRES_PASSWORD}
-      - DB_NAME=${POSTGRES_DB}
-      # pgbouncer.ini variables
-      - LISTEN_ADDR=*
-      - LISTEN_PORT=${POSTGRES_PORT}
-      - POOL_MODE=transaction
-      - MAX_CLIENT_CONN=10000 # we keep some for other OPS higher level services
-      - DEFAULT_POOL_SIZE=20
-      - MAX_DB_CONNECTIONS=90
-      - APPLICATION_NAME_ADD_HOST=1
-      - ADMIN_USERS=${POSTGRES_USER}
-    networks:
-      - default
-      - interactive_services_subnet
-      - computational_services_subnet
-      - postgres_network
-
   postgres:
     image: "postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f"
     init: true
@@ -298,7 +274,9 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
-      - postgres_network
+      - default
+      - interactive_services_subnet
+      - computational_services_subnet
     healthcheck:
       test:
         [

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -277,6 +277,7 @@ services:
       - default
       - interactive_services_subnet
       - computational_services_subnet
+    shm_size: ‘256mb’
     healthcheck:
       test:
         [

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -308,6 +308,10 @@ services:
         "tcp_keepalives_interval=600",
         "-c",
         "tcp_keepalives_count=5",
+        "-c",
+        "max_connections=413",
+        "-c",
+        "shared_buffers=256MB"
       ]
 
   redis:

--- a/services/sidecar/tests/integration/test_sidecar.py
+++ b/services/sidecar/tests/integration/test_sidecar.py
@@ -27,7 +27,7 @@ SIMCORE_S3_ID = 0
 #
 # SEE packages/pytest-simcore/src/pytest_simcore/docker_compose.py
 #
-pytest_simcore_core_services_selection = ["postgres", "pgbouncer", "rabbit", "storage"]
+pytest_simcore_core_services_selection = ["postgres", "rabbit", "storage"]
 
 pytest_simcore_ops_services_selection = ["minio", "adminer"]
 

--- a/services/storage/src/simcore_service_storage/data/docker-prod-config.yaml
+++ b/services/storage/src/simcore_service_storage/data/docker-prod-config.yaml
@@ -4,16 +4,16 @@ port: 8080
 testing: False
 monitoring_enabled: ${STORAGE_MONITORING_ENABLED}
 test_datcore:
-    token_key: ${BF_API_KEY}
-    token_secret: ${BF_API_SECRET}
+  token_key: ${BF_API_KEY}
+  token_secret: ${BF_API_SECRET}
 postgres:
   db: ${POSTGRES_DB}
   user: ${POSTGRES_USER}
   password: ${POSTGRES_PASSWORD}
   host: ${POSTGRES_HOST}
   port: ${POSTGRES_PORT}
-  minsize: 10
-  maxsize: 100
+  minsize: 1
+  maxsize: 50
 s3:
   endpoint: ${S3_ENDPOINT}
   access_key: ${S3_ACCESS_KEY}

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -125,7 +125,7 @@ def postgres_service(docker_services, docker_ip):
         password=PASS,
         database=DATABASE,
         host=docker_ip,
-        port=docker_services.port_for("pgbouncer", 5432),
+        port=docker_services.port_for("postgres", 5432),
     )
 
     # Wait until service is responsive.

--- a/services/storage/tests/docker-compose.yml
+++ b/services/storage/tests/docker-compose.yml
@@ -1,27 +1,5 @@
 version: "3.4"
 services:
-  pgbouncer:
-    image: "edoburu/pgbouncer:1.15.0@sha256:2f47bf272fa9fdf25c100d11f1972b23af61a351a136d3721bfa6bdb52630426"
-    init: true
-    restart: always
-    environment:
-      - DB_HOST=postgres
-      - DB_PORT=5432
-      - DB_USER=${POSTGRES_USER:-admin}
-      - DB_PASSWORD=${POSTGRES_PASSWORD:-admin}
-      - DB_NAME=${POSTGRES_DB:-aio_login_tests}
-      # pgbouncer.ini variables
-      - LISTEN_ADDR=*
-      - LISTEN_PORT=${POSTGRES_PORT}
-      - POOL_MODE=transaction
-      - MAX_CLIENT_CONN=10000 # we keep some for other OPS higher level services
-      - DEFAULT_POOL_SIZE=80
-      - MAX_DB_CONNECTIONS=90
-      - APPLICATION_NAME_ADD_HOST=1
-      - ADMIN_USERS=${POSTGRES_USER:-admin}
-      - VERBOSE=1
-    ports:
-      - "6432:5432"
   postgres:
     image: postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f
     restart: always

--- a/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
@@ -15,13 +15,13 @@ from models_library.projects import ProjectID
 from models_library.projects_nodes import NodeID
 from models_library.projects_state import RunningState
 from pydantic.types import PositiveInt
+from servicelib.application_keys import APP_DB_ENGINE_KEY
 from servicelib.logging_utils import log_decorator
 from servicelib.utils import logged_gather
 from simcore_postgres_database.webserver_models import DB_CHANNEL_NAME, projects
 from sqlalchemy.sql import select
 
 from .computation_api import convert_state_from_db
-from .db import APP_LONG_RUNNING_DB_ENGINE_KEY
 from .projects import projects_api, projects_exceptions
 from .projects.projects_utils import project_get_depending_nodes
 
@@ -170,7 +170,7 @@ async def comp_tasks_listening_task(app: web.Application) -> None:
     while True:
         try:
             # create a special connection here
-            db_engine = app[APP_LONG_RUNNING_DB_ENGINE_KEY]
+            db_engine = app[APP_DB_ENGINE_KEY]
             log.info("listening to comp_task events...")
             await listen(app, db_engine)
         except asyncio.CancelledError:

--- a/services/web/server/src/simcore_service_webserver/config/server-defaults.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-defaults.yaml
@@ -22,7 +22,6 @@ db:
     database: simcoredb
     endpoint: postgres:5432
     host: postgres
-    long_running_session_host: postgres
     maxsize: 5
     minsize: 1
     password: simcore

--- a/services/web/server/src/simcore_service_webserver/config/server-docker-dev.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-docker-dev.yaml
@@ -29,8 +29,8 @@ db:
     password: ${POSTGRES_PASSWORD}
     host: ${POSTGRES_HOST}
     port: ${POSTGRES_PORT}
-    minsize: 10
-    maxsize: 100
+    minsize: 1
+    maxsize: 50
 resource_manager:
   enabled: True
   resource_deletion_timeout_seconds: ${WEBSERVER_RESOURCES_DELETION_TIMEOUT_SECONDS}

--- a/services/web/server/src/simcore_service_webserver/config/server-docker-dev.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-docker-dev.yaml
@@ -28,7 +28,6 @@ db:
     user: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
     host: ${POSTGRES_HOST}
-    long_running_session_host: ${POSTGRES_LONG_RUNNING_SESSION_HOST}
     port: ${POSTGRES_PORT}
     minsize: 10
     maxsize: 100

--- a/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
@@ -29,8 +29,8 @@ db:
     password: ${POSTGRES_PASSWORD}
     host: ${POSTGRES_HOST}
     port: ${POSTGRES_PORT}
-    minsize: 10
-    maxsize: 100
+    minsize: 1
+    maxsize: 50
 resource_manager:
   enabled: True
   resource_deletion_timeout_seconds: ${WEBSERVER_RESOURCES_DELETION_TIMEOUT_SECONDS}

--- a/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
+++ b/services/web/server/src/simcore_service_webserver/config/server-docker-prod.yaml
@@ -28,7 +28,6 @@ db:
     user: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
     host: ${POSTGRES_HOST}
-    long_running_session_host: ${POSTGRES_LONG_RUNNING_SESSION_HOST}
     port: ${POSTGRES_PORT}
     minsize: 10
     maxsize: 100

--- a/services/web/server/src/simcore_service_webserver/login/module_setup.py
+++ b/services/web/server/src/simcore_service_webserver/login/module_setup.py
@@ -38,7 +38,6 @@ async def _setup_config_and_pgpool(app: web.Application):
         min_size=db_cfg["minsize"],
         max_size=db_cfg["maxsize"],
         loop=asyncio.get_event_loop(),
-        statement_cache_size=0,  # necessary for usage with pgbouncer
     )
 
     storage = AsyncpgStorage(pool)  # NOTE: this key belongs to cfg, not settings!

--- a/services/web/server/tests/integration/01/test_exporter.py
+++ b/services/web/server/tests/integration/01/test_exporter.py
@@ -62,7 +62,6 @@ pytest_simcore_core_services_selection = [
     "director",
     "director-v2",
     "postgres",
-    "pgbouncer",
     "storage",
 ]
 pytest_simcore_ops_services_selection = ["minio"]

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -42,7 +42,6 @@ log = logging.getLogger(__name__)
 
 pytest_simcore_core_services_selection = [
     "postgres",
-    "pgbouncer",
     "redis",
     "storage",
 ]

--- a/services/web/server/tests/integration/01/test_project_workflow.py
+++ b/services/web/server/tests/integration/01/test_project_workflow.py
@@ -41,7 +41,6 @@ pytest_simcore_core_services_selection = [
     "catalog",
     "director",
     "postgres",
-    "pgbouncer",
     "redis",
 ]
 

--- a/services/web/server/tests/integration/02/test_computation.py
+++ b/services/web/server/tests/integration/02/test_computation.py
@@ -52,7 +52,6 @@ pytest_simcore_core_services_selection = [
     "director",
     "director-v2",
     "postgres",
-    "pgbouncer",
     "sidecar",
     "storage",
 ]

--- a/services/web/server/tests/integration/02/test_rabbit.py
+++ b/services/web/server/tests/integration/02/test_rabbit.py
@@ -33,7 +33,6 @@ API_VERSION = "v0"
 # Selection of core and tool services started in this swarm fixture (integration)
 pytest_simcore_core_services_selection = [
     "postgres",
-    "pgbouncer",
     "redis",
     "rabbit",
 ]

--- a/services/web/server/tests/integration/conftest.py
+++ b/services/web/server/tests/integration/conftest.py
@@ -97,9 +97,6 @@ def webserver_environ(
         if "ports" in simcore_docker_compose["services"][name]
     ]
     for name in services_with_published_ports:
-        if name == "pgbouncer":
-            # skip it since pgbouncer wraps postgres and uses the same envs
-            continue
         host_key = f"{name.upper().replace('-', '_')}_HOST"
         port_key = f"{name.upper().replace('-', '_')}_PORT"
 
@@ -113,12 +110,6 @@ def webserver_environ(
         published_port = get_service_published_port(name, int(environ.get(port_key)))
         environ[host_key] = "127.0.0.1"
         environ[port_key] = published_port
-        if name == "postgres":
-            # special case for postgres
-            assert (
-                "POSTGRES_LONG_RUNNING_SESSION_HOST" in environ
-            ), "POSTGRES_LONG_RUNNING_SESSION_HOST is missing from .env"
-            environ["POSTGRES_LONG_RUNNING_SESSION_HOST"] = "127.0.0.1"
 
     pprint(environ)  # NOTE: displayed only if error
     return environ

--- a/services/web/server/tests/unit/with_dbs/config-devel.yml
+++ b/services/web/server/tests/unit/with_dbs/config-devel.yml
@@ -14,7 +14,6 @@ db:
     database: test
     endpoint: 127.0.0.1:5432
     host: 127.0.0.1
-    long_running_session_host: 127.0.0.1
     maxsize: 5
     minsize: 1
     password: admin

--- a/services/web/server/tests/unit/with_dbs/config.yaml
+++ b/services/web/server/tests/unit/with_dbs/config.yaml
@@ -20,7 +20,6 @@ db:
     user: admin
     password: admin
     host: 127.0.0.1
-    long_running_session_host: 127.0.0.1
     port: 5432
     maxsize: 5
     minsize: 1

--- a/tests/swarm-deploy/test_swarm_runs.py
+++ b/tests/swarm-deploy/test_swarm_runs.py
@@ -38,7 +38,6 @@ docker_compose_service_names = [
     "webserver",
     "rabbit",
     "postgres",
-    "pgbouncer",
     "redis",
     "traefik",
     "whoami",


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- since the pgbouncer experiment failed (adds complexity, unknown errors, etc. I decided to remove it and increase the number of clients in the postgresql instead)
- increase clients in postgresql to 413 like in AWS
- each service maxsize is set to 50 (api-server, catalog, director-v2, storage, webserver), sidecar has max 4
- as most of these long running mostly idle connections, it might be ok.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)


should help with #2012 
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
