### PR TITLE
  🏗️ maintenance: upgrade minio

### DIFF
--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -35,8 +35,6 @@ chardet==4.0.0
     #   -c requirements/_base.txt
     #   aiohttp
     #   requests
-configparser==5.0.2
-    # via minio
 coverage==5.5
     # via
     #   -r requirements/_test.in
@@ -83,10 +81,8 @@ markupsafe==1.1.1
     # via mako
 mccabe==0.6.1
     # via pylint
-minio==6.0.2
-    # via
-    #   -c requirements/../../../requirements/constraints.txt
-    #   -r requirements/_test.in
+minio==7.0.3
+    # via -r requirements/_test.in
 multidict==5.1.0
     # via
     #   -c requirements/_base.txt
@@ -148,13 +144,10 @@ python-dateutil==2.8.1
     # via
     #   alembic
     #   faker
-    #   minio
 python-dotenv==0.17.0
     # via -r requirements/_test.in
 python-editor==1.0.4
     # via alembic
-pytz==2021.1
-    # via minio
 requests==2.25.1
     # via
     #   -r requirements/_test.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -25,11 +25,6 @@ httpx<0.15.0
 respx<0.13.0
 
 
-# limited by aiobotocore in storage. In addition, pytest_simcore.minio_service uses minio
-# Version 7 changes API! Has Breaking changes TODO: review ASAP
- minio<7.0.0
-
-
 # Keeps all docker compose to the same version. TODO: remove when all synced
 docker-compose==1.29.1
 

--- a/services/sidecar/requirements/_test.txt
+++ b/services/sidecar/requirements/_test.txt
@@ -40,8 +40,6 @@ chardet==3.0.4
     #   -c requirements/_packages.txt
     #   aiohttp
     #   requests
-configparser==5.0.2
-    # via minio
 coverage==5.5
     # via
     #   -r requirements/_test.in
@@ -89,10 +87,8 @@ markupsafe==1.1.1
     # via mako
 mccabe==0.6.1
     # via pylint
-minio==6.0.2
-    # via
-    #   -c requirements/../../../requirements/constraints.txt
-    #   -r requirements/_test.in
+minio==7.0.3
+    # via -r requirements/_test.in
 multidict==4.7.6
     # via
     #   -c requirements/_base.txt
@@ -152,15 +148,10 @@ python-dateutil==2.8.1
     # via
     #   alembic
     #   faker
-    #   minio
 python-dotenv==0.17.0
     # via -r requirements/_test.in
 python-editor==1.0.4
     # via alembic
-pytz==2020.1
-    # via
-    #   -c requirements/_base.txt
-    #   minio
 requests==2.25.1
     # via
     #   coveralls

--- a/services/storage/requirements/_base.in
+++ b/services/storage/requirements/_base.in
@@ -1,14 +1,15 @@
+# WARNING: manually disabled urllib3 contraint to upgrade minio
 -c ../../../requirements/constraints.txt
 
 -r ../../../packages/postgres-database/requirements/_base.in
 -r ../../../packages/service-library/requirements/_base.in
 -r ../../../packages/models-library/requirements/_base.in
 
+-c ./constraints.txt
+
 # These packages introduce incompatible dependencies:
 blackfynn==4.0.0
 aiobotocore==1.0.7
-
--c ./constraints.txt
 
 
 aiohttp

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -64,9 +64,7 @@ chardet==4.0.0
 click==7.1.2
     # via -r requirements/_base.in
 configparser==5.0.2
-    # via
-    #   blackfynn
-    #   minio
+    # via blackfynn
 dataclasses==0.8
     # via pydantic
 deprecated==1.2.12
@@ -99,7 +97,12 @@ isodate==0.6.0
     #   openapi-core
     #   openapi-schema-validator
 jinja2==2.11.3
-    # via aiohttp-swagger
+    # via
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   aiohttp-swagger
 jmespath==0.10.0
     # via
     #   boto3
@@ -117,13 +120,8 @@ markupsafe==1.1.1
     # via
     #   aiohttp-swagger
     #   jinja2
-minio==6.0.2
-    # via
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   -r requirements/_base.in
+minio==7.0.3
+    # via -r requirements/_base.in
 multidict==5.1.0
     # via
     #   aiohttp
@@ -155,11 +153,8 @@ python-dateutil==2.8.1
     # via
     #   blackfynn
     #   botocore
-    #   minio
 pytz==2021.1
-    # via
-    #   blackfynn
-    #   minio
+    # via blackfynn
 pyyaml==5.4.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -218,10 +213,6 @@ ujson==4.0.2
     #   aiohttp-swagger
 urllib3==1.25.11
     # via
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
     #   botocore
     #   minio

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -208,7 +208,6 @@ typing-extensions==3.7.4.3
     #   yarl
 urllib3==1.25.11
     # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   requests
 websocket-client==0.58.0

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -348,7 +348,7 @@ def dsm_mockup_db(
         tests.utils.insert_metadata(postgres_service_url, data[object_name])
 
     total_count = 0
-    for _obj in s3_client.list_objects_v2(bucket_name, recursive=True):
+    for _obj in s3_client.list_objects(bucket_name, recursive=True):
         total_count = total_count + 1
 
     assert total_count == N

--- a/services/storage/tests/s3wrapper/test_minio.py
+++ b/services/storage/tests/s3wrapper/test_minio.py
@@ -19,7 +19,6 @@ def is_responsive(url, code=200):
     return False
 
 
-@pytest.mark.enable_travis
 def test_minio(docker_ip, docker_services):
     """wait for minio to be up"""
 

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -68,8 +68,6 @@ click==7.1.2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/_test.in
-configparser==5.0.2
-    # via minio
 coverage==5.5
     # via
     #   -r requirements/_test.in
@@ -130,16 +128,8 @@ markupsafe==1.1.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   mako
-minio==6.0.2
-    # via
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   -r requirements/_test.in
+minio==7.0.3
+    # via -r requirements/_test.in
 multidict==5.1.0
     # via
     #   aiohttp
@@ -212,15 +202,12 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   alembic
-    #   minio
 python-dotenv==0.17.0
     # via -r requirements/_test.in
 python-editor==1.0.4
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   alembic
-pytz==2021.1
-    # via minio
 pyyaml==5.4.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

Upgrades to latest [minio 7.0.3](https://github.com/minio/minio-py/releases)  
- In a separate PR because this version has API breaking changes
- Affects mainly 
    - storage service: ``services/storage/src/simcore_service_storage/s3wrapper``
    - modules using ``packages/pytest-simcore/src/pytest_simcore/minio_service.py`` test fixtures (i.e. simcore-sdk, storage, tests/swarm-deploy and sidecar``

## Related issue/s

- Removes constraints on minio PR #2318 (storage)
- Part of storage refactorin PR #2276 

## How to test

```console
make devenv
source .venv/bin/activate
cd services/storage
make install-dev
pytest  tests/s3wrapper
```

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes


<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
