### PR TITLE
🐛 SIMCORE_SERVICES_NETWORK_NAME now allows dashes

### DIFF
--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -27,7 +27,7 @@ SERVICE_KEY_RE = r"^(simcore)/(services)/(comp|dynamic|frontend)(/[\w/-]+)+$"
 DYNAMIC_SERVICE_KEY_RE = r"^(simcore)/(services)/dynamic(/[\w/-]+)+$"
 COMPUTATIONAL_SERVICE_KEY_RE = r"^(simcore)/(services)/comp(/[\w/-]+)+$"
 KEY_RE = SERVICE_KEY_RE  # TODO: deprecate this global constant by SERVICE_KEY_RE
-SERVICE_NETWORK_RE = r"^([a-zA-Z0-9_]+)$"
+SERVICE_NETWORK_RE = r"^([a-zA-Z0-9_-]+)$"
 
 PROPERTY_TYPE_RE = r"^(number|integer|boolean|string|data:([^/\s,]+/[^/\s,]+|\[[^/\s,]+/[^/\s,]+(,[^/\s]+/[^/,\s]+)*\]))$"
 PROPERTY_KEY_RE = r"^[-_a-zA-Z0-9]+$"

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_api.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_api.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List
 from uuid import UUID, uuid4
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from settings_library.docker_registry import RegistrySettings
@@ -48,10 +49,8 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
-def dynamic_sidecar_settings(monkeypatch) -> DynamicSidecarSettings:
-    monkeypatch.setenv(
-        "DYNAMIC_SIDECAR_IMAGE", "local/dynamic-sidecar:TEST_MOCKED_TAG_NOT_PRESENT"
-    )
+def dynamic_sidecar_settings(monkeypatch: MonkeyPatch) -> DynamicSidecarSettings:
+    monkeypatch.setenv("DYNAMIC_SIDECAR_IMAGE", "local/dynamic-sidecar:MOCKED")
     return DynamicSidecarSettings(REGISTRY=RegistrySettings())
 
 
@@ -251,6 +250,19 @@ async def _count_services_in_stack(
 
 
 # TESTS
+
+
+@pytest.mark.parametrize(
+    "simcore_services_network_name",
+    ("n", "network", "with_underscore", "with-dash", "with-dash_with_underscore"),
+)
+def test_valid_network_names(
+    simcore_services_network_name: str, monkeypatch: MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DYNAMIC_SIDECAR_IMAGE", "local/dynamic-sidecar:MOCKED")
+    monkeypatch.setenv("SIMCORE_SERVICES_NETWORK_NAME", simcore_services_network_name)
+    dynamic_sidecar_settings = DynamicSidecarSettings(REGISTRY=RegistrySettings())
+    assert dynamic_sidecar_settings
 
 
 async def test_failed_docker_client_request(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

The `SIMCORE_SERVICES_NETWORK_NAME` is prefixed with the stack name which contains dashes (`-`):
- added regression test
- dashes are now allowed for `SIMCORE_SERVICES_NETWORK_NAME`

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->

- [x] Unit tests for the changes exist