### PR TITLE
🐛 Fixes dynamic-sidecar settings in director-v2

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/core/application.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/application.py
@@ -57,20 +57,23 @@ def init_app(settings: Optional[AppSettings] = None) -> FastAPI:
     if settings.DIRECTOR_V0.DIRECTOR_V0_ENABLED:
         director_v0.setup(app, settings.DIRECTOR_V0)
 
-    if settings.DYNAMIC_SERVICES.DIRECTOR_V2_DYNAMIC_SERVICES_ENABLED:
-        dynamic_services.setup(app, settings.DYNAMIC_SERVICES)
-
     if settings.POSTGRES.DIRECTOR_V2_POSTGRES_ENABLED:
         db.setup(app, settings.POSTGRES)
-
-    if settings.DYNAMIC_SERVICES.DIRECTOR_V2_DYNAMIC_SIDECAR_ENABLED:
-        dynamic_sidecar.setup(app)
 
     if settings.CELERY.DIRECTOR_V2_CELERY_ENABLED:
         celery.setup(app, settings.CELERY)
 
     if settings.CELERY_SCHEDULER.DIRECTOR_V2_CELERY_SCHEDULER_ENABLED:
         scheduler.setup(app)
+
+    if settings.DYNAMIC_SERVICES.DIRECTOR_V2_DYNAMIC_SERVICES_ENABLED:
+        dynamic_services.setup(app, settings.DYNAMIC_SERVICES)
+
+    if settings.DYNAMIC_SERVICES.DYNAMIC_SIDECAR and (
+        settings.DYNAMIC_SERVICES.DYNAMIC_SCHEDULER
+        and settings.DYNAMIC_SERVICES.DYNAMIC_SCHEDULER.DIRECTOR_V2_DYNAMIC_SCHEDULER_ENABLED
+    ):
+        dynamic_sidecar.setup(app)
 
     # setup app --
     app.add_event_handler("startup", on_startup)

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -210,6 +210,7 @@ class DaskSchedulerSettings(BaseCustomSettings):
 
 
 class AppSettings(BaseCustomSettings, MixinLoggingSettings):
+
     # docker environs
     SC_BOOT_MODE: Optional[BootModeEnum]
     SC_BOOT_TARGET: Optional[BuildTargetEnum]

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -179,8 +179,10 @@ class DynamicServicesSchedulerSettings(BaseCustomSettings):
 
 
 class DynamicServicesSettings(BaseCustomSettings):
-    DIRECTOR_V2_DYNAMIC_SIDECAR_ENABLED: bool = Field(
-        False, description="Enables/Disables the dynamic_sidecar submodule"
+    # TODO: PC->ANE: refactor dynamic-sidecar settings. One settings per app module
+    # WARNING: THIS IS NOT the same module as dynamic-sidecar
+    DIRECTOR_V2_DYNAMIC_SERVICES_ENABLED: bool = Field(
+        True, description="Enables/Disables the dynamic_sidecar submodule"
     )
 
     # FIXME: PC -> ANE: this module was disabled since no default settings were provided and failed at startup

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -179,18 +179,15 @@ class DynamicServicesSchedulerSettings(BaseCustomSettings):
 
 
 class DynamicServicesSettings(BaseCustomSettings):
-    DIRECTOR_V2_DYNAMIC_SERVICES_ENABLED: bool = Field(
-        True, description="Enables/Disables connection with service"
-    )
     DIRECTOR_V2_DYNAMIC_SIDECAR_ENABLED: bool = Field(
-        True, description="Enables/Disables the dynamic_sidecar submodule"
+        False, description="Enables/Disables the dynamic_sidecar submodule"
     )
 
-    # dynamic sidecar
-    DYNAMIC_SIDECAR: DynamicSidecarSettings
+    # FIXME: PC -> ANE: this module was disabled since no default settings were provided and failed at startup
+    DYNAMIC_SIDECAR: Optional[DynamicSidecarSettings] = None
 
-    # dynamic services scheduler
-    DYNAMIC_SCHEDULER: DynamicServicesSchedulerSettings
+    # FIXME: PC -> ANE: this module was disabled since no default settings were provided and failed at startup
+    DYNAMIC_SCHEDULER: Optional[DynamicServicesSchedulerSettings] = None
 
 
 class PGSettings(PostgresSettings):
@@ -211,7 +208,7 @@ class DaskSchedulerSettings(BaseCustomSettings):
 
 
 class AppSettings(BaseCustomSettings, MixinLoggingSettings):
-    # DOCKER
+    # docker environs
     SC_BOOT_MODE: Optional[BootModeEnum]
     SC_BOOT_TARGET: Optional[BuildTargetEnum]
 
@@ -219,21 +216,6 @@ class AppSettings(BaseCustomSettings, MixinLoggingSettings):
         LogLevel.INFO.value,
         env=["DIRECTOR_V2_LOGLEVEL", "LOG_LEVEL", "LOGLEVEL"],
     )
-
-    # CELERY submodule
-    CELERY: CelerySettings
-
-    # DIRECTOR submodule
-    DIRECTOR_V0: DirectorV0Settings
-
-    # Dynamic Services submodule
-    DYNAMIC_SERVICES: DynamicServicesSettings
-
-    # POSTGRES
-    POSTGRES: PGSettings
-
-    # STORAGE
-    STORAGE_ENDPOINT: str = Field("storage:8080", env="STORAGE_ENDPOINT")
 
     # for passing self-signed certificate to spawned services
     # TODO: fix these variables once the timeout-minutes: 30 is able to start dynamic services
@@ -246,13 +228,11 @@ class AppSettings(BaseCustomSettings, MixinLoggingSettings):
     PUBLISHED_HOSTS_NAME: str = Field("", env="PUBLISHED_HOSTS_NAME")
     SWARM_STACK_NAME: str = Field("undefined-please-check", env="SWARM_STACK_NAME")
 
-    #
     NODE_SCHEMA_LOCATION: str = Field(
         f"{API_ROOT}/{api_vtag}/schemas/node-meta-v0.0.1.json",
         description="used when in devel mode vs release mode",
     )
 
-    #
     SIMCORE_SERVICES_NETWORK_NAME: Optional[str] = Field(
         None,
         description="used to find the right network name",
@@ -261,9 +241,6 @@ class AppSettings(BaseCustomSettings, MixinLoggingSettings):
         "simcore/services",
         description="useful when developing with an alternative registry namespace",
     )
-
-    # traefik
-    TRAEFIK_SIMCORE_ZONE: str = Field("internal_simcore_stack")
 
     # monitoring
     MONITORING_ENABLED: bool = False
@@ -275,6 +252,20 @@ class AppSettings(BaseCustomSettings, MixinLoggingSettings):
     DIRECTOR_V2_REMOTE_DEBUG_PORT: PortInt = 3000
 
     CLIENT_REQUEST: ClientRequestSettings
+
+    # App modules settings ---------------------
+
+    CELERY: CelerySettings
+
+    DIRECTOR_V0: DirectorV0Settings
+
+    DYNAMIC_SERVICES: DynamicServicesSettings
+
+    POSTGRES: PGSettings
+
+    STORAGE_ENDPOINT: str = Field("storage:8080", env="STORAGE_ENDPOINT")
+
+    TRAEFIK_SIMCORE_ZONE: str = Field("internal_simcore_stack")
 
     CELERY_SCHEDULER: CelerySchedulerSettings
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_services.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_services.py
@@ -8,14 +8,10 @@ from dataclasses import dataclass
 import httpx
 from fastapi import FastAPI, Response
 
-# Module's business logic ---------------------------------------------
 from ..core.settings import DynamicServicesSettings
 from ..utils.client_decorators import handle_errors, handle_retry
 
 logger = logging.getLogger(__name__)
-
-
-# Module's setup logic ---------------------------------------------
 
 
 def setup(app: FastAPI, settings: DynamicServicesSettings):

--- a/services/director-v2/tests/conftest.py
+++ b/services/director-v2/tests/conftest.py
@@ -30,6 +30,7 @@ pytest_plugins = [
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
+    "pytest_simcore.environment_configs",
     "pytest_simcore.postgres_service",
     "pytest_simcore.pydantic_models",
     "pytest_simcore.rabbit_service",

--- a/services/director-v2/tests/conftest.py
+++ b/services/director-v2/tests/conftest.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, Iterator
 
@@ -67,12 +68,12 @@ def project_env_devel_dict(project_slug_dir: Path) -> Dict[str, Any]:
 
 
 @pytest.fixture(scope="function")
-def project_env_devel_environment(project_env_devel_dict: Dict[str, Any], monkeypatch):
+def project_env_devel_environment(
+    project_env_devel_dict: Dict[str, Any], monkeypatch
+) -> Dict[str, Any]:
     for key, value in project_env_devel_dict.items():
         monkeypatch.setenv(key, value)
-    monkeypatch.setenv(
-        "DYNAMIC_SIDECAR_IMAGE", "local/dynamic-sidecar:TEST_MOCKED_TAG_NOT_PRESENT"
-    )
+    return deepcopy(project_env_devel_dict)
 
 
 @pytest.fixture(scope="module")
@@ -83,6 +84,10 @@ def loop() -> asyncio.AbstractEventLoop:
 
 @pytest.fixture(scope="function")
 def mock_env(monkeypatch) -> None:
+    # TODO: PC-> ANE: Avoid using stand-alone environs setups and
+    # use instead mock_env_devel_environment or project_env_devel_environment
+    # which resemble real environment
+
     # Works as below line in docker.compose.yml
     # ${DOCKER_REGISTRY:-itisfoundation}/dynamic-sidecar:${DOCKER_IMAGE_TAG:-latest}
 

--- a/services/director-v2/tests/conftest.py
+++ b/services/director-v2/tests/conftest.py
@@ -96,13 +96,18 @@ def mock_env(monkeypatch) -> None:
     image_tag = os.environ.get("DOCKER_IMAGE_TAG", "production")
 
     image_name = f"{registry}/dynamic-sidecar:{image_tag}".strip("/")
+
     logger.warning("Patching to: DYNAMIC_SIDECAR_IMAGE=%s", image_name)
     monkeypatch.setenv("DYNAMIC_SIDECAR_IMAGE", image_name)
 
     monkeypatch.setenv("SIMCORE_SERVICES_NETWORK_NAME", "test_network_name")
     monkeypatch.setenv("TRAEFIK_SIMCORE_ZONE", "test_traefik_zone")
     monkeypatch.setenv("SWARM_STACK_NAME", "test_swarm_name")
-    monkeypatch.setenv("DIRECTOR_V2_DYNAMIC_SIDECAR_ENABLED", "false")
+
+    # DISABLE dynamic-service app module
+    monkeypatch.setenv("DIRECTOR_V2_DYNAMIC_SCHEDULER_ENABLED", "false")
+    monkeypatch.setenv("DYNAMIC_SCHEDULER", "null")
+    monkeypatch.setenv("DYNAMIC_SIDECAR", "null")
 
     monkeypatch.setenv("SC_BOOT_MODE", "production")
 

--- a/services/director-v2/tests/unit/conftest.py
+++ b/services/director-v2/tests/unit/conftest.py
@@ -21,10 +21,11 @@ def simcore_services_network_name() -> str:
 def disable_dynamic_sidecar_scheduler_in_unit_tests(
     monkeypatch, simcore_services_network_name: str
 ) -> None:
-    monkeypatch.setenv("REGISTRY_auth", "false")
-    monkeypatch.setenv("REGISTRY_user", "test")
+    # FIXME: PC-> ANE: please avoid autouse!!!
+    monkeypatch.setenv("REGISTRY_AUTH", "false")
+    monkeypatch.setenv("REGISTRY_USER", "test")
     monkeypatch.setenv("REGISTRY_PW", "test")
-    monkeypatch.setenv("REGISTRY_ssl", "false")
+    monkeypatch.setenv("REGISTRY_SSL", "false")
     monkeypatch.setenv("SIMCORE_SERVICES_NETWORK_NAME", simcore_services_network_name)
     monkeypatch.setenv("TRAEFIK_SIMCORE_ZONE", "test_traefik_zone")
     monkeypatch.setenv("SWARM_STACK_NAME", "test_swarm_name")

--- a/services/director-v2/tests/unit/test_core_settings.py
+++ b/services/director-v2/tests/unit/test_core_settings.py
@@ -12,8 +12,7 @@ from simcore_service_director_v2.core.settings import (
 )
 
 
-def test_loading_env_devel_in_settings(project_env_devel_environment):
-
+def test_settings_with_project_env_devel(project_env_devel_environment):
     # loads from environ
     settings = AppSettings.create_from_envs()
     print("captured settings: \n", settings.json(indent=2))
@@ -22,6 +21,12 @@ def test_loading_env_devel_in_settings(project_env_devel_environment):
     assert settings.LOG_LEVEL == LogLevel.DEBUG
 
     assert settings.POSTGRES.dsn == "postgresql://test:test@localhost:5432/test"
+
+
+def test_settings_with_env_devel(mock_env_devel_environment):
+    settings = AppSettings.create_from_envs()
+    print("captured settings: \n", settings.json(indent=2))
+    assert settings
 
 
 @pytest.mark.parametrize(

--- a/services/director-v2/tests/unit/test_modules_celery.py
+++ b/services/director-v2/tests/unit/test_modules_celery.py
@@ -88,10 +88,10 @@ def test_create_task(
 
 @pytest.mark.parametrize("runtime_requirements", ["cpu", "gpu", "mpi", "gpu:mpi"])
 def test_send_computation_tasks(
-    minimal_celery_config: None,
+    minimal_celery_config,
     minimal_app: FastAPI,
     celery_app: Celery,
-    celery_worker_parameters: None,
+    celery_worker_parameters,
     celery_worker: TestWorkController,
     celery_configuration: CeleryConfig,
     user_id: PositiveInt,


### PR DESCRIPTION
## What do these changes do?

Settings introduced in PR #2411 fail to initialize when deployed in master environment

```log
Traceback (most recent call last):
  File "/home/scu/.venv/bin/uvicorn", line 8, in <module>
    sys.exit(main())
  File "/home/scu/.venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/scu/.venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/scu/.venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/scu/.venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/scu/.venv/lib/python3.8/site-packages/uvicorn/main.py", line 362, in main
    run(**kwargs)
  File "/home/scu/.venv/lib/python3.8/site-packages/uvicorn/main.py", line 386, in run
    server.run()
  File "/home/scu/.venv/lib/python3.8/site-packages/uvicorn/server.py", line 49, in run
    loop.run_until_complete(self.serve(sockets=sockets))
  File "uvloop/loop.pyx", line 1456, in uvloop.loop.Loop.run_until_complete
  File "/home/scu/.venv/lib/python3.8/site-packages/uvicorn/server.py", line 56, in serve
    config.load()
  File "/home/scu/.venv/lib/python3.8/site-packages/uvicorn/config.py", line 308, in load
    self.loaded_app = import_from_string(self.app)
  File "/home/scu/.venv/lib/python3.8/site-packages/uvicorn/importer.py", line 20, in import_from_string
    module = importlib.import_module(module_str)
  File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_director_v2/main.py", line 7, in <module>
    the_app: FastAPI = init_app()
  File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_director_v2/core/application.py", line 34, in init_app
    settings = AppSettings.create_from_envs()
  File "/home/scu/.venv/lib/python3.8/site-packages/settings_library/base.py", line 56, in create_from_envs
    obj = cls()
  File "pydantic/env_settings.py", line 36, in pydantic.env_settings.BaseSettings.__init__
  File "pydantic/main.py", line 406, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for AppSettings
DYNAMIC_SERVICES
  field required (type=value_error.missing)
```

@GitHK when dynamic-sidecar is in place, please make sure ``test_core_settings.py`` runs with an environment as close as possible to production. We need to have a better control on  the env vars while running tests,  e.g. **avoid autouse ** in ``disable_dynamic_sidecar_scheduler_in_unit_tests`` or see also comments in ``mock_env``, 

## Related issue/s

- Issue introduced in PR #2411

## How to test

directorv2 test
