### PR TITLE
e2e: fix delete study

### DIFF
--- a/tests/e2e/utils/auto.js
+++ b/tests/e2e/utils/auto.js
@@ -254,14 +254,23 @@ async function deleteFirstStudy(page, studyName) {
 
   await page.waitForSelector('[osparc-test-id="userStudiesList"]')
   const children = await utils.getVisibleChildrenIDs(page, '[osparc-test-id="userStudiesList"]');
+
+  // filter out the cards that are not studies
+  [
+    "newStudyBtn",
+    "studiesLoading"
+  ].forEach(notAStudy => {
+    const idx = children.indexOf(notAStudy);
+    if (idx > -1) {
+      children.splice(idx, 1);
+    }
+  });
   if (children.length === 0) {
     console.log("Deleting first Study: no study found");
     return;
   }
-  let studyCardId = children[0];
-  if (studyCardId === "newStudyBtn") {
-    studyCardId = children[1];
-  }
+
+  const studyCardId = children[0];
   const firstChildId = '[osparc-test-id="' + studyCardId + '"]';
   const studyCardStyle = await utils.getStyle(page, firstChildId);
   if (studyCardStyle.cursor === "not-allowed") {

--- a/tests/e2e/utils/auto.js
+++ b/tests/e2e/utils/auto.js
@@ -267,7 +267,7 @@ async function deleteFirstStudy(page, studyName) {
   });
   if (children.length === 0) {
     console.log("Deleting first Study: no study found");
-    return;
+    return false;
   }
 
   const studyCardId = children[0];


### PR DESCRIPTION
## What do these changes do?

Fix: the first study puppeteer was trying to delete could be the "Loading studies card"