### PR TITLE
BugFix: Fixes env_prefix for director2 in api-server

### DIFF
--- a/services/api-server/.env-devel
+++ b/services/api-server/.env-devel
@@ -34,4 +34,4 @@ CATALOG_HOST=catalog
 STORAGE_HOST=storage
 
 # director
-DIRECTO2_HOST=director-v2
+DIRECTOR_V2_HOST=director-v2

--- a/services/api-server/src/simcore_service_api_server/core/settings.py
+++ b/services/api-server/src/simcore_service_api_server/core/settings.py
@@ -60,7 +60,7 @@ class DirectorV2Settings(BaseServiceSettings):
     vtag: str = "v2"
 
     class Config(_CommonConfig):
-        env_prefix = "DIRECTOR2_"
+        env_prefix = "DIRECTOR_V2_"
 
 
 class PGSettings(PostgresSettings):


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

``osparc-ops-environments`` repo defines host variable as ``DIRECTOR_V2_HOST`` in ``services/simcore/.env`` and api-server could not capture it so it could not communicate with the director-v2 service.


## Related issue/s

Fixes error ``service not found`` in api-server when queried solvers resources

## How to test

``/v0/status`` should return all services healty

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
