### PR TITLE
WIP:   ✨  allowing to log back into a study when the tab was closed 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,8 @@ printf "%80s| %22s| %12s| %12s\n" Endpoint Name User Password;\
 printf "%.$${TableWidth}s\n" "$$seperator";\
 printf "$$rows" 'http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):9081' 'oSparc platform';\
 printf "$$rows" 'http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):18080/?pgsql=postgres&username=scu&db=simcoredb&ns=public' 'Postgres DB' $${POSTGRES_USER} $${POSTGRES_PASSWORD};\
-printf "$$rows" 'http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):9000' Portainer admin adminadmin
+printf "$$rows" 'http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):9000' Portainer admin adminadmin;\
+printf "$$rows" 'http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):18081' Redis
 endef
 
 show_endpoints:

--- a/Makefile
+++ b/Makefile
@@ -189,10 +189,22 @@ endif
 
 define _show_endpoints
 # The following endpoints are available
-echo "http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):9081                                                                 - oSparc platform"
-echo "http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):18080/?pgsql=postgres&username=scu&db=simcoredb&ns=public  - Postgres DB"
-echo "http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):9000                                                                 - Portainer"
+set -o allexport; \
+source $(CURDIR)/.env; \
+set +o allexport; \
+seperator=------------------------------------------;\
+seperator=$${seperator}$${seperator}$${seperator};\
+rows="%-80s| %22s| %12s| %12s\n";\
+TableWidth=140;\
+printf "%80s| %22s| %12s| %12s\n" Endpoint Name User Password;\
+printf "%.$${TableWidth}s\n" "$$seperator";\
+printf "$$rows" 'http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):9081' 'oSparc platform';\
+printf "$$rows" 'http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):18080/?pgsql=postgres&username=scu&db=simcoredb&ns=public' 'Postgres DB' $${POSTGRES_USER} $${POSTGRES_PASSWORD};\
+printf "$$rows" 'http://$(if $(IS_WSL2),$(get_my_ip),127.0.0.1):9000' Portainer admin adminadmin
 endef
+
+show_endpoints:
+	@$(_show_endpoints)
 
 up-devel: .stack-simcore-development.yml .init-swarm $(CLIENT_WEB_OUTPUT) ## Deploys local development stack, qx-compile+watch and ops stack (pass 'make ops_disabled=1 up-...' to disable)
 	# Start compile+watch front-end container [front-end]

--- a/packages/models-library/src/models_library/settings/celery.py
+++ b/packages/models-library/src/models_library/settings/celery.py
@@ -1,13 +1,14 @@
 from pydantic import BaseSettings, PositiveInt
-from .redis import RedisConfig
+
 from .rabbit import RabbitConfig
+from .redis import RedisConfig
 
 
 class CeleryConfig(BaseSettings):
     @classmethod
     def create_from_env(cls, **override) -> "CeleryConfig":
         # this calls trigger env parsers
-        return cls(rabbit=RabbitConfig(), redis=RedisConfig(), **override)
+        return cls(rabbit=RabbitConfig(), redis=RedisConfig(db="2"), **override)
 
     # NOTE: Defaults are evaluated at import time, use create_from_env to build instances
     rabbit: RabbitConfig = RabbitConfig()

--- a/services/docker-compose-ops.yml
+++ b/services/docker-compose-ops.yml
@@ -67,7 +67,7 @@ services:
     image: rediscommander/redis-commander:latest
     init: true
     environment:
-      - REDIS_HOSTS=${REDIS_HOST}
+      - REDIS_HOSTS=resources:${REDIS_HOST}:${REDIS_PORT}:0,locks:${REDIS_HOST}:${REDIS_PORT}:1,celery_backend:${REDIS_HOST}:${REDIS_PORT}:2
     ports:
       - "18081:8081"
     networks:

--- a/services/sidecar/src/simcore_service_sidecar/mpi_lock.py
+++ b/services/sidecar/src/simcore_service_sidecar/mpi_lock.py
@@ -63,7 +63,7 @@ async def _acquire_and_extend_lock_forever(
         {
             "host": config.CELERY_CONFIG.redis.host,
             "port": config.CELERY_CONFIG.redis.port,
-            "db": int(config.CELERY_CONFIG.redis.db),
+            "db": 1,
         }
     ]
 

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -404,8 +404,6 @@ async def open_project(request: web.Request) -> web.Response:
                             return other_users
                         await rt.add("project_id", project_uuid)
                 except aioredlock.LockError as exc:
-                    # TODO: this lock is not a good solution for long term
-                    # maybe a project key in redis might improve spped of checking
                     raise HTTPLocked(reason="Project is locked") from exc
 
         other_users = await try_add_project()

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -392,7 +392,9 @@ async def open_project(request: web.Request) -> web.Response:
         async def try_add_project() -> Optional[Set[int]]:
             with managed_resource(user_id, client_session_id, request.app) as rt:
                 try:
-                    async with await rt.get_registry_lock():
+                    # NOTE: we need to lock the access to the project so that no one else opens it
+                    # at the same time.
+                    async with await rt.get_registry_lock(project_uuid):
                         other_users: Set[int] = set(
                             await rt.find_users_of_resource("project_id", project_uuid)
                         )

--- a/services/web/server/src/simcore_service_webserver/resource_manager/config.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/config.py
@@ -13,7 +13,7 @@ from servicelib.application_keys import APP_CONFIG_KEY
 
 CONFIG_SECTION_NAME = "resource_manager"
 APP_CLIENT_REDIS_CLIENT_KEY = __name__ + ".resource_manager.redis_client"
-APP_CLIENT_REDIS_LOCK_KEY = __name__ + ".resource_manager.redis_lock"
+APP_CLIENT_REDIS_LOCK_MANAGER_KEY = __name__ + ".resource_manager.redis_lock"
 APP_CLIENT_SOCKET_REGISTRY_KEY = __name__ + ".resource_manager.registry"
 APP_RESOURCE_MANAGER_TASKS_KEY = __name__ + ".resource_manager.tasks.key"
 

--- a/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
@@ -43,7 +43,7 @@ from simcore_service_webserver.users_api import (
 from simcore_service_webserver.users_to_groups_api import get_users_for_gid
 
 from .config import (
-    APP_CLIENT_REDIS_LOCK_KEY,
+    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
     GUEST_USER_RC_LOCK_FORMAT,
     get_garbage_collector_interval,
 )
@@ -147,7 +147,7 @@ async def collect_garbage(app: web.Application):
 async def remove_disconnected_user_resources(
     registry: RedisResourceRegistry, app: web.Application
 ) -> None:
-    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_KEY]
+    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
 
     #
     # In redis jargon, every entry is denoted as "key"
@@ -283,7 +283,7 @@ async def remove_users_manually_marked_as_guests(
     Removes all the projects associated with GUEST users in the system.
     If the user defined a TEMPLATE, this one also gets removed.
     """
-    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_KEY]
+    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
 
     # collects all users with registed sessions
     alive_keys, dead_keys = await registry.get_all_resource_keys()

--- a/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
@@ -11,42 +11,30 @@ from aiopg.sa.result import RowProxy
 from aioredlock import Aioredlock
 from servicelib.observer import emit
 from servicelib.utils import logged_gather
-from simcore_service_webserver import users_exceptions
-from simcore_service_webserver.db_models import GroupType
-from simcore_service_webserver.director.director_api import (
-    get_running_interactive_services,
-    stop_service,
-)
-from simcore_service_webserver.director.director_exceptions import (
-    DirectorException,
-    ServiceNotFoundError,
-)
-from simcore_service_webserver.groups_api import get_group_from_gid
-from simcore_service_webserver.projects.projects_api import (
+
+from .. import users_exceptions
+from ..db_models import GroupType
+from ..director.director_api import get_running_interactive_services, stop_service
+from ..director.director_exceptions import DirectorException, ServiceNotFoundError
+from ..groups_api import get_group_from_gid
+from ..projects.projects_api import (
     delete_project_from_db,
     get_project_for_user,
     get_workbench_node_ids_from_project_uuid,
     is_node_id_present_in_any_project_workbench,
 )
-from simcore_service_webserver.projects.projects_db import (
-    APP_PROJECT_DBAPI,
-    ProjectAccessRights,
-)
-from simcore_service_webserver.projects.projects_exceptions import ProjectNotFoundError
-from simcore_service_webserver.users_api import (
+from ..projects.projects_db import APP_PROJECT_DBAPI, ProjectAccessRights
+from ..projects.projects_exceptions import ProjectNotFoundError
+from ..resource_manager.redis import get_redis_lock_manager
+from ..users_api import (
     delete_user,
     get_guest_user_ids_and_names,
     get_user,
     get_user_id_from_gid,
     is_user_guest,
 )
-from simcore_service_webserver.users_to_groups_api import get_users_for_gid
-
-from .config import (
-    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
-    GUEST_USER_RC_LOCK_FORMAT,
-    get_garbage_collector_interval,
-)
+from ..users_to_groups_api import get_users_for_gid
+from .config import GUEST_USER_RC_LOCK_FORMAT, get_garbage_collector_interval
 from .registry import RedisResourceRegistry, get_registry
 
 logger = logging.getLogger(__name__)
@@ -147,7 +135,7 @@ async def collect_garbage(app: web.Application):
 async def remove_disconnected_user_resources(
     registry: RedisResourceRegistry, app: web.Application
 ) -> None:
-    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
+    lock_manager: Aioredlock = get_redis_lock_manager(app)
 
     #
     # In redis jargon, every entry is denoted as "key"
@@ -283,7 +271,7 @@ async def remove_users_manually_marked_as_guests(
     Removes all the projects associated with GUEST users in the system.
     If the user defined a TEMPLATE, this one also gets removed.
     """
-    lock_manager: Aioredlock = app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
+    lock_manager: Aioredlock = get_redis_lock_manager(app)
 
     # collects all users with registed sessions
     alive_keys, dead_keys = await registry.get_all_resource_keys()

--- a/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
@@ -16,7 +16,7 @@ from .config import (
 log = logging.getLogger(__name__)
 
 THIS_SERVICE_NAME = "redis"
-DSN = "redis://{host}:{port}"
+DSN = "redis://{host}:{port}/1"
 
 retry_upon_init_policy = dict(
     stop=stop_after_attempt(4),
@@ -79,5 +79,5 @@ def get_redis_client(app: web.Application) -> aioredis.Redis:
     return app[APP_CLIENT_REDIS_CLIENT_KEY]
 
 
-def get_redis_lock(app: web.Application) -> Aioredlock:
+def get_redis_lock_manager(app: web.Application) -> Aioredlock:
     return app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]

--- a/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
@@ -16,7 +16,7 @@ from .config import (
 log = logging.getLogger(__name__)
 
 THIS_SERVICE_NAME = "redis"
-DSN = "redis://{host}:{port}/1"
+DSN = "redis://{host}:{port}"
 
 retry_upon_init_policy = dict(
     stop=stop_after_attempt(4),
@@ -38,8 +38,8 @@ async def redis_client(app: web.Application):
             if not client:
                 raise ValueError("Expected aioredis client instance, got {client}")
 
-    # create lock manager
-    lock_manager = Aioredlock([url])
+    # create lock manager but use DB 1
+    lock_manager = Aioredlock([url + "/1"])
 
     assert client  # nosec
     app[APP_CLIENT_REDIS_CLIENT_KEY] = client

--- a/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/redis.py
@@ -9,7 +9,7 @@ from tenacity import AsyncRetrying, before_log, stop_after_attempt, wait_fixed
 
 from .config import (
     APP_CLIENT_REDIS_CLIENT_KEY,
-    APP_CLIENT_REDIS_LOCK_KEY,
+    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
     CONFIG_SECTION_NAME,
 )
 
@@ -45,13 +45,13 @@ async def redis_client(app: web.Application):
     app[APP_CLIENT_REDIS_CLIENT_KEY] = client
 
     assert lock_manager  # nosec
-    app[APP_CLIENT_REDIS_LOCK_KEY] = lock_manager
+    app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY] = lock_manager
 
     yield
 
     if client is not app[APP_CLIENT_REDIS_CLIENT_KEY]:
         log.critical("Invalid redis client in app")
-    if lock_manager is not app[APP_CLIENT_REDIS_LOCK_KEY]:
+    if lock_manager is not app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]:
         log.critical("Invalid redis lock manager in app")
 
     # close client
@@ -80,4 +80,4 @@ def get_redis_client(app: web.Application) -> aioredis.Redis:
 
 
 def get_redis_lock(app: web.Application) -> Aioredlock:
-    return app[APP_CLIENT_REDIS_LOCK_KEY]
+    return app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -16,7 +16,7 @@
 
 import logging
 from contextlib import contextmanager
-from typing import Dict, Iterator, List, Optional, Union
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 import aioredlock
 import attr
@@ -72,7 +72,7 @@ class WebsocketRegistry:
 
     async def get_socket_id(self) -> Optional[str]:
         log.debug(
-            "user %s/tab %s removing socket from registry...",
+            "user %s/tab %s getting socket from registry...",
             self.user_id,
             self.client_session_id,
         )
@@ -150,7 +150,9 @@ class WebsocketRegistry:
         registry = get_registry(self.app)
         await registry.remove_resource(self._resource_key(), key)
 
-    async def find_users_of_resource(self, key: str, value: str) -> List[int]:
+    async def find_users_of_resource(
+        self, key: str, value: str
+    ) -> List[Tuple[int, str]]:
         log.debug(
             "user %s/tab %s finding %s:%s in registry...",
             self.user_id,
@@ -160,8 +162,10 @@ class WebsocketRegistry:
         )
         registry = get_registry(self.app)
         registry_keys = await registry.find_keys((key, value))
-        users = [int(x["user_id"]) for x in registry_keys]
-        return users
+        user_session_id_list = [
+            (int(x["user_id"]), x["client_session_id"]) for x in registry_keys
+        ]
+        return user_session_id_list
 
     async def get_registry_lock(self, resource_name: str) -> aioredlock.Lock:
         """use in a context manager:

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -163,13 +163,23 @@ class WebsocketRegistry:
         users = [int(x["user_id"]) for x in registry_keys]
         return users
 
-    async def get_registry_lock(self) -> aioredlock.Lock:
+    async def get_registry_lock(self, resource_name: str) -> aioredlock.Lock:
+        """use in a context manager:
+        ```async with rt.get_gegistry_lock(resource_name="project_uuid") as lock:
+            # do some useful stuff
+            pass
+        ```
+        """
         log.debug(
             "user %s/tab %s getting registry lock...",
             self.user_id,
             self.client_session_id,
         )
-        return await get_redis_lock_manager(self.app).lock(__name__, lock_timeout=10)
+        # NOTE: passing a lock_timeout=None means the lock manager will auto-extend the timeout as long
+        # the context manager is on
+        return await get_redis_lock_manager(self.app).lock(
+            f"{__name__}.{resource_name}", lock_timeout=None
+        )
 
 
 @contextmanager

--- a/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/websocket_manager.py
@@ -23,7 +23,7 @@ import attr
 from aiohttp import web
 
 from .config import get_service_deletion_timeout
-from .redis import get_redis_lock
+from .redis import get_redis_lock_manager
 from .registry import get_registry
 
 log = logging.getLogger(__file__)
@@ -99,7 +99,7 @@ class WebsocketRegistry:
         )
 
     async def set_heartbeat(self) -> None:
-        """Extends TTL to avoid expiration of all resources under this session """
+        """Extends TTL to avoid expiration of all resources under this session"""
         registry = get_registry(self.app)
         await registry.set_key_alive(
             self._resource_key(), get_service_deletion_timeout(self.app)
@@ -169,7 +169,7 @@ class WebsocketRegistry:
             self.user_id,
             self.client_session_id,
         )
-        return await get_redis_lock(self.app).lock(__name__, lock_timeout=10)
+        return await get_redis_lock_manager(self.app).lock(__name__, lock_timeout=10)
 
 
 @contextmanager

--- a/services/web/server/src/simcore_service_webserver/studies_access.py
+++ b/services/web/server/src/simcore_service_webserver/studies_access.py
@@ -23,7 +23,7 @@ from servicelib.application_setup import ModuleCategory, app_module_setup
 from .constants import INDEX_RESOURCE_NAME
 from .login.decorators import login_required
 from .resource_manager.config import (
-    APP_CLIENT_REDIS_LOCK_KEY,
+    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
     GUEST_USER_RC_LOCK_FORMAT,
 )
 from .security_api import is_anonymous, remember
@@ -70,7 +70,7 @@ async def create_temporary_user(request: web.Request):
     from .security_api import encrypt_password
 
     db = get_storage(request.app)
-    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_KEY]
+    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
 
     # TODO: avatar is an icon of the hero!
     random_uname = get_random_string(min_len=5)

--- a/services/web/server/src/simcore_service_webserver/studies_access.py
+++ b/services/web/server/src/simcore_service_webserver/studies_access.py
@@ -22,10 +22,8 @@ from servicelib.application_setup import ModuleCategory, app_module_setup
 
 from .constants import INDEX_RESOURCE_NAME
 from .login.decorators import login_required
-from .resource_manager.config import (
-    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
-    GUEST_USER_RC_LOCK_FORMAT,
-)
+from .resource_manager.config import GUEST_USER_RC_LOCK_FORMAT
+from .resource_manager.redis import get_redis_lock_manager
 from .security_api import is_anonymous, remember
 from .storage_api import copy_data_folders_from_project
 from .utils import compose_error_msg
@@ -70,7 +68,7 @@ async def create_temporary_user(request: web.Request):
     from .security_api import encrypt_password
 
     db = get_storage(request.app)
-    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
+    lock_manager: Aioredlock = get_redis_lock_manager(request.app)
 
     # TODO: avatar is an icon of the hero!
     random_uname = get_random_string(min_len=5)

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
@@ -18,7 +18,7 @@ from ..login.cfg import get_storage
 from ..login.handlers import ACTIVE, GUEST
 from ..login.utils import get_client_ip, get_random_string
 from ..resource_manager.config import (
-    APP_CLIENT_REDIS_LOCK_KEY,
+    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
     GUEST_USER_RC_LOCK_FORMAT,
 )
 from ..security_api import authorized_userid, encrypt_password, is_anonymous, remember
@@ -52,7 +52,7 @@ async def _get_authorized_user(request: web.Request) -> Optional[Dict]:
 
 async def _create_temporary_user(request: web.Request):
     db = get_storage(request.app)
-    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_KEY]
+    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
 
     # TODO: avatar is an icon of the hero!
     random_user_name = get_random_string(min_len=5)

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
@@ -17,10 +17,8 @@ from pydantic import BaseModel
 from ..login.cfg import get_storage
 from ..login.handlers import ACTIVE, GUEST
 from ..login.utils import get_client_ip, get_random_string
-from ..resource_manager.config import (
-    APP_CLIENT_REDIS_LOCK_MANAGER_KEY,
-    GUEST_USER_RC_LOCK_FORMAT,
-)
+from ..resource_manager.config import GUEST_USER_RC_LOCK_FORMAT
+from ..resource_manager.redis import get_redis_lock_manager
 from ..security_api import authorized_userid, encrypt_password, is_anonymous, remember
 from ..users_api import get_user
 from ..users_exceptions import UserNotFoundError
@@ -52,7 +50,7 @@ async def _get_authorized_user(request: web.Request) -> Optional[Dict]:
 
 async def _create_temporary_user(request: web.Request):
     db = get_storage(request.app)
-    lock_manager: Aioredlock = request.app[APP_CLIENT_REDIS_LOCK_MANAGER_KEY]
+    lock_manager: Aioredlock = get_redis_lock_manager(request.app)
 
     # TODO: avatar is an icon of the hero!
     random_user_name = get_random_string(min_len=5)

--- a/services/web/server/tests/unit/with_dbs/01/test_redis_registry.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_redis_registry.py
@@ -3,7 +3,7 @@
 # pylint:disable=redefined-outer-name
 import time
 from random import randint
-from typing import Dict, List
+from typing import Dict, List, Tuple
 from uuid import uuid4
 
 import pytest
@@ -209,10 +209,10 @@ async def test_websocket_manager(loop, redis_enabled_app, redis_registry, user_i
                 # resource key shall be filled
                 assert await rt.find(res_key) == [res_value]
                 list_of_same_resource_users: List[
-                    int
+                    Tuple[int, str]
                 ] = await rt.find_users_of_resource(res_key, res_value)
                 assert list_user_ids[: (list_user_ids.index(user_id) + 1)] == sorted(
-                    set(list_of_same_resource_users)
+                    {uid for uid, _ in list_of_same_resource_users}
                 )
 
     # remove sockets


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  🔨 refactoring
  🏗️ maintenance
  📚 documentation

and append (⚠️ devops) if changes in devops configuration required before deploying

  SEE https://github.com/dannyfritz/commit-message-emoji
  SEE https://emojipedia.org
-->

## What do these changes do?

The backend maintain a Redis-based registry where all user-allocated resources are kept (for now only socket IDs and project IDs).
These resources are linked to the user so-called "client session id" which is given by the frontend as the Broswer Tab ID when the websocket connection is created (Socket ID).

FRom the backend side it is not possible to distinguish between a network disconnection and a tab-closed. Therefore we do use a TTL (time-to-live) field in the Redis registry of 900 seconds. During that time, the same browser tab would be able to re-open the same study in case that it reconnects.

In the case of a closed tab, re-opening a new tab creates a new Tab ID. Therefore the backend treats that as "the user opened another tab and is trying to open a study that is already opened in another tab". Therefore it appears locked, and the user must wait 15 minutes until it gets closed, and after that the user may open it again.

# Changes
- [x] Listing the projects now will check if the user project is already opened by that very same user. If yes, it will check if a socket ID exists. If yes, then the behavior will remain the same. If not, then the project will not be defined as Locked and the user can re-open it.
- [ ] If the project is just in the process of closing (e.g. dynamic services are saving their state and closing). then it should not be allowed to re-enter the project until the process is completed.


## Related issue/s

<!-- Enumerate REVIEWERS other issues
fixes [#431](https://github.com/ITISFoundation/osparc-issues/issues/431)
e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
