### PR TITLE
  🐛 Dask scheduler: set bound folders inside container without job id

### DIFF
--- a/services/sidecar/src/simcore_service_sidecar/executor.py
+++ b/services/sidecar/src/simcore_service_sidecar/executor.py
@@ -236,7 +236,7 @@ class Executor:
     ) -> Dict:
         # NOTE: Env/Binds for log folder is only necessary for integraion "0"
         env_vars = [
-            f"{name.upper()}_FOLDER=/{name}/{self.task.job_id}"
+            f"{name.upper()}_FOLDER=/{name}"
             for name in [
                 "input",
                 "output",
@@ -308,9 +308,9 @@ class Executor:
                 "Binds": [
                     # NOTE: the docker engine is mounted, so only named volumes are usable. Therefore for a selective
                     # subfolder mount we need to get the path as seen from the host computer (see https://github.com/ITISFoundation/osparc-simcore/issues/1723)
-                    f"{host_input_path}/{self.task.job_id}:/input/{self.task.job_id}",
-                    f"{host_output_path}/{self.task.job_id}:/output/{self.task.job_id}",
-                    f"{host_log_path}/{self.task.job_id}:/log/{self.task.job_id}",
+                    f"{host_input_path}/{self.task.job_id}:/input",
+                    f"{host_output_path}/{self.task.job_id}:/output",
+                    f"{host_log_path}/{self.task.job_id}:/log",
                 ],
             },
         }


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?
While using the dask scheduler the job_id of each task has been modified to follow the pattern:
```job_id=SERVICEKEY_SERVICEVERSION__projectid_PROJECTID__nodeid_NODEID__UUID```

The sidecar binds this path inside the computational service in the following paths:
```bash
/input/job_id
/output/job_id
/log/job_id
```

The CC 0D services fails with a segfault and this seems to be related.
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
