### PR TITLE
Bugfix: make listing of S3 objects faster in storage

### DIFF
--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -436,10 +436,13 @@ class DataStorageManager:
             continue_loop = True
             sleep_generator = expo()
             update_succeeded = False
-
+            # Note: the / at the end of the Prefix is VERY important, makes the listing several order of magnitudes faster
+            listing_prefix = (
+                object_name if object_name.endswith("/") else f"{object_name}/"
+            )
             while continue_loop:
                 result = await client.list_objects_v2(
-                    Bucket=bucket_name, Prefix=object_name
+                    Bucket=bucket_name, Prefix=listing_prefix
                 )
                 sleep_amount = next(sleep_generator)
                 continue_loop = current_iteraction <= max_update_retries
@@ -757,8 +760,9 @@ class DataStorageManager:
 
             # Step 1: List all objects for this project replace them with the destination object name
             # and do a copy at the same time collect some names
+            # Note: the / at the end of the Prefix is VERY important, makes the listing several order of magnitudes faster
             response = await client.list_objects_v2(
-                Bucket=self.simcore_bucket_name, Prefix=source_folder
+                Bucket=self.simcore_bucket_name, Prefix=f"{source_folder}/"
             )
 
             for item in response.get("Contents", []):
@@ -821,8 +825,9 @@ class DataStorageManager:
         async with self._create_client_context() as client:
 
             # step 3: list files first to create fmds
+            # Note: the / at the end of the Prefix is VERY important, makes the listing several order of magnitudes faster
             response = await client.list_objects_v2(
-                Bucket=self.simcore_bucket_name, Prefix=dest_folder + "/"
+                Bucket=self.simcore_bucket_name, Prefix=f"{dest_folder}/"
             )
 
             if "Contents" in response:
@@ -946,6 +951,7 @@ class DataStorageManager:
             await conn.execute(delete_me)
 
         async with self._create_client_context() as client:
+            # Note: the / at the end of the Prefix is VERY important, makes the listing several order of magnitudes faster
             response = await client.list_objects_v2(
                 Bucket=self.simcore_bucket_name,
                 Prefix=f"{project_id}/{node_id}/" if node_id else f"{project_id}/",


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?
calling aiobotocore.list_objects_v2 method with a Prefix is several order of magnitudes faster when Prefix is ending with a /

e.g.:
looking for files in of project 0000802f-1e81-551f-8ab2-769c941aac66:
```python
client.list_objects_v2(Prefix="0000802f-1e81-551f-8ab2-769c941aac66") # this is SLOWWWWWWWWWW
client.list_objects_v2(Prefix="0000802f-1e81-551f-8ab2-769c941aac66/") # this is FASTTTTTTTTTT
```

for example on master, the first call takes 12 seconds to complete... while the second call takes a few ms...


<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
