### PR TITLE
Show the Theme Switcher also in the Login Page

### DIFF
--- a/services/web/client/source/class/osparc/Application.js
+++ b/services/web/client/source/class/osparc/Application.js
@@ -37,6 +37,7 @@ qx.Class.define("osparc.Application", {
 
   members: {
     __current: null,
+    __themeSwitcher: null,
     __mainPage: null,
 
     /**
@@ -351,12 +352,25 @@ qx.Class.define("osparc.Application", {
       this.assert(view!==null);
       // Update root document and currentness
       let doc = this.getRoot();
-      if (doc.hasChildren() && this.__current) {
-        doc.remove(this.__current);
-        // this.__current.destroy();
+      if (doc.hasChildren()) {
+        if (this.__current) {
+          doc.remove(this.__current);
+        }
+        if (this.__themeSwitcher) {
+          doc.remove(this.__themeSwitcher);
+          this.__themeSwitcher = null;
+        }
       }
       doc.add(view, options);
       this.__current = view;
+      if (!(view instanceof osparc.desktop.MainPage)) {
+        this.__themeSwitcher = new osparc.ui.switch.ThemeSwitcher();
+        doc.add(this.__themeSwitcher, {
+          top: 10,
+          right: 15
+        });
+      }
+
       // Clear URL
       window.history.replaceState(null, "", "/");
     },

--- a/services/web/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/web/client/source/class/osparc/navigation/NavigationBar.js
@@ -220,9 +220,7 @@ qx.Class.define("osparc.navigation.NavigationBar", {
           this._add(control);
           break;
         case "theme-switch":
-          control = new osparc.ui.switch.ThemeSwitcher().set({
-            checked: qx.theme.manager.Meta.getInstance().getTheme().name === "osparc.theme.ThemeLight"
-          });
+          control = new osparc.ui.switch.ThemeSwitcher();
           this._add(control);
           break;
         case "user-menu":

--- a/services/web/client/source/class/osparc/ui/switch/ThemeSwitcher.js
+++ b/services/web/client/source/class/osparc/ui/switch/ThemeSwitcher.js
@@ -21,7 +21,10 @@ qx.Class.define("osparc.ui.switch.ThemeSwitcher", {
       return;
     }
 
-    this.setToolTipText(this.tr("Switch theme"));
+    this.set({
+      checked: qx.theme.manager.Meta.getInstance().getTheme().name === validThemes[1].name,
+      toolTipText: this.tr("Switch theme")
+    });
 
     this.addListener("changeChecked", () => {
       this.__switchTheme();


### PR DESCRIPTION
## What do these changes do?
This PR brings the Theme Switcher to the login page

osparc:
![switch-osparc](https://user-images.githubusercontent.com/33152403/129057275-bead6279-3f00-47eb-829f-06214cffad1e.gif)

s4l:
![switch-s4l](https://user-images.githubusercontent.com/33152403/129058326-9917b824-1b39-4fac-bc5e-f5e5f6d6c22f.gif)


## Related issue/s
closes https://github.com/ITISFoundation/osparc-simcore/issues/2482

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
