### PR TITLE
Bugfix/clean storage meta data table

### DIFF
--- a/api/specs/storage/openapi.yaml
+++ b/api/specs/storage/openapi.yaml
@@ -97,6 +97,26 @@ paths:
         default:
           $ref: "#/components/responses/DefaultErrorResponse"
 
+  /locations/{location_id}:sync:
+    post:
+      summary: Manually triggers the synchronisation of the file meta data table in the database
+      operationId: synchronise_meta_data_table
+      parameters:
+        - name: location_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: An object containing added, changed and removed paths
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TableSynchronisationEnveloped"
+        default:
+          $ref: "#/components/responses/DefaultErrorResponse"
+
   /locations/{location_id}/datasets:
     get:
       summary: Lists all dataset's metadata
@@ -627,6 +647,46 @@ components:
         body_value:
           key1: value1
           key2: value2
+
+    TableSynchronisationEnveloped:
+      type: object
+      required:
+        - data
+        - error
+      properties:
+        data:
+          $ref: "#/components/schemas/TableSynchronisation"
+        error:
+          nullable: true
+          default: null
+
+    TableSynchronisation:
+      type: object
+      required:
+        - added
+        - changed
+        - removed
+      properties:
+        added:
+          type: array
+          items:
+            type: string
+        changed:
+          type: array
+          items:
+            type: object
+            required:
+              - old
+              - new
+            properties:
+              old:
+                type: string
+              new:
+                type: string
+        removed:
+          type: array
+          items:
+            type: string
 
     FileLocationArrayEnveloped:
       type: object

--- a/api/specs/storage/openapi.yaml
+++ b/api/specs/storage/openapi.yaml
@@ -113,7 +113,6 @@ paths:
           schema:
             type: boolean
             default: true
-
       responses:
         "200":
           description: An object containing added, changed and removed paths

--- a/api/specs/storage/openapi.yaml
+++ b/api/specs/storage/openapi.yaml
@@ -107,6 +107,13 @@ paths:
           required: true
           schema:
             type: string
+        - name: dry_run
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: true
+
       responses:
         "200":
           description: An object containing added, changed and removed paths
@@ -663,26 +670,8 @@ components:
     TableSynchronisation:
       type: object
       required:
-        - added
-        - changed
         - removed
       properties:
-        added:
-          type: array
-          items:
-            type: string
-        changed:
-          type: array
-          items:
-            type: object
-            required:
-              - old
-              - new
-            properties:
-              old:
-                type: string
-              new:
-                type: string
         removed:
           type: array
           items:

--- a/api/specs/webserver/components/schemas/locations.yaml
+++ b/api/specs/webserver/components/schemas/locations.yaml
@@ -4,7 +4,7 @@ FileLocationEnveloped:
     - data
   properties:
     data:
-      $ref: '#/FileLocation'
+      $ref: "#/FileLocation"
     error:
       nullable: true
       default: null
@@ -17,10 +17,32 @@ FileLocation:
     id:
       type: number
   example:
-    filename: 'simcore.s3'
+    filename: "simcore.s3"
     id: 0
 
 FileLocationArray:
   type: array
   items:
-    $ref: '#/FileLocation'
+    $ref: "#/FileLocation"
+
+TableSynchronisationEnveloped:
+  type: object
+  required:
+    - data
+    - error
+  properties:
+    data:
+      $ref: "#/TableSynchronisation"
+    error:
+      nullable: true
+      default: null
+
+TableSynchronisation:
+  type: object
+  required:
+    - removed
+  properties:
+    removed:
+      type: array
+      items:
+        type: string

--- a/api/specs/webserver/openapi-storage.yaml
+++ b/api/specs/webserver/openapi-storage.yaml
@@ -15,6 +15,34 @@ paths:
         default:
           $ref: "#/components/responses/DefaultErrorResponse"
 
+  /storage/locations/{location_id}:sync:
+    post:
+      summary: Manually triggers the synchronisation of the file meta data table in the database
+      tags:
+        - storage
+      operationId: synchronise_meta_data_table
+      parameters:
+        - name: location_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: dry_run
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: true
+      responses:
+        "200":
+          description: An object containing added, changed and removed paths
+          content:
+            application/json:
+              schema:
+                $ref: "./components/schemas/locations.yaml#/TableSynchronisationEnveloped"
+        default:
+          $ref: "#/components/responses/DefaultErrorResponse"
+
   /storage/locations/{location_id}/datasets:
     get:
       summary: Get datasets metadata

--- a/api/specs/webserver/openapi.yaml
+++ b/api/specs/webserver/openapi.yaml
@@ -139,6 +139,9 @@ paths:
   /storage/locations:
     $ref: "./openapi-storage.yaml#/paths/~1storage~1locations"
 
+  /storage/locations/{location_id}:sync:
+    $ref: "./openapi-storage.yaml#/paths/~1storage~1locations~1{location_id}:sync"
+
   /storage/locations/{location_id}/files/metadata:
     $ref: "./openapi-storage.yaml#/paths/~1storage~1locations~1{location_id}~1files~1metadata"
 

--- a/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
+++ b/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
@@ -95,6 +95,25 @@ paths:
                 $ref: '#/components/schemas/FileLocationArrayEnveloped'
         default:
           $ref: '#/components/responses/DefaultErrorResponse'
+  '/locations/{location_id}:sync':
+    post:
+      summary: Manually triggers the synchronisation of the file meta data table in the database
+      operationId: synchronise_meta_data_table
+      parameters:
+        - name: location_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'An object containing added, changed and removed paths'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TableSynchronisationEnveloped'
+        default:
+          $ref: '#/components/responses/DefaultErrorResponse'
   '/locations/{location_id}/datasets':
     get:
       summary: Lists all dataset's metadata
@@ -597,6 +616,44 @@ components:
         body_value:
           key1: value1
           key2: value2
+    TableSynchronisationEnveloped:
+      type: object
+      required:
+        - data
+        - error
+      properties:
+        data:
+          $ref: '#/components/schemas/TableSynchronisation'
+        error:
+          nullable: true
+          default: null
+    TableSynchronisation:
+      type: object
+      required:
+        - added
+        - changed
+        - removed
+      properties:
+        added:
+          type: array
+          items:
+            type: string
+        changed:
+          type: array
+          items:
+            type: object
+            required:
+              - old
+              - new
+            properties:
+              old:
+                type: string
+              new:
+                type: string
+        removed:
+          type: array
+          items:
+            type: string
     FileLocationArrayEnveloped:
       type: object
       required:

--- a/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
+++ b/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
@@ -105,6 +105,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: dry_run
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: true
       responses:
         '200':
           description: 'An object containing added, changed and removed paths'
@@ -630,26 +636,8 @@ components:
     TableSynchronisation:
       type: object
       required:
-        - added
-        - changed
         - removed
       properties:
-        added:
-          type: array
-          items:
-            type: string
-        changed:
-          type: array
-          items:
-            type: object
-            required:
-              - old
-              - new
-            properties:
-              old:
-                type: string
-              new:
-                type: string
         removed:
           type: array
           items:

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -13,7 +13,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from random import randrange
-from typing import Dict, Iterator, Tuple
+from typing import Any, Dict, Iterator, Tuple
 
 import dotenv
 import pytest
@@ -188,7 +188,7 @@ async def postgres_engine(loop, postgres_service_url):
 
 
 @pytest.fixture(scope="session")
-def minio_service(docker_services, docker_ip):
+def minio_service(docker_services, docker_ip) -> Dict[str, Any]:
 
     # Build URL to service listening on random port.
     url = "http://%s:%d/" % (
@@ -215,7 +215,7 @@ def minio_service(docker_services, docker_ip):
 
 
 @pytest.fixture(scope="module")
-def s3_client(minio_service):
+def s3_client(minio_service: Dict[str, Any]) -> MinioClientWrapper:
 
     s3_client = MinioClientWrapper(
         endpoint=minio_service["endpoint"],

--- a/services/storage/tests/utils.py
+++ b/services/storage/tests/utils.py
@@ -19,7 +19,7 @@ from simcore_service_storage.models import (
 log = logging.getLogger(__name__)
 
 
-DATABASE = "aio_login_tests"
+DATABASE = "test"
 USER = "admin"
 PASS = "admin"
 

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -5080,6 +5080,130 @@ paths:
                             message: Password is not secure
                             field: pasword
                         status: 400
+  '/storage/locations/{location_id}:sync':
+    post:
+      summary: Manually triggers the synchronisation of the file meta data table in the database
+      tags:
+        - storage
+      operationId: synchronise_meta_data_table
+      parameters:
+        - name: location_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: dry_run
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: true
+      responses:
+        '200':
+          description: 'An object containing added, changed and removed paths'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                  - error
+                properties:
+                  data:
+                    type: object
+                    required:
+                      - removed
+                    properties:
+                      removed:
+                        type: array
+                        items:
+                          type: string
+                  error:
+                    nullable: true
+                    default: null
+        default:
+          description: Default http error response body
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  data:
+                    nullable: true
+                    default: null
+                  error:
+                    type: object
+                    nullable: true
+                    properties:
+                      logs:
+                        description: log messages
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            level:
+                              description: log level
+                              type: string
+                              default: INFO
+                              enum:
+                                - DEBUG
+                                - WARNING
+                                - INFO
+                                - ERROR
+                            message:
+                              description: 'log message. If logger is USER, then it MUST be human readable'
+                              type: string
+                            logger:
+                              description: name of the logger receiving this message
+                              type: string
+                          required:
+                            - message
+                          example:
+                            message: 'Hi there, Mr user'
+                            level: INFO
+                            logger: user-logger
+                      errors:
+                        description: errors metadata
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - code
+                            - message
+                          properties:
+                            code:
+                              type: string
+                              description: Typically the name of the exception that produced it otherwise some known error code
+                            message:
+                              type: string
+                              description: Error message specific to this item
+                            resource:
+                              type: string
+                              description: API resource affected by this error
+                            field:
+                              type: string
+                              description: Specific field within the resource
+                      status:
+                        description: HTTP error code
+                        type: integer
+                    example:
+                      BadRequestError:
+                        logs:
+                          - message: Requested information is incomplete or malformed
+                            level: ERROR
+                          - message: Invalid email and password
+                            level: ERROR
+                            logger: USER
+                        errors:
+                          - code: InvalidEmail
+                            message: Email is malformed
+                            field: email
+                          - code: UnsavePassword
+                            message: Password is not secure
+                            field: pasword
+                        status: 400
   '/storage/locations/{location_id}/files/metadata':
     get:
       summary: Get list of file meta data

--- a/services/web/server/src/simcore_service_webserver/security_roles.py
+++ b/services/web/server/src/simcore_service_webserver/security_roles.py
@@ -78,6 +78,7 @@ ROLES_PERMISSIONS = {
     UserRole.TESTER: {
         "can": [
             "diagnostics.read",
+            "storage.files.sync",
         ],
         "inherits": [UserRole.USER],
     },

--- a/services/web/server/src/simcore_service_webserver/storage_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/storage_handlers.py
@@ -13,7 +13,7 @@ from servicelib.rest_utils import extract_and_validate
 from yarl import URL
 
 from .login.decorators import login_required
-from .security_api import check_permission
+from .security_decorators import permission_required
 from .storage_config import get_client_session, get_storage_config
 
 log = logging.getLogger(__name__)
@@ -89,66 +89,73 @@ def extract_link(data: Optional[Dict]) -> str:
 
 
 @login_required
+@permission_required("storage.files.*")
 async def get_storage_locations(request: web.Request):
-    await check_permission(request, "storage.locations.*")
     payload = await _request_storage(request, "GET")
     return payload
 
 
 @login_required
+@permission_required("storage.files.*")
 async def get_datasets_metadata(request: web.Request):
-    await check_permission(request, "storage.files.*")
     payload = await _request_storage(request, "GET")
     return payload
 
 
 @login_required
+@permission_required("storage.files.*")
 async def get_files_metadata(request: web.Request):
-    await check_permission(request, "storage.files.*")
     payload = await _request_storage(request, "GET")
     return payload
 
 
 @login_required
+@permission_required("storage.files.*")
 async def get_files_metadata_dataset(request: web.Request):
-    await check_permission(request, "storage.files.*")
     payload = await _request_storage(request, "GET")
     return payload
 
 
 @login_required
+@permission_required("storage.files.*")
 async def get_file_metadata(request: web.Request):
-    await check_permission(request, "storage.files.*")
     payload = await _request_storage(request, "GET")
     return payload
 
 
 @login_required
+@permission_required("storage.files.*")
 async def update_file_meta_data(request: web.Request):
-    await check_permission(request, "storage.files.*")
     raise NotImplementedError
     # payload = await _request_storage(request, 'PATCH' or 'PUT'???) See projects
     # return payload
 
 
 @login_required
+@permission_required("storage.files.*")
 async def download_file(request: web.Request):
-    await check_permission(request, "storage.files.*")
     payload = await _request_storage(request, "GET")
     return payload
 
 
 @login_required
+@permission_required("storage.files.*")
 async def upload_file(request: web.Request):
-    await check_permission(request, "storage.files.*")
     payload = await _request_storage(request, "PUT")
     return payload
 
 
 @login_required
+@permission_required("storage.files.*")
 async def delete_file(request: web.Request):
-    await check_permission(request, "storage.files.*")
     payload = await _request_storage(request, "DELETE")
+    return payload
+
+
+@login_required
+@permission_required("storage.files.sync")
+async def synchronise_meta_data_table(request: web.Request):
+    payload = await _request_storage(request, "POST")
     return payload
 
 

--- a/services/web/server/src/simcore_service_webserver/storage_routes.py
+++ b/services/web/server/src/simcore_service_webserver/storage_routes.py
@@ -31,6 +31,13 @@ def create(specs: openapi.Spec) -> List[web.RouteDef]:
     routes.append(web.get(BASEPATH + path, handler, name=operation_id))
 
     path, handler = (
+        "/storage/locations/{location_id}:sync",
+        storage_handlers.synchronise_meta_data_table,
+    )
+    operation_id = specs.paths[path].operations["post"].operation_id
+    routes.append(web.post(BASEPATH + path, handler, name=operation_id))
+
+    path, handler = (
         "/storage/locations/{location_id}/datasets",
         storage_handlers.get_datasets_metadata,
     )

--- a/services/web/server/tests/unit/with_dbs/04/test_storage.py
+++ b/services/web/server/tests/unit/with_dbs/04/test_storage.py
@@ -2,17 +2,12 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-import logging
-from copy import deepcopy
 from urllib.parse import quote
 
 import pytest
 from aiohttp import web
 from pytest_simcore.helpers.utils_assert import assert_status
-from pytest_simcore.helpers.utils_login import LoggedUser
 from servicelib.application import create_safe_application
-from servicelib.rest_responses import unwrap_envelope
-from servicelib.rest_utils import extract_and_validate
 from simcore_service_webserver.security_roles import UserRole
 
 API_VERSION = "v0"
@@ -37,6 +32,20 @@ def storage_server(loop, aiohttp_server, app_cfg):
                 "data": [
                     {"user_id": int(query["user_id"])},
                 ]
+            }
+        )
+
+    async def _post_sync_meta_data(request: web.Request):
+        assert not request.has_body
+
+        query = request.query
+        assert query
+        assert "dry_run" in query
+
+        assert query["dry_run"] == "true"
+        return web.json_response(
+            {
+                "data": {"removed": []},
             }
         )
 
@@ -114,6 +123,9 @@ def storage_server(loop, aiohttp_server, app_cfg):
     ), "backend service w/ different version as webserver entrypoint"
 
     app.router.add_get(f"/{storage_api_version}/locations", _get_locs)
+    app.router.add_post(
+        f"/{storage_api_version}/locations/0:sync", _post_sync_meta_data
+    )
     app.router.add_get(
         f"/{storage_api_version}/locations/0/files/{{file_id}}/metadata", _get_filemeta
     )
@@ -155,6 +167,28 @@ async def test_get_storage_locations(client, storage_server, logged_user, expect
     if not error:
         assert len(data) == 1
         assert data[0]["user_id"] == logged_user["id"]
+
+
+@pytest.mark.parametrize(
+    "user_role,expected",
+    [
+        (UserRole.ANONYMOUS, web.HTTPUnauthorized),
+        (UserRole.GUEST, web.HTTPForbidden),
+        (UserRole.USER, web.HTTPForbidden),
+        (UserRole.TESTER, web.HTTPOk),
+    ],
+)
+async def test_sync_file_meta_table(client, storage_server, logged_user, expected):
+    url = "/v0/storage/locations/0:sync"
+    assert url.startswith(PREFIX)
+
+    resp = await client.post(url, params={"dry_run": "true"})
+    data, error = await assert_status(resp, expected)
+
+    if not error:
+        # the test of the functionality is already done in storage
+        assert "removed" in data
+        assert not data["removed"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  🔨 refactoring
  🏗️ maintenance
  📚 documentation

or get your emoji from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?
once upon a time, storage micro-service was not removing the entries in the file_meta_data table correctly after deleting projects.

This PR aims to bring a special maintenant API entrypoint in storage that triggers a synchronisation of the table with the actual S3 backend by checking:
- each entry of the file_meta_data table is compared against S3
- if an entry is not visible in S3, it is then added to the "to be removed" list
- if the call is not in dry-run mode, each entry will be removed from the table
- the list of files to removed is returned


The endpoint is available form the webserver for TESTER only.


<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s
solves [#411](https://github.com/ITISFoundation/osparc-issues/issues/411)
<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
1. Upload some files to osparc through f.ex. file-picker ```http://127.0.0.1:9081```
2. Log into S3 ```http://127.0.0.1:9001```
3. remove the file(s) through minio interface
4. go back to osparc, edit the url by adding ```/dev/doc``` (this will automatically log as yourself in the Swagger UI)
5. Go to POST ```/v0/storage/locations/{id}:sync```
6. Set 0 as location id
7. Run, you should receive a list of files with the ones to be removed
8. Run with query parameter ```dry_run``` as false, this will effectively delete the entries in the DB


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
