### PR TITLE
🩹 Adds query option to avoid timeout for storage metadata sync

### DIFF
--- a/api/specs/storage/openapi.yaml
+++ b/api/specs/storage/openapi.yaml
@@ -116,10 +116,6 @@ paths:
       responses:
         "200":
           description: An object containing added, changed and removed paths
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TableSynchronisationEnveloped"
         default:
           $ref: "#/components/responses/DefaultErrorResponse"
 
@@ -653,28 +649,6 @@ components:
         body_value:
           key1: value1
           key2: value2
-
-    TableSynchronisationEnveloped:
-      type: object
-      required:
-        - data
-        - error
-      properties:
-        data:
-          $ref: "#/components/schemas/TableSynchronisation"
-        error:
-          nullable: true
-          default: null
-
-    TableSynchronisation:
-      type: object
-      required:
-        - removed
-      properties:
-        removed:
-          type: array
-          items:
-            type: string
 
     FileLocationArrayEnveloped:
       type: object

--- a/api/specs/storage/openapi.yaml
+++ b/api/specs/storage/openapi.yaml
@@ -113,9 +113,19 @@ paths:
           schema:
             type: boolean
             default: true
+        - name: fire_and_forget
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: An object containing added, changed and removed paths
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TableSynchronisationEnveloped"
         default:
           $ref: "#/components/responses/DefaultErrorResponse"
 
@@ -649,6 +659,28 @@ components:
         body_value:
           key1: value1
           key2: value2
+
+    TableSynchronisationEnveloped:
+      type: object
+      required:
+        - data
+        - error
+      properties:
+        data:
+          $ref: "#/components/schemas/TableSynchronisation"
+        error:
+          nullable: true
+          default: null
+
+    TableSynchronisation:
+      type: object
+      required:
+        - removed
+      properties:
+        removed:
+          type: array
+          items:
+            type: string
 
     FileLocationArrayEnveloped:
       type: object

--- a/api/specs/storage/openapi.yaml
+++ b/api/specs/storage/openapi.yaml
@@ -677,6 +677,10 @@ components:
       required:
         - removed
       properties:
+        dry_run:
+          type: boolean
+        fire_and_forget:
+          type: boolean
         removed:
           type: array
           items:

--- a/api/specs/webserver/components/schemas/locations.yaml
+++ b/api/specs/webserver/components/schemas/locations.yaml
@@ -42,6 +42,10 @@ TableSynchronisation:
   required:
     - removed
   properties:
+    dry_run:
+      type: boolean
+    fire_and_forget:
+      type: boolean
     removed:
       type: array
       items:

--- a/api/specs/webserver/openapi-storage.yaml
+++ b/api/specs/webserver/openapi-storage.yaml
@@ -33,6 +33,12 @@ paths:
           schema:
             type: boolean
             default: true
+        - name: fire_and_forget
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: An object containing added, changed and removed paths

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/c2d3acc313e1_adds_admin_to_userrole_enum.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/c2d3acc313e1_adds_admin_to_userrole_enum.py
@@ -1,0 +1,34 @@
+"""Adds ADMIN to userrole enum
+
+Revision ID: c2d3acc313e1
+Revises: 87a7b69f6723
+Create Date: 2021-07-12 13:05:05.782876+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c2d3acc313e1"
+down_revision = "87a7b69f6723"
+branch_labels = None
+depends_on = None
+
+
+# SEE https://medium.com/makimo-tech-blog/upgrading-postgresqls-enum-type-with-sqlalchemy-using-alembic-migration-881af1e30abe
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE userrole ADD VALUE 'ADMIN'")
+
+
+def downgrade():
+    op.execute("ALTER TYPE userrole RENAME TO userrole_old")
+    op.execute("CREATE TYPE userrole AS ENUM('ANONYMOUS', 'GUEST', 'USER', 'TESTER')")
+    op.execute(
+        (
+            "ALTER TABLE users ALTER COLUMN role TYPE userrole USING "
+            "role::text::userrole"
+        )
+    )
+    op.execute("DROP TYPE userrole_old")

--- a/packages/postgres-database/src/simcore_postgres_database/models/users.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/users.py
@@ -14,7 +14,7 @@ from .base import metadata
 
 
 class UserRole(Enum):
-    """ SORTED enumeration of user roles
+    """SORTED enumeration of user roles
 
     A role defines a set of privileges the user can perform
     Roles are sorted from lower to highest privileges
@@ -25,6 +25,7 @@ class UserRole(Enum):
     USER      : Registered user. Basic permissions to use the platform [default]
     TESTER    : Upgraded user. First level of super-user with privileges to test the framework.
                 Can use everything but does not have an effect in other users or actual data
+    ADMIN     : Framework admin.
 
     See security_access.py
     """
@@ -33,6 +34,7 @@ class UserRole(Enum):
     GUEST = "GUEST"
     USER = "USER"
     TESTER = "TESTER"
+    ADMIN = "ADMIN"
 
     @classmethod
     def super_users(cls):
@@ -43,9 +45,9 @@ class UserRole(Enum):
 
 class UserStatus(Enum):
     """
-        pending: user registered but not confirmed
-        active: user is confirmed and can use the platform
-        banned: user is not authorized
+    pending: user registered but not confirmed
+    active: user is confirmed and can use the platform
+    banned: user is not authorized
     """
 
     CONFIRMATION_PENDING = "PENDING"
@@ -99,7 +101,7 @@ DROP TRIGGER IF EXISTS user_modification on users;
 CREATE TRIGGER user_modification
 AFTER INSERT OR UPDATE OR DELETE ON users
     FOR EACH ROW
-    EXECUTE PROCEDURE set_user_groups();    
+    EXECUTE PROCEDURE set_user_groups();
 """
 )
 
@@ -130,5 +132,7 @@ END; $$ LANGUAGE 'plpgsql';
 
 sa.event.listen(users, "after_create", set_user_groups_procedure)
 sa.event.listen(
-    users, "after_create", new_user_trigger,
+    users,
+    "after_create",
+    new_user_trigger,
 )

--- a/services/storage/requirements/_base.in
+++ b/services/storage/requirements/_base.in
@@ -1,4 +1,7 @@
-# WARNING: manually disabled urllib3 contraint to upgrade minio
+#
+# Specifies dependencies required by 'storage' service
+#
+
 --constraint ../../../requirements/constraints.txt
 
 --requirement ../../../packages/models-library/requirements/_base.in
@@ -6,21 +9,19 @@
 --requirement ../../../packages/service-library/requirements/_base.in
 --requirement ../../../packages/settings-library/requirements/_base.in
 
-
-aiobotocore
-
+# server
 aiohttp
 aiohttp-swagger[performance]
 
+# s3 storage
+aiobotocore
+minio
+
+# i/o + db
 aiofiles
 aiopg[sa]
 
-tenacity
+# misc
 semantic_version
+tenacity
 typer
-minio
-urllib3
-
-#
-# FIXME: pip copiling these requirements wil fail due to incompatible contraints on urllib3 (ongoing in weekely mainteinance)
-#

--- a/services/storage/requirements/_test.in
+++ b/services/storage/requirements/_test.in
@@ -1,10 +1,8 @@
 #
-# Specifies dependencies required to run 'storage'
+# Specifies dependencies required to TEST 'storage'
 #
+
 --constraint ../../../requirements/constraints.txt
-# Adds base AS CONSTRAINT specs, not requirement.
-#  - Resulting _text.txt is a frozen list of EXTRA packages for testing, besides _base.txt
-#
 --constraint _base.txt
 
 # testing
@@ -16,17 +14,17 @@ pytest-instafail
 pytest-mock
 pytest-runner
 pytest-sugar
-pylint
-python-dotenv
 
 # test coverage
 coverage
 coveralls
 codecov
+
+# fixtures
 faker
-
-# remote debugging
-ptvsd
-
-# utils
 pandas
+pylint
+python-dotenv
+
+# remote debugger
+ptvsd

--- a/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
+++ b/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
@@ -644,6 +644,10 @@ components:
       required:
         - removed
       properties:
+        dry_run:
+          type: boolean
+        fire_and_forget:
+          type: boolean
         removed:
           type: array
           items:

--- a/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
+++ b/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
@@ -111,9 +111,19 @@ paths:
           schema:
             type: boolean
             default: true
+        - name: fire_and_forget
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: 'An object containing added, changed and removed paths'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TableSynchronisationEnveloped'
         default:
           $ref: '#/components/responses/DefaultErrorResponse'
   '/locations/{location_id}/datasets':
@@ -618,6 +628,26 @@ components:
         body_value:
           key1: value1
           key2: value2
+    TableSynchronisationEnveloped:
+      type: object
+      required:
+        - data
+        - error
+      properties:
+        data:
+          $ref: '#/components/schemas/TableSynchronisation'
+        error:
+          nullable: true
+          default: null
+    TableSynchronisation:
+      type: object
+      required:
+        - removed
+      properties:
+        removed:
+          type: array
+          items:
+            type: string
     FileLocationArrayEnveloped:
       type: object
       required:

--- a/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
+++ b/services/storage/src/simcore_service_storage/api/v0/openapi.yaml
@@ -114,10 +114,6 @@ paths:
       responses:
         '200':
           description: 'An object containing added, changed and removed paths'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TableSynchronisationEnveloped'
         default:
           $ref: '#/components/responses/DefaultErrorResponse'
   '/locations/{location_id}/datasets':
@@ -622,26 +618,6 @@ components:
         body_value:
           key1: value1
           key2: value2
-    TableSynchronisationEnveloped:
-      type: object
-      required:
-        - data
-        - error
-      properties:
-        data:
-          $ref: '#/components/schemas/TableSynchronisation'
-        error:
-          nullable: true
-          default: null
-    TableSynchronisation:
-      type: object
-      required:
-        - removed
-      properties:
-        removed:
-          type: array
-          items:
-            type: string
     FileLocationArrayEnveloped:
       type: object
       required:

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -155,6 +155,8 @@ class DataStorageManager:
     def _create_client_context(self) -> ClientCreatorContext:
         assert hasattr(self.session, "create_client")
         # pylint: disable=no-member
+
+        # SEE API in https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html
         return self.session.create_client(
             "s3",
             endpoint_url=self.s3_client.endpoint_url,
@@ -1011,47 +1013,56 @@ class DataStorageManager:
             link = to_meta_data_extended(await result.first())
             return link
 
-    async def synchronise_meta_data_table(
-        self, location: str, dry_run: bool
-    ) -> Dict[str, Any]:
-        sync_results = {"removed": []}
+    async def synchronise_meta_data_table(self, location: str, dry_run: bool):
 
-        assert (
+        assert (  # nosec
             location == SIMCORE_S3_STR
         ), "Only with s3, no other sync implemented"  # nosec
 
         if location == SIMCORE_S3_STR:
-            # NOTE: only valid for Simcore, since datcore data is not in the database table
-            # let's get all the files in the table
-            logger.warning(
-                "synchronisation of database/s3 storage started, this will take some time..."
-            )
-            async with self.engine.acquire() as conn, self._create_client_context() as s3_client:
-                number_of_rows_in_db = await conn.scalar(file_meta_data.count())
+
+            async def sync_task():
+                to_remove = []
+
+                # NOTE: only valid for Simcore, since datcore data is not in the database table
+                # let's get all the files in the table
                 logger.warning(
-                    "total number of entries to check %d",
-                    number_of_rows_in_db,
+                    "synchronisation of database/s3 storage started, this will take some time..."
                 )
-
-                assert isinstance(s3_client, AioBaseClient)  # nosec
-
-                async for row in conn.execute(file_meta_data.select()):
-                    s3_key = row.object_name  # type: ignore
-
-                    # now check if the file exists in S3
-                    try:
-                        await s3_client.get_object(
-                            Bucket=self.simcore_bucket_name, Key=s3_key
-                        )
-                    except s3_client.exceptions.NoSuchKey:
-                        # this file does not exist
-                        sync_results["removed"].append(s3_key)
-
-                if not dry_run:
-                    await conn.execute(
-                        file_meta_data.delete().where(
-                            file_meta_data.c.object_name.in_(sync_results["removed"])
-                        )
+                async with self.engine.acquire() as conn, self._create_client_context() as s3_client:
+                    number_of_rows_in_db = await conn.scalar(file_meta_data.count())
+                    logger.warning(
+                        "total number of entries to check %d",
+                        number_of_rows_in_db,
                     )
 
-        return sync_results
+                    assert isinstance(s3_client, AioBaseClient)  # nosec
+
+                    async for row in conn.execute(
+                        sa.select([file_meta_data.c.object_name])
+                    ):
+                        s3_key = row.object_name  # type: ignore
+
+                        # now check if the file exists in S3
+                        # SEE https://www.peterbe.com/plog/fastest-way-to-find-out-if-a-file-exists-in-s3
+
+                        response = await s3_client.list_objects_v2(
+                            Bucket=self.simcore_bucket_name, Prefix=s3_key
+                        )
+                        if response.get("KeyCount", 0) == 0:
+                            # this file does not exist
+                            to_remove.append(s3_key)
+
+                    logger.info(
+                        "%s %d entries ",
+                        "Would delete" if dry_run else "Deleting",
+                        len(to_remove),
+                    )
+                    if not dry_run:
+                        await conn.execute(
+                            file_meta_data.delete().where(
+                                file_meta_data.c.object_name.in_(to_remove)
+                            )
+                        )
+
+        fire_and_forget_task(sync_task())

--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 import attr
 from aiohttp import web
 from aiohttp.web import RouteTableDef
+from pydantic.types import PositiveInt
 from servicelib.rest_utils import extract_and_validate
 
 from .access_layer import InvalidFileIdentifier
@@ -230,7 +231,12 @@ async def synchronise_meta_data_table(request: web.Request):
         dry_run = query["dry_run"]
         dsm = await _prepare_storage_manager(params, query, request)
         location = dsm.location_from_id(location_id)
-        await dsm.synchronise_meta_data_table(location, dry_run)
+        entries_in_db: PositiveInt = await dsm.synchronise_meta_data_table(
+            location, dry_run
+        )
+
+        # informative
+        return {"error": None, "data": {"total_db_entries": entries_in_db}}
 
 
 # DISABLED: @routes.patch(f"/{api_vtag}/locations/{{location_id}}/files/{{fileId}}/metadata") # type: ignore

--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -230,13 +230,18 @@ async def synchronise_meta_data_table(request: web.Request):
 
     with handle_storage_errors():
         location_id = params["location_id"]
-        fire_and_forget = params.get("fire_and_forget", False)
+        fire_and_forget: bool = params.get("fire_and_forget", False)
+        dry_run: bool = query["dry_run"]
 
         dsm = await _prepare_storage_manager(params, query, request)
         location = dsm.location_from_id(location_id)
 
-        sync_results = {"removed": []}
-        sync_coro = dsm.synchronise_meta_data_table(location, dry_run=query["dry_run"])
+        sync_results = {
+            "removed": [],
+            "fire_and_forget": fire_and_forget,
+            "dry_run": dry_run,
+        }
+        sync_coro = dsm.synchronise_meta_data_table(location, dry_run)
 
         if fire_and_forget:
             settings: Settings = request.app[APP_CONFIG_KEY]

--- a/services/storage/src/simcore_service_storage/handlers.py
+++ b/services/storage/src/simcore_service_storage/handlers.py
@@ -220,7 +220,7 @@ async def get_file_metadata(request: web.Request):
 
 
 @routes.post(f"/{api_vtag}/locations/{{location_id}}:sync")  # type: ignore
-async def synchronise_meta_data_table(request: web.Request) -> Dict[str, Any]:
+async def synchronise_meta_data_table(request: web.Request):
     params, query, *_ = await extract_and_validate(request)
     assert query["dry_run"] is not None  # nosec
     assert params["location_id"]  # nosec
@@ -230,11 +230,7 @@ async def synchronise_meta_data_table(request: web.Request) -> Dict[str, Any]:
         dry_run = query["dry_run"]
         dsm = await _prepare_storage_manager(params, query, request)
         location = dsm.location_from_id(location_id)
-        data_changed: Dict[str, Any] = await dsm.synchronise_meta_data_table(
-            location, dry_run
-        )
-
-    return {"error": None, "data": data_changed}
+        await dsm.synchronise_meta_data_table(location, dry_run)
 
 
 # DISABLED: @routes.patch(f"/{api_vtag}/locations/{{location_id}}/files/{{fileId}}/metadata") # type: ignore

--- a/services/storage/src/simcore_service_storage/settings.py
+++ b/services/storage/src/simcore_service_storage/settings.py
@@ -53,7 +53,7 @@ class Settings(BaseCustomSettings, MixinLoggingSettings):
     DATCORE_ADAPTER: DatcoreAdapterSettings
 
     STORAGE_SYNC_METADATA_TIMEOUT: PositiveInt = Field(
-        120, description="Timeout (seconds) for metadata sync task"
+        180, description="Timeout (seconds) for metadata sync task"
     )
 
     @validator("LOG_LEVEL")

--- a/services/storage/src/simcore_service_storage/settings.py
+++ b/services/storage/src/simcore_service_storage/settings.py
@@ -52,6 +52,10 @@ class Settings(BaseCustomSettings, MixinLoggingSettings):
 
     DATCORE_ADAPTER: DatcoreAdapterSettings
 
+    STORAGE_SYNC_METADATA_TIMEOUT: PositiveInt = Field(
+        120, description="Timeout (seconds) for metadata sync task"
+    )
+
     @validator("LOG_LEVEL")
     @classmethod
     def _validate_loglevel(cls, value) -> str:

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -5120,6 +5120,10 @@ paths:
                     required:
                       - removed
                     properties:
+                      dry_run:
+                        type: boolean
+                      fire_and_forget:
+                        type: boolean
                       removed:
                         type: array
                         items:

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -5098,6 +5098,12 @@ paths:
           schema:
             type: boolean
             default: true
+        - name: fire_and_forget
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: 'An object containing added, changed and removed paths'

--- a/services/web/server/src/simcore_service_webserver/security_roles.py
+++ b/services/web/server/src/simcore_service_webserver/security_roles.py
@@ -78,9 +78,14 @@ ROLES_PERMISSIONS = {
     UserRole.TESTER: {
         "can": [
             "diagnostics.read",
-            "storage.files.sync",
         ],
         "inherits": [UserRole.USER],
+    },
+    UserRole.ADMIN: {
+        "can": [
+            "storage.files.sync",
+        ],
+        "inherits": [UserRole.TESTER],
     },
 }
 

--- a/services/web/server/src/simcore_service_webserver/storage_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/storage_handlers.py
@@ -157,7 +157,7 @@ async def delete_file(request: web.Request):
 @login_required
 @permission_required("storage.files.sync")
 async def synchronise_meta_data_table(request: web.Request):
-    payload = await _request_storage(request, "POST", timeout=ClientTimeout(total=300))
+    payload = await _request_storage(request, "POST")
     return payload
 
 

--- a/services/web/server/src/simcore_service_webserver/storage_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/storage_handlers.py
@@ -6,7 +6,7 @@ import logging
 import urllib
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
-from aiohttp import ClientTimeout, web
+from aiohttp import web
 from servicelib.request_keys import RQT_USERID_KEY
 from servicelib.rest_responses import unwrap_envelope
 from servicelib.rest_utils import extract_and_validate

--- a/services/web/server/tests/unit/with_dbs/04/test_storage.py
+++ b/services/web/server/tests/unit/with_dbs/04/test_storage.py
@@ -175,7 +175,8 @@ async def test_get_storage_locations(client, storage_server, logged_user, expect
         (UserRole.ANONYMOUS, web.HTTPUnauthorized),
         (UserRole.GUEST, web.HTTPForbidden),
         (UserRole.USER, web.HTTPForbidden),
-        (UserRole.TESTER, web.HTTPOk),
+        (UserRole.TESTER, web.HTTPForbidden),
+        (UserRole.ADMIN, web.HTTPOk),
     ],
 )
 async def test_sync_file_meta_table(client, storage_server, logged_user, expected):
@@ -189,6 +190,7 @@ async def test_sync_file_meta_table(client, storage_server, logged_user, expecte
         # the test of the functionality is already done in storage
         assert "removed" in data
         assert not data["removed"]
+        assert data["dry_run"] == True
 
 
 @pytest.mark.parametrize(

--- a/services/web/server/tests/unit/with_dbs/04/test_storage.py
+++ b/services/web/server/tests/unit/with_dbs/04/test_storage.py
@@ -190,7 +190,6 @@ async def test_sync_file_meta_table(client, storage_server, logged_user, expecte
         # the test of the functionality is already done in storage
         assert "removed" in data
         assert not data["removed"]
-        assert data["dry_run"] == True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What do these changes do?

storage metadata table keeps track of the data in S3. We noticed that the information is out-of-sync in many deploys mostly due to data deleted in S3 but still remains annotated in the storage metadata table. Previous PR added a sync method to syncronize the metadata table but due to the large amount of objects in S3 the requests timed out and the operation could not be completed.

- 🩹 fix sync between storage's metadata table and s3 objects: 
     - PROBLEM: current sync makes webserver handler time out when s3 holds a lot of data.
     - SOLUTION: improves check speed in S3 and adds option to fire&forget in query
- ✨ adds new user role **ADMIN**. Resync operation can only be done by **ADMIN users**

### Next (in separate PR)
- ✨  api data lifetime: all files created via API (e.g. uploads OR job results) have an expiration date in S3 
   - review combining S3 retention policy + resync (how does that differ from minio to s3?)
   - review direct delete from admin account role (adds special rights + )


## Related issue/s

- 💚 fixes CI in #2421 



## How to test

```command
make devenv
source .venv/bin/activate
make build-devel
make up-devel

# create admin user, login and go to api's dev/doc
```
![image](https://user-images.githubusercontent.com/32402063/125298176-34dc9380-e328-11eb-828c-96da88e60d21.png)



