### PR TITLE
Dynamic sidecar isse: use X-Forwarded-Proto if available

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -161,7 +161,7 @@ async def start_project_interactive_services(
             service_version=service["version"],
             service_uuid=service_uuid,
             request_dns=extract_dns_without_default_port(request.url),
-            request_scheme=request.url.scheme,
+            request_scheme=request.headers.get("X-Forwarded-Proto", request.url.scheme),
         )
         for service_uuid, service in project_needed_services.items()
     ]

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -348,7 +348,7 @@ async def add_project_node(
             service_version=service_version,
             service_uuid=node_uuid,
             request_dns=extract_dns_without_default_port(request.url),
-            request_scheme=request.url.scheme,
+            request_scheme=request.headers.get("X-Forwarded-Proto", request.url.scheme),
         )
     return node_uuid
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Context:
the webserver starts the dynamic services by calling the director-v2.

When dynamic services that use the NEW dynamic sidecar are started, they set up a traefik proxy with some specific parameters regarding CORS. These needs to have the correct scheme (http/https).
In deployment cases the scheme is https and is given by the X-Forwarded-Proto header.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
