### PR TITLE
🏗️ updates dependencies for testing/tooling + examples scripts

### DIFF
--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -53,7 +53,7 @@ multidict==5.1.0
     # via
     #   aiohttp
     #   yarl
-openapi-core==0.14.0
+openapi-core==0.14.1
     # via -r requirements.in
 openapi-schema-validator==0.1.5
     # via

--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -51,7 +51,7 @@ multidict==5.1.0
     # via
     #   aiohttp
     #   yarl
-openapi-core==0.13.7
+openapi-core==0.13.8
     # via -r requirements.in
 openapi-schema-validator==0.1.5
     # via
@@ -81,7 +81,7 @@ pytest-instafail==0.4.2
     # via -r requirements.in
 pytest-sugar==0.9.4
     # via -r requirements.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements.in
     #   pytest-aiohttp
@@ -103,7 +103,7 @@ termcolor==1.1.0
     # via pytest-sugar
 toml==0.10.2
     # via pytest
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   aiohttp
     #   importlib-metadata

--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -22,6 +22,8 @@ coverage==5.5
     # via
     #   -r requirements.in
     #   pytest-cov
+dataclasses==0.8
+    # via werkzeug
 dictpath==0.1.3
     # via openapi-core
 idna-ssl==1.1.0
@@ -59,7 +61,7 @@ openapi-schema-validator==0.1.5
     # via
     #   openapi-core
     #   openapi-spec-validator
-openapi-spec-validator==0.3.0
+openapi-spec-validator==0.3.1
     # via openapi-core
 packaging==20.9
     # via
@@ -110,7 +112,7 @@ typing-extensions==3.10.0.0
     #   aiohttp
     #   importlib-metadata
     #   yarl
-werkzeug==1.0.1
+werkzeug==2.0.0
     # via openapi-core
 yarl==1.6.3
     # via aiohttp

--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -10,7 +10,7 @@ aiohttp==3.7.4.post0
     #   pytest-aiohttp
 async-timeout==3.0.1
     # via aiohttp
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   aiohttp
     #   jsonschema
@@ -22,6 +22,8 @@ coverage==5.5
     # via
     #   -r requirements.in
     #   pytest-cov
+dictpath==0.1.3
+    # via openapi-core
 idna-ssl==1.1.0
     # via aiohttp
 idna==3.1
@@ -51,7 +53,7 @@ multidict==5.1.0
     # via
     #   aiohttp
     #   yarl
-openapi-core==0.13.8
+openapi-core==0.14.0
     # via -r requirements.in
 openapi-schema-validator==0.1.5
     # via
@@ -92,7 +94,7 @@ pyyaml==5.4.1
     # via
     #   -c ../../requirements/constraints.txt
     #   openapi-spec-validator
-six==1.15.0
+six==1.16.0
     # via
     #   isodate
     #   jsonschema

--- a/api/tests/test_against_openapi_core.py
+++ b/api/tests/test_against_openapi_core.py
@@ -12,8 +12,7 @@ from pathlib import Path
 import openapi_core
 import pytest
 import yaml
-from openapi_core.schema.specs.models import Spec as OpenApiSpec
-
+from openapi_core.spec.paths import SpecPath as OpenApiSpec
 from utils import list_all_openapi
 
 

--- a/packages/models-library/requirements/_base.txt
+++ b/packages/models-library/requirements/_base.txt
@@ -16,5 +16,5 @@ idna==2.10
     #   email-validator
 pydantic[email]==1.8.1
     # via -r requirements/_base.in
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via pydantic

--- a/packages/models-library/requirements/_base.txt
+++ b/packages/models-library/requirements/_base.txt
@@ -14,7 +14,7 @@ idna==2.10
     # via
     #   -r requirements/_base.in
     #   email-validator
-pydantic[email]==1.8.1
+pydantic[email]==1.8.2
     # via -r requirements/_base.in
 typing-extensions==3.10.0.0
     # via pydantic

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -6,7 +6,7 @@
 #
 aiohttp==3.7.4.post0
     # via pytest-aiohttp
-astroid==2.5.3
+astroid==2.5.6
     # via pylint
 async-timeout==3.0.1
     # via aiohttp
@@ -71,7 +71,7 @@ pprintpp==0.4.0
     # via pytest-icdiff
 py==1.10.0
     # via pytest
-pylint==2.7.4
+pylint==2.8.2
     # via -r requirements/_test.in
 pyparsing==2.4.7
     # via packaging
@@ -83,13 +83,13 @@ pytest-icdiff==0.5
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.5.1
+pytest-mock==3.6.0
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
@@ -112,7 +112,7 @@ toml==0.10.2
     #   pytest
 typed-ast==1.4.3
     # via astroid
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -44,7 +44,7 @@ importlib-metadata==4.0.1
     #   pint
     #   pluggy
     #   pytest
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via pint
 iniconfig==1.1.1
     # via pytest

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -10,7 +10,7 @@ astroid==2.5.6
     # via pylint
 async-timeout==3.0.1
     # via aiohttp
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   aiohttp
     #   pytest
@@ -83,7 +83,7 @@ pytest-icdiff==0.5
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.0
+pytest-mock==3.6.1
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in

--- a/packages/models-library/requirements/_tools.txt
+++ b/packages/models-library/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt

--- a/packages/models-library/requirements/_tools.txt
+++ b/packages/models-library/requirements/_tools.txt
@@ -62,7 +62,7 @@ pyyaml==5.4.1
     #   pre-commit
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via virtualenv
 toml==0.10.2
     # via
@@ -80,7 +80,7 @@ typing-extensions==3.10.0.0
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 zipp==3.4.1
     # via

--- a/packages/models-library/requirements/_tools.txt
+++ b/packages/models-library/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -74,13 +74,13 @@ typed-ast==1.4.3
     # via
     #   -c requirements/_test.txt
     #   black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
 zipp==3.4.1
     # via

--- a/packages/models-library/requirements/_tools.txt
+++ b/packages/models-library/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.2.0
     # via pre-commit
-click==7.1.2
+click==8.0.0
     # via
     #   black
     #   pip-tools
@@ -34,7 +34,7 @@ importlib-metadata==4.0.1
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   -c requirements/_test.txt
     #   pre-commit

--- a/packages/postgres-database/requirements/_base.txt
+++ b/packages/postgres-database/requirements/_base.txt
@@ -16,7 +16,7 @@ sqlalchemy[postgresql_psycopg2binary]==1.3.24
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via yarl
 yarl==1.6.3
     # via -r requirements/_base.in

--- a/packages/postgres-database/requirements/_migration.txt
+++ b/packages/postgres-database/requirements/_migration.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_migration.txt requirements/_migration.in
 #
-alembic==1.6.0
+alembic==1.6.2
     # via -r requirements/_migration.in
 certifi==2020.12.5
     # via requests
@@ -32,7 +32,7 @@ python-editor==1.0.4
     # via alembic
 requests==2.25.1
     # via docker
-six==1.15.0
+six==1.16.0
     # via
     #   python-dateutil
     #   tenacity

--- a/packages/postgres-database/requirements/_migration.txt
+++ b/packages/postgres-database/requirements/_migration.txt
@@ -10,7 +10,7 @@ certifi==2020.12.5
     # via requests
 chardet==4.0.0
     # via requests
-click==7.1.2
+click==8.0.0
     # via -r requirements/_migration.in
 docker==5.0.0
     # via -r requirements/_migration.in
@@ -20,7 +20,7 @@ idna==2.10
     #   requests
 mako==1.1.4
     # via alembic
-markupsafe==1.1.1
+markupsafe==2.0.0
     # via mako
 psycopg2-binary==2.8.6
     # via

--- a/packages/postgres-database/requirements/_migration.txt
+++ b/packages/postgres-database/requirements/_migration.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_migration.txt requirements/_migration.in
 #
-alembic==1.5.8
+alembic==1.6.0
     # via -r requirements/_migration.in
 certifi==2020.12.5
     # via requests
@@ -17,7 +17,6 @@ docker==5.0.0
 idna==2.10
     # via
     #   -c requirements/_base.txt
-    #   -r requirements/_migration.in
     #   requests
 mako==1.1.4
     # via alembic
@@ -50,5 +49,5 @@ urllib3==1.26.4
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_migration.in
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via docker

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -154,7 +154,7 @@ requests==2.25.1
     #   coveralls
     #   docker
     #   docker-compose
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_migration.txt
     #   bcrypt

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -65,7 +65,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.2
+faker==8.1.3
     # via -r requirements/_test.in
 idna-ssl==1.1.0
     # via aiohttp

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -65,7 +65,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.3
+faker==8.1.4
     # via -r requirements/_test.in
 idna-ssl==1.1.0
     # via aiohttp

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -8,7 +8,7 @@ aiohttp==3.7.4.post0
     # via pytest-aiohttp
 aiopg[sa]==1.2.1
     # via -r requirements/_test.in
-astroid==2.5.3
+astroid==2.5.6
     # via pylint
 async-timeout==3.0.1
     # via
@@ -65,7 +65,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.0
+faker==8.1.2
     # via -r requirements/_test.in
 idna-ssl==1.1.0
     # via aiohttp
@@ -112,7 +112,7 @@ py==1.10.0
     # via pytest
 pycparser==2.20
     # via cffi
-pylint==2.7.4
+pylint==2.8.2
     # via -r requirements/_test.in
 pynacl==1.4.0
     # via paramiko
@@ -130,7 +130,7 @@ pytest-instafail==0.4.2
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
@@ -141,7 +141,7 @@ python-dateutil==2.8.1
     # via
     #   -c requirements/_migration.txt
     #   faker
-python-dotenv==0.17.0
+python-dotenv==0.17.1
     # via docker-compose
 pyyaml==5.4.1
     # via
@@ -179,7 +179,7 @@ toml==0.10.2
     #   pytest
 typed-ast==1.4.3
     # via astroid
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -190,7 +190,7 @@ urllib3==1.26.4
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_migration.txt
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via
     #   -c requirements/_migration.txt
     #   docker

--- a/packages/postgres-database/requirements/_tools.txt
+++ b/packages/postgres-database/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt

--- a/packages/postgres-database/requirements/_tools.txt
+++ b/packages/postgres-database/requirements/_tools.txt
@@ -59,7 +59,7 @@ pyyaml==5.4.1
     #   pre-commit
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_test.txt
     #   virtualenv
@@ -79,7 +79,7 @@ typing-extensions==3.10.0.0
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 zipp==3.4.1
     # via

--- a/packages/postgres-database/requirements/_tools.txt
+++ b/packages/postgres-database/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -73,13 +73,13 @@ typed-ast==1.4.3
     # via
     #   -c requirements/_test.txt
     #   black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
 zipp==3.4.1
     # via

--- a/packages/postgres-database/requirements/_tools.txt
+++ b/packages/postgres-database/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.2.0
     # via pre-commit
-click==7.1.2
+click==8.0.0
     # via
     #   black
     #   pip-tools
@@ -32,7 +32,7 @@ importlib-metadata==4.0.1
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_pylint.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_pylint.py
@@ -1,8 +1,8 @@
 """ Helps with running Pylint tests on different modules """
-import subprocess
-import re
-from pathlib import Path
 import os
+import re
+import subprocess
+from pathlib import Path
 
 AUTODETECT = 0
 MATCH = re.compile(r"pdb.set_trace()")
@@ -19,12 +19,14 @@ def assert_pylint_is_passing(pylintrc, package_dir, number_of_jobs: int = AUTODE
             " "
         )
     )
-    pipes = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    std_out, _ = pipes.communicate()
-    if pipes.returncode != 0:
-        assert (
-            False
-        ), f"Pylint failed with error\nExit code {pipes.returncode}\n{std_out.decode('utf-8')}"
+    with subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    ) as process:
+        std_out, _ = process.communicate()
+        if process.returncode != 0:
+            assert (
+                False
+            ), f"Pylint failed with error\nExit code {process.returncode}\n{std_out.decode('utf-8')}"
 
 
 def assert_no_pdb_in_code(code_dir: Path):

--- a/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
@@ -1,9 +1,9 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
 import asyncio
 import json
-
-# pylint:disable=unused-variable
-# pylint:disable=unused-argument
-# pylint:disable=redefined-outer-name
 import logging
 import socket
 from typing import Any, Dict, Optional, Tuple
@@ -11,7 +11,6 @@ from typing import Any, Dict, Optional, Tuple
 import aio_pika
 import pytest
 import tenacity
-
 from models_library.settings.rabbit import RabbitConfig
 
 from .helpers.utils_docker import get_service_published_port
@@ -89,7 +88,7 @@ async def rabbit_channel(
         if exc:
             pytest.fail("rabbit channel closed!")
         else:
-            print("sender was %s", sender)
+            print("sender was '{sender}'")
 
     # create channel
     channel = await rabbit_connection.channel(publisher_confirms=False)

--- a/packages/service-integration/requirements/_base.txt
+++ b/packages/service-integration/requirements/_base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_base.txt requirements/_base.in
 #
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   jsonschema
     #   pytest
@@ -57,7 +57,7 @@ pyyaml==5.4.1
     #   -r requirements/_base.in
 requests==2.25.1
     # via docker
-six==1.15.0
+six==1.16.0
     # via
     #   jsonschema
     #   websocket-client

--- a/packages/service-integration/requirements/_base.txt
+++ b/packages/service-integration/requirements/_base.txt
@@ -12,7 +12,7 @@ certifi==2020.12.5
     # via requests
 chardet==4.0.0
     # via requests
-click==7.1.2
+click==8.0.0
     # via -r requirements/_base.in
 dataclasses==0.8
     # via pydantic
@@ -42,7 +42,7 @@ pluggy==0.13.1
     # via pytest
 py==1.10.0
     # via pytest
-pydantic[email]==1.8.1
+pydantic[email]==1.8.2
     # via -r requirements/../../../packages/models-library/requirements/_base.in
 pyparsing==2.4.7
     # via packaging

--- a/packages/service-integration/requirements/_base.txt
+++ b/packages/service-integration/requirements/_base.txt
@@ -48,7 +48,7 @@ pyparsing==2.4.7
     # via packaging
 pyrsistent==0.17.3
     # via jsonschema
-pytest==6.2.3
+pytest==6.2.4
     # via -r requirements/_base.in
 pyyaml==5.4.1
     # via
@@ -63,7 +63,7 @@ six==1.15.0
     #   websocket-client
 toml==0.10.2
     # via pytest
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   importlib-metadata
     #   pydantic
@@ -72,7 +72,7 @@ urllib3==1.26.4
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via docker
 zipp==3.4.1
     # via importlib-metadata

--- a/packages/service-integration/requirements/_test.txt
+++ b/packages/service-integration/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt requirements/_test.in
 #
-astroid==2.5.3
+astroid==2.5.6
     # via pylint
 attrs==20.3.0
     # via
@@ -59,7 +59,7 @@ py==1.10.0
     # via
     #   -c requirements/_base.txt
     #   pytest
-pylint==2.7.4
+pylint==2.8.2
     # via -r requirements/_test.in
 pyparsing==2.4.7
     # via
@@ -73,7 +73,7 @@ pytest-runner==5.3.0
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -93,7 +93,7 @@ toml==0.10.2
     #   pytest
 typed-ast==1.4.3
     # via astroid
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   importlib-metadata

--- a/packages/service-integration/requirements/_test.txt
+++ b/packages/service-integration/requirements/_test.txt
@@ -6,7 +6,7 @@
 #
 astroid==2.5.6
     # via pylint
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -c requirements/_base.txt
     #   pytest

--- a/packages/service-integration/requirements/_tools.txt
+++ b/packages/service-integration/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt

--- a/packages/service-integration/requirements/_tools.txt
+++ b/packages/service-integration/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -78,13 +78,13 @@ typed-ast==1.4.3
     # via
     #   -c requirements/_test.txt
     #   black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
 zipp==3.4.1
     # via

--- a/packages/service-integration/requirements/_tools.txt
+++ b/packages/service-integration/requirements/_tools.txt
@@ -63,7 +63,7 @@ pyyaml==5.4.1
     #   pre-commit
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   virtualenv
@@ -84,7 +84,7 @@ typing-extensions==3.10.0.0
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 zipp==3.4.1
     # via

--- a/packages/service-integration/requirements/_tools.txt
+++ b/packages/service-integration/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.2.0
     # via pre-commit
-click==7.1.2
+click==8.0.0
     # via
     #   -c requirements/_base.txt
     #   black
@@ -36,7 +36,7 @@ importlib-metadata==4.0.1
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/packages/service-library/requirements/_base.in
+++ b/packages/service-library/requirements/_base.in
@@ -22,7 +22,14 @@ sqlalchemy
 psycopg2-binary
 pyyaml
 
-# There are incompatible versions in the resolved dependencies:
+
+# These are limitations introduced by testing libraries
+
 #   idna==3.1 (from -c requirements/_base.txt (line 35))
 #   idna<3,>=2.5 (from requests==2.25.1->coveralls==3.0.1->-r requirements/_test.in (line 24))
 idna<3,>=2.5
+
+
+ # attrs>=19.2.0 (from pytest==6.2.4->-r requirements/_test.in (line 13))
+ # attrs<21,>=19 (from pytest-docker==0.10.1
+ attrs<21,>=19.2.0

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -97,7 +97,7 @@ tenacity==7.0.0
     # via -r requirements/_base.in
 trafaret==2.1.0
     # via -r requirements/_base.in
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   aiohttp
     #   importlib-metadata

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -29,7 +29,9 @@ attrs==20.3.0
 chardet==4.0.0
     # via aiohttp
 dataclasses==0.8
-    # via pydantic
+    # via
+    #   pydantic
+    #   werkzeug
 idna-ssl==1.1.0
     # via aiohttp
 idna==2.10
@@ -60,7 +62,7 @@ openapi-core==0.12.0
     # via -r requirements/_base.in
 openapi-schema-validator==0.1.5
     # via openapi-spec-validator
-openapi-spec-validator==0.3.0
+openapi-spec-validator==0.3.1
     # via openapi-core
 prometheus-client==0.10.1
     # via -r requirements/_base.in
@@ -69,7 +71,7 @@ psycopg2-binary==2.8.6
     #   -r requirements/_base.in
     #   aiopg
     #   sqlalchemy
-pydantic==1.8.1
+pydantic==1.8.2
     # via -r requirements/_base.in
 pyrsistent==0.17.3
     # via jsonschema
@@ -105,7 +107,7 @@ typing-extensions==3.10.0.0
     #   yarl
 ujson==4.0.2
     # via -r requirements/_base.in
-werkzeug==1.0.1
+werkzeug==2.0.0
     # via -r requirements/_base.in
 yarl==1.6.3
     # via aiohttp

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -20,7 +20,7 @@ async-timeout==3.0.1
     # via
     #   aiohttp
     #   aiopg
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -r requirements/_base.in
     #   aiohttp
@@ -78,7 +78,7 @@ pyyaml==5.4.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
     #   openapi-spec-validator
-six==1.15.0
+six==1.16.0
     # via
     #   isodate
     #   jsonschema

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -20,7 +20,7 @@ async-timeout==3.0.1
     # via
     #   aiohttp
     #   aiopg
-attrs==21.2.0
+attrs==20.3.0
     # via
     #   -r requirements/_base.in
     #   aiohttp

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -8,7 +8,7 @@ aiohttp==3.7.4.post0
     # via
     #   -c requirements/_base.txt
     #   pytest-aiohttp
-astroid==2.5.3
+astroid==2.5.6
     # via pylint
 async-timeout==3.0.1
     # via
@@ -109,7 +109,7 @@ py==1.10.0
     # via pytest
 pycparser==2.20
     # via cffi
-pylint==2.7.4
+pylint==2.8.2
     # via -r requirements/_test.in
 pynacl==1.4.0
     # via paramiko
@@ -127,13 +127,13 @@ pytest-docker==0.10.1
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.5.1
+pytest-mock==3.6.0
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
@@ -142,7 +142,7 @@ pytest==6.2.3
     #   pytest-instafail
     #   pytest-mock
     #   pytest-sugar
-python-dotenv==0.17.0
+python-dotenv==0.17.1
     # via docker-compose
 pyyaml==5.4.1
     # via
@@ -172,7 +172,7 @@ toml==0.10.2
     #   pytest
 typed-ast==1.4.3
     # via astroid
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -182,7 +182,7 @@ urllib3==1.26.4
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -127,7 +127,7 @@ pytest-docker==0.10.1
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.0
+pytest-mock==3.6.1
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
@@ -154,7 +154,7 @@ requests==2.25.1
     #   coveralls
     #   docker
     #   docker-compose
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   bcrypt

--- a/packages/service-library/requirements/_tools.txt
+++ b/packages/service-library/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt

--- a/packages/service-library/requirements/_tools.txt
+++ b/packages/service-library/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.2.0
     # via pre-commit
-click==7.1.2
+click==8.0.0
     # via
     #   black
     #   pip-tools
@@ -35,7 +35,7 @@ importlib-metadata==4.0.1
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/packages/service-library/requirements/_tools.txt
+++ b/packages/service-library/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -78,13 +78,13 @@ typed-ast==1.4.3
     # via
     #   -c requirements/_test.txt
     #   black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
 zipp==3.4.1
     # via

--- a/packages/service-library/requirements/_tools.txt
+++ b/packages/service-library/requirements/_tools.txt
@@ -63,7 +63,7 @@ pyyaml==5.4.1
     #   pre-commit
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -84,7 +84,7 @@ typing-extensions==3.10.0.0
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 zipp==3.4.1
     # via

--- a/packages/service-library/src/servicelib/rest_pagination_utils.py
+++ b/packages/service-library/src/servicelib/rest_pagination_utils.py
@@ -13,48 +13,6 @@ from pydantic import (
 from yarl import URL
 
 
-def monkey_patch_pydantic_url_regex() -> None:
-    # waiting for PR https://github.com/samuelcolvin/pydantic/pull/2512 to be released into
-    # pydantic main codebase
-    import pydantic
-
-    if pydantic.VERSION > "1.8.1":
-        raise RuntimeError(
-            (
-                "Please check that PR https://github.com/samuelcolvin/pydantic/pull/2512 "
-                "was merged. If already present in this version, remove this monkey_patch"
-            )
-        )
-
-    from typing import Pattern
-    from pydantic import networks
-    import re
-
-    def url_regex() -> Pattern[str]:
-        _url_regex_cache = networks._url_regex_cache  # pylint: disable=protected-access
-        if _url_regex_cache is None:
-            _url_regex_cache = re.compile(
-                r"(?:(?P<scheme>[a-z][a-z0-9+\-.]+)://)?"  # scheme https://tools.ietf.org/html/rfc3986#appendix-A
-                r"(?:(?P<user>[^\s:/]*)(?::(?P<password>[^\s/]*))?@)?"  # user info
-                r"(?:"
-                r"(?P<ipv4>(?:\d{1,3}\.){3}\d{1,3})(?=$|[/:#?])|"  # ipv4
-                r"(?P<ipv6>\[[A-F0-9]*:[A-F0-9:]+\])(?=$|[/:#?])|"  # ipv6
-                r"(?P<domain>[^\s/:?#]+)"  # domain, validation occurs later
-                r")?"
-                r"(?::(?P<port>\d+))?"  # port
-                r"(?P<path>/[^\s?#]*)?"  # path
-                r"(?:\?(?P<query>[^\s#]+))?"  # query
-                r"(?:#(?P<fragment>\S+))?",  # fragment
-                re.IGNORECASE,
-            )
-        return _url_regex_cache
-
-    networks.url_regex = url_regex
-
-
-monkey_patch_pydantic_url_regex()
-
-
 class PageMetaInfoLimitOffset(BaseModel):
     limit: PositiveInt
     total: NonNegativeInt

--- a/packages/service-library/src/servicelib/rest_pagination_utils.py
+++ b/packages/service-library/src/servicelib/rest_pagination_utils.py
@@ -13,6 +13,48 @@ from pydantic import (
 from yarl import URL
 
 
+def monkey_patch_pydantic_url_regex() -> None:
+    # waiting for PR https://github.com/samuelcolvin/pydantic/pull/2512 to be released into
+    # pydantic main codebase
+    import pydantic
+
+    if pydantic.VERSION > "1.8.1":
+        raise RuntimeError(
+            (
+                "Please check that PR https://github.com/samuelcolvin/pydantic/pull/2512 "
+                "was merged. If already present in this version, remove this monkey_patch"
+            )
+        )
+
+    from typing import Pattern
+    from pydantic import networks
+    import re
+
+    def url_regex() -> Pattern[str]:
+        _url_regex_cache = networks._url_regex_cache  # pylint: disable=protected-access
+        if _url_regex_cache is None:
+            _url_regex_cache = re.compile(
+                r"(?:(?P<scheme>[a-z][a-z0-9+\-.]+)://)?"  # scheme https://tools.ietf.org/html/rfc3986#appendix-A
+                r"(?:(?P<user>[^\s:/]*)(?::(?P<password>[^\s/]*))?@)?"  # user info
+                r"(?:"
+                r"(?P<ipv4>(?:\d{1,3}\.){3}\d{1,3})(?=$|[/:#?])|"  # ipv4
+                r"(?P<ipv6>\[[A-F0-9]*:[A-F0-9:]+\])(?=$|[/:#?])|"  # ipv6
+                r"(?P<domain>[^\s/:?#]+)"  # domain, validation occurs later
+                r")?"
+                r"(?::(?P<port>\d+))?"  # port
+                r"(?P<path>/[^\s?#]*)?"  # path
+                r"(?:\?(?P<query>[^\s#]+))?"  # query
+                r"(?:#(?P<fragment>\S+))?",  # fragment
+                re.IGNORECASE,
+            )
+        return _url_regex_cache
+
+    networks.url_regex = url_regex
+
+
+monkey_patch_pydantic_url_regex()
+
+
 class PageMetaInfoLimitOffset(BaseModel):
     limit: PositiveInt
     total: NonNegativeInt

--- a/packages/service-library/src/servicelib/rest_pagination_utils.py
+++ b/packages/service-library/src/servicelib/rest_pagination_utils.py
@@ -18,17 +18,19 @@ def monkey_patch_pydantic_url_regex() -> None:
     # pydantic main codebase
     import pydantic
 
-    if pydantic.VERSION > "1.8.1":
+    if pydantic.VERSION > "1.8.2":
         raise RuntimeError(
             (
                 "Please check that PR https://github.com/samuelcolvin/pydantic/pull/2512 "
-                "was merged. If already present in this version, remove this monkey_patch"
+                "was merged AND added in this version."
+                "If already present in this version, remove this monkey_patch"
             )
         )
 
-    from typing import Pattern
-    from pydantic import networks
     import re
+    from typing import Pattern
+
+    from pydantic import networks
 
     def url_regex() -> Pattern[str]:
         _url_regex_cache = networks._url_regex_cache  # pylint: disable=protected-access

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -38,7 +38,9 @@ attrs==20.3.0
 chardet==4.0.0
     # via aiohttp
 dataclasses==0.8
-    # via pydantic
+    # via
+    #   pydantic
+    #   werkzeug
 decorator==4.4.2
     # via networkx
 dnspython==2.1.0
@@ -80,7 +82,7 @@ openapi-core==0.12.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 openapi-schema-validator==0.1.5
     # via openapi-spec-validator
-openapi-spec-validator==0.3.0
+openapi-spec-validator==0.3.1
     # via openapi-core
 packaging==20.9
     # via -r requirements/_base.in
@@ -92,7 +94,7 @@ psycopg2-binary==2.8.6
     #   -r requirements/_base.in
     #   aiopg
     #   sqlalchemy
-pydantic[email]==1.8.1
+pydantic[email]==1.8.2
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -149,7 +151,7 @@ typing-extensions==3.10.0.0
     #   yarl
 ujson==4.0.2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-werkzeug==1.0.1
+werkzeug==2.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 yarl==1.6.3
     # via

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -28,7 +28,7 @@ async-timeout==3.0.1
     # via
     #   aiohttp
     #   aiopg
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
@@ -110,7 +110,7 @@ pyyaml==5.4.1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   openapi-spec-validator
     #   trafaret-config
-six==1.15.0
+six==1.16.0
     # via
     #   isodate
     #   jsonschema

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -141,7 +141,7 @@ trafaret==2.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   trafaret-config
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   aiohttp
     #   importlib-metadata

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -28,7 +28,7 @@ async-timeout==3.0.1
     # via
     #   aiohttp
     #   aiopg
-attrs==21.2.0
+attrs==20.3.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -21,7 +21,7 @@ async-timeout==3.0.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-attrs==21.2.0
+attrs==20.3.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -48,7 +48,7 @@ docopt==0.6.2
     # via coveralls
 execnet==1.8.0
     # via pytest-xdist
-faker==8.1.2
+faker==8.1.3
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -144,7 +144,6 @@ python-dateutil==2.8.1
     # via
     #   alembic
     #   faker
-    #   minio
 python-dotenv==0.17.1
     # via -r requirements/_test.in
 python-editor==1.0.4

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -11,11 +11,11 @@ aiohttp==3.7.4.post0
     #   pytest-aiohttp
 aioresponses==0.7.2
     # via -r requirements/_test.in
-alembic==1.5.8
+alembic==1.6.0
     # via -r requirements/_test.in
 apipkg==1.5
     # via execnet
-astroid==2.5.3
+astroid==2.5.6
     # via pylint
 async-timeout==3.0.1
     # via
@@ -48,7 +48,7 @@ docopt==0.6.2
     # via coveralls
 execnet==1.8.0
     # via pytest-xdist
-faker==8.1.0
+faker==8.1.2
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -105,7 +105,7 @@ py==1.10.0
     # via
     #   pytest
     #   pytest-forked
-pylint==2.7.4
+pylint==2.8.2
     # via -r requirements/_test.in
 pyparsing==2.4.7
     # via
@@ -121,7 +121,7 @@ pytest-icdiff==0.5
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.5.1
+pytest-mock==3.6.0
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
@@ -129,7 +129,7 @@ pytest-sugar==0.9.4
     # via -r requirements/_test.in
 pytest-xdist==2.2.1
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
@@ -144,7 +144,8 @@ python-dateutil==2.8.1
     # via
     #   alembic
     #   faker
-python-dotenv==0.17.0
+    #   minio
+python-dotenv==0.17.1
     # via -r requirements/_test.in
 python-editor==1.0.4
     # via alembic
@@ -173,7 +174,7 @@ toml==0.10.2
     #   pytest
 typed-ast==1.4.3
     # via astroid
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -184,7 +185,7 @@ urllib3==1.26.4
     #   -c requirements/../../../requirements/constraints.txt
     #   minio
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via docker
 wrapt==1.12.1
     # via astroid

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -48,7 +48,7 @@ docopt==0.6.2
     # via coveralls
 execnet==1.8.0
     # via pytest-xdist
-faker==8.1.3
+faker==8.1.4
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -77,7 +77,7 @@ lazy-object-proxy==1.4.3
     #   astroid
 mako==1.1.4
     # via alembic
-markupsafe==1.1.1
+markupsafe==2.0.0
     # via mako
 mccabe==0.6.1
     # via pylint

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -11,7 +11,7 @@ aiohttp==3.7.4.post0
     #   pytest-aiohttp
 aioresponses==0.7.2
     # via -r requirements/_test.in
-alembic==1.6.0
+alembic==1.6.2
     # via -r requirements/_test.in
 apipkg==1.5
     # via execnet
@@ -21,7 +21,7 @@ async-timeout==3.0.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -121,7 +121,7 @@ pytest-icdiff==0.5
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.0
+pytest-mock==3.6.1
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
@@ -154,7 +154,7 @@ requests==2.25.1
     #   -r requirements/_test.in
     #   coveralls
     #   docker
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.2.0
     # via pre-commit
-click==7.1.2
+click==8.0.0
     # via
     #   black
     #   pip-tools
@@ -35,7 +35,7 @@ importlib-metadata==4.0.1
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -62,7 +62,7 @@ pyyaml==5.4.1
     #   pre-commit
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -83,7 +83,7 @@ typing-extensions==3.10.0.0
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 zipp==3.4.1
     # via

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -77,13 +77,13 @@ typed-ast==1.4.3
     # via
     #   -c requirements/_test.txt
     #   black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
 zipp==3.4.1
     # via

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -85,7 +85,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.2
+faker==8.1.3
     # via -r requirements/_test.in
 h11==0.12.0
     # via

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --output-file=requirements/_test.txt requirements/_test.in
 #
-alembic==1.5.8
+alembic==1.6.0
     # via -r requirements/_test.in
 asgi-lifespan==1.0.1
     # via -r requirements/_test.in
-astroid==2.5.3
+astroid==2.5.6
     # via pylint
 async-exit-stack==1.0.1
     # via
@@ -85,7 +85,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.0
+faker==8.1.2
     # via -r requirements/_test.in
 h11==0.12.0
     # via
@@ -160,7 +160,7 @@ pycparser==2.20
     # via
     #   -c requirements/_base.txt
     #   cffi
-pylint==2.7.4
+pylint==2.8.2
     # via -r requirements/_test.in
 pynacl==1.4.0
     # via paramiko
@@ -178,11 +178,11 @@ pytest-cov==2.11.1
     # via -r requirements/_test.in
 pytest-docker==0.10.1
     # via -r requirements/_test.in
-pytest-mock==3.5.1
+pytest-mock==3.6.0
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio
@@ -266,7 +266,7 @@ urllib3==1.26.4
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt requirements/_test.in
 #
-alembic==1.6.0
+alembic==1.6.2
     # via -r requirements/_test.in
 asgi-lifespan==1.0.1
     # via -r requirements/_test.in
@@ -178,7 +178,7 @@ pytest-cov==2.11.1
     # via -r requirements/_test.in
 pytest-docker==0.10.1
     # via -r requirements/_test.in
-pytest-mock==3.6.0
+pytest-mock==3.6.1
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -85,7 +85,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.3
+faker==8.1.4
     # via -r requirements/_test.in
 h11==0.12.0
     # via

--- a/services/api-server/requirements/_tools.txt
+++ b/services/api-server/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -106,7 +106,7 @@ typing-extensions==3.7.4.3
     #   importlib-metadata
 virtualenv==20.4.6
     # via pre-commit
-watchdog[watchmedo]==2.1.0
+watchdog[watchmedo]==2.1.1
     # via -r requirements/_tools.in
 zipp==3.4.0
     # via

--- a/services/api-server/requirements/_tools.txt
+++ b/services/api-server/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -104,9 +104,9 @@ typing-extensions==3.7.4.3
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
-watchdog[watchmedo]==2.0.3
+watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in
 zipp==3.4.0
     # via

--- a/services/api-server/requirements/_tools.txt
+++ b/services/api-server/requirements/_tools.txt
@@ -104,7 +104,7 @@ typing-extensions==3.7.4.3
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -6,9 +6,9 @@
 #
 aiohttp==3.7.4.post0
     # via pytest-aiohttp
-alembic==1.5.8
+alembic==1.6.0
     # via -r requirements/_test.in
-astroid==2.5.3
+astroid==2.5.6
     # via pylint
 async-generator==1.10 ; python_version < "3.7"
     # via
@@ -80,7 +80,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.0
+faker==8.1.2
     # via -r requirements/_test.in
 h11==0.12.0
     # via
@@ -151,7 +151,7 @@ py==1.10.0
     # via pytest
 pycparser==2.20
     # via cffi
-pylint==2.7.4
+pylint==2.8.2
     # via -r requirements/_test.in
 pynacl==1.4.0
     # via paramiko
@@ -165,11 +165,11 @@ pytest-cov==2.11.1
     # via -r requirements/_test.in
 pytest-docker==0.10.1
     # via -r requirements/_test.in
-pytest-mock==3.5.1
+pytest-mock==3.6.0
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
@@ -244,7 +244,7 @@ urllib3==1.26.4
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -80,7 +80,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.3
+faker==8.1.4
     # via -r requirements/_test.in
 h11==0.12.0
     # via

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -80,7 +80,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.2
+faker==8.1.3
     # via -r requirements/_test.in
 h11==0.12.0
     # via

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -6,7 +6,7 @@
 #
 aiohttp==3.7.4.post0
     # via pytest-aiohttp
-alembic==1.6.0
+alembic==1.6.2
     # via -r requirements/_test.in
 astroid==2.5.6
     # via pylint
@@ -165,7 +165,7 @@ pytest-cov==2.11.1
     # via -r requirements/_test.in
 pytest-docker==0.10.1
     # via -r requirements/_test.in
-pytest-mock==3.6.0
+pytest-mock==3.6.1
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in

--- a/services/catalog/requirements/_tools.txt
+++ b/services/catalog/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -89,7 +89,7 @@ typing-extensions==3.7.4.3
     #   importlib-metadata
 virtualenv==20.4.6
     # via pre-commit
-watchdog[watchmedo]==2.1.0
+watchdog[watchmedo]==2.1.1
     # via -r requirements/_tools.in
 zipp==3.4.1
     # via

--- a/services/catalog/requirements/_tools.txt
+++ b/services/catalog/requirements/_tools.txt
@@ -87,7 +87,7 @@ typing-extensions==3.7.4.3
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in

--- a/services/catalog/requirements/_tools.txt
+++ b/services/catalog/requirements/_tools.txt
@@ -38,7 +38,7 @@ importlib-metadata==4.0.1
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/services/catalog/requirements/_tools.txt
+++ b/services/catalog/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -87,9 +87,9 @@ typing-extensions==3.7.4.3
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
-watchdog[watchmedo]==2.0.3
+watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in
 zipp==3.4.1
     # via

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -116,7 +116,7 @@ docopt==0.6.2
     #   docker-compose
 execnet==1.8.0
     # via pytest-xdist
-faker==8.1.2
+faker==8.1.3
     # via -r requirements/_test.in
 h11==0.12.0
     # via

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -14,7 +14,7 @@ aioredis==1.3.1
     # via -r requirements/_test.in
 aiormq==3.3.1
     # via aio-pika
-alembic==1.6.0
+alembic==1.6.2
     # via -r requirements/_test.in
 amqp==5.0.2
     # via
@@ -217,7 +217,7 @@ pyrsistent==0.17.3
     # via jsonschema
 pytest-aiohttp==0.3.0
     # via -r requirements/_test.in
-pytest-celery==0.0.0a1
+pytest-celery==0.0.0
     # via -r requirements/_test.in
 pytest-cov==2.11.1
     # via -r requirements/_test.in
@@ -227,7 +227,7 @@ pytest-forked==1.3.0
     # via pytest-xdist
 pytest-icdiff==0.5
     # via -r requirements/_test.in
-pytest-mock==3.6.0
+pytest-mock==3.6.1
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -14,7 +14,7 @@ aioredis==1.3.1
     # via -r requirements/_test.in
 aiormq==3.3.1
     # via aio-pika
-alembic==1.5.8
+alembic==1.6.0
     # via -r requirements/_test.in
 amqp==5.0.2
     # via
@@ -22,7 +22,7 @@ amqp==5.0.2
     #   kombu
 apipkg==1.5
     # via execnet
-astroid==2.5.3
+astroid==2.5.6
     # via pylint
 async-generator==1.10 ; python_version < "3.7"
     # via
@@ -116,7 +116,7 @@ docopt==0.6.2
     #   docker-compose
 execnet==1.8.0
     # via pytest-xdist
-faker==8.1.0
+faker==8.1.2
     # via -r requirements/_test.in
 h11==0.12.0
     # via
@@ -207,7 +207,7 @@ py==1.10.0
     #   pytest-forked
 pycparser==2.20
     # via cffi
-pylint==2.7.4
+pylint==2.8.2
     # via -r requirements/_test.in
 pynacl==1.4.0
     # via paramiko
@@ -227,13 +227,13 @@ pytest-forked==1.3.0
     # via pytest-xdist
 pytest-icdiff==0.5
     # via -r requirements/_test.in
-pytest-mock==3.5.1
+pytest-mock==3.6.0
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
 pytest-xdist==2.2.1
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
@@ -328,7 +328,7 @@ wcwidth==0.2.5
     # via
     #   -c requirements/_base.txt
     #   prompt-toolkit
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -116,7 +116,7 @@ docopt==0.6.2
     #   docker-compose
 execnet==1.8.0
     # via pytest-xdist
-faker==8.1.3
+faker==8.1.4
     # via -r requirements/_test.in
 h11==0.12.0
     # via

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -88,7 +88,7 @@ typing-extensions==3.7.4.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -90,7 +90,7 @@ typing-extensions==3.7.4.3
     #   black
 virtualenv==20.4.6
     # via pre-commit
-watchdog[watchmedo]==2.1.0
+watchdog[watchmedo]==2.1.1
     # via -r requirements/_tools.in
 zipp==3.4.0
     # via

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -39,7 +39,7 @@ importlib-metadata==2.0.0
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -88,9 +88,9 @@ typing-extensions==3.7.4.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
-watchdog[watchmedo]==2.0.3
+watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in
 zipp==3.4.0
     # via

--- a/services/dynamic-sidecar/requirements/_test.in
+++ b/services/dynamic-sidecar/requirements/_test.in
@@ -1,4 +1,5 @@
 -c ../../../requirements/constraints.txt
+-c _base.txt
 
 pytest
 pytest-cov

--- a/services/dynamic-sidecar/requirements/_test.txt
+++ b/services/dynamic-sidecar/requirements/_test.txt
@@ -20,7 +20,7 @@ chardet==4.0.0
     #   requests
 coverage==5.5
     # via pytest-cov
-faker==8.1.3
+faker==8.1.4
     # via -r requirements/_test.in
 idna==2.10
     # via

--- a/services/dynamic-sidecar/requirements/_test.txt
+++ b/services/dynamic-sidecar/requirements/_test.txt
@@ -20,7 +20,7 @@ chardet==4.0.0
     #   requests
 coverage==5.5
     # via pytest-cov
-faker==8.1.2
+faker==8.1.3
     # via -r requirements/_test.in
 idna==2.10
     # via

--- a/services/dynamic-sidecar/requirements/_test.txt
+++ b/services/dynamic-sidecar/requirements/_test.txt
@@ -14,7 +14,7 @@ chardet==4.0.0
     # via requests
 coverage==5.5
     # via pytest-cov
-faker==8.1.1
+faker==8.1.2
     # via -r requirements/_test.in
 idna==2.10
     # via requests
@@ -40,7 +40,7 @@ pytest-cov==2.11.1
     # via -r requirements/_test.in
 pytest-mock==3.6.0
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio
@@ -56,7 +56,7 @@ text-unidecode==1.3
     # via faker
 toml==0.10.2
     # via pytest
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via importlib-metadata
 urllib3==1.26.4
     # via

--- a/services/dynamic-sidecar/requirements/_test.txt
+++ b/services/dynamic-sidecar/requirements/_test.txt
@@ -7,25 +7,36 @@
 async-asgi-testclient==1.4.6
     # via -r requirements/_test.in
 attrs==20.3.0
-    # via pytest
+    # via
+    #   -c requirements/_base.txt
+    #   pytest
 certifi==2020.12.5
-    # via requests
+    # via
+    #   -c requirements/_base.txt
+    #   requests
 chardet==4.0.0
-    # via requests
+    # via
+    #   -c requirements/_base.txt
+    #   requests
 coverage==5.5
     # via pytest-cov
 faker==8.1.2
     # via -r requirements/_test.in
 idna==2.10
-    # via requests
+    # via
+    #   -c requirements/_base.txt
+    #   requests
 importlib-metadata==4.0.1
     # via
+    #   -c requirements/_base.txt
     #   pluggy
     #   pytest
 iniconfig==1.1.1
     # via pytest
 multidict==5.1.0
-    # via async-asgi-testclient
+    # via
+    #   -c requirements/_base.txt
+    #   async-asgi-testclient
 packaging==20.9
     # via pytest
 pluggy==0.13.1
@@ -38,7 +49,7 @@ pytest-asyncio==0.15.1
     # via -r requirements/_test.in
 pytest-cov==2.11.1
     # via -r requirements/_test.in
-pytest-mock==3.6.0
+pytest-mock==3.6.1
     # via -r requirements/_test.in
 pytest==6.2.4
     # via
@@ -49,18 +60,27 @@ pytest==6.2.4
 python-dateutil==2.8.1
     # via faker
 requests==2.25.1
-    # via async-asgi-testclient
+    # via
+    #   -c requirements/_base.txt
+    #   async-asgi-testclient
 six==1.15.0
-    # via python-dateutil
+    # via
+    #   -c requirements/_base.txt
+    #   python-dateutil
 text-unidecode==1.3
     # via faker
 toml==0.10.2
     # via pytest
-typing-extensions==3.10.0.0
-    # via importlib-metadata
+typing-extensions==3.7.4.3
+    # via
+    #   -c requirements/_base.txt
+    #   importlib-metadata
 urllib3==1.26.4
     # via
     #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   requests
 zipp==3.4.1
-    # via importlib-metadata
+    # via
+    #   -c requirements/_base.txt
+    #   importlib-metadata

--- a/services/dynamic-sidecar/requirements/_tools.txt
+++ b/services/dynamic-sidecar/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 astroid==2.5.6
     # via pylint
-black==21.5b0
+black==21.5b1
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   -r requirements/_tools.in

--- a/services/dynamic-sidecar/requirements/_tools.txt
+++ b/services/dynamic-sidecar/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 astroid==2.5.6
     # via pylint
-black==21.4b0
+black==21.5b0
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   -r requirements/_tools.in
@@ -69,7 +69,7 @@ pip-tools==6.1.0
     # via -r requirements/../../../requirements/devenv.txt
 pre-commit==2.12.1
     # via -r requirements/../../../requirements/devenv.txt
-pylint==2.8.1
+pylint==2.8.2
     # via -r requirements/_tools.in
 pyyaml==5.4.1
     # via
@@ -102,7 +102,7 @@ typing-extensions==3.7.4.3
     #   black
     #   importlib-metadata
     #   mypy
-virtualenv==20.4.4
+virtualenv==20.4.6
     # via pre-commit
 wrapt==1.12.1
     # via astroid

--- a/services/dynamic-sidecar/requirements/_tools.txt
+++ b/services/dynamic-sidecar/requirements/_tools.txt
@@ -40,7 +40,7 @@ importlib-metadata==4.0.1
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -51,7 +51,7 @@ docker==5.0.0
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
-faker==8.1.2
+faker==8.1.3
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -148,7 +148,6 @@ python-dateutil==2.8.1
     # via
     #   alembic
     #   faker
-    #   minio
 python-dotenv==0.17.1
     # via -r requirements/_test.in
 python-editor==1.0.4

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -14,7 +14,7 @@ aiopg[sa]==1.2.1
     #   -c requirements/_base.txt
     #   -c requirements/_packages.txt
     #   -r requirements/_test.in
-alembic==1.6.0
+alembic==1.6.2
     # via -r requirements/_test.in
 astroid==2.5.6
     # via pylint
@@ -130,7 +130,7 @@ pytest-instafail==0.4.2
     # via -r requirements/_test.in
 pytest-lazy-fixture==0.6.3
     # via -r requirements/_test.in
-pytest-mock==3.6.0
+pytest-mock==3.6.1
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -14,9 +14,9 @@ aiopg[sa]==1.2.1
     #   -c requirements/_base.txt
     #   -c requirements/_packages.txt
     #   -r requirements/_test.in
-alembic==1.5.8
+alembic==1.6.0
     # via -r requirements/_test.in
-astroid==2.5.3
+astroid==2.5.6
     # via pylint
 async-timeout==3.0.1
     # via
@@ -30,7 +30,7 @@ attrs==20.2.0
     #   -c requirements/_packages.txt
     #   aiohttp
     #   pytest
-certifi==2020.6.20
+certifi==2020.12.5
     # via
     #   minio
     #   requests
@@ -51,7 +51,7 @@ docker==5.0.0
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
-faker==8.1.0
+faker==8.1.2
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -114,7 +114,7 @@ ptvsd==4.3.2
     # via -r requirements/_test.in
 py==1.10.0
     # via pytest
-pylint==2.7.4
+pylint==2.8.2
     # via -r requirements/_test.in
 pyparsing==2.4.7
     # via
@@ -130,11 +130,11 @@ pytest-instafail==0.4.2
     # via -r requirements/_test.in
 pytest-lazy-fixture==0.6.3
     # via -r requirements/_test.in
-pytest-mock==3.5.1
+pytest-mock==3.6.0
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
@@ -148,7 +148,8 @@ python-dateutil==2.8.1
     # via
     #   alembic
     #   faker
-python-dotenv==0.17.0
+    #   minio
+python-dotenv==0.17.1
     # via -r requirements/_test.in
 python-editor==1.0.4
     # via alembic
@@ -192,7 +193,7 @@ urllib3==1.26.4
     #   -c requirements/_base.txt
     #   minio
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via docker
 wrapt==1.12.1
     # via astroid

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -51,7 +51,7 @@ docker==5.0.0
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
-faker==8.1.3
+faker==8.1.4
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -83,7 +83,7 @@ lazy-object-proxy==1.4.3
     #   astroid
 mako==1.1.4
     # via alembic
-markupsafe==1.1.1
+markupsafe==2.0.0
     # via mako
 mccabe==0.6.1
     # via pylint

--- a/services/sidecar/requirements/_tools.txt
+++ b/services/sidecar/requirements/_tools.txt
@@ -90,7 +90,7 @@ typing-extensions==3.7.4.3
     #   -c requirements/_packages.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in

--- a/services/sidecar/requirements/_tools.txt
+++ b/services/sidecar/requirements/_tools.txt
@@ -40,7 +40,7 @@ importlib-metadata==2.0.0
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/services/sidecar/requirements/_tools.txt
+++ b/services/sidecar/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -92,7 +92,7 @@ typing-extensions==3.7.4.3
     #   black
 virtualenv==20.4.6
     # via pre-commit
-watchdog[watchmedo]==2.1.0
+watchdog[watchmedo]==2.1.1
     # via -r requirements/_tools.in
 zipp==3.2.0
     # via

--- a/services/sidecar/requirements/_tools.txt
+++ b/services/sidecar/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -90,9 +90,9 @@ typing-extensions==3.7.4.3
     #   -c requirements/_packages.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
-watchdog[watchmedo]==2.0.3
+watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in
 zipp==3.2.0
     # via

--- a/services/sidecar/src/simcore_service_sidecar/log_parser.py
+++ b/services/sidecar/src/simcore_service_sidecar/log_parser.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import re
-import tempfile
+import sys
 from enum import Enum
 from pathlib import Path
 from typing import Awaitable, Callable, Optional, Tuple, Union
@@ -13,6 +13,7 @@ from aiofile import AIOFile, Writer
 from servicelib.logging_utils import log_decorator
 
 from . import exceptions
+from .utils import touch_tmpfile
 
 log = logging.getLogger(__name__)
 
@@ -88,30 +89,25 @@ async def _monitor_docker_container(
 ) -> None:
     # Avoids raising UnboundLocalError: local variable 'log_type' referenced before assignment
     log_type, parsed_line = LogType.INSTRUMENTATION, "Undefined"
-    log_file = out_log_file
-    if not out_log_file:
-        # touch a temp file
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".dat") as file_handler:
-            log_file = Path(file_handler.name)
+    log_file = out_log_file or touch_tmpfile(extension=".dat")
 
-        try:
-            async with AIOFile(str(log_file), "w+") as afp:
-                writer = Writer(afp)
-                async for line in container.log(stdout=True, stderr=True, follow=True):
-                    log_type, parsed_line = await parse_line(line)
-                    await log_cb(log_type, parsed_line)
-                    await writer(f"{log_type.name}: {parsed_line}")
+    try:
+        async with AIOFile(str(log_file), "w+") as afp:
+            writer = Writer(afp)
+            async for line in container.log(stdout=True, stderr=True, follow=True):
+                log_type, parsed_line = await parse_line(line)
+                await log_cb(log_type, parsed_line)
+                await writer(f"{log_type.name}: {parsed_line}")
 
-        except DockerError as e:
-            log_type, parsed_line = await parse_line(
-                f"Could not recover logs because: {e}"
-            )
-            await log_cb(log_type, parsed_line)
+    except DockerError as e:
+        log_type, parsed_line = await parse_line(f"Could not recover logs because: {e}")
+        await log_cb(log_type, parsed_line)
 
-        finally:
-            # clean up
-            if not out_log_file and log_file:
-                log_file.unlink()
+    finally:
+        if not out_log_file and log_file:
+            # TODO: Update missing_ok=True in py3.8
+            assert sys.version_info < (3, 8)  # nosec
+            log_file.unlink()
 
 
 @log_decorator(logger=log)

--- a/services/sidecar/src/simcore_service_sidecar/utils.py
+++ b/services/sidecar/src/simcore_service_sidecar/utils.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
+import tempfile
 import uuid
+from pathlib import Path
 from typing import Awaitable, Optional
 
 import aiodocker
@@ -98,3 +100,12 @@ async def get_volume_mount_point(volume_name: str) -> str:
         raise SidecarException(
             f"docker volume {volume_name} does not contain Mountpoint"
         ) from err
+
+
+def touch_tmpfile(extension=".dat") -> Path:
+    """Creates a temporary file and returns its Path
+
+    WARNING: deletion of file is user's responsibility
+    """
+    with tempfile.NamedTemporaryFile(delete=False, suffix=extension) as file_handler:
+        return Path(file_handler.name)

--- a/services/sidecar/tests/unit/test_utils.py
+++ b/services/sidecar/tests/unit/test_utils.py
@@ -1,0 +1,19 @@
+import tempfile
+from pathlib import Path
+
+from simcore_service_sidecar.utils import touch_tmpfile
+
+
+def test_touch_tmpfile():
+
+    try:
+        some_file = touch_tmpfile(extension=".foo")
+        assert some_file.exists()
+        assert some_file.suffix == ".foo"
+
+        assert Path(tempfile.gettempdir()) == some_file.parent
+
+        some_file.write_text("I can write")
+        assert some_file.read_text() == "I can write"
+    finally:
+        some_file.unlink()

--- a/services/storage/client-sdk/sample.py
+++ b/services/storage/client-sdk/sample.py
@@ -11,13 +11,12 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import simcore_service_storage_sdk
-from simcore_service_storage_sdk import UsersApi, Configuration
+from simcore_service_storage_sdk import Configuration, UsersApi
 from simcore_service_storage_sdk.rest import ApiException
 
-temporary_file = tempfile.NamedTemporaryFile(delete=False)
-temporary_file.close()
-
-temp_file_path = Path(temporary_file.name)
+# This is a trick "touch" a temporary file
+with tempfile.NamedTemporaryFile(delete=False) as file_handle:
+    temp_file_path = Path(file_handle.name)
 temp_file_path.write_text("Hey Klingons, greetings from down here...")
 
 user_id = "test"
@@ -27,50 +26,61 @@ bucket_name = "testbucket"
 project_id = uuid.uuid4()
 node_id = uuid.uuid4()
 file_id = temp_file_path.name
-file_uuid = "{bucket_name}/{project_id}/{node_id}/{file_id}".format(bucket_name=bucket_name, project_id=project_id, node_id=node_id, file_id=file_id)
+file_uuid = "{bucket_name}/{project_id}/{node_id}/{file_id}".format(
+    bucket_name=bucket_name, project_id=project_id, node_id=node_id, file_id=file_id
+)
 
 
 @contextmanager
-def api_client(cfg: simcore_service_storage_sdk.Configuration) -> simcore_service_storage_sdk.ApiClient:
+def api_client(
+    cfg: simcore_service_storage_sdk.Configuration,
+) -> simcore_service_storage_sdk.ApiClient:
     client = simcore_service_storage_sdk.ApiClient(cfg)
     try:
         yield client
     except ApiException as err:
         print("%s\n" % err)
     finally:
-        #NOTE: enforces to closing client session and connector.
+        # NOTE: enforces to closing client session and connector.
         # this is a defect of the sdk
         del client.rest_client
 
 
-async def test_health_check(api:UsersApi):
+async def test_health_check(api: UsersApi):
     res = await api.health_check()
     print("health check:", res)
     assert not res.error
     assert res.data
 
-async def test_get_locations(api:UsersApi):
+
+async def test_get_locations(api: UsersApi):
     res = await api.get_storage_locations(user_id=user_id)
     print("get locations:", res)
     assert not res.error
     assert res.data
 
-async def test_upload_file(api:UsersApi):
-    res = await api.upload_file(location_id=location_id, user_id=user_id, file_id=file_uuid)
+
+async def test_upload_file(api: UsersApi):
+    res = await api.upload_file(
+        location_id=location_id, user_id=user_id, file_id=file_uuid
+    )
     print("upload files:", res)
     assert not res.error
     assert res.data
     assert res.data.link
     upload_link = res.data.link
     # upload file using link
-    with Path(temporary_file.name).open('rb') as fp:
+    with Path(temporary_file.name).open("rb") as fp:
         d = fp.read()
-        req = urllib.request.Request(upload_link, data=d, method='PUT')
+        req = urllib.request.Request(upload_link, data=d, method="PUT")
         with urllib.request.urlopen(req) as _f:
             pass
 
-async def test_download_file(api:UsersApi):
-    res = await api.download_file(location_id=location_id, user_id=user_id, file_id=file_uuid)
+
+async def test_download_file(api: UsersApi):
+    res = await api.download_file(
+        location_id=location_id, user_id=user_id, file_id=file_uuid
+    )
     print("download file:", res)
     assert not res.error
     assert res.data
@@ -83,19 +93,26 @@ async def test_download_file(api:UsersApi):
 
     assert filecmp.cmp(tmp_file2.name, temp_file_path)
 
-async def test_delete_file(api:UsersApi):
-    res = await api.delete_file(location_id=location_id, user_id=user_id, file_id=file_uuid)
+
+async def test_delete_file(api: UsersApi):
+    res = await api.delete_file(
+        location_id=location_id, user_id=user_id, file_id=file_uuid
+    )
     print("delete file:", res)
     assert not res
 
-async def test_get_files_metada(api:UsersApi):
+
+async def test_get_files_metada(api: UsersApi):
     res = await api.get_files_metadata(location_id=location_id, user_id=user_id)
     print("get files metadata:", res)
     assert not res.error
     assert res.data
 
-async def test_get_file_metada(api:UsersApi):
-    res = await api.get_file_metadata(user_id=user_id, location_id=location_id, file_id=file_uuid)
+
+async def test_get_file_metada(api: UsersApi):
+    res = await api.get_file_metadata(
+        user_id=user_id, location_id=location_id, file_id=file_uuid
+    )
     print("get file metadata", res)
     assert not res.error
     assert res.data
@@ -103,11 +120,7 @@ async def test_get_file_metada(api:UsersApi):
 
 async def run_test():
     cfg = Configuration()
-    cfg.host = cfg.host.format(
-        host="localhost",
-        port=11111,
-        basePath="v0"
-    )
+    cfg.host = cfg.host.format(host="localhost", port=11111, basePath="v0")
 
     with api_client(cfg) as client:
         api = UsersApi(client)
@@ -121,11 +134,10 @@ async def run_test():
         await test_delete_file(api)
 
 
-
-
 def main():
     loop = asyncio.get_event_loop()
     loop.run_until_complete(run_test())
+
 
 if __name__ == "__main__":
     main()

--- a/services/storage/client-sdk/sample.py
+++ b/services/storage/client-sdk/sample.py
@@ -70,7 +70,7 @@ async def test_upload_file(api: UsersApi):
     assert res.data.link
     upload_link = res.data.link
     # upload file using link
-    with Path(temporary_file.name).open("rb") as fp:
+    with temp_file_path.open("rb") as fp:
         d = fp.read()
         req = urllib.request.Request(upload_link, data=d, method="PUT")
         with urllib.request.urlopen(req) as _f:
@@ -86,12 +86,11 @@ async def test_download_file(api: UsersApi):
     assert res.data
     assert res.data.link
     download_link = res.data.link
-    # upload file using link
-    tmp_file2 = tempfile.NamedTemporaryFile(delete=False)
-    tmp_file2.close()
-    urllib.request.urlretrieve(download_link, tmp_file2.name)
 
-    assert filecmp.cmp(tmp_file2.name, temp_file_path)
+    # upload file using link
+    with tempfile.NamedTemporaryFile() as tmp_file2:
+        urllib.request.urlretrieve(download_link, tmp_file2.name)
+        assert filecmp.cmp(tmp_file2.name, temp_file_path)
 
 
 async def test_delete_file(api: UsersApi):

--- a/services/storage/requirements/_base.in
+++ b/services/storage/requirements/_base.in
@@ -23,3 +23,7 @@ semantic_version
 click
 minio
 urllib3
+
+#
+# FIXME: pip copiling these requirements wil fail due to incompatible contraints on urllib3 (ongoing in weekely mainteinance)
+#

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -172,7 +172,7 @@ semantic-version==2.8.5
     # via -r requirements/_base.in
 semver==2.13.0
     # via blackfynn
-six==1.15.0
+six==1.16.0
     # via
     #   isodate
     #   jsonschema
@@ -200,7 +200,7 @@ tenacity==7.0.0
     #   -r requirements/_base.in
 trafaret==2.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   aiohttp
     #   aioitertools
@@ -217,7 +217,7 @@ urllib3==1.25.11
     #   botocore
     #   minio
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via blackfynn
 werkzeug==1.0.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -68,7 +68,7 @@ docopt==0.6.2
     #   -c requirements/_base.txt
     #   coveralls
     #   docker-compose
-faker==8.1.1
+faker==8.1.3
     # via -r requirements/_test.in
 idna-ssl==1.1.0
     # via
@@ -141,13 +141,13 @@ pytest-docker==0.10.1
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.0
+pytest-mock==3.6.1
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
@@ -161,7 +161,7 @@ python-dateutil==2.8.1
     #   -c requirements/_base.txt
     #   faker
     #   pandas
-python-dotenv==0.17.0
+python-dotenv==0.17.1
     # via docker-compose
 pytz==2021.1
     # via
@@ -179,7 +179,7 @@ requests==2.25.1
     #   coveralls
     #   docker
     #   docker-compose
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   bcrypt
@@ -200,7 +200,7 @@ toml==0.10.2
     #   pytest
 typed-ast==1.4.3
     # via astroid
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -210,7 +210,7 @@ urllib3==1.25.11
     # via
     #   -c requirements/_base.txt
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via
     #   -c requirements/_base.txt
     #   docker

--- a/services/storage/requirements/_tools.txt
+++ b/services/storage/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==21.4b1
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -67,7 +67,7 @@ pyyaml==5.4.1
     #   watchdog
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -82,15 +82,15 @@ typed-ast==1.4.3
     # via
     #   -c requirements/_test.txt
     #   black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.4
+virtualenv==20.4.6
     # via pre-commit
-watchdog[watchmedo]==2.0.3
+watchdog[watchmedo]==2.1.1
     # via -r requirements/_tools.in
 zipp==3.4.1
     # via

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -11,7 +11,7 @@ aiohttp==3.6.3
     #   pytest-aiohttp
 aioresponses==0.7.2
     # via -r requirements/_test.in
-alembic==1.6.0
+alembic==1.6.2
     # via -r requirements/_test.in
 astroid==2.5
     # via pylint
@@ -171,7 +171,7 @@ pytest-icdiff==0.5
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.0
+pytest-mock==3.6.1
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -78,7 +78,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.3
+faker==8.1.4
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -11,7 +11,7 @@ aiohttp==3.6.3
     #   pytest-aiohttp
 aioresponses==0.7.2
     # via -r requirements/_test.in
-alembic==1.5.8
+alembic==1.6.0
     # via -r requirements/_test.in
 astroid==2.5
     # via pylint
@@ -78,7 +78,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.0
+faker==8.1.2
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -171,13 +171,13 @@ pytest-icdiff==0.5
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.5.1
+pytest-mock==3.6.0
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
@@ -191,7 +191,7 @@ python-dateutil==2.8.1
     # via
     #   alembic
     #   faker
-python-dotenv==0.17.0
+python-dotenv==0.17.1
     # via
     #   -r requirements/_test.in
     #   docker-compose
@@ -255,11 +255,11 @@ urllib3==1.26.4
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-websockets==8.1
+websockets==9.0.1
     # via -r requirements/_test.in
 wrapt==1.12.1
     # via astroid

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -78,7 +78,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.2
+faker==8.1.3
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -88,7 +88,7 @@ typing-extensions==3.7.4.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../../requirements/devenv.txt
@@ -90,7 +90,7 @@ typing-extensions==3.7.4.3
     #   black
 virtualenv==20.4.6
     # via pre-commit
-watchdog[watchmedo]==2.1.0
+watchdog[watchmedo]==2.1.1
     # via -r requirements/_tools.in
 zipp==3.1.0
     # via

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -39,7 +39,7 @@ importlib-metadata==3.1.1
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../../requirements/devenv.txt
@@ -88,9 +88,9 @@ typing-extensions==3.7.4.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
-watchdog[watchmedo]==2.0.3
+watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in
 zipp==3.1.0
     # via

--- a/tests/e2e/requirements/requirements.txt
+++ b/tests/e2e/requirements/requirements.txt
@@ -18,7 +18,7 @@ pyyaml==5.4.1
     #   -r requirements.in
 requests==2.25.1
     # via docker
-six==1.15.0
+six==1.16.0
     # via
     #   tenacity
     #   websocket-client

--- a/tests/e2e/requirements/requirements.txt
+++ b/tests/e2e/requirements/requirements.txt
@@ -28,5 +28,5 @@ urllib3==1.26.4
     # via
     #   -c ../../../requirements/constraints.txt
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via docker

--- a/tests/environment-setup/requirements/requirements.txt
+++ b/tests/environment-setup/requirements/requirements.txt
@@ -8,7 +8,7 @@ aiohttp==3.7.4.post0
     # via pytest-aiohttp
 async-timeout==3.0.1
     # via aiohttp
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   aiohttp
     #   pytest

--- a/tests/environment-setup/requirements/requirements.txt
+++ b/tests/environment-setup/requirements/requirements.txt
@@ -48,7 +48,7 @@ pytest-runner==5.3.0
     # via -r requirements/requirements.in
 pytest-sugar==0.9.4
     # via -r requirements/requirements.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/requirements.in
     #   pytest-aiohttp
@@ -62,7 +62,7 @@ termcolor==1.1.0
     # via pytest-sugar
 toml==0.10.2
     # via pytest
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   aiohttp
     #   importlib-metadata

--- a/tests/performance/requirements/_test.txt
+++ b/tests/performance/requirements/_test.txt
@@ -28,7 +28,7 @@ gevent==21.1.2
     #   locust
 geventhttpclient==1.4.4
     # via locust
-greenlet==1.0.0
+greenlet==1.1.0
     # via gevent
 idna==2.10
     # via requests
@@ -52,7 +52,7 @@ pyzmq==22.0.3
     # via locust
 requests==2.25.1
     # via locust
-six==1.15.0
+six==1.16.0
     # via
     #   geventhttpclient
     #   python-dateutil

--- a/tests/performance/requirements/_test.txt
+++ b/tests/performance/requirements/_test.txt
@@ -10,11 +10,13 @@ certifi==2020.12.5
     #   requests
 chardet==4.0.0
     # via requests
-click==7.1.2
+click==8.0.0
     # via flask
 configargparse==1.4.1
     # via locust
-faker==8.1.3
+dataclasses==0.8
+    # via werkzeug
+faker==8.1.4
     # via -r requirements/_test.in
 flask-basicauth==0.2.0
     # via locust
@@ -32,13 +34,13 @@ greenlet==1.1.0
     # via gevent
 idna==2.10
     # via requests
-itsdangerous==1.1.0
+itsdangerous==2.0.0
     # via flask
-jinja2==2.11.3
+jinja2==3.0.0
     # via flask
-locust==1.5.1
+locust==1.5.2
     # via -r requirements/_test.in
-markupsafe==1.1.1
+markupsafe==2.0.0
     # via jinja2
 msgpack==1.0.2
     # via locust
@@ -60,7 +62,7 @@ text-unidecode==1.3
     # via faker
 urllib3==1.26.4
     # via requests
-werkzeug==1.0.1
+werkzeug==2.0.0
     # via
     #   flask
     #   locust

--- a/tests/performance/requirements/_test.txt
+++ b/tests/performance/requirements/_test.txt
@@ -14,7 +14,7 @@ click==7.1.2
     # via flask
 configargparse==1.4
     # via locust
-faker==8.1.1
+faker==8.1.2
     # via -r requirements/_test.in
 flask-basicauth==0.2.0
     # via locust
@@ -36,7 +36,7 @@ itsdangerous==1.1.0
     # via flask
 jinja2==2.11.3
     # via flask
-locust==1.4.4
+locust==1.5.1
     # via -r requirements/_test.in
 markupsafe==1.1.1
     # via jinja2
@@ -46,7 +46,7 @@ psutil==5.8.0
     # via locust
 python-dateutil==2.8.1
     # via faker
-python-dotenv==0.17.0
+python-dotenv==0.17.1
     # via -r requirements/_test.in
 pyzmq==22.0.3
     # via locust

--- a/tests/performance/requirements/_test.txt
+++ b/tests/performance/requirements/_test.txt
@@ -12,9 +12,9 @@ chardet==4.0.0
     # via requests
 click==7.1.2
     # via flask
-configargparse==1.4
+configargparse==1.4.1
     # via locust
-faker==8.1.2
+faker==8.1.3
     # via -r requirements/_test.in
 flask-basicauth==0.2.0
     # via locust

--- a/tests/performance/requirements/_tools.txt
+++ b/tests/performance/requirements/_tools.txt
@@ -14,13 +14,15 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.2.0
     # via pre-commit
-click==7.1.2
+click==8.0.0
     # via
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
 dataclasses==0.8
-    # via black
+    # via
+    #   -c requirements/_test.txt
+    #   black
 distlib==0.3.1
     # via virtualenv
 filelock==3.0.12
@@ -32,7 +34,7 @@ importlib-metadata==4.0.1
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/tests/performance/requirements/_tools.txt
+++ b/tests/performance/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt

--- a/tests/performance/requirements/_tools.txt
+++ b/tests/performance/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==21.4b2
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -67,11 +67,11 @@ toml==0.10.2
     #   pre-commit
 typed-ast==1.4.3
     # via black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   black
     #   importlib-metadata
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
 zipp==3.4.1
     # via

--- a/tests/performance/requirements/_tools.txt
+++ b/tests/performance/requirements/_tools.txt
@@ -56,7 +56,7 @@ pyyaml==5.4.1
     #   pre-commit
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_test.txt
     #   virtualenv
@@ -71,7 +71,7 @@ typing-extensions==3.10.0.0
     # via
     #   black
     #   importlib-metadata
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 zipp==3.4.1
     # via

--- a/tests/public-api/examples/.gitignore
+++ b/tests/public-api/examples/.gitignore
@@ -1,3 +1,4 @@
 # outputs from scripts
 *.json
 *.txt
+*.ipynb

--- a/tests/public-api/examples/Makefile
+++ b/tests/public-api/examples/Makefile
@@ -1,5 +1,9 @@
 .DEFAULT_GOAL := help
 
+.PHONY: help
+help: ## help on rule's targets
+	@awk --posix 'BEGIN {FS = ":.*?## "} /^[[:alpha:][:space:]_-]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
 
 .env: .env-devel ## creates .env file from defaults in .env-devel
 	$(if $(wildcard $@), \
@@ -10,10 +14,24 @@
 .PHONY: install-ci
 install-ci: ## installs osparc client and dependencies
 	pip install git+https://github.com/ITISFoundation/osparc-simcore-python-client.git
-	pip install python-dotenv
+	pip install python-dotenv jupytext
 
 
-.PHONY: help
+objects = $(wildcard *.py)
+outputs := $(objects:.py=.ipynb)
 
-help: ## help on rule's targets
-	@awk --posix 'BEGIN {FS = ":.*?## "} /^[[:alpha:][:space:]_-]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+%.ipynb: %.py
+	jupytext --to notebook $<
+
+.PHONY: notebooks
+notebooks: $(outputs) ## convert all py scripts inot notebook
+
+
+.PHONY: clean
+_GIT_CLEAN_ARGS = -dxf -e .vscode -e TODO.md
+clean: ## cleans all unversioned files in project and temp files create by this makefile
+	# Cleaning unversioned
+	@git clean -n $(_GIT_CLEAN_ARGS)
+	@echo -n "Are you sure? [y/N] " && read ans && [ $${ans:-N} = y ]
+	@echo -n "$(shell whoami), are you REALLY sure? [y/N] " && read ans && [ $${ans:-N} = y ]
+	@git clean $(_GIT_CLEAN_ARGS)

--- a/tests/public-api/examples/osparc_isolve_api.py
+++ b/tests/public-api/examples/osparc_isolve_api.py
@@ -1,0 +1,192 @@
+import logging
+import os
+import shutil
+import tarfile
+import time
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import osparc
+from EmFdtdSimulator import EmFdtdMultiportSimulation
+from s4l_v1._api.simwrappers import ApiSimulation
+from XSimulator import Simulation, SolverSettings
+
+assert osparc.__version__ == "0.4.3"
+
+HOST = os.environ.get("OSPARC_API_URL", "http://127.0.0.1:8006")
+KEY = os.environ.get("OSPARC_API_KEY")
+SECRET = os.environ.get("OSPARC_API_SECRET")
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# We try to automatically deduce the isolve service that is suited best
+class ISolveType(Enum):
+    cpu = "cpu"
+    gpu = "gpu"
+    mpi = "mpi"
+
+
+def get_isolves(solvers_api: osparc.SolversApi, latest: bool) -> List[osparc.Solver]:
+    solvers: osparc.Solver = (
+        solvers_api.list_solvers() if latest else solvers_api.list_solvers_releases()
+    )
+
+    return [s for s in solvers if "isolve" in s.title]
+
+
+def is_type(solver: osparc.Solver, solver_type: ISolveType) -> bool:
+    if solver_type == ISolveType.cpu:
+        return (
+            ISolveType.mpi.value not in solver.title
+            and ISolveType.gpu.value not in solver.title
+        )
+
+    return solver_type.value in solver.title
+
+
+def get_isolve(
+    solvers_api: osparc.SolversApi, solver_type: ISolveType, version: str
+) -> osparc.Solver:
+    # finds the correct isolve version among all availables
+    use_latest = version == "latest"
+    isolves = get_isolves(solvers_api, use_latest)
+    isolve = next(
+        (
+            solver
+            for solver in isolves
+            if (use_latest or solver.version == version)
+            and is_type(solver, solver_type)
+        ),
+        None,
+    )
+    return isolve
+
+
+def get_solver_type(sim: Simulation) -> ISolveType:
+    run_type = sim.SolverSettings.RunType()
+    if run_type in [SolverSettings.eRunType.kSerial, SolverSettings.eRunType.kShared]:
+        return ISolveType.cpu
+    if run_type in [
+        SolverSettings.eRunType.kDistributed,
+        SolverSettings.eRunType.kHybrid,
+    ]:
+        return ISolveType.mpi
+
+    return ISolveType.gpu
+
+
+def submit_simulation(
+    solvers_api: osparc.SolversApi,
+    files_api: osparc.FilesApi,
+    sim: Simulation,
+    solver_version: str,
+    wait: Optional[bool] = True,
+) -> Tuple[osparc.Job, osparc.JobStatus]:
+    solver_type = get_solver_type(sim)
+    solver: osparc.Solver = get_isolve(solvers_api, solver_type, version=solver_version)
+
+    # the input file if not multiport
+    if isinstance(sim, EmFdtdMultiportSimulation):
+        raise NotImplementedError
+
+    input_1: osparc.File = files_api.upload_file(file=sim.InputFileName(0))
+
+    input_2 = None
+
+    # parallelization
+    nranks = ngpus = None
+    if solver_type == ISolveType.mpi:
+        nranks = sim.SolverSettings.NumberOfProcesses.Value
+        input_2 = nranks
+    elif solver_type == ISolveType.gpu:
+        ngpus = sim.SolverSettings.NumberOfGpus.Value
+        input_2 = ngpus
+
+    job_inputs = {"input_1": input_1}
+    if input_2 is not None:
+        job_inputs.update({"input_2": input_2})
+
+    job = solvers_api.create_job(
+        solver_key=solver.id,
+        version=solver.version,
+        job_inputs=osparc.JobInputs(job_inputs),
+    )
+
+    status: osparc.JobStatus = solvers_api.start_job(solver.id, solver.version, job.id)
+
+    while not status.stopped_at:
+        # For sim4life we can crate CJobProgressInfo and register the job in the taskmanager
+        # However, I think the isolve Progress is not captured correctly in the sidecar.
+        time.sleep(0.5)
+        status: osparc.JobStatus = solvers_api.inspect_job(
+            solver.id, solver.version, job.id
+        )
+
+        logger.info(f"Solver progress: {status.progress}/100")
+
+    def get_results():
+        outputs: osparc.JobOutputs = solvers_api.get_job_outputs(
+            solver.id, solver.version, job.id
+        )
+
+        output_file = outputs.results["output_1"]
+        log_file = outputs.results["output_2"]
+
+        # move the output.h5 to the correct place with the correct filename
+        if not output_file is None and isinstance(output_file, osparc.File):
+            download_file_name: str = files_api.download_file(file_id=output_file.id)
+            destination = sim.OutputFileName(0)
+            shutil.move(download_file_name, destination)
+
+        # move the log to the correct place with the correct filename
+        # TODO: the axware logs will be extracted but not renamed. But then again, who needs them?
+        if not log_file is None and isinstance(log_file, osparc.File):
+            download_file_name: str = files_api.download_file(file_id=log_file.id)
+            destination_path = Path(sim.OutputFileName(0)).parent
+            with tarfile.open(download_file_name, "r") as tar:
+                tar.extractall(destination_path)
+                log_file = destination_path / "input.log"
+                if log_file.exists():
+                    destination_file = destination_path / str(
+                        Path(sim.OutputFileName(0)).stem + ".log"
+                    )
+                    shutil.move(log_file, destination_file)
+
+    logger.info(f"Solver finished with status: {status.state}")
+
+    if status.state == "SUCCESS":
+        get_results()
+
+    return job, status
+
+
+def run_simulation(
+    sim: ApiSimulation,
+    isolve_version: Optional[str] = "latest",
+    *,
+    host: str = HOST,
+    api_key: Optional[str] = KEY,
+    api_secret: Optional[str] = SECRET,
+):  # TODO: version should default to latest
+
+    configuration = osparc.Configuration()
+    configuration.host = host
+    configuration.username = api_key
+    configuration.password = api_secret
+
+    with osparc.ApiClient(configuration) as api_client:
+
+        solvers_api = osparc.SolversApi(api_client)
+        files_api = osparc.FilesApi(api_client)
+
+        _job, _status = submit_simulation(
+            solvers_api, files_api, sim.raw, isolve_version, wait=True
+        )
+
+        logger.info(f"Simulation has results: {sim.HasResults()}")
+        logger.info(
+            f"Results have been written to: {Path(sim.GetOutputFileName()).parent}"
+        )

--- a/tests/public-api/examples/s4l_tutorial.py
+++ b/tests/public-api/examples/s4l_tutorial.py
@@ -1,0 +1,138 @@
+import os
+from pathlib import Path
+
+import s4l_v1
+import s4l_v1.analysis.viewers as viewers
+import s4l_v1.document as document
+import s4l_v1.model as model
+import s4l_v1.simulation.emfdtd as fdtd
+import s4l_v1.units as units
+from dotenv import load_dotenv
+from osparc_isolve_api import run_simulation
+from s4l_v1._api.application import get_app_safe, run_application
+from s4l_v1._api.simwrappers import ApiSimulation
+from s4l_v1.model import Vec3
+
+load_dotenv()
+
+
+HOST = os.environ.get("OSPARC_API_URL", "http://127.0.0.1:8006")
+KEY = os.environ["OSPARC_API_KEY"]
+SECRET = os.environ["OSPARC_API_SECRET"]
+
+
+def create_model():
+    wire = model.CreateWireBlock(
+        p0=Vec3(0, 0, 0), p1=Vec3(100, 100, 100), parametrized=True
+    )
+    wire.Name = "Plane Wave Source"
+
+
+def create_simulation() -> ApiSimulation:
+    # retrieve needed entities from model
+    entities = model.AllEntities()
+
+    source_box = entities["Plane Wave Source"]
+
+    sim = fdtd.Simulation()
+
+    sim.Name = "Plane Wave Simulation"
+    sim.SetupSettings.SimulationTime = 10.0, units.Periods
+
+    # Materials:
+    # No materials
+
+    # Sources
+    planesrc_settings = sim.AddPlaneWaveSourceSettings(source_box)
+    options = planesrc_settings.ExcitationType.enum
+    planesrc_settings.ExcitationType = options.Harmonic
+    planesrc_settings.CenterFrequency = 1.0, units.GHz
+
+    # Sensors
+    # Only using overall field sensor
+
+    # Boundary Conditions
+    options = sim.GlobalBoundarySettings.GlobalBoundaryType.enum
+    sim.GlobalBoundarySettings.GlobalBoundaryType = options.UpmlCpml
+
+    # Grid
+    manual_grid_settings = sim.AddManualGridSettings([source_box])
+    manual_grid_settings.MaxStep = (9.0,) * 3  # model units
+    manual_grid_settings.Resolution = (2.0,) * 3  # model units
+
+    # Voxels
+    auto_voxel_settings = sim.AddAutomaticVoxelerSettings(source_box)
+
+    # Solver settings
+    options = sim.SolverSettings.Kernel.enum
+    # sim.SolverSettings.Kernel = options.Software
+    sim.SolverSettings.Kernel = options.Cuda
+    # FIXME: This does not work. WHY??? sim.SolverSettings.Kernel = options.AXware
+
+    return sim
+
+
+def analyze_simulation(sim):
+    # Create extractor for a given simulation output file
+    results = sim.Results()
+
+    # overall field sensor
+    overall_field_sensor = results["Overall Field"]
+
+    # Create a slice viewer for the E field
+    slice_field_viewer_efield = viewers.SliceFieldViewer()
+    slice_field_viewer_efield.Inputs[0].Connect(overall_field_sensor["EM E(x,y,z,f0)"])
+    slice_field_viewer_efield.Data.Mode = (
+        slice_field_viewer_efield.Data.Mode.enum.QuantityRealPart
+    )
+    slice_field_viewer_efield.Data.Component = (
+        slice_field_viewer_efield.Data.Component.enum.Component0
+    )
+    slice_field_viewer_efield.Slice.Plane = (
+        slice_field_viewer_efield.Slice.Plane.enum.YZ
+    )
+    slice_field_viewer_efield.Update(0)
+    slice_field_viewer_efield.GotoMaxSlice()
+    document.AllAlgorithms.Add(slice_field_viewer_efield)
+
+
+def setup_simulation(smash_path: Path) -> ApiSimulation:
+    s4l_v1.document.New()
+
+    create_model()
+
+    sim = create_simulation()
+
+    s4l_v1.document.AllSimulations.Add(sim)
+    sim.UpdateGrid()
+    sim.CreateVoxels(str(smash_path))
+    sim.WriteInputFile()
+
+    return sim
+
+
+def run(smash_path: Path):
+    sim = setup_simulation(smash_path)
+
+    # run using specific version
+    # run_simulation(sim, isolve_version="2.0.79", host=HOST, api_key=KEY, api_secret=SECRET)
+
+    # run using latest version
+    run_simulation(sim, host=HOST, api_key=KEY, api_secret=SECRET)
+
+    analyze_simulation(sim)
+
+
+def main():
+    if get_app_safe() is None:
+        run_application()
+
+    project_dir = Path()
+    filename = "em_fdtd_simulation.smash"
+    smash_path = project_dir / filename
+
+    run(smash_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/public-api/requirements/_test.txt
+++ b/tests/public-api/requirements/_test.txt
@@ -68,7 +68,7 @@ pyyaml==5.4.1
     #   -r requirements/_test.in
 requests==2.25.1
     # via docker
-rfc3986[idna2008]==1.4.0
+rfc3986[idna2008]==1.5.0
     # via httpx
 six==1.16.0
     # via

--- a/tests/public-api/requirements/_test.txt
+++ b/tests/public-api/requirements/_test.txt
@@ -4,9 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt requirements/_test.in
 #
-async-generator==1.10
-    # via httpx
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   jsonschema
     #   pytest
@@ -72,7 +70,7 @@ requests==2.25.1
     # via docker
 rfc3986[idna2008]==1.4.0
     # via httpx
-six==1.15.0
+six==1.16.0
     # via
     #   jsonschema
     #   tenacity

--- a/tests/public-api/requirements/_test.txt
+++ b/tests/public-api/requirements/_test.txt
@@ -57,12 +57,12 @@ pytest-asyncio==0.15.1
     # via -r requirements/_test.in
 pytest-cov==2.11.1
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio
     #   pytest-cov
-python-dotenv==0.17.0
+python-dotenv==0.17.1
     # via -r requirements/_test.in
 pyyaml==5.4.1
     # via
@@ -85,13 +85,13 @@ tenacity==7.0.0
     # via -r requirements/_test.in
 toml==0.10.2
     # via pytest
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via importlib-metadata
 urllib3==1.26.4
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via docker
 zipp==3.4.1
     # via importlib-metadata

--- a/tests/public-api/requirements/_test.txt
+++ b/tests/public-api/requirements/_test.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements/_test.txt requirements/_test.in
 #
+async-generator==1.10
+    # via httpx
 attrs==21.2.0
     # via
     #   jsonschema
@@ -12,7 +14,7 @@ certifi==2020.12.5
     # via
     #   httpx
     #   requests
-chardet==3.0.4
+chardet==4.0.0
     # via requests
 contextvars==2.4
     # via sniffio

--- a/tests/public-api/requirements/_tools.txt
+++ b/tests/public-api/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -69,12 +69,12 @@ toml==0.10.2
     #   pre-commit
 typed-ast==1.4.3
     # via black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
 zipp==3.4.1
     # via

--- a/tests/public-api/requirements/_tools.txt
+++ b/tests/public-api/requirements/_tools.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt

--- a/tests/public-api/requirements/_tools.txt
+++ b/tests/public-api/requirements/_tools.txt
@@ -57,7 +57,7 @@ pyyaml==5.4.1
     #   pre-commit
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_test.txt
     #   virtualenv
@@ -74,7 +74,7 @@ typing-extensions==3.10.0.0
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 zipp==3.4.1
     # via

--- a/tests/public-api/requirements/_tools.txt
+++ b/tests/public-api/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.2.0
     # via pre-commit
-click==7.1.2
+click==8.0.0
     # via
     #   black
     #   pip-tools
@@ -32,7 +32,7 @@ importlib-metadata==4.0.1
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -45,7 +45,7 @@ async-timeout==3.0.1
     # via
     #   aiohttp
     #   aiopg
-attrs==21.2.0
+attrs==20.3.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -37,7 +37,7 @@ aiozipkin==0.7.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-alembic==1.5.8
+alembic==1.6.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/_test.in
@@ -184,13 +184,13 @@ pytest-cov==2.11.1
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.5.1
+pytest-mock==3.6.0
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
@@ -202,7 +202,8 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   alembic
-python-dotenv==0.17.0
+    #   minio
+python-dotenv==0.17.1
     # via -r requirements/_test.in
 python-editor==1.0.4
     # via
@@ -274,7 +275,7 @@ trafaret==2.1.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   trafaret-config
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   aiohttp
     #   importlib-metadata
@@ -296,7 +297,7 @@ urllib3==1.26.4
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   minio
     #   requests
-websocket-client==0.58.0
+websocket-client==0.59.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   docker

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -64,7 +64,7 @@ chardet==4.0.0
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   aiohttp
     #   requests
-click==7.1.2
+click==8.0.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/_test.in
@@ -73,7 +73,9 @@ coverage==5.5
     #   -r requirements/_test.in
     #   pytest-cov
 dataclasses==0.8
-    # via pydantic
+    # via
+    #   pydantic
+    #   werkzeug
 decorator==4.4.2
     # via networkx
 dnspython==2.1.0
@@ -124,7 +126,7 @@ mako==1.1.4
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   alembic
-markupsafe==1.1.1
+markupsafe==2.0.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   mako
@@ -142,7 +144,7 @@ openapi-core==0.12.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 openapi-schema-validator==0.1.5
     # via openapi-spec-validator
-openapi-spec-validator==0.3.0
+openapi-spec-validator==0.3.1
     # via openapi-core
 packaging==20.9
     # via
@@ -167,7 +169,7 @@ psycopg2-binary==2.8.6
     #   sqlalchemy
 py==1.10.0
     # via pytest
-pydantic[email]==1.8.1
+pydantic[email]==1.8.2
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -300,7 +302,7 @@ websocket-client==0.59.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   docker
-werkzeug==1.0.1
+werkzeug==2.0.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -37,7 +37,7 @@ aiozipkin==0.7.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-alembic==1.6.0
+alembic==1.6.2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/_test.in
@@ -45,7 +45,7 @@ async-timeout==3.0.1
     # via
     #   aiohttp
     #   aiopg
-attrs==20.3.0
+attrs==21.2.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -184,7 +184,7 @@ pytest-cov==2.11.1
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.0
+pytest-mock==3.6.1
     # via -r requirements/_test.in
 pytest-runner==5.3.0
     # via -r requirements/_test.in
@@ -227,7 +227,7 @@ requests==2.25.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   docker
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   isodate

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -202,7 +202,6 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   alembic
-    #   minio
 python-dotenv==0.17.1
     # via -r requirements/_test.in
 python-editor==1.0.4

--- a/tests/swarm-deploy/requirements/_tools.txt
+++ b/tests/swarm-deploy/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==21.5b0
+black==21.5b1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -82,7 +82,7 @@ typing-extensions==3.10.0.0
     #   importlib-metadata
 virtualenv==20.4.6
     # via pre-commit
-watchdog[watchmedo]==2.1.0
+watchdog[watchmedo]==2.1.1
     # via -r requirements/_tools.in
 zipp==3.4.1
     # via

--- a/tests/swarm-deploy/requirements/_tools.txt
+++ b/tests/swarm-deploy/requirements/_tools.txt
@@ -63,7 +63,7 @@ pyyaml==5.4.1
     #   watchdog
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_test.txt
     #   virtualenv
@@ -80,7 +80,7 @@ typing-extensions==3.10.0.0
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.5
+virtualenv==20.4.6
     # via pre-commit
 watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in

--- a/tests/swarm-deploy/requirements/_tools.txt
+++ b/tests/swarm-deploy/requirements/_tools.txt
@@ -16,7 +16,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.2.0
     # via pre-commit
-click==7.1.2
+click==8.0.0
     # via
     #   -c requirements/_test.txt
     #   black
@@ -37,7 +37,7 @@ importlib-metadata==4.0.1
     #   pep517
     #   pre-commit
     #   virtualenv
-importlib-resources==5.1.2
+importlib-resources==5.1.3
     # via
     #   pre-commit
     #   virtualenv

--- a/tests/swarm-deploy/requirements/_tools.txt
+++ b/tests/swarm-deploy/requirements/_tools.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     #   virtualenv
 argh==0.26.2
     # via watchdog
-black==20.8b1
+black==21.5b0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -75,14 +75,14 @@ toml==0.10.2
     #   pre-commit
 typed-ast==1.4.3
     # via black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_test.txt
     #   black
     #   importlib-metadata
-virtualenv==20.4.4
+virtualenv==20.4.5
     # via pre-commit
-watchdog[watchmedo]==2.0.3
+watchdog[watchmedo]==2.1.0
     # via -r requirements/_tools.in
 zipp==3.4.1
     # via


### PR DESCRIPTION
## What do these changes do?

Updates only dependencies used for testing and tooling in the entire repository.

### Highlights
   - MAJOR release of [``click==8.0.0``](https://click.palletsprojects.com/en/8.0.x/changes/#version-8-0-0)
   - MINOR release of ``pylint==2.8.2`` 
       - Detected to some new linter errors e.g. enforces ``with`` statement (i.e. context manager) more
       - @mguidon: See creation of temporary files or pool executors (both now use context managers)
   - MINOR release of [``attrs  21.1``](https://github.com/python-attrs/attrs/releases) but ``pytest-docker`` constraint it to ``<21``
   - PATCH release of [``pytest 6.2.4``](https://github.com/pytest-dev/pytest/releases)
   - PATCH release of [``pydantic 1.8.2``](https://github.com/samuelcolvin/pydantic/releases)
      - Has a vulnerability fix
   - PATCH release of black, faker, ...
   - PATCH release 0f back-port libraries (not relevant when py>3.8)
   - Removed the following constraints on
       - minio in PR #2326 (MAJOR release)
       - respx #2309 (testing httpx)  in PR #2327 (MAJOR release)
       - httpx #2305 (limitation with paths in url?)  in PR #2327 
   - NEW example scripts for API
       - @KZzizzle see new examples with s4l API by @mguidon and how are converted to ipynbs
       
## Related issue/s

weekly maintenance

