### PR TITLE
using pyinstrument to log traceback of slow callbacks

### DIFF
--- a/packages/service-library/requirements/_base.in
+++ b/packages/service-library/requirements/_base.in
@@ -22,6 +22,8 @@ sqlalchemy
 psycopg2-binary
 pyyaml
 
+# used for monitoring of slow callbacks
+pyinstrument
 
 # These are limitations introduced by testing libraries
 

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -73,6 +73,10 @@ psycopg2-binary==2.8.6
     #   sqlalchemy
 pydantic==1.8.2
     # via -r requirements/_base.in
+pyinstrument-cext==0.2.4
+    # via pyinstrument
+pyinstrument==3.4.2
+    # via -r requirements/_base.in
 pyrsistent==0.17.3
     # via jsonschema
 pyyaml==5.4.1

--- a/packages/service-library/src/servicelib/monitor_slow_callbacks.py
+++ b/packages/service-library/src/servicelib/monitor_slow_callbacks.py
@@ -31,16 +31,16 @@ def enable(slow_duration_secs: float, incidents: List[SlowCallback]) -> None:
 
             dt = time.monotonic() - t0
 
-        # the indentation is correct, the profiler needs to be stopped when
-        # printing the output, the profiler is started and stopped by the
-        # contextmanger
-        profiler_result = profiler.output_text(unicode=True, color=False, show_all=True)
-
-        slow_callbacks_detected = "No samples were recorded." not in profiler_result
-
-        if slow_callbacks_detected:
+        if dt >= slow_duration_secs:
+            # the indentation is correct, the profiler needs to be stopped when
+            # printing the output, the profiler is started and stopped by the
+            # contextmanger
+            profiler_result = profiler.output_text(
+                unicode=True, color=False, show_all=True
+            )
             incidents.append(SlowCallback(msg=profiler_result, delay_secs=dt))
             logger.warning("Executing took %.3f seconds\n%s", dt, profiler_result)
+
         return retval
 
     asyncio.events.Handle._run = instrumented

--- a/packages/service-library/src/servicelib/monitor_slow_callbacks.py
+++ b/packages/service-library/src/servicelib/monitor_slow_callbacks.py
@@ -1,5 +1,6 @@
 import asyncio.events
 import time
+import sys
 from typing import List
 
 from pyinstrument import Profiler
@@ -20,6 +21,9 @@ def enable(slow_duration_secs: float, incidents: List[SlowCallback]) -> None:
     _run = asyncio.events.Handle._run
 
     def instrumented(self):
+        # unsetting profiler, helps with development mode and tests
+        sys.setprofile(None)
+
         with Profiler(interval=slow_duration_secs) as profiler:
             t0 = time.monotonic()
 

--- a/packages/service-library/src/servicelib/monitor_slow_callbacks.py
+++ b/packages/service-library/src/servicelib/monitor_slow_callbacks.py
@@ -34,7 +34,7 @@ def enable(slow_duration_secs: float, incidents: List[SlowCallback]) -> None:
 
         if slow_callbacks_detected:
             incidents.append(SlowCallback(msg=profiler_result, delay_secs=dt))
-            logger.warning(profiler_result)
+            logger.warning("Executing took %.3f seconds\n%s", dt, profiler_result)
         return retval
 
     asyncio.events.Handle._run = instrumented

--- a/packages/service-library/src/servicelib/monitor_slow_callbacks.py
+++ b/packages/service-library/src/servicelib/monitor_slow_callbacks.py
@@ -31,7 +31,8 @@ def enable(slow_duration_secs: float, incidents: List[SlowCallback]) -> None:
 
             dt = time.monotonic() - t0
 
-        profiler_result = profiler.output_text(unicode=True, color=False, show_all=True)
+            profiler_result = profiler.output_text(unicode=True, color=False, show_all=True)
+
         slow_callbacks_detected = "No samples were recorded." not in profiler_result
 
         if slow_callbacks_detected:

--- a/packages/service-library/src/servicelib/monitor_slow_callbacks.py
+++ b/packages/service-library/src/servicelib/monitor_slow_callbacks.py
@@ -20,14 +20,12 @@ def enable(slow_duration_secs: float, incidents: List[SlowCallback]) -> None:
     _run = asyncio.events.Handle._run
 
     def instrumented(self):
-        profiler = Profiler(interval=slow_duration_secs)
-        profiler.start()
-        t0 = time.monotonic()
+        with Profiler(interval=slow_duration_secs) as profiler:
+            t0 = time.monotonic()
 
-        retval = _run(self)
+            retval = _run(self)
 
-        dt = time.monotonic() - t0
-        profiler.stop()
+            dt = time.monotonic() - t0
 
         profiler_result = profiler.output_text(unicode=True, color=False, show_all=True)
         slow_callbacks_detected = "No samples were recorded." not in profiler_result

--- a/packages/service-library/src/servicelib/monitor_slow_callbacks.py
+++ b/packages/service-library/src/servicelib/monitor_slow_callbacks.py
@@ -31,7 +31,10 @@ def enable(slow_duration_secs: float, incidents: List[SlowCallback]) -> None:
 
             dt = time.monotonic() - t0
 
-            profiler_result = profiler.output_text(unicode=True, color=False, show_all=True)
+        # the indentation is correct, the profiler needs to be stopped when
+        # printing the output, the profiler is started and stopped by the
+        # contextmanger
+        profiler_result = profiler.output_text(unicode=True, color=False, show_all=True)
 
         slow_callbacks_detected = "No samples were recorded." not in profiler_result
 

--- a/services/web/server/tests/unit/isolated/test_healthcheck.py
+++ b/services/web/server/tests/unit/isolated/test_healthcheck.py
@@ -70,7 +70,7 @@ async def health_check_emulator(
 
 @pytest.fixture
 def client(loop, aiohttp_unused_port, aiohttp_client, api_version_prefix):
-    SLOW_HANDLER_DELAY_SECS = 1.0  # secs
+    SLOW_HANDLER_DELAY_SECS = 2.0  # secs
 
     # pylint:disable=unused-variable
     routes = web.RouteTableDef()
@@ -124,11 +124,11 @@ def client(loop, aiohttp_unused_port, aiohttp_client, api_version_prefix):
         app,
         slow_duration_secs=SLOW_HANDLER_DELAY_SECS / 10,
         max_task_delay=SLOW_HANDLER_DELAY_SECS,
-        max_avg_response_latency=1.0,
+        max_avg_response_latency=2.0,
         start_sensing_delay=0,  # inmidiately!
     )
 
-    assert app[kMAX_AVG_RESP_LATENCY] == 1.0
+    assert app[kMAX_AVG_RESP_LATENCY] == 2.0
 
     app.router.add_routes(routes)
 

--- a/services/web/server/tests/unit/isolated/test_healthcheck.py
+++ b/services/web/server/tests/unit/isolated/test_healthcheck.py
@@ -128,7 +128,7 @@ def client(loop, aiohttp_unused_port, aiohttp_client, api_version_prefix):
         start_sensing_delay=0,  # inmidiately!
     )
 
-    assert app[kMAX_AVG_RESP_LATENCY] == 2.0
+    assert app[kMAX_AVG_RESP_LATENCY] == 1.0
 
     app.router.add_routes(routes)
 

--- a/services/web/server/tests/unit/isolated/test_healthcheck.py
+++ b/services/web/server/tests/unit/isolated/test_healthcheck.py
@@ -124,7 +124,7 @@ def client(loop, aiohttp_unused_port, aiohttp_client, api_version_prefix):
         app,
         slow_duration_secs=SLOW_HANDLER_DELAY_SECS / 10,
         max_task_delay=SLOW_HANDLER_DELAY_SECS,
-        max_avg_response_latency=2.0,
+        max_avg_response_latency=1.0,
         start_sensing_delay=0,  # inmidiately!
     )
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

During the analysis of logs coming from production there were lots of entries similar to:

```bash
servicelib.monitor_slow_callbacks:instrumented(28) - Executing <Task finished coro=<Application._handle() done, defined at /home/scu/.venv/lib/python3.6/site-packages/aiohttp/web_app.py:428> result=<Response OK not prepared>> took 7.647 seconds
```

Adding `pyinstrument.Profiler` will help  format the output of the slow callbacks. A full traceback of the call will be logged.

**WARNING:** there is a [slight performance hit](https://github.com/joerick/pyinstrument#how-is-it-different-to-profile-or-cprofile) for running the profiler. I think this is worth it in order to have more meaningful log messages which will help debugging the stack.

**Trivia**

While looking for the current solution, [aioprof](https://github.com/leetreveil/aioprof) was considered and in part used as inspiration. Our codebase already had most of the tests and implementation in place to easily integrate `pyinstrument` on top of which `aioprof` is built.


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
