### PR TITLE
Dynamic service: Do not save state for GUEST users

### DIFF
--- a/api/specs/common/schemas/running_service.yaml
+++ b/api/specs/common/schemas/running_service.yaml
@@ -6,7 +6,7 @@ components:
         - data
       properties:
         data:
-          $ref: '#/components/schemas/RunningServicesArray'
+          $ref: "#/components/schemas/RunningServicesArray"
         error:
           nullable: true
           default: null
@@ -14,7 +14,7 @@ components:
     RunningServicesArray:
       type: array
       items:
-        $ref: '#/components/schemas/RunningServiceType'
+        $ref: "#/components/schemas/RunningServiceType"
 
     RunningServiceEnveloped:
       type: object
@@ -22,7 +22,7 @@ components:
         - data
       properties:
         data:
-          $ref: '#/components/schemas/RunningServiceType'
+          $ref: "#/components/schemas/RunningServiceType"
         error:
           nullable: true
           default: null
@@ -37,6 +37,7 @@ components:
         - service_host
         - service_port
         - service_state
+        - user_id
       properties:
         published_port:
           description: The ports where the service provides its interface
@@ -80,8 +81,8 @@ components:
         service_basepath:
           description: different base path where current service is mounted otherwise defaults to root
           type: string
-          example: '/x/E1O2E-LAH'
-          default: ''
+          example: "/x/E1O2E-LAH"
+          default: ""
         service_state:
           description: >
             the service state
@@ -104,3 +105,8 @@ components:
             the service message
           type: string
           example: no suitable node (insufficient resources on 1 node)
+        user_id:
+          description: >-
+            the user that started the service
+          type: string
+          example: "123"

--- a/api/specs/director/openapi.yaml
+++ b/api/specs/director/openapi.yaml
@@ -286,6 +286,7 @@ paths:
       operationId: running_interactive_services_delete
       parameters:
         - $ref: "#/components/parameters/ServiceUuid"
+        - $ref: "#/components/parameters/SaveState"
       responses:
         "204":
           description: Succesfully stopped and removed the service from the oSparc platform
@@ -424,6 +425,15 @@ components:
         example:
           - 1.0.0
           - 0.0.1
+
+    SaveState:
+      in: query
+      name: save_state
+      description: Save the state prior to removing the service
+      required: false
+      schema:
+        type: boolean
+        default: true
 
   schemas:
     ErrorEnveloped:

--- a/services/director/requirements/_test.in
+++ b/services/director/requirements/_test.in
@@ -12,6 +12,7 @@
 #
 
 # testing
+aioresponses
 coverage==4.5.1 # TODO: Downgraded because of a bug https://github.com/nedbat/coveragepy/issues/716
 pytest
 pytest-aiohttp  # incompatible with pytest-asyncio. See https://github.com/pytest-dev/pytest-asyncio/issues/76

--- a/services/director/requirements/_test.txt
+++ b/services/director/requirements/_test.txt
@@ -6,6 +6,7 @@
 #
 aiodebug==1.1.2           # via -r requirements/_base.txt, simcore-service-library
 aiodocker==0.14.0         # via -r requirements/_base.txt
+aioresponses==0.7.2       # manually added. needed for mocking http calls and extensive testing.
 git+https://github.com/ITISFoundation/aiohttp_apiset.git@5c8a61ceb6de7ed9e09db5b4609b458a0d3773df  # via -r requirements/_base.txt
 aiohttp==3.3.2            # via -r requirements/_base.txt, aiodocker, aiohttp-apiset, aiozipkin, pytest-aiohttp, simcore-service-library
 aiopg==1.0.0              # via -r requirements/_base.txt, simcore-service-library

--- a/services/director/src/simcore_service_director/api/v0/openapi.yaml
+++ b/services/director/src/simcore_service_director/api/v0/openapi.yaml
@@ -1123,6 +1123,7 @@ paths:
                         - service_host
                         - service_port
                         - service_state
+                        - user_id
                       properties:
                         published_port:
                           description: The ports where the service provides its interface
@@ -1181,6 +1182,10 @@ paths:
                           description: the service message
                           type: string
                           example: no suitable node (insufficient resources on 1 node)
+                        user_id:
+                          description: the user that started the service
+                          type: string
+                          example: '123'
                   error:
                     nullable: true
                     default: null
@@ -1295,6 +1300,7 @@ paths:
                       - service_host
                       - service_port
                       - service_state
+                      - user_id
                     properties:
                       published_port:
                         description: The ports where the service provides its interface
@@ -1353,6 +1359,10 @@ paths:
                         description: the service message
                         type: string
                         example: no suitable node (insufficient resources on 1 node)
+                      user_id:
+                        description: the user that started the service
+                        type: string
+                        example: '123'
                   error:
                     nullable: true
                     default: null
@@ -1561,6 +1571,7 @@ paths:
                       - service_host
                       - service_port
                       - service_state
+                      - user_id
                     properties:
                       published_port:
                         description: The ports where the service provides its interface
@@ -1619,6 +1630,10 @@ paths:
                         description: the service message
                         type: string
                         example: no suitable node (insufficient resources on 1 node)
+                      user_id:
+                        description: the user that started the service
+                        type: string
+                        example: '123'
                   error:
                     nullable: true
                     default: null
@@ -2009,6 +2024,7 @@ components:
             - service_host
             - service_port
             - service_state
+            - user_id
           properties:
             published_port:
               description: The ports where the service provides its interface
@@ -2067,6 +2083,10 @@ components:
               description: the service message
               type: string
               example: no suitable node (insufficient resources on 1 node)
+            user_id:
+              description: the user that started the service
+              type: string
+              example: '123'
         error:
           nullable: true
           default: null
@@ -2087,6 +2107,7 @@ components:
               - service_host
               - service_port
               - service_state
+              - user_id
             properties:
               published_port:
                 description: The ports where the service provides its interface
@@ -2145,6 +2166,10 @@ components:
                 description: the service message
                 type: string
                 example: no suitable node (insufficient resources on 1 node)
+              user_id:
+                description: the user that started the service
+                type: string
+                example: '123'
         error:
           nullable: true
           default: null

--- a/services/director/src/simcore_service_director/api/v0/openapi.yaml
+++ b/services/director/src/simcore_service_director/api/v0/openapi.yaml
@@ -1738,6 +1738,13 @@ paths:
           schema:
             type: string
             example: 123e4567-e89b-12d3-a456-426655440000
+        - in: query
+          name: save_state
+          description: Save the state prior to removing the service
+          required: false
+          schema:
+            type: boolean
+            default: true
       responses:
         '204':
           description: Succesfully stopped and removed the service from the oSparc platform
@@ -1948,6 +1955,14 @@ components:
         example:
           - 1.0.0
           - 0.0.1
+    SaveState:
+      in: query
+      name: save_state
+      description: Save the state prior to removing the service
+      required: false
+      schema:
+        type: boolean
+        default: true
   schemas:
     ErrorEnveloped:
       type: object

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -728,6 +728,7 @@ async def _start_docker_service(
             "service_basepath": node_base_path,
             "service_state": service_state.value,
             "service_message": service_msg,
+            "user_id": user_id,
         }
         return container_meta_data
 
@@ -887,6 +888,7 @@ async def _get_node_details(
     service_state, service_msg = results[2]
     service_name = service["Spec"]["Name"]
     service_uuid = service["Spec"]["Labels"]["uuid"]
+    user_id = service["Spec"]["Labels"]["user_id"]
 
     # get the published port
     published_port, target_port = await _get_docker_image_port_mapping(service)
@@ -901,6 +903,7 @@ async def _get_node_details(
         "service_basepath": service_basepath,
         "service_state": service_state.value,
         "service_message": service_msg,
+        "user_id": user_id,
     }
     return node_details
 

--- a/services/director/src/simcore_service_director/rest/generated_code/models/inline_response2003_data.py
+++ b/services/director/src/simcore_service_director/rest/generated_code/models/inline_response2003_data.py
@@ -172,8 +172,8 @@ class InlineResponse2003Data(Model):
         """
         if service_key is None:
             raise ValueError("Invalid value for `service_key`, must not be `None`")
-        if service_key is not None and not re.search(r'^(simcore)\/(services)\/(comp|dynamic)(\/[^\s\/]+)+$', service_key):
-            raise ValueError("Invalid value for `service_key`, must be a follow pattern or equal to `/^(simcore)\/(services)\/(comp|dynamic)(\/[^\s\/]+)+$/`")
+        if service_key is not None and not re.search(r'^(simcore)\/(services)\/(comp|dynamic)(\/[\w\/-]+)+$', service_key):
+            raise ValueError("Invalid value for `service_key`, must be a follow pattern or equal to `/^(simcore)\/(services)\/(comp|dynamic)(\/[\w\/-]+)+$/`")
 
         self._service_key = service_key
 

--- a/services/director/src/simcore_service_director/rest/generated_code/models/inline_response2003_data.py
+++ b/services/director/src/simcore_service_director/rest/generated_code/models/inline_response2003_data.py
@@ -15,7 +15,7 @@ class InlineResponse2003Data(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, published_port: int=None, entry_point: str=None, service_uuid: str=None, service_key: str=None, service_version: str=None, service_host: str=None, service_port: int=None, service_basepath: str='', service_state: str=None, service_message: str=None):
+    def __init__(self, published_port: int=None, entry_point: str=None, service_uuid: str=None, service_key: str=None, service_version: str=None, service_host: str=None, service_port: int=None, service_basepath: str='', service_state: str=None, service_message: str=None, user_id: str=None):
         """InlineResponse2003Data - a model defined in OpenAPI
 
         :param published_port: The published_port of this InlineResponse2003Data.
@@ -28,6 +28,7 @@ class InlineResponse2003Data(Model):
         :param service_basepath: The service_basepath of this InlineResponse2003Data.
         :param service_state: The service_state of this InlineResponse2003Data.
         :param service_message: The service_message of this InlineResponse2003Data.
+        :param user_id: The user_id of this InlineResponse2003Data.
         """
         self.openapi_types = {
             'published_port': int,
@@ -39,7 +40,8 @@ class InlineResponse2003Data(Model):
             'service_port': int,
             'service_basepath': str,
             'service_state': str,
-            'service_message': str
+            'service_message': str,
+            'user_id': str
         }
 
         self.attribute_map = {
@@ -52,7 +54,8 @@ class InlineResponse2003Data(Model):
             'service_port': 'service_port',
             'service_basepath': 'service_basepath',
             'service_state': 'service_state',
-            'service_message': 'service_message'
+            'service_message': 'service_message',
+            'user_id': 'user_id'
         }
 
         self._published_port = published_port
@@ -65,6 +68,7 @@ class InlineResponse2003Data(Model):
         self._service_basepath = service_basepath
         self._service_state = service_state
         self._service_message = service_message
+        self._user_id = user_id
 
     @classmethod
     def from_dict(cls, dikt: dict) -> 'InlineResponse2003Data':
@@ -330,3 +334,28 @@ class InlineResponse2003Data(Model):
         """
 
         self._service_message = service_message
+
+    @property
+    def user_id(self):
+        """Gets the user_id of this InlineResponse2003Data.
+
+        the user that started the service
+
+        :return: The user_id of this InlineResponse2003Data.
+        :rtype: str
+        """
+        return self._user_id
+
+    @user_id.setter
+    def user_id(self, user_id):
+        """Sets the user_id of this InlineResponse2003Data.
+
+        the user that started the service
+
+        :param user_id: The user_id of this InlineResponse2003Data.
+        :type user_id: str
+        """
+        if user_id is None:
+            raise ValueError("Invalid value for `user_id`, must not be `None`")
+
+        self._user_id = user_id

--- a/services/director/src/simcore_service_director/rest/generated_code/models/simcore_node.py
+++ b/services/director/src/simcore_service_director/rest/generated_code/models/simcore_node.py
@@ -107,8 +107,8 @@ class SimcoreNode(Model):
         """
         if key is None:
             raise ValueError("Invalid value for `key`, must not be `None`")
-        if key is not None and not re.search(r'^(simcore)\/(services)\/(comp|dynamic)(\/[^\s\/]+)+$', key):
-            raise ValueError("Invalid value for `key`, must be a follow pattern or equal to `/^(simcore)\/(services)\/(comp|dynamic)(\/[^\s\/]+)+$/`")
+        if key is not None and not re.search(r'^(simcore)\/(services)\/(comp|dynamic)(\/[\w\/-]+)+$', key):
+            raise ValueError("Invalid value for `key`, must be a follow pattern or equal to `/^(simcore)\/(services)\/(comp|dynamic)(\/[\w\/-]+)+$/`")
 
         self._key = key
 
@@ -184,7 +184,7 @@ class SimcoreNode(Model):
         :param type: The type of this SimcoreNode.
         :type type: str
         """
-        allowed_values = ["computational", "dynamic"]
+        allowed_values = ["frontend", "computational", "dynamic"]
         if type not in allowed_values:
             raise ValueError(
                 "Invalid value for `type` ({0}), must be one of {1}"

--- a/services/director/src/simcore_service_director/rest/handlers.py
+++ b/services/director/src/simcore_service_director/rest/handlers.py
@@ -12,7 +12,9 @@ from simcore_service_director import exceptions, producer, registry_proxy, resou
 log = logging.getLogger(__name__)
 
 
-async def root_get(request: web.Request,) -> web.Response:
+async def root_get(
+    request: web.Request,
+) -> web.Response:
     log.debug("Client does root_get request %s", request)
     distb = pkg_resources.get_distribution("simcore-service-director")
     with resources.stream(resources.RESOURCE_OPEN_API) as file_ptr:
@@ -181,7 +183,7 @@ async def running_interactive_services_get(
 
 
 async def running_interactive_services_delete(
-    request: web.Request, service_uuid: str
+    request: web.Request, service_uuid: str, save_state: Optional[bool] = True
 ) -> web.Response:
     log.debug(
         "Client does running_interactive_services_delete request %s with service_uuid %s",
@@ -189,7 +191,7 @@ async def running_interactive_services_delete(
         service_uuid,
     )
     try:
-        await producer.stop_service(request.app, service_uuid)
+        await producer.stop_service(request.app, service_uuid, save_state)
     except exceptions.ServiceUUIDNotFoundError as err:
         raise web_exceptions.HTTPNotFound(reason=str(err))
     except Exception as err:

--- a/services/director/tests/test_producer.py
+++ b/services/director/tests/test_producer.py
@@ -95,7 +95,7 @@ async def run_services(
     # teardown stop the services
     for service in started_services:
         service_uuid = service["service_uuid"]
-        await producer.stop_service(aiohttp_mock_app, service_uuid)
+        await producer.stop_service(aiohttp_mock_app, service_uuid, True)
         with pytest.raises(exceptions.ServiceUUIDNotFoundError):
             await producer.get_service_details(aiohttp_mock_app, service_uuid)
 

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -11382,6 +11382,7 @@ paths:
                       - service_host
                       - service_port
                       - service_state
+                      - user_id
                     properties:
                       published_port:
                         description: The ports where the service provides its interface
@@ -11440,6 +11441,10 @@ paths:
                         description: the service message
                         type: string
                         example: no suitable node (insufficient resources on 1 node)
+                      user_id:
+                        description: the user that started the service
+                        type: string
+                        example: '123'
                   error:
                     nullable: true
                     default: null

--- a/services/web/server/src/simcore_service_webserver/director/director_api.py
+++ b/services/web/server/src/simcore_service_webserver/director/director_api.py
@@ -111,9 +111,8 @@ async def stop_services(
     )
 
     stop_tasks = [stop_service(app, s["service_uuid"], save_state) for s in services]
-
-    # FIXME: if stop_service is cancelled, it will and is running stop_tasks, it will never cancel!
-    await logged_gather(*stop_tasks, reraise=True)
+    if stop_tasks:
+        await logged_gather(*stop_tasks, reraise=True)
 
 
 async def get_service_by_key_version(

--- a/services/web/server/src/simcore_service_webserver/director/director_api.py
+++ b/services/web/server/src/simcore_service_webserver/director/director_api.py
@@ -76,7 +76,9 @@ async def start_service(
         return payload["data"]
 
 
-async def stop_service(app: web.Application, service_uuid: str) -> None:
+async def stop_service(
+    app: web.Application, service_uuid: str, save_state: Optional[bool] = True
+) -> None:
     session, api_endpoint = _get_director_client(app)
     # stopping a service can take a lot of time
     # bumping the stop command timeout to 1 hour
@@ -86,6 +88,7 @@ async def stop_service(app: web.Application, service_uuid: str) -> None:
         url,
         ssl=False,
         timeout=ServicesCommonSettings().webserver_director_stop_service_timeout,
+        params={"save_state": "true" if save_state else "false"},
     ) as resp:
         if resp.status == 404:
             raise director_exceptions.ServiceNotFoundError(service_uuid)

--- a/services/web/server/src/simcore_service_webserver/director/director_api.py
+++ b/services/web/server/src/simcore_service_webserver/director/director_api.py
@@ -101,6 +101,7 @@ async def stop_services(
     app: web.Application,
     user_id: Optional[str] = None,
     project_id: Optional[str] = None,
+    save_state: Optional[bool] = True,
 ) -> None:
     if not user_id and not project_id:
         raise ValueError("Expected either user or project")
@@ -109,7 +110,7 @@ async def stop_services(
         app, user_id=user_id, project_id=project_id
     )
 
-    stop_tasks = [stop_service(app, s["service_uuid"]) for s in services]
+    stop_tasks = [stop_service(app, s["service_uuid"], save_state) for s in services]
 
     # FIXME: if stop_service is cancelled, it will and is running stop_tasks, it will never cancel!
     await logged_gather(*stop_tasks, reraise=True)

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -44,7 +44,7 @@ from ..storage_api import (
     delete_data_folders_of_project,
     delete_data_folders_of_project_node,
 )
-from ..users_api import get_user_name
+from ..users_api import get_user_name, is_user_guest
 from .config import CONFIG_SECTION_NAME
 from .projects_db import APP_PROJECT_DBAPI
 
@@ -191,8 +191,13 @@ async def remove_project_interactive_services(
     list_of_services = await director_api.get_running_interactive_services(
         app, project_id=project_uuid, user_id=user_id
     )
+    # save the state if the user is not a guest. if we do not know we save in any case.
     stop_tasks = [
-        director_api.stop_service(app, service["service_uuid"])
+        director_api.stop_service(
+            app,
+            service["service_uuid"],
+            save_state=not await is_user_guest(app, user_id) if user_id else True,
+        )
         for service in list_of_services
     ]
     if stop_tasks:

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -271,7 +271,8 @@ async def delete_project_node(
     # stop the service if it is running
     for service in list_of_services:
         if service["service_uuid"] == node_uuid:
-            await director_api.stop_service(request.app, node_uuid)
+            # no need to save the state of the node when deleting it
+            await director_api.stop_service(request.app, node_uuid, save_state=False)
             break
     # remove its data if any
     await delete_data_folders_of_project_node(

--- a/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
@@ -247,7 +247,7 @@ async def remove_disconnected_user_resources(
                     #
                     await emit(
                         event="SIGNAL_PROJECT_CLOSE",
-                        user_id=None,
+                        user_id=int(dead_key["user_id"]),
                         project_uuid=resource_value,
                         app=app,
                     )

--- a/services/web/server/tests/unit/isolated/test_director_api.py
+++ b/services/web/server/tests/unit/isolated/test_director_api.py
@@ -17,7 +17,6 @@ import pytest
 import simcore_service_webserver.director.config as director_config
 import yaml
 from aiohttp import web
-from aiohttp.client import ClientSession
 from aioresponses.core import CallbackResult, aioresponses
 from servicelib.client_session import get_client_session
 from simcore_service_webserver.director.config import DirectorSettings
@@ -235,6 +234,14 @@ def mock_director_service(
 
         def stop_service_handler(url: URL, **kwargs):
             service_uuid = url.parts[-1]
+            required_query_parameter = "save_state"
+            if required_query_parameter not in kwargs["params"]:
+                return CallbackResult(
+                    payload={
+                        "error": f"stop_service endpoint was called without query parameter {required_query_parameter} {url}"
+                    },
+                    status=500,
+                )
 
             try:
                 service = next(

--- a/services/web/server/tests/unit/with_dbs/10/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/10/test_resource_manager.py
@@ -477,7 +477,7 @@ async def test_interactive_services_removed_per_project(
     # wait the defined delay
     await sleep(SERVICE_DELETION_DELAY + GARBAGE_COLLECTOR_INTERVAL)
     # assert dynamic service 1 is removed
-    calls = [call(client.server.app, service["service_uuid"])]
+    calls = [call(client.server.app, service["service_uuid"], exp_save_state)]
     mocked_director_api["stop_service"].assert_has_calls(calls)
     mocked_director_api["stop_service"].reset_mock()
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?
### Director API
- ```/running_interactive_services/{service_uuid}:``` DELETE has now an optional parameter to explicitly ask to save the service state when removing it from the swarm
- ```RunningServiceType``` now contains the user_id. This allows to know who started the service originally

### Director
- uses *aioresponses* mock library for testing (does not add any other dependency to the director frozen requirements)
-  re-generated the handlers code (minor changes, mostly some regexes that were missing)
- add necessary tests

### Webserver
- removed copy/pasted code in projects_api.py and use the director_api.py code instead
- when removing dynamic services, check if the user is a guest. If yes, then ask not to save the service state.
- improve tests to this end

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```
make build
cd services/web/server
make install-dev
pytest -vvx --ff --pdb tests/unit/with_dbs/10/test_resource_manager.py
```

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
