### PR TITLE
🔨adds new api endpoint for labels from PR1887

### DIFF
--- a/api/specs/director/openapi.yaml
+++ b/api/specs/director/openapi.yaml
@@ -128,6 +128,43 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorEnveloped"
 
+  /services/{service_key}/{service_version}/labels:
+    get:
+      tags:
+        - users
+      summary: Returns the list of tags attached to a service
+      operationId: get_service_labels
+      parameters:
+        - $ref: "#/components/parameters/ServiceKeyPath"
+        - $ref: "#/components/parameters/ServiceVersionPath"
+      responses:
+        "200":
+          description: Success, returns the details of the service
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+        "401":
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnveloped"
+        "404":
+          description: Service not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnveloped"
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnveloped"
+
   /service_extras/{service_key}/{service_version}:
     get:
       tags:

--- a/services/director/src/simcore_service_director/api/v0/openapi.yaml
+++ b/services/director/src/simcore_service_director/api/v0/openapi.yaml
@@ -918,6 +918,146 @@ paths:
                         description: Error code
                         type: integer
                         example: 404
+  '/services/{service_key}/{service_version}/labels':
+    get:
+      tags:
+        - users
+      summary: Returns the list of tags attached to a service
+      operationId: get_service_labels
+      parameters:
+        - in: path
+          name: service_key
+          description: The key (url) of the service
+          required: true
+          schema:
+            type: string
+            description: distinctive name for the node based on the docker registry path
+            pattern: '^(simcore)/(services)/(comp|dynamic)(/[\w/-]+)+$'
+            example:
+              - simcore/services/comp/itis/sleeper
+              - simcore/services/dynamic/3dviewer
+        - in: path
+          name: service_version
+          description: The tag/version of the service
+          required: true
+          schema:
+            type: string
+            description: semantic version number
+            pattern: '^(0|[1-9]\d*)(\.(0|[1-9]\d*)){2}(-(0|[1-9]\d*|\d*[-a-zA-Z][-\da-zA-Z]*)(\.(0|[1-9]\d*|\d*[-a-zA-Z][-\da-zA-Z]*))*)?(\+[-\da-zA-Z]+(\.[-\da-zA-Z-]+)*)?$'
+            example:
+              - 1.0.0
+              - 0.0.1
+      responses:
+        '200':
+          description: 'Success, returns the details of the service'
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+        '401':
+          description: Unauthorized access
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  data:
+                    nullable: true
+                    default: null
+                  error:
+                    type: object
+                    required:
+                      - status
+                      - message
+                    properties:
+                      message:
+                        description: Error message
+                        type: string
+                        example: Unexpected error
+                      errors:
+                        type: array
+                        items:
+                          properties:
+                            code:
+                              type: string
+                              description: Server Exception
+                              example: ServiceUUIDNotFoundError
+                      status:
+                        description: Error code
+                        type: integer
+                        example: 404
+        '404':
+          description: Service not found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  data:
+                    nullable: true
+                    default: null
+                  error:
+                    type: object
+                    required:
+                      - status
+                      - message
+                    properties:
+                      message:
+                        description: Error message
+                        type: string
+                        example: Unexpected error
+                      errors:
+                        type: array
+                        items:
+                          properties:
+                            code:
+                              type: string
+                              description: Server Exception
+                              example: ServiceUUIDNotFoundError
+                      status:
+                        description: Error code
+                        type: integer
+                        example: 404
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  data:
+                    nullable: true
+                    default: null
+                  error:
+                    type: object
+                    required:
+                      - status
+                      - message
+                    properties:
+                      message:
+                        description: Error message
+                        type: string
+                        example: Unexpected error
+                      errors:
+                        type: array
+                        items:
+                          properties:
+                            code:
+                              type: string
+                              description: Server Exception
+                              example: ServiceUUIDNotFoundError
+                      status:
+                        description: Error code
+                        type: integer
+                        example: 404
   '/service_extras/{service_key}/{service_version}':
     get:
       tags:

--- a/services/director/src/simcore_service_director/exceptions.py
+++ b/services/director/src/simcore_service_director/exceptions.py
@@ -21,6 +21,8 @@ translate into something like
 
 from typing import Optional
 
+from aiodocker.exceptions import DockerError
+
 
 class DirectorException(Exception):
     """Basic exception"""
@@ -32,8 +34,8 @@ class DirectorException(Exception):
 class GenericDockerError(DirectorException):
     """Generic docker library error"""
 
-    def __init__(self, msg: str, original_exception: Exception):
-        super().__init__(msg + ": {original_exception}")
+    def __init__(self, msg: str, original_exception: DockerError):
+        super().__init__(msg + f": {original_exception.message}")
         self.original_exception = original_exception
 
 

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -729,6 +729,7 @@ async def _start_docker_service(
             "service_state": service_state.value,
             "service_message": service_msg,
             "user_id": user_id,
+            "project_id": project_id,
         }
         return container_meta_data
 
@@ -889,6 +890,7 @@ async def _get_node_details(
     service_name = service["Spec"]["Name"]
     service_uuid = service["Spec"]["Labels"]["uuid"]
     user_id = service["Spec"]["Labels"]["user_id"]
+    project_id = service["Spec"]["Labels"]["study_id"]
 
     # get the published port
     published_port, target_port = await _get_docker_image_port_mapping(service)
@@ -904,6 +906,7 @@ async def _get_node_details(
         "service_state": service_state.value,
         "service_message": service_msg,
         "user_id": user_id,
+        "project_id": project_id,
     }
     return node_details
 
@@ -921,6 +924,7 @@ async def get_services_details(
             list_running_services = await client.services.list(
                 filters={"label": filters}
             )
+
             services_details = [
                 await _get_node_details(app, client, service)
                 for service in list_running_services

--- a/services/director/tests/test_handlers.py
+++ b/services/director/tests/test_handlers.py
@@ -155,6 +155,27 @@ async def test_services_by_key_version_get(
     _check_services(created_services, retrieved_services)
 
 
+async def test_get_service_labels(
+    client, push_services, api_version_prefix
+):  # pylint: disable=W0613, W0621
+    created_services = await push_services(3, 2)
+
+    for service in created_services:
+        service_description = service["service_description"]
+        # note that it is very important to remove the safe="/" from quote!!!!
+        key, version = [
+            quote(service_description[key], safe="") for key in ("key", "version")
+        ]
+        url = f"/{api_version_prefix}/services/{key}/{version}/labels"
+        web_response = await client.get(url)
+        assert web_response.status == 200, await web_response.text()
+
+        services_enveloped = await web_response.json()
+        labels = services_enveloped["data"]
+
+        assert service["docker_labels"] == labels
+
+
 async def test_services_extras_by_key_version_get(
     client, push_services, api_version_prefix
 ):  # pylint: disable=W0613, W0621


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  🔨 refactoring
  🏗️ maintenance
  📚 documentation

or get your emoji from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Moves changes relative to the `director-v0` from https://github.com/ITISFoundation/osparc-simcore/pull/1887

- Adds an API to recover service label. The labels are fetched form the docker image

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
