### PR TITLE
Bugfix: ensure services outputs are updated in frontend when database restarts

### DIFF
--- a/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
@@ -91,7 +91,7 @@ async def _update_project_outputs(
 
 async def listen(app: web.Application, db_engine: Engine):
     listen_query = f"LISTEN {DB_CHANNEL_NAME};"
-
+    _LISTENING_TASK_BASE_SLEEPING_TIME_S = 1
     async with db_engine.acquire() as conn:
         await conn.execute(listen_query)
 
@@ -102,7 +102,7 @@ async def listen(app: web.Application, db_engine: Engine):
             if conn.closed:
                 raise ConnectionError("connection with database is closed!")
             if conn.connection.notifies.empty():
-                await asyncio.sleep(1)
+                await asyncio.sleep(_LISTENING_TASK_BASE_SLEEPING_TIME_S)
                 continue
             notification = conn.connection.notifies.get_nowait()
             log.debug(

--- a/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/computation_comp_tasks_listening_task.py
@@ -98,6 +98,7 @@ async def listen(app: web.Application, db_engine: Engine):
         while True:
             # NOTE: instead of using await get() we check first if the connection was closed
             # since aiopg does not reset the await in such a case (if DB was restarted or so)
+            # see aiopg issue: https://github.com/aio-libs/aiopg/pull/559#issuecomment-826813082
             if conn.closed:
                 raise ConnectionError("connection with database is closed!")
             if conn.connection.notifies.empty():


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

aiopg has a bug when using the listen/notify pattern with postgres. In case postgres is restarted or unavailable the listening task is not reset see [aiopg issue](https://github.com/aio-libs/aiopg/pull/559#issuecomment-826813082).
Therefore the webserver listening task would stop working in such cases.

the listening pattern was slightly changed to first check if the connection is still open. if not the case then an exception is thrown and the listening task is restarted automatically.


fixes #2246 



## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
