### PR TITLE
  🐛 Project locked issue (e2e issue) (⚠️ devops)

### DIFF
--- a/packages/models-library/src/models_library/settings/celery.py
+++ b/packages/models-library/src/models_library/settings/celery.py
@@ -1,13 +1,14 @@
 from pydantic import BaseSettings, PositiveInt
-from .redis import RedisConfig
+
 from .rabbit import RabbitConfig
+from .redis import RedisConfig
 
 
 class CeleryConfig(BaseSettings):
     @classmethod
     def create_from_env(cls, **override) -> "CeleryConfig":
         # this calls trigger env parsers
-        return cls(rabbit=RabbitConfig(), redis=RedisConfig(), **override)
+        return cls(rabbit=RabbitConfig(), redis=RedisConfig(db="2"), **override)
 
     # NOTE: Defaults are evaluated at import time, use create_from_env to build instances
     rabbit: RabbitConfig = RabbitConfig()

--- a/services/docker-compose-ops.yml
+++ b/services/docker-compose-ops.yml
@@ -67,7 +67,7 @@ services:
     image: rediscommander/redis-commander:latest
     init: true
     environment:
-      - REDIS_HOSTS=${REDIS_HOST}
+      - REDIS_HOSTS=resources:${REDIS_HOST}:${REDIS_PORT}:0,locks:${REDIS_HOST}:${REDIS_PORT}:1,celery_backend:${REDIS_HOST}:${REDIS_PORT}:2
     ports:
       - "18081:8081"
     networks:

--- a/services/sidecar/src/simcore_service_sidecar/mpi_lock.py
+++ b/services/sidecar/src/simcore_service_sidecar/mpi_lock.py
@@ -63,7 +63,7 @@ async def _acquire_and_extend_lock_forever(
         {
             "host": config.CELERY_CONFIG.redis.host,
             "port": config.CELERY_CONFIG.redis.port,
-            "db": int(config.CELERY_CONFIG.redis.db),
+            "db": 1,
         }
     ]
 

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -392,7 +392,9 @@ async def open_project(request: web.Request) -> web.Response:
         async def try_add_project() -> Optional[Set[int]]:
             with managed_resource(user_id, client_session_id, request.app) as rt:
                 try:
-                    async with await rt.get_registry_lock():
+                    # NOTE: we need to lock the access to the project so that no one else opens it
+                    # at the same time.
+                    async with await rt.get_registry_lock(project_uuid):
                         other_users: Set[int] = set(
                             await rt.find_users_of_resource("project_id", project_uuid)
                         )

--- a/services/web/server/src/simcore_service_webserver/resource_manager/config.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/config.py
@@ -13,7 +13,7 @@ from servicelib.application_keys import APP_CONFIG_KEY
 
 CONFIG_SECTION_NAME = "resource_manager"
 APP_CLIENT_REDIS_CLIENT_KEY = __name__ + ".resource_manager.redis_client"
-APP_CLIENT_REDIS_LOCK_KEY = __name__ + ".resource_manager.redis_lock"
+APP_CLIENT_REDIS_LOCK_MANAGER_KEY = __name__ + ".resource_manager.redis_lock"
 APP_CLIENT_SOCKET_REGISTRY_KEY = __name__ + ".resource_manager.registry"
 APP_RESOURCE_MANAGER_TASKS_KEY = __name__ + ".resource_manager.tasks.key"
 

--- a/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
@@ -43,7 +43,7 @@ from simcore_service_webserver.users_api import (
 from simcore_service_webserver.users_to_groups_api import get_users_for_gid
 
 from .config import (
-    APP_CLIENT_REDIS_LOCK_KEY,
+    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
     GUEST_USER_RC_LOCK_FORMAT,
     get_garbage_collector_interval,
 )
@@ -147,7 +147,7 @@ async def collect_garbage(app: web.Application):
 async def remove_disconnected_user_resources(
     registry: RedisResourceRegistry, app: web.Application
 ) -> None:
-    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_KEY]
+    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
 
     #
     # In redis jargon, every entry is denoted as "key"
@@ -283,7 +283,7 @@ async def remove_users_manually_marked_as_guests(
     Removes all the projects associated with GUEST users in the system.
     If the user defined a TEMPLATE, this one also gets removed.
     """
-    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_KEY]
+    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
 
     # collects all users with registed sessions
     alive_keys, dead_keys = await registry.get_all_resource_keys()

--- a/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
@@ -11,42 +11,30 @@ from aiopg.sa.result import RowProxy
 from aioredlock import Aioredlock
 from servicelib.observer import emit
 from servicelib.utils import logged_gather
-from simcore_service_webserver import users_exceptions
-from simcore_service_webserver.db_models import GroupType
-from simcore_service_webserver.director.director_api import (
-    get_running_interactive_services,
-    stop_service,
-)
-from simcore_service_webserver.director.director_exceptions import (
-    DirectorException,
-    ServiceNotFoundError,
-)
-from simcore_service_webserver.groups_api import get_group_from_gid
-from simcore_service_webserver.projects.projects_api import (
+
+from .. import users_exceptions
+from ..db_models import GroupType
+from ..director.director_api import get_running_interactive_services, stop_service
+from ..director.director_exceptions import DirectorException, ServiceNotFoundError
+from ..groups_api import get_group_from_gid
+from ..projects.projects_api import (
     delete_project_from_db,
     get_project_for_user,
     get_workbench_node_ids_from_project_uuid,
     is_node_id_present_in_any_project_workbench,
 )
-from simcore_service_webserver.projects.projects_db import (
-    APP_PROJECT_DBAPI,
-    ProjectAccessRights,
-)
-from simcore_service_webserver.projects.projects_exceptions import ProjectNotFoundError
-from simcore_service_webserver.users_api import (
+from ..projects.projects_db import APP_PROJECT_DBAPI, ProjectAccessRights
+from ..projects.projects_exceptions import ProjectNotFoundError
+from ..resource_manager.redis import get_redis_lock_manager
+from ..users_api import (
     delete_user,
     get_guest_user_ids_and_names,
     get_user,
     get_user_id_from_gid,
     is_user_guest,
 )
-from simcore_service_webserver.users_to_groups_api import get_users_for_gid
-
-from .config import (
-    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
-    GUEST_USER_RC_LOCK_FORMAT,
-    get_garbage_collector_interval,
-)
+from ..users_to_groups_api import get_users_for_gid
+from .config import GUEST_USER_RC_LOCK_FORMAT, get_garbage_collector_interval
 from .registry import RedisResourceRegistry, get_registry
 
 logger = logging.getLogger(__name__)
@@ -147,7 +135,7 @@ async def collect_garbage(app: web.Application):
 async def remove_disconnected_user_resources(
     registry: RedisResourceRegistry, app: web.Application
 ) -> None:
-    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
+    lock_manager: Aioredlock = get_redis_lock_manager(app)
 
     #
     # In redis jargon, every entry is denoted as "key"
@@ -283,7 +271,7 @@ async def remove_users_manually_marked_as_guests(
     Removes all the projects associated with GUEST users in the system.
     If the user defined a TEMPLATE, this one also gets removed.
     """
-    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
+    lock_manager: Aioredlock = get_redis_lock_manager(app)
 
     # collects all users with registed sessions
     alive_keys, dead_keys = await registry.get_all_resource_keys()

--- a/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
@@ -16,7 +16,7 @@ from .config import (
 log = logging.getLogger(__name__)
 
 THIS_SERVICE_NAME = "redis"
-DSN = "redis://{host}:{port}"
+DSN = "redis://{host}:{port}/1"
 
 retry_upon_init_policy = dict(
     stop=stop_after_attempt(4),
@@ -79,5 +79,5 @@ def get_redis_client(app: web.Application) -> aioredis.Redis:
     return app[APP_CLIENT_REDIS_CLIENT_KEY]
 
 
-def get_redis_lock(app: web.Application) -> Aioredlock:
+def get_redis_lock_manager(app: web.Application) -> Aioredlock:
     return app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]

--- a/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
@@ -16,7 +16,7 @@ from .config import (
 log = logging.getLogger(__name__)
 
 THIS_SERVICE_NAME = "redis"
-DSN = "redis://{host}:{port}/1"
+DSN = "redis://{host}:{port}"
 
 retry_upon_init_policy = dict(
     stop=stop_after_attempt(4),
@@ -38,8 +38,8 @@ async def redis_client(app: web.Application):
             if not client:
                 raise ValueError("Expected aioredis client instance, got {client}")
 
-    # create lock manager
-    lock_manager = Aioredlock([url])
+    # create lock manager but use DB 1
+    lock_manager = Aioredlock([url + "/1"])
 
     assert client  # nosec
     app[APP_CLIENT_REDIS_CLIENT_KEY] = client

--- a/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
@@ -9,7 +9,7 @@ from tenacity import AsyncRetrying, before_log, stop_after_attempt, wait_fixed
 
 from .config import (
     APP_CLIENT_REDIS_CLIENT_KEY,
-    APP_CLIENT_REDIS_LOCK_KEY,
+    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
     CONFIG_SECTION_NAME,
 )
 
@@ -45,13 +45,13 @@ async def redis_client(app: web.Application):
     app[APP_CLIENT_REDIS_CLIENT_KEY] = client
 
     assert lock_manager  # nosec
-    app[APP_CLIENT_REDIS_LOCK_KEY] = lock_manager
+    app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY] = lock_manager
 
     yield
 
     if client is not app[APP_CLIENT_REDIS_CLIENT_KEY]:
         log.critical("Invalid redis client in app")
-    if lock_manager is not app[APP_CLIENT_REDIS_LOCK_KEY]:
+    if lock_manager is not app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]:
         log.critical("Invalid redis lock manager in app")
 
     # close client
@@ -80,4 +80,4 @@ def get_redis_client(app: web.Application) -> aioredis.Redis:
 
 
 def get_redis_lock(app: web.Application) -> Aioredlock:
-    return app[APP_CLIENT_REDIS_LOCK_KEY]
+    return app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -163,13 +163,23 @@ class WebsocketRegistry:
         users = [int(x["user_id"]) for x in registry_keys]
         return users
 
-    async def get_registry_lock(self) -> aioredlock.Lock:
+    async def get_registry_lock(self, resource_name: str) -> aioredlock.Lock:
+        """use in a context manager:
+        ```async with rt.get_gegistry_lock(resource_name="project_uuid") as lock:
+            # do some useful stuff
+            pass
+        ```
+        """
         log.debug(
             "user %s/tab %s getting registry lock...",
             self.user_id,
             self.client_session_id,
         )
-        return await get_redis_lock_manager(self.app).lock(__name__, lock_timeout=10)
+        # NOTE: passing a lock_timeout=None means the lock manager will auto-extend the timeout as long
+        # the context manager is on
+        return await get_redis_lock_manager(self.app).lock(
+            f"{__name__}.{resource_name}", lock_timeout=None
+        )
 
 
 @contextmanager

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -23,7 +23,7 @@ import attr
 from aiohttp import web
 
 from .config import get_service_deletion_timeout
-from .redis import get_redis_lock
+from .redis import get_redis_lock_manager
 from .registry import get_registry
 
 log = logging.getLogger(__file__)
@@ -99,7 +99,7 @@ class WebsocketRegistry:
         )
 
     async def set_heartbeat(self) -> None:
-        """Extends TTL to avoid expiration of all resources under this session """
+        """Extends TTL to avoid expiration of all resources under this session"""
         registry = get_registry(self.app)
         await registry.set_key_alive(
             self._resource_key(), get_service_deletion_timeout(self.app)
@@ -169,7 +169,7 @@ class WebsocketRegistry:
             self.user_id,
             self.client_session_id,
         )
-        return await get_redis_lock(self.app).lock(__name__, lock_timeout=10)
+        return await get_redis_lock_manager(self.app).lock(__name__, lock_timeout=10)
 
 
 @contextmanager

--- a/services/web/server/src/simcore_service_webserver/studies_access.py
+++ b/services/web/server/src/simcore_service_webserver/studies_access.py
@@ -23,7 +23,7 @@ from servicelib.application_setup import ModuleCategory, app_module_setup
 from .constants import INDEX_RESOURCE_NAME
 from .login.decorators import login_required
 from .resource_manager.config import (
-    APP_CLIENT_REDIS_LOCK_KEY,
+    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
     GUEST_USER_RC_LOCK_FORMAT,
 )
 from .security_api import is_anonymous, remember
@@ -70,7 +70,7 @@ async def create_temporary_user(request: web.Request):
     from .security_api import encrypt_password
 
     db = get_storage(request.app)
-    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_KEY]
+    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
 
     # TODO: avatar is an icon of the hero!
     random_uname = get_random_string(min_len=5)

--- a/services/web/server/src/simcore_service_webserver/studies_access.py
+++ b/services/web/server/src/simcore_service_webserver/studies_access.py
@@ -22,10 +22,8 @@ from servicelib.application_setup import ModuleCategory, app_module_setup
 
 from .constants import INDEX_RESOURCE_NAME
 from .login.decorators import login_required
-from .resource_manager.config import (
-    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
-    GUEST_USER_RC_LOCK_FORMAT,
-)
+from .resource_manager.config import GUEST_USER_RC_LOCK_FORMAT
+from .resource_manager.redis import get_redis_lock_manager
 from .security_api import is_anonymous, remember
 from .storage_api import copy_data_folders_from_project
 from .utils import compose_error_msg
@@ -70,7 +68,7 @@ async def create_temporary_user(request: web.Request):
     from .security_api import encrypt_password
 
     db = get_storage(request.app)
-    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
+    lock_manager: Aioredlock = get_redis_lock_manager(request.app)
 
     # TODO: avatar is an icon of the hero!
     random_uname = get_random_string(min_len=5)

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
@@ -18,7 +18,7 @@ from ..login.cfg import get_storage
 from ..login.handlers import ACTIVE, GUEST
 from ..login.utils import get_client_ip, get_random_string
 from ..resource_manager.config import (
-    APP_CLIENT_REDIS_LOCK_KEY,
+    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
     GUEST_USER_RC_LOCK_FORMAT,
 )
 from ..security_api import authorized_userid, encrypt_password, is_anonymous, remember
@@ -52,7 +52,7 @@ async def _get_authorized_user(request: web.Request) -> Optional[Dict]:
 
 async def _create_temporary_user(request: web.Request):
     db = get_storage(request.app)
-    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_KEY]
+    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
 
     # TODO: avatar is an icon of the hero!
     random_user_name = get_random_string(min_len=5)

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
@@ -17,10 +17,8 @@ from pydantic import BaseModel
 from ..login.cfg import get_storage
 from ..login.handlers import ACTIVE, GUEST
 from ..login.utils import get_client_ip, get_random_string
-from ..resource_manager.config import (
-    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
-    GUEST_USER_RC_LOCK_FORMAT,
-)
+from ..resource_manager.config import GUEST_USER_RC_LOCK_FORMAT
+from ..resource_manager.redis import get_redis_lock_manager
 from ..security_api import authorized_userid, encrypt_password, is_anonymous, remember
 from ..users_api import get_user
 from ..users_exceptions import UserNotFoundError
@@ -52,7 +50,7 @@ async def _get_authorized_user(request: web.Request) -> Optional[Dict]:
 
 async def _create_temporary_user(request: web.Request):
     db = get_storage(request.app)
-    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
+    lock_manager: Aioredlock = get_redis_lock_manager(request.app)
 
     # TODO: avatar is an icon of the hero!
     random_user_name = get_random_string(min_len=5)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  🔨 refactoring
  🏗️ maintenance
  📚 documentation

and append (⚠️ devops) if changes in devops configuration required before deploying

  SEE https://github.com/dannyfritz/commit-message-emoji
  SEE https://emojipedia.org
-->

## What do these changes do?

When a project is opened in the backend (:open endpoint in webserver) a distributed redis lock for the whole resource registry is acquired to prevent multiple opening of the same project by different users. 
In case the lock acquisition fails, an exception is risen and the secure fallback is to report that the project is locked, which is fine.

The problem arise when on e2e when 20 users are creating a project at the same time, trying to lock the whole resource registry at the same time, which is a bottleneck. Why it suddenly appeared is an unknown, but might be due to computer power, or some changes in the docker swarm distribution of services.

as a reminder: to lock a redis distributed lock we use aioredlock library, which by default tries 3 times to lock and then raise an exception in case of failure

# Changes:
- acquire a lock per project instead of the whole project registry (using the project uuid)
- separate redis entries: in DB 0 go the resource manager entries, in DB1 go the locks, in DB3 go the celery result-backend entries for simplified checks in redis-commander
- redis-commander now automatically shows the 3 entries (see screenshot)
![image](https://user-images.githubusercontent.com/35365065/121658781-f1c99f00-caa1-11eb-9a8d-17293e1ed0e5.png)
- a bit of refactoring


⚠️ devops:
- add the REDIS_HOSTS to redis-commander as in
```
environment:
      - REDIS_HOSTS=resources:${REDIS_HOST}:${REDIS_PORT}:0,locks:${REDIS_HOST}:${REDIS_PORT}:1,celery_backend:${REDIS_HOST}:${REDIS_PORT}:2
```

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->

fixes #2375 
## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
