### PR TITLE
🐛 aborting tasks fails

### DIFF
--- a/services/sidecar/src/simcore_service_sidecar/celery.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery.py
@@ -4,9 +4,9 @@ from celery.signals import worker_ready, worker_shutting_down
 
 from .__version__ import __version__
 from .celery_configurator import create_celery_app
-from .celery_task_utils import cancel_task
 from .cli import run_sidecar
 from .remote_debug import setup_remote_debugging
+from .utils import cancel_task_by_fct_name
 
 setup_remote_debugging()
 
@@ -14,16 +14,17 @@ app = create_celery_app()
 
 log = logging.getLogger(__name__)
 
+#
+# SEE https://patorjk.com/software/taag/#p=display&h=0&f=Ogre&t=Celery-sidecar
+#
 WELCOME_MSG = r"""
-  .-')            _ .-') _     ('-.               ('-.     _  .-')
- ( OO ).         ( (  OO) )  _(  OO)             ( OO ).-.( \( -O )
-(_)---\_)  ,-.-') \     .'_ (,------.   .-----.  / . --. / ,------.
-/    _ |   |  |OO),`'--..._) |  .---'  '  .--./  | \-.  \  |   /`. '
-\  :` `.   |  |  \|  |  \  ' |  |      |  |('-..-'-'  |  | |  /  | |
- '..`''.)  |  |(_/|  |   ' |(|  '--.  /_) |OO  )\| |_.'  | |  |_.' |
-.-._)   \ ,|  |_.'|  |   / : |  .--'  ||  |`-'|  |  .-.  | |  .  '.'
-\       /(_|  |   |  '--'  / |  `---.(_'  '--'\  |  | |  | |  |\  \
- `-----'   `--'   `-------'  `------'   `-----'  `--' `--' `--' '--' {0} - {1}
+
+   ___        _                                 _      _
+  / __\  ___ | |  ___  _ __  _   _         ___ (_)  __| |  ___   ___   __ _  _ __
+ / /    / _ \| | / _ \| '__|| | | | _____ / __|| | / _` | / _ \ / __| / _` || '__|
+/ /___ |  __/| ||  __/| |   | |_| ||_____|\__ \| || (_| ||  __/| (__ | (_| || |
+\____/  \___||_| \___||_|    \__, |       |___/|_| \__,_| \___| \___| \__,_||_|
+                             |___/                                                 {0} - {1}
 """.format(
     __version__, app.conf.osparc_sidecar_bootmode.value
 )
@@ -39,7 +40,7 @@ def worker_shutting_down_handler(
 ):
     # NOTE: this function shall be adapted when we switch to python 3.7+
     log.warning("detected worker_shutting_down signal(%s, %s, %s)", sig, how, exitcode)
-    cancel_task(run_sidecar)
+    cancel_task_by_fct_name(run_sidecar.__name__)
 
 
 @worker_ready.connect

--- a/services/sidecar/src/simcore_service_sidecar/celery_task.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery_task.py
@@ -1,8 +1,8 @@
+import asyncio
 import logging
 from asyncio import CancelledError
 
 from .cli import run_sidecar
-from .utils import wrap_async_call
 
 log = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ def _shared_task_dispatch(
         celery_request.max_retries,
     )
     try:
-        wrap_async_call(
+        asyncio.run(
             run_sidecar(
                 celery_request.request.id,
                 user_id,

--- a/services/sidecar/src/simcore_service_sidecar/celery_task_utils.py
+++ b/services/sidecar/src/simcore_service_sidecar/celery_task_utils.py
@@ -1,7 +1,5 @@
-import asyncio
 import logging
 from pprint import pformat
-from typing import Callable
 
 log = logging.getLogger(__name__)
 
@@ -39,12 +37,3 @@ def on_task_success_handler(
         args if args else "none",
         pformat(kwargs) if kwargs else "none",
     )
-
-
-def cancel_task(function: Callable) -> None:
-    tasks = asyncio.all_tasks()
-    for task in tasks:
-        # pylint: disable=protected-access
-        if task._coro.__name__ == function.__name__:
-            log.warning("canceling task....................")
-            task.cancel()

--- a/services/sidecar/src/simcore_service_sidecar/cli.py
+++ b/services/sidecar/src/simcore_service_sidecar/cli.py
@@ -6,12 +6,11 @@ import click
 from servicelib.logging_utils import log_decorator
 
 from .boot_mode import BootMode
-from .celery_task_utils import cancel_task
 from .config import SIDECAR_INTERVAL_TO_CHECK_TASK_ABORTED_S
 from .core import run_computational_task
 from .db import DBContextManager
 from .rabbitmq import RabbitMQ
-from .utils import wrap_async_call
+from .utils import cancel_task
 
 log = logging.getLogger(__name__)
 
@@ -24,20 +23,22 @@ log = logging.getLogger(__name__)
 def main(job_id: str, user_id: str, project_id: str, node_id: str) -> None:
 
     try:
-        wrap_async_call(run_sidecar(job_id, user_id, project_id, node_id=node_id))
+        asyncio.run(run_sidecar(job_id, user_id, project_id, node_id=node_id))
     except Exception:  # pylint: disable=broad-except
         log.exception("Unexpected problem while running sidecar")
 
 
 @log_decorator(logger=log, level=logging.INFO)
-async def perdiodicaly_check_if_aborted(is_aborted_cb: Callable[[], bool]) -> None:
+async def perdiodicaly_check_if_aborted(
+    is_aborted_cb: Callable[[], bool], task_name: str
+) -> None:
     try:
         while await asyncio.sleep(
             SIDECAR_INTERVAL_TO_CHECK_TASK_ABORTED_S, result=True
         ):
             if is_aborted_cb():
-                log.info("Task was aborted. Cancelling...")
-                asyncio.get_event_loop().call_soon(cancel_task(run_sidecar))
+                log.info("Task was aborted. Cancelling fct [%s]...", task_name)
+                asyncio.get_event_loop().call_soon(cancel_task, task_name)
     except asyncio.CancelledError:
         pass
 
@@ -53,13 +54,16 @@ async def run_sidecar(  # pylint: disable=too-many-arguments
     max_retries: int = 1,
     sidecar_mode: BootMode = BootMode.CPU,
 ) -> None:
-    abortion_task = (
-        asyncio.get_event_loop().create_task(
-            perdiodicaly_check_if_aborted(is_aborted_cb)
+
+    abortion_task: Optional[asyncio.Task] = None
+    if current_task := asyncio.current_task():
+        abortion_task = (
+            asyncio.create_task(
+                perdiodicaly_check_if_aborted(is_aborted_cb, current_task.get_name())
+            )
+            if is_aborted_cb
+            else None
         )
-        if is_aborted_cb
-        else None
-    )
     try:
         async with DBContextManager() as db_engine, RabbitMQ() as rabbit_mq:
             await run_computational_task(

--- a/services/sidecar/src/simcore_service_sidecar/utils.py
+++ b/services/sidecar/src/simcore_service_sidecar/utils.py
@@ -118,12 +118,14 @@ def cancel_task(task_name: str) -> None:
         if task.get_name() == task_name:
             logger.warning("canceling task %s....................", task)
             task.cancel()
+            break
 
 
 def cancel_task_by_fct_name(fct_name: str) -> None:
     tasks = asyncio.all_tasks()
     logger.debug("running tasks: %s", tasks)
     for task in tasks:
-        if task.get_coro().__name__ == fct_name:
+        if task.get_coro().__name__ == fct_name:  # type: ignore
             logger.warning("canceling task %s....................", task)
             task.cancel()
+            break

--- a/services/sidecar/src/simcore_service_sidecar/utils.py
+++ b/services/sidecar/src/simcore_service_sidecar/utils.py
@@ -109,3 +109,21 @@ def touch_tmpfile(extension=".dat") -> Path:
     """
     with tempfile.NamedTemporaryFile(delete=False, suffix=extension) as file_handler:
         return Path(file_handler.name)
+
+
+def cancel_task(task_name: str) -> None:
+    tasks = asyncio.all_tasks()
+    logger.debug("running tasks: %s", tasks)
+    for task in tasks:
+        if task.get_name() == task_name:
+            logger.warning("canceling task %s....................", task)
+            task.cancel()
+
+
+def cancel_task_by_fct_name(fct_name: str) -> None:
+    tasks = asyncio.all_tasks()
+    logger.debug("running tasks: %s", tasks)
+    for task in tasks:
+        if task.get_coro().__name__ == fct_name:
+            logger.warning("canceling task %s....................", task)
+            task.cancel()

--- a/services/sidecar/tests/unit/test_rabbitmq.py
+++ b/services/sidecar/tests/unit/test_rabbitmq.py
@@ -53,7 +53,7 @@ async def test_rabbitmq(
     await rabbit_queue.consume(rabbit_message_handler, exclusive=True, no_ack=True)
 
     async with RabbitMQ() as rabbitmq:
-        assert rabbitmq.connection.ready
+        assert rabbitmq._connection.ready  # pylint: disable=protected-access
 
         await rabbitmq.post_log_message(user_id, project_id, node_id, log_msg)
         await rabbitmq.post_log_message(user_id, project_id, node_id, log_messages)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Cancelling tasks seems to have been failing since a couple of PRs went in.
First, the python 3.8 PR changed how asyncio.loop.call_soon is to used.
Then, when the redis database was splitted in 3 separate DBs (one redis instance with 3 databases) instead of 1. the director-v2 celery client was not fixed accordingly.

This has lead to the following:
1. Cancelling a pipeline would cancel the tasks AFTER the one currently running correctly. BUT the currently running tasks would still run until completion instead of being stopped.
2. When a sidecar is shutdown, the currently running task would not be correctly cancelled.

Both of these issues are now fixed.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```
make build-devel up-devel
```
then start a pipeline with 1sleeper that lasts more than 2 seconds... cancel it. it should instantly be cancelled.

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
