### PR TITLE
Bugfix: Share study with Organization

### DIFF
--- a/services/web/client/source/class/osparc/auth/Data.js
+++ b/services/web/client/source/class/osparc/auth/Data.js
@@ -44,6 +44,15 @@ qx.Class.define("osparc.auth.Data", {
     },
 
     /**
+     *  org IDs
+     */
+    orgIds: {
+      init: [],
+      nullable: false,
+      check: "Array"
+    },
+
+    /**
      *  Basic authentification with a token
     */
     auth: {

--- a/services/web/client/source/class/osparc/auth/Manager.js
+++ b/services/web/client/source/class/osparc/auth/Manager.js
@@ -148,6 +148,11 @@ qx.Class.define("osparc.auth.Manager", {
       osparc.auth.Data.getInstance().setToken(profile.login);
       osparc.auth.Data.getInstance().setUserId(profile.id);
       osparc.auth.Data.getInstance().setGroupId(profile["groups"]["me"]["gid"]);
+      if ("organizations" in profile["groups"]) {
+        const orgIds = [];
+        profile["groups"]["organizations"].forEach(org => orgIds.push(org["gid"]));
+        osparc.auth.Data.getInstance().setOrgIds(orgIds);
+      }
       osparc.data.Permissions.getInstance().setRole(profile.role);
     },
 

--- a/services/web/client/source/class/osparc/component/metadata/QualityEditor.js
+++ b/services/web/client/source/class/osparc/component/metadata/QualityEditor.js
@@ -692,7 +692,9 @@ qx.Class.define("osparc.component.metadata.QualityEditor", {
         if (osparc.utils.Resources.isService(this.__resourceData)) {
           return osparc.component.permissions.Service.canGroupWrite(this.__resourceData["access_rights"], myGid);
         }
-        return osparc.component.permissions.Study.canGroupWrite(this.__resourceData["accessRights"], myGid);
+        const orgIDs = osparc.auth.Data.getInstance().getOrgIds();
+        orgIDs.push(myGid);
+        return osparc.component.permissions.Study.canGroupsWrite(this.__resourceData["accessRights"], orgIDs);
       }
       return false;
     }

--- a/services/web/client/source/class/osparc/component/metadata/ServicesInStudy.js
+++ b/services/web/client/source/class/osparc/component/metadata/ServicesInStudy.js
@@ -193,7 +193,11 @@ qx.Class.define("osparc.component.metadata.ServicesInStudy", {
           column: this.self().gridPos.latestVersion
         });
 
-        if (osparc.data.Permissions.getInstance().canDo("study.service.update") && osparc.data.model.Study.canIWrite(this.__studyData["accessRights"])) {
+        const myGroupId = osparc.auth.Data.getInstance().getGroupId();
+        const orgIDs = osparc.auth.Data.getInstance().getOrgIds();
+        orgIDs.push(myGroupId);
+        const canIWrite = osparc.component.permissions.Study.canGroupsWrite(this.__studyData["accessRights"], orgIDs);
+        if (osparc.data.Permissions.getInstance().canDo("study.service.update") && canIWrite) {
           const updateButton = new osparc.ui.form.FetchButton(null, "@MaterialIcons/update/14");
           updateButton.set({
             label: node["version"] === latestCompatibleMetadata["version"] ? this.tr("Up-to-date") : this.tr("Update"),

--- a/services/web/client/source/class/osparc/component/permissions/Study.js
+++ b/services/web/client/source/class/osparc/component/permissions/Study.js
@@ -60,6 +60,14 @@ qx.Class.define("osparc.component.permissions.Study", {
       return false;
     },
 
+    canGroupsWrite: function(accessRights, GIDs) {
+      let canWrite = false;
+      for (let i=0; i<GIDs.length && !canWrite; i++) {
+        canWrite = this.self().canGroupWrite(accessRights, GIDs[i]);
+      }
+      return canWrite;
+    },
+
     getViewerAccessRight: function() {
       return {
         "read": true,

--- a/services/web/client/source/class/osparc/component/permissions/Study.js
+++ b/services/web/client/source/class/osparc/component/permissions/Study.js
@@ -47,7 +47,7 @@ qx.Class.define("osparc.component.permissions.Study", {
       }
       return false;
     },
-    canGroupWrite: function(accessRights, GID) {
+    __canGroupWrite: function(accessRights, GID) {
       if (GID in accessRights) {
         return accessRights[GID]["write"];
       }
@@ -63,7 +63,8 @@ qx.Class.define("osparc.component.permissions.Study", {
     canGroupsWrite: function(accessRights, GIDs) {
       let canWrite = false;
       for (let i=0; i<GIDs.length && !canWrite; i++) {
-        canWrite = this.self().canGroupWrite(accessRights, GIDs[i]);
+        // eslint-disable-next-line no-underscore-dangle
+        canWrite = this.self().__canGroupWrite(accessRights, GIDs[i]);
       }
       return canWrite;
     },

--- a/services/web/client/source/class/osparc/component/permissions/Study.js
+++ b/services/web/client/source/class/osparc/component/permissions/Study.js
@@ -41,12 +41,6 @@ qx.Class.define("osparc.component.permissions.Study", {
   },
 
   statics: {
-    canGroupRead: function(accessRights, GID) {
-      if (GID in accessRights) {
-        return accessRights[GID]["read"];
-      }
-      return false;
-    },
     __canGroupWrite: function(accessRights, GID) {
       if (GID in accessRights) {
         return accessRights[GID]["write"];

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
@@ -454,8 +454,11 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonItem", {
 
     __setStudyPermissions: function(accessRights) {
       const myGroupId = osparc.auth.Data.getInstance().getGroupId();
+      const orgIDs = osparc.auth.Data.getInstance().getOrgIds();
+      orgIDs.push(myGroupId);
+
       const image = this.getChildControl("permission-icon");
-      if (osparc.component.permissions.Study.canGroupWrite(accessRights, myGroupId)) {
+      if (osparc.component.permissions.Study.canGroupsWrite(accessRights, orgIDs)) {
         image.exclude();
       } else {
         image.setSource(this.self().PERM_READ);

--- a/services/web/client/source/class/osparc/data/model/Study.js
+++ b/services/web/client/source/class/osparc/data/model/Study.js
@@ -250,8 +250,11 @@ qx.Class.define("osparc.data.model.Study", {
 
     __applyAccessRights: function(value) {
       const myGid = osparc.auth.Data.getInstance().getGroupId();
+      const orgIDs = osparc.auth.Data.getInstance().getOrgIds();
+      orgIDs.push(myGid);
+
       if (myGid) {
-        const canIWrite = osparc.component.permissions.Study.canGroupWrite(value, myGid);
+        const canIWrite = osparc.component.permissions.Study.canGroupsWrite(value, orgIDs);
         this.setReadOnly(!canIWrite);
       } else {
         this.setReadOnly(true);

--- a/services/web/client/source/class/osparc/data/model/Study.js
+++ b/services/web/client/source/class/osparc/data/model/Study.js
@@ -223,14 +223,6 @@ qx.Class.define("osparc.data.model.Study", {
       return osparc.component.permissions.Study.canGroupExecute(aceessRights, myGid);
     },
 
-    canIWrite: function(accessRights) {
-      const myGid = osparc.auth.Data.getInstance().getGroupId();
-      if (myGid) {
-        return osparc.component.permissions.Study.canGroupWrite(accessRights, myGid);
-      }
-      return false;
-    },
-
     hasSlideshow: function(studyData) {
       if ("ui" in studyData && "slideshow" in studyData["ui"] && Object.keys(studyData["ui"]["slideshow"]).length) {
         return true;

--- a/tests/e2e/portal-files/VTK_file.js
+++ b/tests/e2e/portal-files/VTK_file.js
@@ -41,9 +41,10 @@ async function runTutorial () {
     const workbenchData = utils.extractWorkbenchData(studyData["data"]);
     const nodeIdViewer = workbenchData["nodeIds"][1];
     await tutorial.waitForServices(workbenchData["studyId"], [nodeIdViewer]);
-
-    // Some time for starting the service
     await utils.takeScreenshot(page, screenshotPrefix + 'service_started');
+
+    // Some time for setting up service's frontend
+    await tutorial.waitFor(3000);
 
     const iframeHandles = await page.$$("iframe");
     const iframes = [];


### PR DESCRIPTION
## What do these changes do?
When sharing a study with an Organization, no matter Organization's role in the collaboration, its' members will only have ```viewer``` access to it.
This PR fixes that bug.

Before:
![share-before](https://user-images.githubusercontent.com/33152403/121022700-de1cf080-c7a2-11eb-8274-26a125f812c3.gif)

After:
![share-after](https://user-images.githubusercontent.com/33152403/121022738-e83eef00-c7a2-11eb-8c24-63652c8f925e.gif)

## Related issue/s
closes https://github.com/ITISFoundation/osparc-simcore/issues/2272

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
