### PR TITLE
🐛 Allows port matching from general to concrete data

### DIFF
--- a/services/web/client/source/class/osparc/component/form/renderer/PropForm.js
+++ b/services/web/client/source/class/osparc/component/form/renderer/PropForm.js
@@ -76,7 +76,12 @@ qx.Class.define("osparc.component.form.renderer.PropForm", {
         this.__createDropMechanism(item, item.key);
 
         // Notify focus and focus out
-        const msgDataFn = (nodeId, portId) => this.__arePortsCompatible(nodeId, portId, this.getNode().getNodeId(), item.key);
+        const msgDataFn = (nodeId, portId) => {
+          if (nodeId === this.getNode().getNodeId()) {
+            return false;
+          }
+          return this.__arePortsCompatible(nodeId, portId, this.getNode().getNodeId(), item.key);
+        };
 
         item.addListener("focus", () => {
           if (this.getNode()) {

--- a/services/web/server/src/simcore_service_webserver/catalog_api_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/catalog_api_handlers.py
@@ -276,7 +276,9 @@ async def get_compatible_outputs_given_target_input_handler(request: Request):
 #
 
 
-def can_connect(from_output: ServiceOutput, to_input: ServiceInput) -> bool:
+def can_connect(
+    from_output: ServiceOutput, to_input: ServiceInput, *, strict: bool = False
+) -> bool:
     # FIXME: can_connect is a very very draft version
 
     # compatible units
@@ -303,9 +305,18 @@ def can_connect(from_output: ServiceOutput, to_input: ServiceInput) -> bool:
         ok = from_output.property_type == to_input.property_type
         if not ok:
             ok = (
+                # data:  -> data:*/*
                 to_input.property_type == "data:*/*"
                 and from_output.property_type.startswith("data:")
             )
+
+            if not strict:
+                # NOTE: by default, this is allowed in the UI but not in a more strict plausibility check
+                # data:*/*  -> data:
+                ok |= (
+                    from_output.property_type == "data:*/*"
+                    and to_input.property_type.startswith("data:")
+                )
     return ok
 
 

--- a/services/web/server/tests/unit/isolated/test_catalog_api_handlers.py
+++ b/services/web/server/tests/unit/isolated/test_catalog_api_handlers.py
@@ -1,0 +1,41 @@
+from models_library.services import ServiceInput, ServiceOutput
+from simcore_service_webserver.catalog_api_handlers import can_connect
+
+
+def test_can_connect():
+    # Reproduces https://github.com/ITISFoundation/osparc-issues/issues/442
+    file_picker_outfile = {
+        "displayOrder": 2,
+        "label": "File Picker",
+        "description": "Picker",
+        "type": "data:*/*",
+    }
+
+    input_sleeper_input_1 = {
+        "displayOrder": 1,
+        "label": "Sleeper",
+        "description": "sleeper input file",
+        "type": "data:text/plain",
+    }
+
+    # data:*/* -> data:text/plain
+    assert can_connect(
+        from_output=ServiceOutput.parse_obj(file_picker_outfile),
+        to_input=ServiceInput.parse_obj(input_sleeper_input_1),
+    )
+    assert not can_connect(
+        from_output=ServiceOutput.parse_obj(file_picker_outfile),
+        to_input=ServiceInput.parse_obj(input_sleeper_input_1),
+        strict=True,
+    )
+
+    # data:text/plain  -> data:*/*
+    assert can_connect(
+        from_output=ServiceOutput.parse_obj(input_sleeper_input_1),
+        to_input=ServiceInput.parse_obj(file_picker_outfile),
+    )
+    assert can_connect(
+        from_output=ServiceOutput.parse_obj(input_sleeper_input_1),
+        to_input=ServiceInput.parse_obj(file_picker_outfile),
+        strict=True,
+    )


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  🔨 refactoring
  🏗️ maintenance
  📚 documentation

and append (⚠️ devops) if changes in devops configuration required before deploying

  SEE https://github.com/dannyfritz/commit-message-emoji
  SEE https://emojipedia.org
-->

## What do these changes do?

We will allow matching ``data:*/* -> data:concrete`` types in a non-strict check mode. This will allow e.g. connecting a file picker (producing ``data:*/*``) with a sleeper (accepts ``data:text/plain``). 

There is obviously a chance that the file produced by the file-picker is not ``data:text/plain`` but this API is intended for a first check. Further plausibility checks will use strict mode and detect this failure. 

This strict/non-strict approach is convenient for UI/UX purposes.

## Related issue/s

- Fixes ITISFoundation/osparc-issues#442: cannot link files from File Picker to some cardiac model nodes

## How to test

```command
make devenv
source .venv/bin/activate
cd web/server
make install-dev
pytest tests/unit/isolated/test_catalog_api_handlers.py 
```

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
