### PR TITLE
  🐛 fixing push to docker hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,8 +309,6 @@ push-latest: tag-latest
 	@export DOCKER_IMAGE_TAG=latest; \
 	$(MAKE) push-version
 
-# NOTE: docker-compose only pushes images with a 'build' section.
-# TODO: change to docker-compose push when make config-version available
 push-version: tag-version
 	# pushing '${DOCKER_REGISTRY}/{service}:${DOCKER_IMAGE_TAG}'
 	$(foreach service, $(SERVICES_LIST)\

--- a/ci/deploy/dockerhub-deploy.bash
+++ b/ci/deploy/dockerhub-deploy.bash
@@ -29,7 +29,9 @@ make info-images
 
 # re-tag build
 DOCKER_IMAGE_TAG="$TAG_PREFIX-latest"
+BUILD_TARGET="fake" # this gets overwritten but is required when merging yaml files
 export DOCKER_IMAGE_TAG
+export BUILD_TARGET
 log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}"
 make push-version
 

--- a/ci/deploy/dockerhub-deploy.bash
+++ b/ci/deploy/dockerhub-deploy.bash
@@ -29,7 +29,7 @@ make info-images
 
 # re-tag build
 DOCKER_IMAGE_TAG="$TAG_PREFIX-latest"
-BUILD_TARGET="fake" # this gets overwritten but is required when merging yaml files
+BUILD_TARGET="undefined" # this gets overwritten but is required when merging yaml files
 export DOCKER_IMAGE_TAG
 export BUILD_TARGET
 log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}"


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
`BUILD_TARGET` is now required by `docker-compose-build.yml` when using `make push`. 
The command will merge `docker-compose-build.yml` and `docker-compose-deploy.yml` and the `image` field will be overwritten with the values from `docker-compose-deploy.yml`. 
The value assigned to `BUILD_TARGET` is not important, it just needs to be present.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
