### PR TITLE
added script to create new users, and import projects as template

### DIFF
--- a/scripts/maintenance/create_user.py
+++ b/scripts/maintenance/create_user.py
@@ -1,0 +1,58 @@
+#! /usr/bin/env python3
+
+import asyncio
+
+import typer
+from httpx import URL, AsyncClient
+from pydantic.networks import EmailStr
+from pydantic.types import SecretStr
+
+
+async def logout_current_user(client: AsyncClient):
+    path = "/auth/logout"
+    r = await client.post(path)
+    r.raise_for_status()
+
+
+async def register_user(client: AsyncClient, email: EmailStr, password: SecretStr):
+    path = "/auth/register"
+    await client.post(
+        path,
+        json={
+            "email": email,
+            "password": password.get_secret_value(),
+            "confirm": password.get_secret_value(),
+            "invitation": "",
+        },
+    )
+
+
+async def create_user_with_password(
+    endpoint: URL, username: EmailStr, password: SecretStr
+) -> int:
+    try:
+        async with AsyncClient(base_url=endpoint.join("v0")) as client:
+            typer.secho(
+                f"registering user {username} with password {password}",
+                fg=typer.colors.YELLOW,
+            )
+            await register_user(client, username, password)
+            typer.secho(f"user registered", fg=typer.colors.YELLOW)
+            await logout_current_user(client)
+            typer.secho(f"registration done", fg=typer.colors.YELLOW)
+    except Exception as exc:  # pylint: disable=broad-except
+        typer.secho(f"Unexpected issue: {exc}", fg=typer.colors.RED, err=True)
+        return 1
+    return 0
+
+
+def main(endpoint: str, username: str, password: str) -> int:
+    return asyncio.get_event_loop().run_until_complete(
+        create_user_with_password(
+            URL(endpoint), EmailStr(username), SecretStr(password)
+        )
+    )
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/maintenance/import_projects_as_template.py
+++ b/scripts/maintenance/import_projects_as_template.py
@@ -1,0 +1,153 @@
+#! /usr/bin/env python3
+
+import asyncio
+from pathlib import Path
+from typing import Optional
+
+import typer
+from httpx import URL, AsyncClient
+from pydantic.networks import EmailStr
+from pydantic.types import SecretStr
+
+
+async def login_user(client: AsyncClient, email: EmailStr, password: SecretStr):
+    typer.secho(
+        f"loging user {email}",
+    )
+    path = "/auth/login"
+    r = await client.post(
+        path, json={"email": email, "password": password.get_secret_value()}
+    )
+    r.raise_for_status()
+    typer.secho(
+        f"user {email} logged in",
+        fg=typer.colors.YELLOW,
+    )
+
+
+async def import_project(client: AsyncClient, project_file: Path) -> str:
+    typer.secho(
+        f"importing project {project_file}",
+    )
+    path = "/projects%3Aimport"
+    files = {"fileName": open(project_file, mode="rb")}
+    r = await client.post(path, files=files, timeout=20)
+    r.raise_for_status()
+    typer.secho(
+        f"project {project_file} imported, received uuid is {r.json()['data']}",
+        fg=typer.colors.YELLOW,
+    )
+    return r.json()["data"]["uuid"]
+
+
+async def rename_project(client: AsyncClient, project_uuid: str, project_name: str):
+    path = f"/projects/{project_uuid}"
+    r = await client.get(path)
+    r.raise_for_status()
+    typer.secho(
+        f"project {project_uuid} received, current name is {r.json()['data']['name']}",
+    )
+
+    modified_project = r.json()["data"]
+    modified_project["name"] = project_name
+
+    typer.secho(
+        f"renaming project {project_uuid} to {project_name}",
+        fg=typer.colors.YELLOW,
+    )
+
+    r = await client.put(path, json=modified_project)
+    r.raise_for_status()
+    typer.secho(
+        f"project {project_uuid} renamed",
+        fg=typer.colors.YELLOW,
+    )
+
+
+async def publish_as_template(client: AsyncClient, project_uuid: str) -> str:
+    path = f"/projects/{project_uuid}"
+    r = await client.get(path)
+    r.raise_for_status()
+    typer.secho(
+        f"project {project_uuid} received, current name is {r.json()['data']['name']}",
+    )
+
+    # set access rights
+    modified_project = r.json()["data"]
+    modified_project["accessRights"].update(
+        {"1": {"read": True, "write": False, "delete": False}}
+    )
+
+    path = "/projects"
+    typer.secho(
+        f"publishing project {project_uuid} as template...",
+        fg=typer.colors.YELLOW,
+    )
+    r = await client.post(
+        path, params={"as_template": project_uuid}, json=modified_project
+    )
+    r.raise_for_status()
+    typer.secho(
+        f"project published as template {r.json()['data']['uuid']}",
+        fg=typer.colors.YELLOW,
+    )
+    return r.json()["data"]["uuid"]
+
+
+async def import_project_as_template(
+    endpoint: URL,
+    username: EmailStr,
+    password: SecretStr,
+    project_file: Path,
+    project_name: str,
+    share_with_gid: int,
+) -> int:
+    try:
+        async with AsyncClient(base_url=endpoint.join("v0")) as client:
+            await login_user(client, username, password)
+            project_uuid = await import_project(client, project_file)
+            await rename_project(client, project_uuid, project_name)
+            template_uuid = await publish_as_template(client, project_uuid)
+            typer.secho(
+                f"project published as template! uuid [{template_uuid}]",
+                fg=typer.colors.BRIGHT_WHITE,
+            )
+
+    except Exception as exc:  # pylint: disable=broad-except
+        typer.secho(f"Unexpected issue: {exc}", fg=typer.colors.RED, err=True)
+        return 1
+
+    return 0
+
+
+def main(
+    endpoint: str,
+    username: str,
+    password: str,
+    project_file: Path,
+    project_name: Optional[str] = None,
+    share_with_gid: Optional[int] = 1,
+) -> int:
+
+    if project_name is None:
+        project_name = project_file.name
+
+    typer.secho(
+        f"project {project_file} will be imported and named as {project_name}",
+        fg=typer.colors.YELLOW,
+    )
+
+    return asyncio.get_event_loop().run_until_complete(
+        import_project_as_template(
+            URL(endpoint),
+            EmailStr(username),
+            SecretStr(password),
+            project_file,
+            project_name,
+            share_with_gid,
+        )
+    )
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/maintenance/requirements.txt
+++ b/scripts/maintenance/requirements.txt
@@ -1,2 +1,5 @@
+black
 httpx
+pydantic[email,dotenv]
+pylint
 typer[colorama]


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- [x] added a scipt to add new users
- [x] added a script to import/rename/publish as template an exported project


Example:
```console
# this will create 20 users
for i in {01..20}; do ./create_user.py ENDPOINT puppeteer_$i@itis.testing PASSWORD; done
```

```console
# this will import the project, and publish it as a template project shared with group with gid 2 and name it accordingly
./import_projects_as_template.py http://127.0.0.1:9081 iamauser@osparc.io PASSWORD /my/file/path/50b7\#SHA256=2538b018162c842fd1c67096a88ba2cb19366b39b8b93ec19a7afafeca7a7fdc.osparc --project-name "some funky name" --share-with-gid 2
```

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
