### PR TITLE
Frontend SelectBox complies with schema

### DIFF
--- a/services/web/client/source/class/osparc/component/form/Auto.js
+++ b/services/web/client/source/class/osparc/component/form/Auto.js
@@ -20,15 +20,13 @@
  *       type: "string",
  *       widget: {
  *         type: "SelectBox",
- *         details: {
- *           structure: [{
- *             key: "dog",
- *             label: "A Dog"
- *           }, {
- *             key: "cat",
- *             label: "A Cat"
- *           }]
- *         }
+ *         structure: [{
+ *           key: "dog",
+ *           label: "A Dog"
+ *         }, {
+ *           key: "cat",
+ *           label: "A Cat"
+ *         }]
  *       }
  *     },
  *   }
@@ -351,7 +349,7 @@ qx.Class.define("osparc.component.form.Auto", {
         }
       });
       const cfg = s.widget;
-      let structure = cfg.details.structure;
+      let structure = cfg.structure;
       if (structure) {
         structure.forEach(item => {
           item.label = item.label || "";


### PR DESCRIPTION
## What do these changes do?

Frontend was expecting the enum options to be under widget.details.structure while the schema says it goes under widget.structure


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
