### PR TITLE
Two lines max for Study Title card

### DIFF
--- a/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonBase.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonBase.js
@@ -99,6 +99,9 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonBase", {
             margin: [5, 0],
             font: "title-14",
             maxWidth: this.self().ITEM_WIDTH - 2*this.self().PADDING - osparc.dashboard.StudyBrowserButtonItem.MENU_BTN_WIDTH,
+            maxHeight: 34, // two lines
+            rich: true,
+            wrap: true,
             breakWithinWords: true
           });
           this._mainLayout.addAt(control, this.self().POS.TITLE);


### PR DESCRIPTION
## What do these changes do?
2 lines for the title and text wrapping:
![image](https://user-images.githubusercontent.com/33152403/116099641-74da9580-a6ac-11eb-8231-c2b25f01e725.png)

## Related issue/s
closes https://github.com/ITISFoundation/osparc-issues/issues/447


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
