### PR TITLE
⚗️ WIP: feature database trash tables

### DIFF
--- a/packages/postgres-database/src/simcore_postgres_database/models/projects.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/projects.py
@@ -144,7 +144,7 @@ projects = sa.Table("projects", metadata, *[deepcopy(c) for c in _columns])
 #    - advisable to have an extra unique identifier (e.g. projects.uuid)
 #    - what about other tables with foreign keys and ondelete clauses?
 #      can hook 'trash' procedure to ondelete clauses instead of CASCADE?
-#
+# - ALTERNATIVE: avoid separate trash and add deleted column in 'table' as a marker
 
 _trash_columns = _columns + [
     sa.Column(

--- a/packages/postgres-database/src/simcore_postgres_database/models/projects.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/projects.py
@@ -133,7 +133,7 @@ _columns = [
 projects = sa.Table("projects", metadata, *[deepcopy(c) for c in _columns])
 
 
-# TRASH table
+# TRASH table (experimental)
 #
 # NOTE: this is the rationale around "trash" tables
 #
@@ -142,6 +142,8 @@ projects = sa.Table("projects", metadata, *[deepcopy(c) for c in _columns])
 # - Is this pattern applicable to any 'table' with disposable rows? Probably but ...
 #    - primary_key might be a problem when a row is "restored" from trash
 #    - advisable to have an extra unique identifier (e.g. projects.uuid)
+#    - what about other tables with foreign keys and ondelete clauses?
+#      can hook 'trash' procedure to ondelete clauses instead of CASCADE?
 #
 
 _trash_columns = _columns + [

--- a/packages/postgres-database/tests/projects/test_models_projects.py
+++ b/packages/postgres-database/tests/projects/test_models_projects.py
@@ -1,0 +1,64 @@
+# pylint: disable=no-value-for-parameter
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+# from sqlalchemy.dialects.postgresql.base import UUID <<<<<<<<<
+
+from uuid import UUID
+
+from aiopg.sa.connection import SAConnection
+from aiopg.sa.engine import Engine
+from aiopg.sa.result import RowProxy
+from simcore_postgres_database.models.projects import projects, projects_trash
+from sqlalchemy.sql.expression import exists
+
+# concepts/prototypes
+
+
+async def trash(project_uuid: UUID, conn: SAConnection):
+    # TODO: move row from projects -> projects_trash
+    ...
+
+
+async def restore(project_uuid: UUID, conn: SAConnection):
+    # TODO: move from projects_trash -> projects except the 'deleted' column
+    ...
+
+
+async def test_trash_and_restore_a_project(
+    pg_engine: Engine, project: RowProxy, conn: SAConnection
+):
+    async def _in(table) -> bool:
+        return bool(await conn.scalar(exists().where(table.c.uuid == project.uuid)))
+
+    # -------
+    # TODO: trash a project and restore it back
+
+    assert not await _in(projects_trash)
+    assert await _in(projects)
+
+    await trash(project.uuid, conn)
+
+    assert await _in(projects_trash)
+    assert not await _in(projects)
+
+    await restore(project.uuid, conn)
+
+    assert not await _in(projects_trash)
+    assert await _in(projects)
+
+
+async def test_gc_detect_trashes():
+    #
+    # TODO: gc searches for trash tables and has a flushing mechanism based
+    # defined by some trash policy e.g. age,
+    #
+    assert False
+
+
+#
+# TODO: what about the linked tables?? probably need to create trashes for
+#       those
+#
+#


### PR DESCRIPTION
## What do these changes do?

I did want to draft the idea by @sanderegg  of having *trash* tables in the database. 

The idea is to implement a *trash* (e.g. for studies) that boils down to moving the trashed item into a separate identical *trash* table. This way restoring would be accomplished by moving it back to the original location.

An *alternative* approach would be to add a *deleted* column that could be simple flag or something a bit more versatile as
```
    sa.Column(
        "deleted",
        sa.DateTime(),
        nullable=True,
        doc="Marks as deleted or an expiration date",
    ),
```

This PR explores these ideas and tests them in different contexts. The changes here stop at the database level but the tests should give enough insight to extend this functionality to other services and the APIs.


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
