### PR TITLE
Locked study icons

### DIFF
--- a/services/web/client/source/class/osparc/component/task/Export.js
+++ b/services/web/client/source/class/osparc/component/task/Export.js
@@ -24,6 +24,10 @@ qx.Class.define("osparc.component.task.Export", {
     this.base(arguments);
   },
 
+  statics: {
+    EXPORT_ICON: "@FontAwesome5Solid/cloud-download-alt" // "@FontAwesome5Solid/file-export"
+  },
+
   members: {
     __study: null,
 
@@ -31,8 +35,7 @@ qx.Class.define("osparc.component.task.Export", {
       let control;
       switch (id) {
         case "icon":
-          // control = new qx.ui.basic.Image("@FontAwesome5Solid/file-export/14");
-          control = new qx.ui.basic.Image("@FontAwesome5Solid/cloud-download-alt/14").set({
+          control = new qx.ui.basic.Image(this.self().EXPORT_ICON+"/14").set({
             alignY: "middle",
             alignX: "center",
             paddingLeft: 3,

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
@@ -469,7 +469,6 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonItem", {
     },
 
     _applyState: function(state) {
-      console.log(state);
       const locked = ("locked" in state) ? state["locked"]["value"] : false;
       this.setLocked(locked);
       if (locked) {

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
@@ -518,6 +518,7 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonItem", {
     _applyLocked: function(locked) {
       this.__enableCard(!locked);
       this.getChildControl("lock-status").set({
+        opacity: 1.0,
         visibility: locked ? "visible" : "excluded"
       });
     },

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowserButtonItem.js
@@ -174,8 +174,8 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonItem", {
             right: 4
           });
           break;
-        case "lock":
-          control = new osparc.ui.basic.Thumbnail("@FontAwesome5Solid/lock/70");
+        case "lock-status":
+          control = new osparc.ui.basic.Thumbnail();
           this._add(control, {
             top: 0,
             right: 0,
@@ -469,15 +469,57 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonItem", {
     },
 
     _applyState: function(state) {
+      console.log(state);
       const locked = ("locked" in state) ? state["locked"]["value"] : false;
+      this.setLocked(locked);
       if (locked) {
-        this.setLocked(state["locked"]["value"]);
-        const owner = state["locked"]["owner"];
-        const status = state["locked"]["status"];
-        this.__setLockedBy(osparc.utils.Utils.firstsUp(owner["first_name"], owner["last_name"]), status);
-      } else {
-        this.setLocked(false);
+        this.__setLockedStatus(state["locked"]);
       }
+    },
+
+    __setLockedStatus: function(lockedStatus) {
+      const status = lockedStatus["status"];
+      const owner = lockedStatus["owner"];
+      const lock = this.getChildControl("lock-status");
+      const lockImage = this.getChildControl("lock-status").getChildControl("image");
+      let toolTipText = osparc.utils.Utils.firstsUp(owner["first_name"], owner["last_name"]);
+      let source = null;
+      switch (status) {
+        case "CLOSING":
+          source = "@FontAwesome5Solid/key/70";
+          toolTipText += this.tr(" is closing it...");
+          break;
+        case "CLONING":
+          source = "@FontAwesome5Solid/clone/70";
+          toolTipText += this.tr(" is cloning it...");
+          break;
+        case "EXPORTING":
+          source = osparc.component.task.Export.EXPORT_ICON+"/70";
+          toolTipText += this.tr(" is exporting it...");
+          break;
+        case "OPENING":
+          source = "@FontAwesome5Solid/key/70";
+          toolTipText += this.tr(" is opening it...");
+          break;
+        case "OPENED":
+          source = "@FontAwesome5Solid/lock/70";
+          toolTipText += this.tr(" is using it.");
+          break;
+        default:
+          source = "@FontAwesome5Solid/lock/70";
+          break;
+      }
+      lock.set({
+        toolTipText: toolTipText
+      });
+      lockImage.setSource(source);
+    },
+
+    _applyLocked: function(locked) {
+      this.__enableCard(!locked);
+      this.getChildControl("lock-status").set({
+        visibility: locked ? "visible" : "excluded"
+      });
     },
 
     __enableCard: function(enabled) {
@@ -498,41 +540,6 @@ qx.Class.define("osparc.dashboard.StudyBrowserButtonItem", {
         child.set({
           enabled
         });
-      });
-    },
-
-    _applyLocked: function(locked) {
-      this.__enableCard(!locked);
-
-      const lock = this.getChildControl("lock");
-      lock.set({
-        opacity: 1.0,
-        visibility: locked ? "visible" : "excluded"
-      });
-    },
-
-    __setLockedBy: function(lockedBy, status) {
-      const lock = this.getChildControl("lock");
-      let toolTipText = null;
-      switch (status) {
-        case "CLOSING":
-          toolTipText = lockedBy + this.tr(" is closing it...");
-          break;
-        case "CLONING":
-          toolTipText = lockedBy + this.tr(" is cloning it...");
-          break;
-        case "EXPORTING":
-          toolTipText = lockedBy + this.tr(" is exporting it...");
-          break;
-        case "OPENING":
-          toolTipText = lockedBy + this.tr(" is opening it...");
-          break;
-        case "OPENED":
-          toolTipText = lockedBy + this.tr(" is using it.");
-          break;
-      }
-      lock.set({
-        toolTipText: toolTipText
       });
     },
 


### PR DESCRIPTION
## What do these changes do?

Implements the front end part for locked studies:
- [x] Show lock icon if the study is open
- [x] Show key icon if the study is being opened/closed
- [x] Show copy icon if the study is being cloned/exported

![openclose](https://user-images.githubusercontent.com/33152403/123780701-bd444880-d8d3-11eb-98fb-06daebfae2ac.gif)


## Related issue/s
related to https://github.com/ITISFoundation/osparc-simcore/issues/1952: frontend part


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
