### PR TITLE
🏗️ Arbitrarily cap unarchiving to 2 workers

### DIFF
--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -76,7 +76,7 @@ async def unarchive_dir(
     all tree leafs, which might include files or empty folders
     """
     with zipfile.ZipFile(archive_to_extract, mode="r") as zip_file_handler:
-        with ProcessPoolExecutor() as pool:
+        with ProcessPoolExecutor(max_workers=2) as pool:
             loop = asyncio.get_event_loop()
 
             # running in process poll is not ideal for concurrency issues


### PR DESCRIPTION
## What do these changes do?

Currently, extracting zip files is done with a ProcessPool using all available cpu cores. This can be pretty heavy and, for instance on AWS, can make a cluster node completely unresponsive. I suggest to cap at 2. Once this is in, all dynamic services that consume that need to be updated.