### PR TITLE
Is2244/auto upgrade service patch

### DIFF
--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -305,7 +305,7 @@ ServiceOutputs = Dict[PropertyName, ServiceOutput]
 
 class ServiceDockerData(ServiceKeyVersion, ServiceCommonData):
     """
-    Static metadata for a service injecte in the image labels
+    Static metadata for a service injected in the image labels
     """
 
     integration_version: Optional[constr(regex=VERSION_RE)] = Field(
@@ -402,7 +402,11 @@ class ServiceAccessRights(BaseModel):
 
 class ServiceMetaData(ServiceCommonData):
     # Overrides all fields of ServiceCommonData:
-    #    - for a partial update all members must be Optional FIXME: create a different model for updates!
+    #    - for a partial update all members must be Optional
+    #  FIXME: if API entry needs a schema to allow partial updates (e.g. patch/put),
+    #        it should be implemented with a different model e.g. ServiceMetaDataUpdate
+    #
+
     name: Optional[str]
     thumbnail: Optional[HttpUrl]
     description: Optional[str]

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -365,7 +365,7 @@ class ServiceAccessRights(BaseModel):
 
 class ServiceMetaData(ServiceCommonData):
     # Overrides all fields of ServiceCommonData:
-    #    - for a partial update all members must be Optional
+    #    - for a partial update all members must be Optional FIXME: create a different model for updates!
     name: Optional[str]
     thumbnail: Optional[HttpUrl]
     description: Optional[str]
@@ -373,6 +373,34 @@ class ServiceMetaData(ServiceCommonData):
     # user-defined metatada
     classifiers: Optional[List[str]]
     quality: Dict[str, Any] = {}
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "key": "simcore/services/dynamic/sim4life",
+                "version": "1.0.9",
+                "name": "sim4life",
+                "description": "s4l web",
+                "thumbnail": "http://thumbnailit.org/image",
+                "quality": {
+                    "enabled": True,
+                    "tsr_target": {
+                        f"r{n:02d}": {"level": 4, "references": ""}
+                        for n in range(1, 11)
+                    },
+                    "annotations": {
+                        "vandv": "",
+                        "limitations": "",
+                        "certificationLink": "",
+                        "certificationStatus": "Uncertified",
+                    },
+                    "tsr_current": {
+                        f"r{n:02d}": {"level": 0, "references": ""}
+                        for n in range(1, 11)
+                    },
+                },
+            }
+        }
 
 
 # -------------------------------------------------------------------

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -4,7 +4,7 @@ NOTE: to dump json-schema from CLI use
     python -c "from models_library.services import ServiceDockerData as cls; print(cls.schema_json(indent=2))" > services-schema.json
 """
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import (
     BaseModel,

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -253,6 +253,8 @@ class ServiceOutput(ServiceProperty):
 
 
 class ServiceKeyVersion(BaseModel):
+    """ This pair uniquely identifies a services """
+
     key: constr(regex=KEY_RE) = Field(
         ...,
         description="distinctive name for the node based on the docker registry path",
@@ -303,7 +305,7 @@ ServiceOutputs = Dict[PropertyName, ServiceOutput]
 
 class ServiceDockerData(ServiceKeyVersion, ServiceCommonData):
     """
-    Service base schema (used for docker labels on docker images)
+    Static metadata for a service injecte in the image labels
     """
 
     integration_version: Optional[constr(regex=VERSION_RE)] = Field(
@@ -350,6 +352,10 @@ class ServiceGroupAccessRights(BaseModel):
         False, description="defines whether the group can modify the service"
     )
 
+    @classmethod
+    def full(cls) -> "ServiceGroupAccessRights":
+        return cls(execute_access=True, write_access=True)
+
 
 class ServiceAccessRights(BaseModel):
     access_rights: Optional[Dict[GroupId, ServiceGroupAccessRights]] = Field(
@@ -369,7 +375,12 @@ class ServiceMetaData(ServiceCommonData):
     quality: Dict[str, Any] = {}
 
 
-# Databases models (tables services_meta_data and services_access_rights)
+# -------------------------------------------------------------------
+# Databases models
+#  - table services_meta_data
+#  - table services_access_rights
+
+
 class ServiceMetaDataAtDB(ServiceKeyVersion, ServiceMetaData):
     # for a partial update all members must be Optional
     classifiers: Optional[List[str]] = Field([])
@@ -377,6 +388,36 @@ class ServiceMetaDataAtDB(ServiceKeyVersion, ServiceMetaData):
 
     class Config:
         orm_mode = True
+        schema_extra = {
+            "example": {
+                "key": "simcore/services/dynamic/sim4life",
+                "version": "1.0.9",
+                "owner": 8,
+                "name": "sim4life",
+                "description": "s4l web",
+                "thumbnail": "http://thumbnailit.org/image",
+                "classifiers": "",
+                "created": "2021-01-18 12:46:57.7315",
+                "modified": "2021-01-19 12:45:00",
+                "quality": {
+                    "enabled": True,
+                    "tsr_target": {
+                        f"r{n:02d}": {"level": 4, "references": ""}
+                        for n in range(1, 11)
+                    },
+                    "annotations": {
+                        "vandv": "",
+                        "limitations": "",
+                        "certificationLink": "",
+                        "certificationStatus": "Uncertified",
+                    },
+                    "tsr_current": {
+                        f"r{n:02d}": {"level": 0, "references": ""}
+                        for n in range(1, 11)
+                    },
+                },
+            }
+        }
 
 
 class ServiceAccessRightsAtDB(ServiceKeyVersion, ServiceGroupAccessRights):
@@ -387,3 +428,15 @@ class ServiceAccessRightsAtDB(ServiceKeyVersion, ServiceGroupAccessRights):
 
     class Config:
         orm_mode = True
+        schema_extra = {
+            "example": {
+                "key": "simcore/services/dynamic/sim4life",
+                "version": "1.0.9",
+                "gid": 8,
+                "execute_access": True,
+                "write_access": True,
+                "created": "2021-01-18 12:46:57.7315",
+                "modified": "2021-01-19 12:45:00",
+                "product_name": "osparc",
+            }
+        }

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -424,7 +424,6 @@ class ServiceMetaDataAtDB(ServiceKeyVersion, ServiceMetaData):
                 "name": "sim4life",
                 "description": "s4l web",
                 "thumbnail": "http://thumbnailit.org/image",
-                "classifiers": "",
                 "created": "2021-01-18 12:46:57.7315",
                 "modified": "2021-01-19 12:45:00",
                 "quality": {

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -494,24 +494,6 @@ class ServiceAccessRightsAtDB(ServiceKeyVersion, ServiceGroupAccessRights):
         ..., description="defines the product name", example="osparc"
     )
 
-    @classmethod
-    def create_from(
-        cls, resource: Tuple[Union[str, int], ...], flags: Dict[str, bool]
-    ) -> "ServiceAccessRightsAtDB":
-        return cls(
-            key=resource[0],
-            version=resource[1],
-            gid=resource[2],
-            product_name=resource[3],
-            **flags,
-        )
-
-    def get_resource(self) -> Tuple[Union[str, int], ...]:
-        return tuple([self.key, self.version, self.gid, self.product_name])
-
-    def get_flags(self) -> Dict[str, bool]:
-        return self.dict(include={"execute_access", "write_access"})
-
     class Config:
         orm_mode = True
         schema_extra = {

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -341,6 +341,47 @@ class ServiceDockerData(ServiceKeyVersion, ServiceCommonData):
         description = "Description of a simcore node 'class' with input and output"
         extra = Extra.forbid
 
+        schema_extra = {
+            "example": {
+                "name": "oSparc Python Runner",
+                "key": "simcore/services/comp/osparc-python-runner",
+                "type": "computational",
+                "integration-version": "1.0.0",
+                "version": "1.7.0",
+                "description": "oSparc Python Runner",
+                "contact": "smith@company.com",
+                "authors": [
+                    {
+                        "name": "John Smith",
+                        "email": "smith@company.com",
+                        "affiliation": "Company",
+                    },
+                    {
+                        "name": "Richard Brown",
+                        "email": "brown@uni.edu",
+                        "affiliation": "University",
+                    },
+                ],
+                "inputs": {
+                    "input_1": {
+                        "displayOrder": 1,
+                        "label": "Input data",
+                        "description": "Any code, requirements or data file",
+                        "type": "data:*/*",
+                    }
+                },
+                "outputs": {
+                    "output_1": {
+                        "displayOrder": 1,
+                        "label": "Output data",
+                        "description": "All data produced by the script is zipped as output_data.zip",
+                        "type": "data:*/*",
+                        "fileToKeyMap": {"output_data.zip": "output_1"},
+                    }
+                },
+            }
+        }
+
 
 # Service access rights models
 class ServiceGroupAccessRights(BaseModel):

--- a/packages/models-library/tests/test_services.py
+++ b/packages/models-library/tests/test_services.py
@@ -10,9 +10,11 @@ import pytest
 import yaml
 from models_library.services import (
     SERVICE_KEY_RE,
+    ServiceAccessRightsAtDB,
     ServiceCommonData,
     ServiceDockerData,
     ServiceInput,
+    ServiceMetaDataAtDB,
     ServiceOutput,
 )
 from pint import Unit, UnitRegistry
@@ -164,3 +166,14 @@ def test_service_key_regex_patterns(service_key, regex_pattern):
     assert match.group(2) == "services"
     assert match.group(3) in ["comp", "dynamic", "frontend"]
     assert match.group(4) is not None
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    (ServiceAccessRightsAtDB, ServiceMetaDataAtDB),
+)
+def test_services_model_examples(model_cls, model_cls_examples):
+    for name, example in model_cls_examples.items():
+        print(name, ":", pformat(example))
+        model_instance = model_cls(**example)
+        assert model_instance, f"Failed with {name}"

--- a/packages/models-library/tests/test_services.py
+++ b/packages/models-library/tests/test_services.py
@@ -2,7 +2,6 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-import collections
 import re
 from pprint import pformat
 from typing import Any, Dict

--- a/packages/models-library/tests/test_services.py
+++ b/packages/models-library/tests/test_services.py
@@ -179,36 +179,3 @@ def test_services_model_examples(model_cls, model_cls_examples):
         print(name, ":", pformat(example))
         model_instance = model_cls(**example)
         assert model_instance, f"Failed with {name}"
-
-
-def test_override_access_rights():
-
-    read_access = ServiceAccessRightsAtDB.parse_obj(
-        {
-            "key": "simcore/services/dynamic/sim4life",
-            "version": "1.0.9",
-            "gid": 8,
-            "product_name": "osparc",
-        }
-    )
-
-    execute_access = read_access.copy(update={"execute_access": True})
-    read_write_access = read_access.copy(
-        update={"execute_access": False, "write_access": True}
-    )
-
-    resource = read_access.get_resource()
-    assert isinstance(resource, collections.Hashable)
-
-    # merge
-    flags = read_access.get_flags()
-    for access in [execute_access, read_write_access]:
-        assert access.get_resource() == resource
-        for key, value in access.get_flags().items():
-            flags[key] |= value
-
-    assert {"execute_access": True, "write_access": True} == flags
-
-    access_rights = ServiceAccessRightsAtDB.create_from(resource, flags)
-    assert access_rights.get_resource() == resource
-    assert access_rights.get_flags() == flags

--- a/packages/models-library/tests/test_services.py
+++ b/packages/models-library/tests/test_services.py
@@ -172,7 +172,7 @@ def test_service_key_regex_patterns(service_key, regex_pattern):
 
 @pytest.mark.parametrize(
     "model_cls",
-    (ServiceAccessRightsAtDB, ServiceMetaDataAtDB, ServiceMetaData),
+    (ServiceAccessRightsAtDB, ServiceMetaDataAtDB, ServiceMetaData, ServiceDockerData),
 )
 def test_services_model_examples(model_cls, model_cls_examples):
     for name, example in model_cls_examples.items():

--- a/packages/models-library/tests/test_services.py
+++ b/packages/models-library/tests/test_services.py
@@ -2,6 +2,7 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
+import collections
 import re
 from pprint import pformat
 from typing import Any, Dict
@@ -178,3 +179,36 @@ def test_services_model_examples(model_cls, model_cls_examples):
         print(name, ":", pformat(example))
         model_instance = model_cls(**example)
         assert model_instance, f"Failed with {name}"
+
+
+def test_override_access_rights():
+
+    read_access = ServiceAccessRightsAtDB.parse_obj(
+        {
+            "key": "simcore/services/dynamic/sim4life",
+            "version": "1.0.9",
+            "gid": 8,
+            "product_name": "osparc",
+        }
+    )
+
+    execute_access = read_access.copy(update={"execute_access": True})
+    read_write_access = read_access.copy(
+        update={"execute_access": False, "write_access": True}
+    )
+
+    resource = read_access.get_resource()
+    assert isinstance(resource, collections.Hashable)
+
+    # merge
+    flags = read_access.get_flags()
+    for access in [execute_access, read_write_access]:
+        assert access.get_resource() == resource
+        for key, value in access.get_flags().items():
+            flags[key] |= value
+
+    assert {"execute_access": True, "write_access": True} == flags
+
+    access_rights = ServiceAccessRightsAtDB.create_from(resource, flags)
+    assert access_rights.get_resource() == resource
+    assert access_rights.get_flags() == flags

--- a/packages/models-library/tests/test_services.py
+++ b/packages/models-library/tests/test_services.py
@@ -14,6 +14,7 @@ from models_library.services import (
     ServiceCommonData,
     ServiceDockerData,
     ServiceInput,
+    ServiceMetaData,
     ServiceMetaDataAtDB,
     ServiceOutput,
 )
@@ -170,7 +171,7 @@ def test_service_key_regex_patterns(service_key, regex_pattern):
 
 @pytest.mark.parametrize(
     "model_cls",
-    (ServiceAccessRightsAtDB, ServiceMetaDataAtDB),
+    (ServiceAccessRightsAtDB, ServiceMetaDataAtDB, ServiceMetaData),
 )
 def test_services_model_examples(model_cls, model_cls_examples):
     for name, example in model_cls_examples.items():

--- a/packages/postgres-database/src/simcore_postgres_database/models/groups.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/groups.py
@@ -15,9 +15,9 @@ from .base import metadata
 
 class GroupType(enum.Enum):
     """
-        standard: standard group, e.g. any group that is not a primary group or special group such as the everyone group
-        primary: primary group, e.g. the primary group is the user own defined group that typically only contain the user (same as in linux)
-        everyone: the only group for all users
+    standard: standard group, e.g. any group that is not a primary group or special group such as the everyone group
+    primary: primary group, e.g. the primary group is the user own defined group that typically only contain the user (same as in linux)
+    everyone: the only group for all users
     """
 
     STANDARD = "standard"
@@ -29,22 +29,54 @@ class GroupType(enum.Enum):
 groups = sa.Table(
     "groups",
     metadata,
-    sa.Column("gid", sa.BigInteger, nullable=False, primary_key=True),
-    sa.Column("name", sa.String, nullable=False),
-    sa.Column("description", sa.String, nullable=False),
-    sa.Column("type", sa.Enum(GroupType), nullable=False, server_default="STANDARD"),
-    sa.Column("thumbnail", sa.String, nullable=True),
-    sa.Column("inclusion_rules", JSONB, nullable=False, server_default=sa.text("'{}'::jsonb")),
-    sa.Column("created", sa.DateTime(), nullable=False, server_default=func.now()),
+    sa.Column(
+        "gid",
+        sa.BigInteger,
+        nullable=False,
+        primary_key=True,
+        doc="Group unique IDentifier",
+    ),
+    sa.Column("name", sa.String, nullable=False, doc="Group label"),
+    sa.Column("description", sa.String, nullable=False, doc="Short description"),
+    sa.Column(
+        "type",
+        sa.Enum(GroupType),
+        nullable=False,
+        server_default="STANDARD",
+        doc="Classification of the group based on GroupType enum",
+    ),
+    sa.Column(
+        "thumbnail",
+        sa.String,
+        nullable=True,
+        doc="Link to thumbnail image to use as logo",
+    ),
+    sa.Column(
+        "inclusion_rules",
+        JSONB,
+        nullable=False,
+        server_default=sa.text("'{}'::jsonb"),
+        doc="Maps user's column and regular expression."
+        "Used to automatically assign a user to this group based on it's attributes",
+    ),
+    sa.Column(
+        "created",
+        sa.DateTime(),
+        nullable=False,
+        server_default=func.now(),
+        doc="Timestamp auto-generated upon creation",
+    ),
     sa.Column(
         "modified",
         sa.DateTime(),
         nullable=False,
         server_default=func.now(),
         onupdate=func.now(),  # this will auto-update on modification
+        doc="Timestamp with last row update",
     ),
     sa.CheckConstraint("check_group_uniqueness(name, text(type)) = 0"),
 )
+
 
 user_to_groups = sa.Table(
     "user_to_groups",
@@ -58,6 +90,7 @@ user_to_groups = sa.Table(
             onupdate="CASCADE",
             ondelete="CASCADE",
         ),
+        doc="User unique IDentifier",
     ),
     sa.Column(
         "gid",
@@ -68,6 +101,7 @@ user_to_groups = sa.Table(
             onupdate="CASCADE",
             ondelete="CASCADE",
         ),
+        doc="Group unique IDentifier",
     ),
     sa.Column(
         "access_rights",
@@ -76,14 +110,22 @@ user_to_groups = sa.Table(
         server_default=sa.text(
             '\'{"read": true, "write": false, "delete": false}\'::jsonb'
         ),
+        doc="Group's access-rights to R/W/D a resource",
     ),
-    sa.Column("created", sa.DateTime(), nullable=False, server_default=func.now()),
+    sa.Column(
+        "created",
+        sa.DateTime(),
+        nullable=False,
+        server_default=func.now(),
+        doc="Timestamp auto-generated upon creation",
+    ),
     sa.Column(
         "modified",
         sa.DateTime(),
         nullable=False,
         server_default=func.now(),
         onupdate=func.now(),
+        doc="Timestamp with last row update",
     ),
     sa.UniqueConstraint("uid", "gid"),
 )

--- a/packages/postgres-database/src/simcore_postgres_database/models/groups.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/groups.py
@@ -110,7 +110,7 @@ user_to_groups = sa.Table(
         server_default=sa.text(
             '\'{"read": true, "write": false, "delete": false}\'::jsonb'
         ),
-        doc="Group's access-rights to read, write and delete a resource",
+        doc="User's access rights to the group",
     ),
     sa.Column(
         "created",

--- a/packages/postgres-database/src/simcore_postgres_database/models/groups.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/groups.py
@@ -110,7 +110,7 @@ user_to_groups = sa.Table(
         server_default=sa.text(
             '\'{"read": true, "write": false, "delete": false}\'::jsonb'
         ),
-        doc="Group's access-rights to R/W/D a resource",
+        doc="Group's access-rights to read, write and delete a resource",
     ),
     sa.Column(
         "created",

--- a/packages/postgres-database/src/simcore_postgres_database/models/groups.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/groups.py
@@ -72,7 +72,7 @@ groups = sa.Table(
         nullable=False,
         server_default=func.now(),
         onupdate=func.now(),  # this will auto-update on modification
-        doc="Timestamp with last row update",
+        doc="Timestamp with last update",
     ),
     sa.CheckConstraint("check_group_uniqueness(name, text(type)) = 0"),
 )

--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -16,8 +16,13 @@ from .base import metadata
 products = sa.Table(
     "products",
     metadata,
-    sa.Column("name", sa.String, nullable=False),
-    sa.Column("host_regex", sa.String, nullable=False),
+    sa.Column("name", sa.String, nullable=False, doc="Uniquely identifies a product"),
+    sa.Column(
+        "host_regex",
+        sa.String,
+        nullable=False,
+        doc="Regular expression that matches product hostname from an url string",
+    ),
     sa.Column("created", sa.DateTime(), nullable=False, server_default=func.now()),
     sa.Column(
         "modified",
@@ -25,6 +30,7 @@ products = sa.Table(
         nullable=False,
         server_default=func.now(),
         onupdate=func.now(),  # this will auto-update on modification
+        doc="Automaticaly updates on modification of the row",
     ),
     sa.PrimaryKeyConstraint("name", name="products_pk"),
 )

--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -23,7 +23,13 @@ products = sa.Table(
         nullable=False,
         doc="Regular expression that matches product hostname from an url string",
     ),
-    sa.Column("created", sa.DateTime(), nullable=False, server_default=func.now()),
+    sa.Column(
+        "created",
+        sa.DateTime(),
+        nullable=False,
+        server_default=func.now(),
+        doc="Timestamp auto-generated upon creation",
+    ),
     sa.Column(
         "modified",
         sa.DateTime(),

--- a/packages/postgres-database/src/simcore_postgres_database/models/services.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/services.py
@@ -52,7 +52,7 @@ services_meta_data = sa.Table(
         ARRAY(sa.String, dimensions=1),
         nullable=False,
         server_default="{}",
-        doc="List of tags to describe this service (see classifiers table)",
+        doc="List of standard labels that describe this service (see classifiers table)",
     ),
     sa.Column(
         "created",
@@ -101,7 +101,8 @@ services_access_rights = sa.Table(
         doc="Group Identifier",
     ),
     # Access Rights flags ---
-    #  - Notice that read_access Flag is implicit on the existence of the row
+    #  - Notice that read_access flag is implicit on the existence of the row.  If you have no
+    #  execute/write access then you do not see the service.
     sa.Column(
         "execute_access",
         sa.Boolean,

--- a/packages/postgres-database/src/simcore_postgres_database/models/services.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/services.py
@@ -101,21 +101,19 @@ services_access_rights = sa.Table(
         doc="Group Identifier",
     ),
     # Access Rights flags ---
-    #  - Notice that read_access flag is implicit on the existence of the row.  If you have no
-    #  execute/write access then you do not see the service.
     sa.Column(
         "execute_access",
         sa.Boolean,
         nullable=False,
         server_default=expression.false(),
-        doc="Can execute resource?",
+        doc="If true, group can execute the service",
     ),
     sa.Column(
         "write_access",
         sa.Boolean,
         nullable=False,
         server_default=expression.false(),
-        doc="Can write resource?",
+        doc="If true, group can modify the service",
     ),
     # -----
     sa.Column(

--- a/packages/pytest-simcore/src/pytest_simcore/docker_swarm.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_swarm.py
@@ -99,9 +99,6 @@ def docker_stack(
     testing_environ_vars: Dict,
 ) -> Iterator[Dict]:
 
-    core_stack_name = devel_environ["SWARM_STACK_NAME"]
-    assert core_stack_name.startswith("pytest-")
-
     # WARNING: keep prefix "pytest-" in stack names
     core_stack_name = testing_environ_vars["SWARM_STACK_NAME"]
     ops_stack_name = "pytest-ops"

--- a/packages/pytest-simcore/src/pytest_simcore/docker_swarm.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_swarm.py
@@ -99,6 +99,9 @@ def docker_stack(
     testing_environ_vars: Dict,
 ) -> Iterator[Dict]:
 
+    core_stack_name = devel_environ["SWARM_STACK_NAME"]
+    assert core_stack_name.startswith("pytest-")
+
     # WARNING: keep prefix "pytest-" in stack names
     core_stack_name = testing_environ_vars["SWARM_STACK_NAME"]
     ops_stack_name = "pytest-ops"

--- a/packages/pytest-simcore/src/pytest_simcore/repository_paths.py
+++ b/packages/pytest-simcore/src/pytest_simcore/repository_paths.py
@@ -36,6 +36,7 @@ def osparc_simcore_root_dir(request) -> Path:
 
 @pytest.fixture(scope="session")
 def osparc_simcore_services_dir(osparc_simcore_root_dir) -> Path:
+    """ Path to osparc-simcore/services folder """
     services_dir = osparc_simcore_root_dir / "services"
     assert services_dir.exists()
     return services_dir
@@ -43,6 +44,7 @@ def osparc_simcore_services_dir(osparc_simcore_root_dir) -> Path:
 
 @pytest.fixture(scope="session")
 def env_devel_file(osparc_simcore_root_dir: Path) -> Path:
+    """ Path to osparc-simcore/.env-devel file """
     env_devel_fpath = osparc_simcore_root_dir / ".env-devel"
     assert env_devel_fpath.exists()
     return env_devel_fpath

--- a/services/catalog/requirements/_base.in
+++ b/services/catalog/requirements/_base.in
@@ -27,3 +27,4 @@ httpx
 
 # other
 tenacity
+packaging

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -85,6 +85,8 @@ multidict==5.1.0
     # via yarl
 orjson==3.4.8
     # via fastapi
+packaging==20.9
+    # via -r requirements/_base.in
 promise==2.3
     # via
     #   graphql-core
@@ -98,6 +100,8 @@ pydantic[dotenv,email]==1.7.3
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/_base.in
     #   fastapi
+pyparsing==2.4.7
+    # via packaging
 python-dotenv==0.15.0
     # via
     #   pydantic

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -136,7 +136,9 @@ multidict==5.1.0
     #   aiohttp
     #   yarl
 packaging==20.9
-    # via pytest
+    # via
+    #   -c requirements/_base.txt
+    #   pytest
 paramiko==2.7.2
     # via docker
 pluggy==0.13.1
@@ -156,7 +158,9 @@ pylint==2.8.2
 pynacl==1.4.0
     # via paramiko
 pyparsing==2.4.7
-    # via packaging
+    # via
+    #   -c requirements/_base.txt
+    #   packaging
 pyrsistent==0.17.3
     # via jsonschema
 pytest-aiohttp==0.3.0

--- a/services/catalog/src/simcore_service_catalog/core/background_tasks.py
+++ b/services/catalog/src/simcore_service_catalog/core/background_tasks.py
@@ -97,9 +97,7 @@ async def _create_services_in_db(
         (
             owner_gid,
             service_access_rights,
-        ) = await access_rights.create_service_default_access_rights(
-            app, service_metadata
-        )
+        ) = await access_rights.evaluate_default_policy(app, service_metadata)
 
         # AUTO-UPGRADE PATCH policy
         inherited_access_rights = await access_rights.evaluate_auto_upgrade_policy(

--- a/services/catalog/src/simcore_service_catalog/core/background_tasks.py
+++ b/services/catalog/src/simcore_service_catalog/core/background_tasks.py
@@ -105,7 +105,9 @@ async def _create_services_in_db(
         )
 
         service_access_rights += inherited_access_rights
-        service_access_rights = access_rights.merge_access_rights(service_access_rights)
+        service_access_rights = access_rights.reduce_access_rights(
+            service_access_rights
+        )
 
         # set the service in the DB
         await services_repo.create_service(

--- a/services/catalog/src/simcore_service_catalog/core/background_tasks.py
+++ b/services/catalog/src/simcore_service_catalog/core/background_tasks.py
@@ -117,7 +117,7 @@ async def _create_services_in_db(
 async def _ensure_registry_insync_with_db(app: FastAPI) -> None:
     """Ensures that the services listed in the database is in sync with the registry
 
-    Notice that a services here referes to a 2-tuple (key, version)
+    Notice that a services here refers to a 2-tuple (key, version)
     """
     services_in_registry: Dict[
         Tuple[ServiceKey, ServiceVersion], ServiceDockerData

--- a/services/catalog/src/simcore_service_catalog/db/errors.py
+++ b/services/catalog/src/simcore_service_catalog/db/errors.py
@@ -1,0 +1,6 @@
+""" Custom db.repository errors
+"""
+
+
+class RepositoryError(Exception):
+    pass

--- a/services/catalog/src/simcore_service_catalog/db/repositories/groups.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/groups.py
@@ -6,6 +6,7 @@ from pydantic.networks import EmailStr
 from pydantic.types import PositiveInt
 
 from ...models.domain.group import GroupAtDB
+from ..errors import RepositoryError
 from ..tables import GroupType, groups, user_to_groups, users
 from ._base import BaseRepository
 
@@ -31,8 +32,9 @@ class GroupsRepository(BaseRepository):
                     sa.select([groups]).where(groups.c.type == GroupType.EVERYONE)
                 )
             ).first()
-        if row:
-            return GroupAtDB(**row)
+        if not row:
+            raise RepositoryError(f"{GroupType.EVERYONE} groups was never initialized")
+        return GroupAtDB(**row)
 
     async def get_user_gid_from_email(
         self, user_email: EmailStr

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -122,8 +122,7 @@ class ServicesRepository(BaseRepository):
             .order_by(sa.desc(services_meta_data.c.version))
         )
 
-        if limit_count:
-            assert limit_count > 0  # nosec
+        if limit_count and limit_count > 0:
             query = query.limit(limit_count)
 
         releases = []

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -243,13 +243,14 @@ class ServicesRepository(BaseRepository):
         - If product_name is not specificed, then all are considered in the query
         """
         services_in_db = []
-        query = sa.select([services_access_rights]).where(
-            (services_access_rights.c.key == key)
-            & (services_access_rights.c.version == version)
-            & (services_access_rights.c.product_name == product_name)
-            if product_name
-            else True
+        search_expression = (services_access_rights.c.key == key) & (
+            services_access_rights.c.version == version
         )
+        if product_name:
+            search_expression &= services_access_rights.c.product_name == product_name
+
+        query = sa.select([services_access_rights]).where(search_expression)
+
         async with self.db_engine.acquire() as conn:
             async for row in conn.execute(query):
                 services_in_db.append(ServiceAccessRightsAtDB(**row))

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -96,11 +96,10 @@ class ServicesRepository(BaseRepository):
         minor: Optional[int] = None,
         limit_count: Optional[int] = None,
     ) -> List[ServiceMetaDataAtDB]:
-        """Lists LAST n releases of a given service
+        """Lists LAST n releases of a given service, sorted from latest first
 
-
-        major: filters all releases of a
-        limit_count: limits number of returned matches
+        major, minor is used to filter as major.minor.* or major.*
+        limit_count limits returned value. None or non-positive values returns all matches
         """
         if minor is not None and major is None:
             raise ValueError("Expected only major. or major.minor")

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -7,7 +7,7 @@ from aiopg.sa.result import RowProxy
 from models_library.services import ServiceAccessRightsAtDB, ServiceMetaDataAtDB
 from psycopg2.errors import ForeignKeyViolation  # pylint: disable=no-name-in-module
 from sqlalchemy import literal_column
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.sql import and_, or_
 from sqlalchemy.sql.expression import tuple_
 from sqlalchemy.sql.selectable import Select
@@ -207,7 +207,7 @@ class ServicesRepository(BaseRepository):
                 created_service = ServiceMetaDataAtDB(**row)
 
                 for access_rights in new_service_access_rights:
-                    insert_stmt = insert(services_access_rights).values(
+                    insert_stmt = pg_insert(services_access_rights).values(
                         **access_rights.dict(by_alias=True)
                     )
                     await conn.execute(insert_stmt)
@@ -284,7 +284,7 @@ class ServicesRepository(BaseRepository):
     ) -> None:
         # update the services_access_rights table (some might be added/removed/modified)
         for rights in new_access_rights:
-            insert_stmt = insert(services_access_rights).values(
+            insert_stmt = pg_insert(services_access_rights).values(
                 **rights.dict(by_alias=True)
             )
             on_update_stmt = insert_stmt.on_conflict_do_update(

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -65,6 +65,7 @@ class ServicesRepository(BaseRepository):
 
     async def list_services(
         self,
+        *,
         gids: Optional[List[int]] = None,
         execute_access: Optional[bool] = None,
         write_access: Optional[bool] = None,
@@ -90,6 +91,7 @@ class ServicesRepository(BaseRepository):
         self,
         key: str,
         version: str,
+        *,
         gids: Optional[List[int]] = None,
         execute_access: Optional[bool] = None,
         write_access: Optional[bool] = None,

--- a/services/catalog/src/simcore_service_catalog/models/domain/group.py
+++ b/services/catalog/src/simcore_service_catalog/models/domain/group.py
@@ -17,3 +17,13 @@ class Group(BaseModel):
 class GroupAtDB(Group):
     class Config:
         orm_mode = True
+
+        schema_extra = {
+            "example": {
+                "gid": 218,
+                "name": "Friends group",
+                "description": "Joey, Ross, Rachel, Monica, Phoeby and Chandler",
+                "type": GroupType.STANDARD,
+                "thumbnail": "https://image.flaticon.com/icons/png/512/23/23374.png",
+            }
+        }

--- a/services/catalog/src/simcore_service_catalog/services/access_rights.py
+++ b/services/catalog/src/simcore_service_catalog/services/access_rights.py
@@ -100,7 +100,8 @@ async def evaluate_default_policy(
 
 async def evaluate_auto_upgrade_policy(
     service_metadata: ServiceDockerData, services_repo: ServicesRepository
-):
+) -> List[ServiceAccessRightsAtDB]:
+```?
     # AUTO-UPGRADE PATCH policy:
     #
     #  - Any new patch released, inherits the access rights from previous compatible version

--- a/services/catalog/src/simcore_service_catalog/services/access_rights.py
+++ b/services/catalog/src/simcore_service_catalog/services/access_rights.py
@@ -1,13 +1,101 @@
 """ Services Access Rights policies
 
 """
-from typing import List
+import logging
+from datetime import datetime
+from typing import List, Optional, Tuple
+from urllib.parse import quote_plus
 
+from aiopg.sa.engine import Engine
+from fastapi import FastAPI
 from models_library.services import ServiceAccessRightsAtDB, ServiceDockerData
 from packaging.version import Version
+from pydantic.types import PositiveInt
 
+from ..api.dependencies.director import get_director_api
+from ..db.repositories.groups import GroupsRepository
 from ..db.repositories.services import ServicesRepository
 from ..utils.versioning import as_version, is_patch_release
+
+logger = logging.getLogger(__name__)
+
+OLD_SERVICES_DATE: datetime = datetime(2020, 8, 19)
+
+
+def _is_frontend_service(service: ServiceDockerData) -> bool:
+    return "/frontend/" in service.key
+
+
+async def _is_old_service(app: FastAPI, service: ServiceDockerData) -> bool:
+    # get service build date
+    client = get_director_api(app)
+    data = await client.get(
+        f"/service_extras/{quote_plus(service.key)}/{service.version}"
+    )
+    if not data or "build_date" not in data:
+        return True
+
+    logger.debug("retrieved service extras are %s", data)
+
+    service_build_data = datetime.strptime(data["build_date"], "%Y-%m-%dT%H:%M:%SZ")
+    return service_build_data < OLD_SERVICES_DATE
+
+
+async def create_service_default_access_rights(
+    app: FastAPI, service: ServiceDockerData
+) -> Tuple[Optional[PositiveInt], List[ServiceAccessRightsAtDB]]:
+    """Given a service, it returns the owner's group-id (gid) and a list of access rights following
+    default access-rights policies
+
+    - DEFAULT Access Rights policies:
+        1. All services published in osparc prior 19.08.2020 will be visible to everyone (refered as 'old service').
+        2. Services published after 19.08.2020 will be visible ONLY to his/her owner
+        3. Front-end services are have read-access to everyone
+    """
+    db_engine: Engine = app.state.engine
+
+    groups_repo = GroupsRepository(db_engine)
+    g = await groups_repo.get_everyone_group()
+    everyone_gid = g.gid
+    owner_gid = None
+    reader_gids: List[PositiveInt] = []
+
+    if _is_frontend_service(service) or await _is_old_service(app, service):
+        logger.debug("service %s:%s is old or frontend", service.key, service.version)
+        # let's make that one available to everyone
+        reader_gids.append(everyone_gid)
+
+    # try to find the owner
+    possible_owner_email = [service.contact] + [
+        author.email for author in service.authors
+    ]
+
+    for user_email in possible_owner_email:
+        possible_gid = await groups_repo.get_user_gid_from_email(user_email)
+        if possible_gid:
+            if not owner_gid:
+                owner_gid = possible_gid
+    if not owner_gid:
+        logger.warning("service %s:%s has no owner", service.key, service.version)
+    else:
+        reader_gids.append(owner_gid)
+
+    # we add the owner with full rights, unless it's everyone
+    default_access_rights = [
+        ServiceAccessRightsAtDB(
+            key=service.key,
+            version=service.version,
+            gid=gid,
+            execute_access=True,
+            write_access=(gid == owner_gid),
+            product_name=app.state.settings.access_rights_default_product_name,
+        )
+        for gid in set(reader_gids)
+    ]
+
+    # Patch releases inherit access rights from previous version
+
+    return (owner_gid, default_access_rights)
 
 
 async def evaluate_auto_upgrade_policy(
@@ -21,7 +109,7 @@ async def evaluate_auto_upgrade_policy(
     #
     # SEE https://github.com/ITISFoundation/osparc-simcore/issues/2244)
     #
-    if "/frontend/" in service_metadata.key:
+    if _is_frontend_service(service_metadata):
         return []
 
     service_access_rights = []

--- a/services/catalog/src/simcore_service_catalog/services/access_rights.py
+++ b/services/catalog/src/simcore_service_catalog/services/access_rights.py
@@ -55,8 +55,8 @@ async def create_service_default_access_rights(
     db_engine: Engine = app.state.engine
 
     groups_repo = GroupsRepository(db_engine)
-    g = await groups_repo.get_everyone_group()
-    everyone_gid = g.gid
+
+    everyone_gid = (await groups_repo.get_everyone_group()).gid
     owner_gid = None
     reader_gids: List[PositiveInt] = []
 

--- a/services/catalog/src/simcore_service_catalog/services/access_rights.py
+++ b/services/catalog/src/simcore_service_catalog/services/access_rights.py
@@ -1,0 +1,72 @@
+""" Services Access Rights policies
+
+"""
+from typing import List
+
+from models_library.services import ServiceAccessRightsAtDB, ServiceDockerData
+from packaging.version import Version
+
+from ..db.repositories.services import ServicesRepository
+from ..utils.versioning import as_version, is_patch_release
+
+
+async def evaluate_auto_upgrade_policy(
+    service_metadata: ServiceDockerData, services_repo: ServicesRepository
+):
+    # AUTO-UPGRADE PATCH policy:
+    #
+    #  - Any new patch released, inherits the access rights from previous compatible version
+    #  - TODO: add as option in the publication contract, i.e. in ServiceDockerData
+    #  - Does NOT apply to front-end services
+    #
+    # SEE https://github.com/ITISFoundation/osparc-simcore/issues/2244)
+    #
+    if "/frontend/" in service_metadata.key:
+        return []
+
+    service_access_rights = []
+    version: Version = as_version(service_metadata.version)
+    latest_releases = await services_repo.list_service_releases(
+        service_metadata.key, major=version.major, minor=version.minor, limit_count=1
+    )
+    assert len(latest_releases) <= 1  # nosec
+
+    if latest_releases:
+        latest_patch = latest_releases[0]
+
+        if is_patch_release(latest_patch.version, version):
+            previous_access_rights = await services_repo.get_service_access_rights(
+                latest_patch.key, latest_patch.version
+            )
+            for access in previous_access_rights:
+                service_access_rights.append(
+                    access.copy(
+                        exclude={"created", "modified"},
+                        update={"version": service_metadata.version},
+                    )
+                )
+
+    return service_access_rights
+
+
+def merge_access_rights(
+    access_rights: List[ServiceAccessRightsAtDB],
+) -> List[ServiceAccessRightsAtDB]:
+    # TODO: probably a lot of room to optimize
+    merged = {}
+    for access in access_rights:
+        resource = access.get_resource()
+        flags = merged.get(resource)
+        if flags:
+            for key, value in access.get_flags().items():
+                flags[key] |= value
+        else:
+            merged[resource] = access.get_flags()
+
+    merged_access_rights = []
+    for resource in merged:
+        merged_access_rights.append(
+            ServiceAccessRightsAtDB.create_from(resource, merged[resource])
+        )
+
+    return merged_access_rights

--- a/services/catalog/src/simcore_service_catalog/utils/versioning.py
+++ b/services/catalog/src/simcore_service_catalog/utils/versioning.py
@@ -11,7 +11,7 @@ _VersionT = Union[Version, str]
 
 
 def as_version(v: _VersionT) -> Version:
-    return packaging.version.parse(v) if isinstance(v, str) else v  # type: ignore
+    return packaging.version.Version(v) if isinstance(v, str) else v  # type: ignore
 
 
 def is_patch_release(version: _VersionT, reference: _VersionT) -> bool:

--- a/services/catalog/src/simcore_service_catalog/utils/versioning.py
+++ b/services/catalog/src/simcore_service_catalog/utils/versioning.py
@@ -1,0 +1,21 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from typing import Union
+
+import packaging.version
+from packaging.version import Version
+
+_VersionT = Union[Version, str]
+
+
+def as_version(v: _VersionT) -> Version:
+    return packaging.version.parse(v) if isinstance(v, str) else v  # type: ignore
+
+
+def is_patch_release(version: _VersionT, reference: _VersionT) -> bool:
+    """Returns True if version is a patch release from reference"""
+    v: Version = as_version(version)
+    r: Version = as_version(reference)
+    return v.major == r.major and v.minor == r.minor and r.micro < v.micro

--- a/services/catalog/tests/unit/test_models_domain_groups.py
+++ b/services/catalog/tests/unit/test_models_domain_groups.py
@@ -1,0 +1,17 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+
+from pprint import pformat
+
+import pytest
+from simcore_service_catalog.models.domain.group import GroupAtDB
+
+
+@pytest.mark.parametrize("model_cls", (GroupAtDB,))
+def test_service_api_models_examples(model_cls, model_cls_examples):
+    for name, example in model_cls_examples.items():
+        print(name, ":", pformat(example))
+        model_instance = model_cls(**example)
+        assert model_instance, f"Failed with {name}"

--- a/services/catalog/tests/unit/test_utils_versioning.py
+++ b/services/catalog/tests/unit/test_utils_versioning.py
@@ -14,7 +14,7 @@ def test_is_patch_check():
     assert not is_patch_release("1.0.3", "1.0.4")
 
     # same version
-    assert is_patch_release("1.0.3", "1.0.3")
+    assert not is_patch_release("1.0.3", "1.0.3")
 
     # major and minor releases
     assert not is_patch_release("1.1.4", "1.0.3")

--- a/services/catalog/tests/unit/test_utils_versioning.py
+++ b/services/catalog/tests/unit/test_utils_versioning.py
@@ -1,0 +1,21 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from simcore_service_catalog.utils.versioning import is_patch_release
+
+
+def test_is_patch_check():
+
+    assert is_patch_release("1.0.4", "1.0.3")
+    assert is_patch_release("1.0.5", "1.0.3")
+
+    # 1.0.4 is a patch release from 1.0.3 but NOT the reverse
+    assert not is_patch_release("1.0.3", "1.0.4")
+
+    # same version
+    assert is_patch_release("1.0.3", "1.0.3")
+
+    # major and minor releases
+    assert not is_patch_release("1.1.4", "1.0.3")
+    assert not is_patch_release("2.0.4", "1.0.3")

--- a/services/catalog/tests/unit/with_dbs/conftest.py
+++ b/services/catalog/tests/unit/with_dbs/conftest.py
@@ -53,16 +53,17 @@ async def director_mockup(loop, app: FastAPI):
 #
 # These are the tables accessible by the catalog service:
 #
-# - services_meta_data
+# * services_meta_data
 #   -> groups(gid)@owner
-# - services_access_rights
+# * services_access_rights
 #   -> groups(gid)@owner,
 #   -> products(name)@produt_name
 #   -> services_meta_data@key, version
-# - services_consume_filetypes
+# * services_consume_filetypes
 #
 # and therefore these are the coupled tables
 # - groups
+#   -> user, user_to_groups
 # - products
 #
 
@@ -132,6 +133,28 @@ async def user_groups_ids(aiopg_engine: Engine) -> Iterator[List[int]]:
 async def services_db_tables_injector(aiopg_engine: Engine) -> Callable:
     """Returns a helper function to init
     services_meta_data and services_access_rights tables
+
+    Can use service_catalog_faker to generate inputs
+
+    Example:
+        await services_db_tables_injector(
+            [
+                service_catalog_faker(
+                    "simcore/services/dynamic/jupyterlab",
+                    "0.0.1",
+                    team_access=None,
+                    everyone_access=None,
+                    product=target_product,
+                ),
+                service_catalog_faker(
+                    "simcore/services/dynamic/jupyterlab",
+                    "0.0.7",
+                    team_access=None,
+                    everyone_access=None,
+                    product=target_product,
+                ),
+            ]
+        )
     """
     # pylint: disable=no-value-for-parameter
 
@@ -163,6 +186,19 @@ async def service_catalog_faker(
 ) -> Callable:
     """Returns a fake factory that creates catalog data
     that can be used to fill services_meta_data and services_access_rights tables
+
+
+    Example:
+        fake_service, *fake_access_rights = service_catalog_faker(
+                "simcore/services/dynamic/jupyterlab",
+                "0.0.1",
+                team_access=None,
+                everyone_access=None,
+                product=target_product,
+            ),
+
+        owner_access, team_access, everyone_access = fake_access_rights
+
     """
     everyone_gid, user_gid, team_gid = user_groups_ids
 

--- a/services/catalog/tests/unit/with_dbs/conftest.py
+++ b/services/catalog/tests/unit/with_dbs/conftest.py
@@ -3,11 +3,23 @@
 # pylint:disable=redefined-outer-name
 
 
+import itertools
+import random
+from typing import Any, Callable, Dict, Iterator, List, Tuple
+
 import pytest
 import sqlalchemy as sa
+from aiopg.sa.engine import Engine
+from faker import Faker
 from fastapi import FastAPI
+from simcore_postgres_database.models.products import products
 from simcore_service_catalog.api.dependencies.director import get_director_api
 from simcore_service_catalog.core.application import init_app
+from simcore_service_catalog.db.tables import (
+    groups,
+    services_access_rights,
+    services_meta_data,
+)
 from starlette.testclient import TestClient
 
 
@@ -35,3 +47,190 @@ async def director_mockup(loop, app: FastAPI):
     yield
 
     app.dependency_overrides[get_director_api] = None
+
+
+# DATABASE tables fixtures -----------------------------------
+#
+# These are the tables accessible by the catalog service:
+#
+# - services_meta_data
+#   -> groups(gid)@owner
+# - services_access_rights
+#   -> groups(gid)@owner,
+#   -> products(name)@produt_name
+#   -> services_meta_data@key, version
+# - services_consume_filetypes
+#
+# and therefore these are the coupled tables
+# - groups
+# - products
+#
+
+
+@pytest.fixture()
+async def products_names(aiopg_engine: Engine) -> Iterator[List[str]]:
+    """Inits products db table and returns product names"""
+    data = [
+        # already upon creation: ("osparc", r"([\.-]{0,1}osparc[\.-])"),
+        ("s4l", r"(^s4l[\.-])|(^sim4life\.)|(^api.s4l[\.-])|(^api.sim4life\.)"),
+        ("tis", r"(^tis[\.-])|(^ti-solutions\.)"),
+    ]
+
+    # pylint: disable=no-value-for-parameter
+
+    async with aiopg_engine.acquire() as conn:
+        # NOTE: The 'default' dialect with current database version settings does not support in-place multirow inserts
+        for name, regex in data:
+            stmt = products.insert().values(name=name, host_regex=regex)
+            await conn.execute(stmt)
+
+    names = [
+        "osparc",
+    ] + [items[0] for items in data]
+    yield names
+
+    async with aiopg_engine.acquire() as conn:
+        await conn.execute(products.delete())
+
+
+@pytest.fixture()
+async def user_groups_ids(aiopg_engine: Engine) -> Iterator[List[int]]:
+    """Inits groups table and returns group identifiers"""
+
+    cols = ("gid", "name", "description", "type", "thumbnail", "inclusion_rules")
+    data = [
+        (34, "john.smith", "primary group for user", "PRIMARY", None, {}),
+        (
+            20001,
+            "Team Black",
+            "External testers",
+            "STANDARD",
+            "http://mib.org",
+            {"email": "@(foo|testers|mib)+.(org|com)$"},
+        ),
+    ]
+    # pylint: disable=no-value-for-parameter
+
+    async with aiopg_engine.acquire() as conn:
+        for row in data:
+            # NOTE: The 'default' dialect with current database version settings does not support in-place multirow inserts
+            stmt = groups.insert().values(**dict(zip(cols, row)))
+            await conn.execute(stmt)
+
+    gids = [
+        1,
+    ] + [items[0] for items in data]
+
+    yield gids
+
+    async with aiopg_engine.acquire() as conn:
+        await conn.execute(services_meta_data.delete())
+        await conn.execute(groups.delete().where(groups.c.gid.in_(gids[1:])))
+
+
+@pytest.fixture()
+async def services_db_tables_injector(aiopg_engine: Engine) -> Callable:
+    """Returns a helper function to init
+    services_meta_data and services_access_rights tables
+    """
+    # pylint: disable=no-value-for-parameter
+
+    async def inject_in_db(fake_catalog: List[Tuple]):
+        # [(service, ar1, ...), (service2, ar1, ...) ]
+
+        async with aiopg_engine.acquire() as conn:
+            # NOTE: The 'default' dialect with current database version settings does not support in-place multirow inserts
+            for service in [items[0] for items in fake_catalog]:
+                stmt_meta = services_meta_data.insert().values(**service)
+                await conn.execute(stmt_meta)
+
+            for access_rights in itertools.chain(items[1:] for items in fake_catalog):
+                stmt_access = services_access_rights.insert().values(access_rights)
+                await conn.execute(stmt_access)
+
+    yield inject_in_db
+
+    async with aiopg_engine.acquire() as conn:
+        await conn.execute(services_access_rights.delete())
+        await conn.execute(services_meta_data.delete())
+
+
+@pytest.fixture()
+async def service_catalog_faker(
+    user_groups_ids: List[int],
+    products_names: List[str],
+    faker: Faker,
+) -> Callable:
+    """Returns a fake factory that creates catalog data
+    that can be used to fill services_meta_data and services_access_rights tables
+    """
+    everyone_gid, user_gid, team_gid = user_groups_ids
+
+    def _random_service(**overrides) -> Dict[str, Any]:
+        data = dict(
+            key=f"simcore/services/{random.choice(['dynamic', 'computational'])}/{faker.name()}",
+            version=".".join([str(faker.pyint()) for _ in range(3)]),
+            owner=user_gid,
+            name=faker.name(),
+            description=faker.sentence(),
+            thumbnail=random.choice([faker.image_url(), None]),
+            classifiers=[],
+            quality={},
+        )
+        data.update(overrides)
+        return data
+
+    def _random_access(service, **overrides) -> Dict[str, Any]:
+        data = dict(
+            key=service["key"],
+            version=service["version"],
+            gid=random.choice(user_groups_ids),
+            execute_access=faker.pybool(),
+            write_access=faker.pybool(),
+            product_name=random.choice(products_names),
+        )
+        data.update(overrides)
+        return data
+
+    def _fake_factory(
+        key, version, team_access=None, everyone_access=None, product=products_names[0]
+    ) -> Tuple[Dict[str, Any], ...]:
+
+        service = _random_service(key=key, version=version)
+
+        # owner always has full-access
+        owner_access = _random_access(
+            service,
+            gid=service["owner"],
+            execute_access=True,
+            write_access=True,
+            product_name=product,
+        )
+
+        fakes = [
+            service,
+            owner_access,
+        ]
+        if team_access:
+            fakes.append(
+                _random_access(
+                    service,
+                    gid=team_gid,
+                    execute_access="x" in team_access,
+                    write_access="w" in team_access,
+                    product_name=product,
+                )
+            )
+        if everyone_access:
+            fakes.append(
+                _random_access(
+                    service,
+                    gid=everyone_gid,
+                    execute_access="x" in everyone_access,
+                    write_access="w" in everyone_access,
+                    product_name=product,
+                )
+            )
+        return tuple(fakes)
+
+    return _fake_factory

--- a/services/catalog/tests/unit/with_dbs/test_db_repositories.py
+++ b/services/catalog/tests/unit/with_dbs/test_db_repositories.py
@@ -1,0 +1,326 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+import itertools
+import random
+from typing import Any, Callable, Dict, List, Tuple
+
+import pytest
+from aiopg.sa.engine import Engine
+from faker import Faker
+from models_library.services import (
+    ServiceAccessRightsAtDB,
+    ServiceGroupAccessRights,
+    ServiceMetaDataAtDB,
+)
+from simcore_postgres_database.models.products import products
+from simcore_service_catalog.db.repositories.services import ServicesRepository
+from simcore_service_catalog.db.tables import (
+    groups,
+    services_access_rights,
+    services_meta_data,
+)
+
+pytest_simcore_core_services_selection = [
+    "postgres",
+]
+pytest_simcore_ops_services_selection = [
+    "adminer",
+]
+
+
+# DATABASE tables used by the catalog-------
+#
+# services_meta_data       -> groups(gid)@owner
+# services_access_rights   -> groups(gid)@owner, products(name)@produt_name, services_meta_data
+# services_consume_filetypes
+#
+# groups
+# products
+#
+
+
+@pytest.fixture()
+async def products_names(aiopg_engine: Engine) -> List[str]:
+    """ products created in postgres db """
+    data = [
+        ("osparc", r"([\.-]{0,1}osparc[\.-])"),
+        ("s4l", r"(^s4l[\.-])|(^sim4life\.)|(^api.s4l[\.-])|(^api.sim4life\.)"),
+        ("tis", r"(^tis[\.-])|(^ti-solutions\.)"),
+    ]
+    # pylint: disable=no-value-for-parameter
+    stmt = products.insert().values([{"name": n, "host_regex": r} for n, r in data])
+
+    async with aiopg_engine.acquire() as conn:
+        await conn.execute(stmt)
+
+    yield [items[0] for items in data]
+
+    async with aiopg_engine.acquire() as conn:
+        await conn.execute(products.delete())
+
+
+@pytest.fixture()
+async def user_groups_ids(aiopg_engine: Engine) -> List[int]:
+    cols = ("gid", "name", "description", "type", "thumbnail", "inclusion_rules")
+
+    data = [
+        (1, "Everyone", "all users", "EVERYONE", None, {}),
+        (34, "john.smith", "primary group for user", "PRIMARY", None, {}),
+        (
+            20001,
+            "Team Black",
+            "External testers",
+            "STANDARD",
+            "http://mib.org",
+            {"email": "@(foo|testers|mib)+.(org|com)$"},
+        ),
+    ]
+    # pylint: disable=no-value-for-parameter
+
+    stmt = groups.insert().values([dict(zip(cols, row)) for row in data])
+
+    async with aiopg_engine.acquire() as conn:
+        await conn.execute(stmt)
+
+    yield [items[0] for items in data]
+
+    async with aiopg_engine.acquire() as conn:
+        await conn.execute(groups.delete())
+
+
+@pytest.fixture()
+async def service_catalog_faker(
+    user_groups_ids: List[int],
+    products_names: List[str],
+    faker: Faker,
+) -> Callable:
+    """Returns a fake factory fo data as
+        ( service, owner_access, [team_access], [everyone_access] )
+
+    that can be used to fill services_meta_data and services_access_rights tables
+    """
+    everyone_gid, user_gid, team_gid = user_groups_ids
+
+    def _create_random_service(**overrides) -> Dict[str, Any]:
+        data = dict(
+            key=f"simcore/services/{random.choice(['dynamic', 'computational'])}/{faker.name()}",
+            version=".".join([faker.pyint() for _ in range(3)]),
+            owner=user_gid,
+            name=faker.name(),
+            description=faker.sentence(),
+            thumbnail=random.choice([faker.image_url(), None]),
+            classifiers=[],
+            quality={},
+        )
+        data.update(overrides)
+        return data
+
+    def _create_random_access(service, **overrides) -> Dict[str, Any]:
+        data = dict(
+            key=service["key"],
+            version=service["version"],
+            gid=random.choice(user_groups_ids),
+            execute_access=faker.pybool(),
+            write_access=faker.pybool(),
+            product_name=random.choice(products_names),
+        )
+        data.update(overrides)
+        return data
+
+    def _create_fake(
+        key, version, team_access=None, everyone_access=None
+    ) -> Tuple[Dict[str, Any], ...]:
+
+        service = _create_random_service(key=key, version=version)
+
+        # owner always has full-access
+        owner_access = _create_random_access(
+            service, gid=service["owner"], execute_access=True, write_access=True
+        )
+
+        entry = [
+            service,
+            owner_access,
+        ]
+        if team_access:
+            entry.append(
+                _create_random_access(
+                    service,
+                    gid=team_gid,
+                    execute_access="x" in team_access,
+                    write_access="w" in team_access,
+                )
+            )
+        if everyone_access:
+            entry.append(
+                _create_random_access(
+                    service,
+                    gid=everyone_gid,
+                    execute_access="x" in everyone_access,
+                    write_access="w" in everyone_access,
+                )
+            )
+        return tuple(entry)
+
+    return _create_fake
+
+
+@pytest.fixture()
+async def services_catalog(
+    aiopg_engine: Engine,
+    user_groups_ids: List[int],
+    products_names: List[str],
+    faker: Faker,
+) -> List:
+
+    everyone_gid, user_gid, team_gid = user_groups_ids
+
+    def _create_random_service(**overrides) -> Dict[str, Any]:
+        data = dict(
+            key=f"simcore/services/{random.choice(['dynamic', 'computational'])}/{faker.name()}",
+            version=".".join([faker.pyint() for _ in range(3)]),
+            owner=user_gid,
+            name=faker.name(),
+            description=faker.sentence(),
+            thumbnail=random.choice([faker.image_url(), None]),
+            classifiers=[],
+            quality={},
+        )
+        data.update(overrides)
+        return data
+
+    def _create_random_access(service, **overrides) -> Dict[str, Any]:
+        data = dict(
+            key=service["key"],
+            version=service["version"],
+            gid=random.choice(user_groups_ids),
+            execute_access=faker.pybool(),
+            write_access=faker.pybool(),
+            product_name=random.choice(products_names),
+        )
+        data.update(overrides)
+        return data
+
+    def _new_catalog_entry(
+        key, version, team_access=None, everyone_access=None
+    ) -> Tuple[Dict[str, Any], ...]:
+        """ helper to create service entry """
+
+        service = _create_random_service(key=key, version=version)
+
+        # owner always has full-access
+        owner_access = _create_random_access(
+            service, gid=service["owner"], execute_access=True, write_access=True
+        )
+
+        entry = [
+            service,
+            owner_access,
+        ]
+        if team_access:
+            entry.append(
+                _create_random_access(
+                    service,
+                    gid=team_gid,
+                    execute_access="x" in team_access,
+                    write_access="w" in team_access,
+                )
+            )
+        if everyone_access:
+            entry.append(
+                _create_random_access(
+                    service,
+                    gid=everyone_gid,
+                    execute_access="x" in everyone_access,
+                    write_access="w" in everyone_access,
+                )
+            )
+        return tuple(entry)
+
+    # ---
+
+    fake_catalog = [
+        _new_catalog_entry(
+            "simcore/services/dynamic/jupyterlab",
+            "1.0.0",
+            team_access=None,
+            everyone_access=None,
+        ),
+        _new_catalog_entry(
+            "simcore/services/dynamic/jupyterlab",
+            "1.0.2",
+            team_access="x",
+            everyone_access=None,
+        ),
+    ]
+
+    # pylint: disable=no-value-for-parameter
+    stmt_meta = services_meta_data.insert().values([items[0] for items in fake_catalog])
+    stmt_access = services_access_rights.insert().values(
+        list(itertools.chain(items[1:] for items in fake_catalog))
+    )
+
+    async with aiopg_engine.acquire() as conn:
+        await conn.execute(stmt_meta)
+        await conn.execute(stmt_access)
+
+    yield fake_catalog
+
+    async with aiopg_engine.acquire() as conn:
+        await conn.execute(services_access_rights.delete())
+        await conn.execute(services_meta_data.delete())
+
+
+@pytest.fixture
+def services_repo(aiopg_engine):
+    repo = ServicesRepository(aiopg_engine)
+    return repo
+
+
+async def test_create_service(services_repo, service_catalog_faker):
+    # creates fake data
+    fake_service, *fake_access_rights = service_catalog_faker(
+        "simcore/services/dynamic/jupyterlab",
+        "1.0.0",
+        team_access=None,
+        everyone_access=None,
+    )
+
+    # validation
+    service = ServiceMetaDataAtDB.parse_obj(fake_service)
+    service_access_rights = [
+        ServiceAccessRightsAtDB.parse_obj(a) for a in fake_access_rights
+    ]
+
+    new_service = await services_repo.create_service(service, service_access_rights)
+
+    assert new_service.dict(include=set(fake_service.keys())) == service.dict()
+
+
+async def test_read_services(aiopg_engine, services_catalog):
+
+    await repo.list_services()
+
+    await repo.get_service()
+
+
+@pytest.mark.skip(reason="dev")
+def test_auto_upgrade(services_catalog):
+
+    # service S has a new patch released: 1.2.5 (i.e. backwards compatible bug fix, according to semver policies )
+    current_version = "1.10.5"
+    new_version = "1.10.6"
+
+    # the owner of service, checked the auto-upgrade patch policy in the publication contract (i.e.metadata.yml)
+
+    # service S:1.2.5 gets automatically the same access rights as S:1.2.4.
+    # access_rights = get_access_rights(service_key, service_version)
+
+    # set_access_rights(service_key, service_version, access_rights)
+
+    # NO
+    # all projects with nodes assigned to S:1.2.X get promoted to the latest patch S:1.2.5
+
+    # services can be published on different products (including file-picker and group nodes)

--- a/services/catalog/tests/unit/with_dbs/test_db_repositories.py
+++ b/services/catalog/tests/unit/with_dbs/test_db_repositories.py
@@ -4,7 +4,7 @@
 
 import itertools
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterator, List, Tuple
 
 import pytest
@@ -222,8 +222,8 @@ class FakeCatalogInfo:
     jupyter_service_key: str = "simcore/services/dynamic/jupyterlab"
     expected_services_count: int = 5
     expected_latest: str = "1.1.3"
-    expected_1_1_x: List[str] = []
-    expected_0_x_x: List[str] = []
+    expected_1_1_x: List[str] = field(default_factory=list)
+    expected_0_x_x: List[str] = field(default_factory=list)
 
 
 @pytest.fixture()

--- a/services/catalog/tests/unit/with_dbs/test_db_repositories.py
+++ b/services/catalog/tests/unit/with_dbs/test_db_repositories.py
@@ -118,40 +118,6 @@ async def test_create_services(
     assert new_service.dict(include=set(fake_service.keys())) == service.dict()
 
 
-@pytest.mark.skip(reason="dev")
-async def test_access_rights_upon_creation(
-    services_repo: ServicesRepository,
-    service_catalog_faker: Callable,
-    user_groups_ids: List[int],
-):
-
-    everyone_gid, user_gid, team_gid = user_groups_ids
-
-    # creates fake data
-    fake_service, *fake_access_rights = service_catalog_faker(
-        "simcore/services/dynamic/jupyterlab", "1.0.0"
-    )
-
-    access: ServiceAccessRightsAtDB = fake_access_rights[0]
-    assert access.gid == user_gid
-
-    # validation
-    service = ServiceMetaDataAtDB.parse_obj(fake_service)
-    service_access_rights = [
-        access,
-        access.copy(
-            update={"gid": team_gid, "execute_access": True, "write_access": True}
-        ),
-        access.copy(
-            update={"gid": team_gid, "execute_access": True, "write_access": False}
-        ),
-    ]
-
-    new_service = await services_repo.create_service(service, service_access_rights)
-
-    assert new_service.dict(include=set(fake_service.keys())) == service.dict()
-
-
 async def test_read_services(
     services_repo: ServicesRepository,
     user_groups_ids: List[int],

--- a/services/catalog/tests/unit/with_dbs/test_db_repositories.py
+++ b/services/catalog/tests/unit/with_dbs/test_db_repositories.py
@@ -251,30 +251,3 @@ async def test_list_service_releases_version_filtered(
     assert [
         s.version for s in expected_0_x_x
     ] == fake_catalog_with_jupyterlab.expected_0_x_x
-
-
-async def test_copy_access_rights_from_previous_release(
-    fake_catalog_with_jupyterlab: FakeCatalogInfo,
-    services_repo: ServicesRepository,
-):
-    releases = await services_repo.list_service_releases(
-        "simcore/services/dynamic/jupyterlab", limit_count=2, major=1, minor=1
-    )
-    assert len(releases) == 2
-    latest_release, previous_patch = releases
-
-    # get all access-rights set for previous_patch (for all products!!!)
-    access_rights: List[
-        ServiceAccessRightsAtDB
-    ] = await services_repo.get_service_access_rights(
-        **previous_patch.dict(include={"key", "version"})
-    )
-
-    # copy them over to latest-release.
-    #
-    # Notice that if latest-release had already access-rights
-    # those get overriden or ADD new access-rights.
-    #
-    for access in access_rights:
-        access.version = latest_release.version
-    await services_repo.upsert_service_access_rights(access_rights)

--- a/services/catalog/tests/unit/with_dbs/test_db_repositories.py
+++ b/services/catalog/tests/unit/with_dbs/test_db_repositories.py
@@ -2,23 +2,13 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
-import itertools
-import random
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterator, List, Tuple
+from typing import Callable, List
 
 import pytest
-from aiopg.sa.engine import Engine
-from faker import Faker
 from models_library.services import ServiceAccessRightsAtDB, ServiceMetaDataAtDB
 from packaging import version
-from simcore_postgres_database.models.products import products
 from simcore_service_catalog.db.repositories.services import ServicesRepository
-from simcore_service_catalog.db.tables import (
-    groups,
-    services_access_rights,
-    services_meta_data,
-)
 from simcore_service_catalog.utils.versioning import is_patch_release
 
 pytest_simcore_core_services_selection = [
@@ -27,188 +17,6 @@ pytest_simcore_core_services_selection = [
 pytest_simcore_ops_services_selection = [
     "adminer",
 ]
-
-
-# DATABASE tables used by the catalog-------
-#
-# services_meta_data       -> groups(gid)@owner
-# services_access_rights   -> groups(gid)@owner, products(name)@produt_name, services_meta_data
-# services_consume_filetypes
-#
-# groups
-# products
-#
-
-
-@pytest.fixture()
-async def products_names(aiopg_engine: Engine) -> Iterator[List[str]]:
-    """Inserts products in pg db table and returns its names"""
-    data = [
-        # already upon creation: ("osparc", r"([\.-]{0,1}osparc[\.-])"),
-        ("s4l", r"(^s4l[\.-])|(^sim4life\.)|(^api.s4l[\.-])|(^api.sim4life\.)"),
-        ("tis", r"(^tis[\.-])|(^ti-solutions\.)"),
-    ]
-
-    # pylint: disable=no-value-for-parameter
-
-    async with aiopg_engine.acquire() as conn:
-        # NOTE: The 'default' dialect with current database version settings does not support in-place multirow inserts
-        for name, regex in data:
-            stmt = products.insert().values(name=name, host_regex=regex)
-            await conn.execute(stmt)
-
-    names = [
-        "osparc",
-    ] + [items[0] for items in data]
-    yield names
-
-    async with aiopg_engine.acquire() as conn:
-        await conn.execute(products.delete())
-
-
-@pytest.fixture()
-async def user_groups_ids(aiopg_engine: Engine) -> Iterator[List[int]]:
-    """Inserts groups in the pg-db table and returns group identifiers"""
-
-    cols = ("gid", "name", "description", "type", "thumbnail", "inclusion_rules")
-    data = [
-        (34, "john.smith", "primary group for user", "PRIMARY", None, {}),
-        (
-            20001,
-            "Team Black",
-            "External testers",
-            "STANDARD",
-            "http://mib.org",
-            {"email": "@(foo|testers|mib)+.(org|com)$"},
-        ),
-    ]
-    # pylint: disable=no-value-for-parameter
-
-    async with aiopg_engine.acquire() as conn:
-        for row in data:
-            # NOTE: The 'default' dialect with current database version settings does not support in-place multirow inserts
-            stmt = groups.insert().values(**dict(zip(cols, row)))
-            await conn.execute(stmt)
-
-    gids = [
-        1,
-    ] + [items[0] for items in data]
-
-    yield gids
-
-    async with aiopg_engine.acquire() as conn:
-        await conn.execute(services_meta_data.delete())
-        await conn.execute(groups.delete().where(groups.c.gid.in_(gids[1:])))
-
-
-@pytest.fixture()
-async def services_db_tables_injector(aiopg_engine: Engine) -> Callable:
-    """Returns a helper to add services in pg db by inserting in
-    services_meta_data and services_access_rights tables
-
-    """
-    # pylint: disable=no-value-for-parameter
-
-    async def inject_in_db(fake_catalog: List[Tuple]):
-        # [(service, ar1, ...), (service2, ar1, ...) ]
-
-        async with aiopg_engine.acquire() as conn:
-            # NOTE: The 'default' dialect with current database version settings does not support in-place multirow inserts
-            for service in [items[0] for items in fake_catalog]:
-                stmt_meta = services_meta_data.insert().values(**service)
-                await conn.execute(stmt_meta)
-
-            for access_rights in itertools.chain(items[1:] for items in fake_catalog):
-                stmt_access = services_access_rights.insert().values(access_rights)
-                await conn.execute(stmt_access)
-
-    yield inject_in_db
-
-    async with aiopg_engine.acquire() as conn:
-        await conn.execute(services_access_rights.delete())
-        await conn.execute(services_meta_data.delete())
-
-
-@pytest.fixture()
-async def service_catalog_faker(
-    user_groups_ids: List[int],
-    products_names: List[str],
-    faker: Faker,
-) -> Callable:
-    """Returns a fake factory function with arguments
-        service, owner_access, [team_access], [everyone_access]
-    that can be used to fill services_meta_data and services_access_rights tables
-    """
-    everyone_gid, user_gid, team_gid = user_groups_ids
-
-    def _random_service(**overrides) -> Dict[str, Any]:
-        data = dict(
-            key=f"simcore/services/{random.choice(['dynamic', 'computational'])}/{faker.name()}",
-            version=".".join([str(faker.pyint()) for _ in range(3)]),
-            owner=user_gid,
-            name=faker.name(),
-            description=faker.sentence(),
-            thumbnail=random.choice([faker.image_url(), None]),
-            classifiers=[],
-            quality={},
-        )
-        data.update(overrides)
-        return data
-
-    def _random_access(service, **overrides) -> Dict[str, Any]:
-        data = dict(
-            key=service["key"],
-            version=service["version"],
-            gid=random.choice(user_groups_ids),
-            execute_access=faker.pybool(),
-            write_access=faker.pybool(),
-            product_name=random.choice(products_names),
-        )
-        data.update(overrides)
-        return data
-
-    def _create_fakes(
-        key, version, team_access=None, everyone_access=None, product=products_names[0]
-    ) -> Tuple[Dict[str, Any], ...]:
-
-        service = _random_service(key=key, version=version)
-
-        # owner always has full-access
-        owner_access = _random_access(
-            service,
-            gid=service["owner"],
-            execute_access=True,
-            write_access=True,
-            product_name=product,
-        )
-
-        fakes = [
-            service,
-            owner_access,
-        ]
-        if team_access:
-            fakes.append(
-                _random_access(
-                    service,
-                    gid=team_gid,
-                    execute_access="x" in team_access,
-                    write_access="w" in team_access,
-                    product_name=product,
-                )
-            )
-        if everyone_access:
-            fakes.append(
-                _random_access(
-                    service,
-                    gid=everyone_gid,
-                    execute_access="x" in everyone_access,
-                    write_access="w" in everyone_access,
-                    product_name=product,
-                )
-            )
-        return tuple(fakes)
-
-    return _create_fakes
 
 
 @pytest.fixture
@@ -504,23 +312,3 @@ async def test_copy_access_rights_from_previous_release(
     for access in access_rights:
         access.version = latest_release.version
     await services_repo.upsert_service_access_rights(access_rights)
-
-
-@pytest.mark.skip(reason="dev")
-def test_it(services_catalog):
-
-    # service S has a new patch released: 1.2.5 (i.e. backwards compatible bug fix, according to semver policies )
-    current_version = "1.10.5"
-    new_version = "1.10.6"
-
-    # the owner of service, checked the auto-upgrade patch policy in the publication contract (i.e.metadata.yml)
-
-    # service S:1.2.5 gets automatically the same access rights as S:1.2.4.
-    # access_rights = get_access_rights(service_key, service_version)
-
-    # set_access_rights(service_key, service_version, access_rights)
-
-    # NO
-    # all projects with nodes assigned to S:1.2.X get promoted to the latest patch S:1.2.5
-
-    # services can be published on different products (including file-picker and group nodes)

--- a/services/catalog/tests/unit/with_dbs/test_services_access_rights.py
+++ b/services/catalog/tests/unit/with_dbs/test_services_access_rights.py
@@ -1,0 +1,148 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from typing import Callable, List
+
+import pytest
+from aiopg.sa.engine import Engine
+from fastapi import FastAPI
+from models_library.services import ServiceAccessRightsAtDB, ServiceDockerData
+from pytest_simcore.helpers.utils_mock import future_with_result
+from simcore_service_catalog.db.repositories.services import ServicesRepository
+from simcore_service_catalog.services.access_rights import (
+    create_service_default_access_rights,
+    evaluate_auto_upgrade_policy,
+    merge_access_rights,
+)
+
+
+def test_merge_access_rights():
+    sample = ServiceAccessRightsAtDB.parse_obj(
+        {
+            "key": "simcore/services/dynamic/sim4life",
+            "version": "1.0.9",
+            "gid": 8,
+            "execute_access": True,
+            "write_access": True,
+            "product_name": "osparc",
+        }
+    )
+
+    # overrides and with other products
+    merged = merge_access_rights(
+        [
+            sample.copy(deep=True),
+            sample.copy(deep=True),
+            sample.copy(update={"execute_access": False}, deep=True),
+            sample.copy(update={"product_name": "s4l"}),
+        ]
+    )
+
+    assert len(merged) == 2
+    assert merged[0].get_flags() == {"execute_access": True, "write_access": True}
+
+    merged = merge_access_rights(
+        [
+            sample.copy(deep=True),
+            sample.copy(
+                update={"gid": 1, "execute_access": True, "write_access": False},
+                deep=True,
+            ),
+        ]
+    )
+
+
+async def test_auto_upgrade_policy(
+    aiopg_engine: Engine,
+    user_groups_ids: List[int],
+    products_names: List[str],
+    services_db_tables_injector: Callable,
+    service_catalog_faker: Callable,
+    mocker,
+):
+    everyone_gid, user_gid, team_gid = user_groups_ids
+
+    # Avoids calls to director API
+    mocker.patch(
+        "simcore_service_catalog.services.access_rights._is_old_service",
+        return_value=False,
+    )
+    # Avoids creating a users + user_to_group table
+    mocker.patch(
+        "simcore_service_catalog.services.access_rights.GroupsRepository.get_everyone_group",
+        return_value=future_with_result(everyone_gid),
+    )
+    mocker.patch(
+        "simcore_service_catalog.services.access_rights.GroupsRepository.get_user_gid_from_email",
+        return_value=future_with_result(user_gid),
+    )
+
+    # SETUP ---
+    new_service_metadata = ServiceDockerData.parse_obj(
+        ServiceDockerData.Config.schema_extra["example"]
+    )
+    new_service_metadata.version = "1.0.1"
+
+    # we two versions of the service in the database
+    await services_db_tables_injector(
+        [
+            service_catalog_faker(
+                new_service_metadata.key,
+                "0.5.0",
+                team_access=None,
+                everyone_access=None,
+                product=products_names[-1],
+            ),
+            service_catalog_faker(
+                new_service_metadata.key,
+                "1.0.0",
+                team_access="x",
+                everyone_access=None,
+                product=products_names[-1],
+            ),
+        ]
+    )
+    # ------------
+
+    app = FastAPI()
+    app.state.engine = aiopg_engine
+    services_repo = ServicesRepository(app.state.engine)
+
+    # DEFAULT policies
+    owner_gid, service_access_rights = await create_service_default_access_rights(
+        app, new_service_metadata
+    )
+
+    assert len(service_access_rights) == 1
+
+    # AUTO-UPGRADE PATCH policy
+    inherited_access_rights = await evaluate_auto_upgrade_policy(
+        new_service_metadata, services_repo
+    )
+
+    assert len(inherited_access_rights) == 1
+
+    service_access_rights += inherited_access_rights
+
+    service_access_rights = merge_access_rights(service_access_rights)
+
+
+@pytest.mark.skip(reason="dev")
+def test_it2(services_catalog):
+
+    # service S has a new patch released: 1.2.5 (i.e. backwards compatible bug fix, according to semver policies )
+    current_version = "1.10.5"
+    new_version = "1.10.6"
+
+    # the owner of service, checked the auto-upgrade patch policy in the publication contract (i.e.metadata.yml)
+
+    # service S:1.2.5 gets automatically the same access rights as S:1.2.4.
+    # access_rights = get_access_rights(service_key, service_version)
+
+    # set_access_rights(service_key, service_version, access_rights)
+
+    # NO
+    # all projects with nodes assigned to S:1.2.X get promoted to the latest patch S:1.2.5
+
+    # services can be published on different products (including file-picker and group nodes)

--- a/services/catalog/tests/unit/with_dbs/test_services_access_rights.py
+++ b/services/catalog/tests/unit/with_dbs/test_services_access_rights.py
@@ -184,7 +184,7 @@ async def test_auto_upgrade_policy(
     service_access_rights += inherited_access_rights
     service_access_rights = reduce_access_rights(service_access_rights)
 
-    assert len(service_access_rights) == 3
+    assert len(service_access_rights) == 4
     assert {a.gid for a in service_access_rights} == {team_gid, owner_gid}
     assert {a.product_name for a in service_access_rights} == {
         target_product,

--- a/services/catalog/tests/unit/with_dbs/test_services_access_rights.py
+++ b/services/catalog/tests/unit/with_dbs/test_services_access_rights.py
@@ -10,11 +10,19 @@ from fastapi import FastAPI
 from models_library.services import ServiceAccessRightsAtDB, ServiceDockerData
 from pytest_simcore.helpers.utils_mock import future_with_result
 from simcore_service_catalog.db.repositories.services import ServicesRepository
+from simcore_service_catalog.models.domain.group import GroupAtDB
 from simcore_service_catalog.services.access_rights import (
-    create_service_default_access_rights,
     evaluate_auto_upgrade_policy,
+    evaluate_default_policy,
     merge_access_rights,
 )
+
+pytest_simcore_core_services_selection = [
+    "postgres",
+]
+pytest_simcore_ops_services_selection = [
+    "adminer",
+]
 
 
 def test_merge_access_rights():
@@ -62,16 +70,19 @@ async def test_auto_upgrade_policy(
     mocker,
 ):
     everyone_gid, user_gid, team_gid = user_groups_ids
+    target_product = products_names[0]
 
     # Avoids calls to director API
     mocker.patch(
         "simcore_service_catalog.services.access_rights._is_old_service",
-        return_value=False,
+        return_value=future_with_result(False),
     )
     # Avoids creating a users + user_to_group table
+    data = GroupAtDB.Config.schema_extra["example"]
+    data["gid"] = everyone_gid
     mocker.patch(
         "simcore_service_catalog.services.access_rights.GroupsRepository.get_everyone_group",
-        return_value=future_with_result(everyone_gid),
+        return_value=future_with_result(GroupAtDB.parse_obj(data)),
     )
     mocker.patch(
         "simcore_service_catalog.services.access_rights.GroupsRepository.get_user_gid_from_email",
@@ -92,7 +103,14 @@ async def test_auto_upgrade_policy(
                 "0.5.0",
                 team_access=None,
                 everyone_access=None,
-                product=products_names[-1],
+                product=target_product,
+            ),
+            service_catalog_faker(
+                new_service_metadata.key,
+                "1.0.0",
+                team_access="x",
+                everyone_access=None,
+                product=target_product,
             ),
             service_catalog_faker(
                 new_service_metadata.key,
@@ -107,25 +125,50 @@ async def test_auto_upgrade_policy(
 
     app = FastAPI()
     app.state.engine = aiopg_engine
+    app.state.settings = mocker.Mock()
+    app.state.settings.access_rights_default_product_name = target_product
+
     services_repo = ServicesRepository(app.state.engine)
 
     # DEFAULT policies
-    owner_gid, service_access_rights = await create_service_default_access_rights(
+    owner_gid, service_access_rights = await evaluate_default_policy(
         app, new_service_metadata
     )
-
+    assert owner_gid == user_gid
     assert len(service_access_rights) == 1
+    assert {a.gid for a in service_access_rights} == {owner_gid}
+    assert service_access_rights[0].dict() == {
+        "key": new_service_metadata.key,
+        "version": new_service_metadata.version,
+        "gid": user_gid,
+        "product_name": target_product,
+        "execute_access": True,
+        "write_access": True,
+    }
+    assert service_access_rights[0].product_name == target_product
 
     # AUTO-UPGRADE PATCH policy
     inherited_access_rights = await evaluate_auto_upgrade_policy(
         new_service_metadata, services_repo
     )
 
-    assert len(inherited_access_rights) == 1
+    assert len(inherited_access_rights) == 4
+    assert {a.gid for a in inherited_access_rights} == {team_gid, owner_gid}
+    assert {a.product_name for a in inherited_access_rights} == {
+        target_product,
+        products_names[-1],
+    }
 
+    # ALL
     service_access_rights += inherited_access_rights
-
     service_access_rights = merge_access_rights(service_access_rights)
+
+    assert len(service_access_rights) == 3
+    assert {a.gid for a in service_access_rights} == {team_gid, owner_gid}
+    assert {a.product_name for a in service_access_rights} == {
+        target_product,
+        products_names[-1],
+    }
 
 
 @pytest.mark.skip(reason="dev")

--- a/services/catalog/tests/unit/with_dbs/test_services_access_rights.py
+++ b/services/catalog/tests/unit/with_dbs/test_services_access_rights.py
@@ -105,6 +105,8 @@ async def test_auto_upgrade_policy(
                 everyone_access=None,
                 product=target_product,
             ),
+            # new release is a patch on released 1.0.X
+            # which were released in two different product
             service_catalog_faker(
                 new_service_metadata.key,
                 "1.0.0",
@@ -169,23 +171,3 @@ async def test_auto_upgrade_policy(
         target_product,
         products_names[-1],
     }
-
-
-@pytest.mark.skip(reason="dev")
-def test_it2(services_catalog):
-
-    # service S has a new patch released: 1.2.5 (i.e. backwards compatible bug fix, according to semver policies )
-    current_version = "1.10.5"
-    new_version = "1.10.6"
-
-    # the owner of service, checked the auto-upgrade patch policy in the publication contract (i.e.metadata.yml)
-
-    # service S:1.2.5 gets automatically the same access rights as S:1.2.4.
-    # access_rights = get_access_rights(service_key, service_version)
-
-    # set_access_rights(service_key, service_version, access_rights)
-
-    # NO
-    # all projects with nodes assigned to S:1.2.X get promoted to the latest patch S:1.2.5
-
-    # services can be published on different products (including file-picker and group nodes)

--- a/services/catalog/tests/unit/with_dbs/test_services_access_rights.py
+++ b/services/catalog/tests/unit/with_dbs/test_services_access_rights.py
@@ -4,7 +4,6 @@
 
 from typing import Callable, List
 
-import pytest
 from aiopg.sa.engine import Engine
 from fastapi import FastAPI
 from models_library.services import ServiceAccessRightsAtDB, ServiceDockerData


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

**Patch** releases inherit access rights from previous version (ONLY patch releases)

For instance: if the owner of service S releases version ``1.3.5``, the catalog service will automatically inherit and apply the access rights of the latest ``1.3.X`` released version. Notice that this auto-upgrade only applies to patch releases (i.e. only with the micro digit of the version increases)!  

#### catalog service
- CHANGED: Extends ``ServicesRepository``
      - Adds tests ``services/catalog/tests/unit/with_dbs/test_db_repositories.py``
- ADDED: Moves all access-rights policies to ``services/catalog/src/simcore_service_catalog/services/access_rights.py``
     - Adds tests ``services/catalog/tests/unit/with_dbs/test_services_access_rights.py``  
- ADDED: Versioning utils ``services/catalog/src/simcore_service_catalog/utils/versioning.py`` and associated tests ``services/catalog/tests/unit/test_utils_versioning.py``

#### packages
- Documents some of the ``packages/postgres-database/src/simcore_postgres_database/models`` tables
- Adds examples to ``packages/models-library/src/models_library/services.py`` models and created associated tests 

## Related issue/s

- Implements part of #2244: Auto-upgrade patch policy (point 3: patch releases inherit access rights from previous version)


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

```command
cd osparc-simcore
make devenv
source .venv/bin/activate
cd services/catalog
make install-dev
make test-dev-unit
```
will run new tests ... in particular ``test_services_access_rights`` and ``test_db_repositories``

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
