### PR TITLE
Guided Mode: Plus buttons only at the beginning and end

### DIFF
--- a/services/web/client/source/class/osparc/navigation/BreadcrumbsSlideShowEdit.js
+++ b/services/web/client/source/class/osparc/navigation/BreadcrumbsSlideShowEdit.js
@@ -47,7 +47,7 @@ qx.Class.define("osparc.navigation.BreadcrumbsSlideShowEdit", {
 
       const slideShow = study.getUi().getSlideshow();
       let currentPos = 0;
-      nodeIds.forEach(nodeId => {
+      nodeIds.forEach((nodeId, i) => {
         newServiceBtn.rightNodeId = nodeId;
         if (!study.getWorkbench().getNode(nodeId).hasInputs()) {
           newServiceBtn.exclude();
@@ -80,13 +80,16 @@ qx.Class.define("osparc.navigation.BreadcrumbsSlideShowEdit", {
 
         this.__addEditNodeMenu(btn, currentPos);
 
-        newServiceBtn = this.__createNewServiceBtn();
-        newServiceBtn.leftNodeId = nodeId;
-        newServiceBtn.rightNodeId = null;
-        this._add(newServiceBtn);
+        if (i === nodeIds.length-1) {
+          // for now, plus buttons only at the beginning and end
+          newServiceBtn = this.__createNewServiceBtn();
+          newServiceBtn.leftNodeId = nodeId;
+          newServiceBtn.rightNodeId = null;
+          this._add(newServiceBtn);
 
-        if (!study.getWorkbench().getNode(nodeId).hasOutputs()) {
-          newServiceBtn.exclude();
+          if (!study.getWorkbench().getNode(nodeId).hasOutputs()) {
+            newServiceBtn.exclude();
+          }
         }
       });
     },


### PR DESCRIPTION
## What do these changes do?
 Since the plus buttons in the edition of the guided mode are able to modify the pipeline connections, in order to avoid issues with services that might have some work done and lose their input connections, for now, plus buttons will only be placed at the beginning and end. That way the intermediate connections will not be modified.

![plusButtons](https://user-images.githubusercontent.com/33152403/130747304-04cd02da-dc48-47f8-b88d-55d2e3ea32f3.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
