### PR TITLE
Bugfix: re-enable SC_COMP_SERVICES_SCHEDULED_AS passed to computational services

### DIFF
--- a/services/sidecar/src/simcore_service_sidecar/boot_mode.py
+++ b/services/sidecar/src/simcore_service_sidecar/boot_mode.py
@@ -1,22 +1,8 @@
 # pylint: disable=global-statement
 from enum import Enum
-from typing import Optional
 
 
 class BootMode(Enum):
     CPU = "CPU"
     GPU = "GPU"
     MPI = "MPI"
-
-
-_sidecar_boot_mode: Optional[BootMode] = None
-
-
-def get_boot_mode() -> Optional[BootMode]:
-    global _sidecar_boot_mode
-    return _sidecar_boot_mode
-
-
-def set_boot_mode(boot_mode: BootMode) -> None:
-    global _sidecar_boot_mode
-    _sidecar_boot_mode = boot_mode

--- a/services/sidecar/src/simcore_service_sidecar/celery.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery.py
@@ -3,7 +3,6 @@ import logging
 from celery.signals import worker_ready, worker_shutting_down
 
 from .__version__ import __version__
-from .boot_mode import get_boot_mode
 from .celery_configurator import create_celery_app
 from .celery_task_utils import cancel_task
 from .cli import run_sidecar
@@ -26,7 +25,7 @@ WELCOME_MSG = r"""
 \       /(_|  |   |  '--'  / |  `---.(_'  '--'\  |  | |  | |  |\  \
  `-----'   `--'   `-------'  `------'   `-----'  `--' `--' `--' '--' {0} - {1}
 """.format(
-    __version__, get_boot_mode().value
+    __version__, app.conf.osparc_sidecar_bootmode.value
 )
 
 

--- a/services/sidecar/src/simcore_service_sidecar/celery_configurator.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery_configurator.py
@@ -61,6 +61,7 @@ def configure_node(bootmode: BootMode) -> Celery:
         Queue("celery"),
         Queue(CELERY_APP_CONFIGS[bootmode]["queue_name"]),
     ]
+    app.conf.osparc_sidecar_bootmode = bootmode
 
     define_celery_task(app, config.CELERY_CONFIG.task_name)
     set_boot_mode(bootmode)

--- a/services/sidecar/src/simcore_service_sidecar/celery_configurator.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery_configurator.py
@@ -14,7 +14,7 @@ from celery.contrib.abortable import AbortableTask
 from kombu import Queue
 
 from . import config
-from .boot_mode import BootMode, get_boot_mode, set_boot_mode
+from .boot_mode import BootMode
 from .celery_task import entrypoint
 from .celery_task_utils import (
     on_task_failure_handler,
@@ -64,8 +64,7 @@ def configure_node(bootmode: BootMode) -> Celery:
     app.conf.osparc_sidecar_bootmode = bootmode
 
     define_celery_task(app, config.CELERY_CONFIG.task_name)
-    set_boot_mode(bootmode)
-    log.info("Initialized celery app in %s", get_boot_mode())
+    log.info("Initialized celery app in %s", bootmode)
     return app
 
 

--- a/services/sidecar/src/simcore_service_sidecar/celery_task.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery_task.py
@@ -1,7 +1,6 @@
 import logging
 from asyncio import CancelledError
 
-from .boot_mode import BootMode
 from .cli import run_sidecar
 from .utils import wrap_async_call
 

--- a/services/sidecar/src/simcore_service_sidecar/celery_task.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery_task.py
@@ -1,6 +1,7 @@
 import logging
 from asyncio import CancelledError
 
+from .boot_mode import BootMode
 from .cli import run_sidecar
 from .utils import wrap_async_call
 
@@ -16,7 +17,12 @@ def entrypoint(
         *args,
         **kwargs
     )
-    _shared_task_dispatch(self, user_id, project_id, node_id)
+    _shared_task_dispatch(
+        self,
+        user_id,
+        project_id,
+        node_id,
+    )
     log.info("Completed task %s", self.request.id)
 
 
@@ -41,6 +47,7 @@ def _shared_task_dispatch(
                 celery_request.is_aborted,
                 retry=celery_request.request.retries,
                 max_retries=celery_request.max_retries,
+                sidecar_mode=celery_request.app.conf.osparc_sidecar_bootmode,
             )
         )
     except CancelledError:

--- a/services/sidecar/src/simcore_service_sidecar/cli.py
+++ b/services/sidecar/src/simcore_service_sidecar/cli.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional
 import click
 from servicelib.logging_utils import log_decorator
 
+from .boot_mode import BootMode
 from .celery_task_utils import cancel_task
 from .config import SIDECAR_INTERVAL_TO_CHECK_TASK_ABORTED_S
 from .core import run_computational_task
@@ -42,7 +43,7 @@ async def perdiodicaly_check_if_aborted(is_aborted_cb: Callable[[], bool]) -> No
 
 
 @log_decorator(logger=log, level=logging.INFO)
-async def run_sidecar(
+async def run_sidecar(  # pylint: disable=too-many-arguments
     job_id: str,
     user_id: str,
     project_id: str,
@@ -50,6 +51,7 @@ async def run_sidecar(
     is_aborted_cb: Optional[Callable[[], bool]] = None,
     retry: int = 1,
     max_retries: int = 1,
+    sidecar_mode: BootMode = BootMode.CPU,
 ) -> None:
     abortion_task = (
         asyncio.get_event_loop().create_task(
@@ -69,6 +71,7 @@ async def run_sidecar(
                 node_id=node_id,
                 retry=retry,
                 max_retries=max_retries,
+                sidecar_mode=sidecar_mode,
             )
     finally:
         if abortion_task:

--- a/services/sidecar/src/simcore_service_sidecar/core.py
+++ b/services/sidecar/src/simcore_service_sidecar/core.py
@@ -16,6 +16,7 @@ from simcore_sdk.node_ports_v2 import log as node_port_v2_log
 from sqlalchemy import and_, literal_column
 
 from . import config, exceptions
+from .boot_mode import BootMode
 from .executor import Executor
 from .rabbitmq import RabbitMQ
 from .utils import execution_graph
@@ -131,6 +132,7 @@ async def run_computational_task(
     node_id: str,
     retry: int,
     max_retries: int,
+    sidecar_mode: BootMode,
 ) -> None:
 
     async with db_engine.acquire() as connection:
@@ -185,6 +187,7 @@ async def run_computational_task(
                 rabbit_mq=rabbit_mq,
                 task=task,
                 user_id=user_id,
+                sidecar_mode=sidecar_mode,
             )
             await executor.run()
             run_result = StateType.SUCCESS

--- a/services/sidecar/src/simcore_service_sidecar/executor.py
+++ b/services/sidecar/src/simcore_service_sidecar/executor.py
@@ -263,7 +263,9 @@ class Executor:
                 "output",
                 "log",
             ]
-        ] + [f"SC_COMP_SERVICES_SCHEDULED_AS={self.sidecar_mode.value}"]
+        ] + [
+            f"SC_COMP_SERVICES_SCHEDULED_AS={self.sidecar_mode.value}"
+        ]  # NOTE: this variable is used by some comp services such as iSolve
 
         host_input_path = await get_volume_mount_point(
             config.SIDECAR_DOCKER_VOLUME_INPUT

--- a/services/sidecar/src/simcore_service_sidecar/executor.py
+++ b/services/sidecar/src/simcore_service_sidecar/executor.py
@@ -23,6 +23,7 @@ from simcore_sdk import node_data, node_ports_v2
 from simcore_sdk.node_ports_v2 import DBManager
 
 from . import config, exceptions
+from .boot_mode import BootMode
 from .log_parser import LogType, monitor_logs_task
 from .rabbitmq import RabbitMQ
 from .utils import get_volume_mount_point
@@ -90,6 +91,7 @@ class Executor:
     shared_folders: TaskSharedVolumes = None
     integration_version: version.Version = version.parse("0.0.0")
     service_settings: ServiceSettings = []
+    sidecar_mode: BootMode = BootMode.CPU
 
     @log_decorator(logger=log)
     async def run(self):
@@ -261,7 +263,7 @@ class Executor:
                 "output",
                 "log",
             ]
-        ]
+        ] + [f"SC_COMP_SERVICES_SCHEDULED_AS={self.sidecar_mode.value}"]
 
         host_input_path = await get_volume_mount_point(
             config.SIDECAR_DOCKER_VOLUME_INPUT

--- a/services/sidecar/tests/integration/conftest.py
+++ b/services/sidecar/tests/integration/conftest.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 
 import pytest
-from simcore_service_sidecar.boot_mode import BootMode, set_boot_mode
 
 current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
@@ -37,9 +36,3 @@ def python_sample_script(mock_dir: Path) -> Path:
     file_path = mock_dir / "osparc_python_sample.py"
     assert file_path.exists()
     return file_path
-
-
-@pytest.fixture()
-def mock_boot_mode():
-    """by default only CPU is mocked which is enough"""
-    set_boot_mode(BootMode.CPU)

--- a/services/sidecar/tests/integration/test_sidecar.py
+++ b/services/sidecar/tests/integration/test_sidecar.py
@@ -426,7 +426,6 @@ async def test_run_services(
     pipeline_cfg: Dict,
     user_id: int,
     mocker,
-    mock_boot_mode,
 ):
     """
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?
- [x] SC_COMP_SERVICES_SCHEDULED_AS was removed by error
- [x] now there is not any global variables anymore in the sidecar.


<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
