### PR TITLE
Disable test_swarm_runs failing 2/3 of the time

### DIFF
--- a/tests/swarm-deploy/test_swarm_runs.py
+++ b/tests/swarm-deploy/test_swarm_runs.py
@@ -41,6 +41,9 @@ SWARM_TASK_FAILED_STATES = [
 ]
 
 
+@pytest.mark.skip(
+    reason="this test is constantly failing because the postgres/migration is not available when other services are starting"
+)
 @pytest.fixture
 def core_services_running(
     docker_client: DockerClient, core_stack_name: str


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- Disable test_swarm_runs test that is testing:
  1. whether all services are up on the first trial
  2. implicitely should show that the services are up in a specific amount of time

Currently the problem is that most of the services are depending on *postgres* service being up and migrated by the *migration* service. If the computer running the stack is a bit slow, then we might have director-v2 trying to access tables that are not existing yet and then failing -> failing the test cause the director-v2 will be restarted.

For now we decided to disable the test since, we already have others that test whether all the services EVENTUALLY finally started and it seems to be ok for now.
Let's see if we end up having services needing 10 trials to start up in the next weeks.

closes #2430 

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
