### PR TITLE
✨Enhancement/detect user logged out

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -28,6 +28,9 @@ from models_library.projects_state import (
 )
 from servicelib.application_keys import APP_JSONSCHEMA_SPECS_KEY
 from servicelib.jsonschema_validation import validate_instance
+
+## PROJECT NODES -----------------------------------------------------
+from servicelib.observer import observe
 from servicelib.utils import fire_and_forget_task, logged_gather
 from simcore_service_webserver.director import director_exceptions
 
@@ -46,6 +49,7 @@ from ..socketio.events import (
     SOCKET_IO_NODE_UPDATED_EVENT,
     SOCKET_IO_PROJECT_UPDATED_EVENT,
     post_group_messages,
+    post_messages,
 )
 from ..storage_api import (
     delete_data_folders_of_project,
@@ -190,14 +194,34 @@ async def delete_project(app: web.Application, project_uuid: str, user_id: int) 
     fire_and_forget_task(remove_services_and_data())
 
 
-## PROJECT NODES -----------------------------------------------------
+@observe(event="SIGNAL_USER_DISCONNECTED")
+async def user_disconnected(
+    user_id: int, client_session_id: str, app: web.Application
+) -> None:
+    # check if there is a project resource
+    with managed_resource(user_id, client_session_id, app) as rt:
+        list_projects: List[str] = await rt.find(PROJECT_ID_KEY)
+
+    await logged_gather(
+        *[
+            retrieve_and_notify_project_locked_state(
+                user_id, prj, app, notify_only_prj_user=True
+            )
+            for prj in list_projects
+        ]
+    )
 
 
 async def retrieve_and_notify_project_locked_state(
-    user_id: int, project_uuid: str, app: web.Application
+    user_id: int,
+    project_uuid: str,
+    app: web.Application,
+    notify_only_prj_user: bool = False,
 ):
     project = await get_project_for_user(app, project_uuid, user_id, include_state=True)
-    await notify_project_state_update(app, project)
+    await notify_project_state_update(
+        app, project, notify_only_user=user_id if notify_only_prj_user else None
+    )
 
 
 @contextlib.asynccontextmanager
@@ -485,11 +509,11 @@ async def is_node_id_present_in_any_project_workbench(
     return node_id in await db.get_all_node_ids_from_workbenches()
 
 
-async def notify_project_state_update(app: web.Application, project: Dict) -> None:
-    rooms_to_notify = [
-        f"{gid}" for gid, rights in project["accessRights"].items() if rights["read"]
-    ]
-
+async def notify_project_state_update(
+    app: web.Application,
+    project: Dict,
+    notify_only_user: Optional[int] = None,
+) -> None:
     messages = {
         SOCKET_IO_PROJECT_UPDATED_EVENT: {
             "project_uuid": project["uuid"],
@@ -497,8 +521,16 @@ async def notify_project_state_update(app: web.Application, project: Dict) -> No
         }
     }
 
-    for room in rooms_to_notify:
-        await post_group_messages(app, room, messages)
+    if notify_only_user:
+        await post_messages(app, user_id=str(notify_only_user), messages=messages)
+    else:
+        rooms_to_notify = [
+            f"{gid}"
+            for gid, rights in project["accessRights"].items()
+            if rights["read"]
+        ]
+        for room in rooms_to_notify:
+            await post_group_messages(app, room, messages)
 
 
 async def notify_project_node_update(

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -636,7 +636,7 @@ async def try_close_project_for_user(
     app: web.Application,
 ):
     with managed_resource(user_id, client_session_id, app) as rt:
-        user_to_session_ids: List[Tuple(int, str)] = await rt.find_users_of_resource(
+        user_to_session_ids: List[UserSessionID] = await rt.find_users_of_resource(
             PROJECT_ID_KEY, project_uuid
         )
         # first check we have it opened now
@@ -654,7 +654,7 @@ async def try_close_project_for_user(
         )
         await rt.remove(PROJECT_ID_KEY)
     # check it is not opened by someone else
-    user_to_session_ids.remove((user_id, client_session_id))
+    user_to_session_ids.remove(UserSessionID(user_id, client_session_id))
     log.debug("remaining user_to_session_ids: %s", user_to_session_ids)
     if not user_to_session_ids:
         # NOTE: depending on the garbage collector speed, it might already be removing it

--- a/services/web/server/tests/unit/with_dbs/10/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/10/test_resource_manager.py
@@ -4,8 +4,9 @@
 
 
 import asyncio
-from asyncio import Future, sleep
+import json
 import logging
+from asyncio import Future, sleep
 from copy import deepcopy
 from typing import Any, Callable, Dict
 from unittest.mock import call
@@ -18,6 +19,9 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient
 from aioredis import Redis
 from aioresponses import aioresponses
+from pytest_mock.plugin import MockerFixture
+from tenacity import after_log, retry_if_exception_type, stop_after_attempt, wait_fixed
+
 from pytest_simcore.helpers.utils_assert import assert_status
 from pytest_simcore.helpers.utils_projects import NewProject
 from servicelib.application import create_safe_application
@@ -40,13 +44,8 @@ from simcore_service_webserver.security import setup_security
 from simcore_service_webserver.security_roles import UserRole
 from simcore_service_webserver.session import setup_session
 from simcore_service_webserver.socketio import setup_socketio
+from simcore_service_webserver.socketio.events import SOCKET_IO_PROJECT_UPDATED_EVENT
 from simcore_service_webserver.users import setup_users
-from tenacity import (
-    after_log,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_fixed,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -279,7 +278,9 @@ async def test_websocket_multiple_connections(
         sid = sio.sid
         await sio.disconnect()
         # need to attend the disconnect event to pass through the socketio internal queues
-        await asyncio.sleep(0.1)  # must be >= 0.01 to work without issues, added some padding
+        await asyncio.sleep(
+            0.1
+        )  # must be >= 0.01 to work without issues, added some padding
         assert not sio.sid
         assert not await socket_registry.find_keys(("socket_id", sio.sid))
         assert not sid in await socket_registry.find_resources(
@@ -424,6 +425,7 @@ async def test_interactive_services_remain_after_websocket_reconnection_from_2_t
     client_session_id_factory: Callable[[], str],
     storage_subsystem_mock,  # when guest user logs out garbage is collected
     exp_save_state: bool,
+    mocker: MockerFixture,
 ):
     set_service_deletion_delay(SERVICE_DELETION_DELAY, client.server.app)
 
@@ -443,9 +445,36 @@ async def test_interactive_services_remain_after_websocket_reconnection_from_2_t
     client_session_id2 = client_session_id_factory()
     sio2 = await socketio_client_factory(client_session_id2)
     assert sio.sid != sio2.sid
+    socket_project_state_update_mock_callable = mocker.Mock()
+    sio2.on(
+        SOCKET_IO_PROJECT_UPDATED_EVENT,
+        handler=socket_project_state_update_mock_callable,
+    )
     # disconnect first websocket
+    # NOTE: since the service deletion delay is set to 1 second for the test, we should not sleep as long here, or the user will be deleted
+    # We have no mock-up for the heatbeat...
     await sio.disconnect()
     assert not sio.sid
+    await asyncio.sleep(0.1)  # let the thread call the method
+    socket_project_state_update_mock_callable.assert_called_with(
+        json.dumps(
+            {
+                "project_uuid": empty_user_project["uuid"],
+                "data": {
+                    "locked": {
+                        "value": False,
+                        "owner": {
+                            "user_id": logged_user["id"],
+                            "first_name": logged_user["name"],
+                            "last_name": "",
+                        },
+                        "status": "OPENED",
+                    },
+                    "state": {"value": "NOT_STARTED"},
+                },
+            }
+        )
+    )
     # open project in second client
     await open_project(client, empty_user_project["uuid"], client_session_id2)
     # ensure sufficient time is wasted here

--- a/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
@@ -38,5 +38,6 @@ services:
     restart: always
     environment:
       - REDIS_HOSTS=redis
+      - REDIS_HOSTS=resources:redis:6379:0,locks:redis:6379:1,celery_backend:redis:6379:2
     ports:
       - "18081:8081"


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  🔨 refactoring
  🏗️ maintenance
  📚 documentation

or get your emoji from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
if a user closes a tab opened on a study, and has another tab showing the dashboard, the project will not automatically unlock unless the user refreshes the remaining tab.
This PR shall solve this by sending a websocket event to all tabs a user has opened.



## Related issue/s
fixes [#431](https://github.com/ITISFoundation/osparc-issues/issues/431)
<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
