### PR TITLE
Hotfix: Fix/validation diagnostics

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -117,18 +117,18 @@ services:
     image: ${DOCKER_REGISTRY:-itisfoundation}/webserver:${DOCKER_IMAGE_TAG:-latest}
     init: true
     environment:
+      - CATALOG_HOST=${CATALOG_HOST:-catalog}
+      - CATALOG_PORT=${CATALOG_PORT:-8000}
+      - DIAGNOSTICS_MAX_AVG_LATENCY=10
+      - DIAGNOSTICS_MAX_TASK_DELAY=30
       - DIRECTOR_HOST=${DIRECTOR_HOST:-director}
       - DIRECTOR_PORT=${DIRECTOR_PORT:-8080}
       - DIRECTOR_V2_HOST=${DIRECTOR_V2_HOST:-director-v2}
       - DIRECTOR_V2_PORT=${DIRECTOR_V2_PORT:-8000}
       - STORAGE_HOST=${STORAGE_HOST:-storage}
       - STORAGE_PORT=${STORAGE_PORT:-8080}
-      - CATALOG_HOST=${CATALOG_HOST:-catalog}
-      - CATALOG_PORT=${CATALOG_PORT:-8000}
       - SWARM_STACK_NAME=${SWARM_STACK_NAME:-simcore}
       - WEBSERVER_LOGLEVEL=${LOG_LEVEL:-WARNING}
-      - DIAGNOSTICS_MAX_DELAY_SECS=30
-      - DIAGNOSTICS_MAX_AVG_LATENCY=10
     env_file:
       - ../.env
     deploy:

--- a/services/web/server/src/simcore_service_webserver/diagnostics_config.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics_config.py
@@ -32,11 +32,12 @@ class DiagnosticsSettings(BaseSettings):
     start_sensing_delay: NonNegativeFloat = 60.0
 
     @validator("max_task_delay", pre=True)
+    @classmethod
     def validate_max_task_delay(cls, v, values):
-        slow_duration_secs = values["slow_duration_secs"]
+        slow_duration_secs = float(values["slow_duration_secs"])
         return max(
             10 * slow_duration_secs,
-            v,
+            float(v),
         )  # secs
 
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

Fixes validation function for ``DiagnosticsSettings.max_task_delay``.  The variable failed when set using ``DIAGNOSTICS_MAX_TASK_DELAY`` environment variable. 

Now ``DIAGNOSTICS_MAX_TASK_DELAY=30`` secs


###  HOTFIX in production NEEDED after testing this fix in dev.
  - Probably cause for frequent restart of web-server in production
  - Currently production defaults ``DiagnosticsSettings.max_task_delay`` to 3 secs (after fixing #2288) which marks the webserver as un-healthy after a request takes more than 3 secs !!


## Related issue/s

- #2288
-  Frequent restart of web-server in production