### PR TITLE
Refactoring webserver: async metrics handler, upgrades dependencies and fixes testing fixtures

### DIFF
--- a/packages/models-library/tests/test_package.py
+++ b/packages/models-library/tests/test_package.py
@@ -1,37 +1,19 @@
 # pylint:disable=unused-variable
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
-import os
-import re
-from pathlib import Path
-
-import pytest
-from pytest_simcore.helpers.utils_pylint import assert_pylint_is_passing
 
 
-@pytest.fixture
-def pylintrc(osparc_simcore_root_dir):
-    pylintrc = osparc_simcore_root_dir / ".pylintrc"
-    assert pylintrc.exists()
-    return pylintrc
+from pytest_simcore.helpers.utils_pylint import (
+    assert_no_pdb_in_code,
+    assert_pylint_is_passing,
+)
 
 
 def test_run_pylint(pylintrc, package_dir):
+    # fixtures in pytest_simcore.environs
     assert_pylint_is_passing(pylintrc=pylintrc, package_dir=package_dir)
 
 
 def test_no_pdbs_in_place(package_dir):
-    # TODO: add also test_dir excluding this function!?
-    # TODO: it can be commented!
-    # TODO: add check on other undesired code strings?!
-    MATCH = re.compile(r"pdb.set_trace()")
-    EXCLUDE = ["__pycache__", ".git"]
-    for root, dirs, files in os.walk(package_dir):
-        for name in files:
-            if name.endswith(".py"):
-                pypth = Path(root) / name
-                code = pypth.read_text()
-                found = MATCH.findall(code)
-                # TODO: should return line number
-                assert not found, "pbd.set_trace found in %s" % pypth
-        dirs[:] = [d for d in dirs if d not in EXCLUDE]
+    # fixtures in pytest_simcore.environs
+    assert_no_pdb_in_code(code_dir=package_dir)

--- a/packages/pytest-simcore/src/pytest_simcore/websocket_client.py
+++ b/packages/pytest-simcore/src/pytest_simcore/websocket_client.py
@@ -8,22 +8,23 @@ from uuid import uuid4
 import pytest
 import socketio
 from aiohttp import web
+from aiohttp.test_utils import TestClient
 from pytest_simcore.helpers.utils_assert import assert_status
 from yarl import URL
 
 
-@pytest.fixture
-def socketio_url(client) -> Callable:
-    def create_url(client_override: Optional = None) -> str:
+@pytest.fixture()
+def socketio_url_factory(client) -> Callable:
+    def create_url(client_override: Optional[TestClient] = None) -> str:
         SOCKET_IO_PATH = "/socket.io/"
         return str((client_override or client).make_url(SOCKET_IO_PATH))
 
     yield create_url
 
 
-@pytest.fixture
+@pytest.fixture()
 async def security_cookie_factory(client) -> Callable:
-    async def creator(client_override: Optional = None) -> str:
+    async def creator(client_override: Optional[TestClient] = None) -> str:
         # get the cookie by calling the root entrypoint
         resp = await (client_override or client).get("/v0/")
         data, error = await assert_status(resp, web.HTTPOk)
@@ -40,24 +41,19 @@ async def security_cookie_factory(client) -> Callable:
     yield creator
 
 
-@pytest.fixture
-def client_session_id() -> str:
-    return str(uuid4())
-
-
-@pytest.fixture
-async def socketio_client(
-    socketio_url: Callable, security_cookie_factory: Callable
-) -> Callable:
+@pytest.fixture()
+async def socketio_client_factory(
+    socketio_url_factory: Callable, security_cookie_factory: Callable
+) -> Callable[[str, Optional[TestClient]], socketio.AsyncClient]:
     clients = []
 
     async def connect(
-        client_session_id: str, client: Optional = None
+        client_session_id: str, client: Optional[TestClient] = None
     ) -> socketio.AsyncClient:
         sio = socketio.AsyncClient(ssl_verify=False)
         # enginio 3.10.0 introduced ssl verification
         url = str(
-            URL(socketio_url(client)).with_query(
+            URL(socketio_url_factory(client)).with_query(
                 {"client_session_id": client_session_id}
             )
         )
@@ -77,3 +73,11 @@ async def socketio_client(
     for sio in clients:
         await sio.disconnect()
         assert not sio.sid
+
+
+@pytest.fixture()
+def client_session_id_factory() -> Callable[[], str]:
+    def create() -> str:
+        return str(uuid4())
+
+    return create

--- a/packages/pytest-simcore/src/pytest_simcore/websocket_client.py
+++ b/packages/pytest-simcore/src/pytest_simcore/websocket_client.py
@@ -23,7 +23,7 @@ def socketio_url_factory(client) -> Callable:
 
 
 @pytest.fixture()
-async def security_cookie_factory(client) -> Callable:
+async def security_cookie_factory(client: TestClient) -> Callable:
     async def creator(client_override: Optional[TestClient] = None) -> str:
         # get the cookie by calling the root entrypoint
         resp = await (client_override or client).get("/v0/")
@@ -50,6 +50,7 @@ async def socketio_client_factory(
     async def connect(
         client_session_id: str, client: Optional[TestClient] = None
     ) -> socketio.AsyncClient:
+
         sio = socketio.AsyncClient(ssl_verify=False)
         # enginio 3.10.0 introduced ssl verification
         url = str(
@@ -71,7 +72,8 @@ async def socketio_client_factory(
     yield connect
 
     for sio in clients:
-        await sio.disconnect()
+        if sio.connected:
+            await sio.disconnect()
         assert not sio.sid
 
 

--- a/packages/service-library/tests/conftest.py
+++ b/packages/service-library/tests/conftest.py
@@ -10,6 +10,10 @@ import pytest
 import servicelib
 from servicelib.openapi import create_openapi_specs
 
+pytest_plugins = [
+    "pytest_simcore.repository_paths",
+]
+
 
 @pytest.fixture(scope="session")
 def here():

--- a/packages/service-library/tests/test_package.py
+++ b/packages/service-library/tests/test_package.py
@@ -2,42 +2,22 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-import os
-import re
-from pathlib import Path
 
-import pytest
-
-from pytest_simcore.helpers.utils_pylint import assert_pylint_is_passing
+from pytest_simcore.helpers.utils_pylint import (
+    assert_no_pdb_in_code,
+    assert_pylint_is_passing,
+)
 from servicelib.utils import is_osparc_repo_dir, search_osparc_repo_dir
 
 
-@pytest.fixture
-def pylintrc(osparc_simcore_root_dir):
-    pylintrc = osparc_simcore_root_dir / ".pylintrc"
-    assert pylintrc.exists()
-    return pylintrc
-
-
 def test_run_pylint(pylintrc, package_dir):
+    # fixtures in pytest_simcore.environs
     assert_pylint_is_passing(pylintrc=pylintrc, package_dir=package_dir)
 
 
 def test_no_pdbs_in_place(package_dir):
-    # TODO: add also test_dir excluding this function!?
-    # TODO: it can be commented!
-    # TODO: add check on other undesired code strings?!
-    MATCH = re.compile(r"pdb.set_trace()")
-    EXCLUDE = ["__pycache__", ".git"]
-    for root, dirs, files in os.walk(package_dir):
-        for name in files:
-            if name.endswith(".py"):
-                pypth = Path(root) / name
-                code = pypth.read_text()
-                found = MATCH.findall(code)
-                # TODO: should return line number
-                assert not found, "pbd.set_trace found in %s" % pypth
-        dirs[:] = [d for d in dirs if d not in EXCLUDE]
+    # fixtures in pytest_simcore.environs
+    assert_no_pdb_in_code(code_dir=package_dir)
 
 
 def test_utils(osparc_simcore_root_dir, package_dir):

--- a/packages/simcore-sdk/tests/unit/test_package.py
+++ b/packages/simcore-sdk/tests/unit/test_package.py
@@ -2,37 +2,18 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-import os
-import re
-from pathlib import Path
 
-import pytest
-from pytest_simcore.helpers.utils_pylint import assert_pylint_is_passing
-
-
-@pytest.fixture
-def pylintrc(osparc_simcore_root_dir):
-    pylintrc = osparc_simcore_root_dir / ".pylintrc"
-    assert pylintrc.exists()
-    return pylintrc
+from pytest_simcore.helpers.utils_pylint import (
+    assert_no_pdb_in_code,
+    assert_pylint_is_passing,
+)
 
 
 def test_run_pylint(pylintrc, package_dir):
+    # fixtures in pytest_simcore.environs
     assert_pylint_is_passing(pylintrc=pylintrc, package_dir=package_dir)
 
 
 def test_no_pdbs_in_place(package_dir):
-    # TODO: add also test_dir excluding this function!?
-    # TODO: it can be commented!
-    # TODO: add check on other undesired code strings?!
-    MATCH = re.compile(r"pdb.set_trace()")
-    EXCLUDE = ["__pycache__", ".git"]
-    for root, dirs, files in os.walk(package_dir):
-        for name in files:
-            if name.endswith(".py"):
-                pypth = Path(root) / name
-                code = pypth.read_text()
-                found = MATCH.findall(code)
-                # TODO: should return line number
-                assert not found, "pbd.set_trace found in %s" % pypth
-        dirs[:] = [d for d in dirs if d not in EXCLUDE]
+    # fixtures in pytest_simcore.environs
+    assert_no_pdb_in_code(code_dir=package_dir)

--- a/services/api-server/tests/unit/test__code_syntax.py
+++ b/services/api-server/tests/unit/test__code_syntax.py
@@ -2,33 +2,18 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-import os
-import re
-from pathlib import Path
 
-import pytest
-from pytest_simcore.helpers.utils_pylint import assert_pylint_is_passing
-
-
-@pytest.fixture
-def pylintrc(osparc_simcore_root_dir):
-    pylintrc_path = osparc_simcore_root_dir / ".pylintrc"
-    assert pylintrc_path.exists()
-    return pylintrc_path
+from pytest_simcore.helpers.utils_pylint import (
+    assert_no_pdb_in_code,
+    assert_pylint_is_passing,
+)
 
 
 def test_run_pylint(pylintrc, package_dir):
+    # fixtures in pytest_simcore.environs
     assert_pylint_is_passing(pylintrc=pylintrc, package_dir=package_dir)
 
 
 def test_no_pdbs_in_place(package_dir):
-    MATCH = re.compile(r"pdb.set_trace()")
-    EXCLUDE = ["__pycache__", ".git"]
-    for root, dirs, files in os.walk(package_dir):
-        for name in files:
-            if name.endswith(".py"):
-                pypth = Path(root) / name
-                code = pypth.read_text()
-                found = MATCH.findall(code)
-                assert not found, "pbd.set_trace found in %s" % pypth
-        dirs[:] = [d for d in dirs if d not in EXCLUDE]
+    # fixtures in pytest_simcore.environs
+    assert_no_pdb_in_code(code_dir=package_dir)

--- a/services/catalog/tests/unit/test__code_syntax.py
+++ b/services/catalog/tests/unit/test__code_syntax.py
@@ -2,33 +2,18 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-import os
-import re
-from pathlib import Path
 
-import pytest
-from pytest_simcore.helpers.utils_pylint import assert_pylint_is_passing
-
-
-@pytest.fixture
-def pylintrc(osparc_simcore_root_dir):
-    pylintrc_path = osparc_simcore_root_dir / ".pylintrc"
-    assert pylintrc_path.exists()
-    return pylintrc_path
+from pytest_simcore.helpers.utils_pylint import (
+    assert_no_pdb_in_code,
+    assert_pylint_is_passing,
+)
 
 
 def test_run_pylint(pylintrc, package_dir):
+    # fixtures in pytest_simcore.environs
     assert_pylint_is_passing(pylintrc=pylintrc, package_dir=package_dir)
 
 
 def test_no_pdbs_in_place(package_dir):
-    MATCH = re.compile(r"pdb.set_trace()")
-    EXCLUDE = ["__pycache__", ".git"]
-    for root, dirs, files in os.walk(package_dir):
-        for name in files:
-            if name.endswith(".py"):
-                pypth = Path(root) / name
-                code = pypth.read_text()
-                found = MATCH.findall(code)
-                assert not found, "pbd.set_trace found in %s" % pypth
-        dirs[:] = [d for d in dirs if d not in EXCLUDE]
+    # fixtures in pytest_simcore.environs
+    assert_no_pdb_in_code(code_dir=package_dir)

--- a/services/sidecar/tests/unit/test_code_syntax.py
+++ b/services/sidecar/tests/unit/test_code_syntax.py
@@ -1,33 +1,19 @@
 # pylint:disable=unused-variable
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
-import os
-import re
-from pathlib import Path
-
-import pytest
-from pytest_simcore.helpers.utils_pylint import assert_pylint_is_passing
 
 
-@pytest.fixture
-def pylintrc(osparc_simcore_root_dir):
-    pylintrc_path = osparc_simcore_root_dir / ".pylintrc"
-    assert pylintrc_path.exists()
-    return pylintrc_path
+from pytest_simcore.helpers.utils_pylint import (
+    assert_no_pdb_in_code,
+    assert_pylint_is_passing,
+)
 
 
 def test_run_pylint(pylintrc, package_dir):
+    # fixtures in pytest_simcore.environs
     assert_pylint_is_passing(pylintrc=pylintrc, package_dir=package_dir)
 
 
 def test_no_pdbs_in_place(package_dir):
-    MATCH = re.compile(r"pdb.set_trace()")
-    EXCLUDE = ["__pycache__", ".git"]
-    for root, dirs, files in os.walk(package_dir):
-        for name in files:
-            if name.endswith(".py"):
-                pypth = Path(root) / name
-                code = pypth.read_text()
-                found = MATCH.findall(code)
-                assert not found, "pbd.set_trace found in %s" % pypth
-        dirs[:] = [d for d in dirs if d not in EXCLUDE]
+    # fixtures in pytest_simcore.environs
+    assert_no_pdb_in_code(code_dir=package_dir)

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -39,6 +39,7 @@ from tests.utils import (
 )
 
 pytest_plugins = [
+    "pytest_simcore.repository_paths",
     "tests.fixtures.data_models",
 ]
 

--- a/services/storage/tests/test_package.py
+++ b/services/storage/tests/test_package.py
@@ -3,16 +3,17 @@
 # pylint:disable=redefined-outer-name
 
 
-import pytest
-from pytest_simcore.helpers.utils_pylint import assert_pylint_is_passing
-
-
-@pytest.fixture
-def pylintrc(osparc_simcore_root_dir):
-    pylintrc = osparc_simcore_root_dir / ".pylintrc"
-    assert pylintrc.exists()
-    return pylintrc
+from pytest_simcore.helpers.utils_pylint import (
+    assert_no_pdb_in_code,
+    assert_pylint_is_passing,
+)
 
 
 def test_run_pylint(pylintrc, package_dir):
+    # fixtures in pytest_simcore.environs
     assert_pylint_is_passing(pylintrc=pylintrc, package_dir=package_dir)
+
+
+def test_no_pdbs_in_place(package_dir):
+    # fixtures in pytest_simcore.environs
+    assert_no_pdb_in_code(code_dir=package_dir)

--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -7,7 +7,7 @@
 -r ../../../../packages/postgres-database/requirements/_base.in
 -r ../../../../packages/service-library/requirements/_base.in
 
-aiohttp==3.6.3 ## Issue in https://github.com/ITISFoundation/osparc-simcore/issues/2008
+aiohttp # ==3.6.3 ## Issue in https://github.com/ITISFoundation/osparc-simcore/issues/2008
 
 aio-pika
 aiohttp_jinja2

--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -8,14 +8,18 @@
 -r ../../../../packages/service-library/requirements/_base.in
 
 # aiohttp + extensions
-aiohttp==3.6.3 ## Issue in https://github.com/ITISFoundation/osparc-simcore/issues/2008
+## Issue in https://github.com/ITISFoundation/osparc-simcore/issues/2008
+aiohttp==3.6.3
 aiohttp_jinja2
 aiohttp_session[secure]
 aiohttp_security
 aiohttp-swagger[performance]
 
 # web-sockets
-python-socketio
+# From 5.0.0, https://github.com/miguelgrinberg/python-socketio/blob/main/CHANGES.md
+# test_resource_manager.py::test_websocket_resource_management fails because
+# socket_id saved in redis does not correspond to client's sio
+python-socketio~=4.6.1
 
 # databases
 aiopg[sa]

--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -7,32 +7,55 @@
 -r ../../../../packages/postgres-database/requirements/_base.in
 -r ../../../../packages/service-library/requirements/_base.in
 
+# aiohttp + extensions
 aiohttp==3.6.3 ## Issue in https://github.com/ITISFoundation/osparc-simcore/issues/2008
-
-aio-pika
 aiohttp_jinja2
 aiohttp_session[secure]
 aiohttp_security
 aiohttp-swagger[performance]
+
+# web-sockets
+python-socketio
+
+# databases
 aiopg[sa]
+asyncpg
+
+# redis
 aioredis
 aioredlock
-aiosmtplib
-asyncpg
+
+# scheduling, queues and AMQP client
 celery[redis]
+aio-pika
+
+# email
+aiosmtplib
+jinja_app_loader
+
+
+# data models
+pydantic[email]
+
+# security
 cryptography
+passlib
+
+# json
+orjson
+jsondiff
+json2html
+
+# asyncio debug
+aiodebug
+
+
+# misc
 change_case
 expiringdict
-jinja_app_loader
-jsondiff
-passlib
-python-socketio
 semantic_version
-aiodebug
-json2html
+
+# import/export excel
 parfive
 openpyxl
 python-magic
-
-pydantic[email]
-orjson

--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -7,7 +7,7 @@
 -r ../../../../packages/postgres-database/requirements/_base.in
 -r ../../../../packages/service-library/requirements/_base.in
 
-aiohttp # ==3.6.3 ## Issue in https://github.com/ITISFoundation/osparc-simcore/issues/2008
+aiohttp==3.6.3 ## Issue in https://github.com/ITISFoundation/osparc-simcore/issues/2008
 
 aio-pika
 aiohttp_jinja2

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -65,8 +65,6 @@ attrs==20.3.0
     #   aioredlock
     #   jsonschema
     #   openapi-core
-bidict==0.21.2
-    # via python-socketio
 billiard==3.6.4.0
     # via celery
 celery[redis]==5.0.5
@@ -204,11 +202,11 @@ pyinstrument==3.4.2
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
 pyrsistent==0.17.3
     # via jsonschema
-python-engineio==4.2.0
+python-engineio==3.14.2
     # via python-socketio
 python-magic==0.4.22
     # via -r requirements/_base.in
-python-socketio==5.3.0
+python-socketio==4.6.1
     # via -r requirements/_base.in
 pytz==2021.1
     # via celery
@@ -233,6 +231,8 @@ six==1.16.0
     #   openapi-core
     #   openapi-schema-validator
     #   openapi-spec-validator
+    #   python-engineio
+    #   python-socketio
     #   tenacity
 sqlalchemy[postgresql_psycopg2binary]==1.3.24
     # via

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=requirements/_base.txt requirements/_base.in
 #
-aio-pika==6.7.1
+aio-pika==6.8.0
     # via -r requirements/_base.in
 aiodebug==1.1.2
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiohttp-jinja2==1.2.0
+aiohttp-jinja2==1.4.2
     # via -r requirements/_base.in
 aiohttp-security==0.4.0
     # via -r requirements/_base.in
@@ -36,11 +36,11 @@ aioredis==1.3.1
     # via
     #   -r requirements/_base.in
     #   aioredlock
-aioredlock==0.5.2
+aioredlock==0.7.1
     # via -r requirements/_base.in
-aiormq==3.2.3
+aiormq==3.3.1
     # via aio-pika
-aiosmtplib==1.1.3
+aiosmtplib==1.1.6
     # via -r requirements/_base.in
 aiozipkin==0.7.1
     # via
@@ -49,14 +49,14 @@ aiozipkin==0.7.1
     #   -c requirements/../../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
-amqp==5.0.1
+amqp==5.0.6
     # via kombu
 async-timeout==3.0.1
     # via
     #   aiohttp
     #   aiopg
     #   aioredis
-asyncpg==0.21.0
+asyncpg==0.23.0
     # via -r requirements/_base.in
 attrs==20.3.0
     # via
@@ -65,11 +65,13 @@ attrs==20.3.0
     #   aioredlock
     #   jsonschema
     #   openapi-core
-billiard==3.6.3.0
+bidict==0.21.2
+    # via python-socketio
+billiard==3.6.4.0
     # via celery
-celery[redis]==5.0.1
+celery[redis]==5.0.5
     # via -r requirements/_base.in
-cffi==1.14.2
+cffi==1.14.5
     # via cryptography
 change-case==0.5.2
     # via -r requirements/_base.in
@@ -77,14 +79,17 @@ chardet==3.0.4
     # via aiohttp
 click-didyoumean==0.0.3
     # via celery
+click-plugins==1.1.1
+    # via celery
 click-repl==0.1.6
     # via celery
 click==7.1.2
     # via
     #   celery
     #   click-didyoumean
+    #   click-plugins
     #   click-repl
-cryptography==3.4.5
+cryptography==3.4.7
     # via
     #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -92,17 +97,19 @@ cryptography==3.4.5
     #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/_base.in
     #   aiohttp-session
-dataclasses==0.7
-    # via pydantic
-dnspython==2.0.0
+dataclasses==0.8
+    # via
+    #   pydantic
+    #   werkzeug
+dnspython==2.1.0
     # via email-validator
-email-validator==1.1.1
+email-validator==1.1.2
     # via pydantic
-et-xmlfile==1.0.1
+et-xmlfile==1.1.0
     # via openpyxl
 expiringdict==1.2.1
     # via -r requirements/_base.in
-hiredis==1.1.0
+hiredis==2.0.0
     # via aioredis
 idna-ssl==1.1.0
     # via aiohttp
@@ -114,12 +121,14 @@ idna==2.10
     #   email-validator
     #   idna-ssl
     #   yarl
-importlib-metadata==3.1.1
+importlib-metadata==4.0.1
     # via
     #   jsonschema
     #   kombu
 isodate==0.6.0
-    # via openapi-core
+    # via
+    #   openapi-core
+    #   openapi-schema-validator
 jinja-app-loader==1.0.2
     # via -r requirements/_base.in
 jinja2==2.11.3
@@ -132,11 +141,12 @@ jinja2==2.11.3
     #   aiohttp-swagger
 json2html==1.3.0
     # via -r requirements/_base.in
-jsondiff==1.2.0
+jsondiff==1.3.0
     # via -r requirements/_base.in
 jsonschema==3.2.0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
+    #   openapi-schema-validator
     #   openapi-spec-validator
 kombu==5.0.2
     # via celery
@@ -154,23 +164,25 @@ multidict==4.7.6
     #   yarl
 openapi-core==0.12.0
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-openapi-spec-validator==0.2.9
+openapi-schema-validator==0.1.5
+    # via openapi-spec-validator
+openapi-spec-validator==0.3.1
     # via openapi-core
 openpyxl==3.0.7
     # via -r requirements/_base.in
-orjson==3.4.8
+orjson==3.5.2
     # via -r requirements/_base.in
 pamqp==2.3.0
     # via aiormq
 parfive==1.0.2
     # via -r requirements/_base.in
-passlib==1.7.2
+passlib==1.7.4
     # via -r requirements/_base.in
-prometheus-client==0.9.0
+prometheus-client==0.10.1
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-prompt-toolkit==3.0.8
+prompt-toolkit==3.0.18
     # via click-repl
-psycopg2-binary==2.8.5
+psycopg2-binary==2.8.6
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   aiopg
@@ -190,15 +202,15 @@ pyinstrument-cext==0.2.4
     # via pyinstrument
 pyinstrument==3.4.2
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-pyrsistent==0.16.0
+pyrsistent==0.17.3
     # via jsonschema
-python-engineio==3.13.2
+python-engineio==4.2.0
     # via python-socketio
 python-magic==0.4.22
     # via -r requirements/_base.in
-python-socketio==4.6.0
+python-socketio==5.3.0
     # via -r requirements/_base.in
-pytz==2020.1
+pytz==2021.1
     # via celery
 pyyaml==5.4.1
     # via
@@ -213,18 +225,16 @@ redis==3.5.3
     # via celery
 semantic-version==2.8.5
     # via -r requirements/_base.in
-six==1.15.0
+six==1.16.0
     # via
     #   click-repl
     #   isodate
     #   jsonschema
     #   openapi-core
+    #   openapi-schema-validator
     #   openapi-spec-validator
-    #   pyrsistent
-    #   python-engineio
-    #   python-socketio
     #   tenacity
-sqlalchemy[postgresql_psycopg2binary]==1.3.20
+sqlalchemy[postgresql_psycopg2binary]==1.3.24
     # via
     #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -235,18 +245,21 @@ sqlalchemy[postgresql_psycopg2binary]==1.3.20
     #   aiopg
 strict-rfc3339==0.7
     # via openapi-core
-tenacity==6.2.0
+tenacity==7.0.0
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-tqdm==4.54.1
+tqdm==4.60.0
     # via parfive
-trafaret==2.0.2
+trafaret==2.1.0
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   aiohttp
+    #   aiohttp-jinja2
+    #   asyncpg
+    #   importlib-metadata
     #   pydantic
     #   yarl
-ujson==3.1.0
+ujson==4.0.2
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   aiohttp-swagger
@@ -256,7 +269,7 @@ vine==5.0.0
     #   celery
 wcwidth==0.2.5
     # via prompt-toolkit
-werkzeug==1.0.1
+werkzeug==2.0.1
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
 yarl==1.5.1
     # via
@@ -264,7 +277,7 @@ yarl==1.5.1
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.1.0
+zipp==3.4.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -36,7 +36,7 @@ aioredis==1.3.1
     # via
     #   -r requirements/_base.in
     #   aioredlock
-aioredlock==0.5.2
+aioredlock==0.7.1
     # via -r requirements/_base.in
 aiormq==3.3.1
     # via aio-pika
@@ -107,7 +107,7 @@ et-xmlfile==1.1.0
     # via openpyxl
 expiringdict==1.2.1
     # via -r requirements/_base.in
-hiredis==1.1.0
+hiredis==2.0.0
     # via aioredis
 idna-ssl==1.1.0
     # via aiohttp

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -65,6 +65,8 @@ attrs==20.3.0
     #   aioredlock
     #   jsonschema
     #   openapi-core
+bidict==0.21.2
+    # via python-socketio
 billiard==3.6.4.0
     # via celery
 celery[redis]==5.0.5
@@ -202,11 +204,11 @@ pyinstrument==3.4.2
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
 pyrsistent==0.17.3
     # via jsonschema
-python-engineio==3.13.2
+python-engineio==4.2.0
     # via python-socketio
 python-magic==0.4.22
     # via -r requirements/_base.in
-python-socketio==4.6.0
+python-socketio==5.3.0
     # via -r requirements/_base.in
 pytz==2021.1
     # via celery

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -162,11 +162,13 @@ multidict==4.7.6
     #   yarl
 openapi-core==0.12.0
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-openapi-spec-validator==0.2.9
+openapi-schema-validator==0.1.5
+    # via openapi-spec-validator
+openapi-spec-validator==0.3.1
     # via openapi-core
 openpyxl==3.0.7
     # via -r requirements/_base.in
-orjson==3.4.8
+orjson==3.5.2
     # via -r requirements/_base.in
 pamqp==2.3.0
     # via aiormq
@@ -227,12 +229,10 @@ six==1.16.0
     #   isodate
     #   jsonschema
     #   openapi-core
+    #   openapi-schema-validator
     #   openapi-spec-validator
-    #   pyrsistent
-    #   python-engineio
-    #   python-socketio
     #   tenacity
-sqlalchemy[postgresql_psycopg2binary]==1.3.20
+sqlalchemy[postgresql_psycopg2binary]==1.3.24
     # via
     #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -245,7 +245,7 @@ strict-rfc3339==0.7
     # via openapi-core
 tenacity==7.0.0
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-tqdm==4.54.1
+tqdm==4.60.0
     # via parfive
 trafaret==2.1.0
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
@@ -257,7 +257,7 @@ typing-extensions==3.10.0.0
     #   importlib-metadata
     #   pydantic
     #   yarl
-ujson==3.1.0
+ujson==4.0.2
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   aiohttp-swagger

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_base.txt requirements/_base.in
 #
-aio-pika==6.7.1
+aio-pika==6.8.0
     # via -r requirements/_base.in
 aiodebug==1.1.2
     # via
@@ -38,7 +38,7 @@ aioredis==1.3.1
     #   aioredlock
 aioredlock==0.5.2
     # via -r requirements/_base.in
-aiormq==3.2.3
+aiormq==3.3.1
     # via aio-pika
 aiosmtplib==1.1.3
     # via -r requirements/_base.in

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -182,6 +182,10 @@ pycparser==2.20
     # via cffi
 pydantic[email]==1.8.2
     # via
+    #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/../../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
@@ -243,6 +247,7 @@ trafaret==2.0.2
 typing-extensions==3.7.4.3
     # via
     #   aiohttp
+    #   aiohttp-jinja2
     #   pydantic
     #   yarl
 ujson==3.1.0

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -18,7 +18,7 @@ aiohttp-session[secure]==2.9.0
     # via -r requirements/_base.in
 aiohttp-swagger[performance]==1.0.15
     # via -r requirements/_base.in
-aiohttp==3.6.3
+aiohttp==3.7.4.post0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -87,7 +87,7 @@ click==7.1.2
     #   click-didyoumean
     #   click-plugins
     #   click-repl
-cryptography==3.4.5
+cryptography==3.4.7
     # via
     #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -95,11 +95,11 @@ cryptography==3.4.5
     #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/_base.in
     #   aiohttp-session
-dataclasses==0.7
+dataclasses==0.8
     # via pydantic
 dnspython==2.0.0
     # via email-validator
-email-validator==1.1.1
+email-validator==1.1.2
     # via pydantic
 et-xmlfile==1.0.1
     # via openpyxl

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -67,7 +67,7 @@ attrs==20.3.0
     #   openapi-core
 billiard==3.6.3.0
     # via celery
-celery[redis]==5.0.1
+celery[redis]==5.0.5
     # via -r requirements/_base.in
 cffi==1.14.2
     # via cryptography
@@ -77,12 +77,15 @@ chardet==3.0.4
     # via aiohttp
 click-didyoumean==0.0.3
     # via celery
+click-plugins==1.1.1
+    # via celery
 click-repl==0.1.6
     # via celery
 click==7.1.2
     # via
     #   celery
     #   click-didyoumean
+    #   click-plugins
     #   click-repl
 cryptography==3.4.5
     # via

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -18,7 +18,7 @@ aiohttp-session[secure]==2.9.0
     # via -r requirements/_base.in
 aiohttp-swagger[performance]==1.0.15
     # via -r requirements/_base.in
-aiohttp==3.7.4.post0
+aiohttp==3.6.3
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=requirements/_base.txt requirements/_base.in
 #
-aio-pika==6.8.0
+aio-pika==6.7.1
     # via -r requirements/_base.in
 aiodebug==1.1.2
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiohttp-jinja2==1.4.2
+aiohttp-jinja2==1.2.0
     # via -r requirements/_base.in
 aiohttp-security==0.4.0
     # via -r requirements/_base.in
@@ -36,11 +36,11 @@ aioredis==1.3.1
     # via
     #   -r requirements/_base.in
     #   aioredlock
-aioredlock==0.7.1
+aioredlock==0.5.2
     # via -r requirements/_base.in
-aiormq==3.3.1
+aiormq==3.2.3
     # via aio-pika
-aiosmtplib==1.1.6
+aiosmtplib==1.1.3
     # via -r requirements/_base.in
 aiozipkin==0.7.1
     # via
@@ -49,14 +49,14 @@ aiozipkin==0.7.1
     #   -c requirements/../../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
-amqp==5.0.6
+amqp==5.0.1
     # via kombu
 async-timeout==3.0.1
     # via
     #   aiohttp
     #   aiopg
     #   aioredis
-asyncpg==0.23.0
+asyncpg==0.21.0
     # via -r requirements/_base.in
 attrs==20.3.0
     # via
@@ -65,13 +65,11 @@ attrs==20.3.0
     #   aioredlock
     #   jsonschema
     #   openapi-core
-bidict==0.21.2
-    # via python-socketio
-billiard==3.6.4.0
+billiard==3.6.3.0
     # via celery
-celery[redis]==5.0.5
+celery[redis]==5.0.1
     # via -r requirements/_base.in
-cffi==1.14.5
+cffi==1.14.2
     # via cryptography
 change-case==0.5.2
     # via -r requirements/_base.in
@@ -79,17 +77,14 @@ chardet==3.0.4
     # via aiohttp
 click-didyoumean==0.0.3
     # via celery
-click-plugins==1.1.1
-    # via celery
 click-repl==0.1.6
     # via celery
 click==7.1.2
     # via
     #   celery
     #   click-didyoumean
-    #   click-plugins
     #   click-repl
-cryptography==3.4.7
+cryptography==3.4.5
     # via
     #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -97,19 +92,17 @@ cryptography==3.4.7
     #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/_base.in
     #   aiohttp-session
-dataclasses==0.8
-    # via
-    #   pydantic
-    #   werkzeug
-dnspython==2.1.0
-    # via email-validator
-email-validator==1.1.2
+dataclasses==0.7
     # via pydantic
-et-xmlfile==1.1.0
+dnspython==2.0.0
+    # via email-validator
+email-validator==1.1.1
+    # via pydantic
+et-xmlfile==1.0.1
     # via openpyxl
 expiringdict==1.2.1
     # via -r requirements/_base.in
-hiredis==2.0.0
+hiredis==1.1.0
     # via aioredis
 idna-ssl==1.1.0
     # via aiohttp
@@ -121,14 +114,12 @@ idna==2.10
     #   email-validator
     #   idna-ssl
     #   yarl
-importlib-metadata==4.0.1
+importlib-metadata==3.1.1
     # via
     #   jsonschema
     #   kombu
 isodate==0.6.0
-    # via
-    #   openapi-core
-    #   openapi-schema-validator
+    # via openapi-core
 jinja-app-loader==1.0.2
     # via -r requirements/_base.in
 jinja2==2.11.3
@@ -141,12 +132,11 @@ jinja2==2.11.3
     #   aiohttp-swagger
 json2html==1.3.0
     # via -r requirements/_base.in
-jsondiff==1.3.0
+jsondiff==1.2.0
     # via -r requirements/_base.in
 jsonschema==3.2.0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
-    #   openapi-schema-validator
     #   openapi-spec-validator
 kombu==5.0.2
     # via celery
@@ -164,25 +154,23 @@ multidict==4.7.6
     #   yarl
 openapi-core==0.12.0
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-openapi-schema-validator==0.1.5
-    # via openapi-spec-validator
-openapi-spec-validator==0.3.1
+openapi-spec-validator==0.2.9
     # via openapi-core
 openpyxl==3.0.7
     # via -r requirements/_base.in
-orjson==3.5.2
+orjson==3.4.8
     # via -r requirements/_base.in
 pamqp==2.3.0
     # via aiormq
 parfive==1.0.2
     # via -r requirements/_base.in
-passlib==1.7.4
+passlib==1.7.2
     # via -r requirements/_base.in
-prometheus-client==0.10.1
+prometheus-client==0.9.0
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-prompt-toolkit==3.0.18
+prompt-toolkit==3.0.8
     # via click-repl
-psycopg2-binary==2.8.6
+psycopg2-binary==2.8.5
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   aiopg
@@ -191,10 +179,6 @@ pycparser==2.20
     # via cffi
 pydantic[email]==1.8.2
     # via
-    #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/../../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
@@ -204,13 +188,13 @@ pyinstrument==3.4.2
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
 pyrsistent==0.17.3
     # via jsonschema
-python-engineio==4.2.0
+python-engineio==3.13.2
     # via python-socketio
 python-magic==0.4.22
     # via -r requirements/_base.in
-python-socketio==5.3.0
+python-socketio==4.6.0
     # via -r requirements/_base.in
-pytz==2021.1
+pytz==2020.1
     # via celery
 pyyaml==5.4.1
     # via
@@ -225,16 +209,18 @@ redis==3.5.3
     # via celery
 semantic-version==2.8.5
     # via -r requirements/_base.in
-six==1.16.0
+six==1.15.0
     # via
     #   click-repl
     #   isodate
     #   jsonschema
     #   openapi-core
-    #   openapi-schema-validator
     #   openapi-spec-validator
+    #   pyrsistent
+    #   python-engineio
+    #   python-socketio
     #   tenacity
-sqlalchemy[postgresql_psycopg2binary]==1.3.24
+sqlalchemy[postgresql_psycopg2binary]==1.3.20
     # via
     #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -245,21 +231,18 @@ sqlalchemy[postgresql_psycopg2binary]==1.3.24
     #   aiopg
 strict-rfc3339==0.7
     # via openapi-core
-tenacity==7.0.0
+tenacity==6.2.0
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-tqdm==4.60.0
+tqdm==4.54.1
     # via parfive
-trafaret==2.1.0
+trafaret==2.0.2
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-typing-extensions==3.10.0.0
+typing-extensions==3.7.4.3
     # via
     #   aiohttp
-    #   aiohttp-jinja2
-    #   asyncpg
-    #   importlib-metadata
     #   pydantic
     #   yarl
-ujson==4.0.2
+ujson==3.1.0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   aiohttp-swagger
@@ -269,7 +252,7 @@ vine==5.0.0
     #   celery
 wcwidth==0.2.5
     # via prompt-toolkit
-werkzeug==2.0.1
+werkzeug==1.0.1
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
 yarl==1.5.1
     # via
@@ -277,7 +260,7 @@ yarl==1.5.1
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.4.1
+zipp==3.1.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -49,7 +49,7 @@ aiozipkin==0.7.1
     #   -c requirements/../../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
-amqp==5.0.1
+amqp==5.0.6
     # via kombu
 async-timeout==3.0.1
     # via
@@ -69,7 +69,7 @@ billiard==3.6.3.0
     # via celery
 celery[redis]==5.0.5
     # via -r requirements/_base.in
-cffi==1.14.2
+cffi==1.14.5
     # via cryptography
 change-case==0.5.2
     # via -r requirements/_base.in
@@ -96,12 +96,14 @@ cryptography==3.4.7
     #   -r requirements/_base.in
     #   aiohttp-session
 dataclasses==0.8
-    # via pydantic
-dnspython==2.0.0
+    # via
+    #   pydantic
+    #   werkzeug
+dnspython==2.1.0
     # via email-validator
 email-validator==1.1.2
     # via pydantic
-et-xmlfile==1.0.1
+et-xmlfile==1.1.0
     # via openpyxl
 expiringdict==1.2.1
     # via -r requirements/_base.in
@@ -117,12 +119,14 @@ idna==2.10
     #   email-validator
     #   idna-ssl
     #   yarl
-importlib-metadata==3.1.1
+importlib-metadata==4.0.1
     # via
     #   jsonschema
     #   kombu
 isodate==0.6.0
-    # via openapi-core
+    # via
+    #   openapi-core
+    #   openapi-schema-validator
 jinja-app-loader==1.0.2
     # via -r requirements/_base.in
 jinja2==2.11.3
@@ -135,11 +139,12 @@ jinja2==2.11.3
     #   aiohttp-swagger
 json2html==1.3.0
     # via -r requirements/_base.in
-jsondiff==1.2.0
+jsondiff==1.3.0
     # via -r requirements/_base.in
 jsonschema==3.2.0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
+    #   openapi-schema-validator
     #   openapi-spec-validator
 kombu==5.0.2
     # via celery
@@ -167,13 +172,13 @@ pamqp==2.3.0
     # via aiormq
 parfive==1.0.2
     # via -r requirements/_base.in
-passlib==1.7.2
+passlib==1.7.4
     # via -r requirements/_base.in
-prometheus-client==0.9.0
+prometheus-client==0.10.1
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-prompt-toolkit==3.0.8
+prompt-toolkit==3.0.18
     # via click-repl
-psycopg2-binary==2.8.5
+psycopg2-binary==2.8.6
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   aiopg
@@ -216,7 +221,7 @@ redis==3.5.3
     # via celery
 semantic-version==2.8.5
     # via -r requirements/_base.in
-six==1.15.0
+six==1.16.0
     # via
     #   click-repl
     #   isodate
@@ -238,17 +243,18 @@ sqlalchemy[postgresql_psycopg2binary]==1.3.20
     #   aiopg
 strict-rfc3339==0.7
     # via openapi-core
-tenacity==6.2.0
+tenacity==7.0.0
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
 tqdm==4.54.1
     # via parfive
-trafaret==2.0.2
+trafaret==2.1.0
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   aiohttp
     #   aiohttp-jinja2
     #   asyncpg
+    #   importlib-metadata
     #   pydantic
     #   yarl
 ujson==3.1.0
@@ -261,7 +267,7 @@ vine==5.0.0
     #   celery
 wcwidth==0.2.5
     # via prompt-toolkit
-werkzeug==1.0.1
+werkzeug==2.0.1
     # via -r requirements/../../../../packages/service-library/requirements/_base.in
 yarl==1.5.1
     # via
@@ -269,7 +275,7 @@ yarl==1.5.1
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.1.0
+zipp==3.4.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -10,7 +10,7 @@ aiodebug==1.1.2
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiohttp-jinja2==1.2.0
+aiohttp-jinja2==1.4.2
     # via -r requirements/_base.in
 aiohttp-security==0.4.0
     # via -r requirements/_base.in

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -56,7 +56,7 @@ async-timeout==3.0.1
     #   aiohttp
     #   aiopg
     #   aioredis
-asyncpg==0.21.0
+asyncpg==0.23.0
     # via -r requirements/_base.in
 attrs==20.3.0
     # via
@@ -248,6 +248,7 @@ typing-extensions==3.7.4.3
     # via
     #   aiohttp
     #   aiohttp-jinja2
+    #   asyncpg
     #   pydantic
     #   yarl
 ujson==3.1.0

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -40,7 +40,7 @@ aioredlock==0.5.2
     # via -r requirements/_base.in
 aiormq==3.3.1
     # via aio-pika
-aiosmtplib==1.1.3
+aiosmtplib==1.1.6
     # via -r requirements/_base.in
 aiozipkin==0.7.1
     # via
@@ -65,7 +65,7 @@ attrs==20.3.0
     #   aioredlock
     #   jsonschema
     #   openapi-core
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via celery
 celery[redis]==5.0.5
     # via -r requirements/_base.in
@@ -208,7 +208,7 @@ python-magic==0.4.22
     # via -r requirements/_base.in
 python-socketio==4.6.0
     # via -r requirements/_base.in
-pytz==2020.1
+pytz==2021.1
     # via celery
 pyyaml==5.4.1
     # via

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -57,7 +57,7 @@ coverage[toml]==5.5
     #   pytest-cov
 coveralls==3.0.1
     # via -r requirements/_test.in
-cryptography==3.4.5
+cryptography==3.4.7
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -32,7 +32,7 @@ cached-property==1.5.2
     # via docker-compose
 certifi==2020.12.5
     # via requests
-cffi==1.14.2
+cffi==1.14.5
     # via
     #   -c requirements/_base.txt
     #   bcrypt
@@ -49,7 +49,7 @@ click==7.1.2
     #   -r requirements/_test.in
 codecov==2.1.11
     # via -r requirements/_test.in
-coverage==5.5
+coverage[toml]==5.5
     # via
     #   -r requirements/_test.in
     #   codecov
@@ -57,7 +57,7 @@ coverage==5.5
     #   pytest-cov
 coveralls==3.0.1
     # via -r requirements/_test.in
-cryptography==3.4.5
+cryptography==3.4.7
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -78,7 +78,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.4
+faker==8.2.0
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -92,7 +92,7 @@ idna==2.10
     #   idna-ssl
     #   requests
     #   yarl
-importlib-metadata==3.1.1
+importlib-metadata==4.0.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
@@ -100,6 +100,10 @@ importlib-metadata==3.1.1
     #   pytest
 iniconfig==1.1.1
     # via pytest
+isodate==0.6.0
+    # via
+    #   -c requirements/_base.txt
+    #   openapi-schema-validator
 isort==4.3.21
     # via pylint
 jsonschema==3.2.0
@@ -107,6 +111,7 @@ jsonschema==3.2.0
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   docker-compose
+    #   openapi-schema-validator
     #   openapi-spec-validator
 lazy-object-proxy==1.4.3
     # via
@@ -125,7 +130,11 @@ multidict==4.7.6
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-openapi-spec-validator==0.2.9
+openapi-schema-validator==0.1.5
+    # via
+    #   -c requirements/_base.txt
+    #   openapi-spec-validator
+openapi-spec-validator==0.3.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -139,7 +148,7 @@ pluggy==0.13.1
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-psycopg2-binary==2.8.5
+psycopg2-binary==2.8.6
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
@@ -157,13 +166,13 @@ pynacl==1.4.0
     # via paramiko
 pyparsing==2.4.7
     # via packaging
-pyrsistent==0.16.0
+pyrsistent==0.17.3
     # via
     #   -c requirements/_base.txt
     #   jsonschema
 pytest-aiohttp==0.3.0
     # via -r requirements/_test.in
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/_test.in
 pytest-docker==0.10.1
     # via -r requirements/_test.in
@@ -173,7 +182,7 @@ pytest-instafail==0.4.2
     # via -r requirements/_test.in
 pytest-mock==3.6.1
     # via -r requirements/_test.in
-pytest-runner==5.3.0
+pytest-runner==5.3.1
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
@@ -213,24 +222,25 @@ requests==2.25.1
     #   coveralls
     #   docker
     #   docker-compose
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   bcrypt
     #   dockerpty
+    #   isodate
     #   jsonschema
+    #   openapi-schema-validator
     #   openapi-spec-validator
     #   pynacl
-    #   pyrsistent
     #   python-dateutil
     #   tenacity
     #   websocket-client
-sqlalchemy[postgresql_psycopg2binary]==1.3.20
+sqlalchemy[postgresql_psycopg2binary]==1.3.24
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   alembic
-tenacity==6.2.0
+tenacity==7.0.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -242,14 +252,16 @@ texttable==1.6.3
     # via docker-compose
 toml==0.10.2
     # via
+    #   coverage
     #   pylint
     #   pytest
 typed-ast==1.4.3
     # via astroid
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
+    #   importlib-metadata
     #   yarl
 urllib3==1.26.4
     # via
@@ -259,7 +271,7 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-websockets==9.0.1
+websockets==9.0.2
     # via -r requirements/_test.in
 wrapt==1.12.1
     # via astroid
@@ -267,7 +279,7 @@ yarl==1.5.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-zipp==3.1.0
+zipp==3.4.1
     # via
     #   -c requirements/_base.txt
     #   importlib-metadata

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -32,7 +32,7 @@ cached-property==1.5.2
     # via docker-compose
 certifi==2020.12.5
     # via requests
-cffi==1.14.2
+cffi==1.14.5
     # via
     #   -c requirements/_base.txt
     #   bcrypt
@@ -92,7 +92,7 @@ idna==2.10
     #   idna-ssl
     #   requests
     #   yarl
-importlib-metadata==3.1.1
+importlib-metadata==4.0.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
@@ -100,6 +100,10 @@ importlib-metadata==3.1.1
     #   pytest
 iniconfig==1.1.1
     # via pytest
+isodate==0.6.0
+    # via
+    #   -c requirements/_base.txt
+    #   openapi-schema-validator
 isort==4.3.21
     # via pylint
 jsonschema==3.2.0
@@ -107,6 +111,7 @@ jsonschema==3.2.0
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   docker-compose
+    #   openapi-schema-validator
     #   openapi-spec-validator
 lazy-object-proxy==1.4.3
     # via
@@ -125,7 +130,11 @@ multidict==4.7.6
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-openapi-spec-validator==0.2.9
+openapi-schema-validator==0.1.5
+    # via
+    #   -c requirements/_base.txt
+    #   openapi-spec-validator
+openapi-spec-validator==0.3.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -139,7 +148,7 @@ pluggy==0.13.1
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-psycopg2-binary==2.8.5
+psycopg2-binary==2.8.6
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
@@ -157,7 +166,7 @@ pynacl==1.4.0
     # via paramiko
 pyparsing==2.4.7
     # via packaging
-pyrsistent==0.16.0
+pyrsistent==0.17.3
     # via
     #   -c requirements/_base.txt
     #   jsonschema
@@ -213,24 +222,25 @@ requests==2.25.1
     #   coveralls
     #   docker
     #   docker-compose
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   bcrypt
     #   dockerpty
+    #   isodate
     #   jsonschema
+    #   openapi-schema-validator
     #   openapi-spec-validator
     #   pynacl
-    #   pyrsistent
     #   python-dateutil
     #   tenacity
     #   websocket-client
-sqlalchemy[postgresql_psycopg2binary]==1.3.20
+sqlalchemy[postgresql_psycopg2binary]==1.3.24
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   alembic
-tenacity==6.2.0
+tenacity==7.0.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -247,10 +257,11 @@ toml==0.10.2
     #   pytest
 typed-ast==1.4.3
     # via astroid
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
+    #   importlib-metadata
     #   yarl
 urllib3==1.26.4
     # via
@@ -268,7 +279,7 @@ yarl==1.5.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-zipp==3.1.0
+zipp==3.4.1
     # via
     #   -c requirements/_base.txt
     #   importlib-metadata

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -32,7 +32,7 @@ cached-property==1.5.2
     # via docker-compose
 certifi==2020.12.5
     # via requests
-cffi==1.14.5
+cffi==1.14.2
     # via
     #   -c requirements/_base.txt
     #   bcrypt
@@ -49,7 +49,7 @@ click==7.1.2
     #   -r requirements/_test.in
 codecov==2.1.11
     # via -r requirements/_test.in
-coverage[toml]==5.5
+coverage==5.5
     # via
     #   -r requirements/_test.in
     #   codecov
@@ -57,7 +57,7 @@ coverage[toml]==5.5
     #   pytest-cov
 coveralls==3.0.1
     # via -r requirements/_test.in
-cryptography==3.4.7
+cryptography==3.4.5
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -78,7 +78,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.2.0
+faker==8.1.4
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -92,7 +92,7 @@ idna==2.10
     #   idna-ssl
     #   requests
     #   yarl
-importlib-metadata==4.0.1
+importlib-metadata==3.1.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
@@ -100,10 +100,6 @@ importlib-metadata==4.0.1
     #   pytest
 iniconfig==1.1.1
     # via pytest
-isodate==0.6.0
-    # via
-    #   -c requirements/_base.txt
-    #   openapi-schema-validator
 isort==4.3.21
     # via pylint
 jsonschema==3.2.0
@@ -111,7 +107,6 @@ jsonschema==3.2.0
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   docker-compose
-    #   openapi-schema-validator
     #   openapi-spec-validator
 lazy-object-proxy==1.4.3
     # via
@@ -130,11 +125,7 @@ multidict==4.7.6
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-openapi-schema-validator==0.1.5
-    # via
-    #   -c requirements/_base.txt
-    #   openapi-spec-validator
-openapi-spec-validator==0.3.1
+openapi-spec-validator==0.2.9
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -148,7 +139,7 @@ pluggy==0.13.1
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-psycopg2-binary==2.8.6
+psycopg2-binary==2.8.5
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
@@ -166,13 +157,13 @@ pynacl==1.4.0
     # via paramiko
 pyparsing==2.4.7
     # via packaging
-pyrsistent==0.17.3
+pyrsistent==0.16.0
     # via
     #   -c requirements/_base.txt
     #   jsonschema
 pytest-aiohttp==0.3.0
     # via -r requirements/_test.in
-pytest-cov==2.12.0
+pytest-cov==2.11.1
     # via -r requirements/_test.in
 pytest-docker==0.10.1
     # via -r requirements/_test.in
@@ -182,7 +173,7 @@ pytest-instafail==0.4.2
     # via -r requirements/_test.in
 pytest-mock==3.6.1
     # via -r requirements/_test.in
-pytest-runner==5.3.1
+pytest-runner==5.3.0
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
@@ -222,25 +213,24 @@ requests==2.25.1
     #   coveralls
     #   docker
     #   docker-compose
-six==1.16.0
+six==1.15.0
     # via
     #   -c requirements/_base.txt
     #   bcrypt
     #   dockerpty
-    #   isodate
     #   jsonschema
-    #   openapi-schema-validator
     #   openapi-spec-validator
     #   pynacl
+    #   pyrsistent
     #   python-dateutil
     #   tenacity
     #   websocket-client
-sqlalchemy[postgresql_psycopg2binary]==1.3.24
+sqlalchemy[postgresql_psycopg2binary]==1.3.20
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   alembic
-tenacity==7.0.0
+tenacity==6.2.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -252,16 +242,14 @@ texttable==1.6.3
     # via docker-compose
 toml==0.10.2
     # via
-    #   coverage
     #   pylint
     #   pytest
 typed-ast==1.4.3
     # via astroid
-typing-extensions==3.10.0.0
+typing-extensions==3.7.4.3
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-    #   importlib-metadata
     #   yarl
 urllib3==1.26.4
     # via
@@ -271,7 +259,7 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-websockets==9.0.2
+websockets==9.0.1
     # via -r requirements/_test.in
 wrapt==1.12.1
     # via astroid
@@ -279,7 +267,7 @@ yarl==1.5.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-zipp==3.4.1
+zipp==3.1.0
     # via
     #   -c requirements/_base.txt
     #   importlib-metadata

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt requirements/_test.in
 #
-aiohttp==3.7.4.post0
+aiohttp==3.6.3
     # via
     #   -c requirements/_base.txt
     #   aioresponses

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt requirements/_test.in
 #
-aiohttp==3.6.3
+aiohttp==3.7.4.post0
     # via
     #   -c requirements/_base.txt
     #   aioresponses

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -49,7 +49,7 @@ click==7.1.2
     #   -r requirements/_test.in
 codecov==2.1.11
     # via -r requirements/_test.in
-coverage==5.5
+coverage[toml]==5.5
     # via
     #   -r requirements/_test.in
     #   codecov
@@ -78,7 +78,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==8.1.4
+faker==8.2.0
     # via -r requirements/_test.in
 icdiff==1.9.1
     # via pytest-icdiff
@@ -163,7 +163,7 @@ pyrsistent==0.16.0
     #   jsonschema
 pytest-aiohttp==0.3.0
     # via -r requirements/_test.in
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/_test.in
 pytest-docker==0.10.1
     # via -r requirements/_test.in
@@ -173,7 +173,7 @@ pytest-instafail==0.4.2
     # via -r requirements/_test.in
 pytest-mock==3.6.1
     # via -r requirements/_test.in
-pytest-runner==5.3.0
+pytest-runner==5.3.1
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
@@ -242,6 +242,7 @@ texttable==1.6.3
     # via docker-compose
 toml==0.10.2
     # via
+    #   coverage
     #   pylint
     #   pytest
 typed-ast==1.4.3
@@ -259,7 +260,7 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-websockets==9.0.1
+websockets==9.0.2
     # via -r requirements/_test.in
 wrapt==1.12.1
     # via astroid

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -22,7 +22,7 @@ click==7.1.2
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-dataclasses==0.7
+dataclasses==0.8
     # via
     #   -c requirements/_base.txt
     #   black

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -32,7 +32,7 @@ filelock==3.0.12
     # via virtualenv
 identify==2.2.4
     # via pre-commit
-importlib-metadata==3.1.1
+importlib-metadata==4.0.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -68,7 +68,7 @@ pyyaml==5.4.1
     #   watchdog
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -83,16 +83,17 @@ typed-ast==1.4.3
     # via
     #   -c requirements/_test.txt
     #   black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
+    #   importlib-metadata
 virtualenv==20.4.6
     # via pre-commit
 watchdog[watchmedo]==2.1.2
     # via -r requirements/_tools.in
-zipp==3.1.0
+zipp==3.4.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -14,7 +14,7 @@ black==21.5b1
     # via -r requirements/../../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../../requirements/devenv.txt
-cfgv==3.2.0
+cfgv==3.3.0
     # via pre-commit
 click==7.1.2
     # via
@@ -90,7 +90,7 @@ typing-extensions==3.7.4.3
     #   black
 virtualenv==20.4.6
     # via pre-commit
-watchdog[watchmedo]==2.1.1
+watchdog[watchmedo]==2.1.2
     # via -r requirements/_tools.in
 zipp==3.1.0
     # via

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -14,7 +14,7 @@ black==21.5b1
     # via -r requirements/../../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../../requirements/devenv.txt
-cfgv==3.2.0
+cfgv==3.3.0
     # via pre-commit
 click==7.1.2
     # via
@@ -22,7 +22,7 @@ click==7.1.2
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-dataclasses==0.7
+dataclasses==0.8
     # via
     #   -c requirements/_base.txt
     #   black
@@ -32,7 +32,7 @@ filelock==3.0.12
     # via virtualenv
 identify==2.2.4
     # via pre-commit
-importlib-metadata==3.1.1
+importlib-metadata==4.0.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -68,7 +68,7 @@ pyyaml==5.4.1
     #   watchdog
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -83,16 +83,17 @@ typed-ast==1.4.3
     # via
     #   -c requirements/_test.txt
     #   black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
+    #   importlib-metadata
 virtualenv==20.4.6
     # via pre-commit
-watchdog[watchmedo]==2.1.1
+watchdog[watchmedo]==2.1.2
     # via -r requirements/_tools.in
-zipp==3.1.0
+zipp==3.4.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -14,7 +14,7 @@ black==21.5b1
     # via -r requirements/../../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../../requirements/devenv.txt
-cfgv==3.3.0
+cfgv==3.2.0
     # via pre-commit
 click==7.1.2
     # via
@@ -22,7 +22,7 @@ click==7.1.2
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-dataclasses==0.8
+dataclasses==0.7
     # via
     #   -c requirements/_base.txt
     #   black
@@ -32,7 +32,7 @@ filelock==3.0.12
     # via virtualenv
 identify==2.2.4
     # via pre-commit
-importlib-metadata==4.0.1
+importlib-metadata==3.1.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -68,7 +68,7 @@ pyyaml==5.4.1
     #   watchdog
 regex==2021.4.4
     # via black
-six==1.16.0
+six==1.15.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -83,17 +83,16 @@ typed-ast==1.4.3
     # via
     #   -c requirements/_test.txt
     #   black
-typing-extensions==3.10.0.0
+typing-extensions==3.7.4.3
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-    #   importlib-metadata
 virtualenv==20.4.6
     # via pre-commit
-watchdog[watchmedo]==2.1.2
+watchdog[watchmedo]==2.1.1
     # via -r requirements/_tools.in
-zipp==3.4.1
+zipp==3.1.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt

--- a/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
@@ -4,7 +4,7 @@
 import concurrent.futures
 import logging
 import time
-from typing import Coroutine
+from typing import Callable, Coroutine
 
 import prometheus_client
 from aiohttp import web
@@ -41,9 +41,11 @@ async def metrics_handler(request: web.Request):
 
 def middleware_factory(app_name: str) -> Coroutine:
     @web.middleware
-    async def _middleware_handler(request: web.Request, handler: Coroutine):
+    async def _middleware_handler(request: web.Request, handler: Callable):
         if request.rel_url.path == "/socket.io/":
             return await handler(request)
+
+        log_exception = None
 
         try:
             request[kSTART_TIME] = time.time()

--- a/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
@@ -1,6 +1,7 @@
 """ Enables monitoring of some quantities needed for diagnostics
 
 """
+import concurrent.futures
 import logging
 import time
 from typing import Coroutine
@@ -9,7 +10,6 @@ import prometheus_client
 from aiohttp import web
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram
 from prometheus_client.registry import CollectorRegistry
-
 from servicelib.monitor_services import add_instrumentation
 
 from .diagnostics_core import DelayWindowProbe, is_sensing_enabled, kLATENCY_PROBE
@@ -23,14 +23,20 @@ kREQUEST_COUNT = f"{__name__}.request_count"
 kCANCEL_COUNT = f"{__name__}.cancel_count"
 
 kCOLLECTOR_REGISTRY = f"{__name__}.collector_registry"
+kPROCESS_POOL_EXECUTOR = f"{__name__}.process_pool_executor.pool"
 
 
 async def metrics_handler(request: web.Request):
-    # TODO: prometheus_client.generate_latest blocking! -> Consider https://github.com/claws/aioprometheus
-    reg = request.app[kCOLLECTOR_REGISTRY]
-    resp = web.Response(body=prometheus_client.generate_latest(registry=reg))
-    resp.content_type = CONTENT_TYPE_LATEST
-    return resp
+    registry = request.app[kCOLLECTOR_REGISTRY]
+    process_pool_executor = request.app[kPROCESS_POOL_EXECUTOR]
+
+    # prometheus_client.generate_latest is cpu intensive since
+    # it creates a website report from a growing registry
+    result = await request.loop.run_in_executor(
+        process_pool_executor, prometheus_client.generate_latest, registry
+    )
+    response = web.Response(body=result, content_type=CONTENT_TYPE_LATEST)
+    return response
 
 
 def middleware_factory(app_name: str) -> Coroutine:
@@ -118,6 +124,12 @@ def middleware_factory(app_name: str) -> Coroutine:
     return _middleware_handler
 
 
+async def process_pool_executor_context(app: web.Application):
+    with concurrent.futures.ProcessPoolExecutor() as pool:
+        app[kPROCESS_POOL_EXECUTOR] = pool
+        yield
+
+
 def setup_monitoring(app: web.Application):
     # app-scope registry
     app[kCOLLECTOR_REGISTRY] = reg = CollectorRegistry(auto_describe=True)
@@ -169,6 +181,8 @@ def setup_monitoring(app: web.Application):
 
     # TODO: in production, it should only be accessible to backend services
     app.router.add_get("/metrics", metrics_handler)
+
+    app.cleanup_ctx.append(process_pool_executor_context)
 
     return True
 

--- a/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
@@ -23,7 +23,6 @@ kREQUEST_COUNT = f"{__name__}.request_count"
 kCANCEL_COUNT = f"{__name__}.cancel_count"
 
 kCOLLECTOR_REGISTRY = f"{__name__}.collector_registry"
-kPROCESS_POOL_EXECUTOR = f"{__name__}.process_pool_executor.pool"
 
 
 def get_collector_registry(app: web.Application) -> CollectorRegistry:
@@ -58,7 +57,6 @@ def middleware_factory(app_name: str) -> Coroutine:
             ).inc()
 
             resp = await handler(request)
-            log_exception = None
 
             assert isinstance(  # nosec
                 resp, web.StreamResponse

--- a/services/web/server/src/simcore_service_webserver/socketio/handlers_utils.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/handlers_utils.py
@@ -1,6 +1,7 @@
 import inspect
 from functools import wraps
 from types import ModuleType
+from typing import Callable
 
 from aiohttp import web
 
@@ -48,7 +49,7 @@ def register_handlers(app: web.Application, module: ModuleType):
         sio.on(func.__name__, handler=func)
 
 
-def register_socketio_handler(func: callable) -> callable:
+def register_socketio_handler(func: Callable) -> Callable:
     """this decorator appends handlers to a registry if they fit certain rules
 
     :param func: the function to call

--- a/services/web/server/tests/integration/01/test_exporter.py
+++ b/services/web/server/tests/integration/01/test_exporter.py
@@ -471,7 +471,7 @@ async def download_files_and_get_checksums(
         return checksums
 
 
-async def get_checksmus_for_files_in_storage(
+async def get_checksums_for_files_in_storage(
     app: aiohttp.web.Application,
     project: Dict[str, Any],
     normalized_project: Dict[str, Any],
@@ -517,7 +517,6 @@ async def test_import_export_import_duplicate(
     loop,
     client,
     push_services_to_registry,
-    socketio_client,
     aiopg_engine,
     redis_client,
     export_version,
@@ -621,19 +620,19 @@ async def test_import_export_import_duplicate(
     )
 
     # check files in storage fingerprint matches
-    imported_files_checksums = await get_checksmus_for_files_in_storage(
+    imported_files_checksums = await get_checksums_for_files_in_storage(
         app=client.app,
         project=imported_project,
         normalized_project=normalized_imported_project,
         user_id=user["id"],
     )
-    reimported_files_checksums = await get_checksmus_for_files_in_storage(
+    reimported_files_checksums = await get_checksums_for_files_in_storage(
         app=client.app,
         project=reimported_project,
         normalized_project=normalized_reimported_project,
         user_id=user["id"],
     )
-    duplicated_files_checksums = await get_checksmus_for_files_in_storage(
+    duplicated_files_checksums = await get_checksums_for_files_in_storage(
         app=client.app,
         project=duplicated_project,
         normalized_project=normalized_duplicated_project,

--- a/services/web/server/tests/integration/01/test_exporter.py
+++ b/services/web/server/tests/integration/01/test_exporter.py
@@ -68,6 +68,8 @@ pytest_simcore_ops_services_selection = ["minio"]
 
 CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
+DATA_DIR = CURRENT_DIR.parent.parent / "data"
+assert DATA_DIR.exists(), "expected folder under tests/data"
 
 API_VERSION = "v0"
 API_PREFIX = "/" + API_VERSION
@@ -86,14 +88,6 @@ KEYS_TO_IGNORE_FROM_COMPARISON = {
     "eTag",  # this must change
     REMAPPING_KEY,
 }
-
-
-@pytest.fixture
-async def db_engine(postgres_dsn: Dict) -> aiopg.sa.Engine:
-    dsn = "postgresql://{user}:{password}@{host}:{port}/{database}".format(
-        **postgres_dsn
-    )
-    return await aiopg.sa.create_engine(dsn)
 
 
 @pytest.fixture(autouse=True)
@@ -193,8 +187,11 @@ async def login_user(client):
 def get_exported_projects() -> List[Path]:
     # These files are generated from the front-end
     # when the formatter be finished
-    exporter_dir = CURRENT_DIR.parent / "data" / "exporter"
-    return [x for x in exporter_dir.glob("*.osparc")]
+    exporter_dir = DATA_DIR / "exporter"
+    assert exporter_dir.exists()
+    exported_files = [x for x in exporter_dir.glob("*.osparc")]
+    assert exported_files, "expected *.osparc files, none found"
+    return exported_files
 
 
 @pytest.fixture
@@ -231,7 +228,7 @@ async def monkey_patch_asyncio_subprocess(mocker):
 
 
 @pytest.fixture
-async def apply_access_rights(db_engine: aiopg.sa.Engine) -> Coroutine:
+async def apply_access_rights(aiopg_engine: aiopg.sa.Engine) -> Coroutine:
     async def grant_rights_to_services(services: List[Tuple[str, str]]) -> None:
         for service_key, service_version in services:
             metada_data_values = dict(
@@ -250,7 +247,7 @@ async def apply_access_rights(db_engine: aiopg.sa.Engine) -> Coroutine:
                 write_access=True,
             )
 
-            async with db_engine.acquire() as conn:
+            async with aiopg_engine.acquire() as conn:
                 # pylint: disable=no-value-for-parameter
                 await conn.execute(
                     pg_insert(services_meta_data)
@@ -319,9 +316,9 @@ def assemble_tmp_file_path(file_name: str) -> Path:
 
 
 async def query_project_from_db(
-    db_engine: aiopg.sa.Engine, project_uuid: str
+    aiopg_engine: aiopg.sa.Engine, project_uuid: str
 ) -> Dict[str, Any]:
-    async with db_engine.acquire() as conn:
+    async with aiopg_engine.acquire() as conn:
         project_result = await conn.execute(
             projects.select().where(projects.c.uuid == project_uuid)
         )
@@ -521,7 +518,7 @@ async def test_import_export_import_duplicate(
     client,
     push_services_to_registry,
     socketio_client,
-    db_engine,
+    aiopg_engine,
     redis_client,
     export_version,
     monkey_patch_asyncio_subprocess,
@@ -590,9 +587,13 @@ async def test_import_export_import_duplicate(
 
         duplicated_project_uuid = reply_data["data"]["uuid"]
 
-    imported_project = await query_project_from_db(db_engine, imported_project_uuid)
-    reimported_project = await query_project_from_db(db_engine, reimported_project_uuid)
-    duplicated_project = await query_project_from_db(db_engine, duplicated_project_uuid)
+    imported_project = await query_project_from_db(aiopg_engine, imported_project_uuid)
+    reimported_project = await query_project_from_db(
+        aiopg_engine, reimported_project_uuid
+    )
+    duplicated_project = await query_project_from_db(
+        aiopg_engine, duplicated_project_uuid
+    )
 
     # uuids are changed each time the project is imported, need to normalize them
     normalized_imported_project = replace_uuids_with_sequences(imported_project)

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -1,5 +1,6 @@
-# pylint:disable=redefined-outer-name,unused-argument,too-many-arguments
-
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
 
 import asyncio
 import logging
@@ -247,7 +248,7 @@ async def disconnect_user_from_socketio(client, sio_connection_data):
     assert not await socket_registry.find_resources(resource_key, "socket_id")
 
 
-async def assert_users_count(db_engine: aiopg.sa.Engine, expected_users: int) -> True:
+async def assert_users_count(db_engine: aiopg.sa.Engine, expected_users: int) -> bool:
     async with db_engine.acquire() as conn:
         users_count = await conn.scalar(users.count())
         assert users_count == expected_users
@@ -256,14 +257,14 @@ async def assert_users_count(db_engine: aiopg.sa.Engine, expected_users: int) ->
 
 async def assert_projects_count(
     db_engine: aiopg.sa.Engine, expected_projects: int
-) -> True:
+) -> bool:
     async with db_engine.acquire() as conn:
         projects_count = await conn.scalar(projects.count())
         assert projects_count == expected_projects
         return True
 
 
-def assert_dicts_match_by_common_keys(first_dict, second_dict) -> True:
+def assert_dicts_match_by_common_keys(first_dict, second_dict) -> bool:
     common_keys = set(first_dict.keys()) & set(second_dict.keys())
     for key in common_keys:
         assert first_dict[key] == second_dict[key], key
@@ -290,7 +291,7 @@ async def query_project_from_db(db_engine: aiopg.sa.Engine, user_project: Dict):
 
 async def assert_user_in_database(
     db_engine: aiopg.sa.Engine, logged_user: Dict
-) -> True:
+) -> bool:
     user = await query_user_from_db(db_engine, logged_user)
     user_as_dict = dict(user)
 
@@ -303,7 +304,7 @@ async def assert_user_in_database(
     return True
 
 
-async def assert_user_not_in_database(db_engine: aiopg.sa.Engine, user: Dict) -> True:
+async def assert_user_not_in_database(db_engine: aiopg.sa.Engine, user: Dict) -> bool:
     user = await query_user_from_db(db_engine, user)
     assert user is None
 
@@ -312,7 +313,7 @@ async def assert_user_not_in_database(db_engine: aiopg.sa.Engine, user: Dict) ->
 
 async def assert_project_in_database(
     db_engine: aiopg.sa.Engine, user_project: Dict
-) -> True:
+) -> bool:
     project = await query_project_from_db(db_engine, user_project)
     project_as_dict = dict(project)
 
@@ -323,7 +324,7 @@ async def assert_project_in_database(
 
 async def assert_user_is_owner_of_project(
     db_engine: aiopg.sa.Engine, owner_user: Dict, owner_project: Dict
-) -> True:
+) -> bool:
     user = await query_user_from_db(db_engine, owner_user)
     project = await query_project_from_db(db_engine, owner_project)
 
@@ -334,7 +335,7 @@ async def assert_user_is_owner_of_project(
 
 async def assert_one_owner_for_project(
     db_engine: aiopg.sa.Engine, project: Dict, possible_owners: List[Dict]
-) -> True:
+) -> bool:
     q_owners = [await query_user_from_db(db_engine, owner) for owner in possible_owners]
     q_project = await query_project_from_db(db_engine, project)
 

--- a/services/web/server/tests/integration/02/test_computation.py
+++ b/services/web/server/tests/integration/02/test_computation.py
@@ -229,7 +229,7 @@ async def test_start_pipeline(
     simcore_services: Dict[str, URL],
     client,
     client_session_id: str,
-    socketio_client: Callable,
+    socketio_client_factory: Callable,
     logged_user: LoggedUser,
     user_project: NewProject,
     mock_workbench_adjacency_list: Dict,
@@ -240,7 +240,7 @@ async def test_start_pipeline(
     mock_workbench_payload = user_project["workbench"]
     # connect websocket (to prevent the GC to remove the project)
     try:
-        sio = await socketio_client(client_session_id)
+        sio = await socketio_client_factory(client_session_id)
         assert sio.sid
     except SocketConnectionError:
         if expected.created == web.HTTPCreated:

--- a/services/web/server/tests/integration/02/test_computation.py
+++ b/services/web/server/tests/integration/02/test_computation.py
@@ -228,7 +228,6 @@ async def test_start_pipeline(
     redis_service: RedisConfig,
     simcore_services: Dict[str, URL],
     client,
-    client_session_id: str,
     socketio_client_factory: Callable,
     logged_user: LoggedUser,
     user_project: NewProject,
@@ -240,7 +239,7 @@ async def test_start_pipeline(
     mock_workbench_payload = user_project["workbench"]
     # connect websocket (to prevent the GC to remove the project)
     try:
-        sio = await socketio_client_factory(client_session_id)
+        sio = await socketio_client_factory()
         assert sio.sid
     except SocketConnectionError:
         if expected.created == web.HTTPCreated:

--- a/services/web/server/tests/integration/02/test_rabbit.py
+++ b/services/web/server/tests/integration/02/test_rabbit.py
@@ -196,7 +196,7 @@ async def test_rabbit_websocket_computation(
     mock_orphaned_services,
     logged_user,
     user_project,
-    socketio_client,
+    socketio_client_factory: Callable,
     client_session_id: str,
     mocker,
     rabbit_exchange: Tuple[aio_pika.Exchange, aio_pika.Exchange],
@@ -209,7 +209,7 @@ async def test_rabbit_websocket_computation(
     websocket_log_event = "logger"
     websocket_node_update_event = "nodeUpdated"
     # connect websocket
-    sio = await socketio_client(client_session_id)
+    sio = await socketio_client_factory(client_session_id)
     # register mock websocket handler functions
     mock_log_handler_fct = mocker.Mock()
     mock_node_update_handler_fct = mocker.Mock()

--- a/services/web/server/tests/unit/conftest.py
+++ b/services/web/server/tests/unit/conftest.py
@@ -26,11 +26,12 @@ current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve(
 log = logging.getLogger(__name__)
 
 pytest_plugins = [
-    "pytest_simcore.repository_paths",
     "pytest_simcore.environment_configs",
-    "pytest_simcore.services_api_mocks_for_aiohttp_clients",
-    "pytest_simcore.schemas",
     "pytest_simcore.pydantic_models",
+    "pytest_simcore.repository_paths",
+    "pytest_simcore.schemas",
+    "pytest_simcore.services_api_mocks_for_aiohttp_clients",
+    "pytest_simcore.websocket_client",
 ]
 
 
@@ -46,7 +47,7 @@ def fake_static_dir(fake_data_dir: Path) -> Path:
     return fake_data_dir / "static"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def api_version_prefix() -> str:
     return "v0"
 

--- a/services/web/server/tests/unit/isolated/test_diagnostics.py
+++ b/services/web/server/tests/unit/isolated/test_diagnostics.py
@@ -17,8 +17,9 @@ from simcore_service_webserver.rest import (
 )
 
 
-class App(dict):
+class MockApp(dict):
     middlewares = []
+    cleanup_ctx = []
     router = Mock()
     _overriden = []
 
@@ -43,7 +44,7 @@ def openapi_specs(api_version_prefix) -> Dict:
 
 @pytest.fixture
 def app_mock(openapi_specs):
-    app = App()
+    app = MockApp()
 
     # some inits to emulate app setup
     app[APP_CONFIG_KEY] = {

--- a/services/web/server/tests/unit/isolated/test_package.py
+++ b/services/web/server/tests/unit/isolated/test_package.py
@@ -1,26 +1,22 @@
 # pylint:disable=unused-variable
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
-
-import os
-import re
-from pathlib import Path
-
 import pytest
-
-from pytest_simcore.helpers.utils_pylint import assert_pylint_is_passing
+from pytest_simcore.helpers.utils_pylint import (
+    assert_no_pdb_in_code,
+    assert_pylint_is_passing,
+)
 from simcore_service_webserver.cli import main
 
 
-@pytest.fixture
-def pylintrc(osparc_simcore_root_dir):
-    pylintrc = osparc_simcore_root_dir / ".pylintrc"
-    assert pylintrc.exists()
-    return pylintrc
-
-
 def test_run_pylint(pylintrc, package_dir):
+    # fixtures in pytest_simcore.environs
     assert_pylint_is_passing(pylintrc=pylintrc, package_dir=package_dir)
+
+
+def test_no_pdbs_in_place(package_dir):
+    # fixtures in pytest_simcore.environs
+    assert_no_pdb_in_code(code_dir=package_dir)
 
 
 def test_main(here):  # pylint: disable=unused-variable
@@ -28,18 +24,3 @@ def test_main(here):  # pylint: disable=unused-variable
         main("--help".split())
 
     assert excinfo.value.code == 0
-
-
-def test_no_pdbs_in_place(package_dir):
-    # TODO: add also test_dir excluding this function!?
-    # TODO: it can be commented!
-    MATCH = re.compile(r"pdb.set_trace()")
-    EXCLUDE = ["__pycache__", ".git"]
-    for root, dirs, files in os.walk(package_dir):
-        for name in files:
-            if name.endswith(".py"):
-                pypth = Path(root) / name
-                code = pypth.read_text()
-                found = MATCH.findall(code)
-                assert not found, "pbd.set_trace found in %s" % pypth
-        dirs[:] = [d for d in dirs if d not in EXCLUDE]

--- a/services/web/server/tests/unit/with_dbs/06/test_projects_02.py
+++ b/services/web/server/tests/unit/with_dbs/06/test_projects_02.py
@@ -387,14 +387,14 @@ async def _replace_project(
 
 
 async def _connect_websocket(
-    socketio_client: Callable,
+    socketio_client_factory: Callable,
     check_connection: bool,
     client,
     client_id: str,
     events: Optional[Dict[str, Callable]] = None,
 ) -> socketio.AsyncClient:
     try:
-        sio = await socketio_client(client_id, client)
+        sio = await socketio_client_factory(client_id, client)
         assert sio.sid
         if events:
             for event, handler in events.items():
@@ -587,7 +587,7 @@ async def test_open_project(
     client,
     logged_user,
     user_project,
-    client_session_id,
+    client_session_id_factory: Callable,
     expected,
     mocked_director_subsystem,
 ):
@@ -595,7 +595,7 @@ async def test_open_project(
     # open project
 
     url = client.app.router["open_project"].url_for(project_id=user_project["uuid"])
-    resp = await client.post(url, json=client_session_id())
+    resp = await client.post(url, json=client_session_id_factory())
     await assert_status(resp, expected)
     if resp.status == web.HTTPOk.status_code:
         dynamic_services = {
@@ -623,7 +623,7 @@ async def test_close_project(
     client,
     logged_user,
     user_project,
-    client_session_id,
+    client_session_id_factory: Callable,
     expected,
     mocked_director_subsystem,
     fake_services,
@@ -636,7 +636,7 @@ async def test_close_project(
     ].return_value = future_with_result(fakes)
 
     # open project
-    client_id = client_session_id()
+    client_id = client_session_id_factory()
     url = client.app.router["open_project"].url_for(project_id=user_project["uuid"])
     resp = await client.post(url, json=client_id)
 
@@ -674,16 +674,16 @@ async def test_get_active_project(
     client,
     logged_user,
     user_project,
-    client_session_id,
+    client_session_id_factory: Callable,
     expected,
-    socketio_client,
+    socketio_client_factory: Callable,
     mocked_director_subsystem,
 ):
     # login with socket using client session id
-    client_id1 = client_session_id()
+    client_id1 = client_session_id_factory()
     sio = None
     try:
-        sio = await socketio_client(client_id1)
+        sio = await socketio_client_factory(client_id1)
         assert sio.sid
     except SocketConnectionError:
         if expected == web.HTTPOk:
@@ -716,9 +716,9 @@ async def test_get_active_project(
         assert data == user_project
 
     # login with socket using client session id2
-    client_id2 = client_session_id()
+    client_id2 = client_session_id_factory()
     try:
-        sio = await socketio_client(client_id2)
+        sio = await socketio_client_factory(client_id2)
         assert sio.sid
     except SocketConnectionError:
         if expected == web.HTTPOk:
@@ -913,8 +913,8 @@ async def test_open_shared_project_2_users_locked(
     client,
     logged_user: Dict,
     shared_project: Dict,
-    socketio_client: Callable,
-    client_session_id: Callable,
+    socketio_client_factory: Callable,
+    client_session_id_factory: Callable,
     user_role: UserRole,
     expected: ExpectedResponse,
     aiohttp_client,
@@ -925,13 +925,13 @@ async def test_open_shared_project_2_users_locked(
     mock_project_state_updated_handler = mocker.Mock()
 
     client_1 = client
-    client_id1 = client_session_id()
+    client_id1 = client_session_id_factory()
     client_2 = await aiohttp_client(client.app)
-    client_id2 = client_session_id()
+    client_id2 = client_session_id_factory()
 
     # 1. user 1 opens project
     sio_1 = await _connect_websocket(
-        socketio_client,
+        socketio_client_factory,
         user_role != UserRole.ANONYMOUS,
         client_1,
         client_id1,
@@ -979,7 +979,7 @@ async def test_open_shared_project_2_users_locked(
         client_2, {"role": user_role.name}, enable_check=user_role != UserRole.ANONYMOUS
     )
     sio_2 = await _connect_websocket(
-        socketio_client,
+        socketio_client_factory,
         user_role != UserRole.ANONYMOUS,
         client_2,
         client_id2,
@@ -1061,8 +1061,8 @@ async def test_open_shared_project_at_same_time(
     client,
     logged_user: Dict,
     shared_project: Dict,
-    socketio_client: Callable,
-    client_session_id: Callable,
+    socketio_client_factory: Callable,
+    client_session_id_factory: Callable,
     user_role: UserRole,
     expected: ExpectedResponse,
     aiohttp_client,
@@ -1071,9 +1071,9 @@ async def test_open_shared_project_at_same_time(
     NUMBER_OF_ADDITIONAL_CLIENTS = 20
     # log client 1
     client_1 = client
-    client_id1 = client_session_id()
+    client_id1 = client_session_id_factory()
     sio_1 = await _connect_websocket(
-        socketio_client,
+        socketio_client_factory,
         user_role != UserRole.ANONYMOUS,
         client_1,
         client_id1,
@@ -1089,9 +1089,9 @@ async def test_open_shared_project_at_same_time(
             {"role": user_role.name},
             enable_check=user_role != UserRole.ANONYMOUS,
         )
-        client_id = client_session_id()
+        client_id = client_session_id_factory()
         sio = await _connect_websocket(
-            socketio_client,
+            socketio_client_factory,
             user_role != UserRole.ANONYMOUS,
             client,
             client_id,

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -391,75 +391,7 @@ def _is_redis_responsive(host: str, port: int) -> bool:
 
 # SOCKETS FIXTURES  --------------------------------------------------------
 
-
-@pytest.fixture()
-def socketio_url(client) -> Callable:
-    def create_url(client_override: Optional[TestClient] = None) -> str:
-        SOCKET_IO_PATH = "/socket.io/"
-        return str((client_override or client).make_url(SOCKET_IO_PATH))
-
-    yield create_url
-
-
-@pytest.fixture()
-async def security_cookie_factory(client) -> Callable:
-    async def creator(client_override: Optional[TestClient] = None) -> str:
-        # get the cookie by calling the root entrypoint
-        resp = await (client_override or client).get("/v0/")
-        data, error = await assert_status(resp, web.HTTPOk)
-        assert data
-        assert not error
-
-        cookie = (
-            resp.request_info.headers["Cookie"]
-            if "Cookie" in resp.request_info.headers
-            else ""
-        )
-        return cookie
-
-    yield creator
-
-
-@pytest.fixture()
-async def socketio_client(
-    socketio_url: Callable, security_cookie_factory: Callable
-) -> Callable:
-    clients = []
-
-    async def connect(
-        client_session_id: str, client: Optional[TestClient] = None
-    ) -> socketio.AsyncClient:
-        sio = socketio.AsyncClient(ssl_verify=False)
-        # enginio 3.10.0 introduced ssl verification
-        url = str(
-            URL(socketio_url(client)).with_query(
-                {"client_session_id": client_session_id}
-            )
-        )
-        headers = {}
-        cookie = await security_cookie_factory(client)
-        if cookie:
-            # WARNING: engineio fails with empty cookies. Expects "key=value"
-            headers.update({"Cookie": cookie})
-
-        await sio.connect(url, headers=headers)
-        assert sio.sid
-        clients.append(sio)
-        return sio
-
-    yield connect
-
-    for sio in clients:
-        await sio.disconnect()
-        assert not sio.sid
-
-
-@pytest.fixture()
-def client_session_id() -> str:
-    def create() -> str():
-        return str(uuid4())
-
-    return create
+# Moved to packages/pytest-simcore/src/pytest_simcore/websocket_client.py
 
 
 # USER GROUP FIXTURES -------------------------------------------------------


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

General maintenance of the ``webserver``

- CHANGES: makes ``metrics_handler``  implementation async by using a thread pool executor ot execute ``prometheos_client.generate_latest`` call
- CHANGES: general upgrade of webserver dependencies:
   - ``aiohttp`` and ``python-socketio`` **cannot be upgraded** to the latest. Needs further refactoring (see #2008 and notes in requirement files)!
- FIXES: ``services/web/server/tests/integration/01/test_exporter.py`` **was de-activated**.  
     -  Minor refactoring of fixtures
- CHANGES: unified pylint testing by reusing ``pytest-simcore`` utils
- CHANGES: moves socket-io fixtures to ``simcore-pytest``


#### Next steps (different PRs)

- Remove trafaret dependency by pydantic-settings
- Remove constraints to aiohttp and python-socketio
- Replace openapi-core by pydantic (evaluate https://github.com/Maillol/aiohttp-pydantic) 

## Related issue/s

Towards spliting webserver

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist


- [x] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Unit tests for the changes exist
- [ ] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
