### PR TITLE
e2e: wait for all templates

### DIFF
--- a/services/web/client/source/class/osparc/dashboard/ExploreBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/ExploreBrowser.js
@@ -175,6 +175,7 @@ qx.Class.define("osparc.dashboard.ExploreBrowser", {
       const tempStudyLayout = this.__createButtonsLayout(this.tr("Templates"), templateStudyContainer);
 
       const loadingTemplatesBtn = this._loadingStudiesBtn = new osparc.dashboard.StudyBrowserButtonLoadMore();
+      osparc.utils.Utils.setIdToWidget(loadingTemplatesBtn, "templatesLoading");
       templateStudyContainer.add(loadingTemplatesBtn);
 
       templateStudyContainer.addListener("changeVisibility", e => {

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -180,6 +180,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       userStudyContainer.add(newStudyButton);
 
       const loadingStudiesBtn = this._loadingStudiesBtn = new osparc.dashboard.StudyBrowserButtonLoadMore();
+      osparc.utils.Utils.setIdToWidget(loadingStudiesBtn, "studiesLoading");
       userStudyContainer.add(loadingStudiesBtn);
 
       osparc.utils.Utils.setIdToWidget(userStudyContainer, "userStudiesList");

--- a/tests/e2e/utils/auto.js
+++ b/tests/e2e/utils/auto.js
@@ -120,6 +120,15 @@ async function toDashboard(page) {
   await utils.waitAndClick(page, '[osparc-test-id="confirmDashboardBtn"]');
 }
 
+async function waitForAllTemplates(page) {
+  await page.waitForSelector('[osparc-test-id="templateStudiesList"]');
+  let loadingTemplatesCardVisible = true;
+  while(loadingTemplatesCardVisible) {
+    const childrenIDs = await utils.getVisibleChildrenIDs(page, '[osparc-test-id="templateStudiesList"]');
+    loadingTemplatesCardVisible = childrenIDs.some('[osparc-test-id="templatesLoading"]');
+  }
+}
+
 async function dashboardOpenFirstTemplate(page, templateName) {
   // Returns true if template is found
   console.log("Creating New Study from template");
@@ -130,7 +139,9 @@ async function dashboardOpenFirstTemplate(page, templateName) {
     await __filterTemplatesByText(page, templateName);
   }
 
-  await page.waitForSelector('[osparc-test-id="templateStudiesList"]')
+  await this.waitForAllTemplates(page);
+
+  await page.waitForSelector('[osparc-test-id="templateStudiesList"]');
   const children = await utils.getVisibleChildrenIDs(page, '[osparc-test-id="templateStudiesList"]');
 
   if (children.length) {
@@ -358,6 +369,7 @@ module.exports = {
   dashboardDataBrowser,
   dashboardStudyBrowser,
   dashboardNewStudy,
+  waitForAllTemplates,
   dashboardOpenFirstTemplate,
   dashboardOpenFirstService,
   showLogger,

--- a/tests/e2e/utils/auto.js
+++ b/tests/e2e/utils/auto.js
@@ -125,7 +125,7 @@ async function waitForAllTemplates(page) {
   let loadingTemplatesCardVisible = true;
   while(loadingTemplatesCardVisible) {
     const childrenIDs = await utils.getVisibleChildrenIDs(page, '[osparc-test-id="templateStudiesList"]');
-    loadingTemplatesCardVisible = childrenIDs.some('[osparc-test-id="templatesLoading"]');
+    loadingTemplatesCardVisible = childrenIDs.some(childrenID => childrenID.includes("templatesLoading"));
   }
 }
 


### PR DESCRIPTION
## What do these changes do?
e2e: Wait until all templates reach the frontend before starting one.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
