### PR TITLE
 WIP:  🏗️ maintenance: /health and /status entrypoints

### DIFF
--- a/api/specs/common/schemas/health_check.yaml
+++ b/api/specs/common/schemas/health_check.yaml
@@ -10,16 +10,13 @@ components:
         error:
           nullable: true
           default: null
-          
+
     HealthCheckType:
       type: object
       properties:
         name:
           type: string
           example: director service
-        status:
-          type: string
-          example: SERVICE_RUNNING
         api_version:
           type: string
           example: 1.0.0-dev

--- a/api/specs/storage/openapi.yaml
+++ b/api/specs/storage/openapi.yaml
@@ -496,15 +496,12 @@ components:
       properties:
         name:
           type: string
-        status:
-          type: string
         api_version:
           type: string
         version:
           type: string
       example:
         name: "simcore-director-service"
-        status: SERVICE_RUNNING
         api_version: 0.1.0-dev+NJuzzD9S
         version: 0.1.0-dev+N127Mfv9H
 

--- a/api/specs/webserver/components/schemas/health_check.yaml
+++ b/api/specs/webserver/components/schemas/health_check.yaml
@@ -15,14 +15,11 @@ HealthCheckType:
   properties:
     name:
       type: string
-    status:
-      type: string
     api_version:
       type: string
     version:
       type: string
   example:
     name: 'simcore-director-service'
-    status: SERVICE_RUNNING
     api_version: 0.1.0-dev+NJuzzD9S
     version: 0.1.0-dev+N127Mfv9H

--- a/packages/models-library/src/models_library/api_schemas_storage.py
+++ b/packages/models-library/src/models_library/api_schemas_storage.py
@@ -19,7 +19,6 @@ from .basic_regex import UUID_RE
 # /
 class HealthCheck(BaseModel):
     name: Optional[str]
-    status: Optional[str]
     api_version: Optional[str]
     version: Optional[str]
 

--- a/packages/service-library/tests/data/oas3/components/schemas/health_check.yaml
+++ b/packages/service-library/tests/data/oas3/components/schemas/health_check.yaml
@@ -10,16 +10,13 @@ HealthCheckEnveloped:
       type: object
       nullable: true
       default: null
-      
+
 HealthCheckType:
   type: object
   properties:
     name:
       type: string
       example: director service
-    status:
-      type: string
-      example: SERVICE_RUNNING
     api_version:
       type: string
       example: 1.0.0-dev

--- a/packages/service-library/tests/data/oas3/enveloped_responses.yaml
+++ b/packages/service-library/tests/data/oas3/enveloped_responses.yaml
@@ -159,9 +159,6 @@ components:
         name:
           type: string
           example: director service
-        status:
-          type: string
-          example: SERVICE_RUNNING
         api_version:
           type: string
           example: 1.0.0-dev

--- a/packages/service-library/tests/tutils.py
+++ b/packages/service-library/tests/tutils.py
@@ -20,7 +20,6 @@ class Handlers:
         out = {
             "name": __name__.split(".")[0],
             "version": "1.0",
-            "status": "SERVICE_RUNNING",
             "invalid_entry": 125,
         }
         return out
@@ -29,7 +28,6 @@ class Handlers:
         out = {
             "name": __name__.split(".")[0],
             "version": "1.0",
-            "status": "SERVICE_RUNNING",
             "api_version": "1.0",
         }
         return out

--- a/services/director/src/simcore_service_director/rest/handlers.py
+++ b/services/director/src/simcore_service_director/rest/handlers.py
@@ -21,7 +21,6 @@ async def root_get(
 
     service_health = dict(
         name=distb.project_name,
-        status="SERVICE_RUNNING",
         api_version=api_dict["info"]["version"],
         version=distb.version,
     )

--- a/services/director/tests/test_handlers.py
+++ b/services/director/tests/test_handlers.py
@@ -42,7 +42,6 @@ async def test_root_get(loop, client, api_version_prefix):
 
     healthcheck = healthcheck_enveloped["data"]
     assert healthcheck["name"] == "simcore-service-director"
-    assert healthcheck["status"] == "SERVICE_RUNNING"
     assert healthcheck["version"] == "0.1.0"
     assert healthcheck["api_version"] == "0.1.0"
 

--- a/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
+++ b/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
@@ -484,15 +484,12 @@ components:
       properties:
         name:
           type: string
-        status:
-          type: string
         api_version:
           type: string
         version:
           type: string
       example:
         name: simcore-director-service
-        status: SERVICE_RUNNING
         api_version: 0.1.0-dev+NJuzzD9S
         version: 0.1.0-dev+N127Mfv9H
     ErrorEnveloped:

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -70,15 +70,12 @@ paths:
                     properties:
                       name:
                         type: string
-                      status:
-                        type: string
                       api_version:
                         type: string
                       version:
                         type: string
                     example:
                       name: simcore-director-service
-                      status: SERVICE_RUNNING
                       api_version: 0.1.0-dev+NJuzzD9S
                       version: 0.1.0-dev+N127Mfv9H
                   error:
@@ -188,15 +185,12 @@ paths:
                     properties:
                       name:
                         type: string
-                      status:
-                        type: string
                       api_version:
                         type: string
                       version:
                         type: string
                     example:
                       name: simcore-director-service
-                      status: SERVICE_RUNNING
                       api_version: 0.1.0-dev+NJuzzD9S
                       version: 0.1.0-dev+N127Mfv9H
                   error:

--- a/services/web/server/src/simcore_service_webserver/diagnostics_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics_handlers.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging
 from contextlib import suppress
+from typing import Any, Dict
 
 from aiohttp import ClientError, ClientSession, web
 from models_library.app_diagnostics import AppStatusCheck
@@ -73,7 +74,7 @@ async def get_app_status(request: web.Request):
 
     def _get_client_session_info():
         client: ClientSession = get_client_session(request.app)
-        info = {"instance": str(client)}
+        info: Dict[str, Any] = {"instance": str(client)}
 
         if not client.closed:
             info.update(

--- a/services/web/server/src/simcore_service_webserver/rest_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/rest_handlers.py
@@ -5,7 +5,6 @@
 import logging
 
 from aiohttp import web
-
 from servicelib.application_keys import APP_CONFIG_KEY
 from servicelib.rest_responses import wrap_as_envelope
 from servicelib.rest_utils import body_to_dict, extract_and_validate
@@ -26,7 +25,6 @@ async def check_running(_request: web.Request):
     data = {
         "name": __name__.split(".")[0],
         "version": str(__version__),
-        "status": "SERVICE_RUNNING",
         "api_version": str(__version__),
     }
     return data

--- a/tests/public-api/examples/sleeper.py
+++ b/tests/public-api/examples/sleeper.py
@@ -62,9 +62,9 @@ with osparc.ApiClient(cfg) as api_client:
         solver.version,
         JobInputs(
             {
-                "input_3": 0,
-                "input_2": 3.0,
-                "input_1": input_file,
+                "input_3": False,  # If true, service will fail after sleep
+                "input_2": 3.0,  # Amount of time-sleep
+                "input_1": input_file,  # File containing only one integer
             }
         ),
     )


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

Standardize *health* and *status* entrypoints throughout all services in osparc

- service **health** check
   - TODO: define
      - Used by swarm/front-end/nginx/trafik  to determine services health
      - Includes time snapshot (since response MUST NOT be cached!) 
      - Response SHALL NOT be [cached](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
      - MUST be fast and const-time response
   - paths: ``/`` or ``/health``
   - anonymous access
- service **meta** data
   - TODO: define
      - Includes all distribution metadata  (i.e. as defined in``setup.py``) 
   -  paths: ``/meta``
   - login required?  
   - full info with tester-access and limited as anonymous
- service **status** check
   - .. TODO: define
   - paths: ``/status``, ``/status/{service_name}``, ``/status/diagnostics`` 
   - full info tester-access and limited as anonymous


```
 "Health": {
        "Status": "healthy",
        "FailingStreak": 0,
        "Log": [
          {
            "Start": "2021-04-20T01:22:31.882407709+02:00",
            "End": "2021-04-20T01:22:32.071672643+02:00",
            "ExitCode": 0,
            "Output": "/var/run/postgresql:5432 - accepting connections\n"
          },
          {
            "Start": "2021-04-20T01:22:47.077467315+02:00",
            "End": "2021-04-20T01:22:47.249253063+02:00",
            "ExitCode": 0,
            "Output": "/var/run/postgresql:5432 - accepting connections\n"
          },
          {
            "Start": "2021-04-20T01:23:02.255140862+02:00",
            "End": "2021-04-20T01:23:02.39851453+02:00",
            "ExitCode": 0,
            "Output": "/var/run/postgresql:5432 - accepting connections\n"
          },
          {
            "Start": "2021-04-20T01:23:17.404124031+02:00",
            "End": "2021-04-20T01:23:17.577356481+02:00",
            "ExitCode": 0,
            "Output": "/var/run/postgresql:5432 - accepting connections\n"
          },
          {
            "Start": "2021-04-20T01:23:32.584734376+02:00",
            "End": "2021-04-20T01:23:32.753396149+02:00",
            "ExitCode": 0,
            "Output": "/var/run/postgresql:5432 - accepting connections\n"
          }
        ]
      }
```


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

- [ ] ``is_responsive`` functions 
    - [ ] pg
    - [ ] minio (https://docs.min.io/docs/minio-monitoring-guide.html)
    - [ ] redis 
- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Add ``api/routes/health.py, status.py, meta.py`` in pcrespov/cookiecutter-simcore-py-fastapi
- [ ] See how much of this concept #1728 can be achieved with this approach
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
