### PR TITLE
removing unused metrics that might be the culprit

### DIFF
--- a/packages/service-library/src/servicelib/monitor_services.py
+++ b/packages/service-library/src/servicelib/monitor_services.py
@@ -19,6 +19,7 @@ from prometheus_client.registry import CollectorRegistry
 # https://www.robustperception.io/cardinality-is-key
 # https://www.robustperception.io/why-does-prometheus-use-so-much-ram
 # https://promcon.io/2019-munich/slides/containing-your-cardinality.pdf
+# https://grafana.com/docs/grafana-cloud/how-do-i/control-prometheus-metrics-usage/usage-analysis-explore/
 #
 
 # TODO: the user_id label on the http_requests_total Counter is a candidate to be removed. as endpoints also contain all kind of UUIDs

--- a/packages/service-library/src/servicelib/monitor_services.py
+++ b/packages/service-library/src/servicelib/monitor_services.py
@@ -5,6 +5,24 @@ from aiohttp import web
 from prometheus_client import Counter
 from prometheus_client.registry import CollectorRegistry
 
+#
+# CAUTION CAUTION CAUTION NOTE:
+# Be very careful with metrics. pay attention to metrics cardinatity.
+# Each time series takes about 3kb of overhead in Prometheus
+#
+# CAUTION: every unique combination of key-value label pairs represents a new time series
+#
+# If a metrics is not needed, don't add it!! It will collapse the application AND prometheus
+#
+# references:
+# https://prometheus.io/docs/practices/naming/
+# https://www.robustperception.io/cardinality-is-key
+# https://www.robustperception.io/why-does-prometheus-use-so-much-ram
+# https://promcon.io/2019-munich/slides/containing-your-cardinality.pdf
+#
+
+# TODO: the user_id label on the http_requests_total Counter is a candidate to be removed. as endpoints also contain all kind of UUIDs
+
 kSERVICE_STARTED = f"{__name__}.services_started"
 kSERVICE_STOPPED = f"{__name__}.services_stopped"
 

--- a/packages/service-library/src/servicelib/monitoring.py
+++ b/packages/service-library/src/servicelib/monitoring.py
@@ -15,9 +15,29 @@ import time
 
 import prometheus_client
 from aiohttp import web
-from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram
+from prometheus_client import CONTENT_TYPE_LATEST, Counter
 
 log = logging.getLogger(__name__)
+
+
+#
+# CAUTION CAUTION CAUTION NOTE:
+# Be very careful with metrics. pay attention to metrics cardinatity.
+# Each time series takes about 3kb of overhead in Prometheus
+#
+# CAUTION: every unique combination of key-value label pairs represents a new time series
+#
+# If a metrics is not needed, don't add it!! It will collapse the application AND prometheus
+#
+# references:
+# https://prometheus.io/docs/practices/naming/
+# https://www.robustperception.io/cardinality-is-key
+# https://www.robustperception.io/why-does-prometheus-use-so-much-ram
+# https://promcon.io/2019-munich/slides/containing-your-cardinality.pdf
+#
+
+
+# TODO: the endpoint label on the http_requests_total Counter is a candidate to be removed. as endpoints also contain all kind of UUIDs
 
 
 async def metrics_handler(_request: web.Request):
@@ -35,9 +55,6 @@ def middleware_factory(app_name):
         resp = None
         try:
             request["start_time"] = time.time()
-            request.app["REQUEST_IN_PROGRESS"].labels(
-                app_name, request.path, request.method
-            ).inc()
 
             resp = await handler(request)
 
@@ -65,15 +82,6 @@ def middleware_factory(app_name):
 
         finally:
             # metrics on the same request
-            resp_time = time.time() - request["start_time"]
-            request.app["REQUEST_LATENCY"].labels(app_name, request.path).observe(
-                resp_time
-            )
-
-            request.app["REQUEST_IN_PROGRESS"].labels(
-                app_name, request.path, request.method
-            ).dec()
-
             if resp:
                 request.app["REQUEST_COUNT"].labels(
                     app_name, request.method, request.path, resp.status
@@ -119,18 +127,6 @@ def setup_monitoring(app: web.Application, app_name: str):
         "http_requests_total",
         "Total Request Count",
         ["app_name", "method", "endpoint", "http_status"],
-    )
-
-    # Latency of a request in seconds
-    app["REQUEST_LATENCY"] = Histogram(
-        "http_request_latency_seconds", "Request latency", ["app_name", "endpoint"]
-    )
-
-    # Number of requests in progress
-    app["REQUEST_IN_PROGRESS"] = Gauge(
-        "http_requests_in_progress_total",
-        "Requests in progress",
-        ["app_name", "endpoint", "method"],
     )
 
     # ensures is first layer but cannot guarantee the order setup is applied

--- a/packages/service-library/src/servicelib/monitoring.py
+++ b/packages/service-library/src/servicelib/monitoring.py
@@ -34,6 +34,7 @@ log = logging.getLogger(__name__)
 # https://www.robustperception.io/cardinality-is-key
 # https://www.robustperception.io/why-does-prometheus-use-so-much-ram
 # https://promcon.io/2019-munich/slides/containing-your-cardinality.pdf
+# https://grafana.com/docs/grafana-cloud/how-do-i/control-prometheus-metrics-usage/usage-analysis-explore/
 #
 
 

--- a/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
@@ -30,6 +30,7 @@ log = logging.getLogger(__name__)
 # https://www.robustperception.io/cardinality-is-key
 # https://www.robustperception.io/why-does-prometheus-use-so-much-ram
 # https://promcon.io/2019-munich/slides/containing-your-cardinality.pdf
+# https://grafana.com/docs/grafana-cloud/how-do-i/control-prometheus-metrics-usage/usage-analysis-explore/
 #
 
 # TODO: the endpoint label on the http_requests_total Counter is a candidate to be removed. as endpoints also contain all kind of UUIDs


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->


After some googling on prometheus and the way metrics  are named and labelled some first conclusions:
1. a metrics shall only be generated if it is needed
2. each pair of metric-label equals a time series with an overhead of about 3kb
3. promeheus AND the application creating the metrics stores the metrics in the form of time series

Now we currently generate the following metrics in storage, director, webserver and any aiohttp-based service:
1. http_requests_total as a prometheus Counter
2. http_request_latency_seconds as a prometheus Histogram
3. http_requests_in_progress_total as a prometheus Gauge

We currently only need http_requests_total in the grafana dashboards. Therefore 2. and 3. are removed in this PR. Checking the prometheus GUI one can see that the Cardinality of the Histogram-generated metrics is the highest, at a value of above 400000.. which is way beyond anything reasonable and explains why prometheus starts having issues and maybe also our webserver.

Still to be seen is the fact that the remaining metrics (http_requests_total) contains the labels (app_name, endpoint and method).
This creates a cardinality of:
app_name = 2
endpoint = inf() (/v0/studies/study_UUID/..., etc etc...)
method = 6 (PUT, GET, POST, UPDATE, DELETE, PATCH)
This PR does not take care of this problem yet but we will have to fix it.

a cardinality above 1000 is considered bad.

some references:
https://prometheus.io/docs/practices/naming/
https://www.robustperception.io/cardinality-is-key
https://www.robustperception.io/why-does-prometheus-use-so-much-ram
https://promcon.io/2019-munich/slides/containing-your-cardinality.pdf
https://grafana.com/docs/grafana-cloud/how-do-i/control-prometheus-metrics-usage/usage-analysis-explore/

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
