### PR TITLE
remove super tight timeout in calling catalog dags endpoints

### DIFF
--- a/services/web/server/src/simcore_service_webserver/catalog_client.py
+++ b/services/web/server/src/simcore_service_webserver/catalog_client.py
@@ -73,9 +73,7 @@ async def make_request_and_envelope_response(
 
     try:
 
-        async with session.request(
-            method, url, headers=headers, data=data, timeout=ClientTimeout()
-        ) as resp:
+        async with session.request(method, url, headers=headers, data=data) as resp:
             payload = await resp.json()
 
             try:

--- a/services/web/server/src/simcore_service_webserver/catalog_client.py
+++ b/services/web/server/src/simcore_service_webserver/catalog_client.py
@@ -74,7 +74,7 @@ async def make_request_and_envelope_response(
     try:
 
         async with session.request(
-            method, url, headers=headers, data=data, timeout=ClientTimeout(total=0.01)
+            method, url, headers=headers, data=data, timeout=ClientTimeout()
         ) as resp:
             payload = await resp.json()
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
PR [#2302](https://github.com/ITISFoundation/osparc-simcore/issues/2302) incorrectly set a super tight timeout for testing purpose and this went into the code by mistake.

This PR sets it back to defaults.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
