### PR TITLE
Minor fix on diagnistics settings

### DIFF
--- a/services/web/server/src/simcore_service_webserver/diagnostics.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics.py
@@ -46,7 +46,7 @@ def setup_diagnostics(
     # Aims to identify possible blocking calls
     #
     if slow_duration_secs is None:
-        slow_duration_secs = float(os.environ.get("AIODEBUG_SLOW_DURATION_SECS", 0.3))
+        slow_duration_secs = float(os.environ.get("AIODEBUG_SLOW_DURATION_SECS", 1.0))
     else:
         settings_kwargs["slow_duration_secs"] = slow_duration_secs
 

--- a/services/web/server/src/simcore_service_webserver/diagnostics.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics.py
@@ -103,10 +103,10 @@ def setup_diagnostics(
     # -----
 
     # TODO: redesign ... too convoluted!!
-    registry = IncidentsRegistry(order_by=attrgetter("delay_secs"))
-    app[kINCIDENTS_REGISTRY] = registry
+    incidents_registry = IncidentsRegistry(order_by=attrgetter("delay_secs"))
+    app[kINCIDENTS_REGISTRY] = incidents_registry
 
-    monitor_slow_callbacks.enable(max_task_delay, registry)
+    monitor_slow_callbacks.enable(slow_duration_secs, incidents_registry)
 
     # adds middleware and /metrics
     setup_monitoring(app)

--- a/services/web/server/src/simcore_service_webserver/diagnostics_config.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics_config.py
@@ -3,16 +3,15 @@
 from typing import Dict
 
 from aiohttp.web import Application
-from pydantic import BaseSettings, Field, PositiveFloat, validator
-
-from servicelib.application_keys import APP_CONFIG_KEY
 from models_library.basic_types import NonNegativeFloat
+from pydantic import BaseSettings, Field, PositiveFloat, validator
+from servicelib.application_keys import APP_CONFIG_KEY
 
 
 class DiagnosticsSettings(BaseSettings):
 
     slow_duration_secs: PositiveFloat = Field(
-        0.3,
+        1.0,
         description=(
             "Any task blocked more than slow_duration_secs is logged as WARNING"
             "Aims to identify possible blocking calls"


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

Variable setting the time threshold for slow callbacks was wrong. This is set by ``AIODEBUG_SLOW_DURATION_SECS`` which defaults to 1 seconds. 

How does this work? If an async task in the loop blocks more than``AIODEBUG_SLOW_DURATION_SECS`` then a warning is logged in the console. This allows us to detect blocking of tasks by sync calls.

It should help to answer why traffik qualifies the webserver as unhealth on his 1secs periodic checks

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
