### PR TITLE
  🐛 bugfix fails to copy studies with lots of data

### DIFF
--- a/services/storage/src/simcore_service_storage/datcore_adapter/datcore_adapter.py
+++ b/services/storage/src/simcore_service_storage/datcore_adapter/datcore_adapter.py
@@ -113,6 +113,10 @@ async def check_service_health(app: web.Application) -> bool:
 async def check_user_can_connect(
     app: web.Application, api_key: str, api_secret: str
 ) -> bool:
+    if not api_key or not api_secret:
+        # no need to ask, datcore is an authenticated service
+        return False
+
     try:
         await _request(app, api_key, api_secret, "GET", "/user/profile")
         return True

--- a/services/storage/src/simcore_service_storage/datcore_adapter/datcore_adapter.py
+++ b/services/storage/src/simcore_service_storage/datcore_adapter/datcore_adapter.py
@@ -3,6 +3,7 @@ import logging
 from math import ceil
 from typing import Any, Callable, Dict, List, Optional, Type, Union, cast
 
+import aiohttp
 from aiohttp import web
 from servicelib.aiohttp.application_keys import APP_CONFIG_KEY
 from servicelib.aiohttp.client_session import ClientSession, get_client_session
@@ -166,7 +167,7 @@ async def list_all_files_metadatas_in_dataset(
                 created_at=d["created_at"],
                 last_modified=d["last_modified_at"],
                 display_file_path=d["name"],
-            ),
+            ),  # type: ignore
         )
         for d in all_files
     ]

--- a/services/storage/src/simcore_service_storage/datcore_adapter/datcore_adapter.py
+++ b/services/storage/src/simcore_service_storage/datcore_adapter/datcore_adapter.py
@@ -3,7 +3,7 @@ import logging
 from math import ceil
 from typing import Any, Callable, Dict, List, Optional, Type, Union, cast
 
-import aiohttp
+from aiohttp import web
 from servicelib.aiohttp.application_keys import APP_CONFIG_KEY
 from servicelib.aiohttp.client_session import ClientSession, get_client_session
 from yarl import URL
@@ -30,7 +30,7 @@ class _DatcoreAdapterResponseError(DatcoreAdapterException):
 
 
 async def _request(
-    app: aiohttp.web.Application,
+    app: web.Application,
     api_key: str,
     api_secret: str,
     method: str,
@@ -56,16 +56,19 @@ async def _request(
             params=params,
         ) as response:
             return await response.json()
+
     except aiohttp.ClientResponseError as exc:
         raise _DatcoreAdapterResponseError(status=exc.status, reason=f"{exc}") from exc
-    except TimeoutError as exc:
+
+    except asyncio.TimeoutError as exc:
         raise DatcoreAdapterClientError("datcore-adapter server timed-out") from exc
+
     except aiohttp.ClientError as exc:
         raise DatcoreAdapterClientError(f"unexpected client error: {exc}") from exc
 
 
 async def _retrieve_all_pages(
-    app: aiohttp.web.Application,
+    app: web.Application,
     api_key: str,
     api_secret: str,
     method: str,
@@ -96,19 +99,19 @@ async def _retrieve_all_pages(
     return objs
 
 
-async def check_service_health(app: aiohttp.web.Application) -> bool:
+async def check_service_health(app: web.Application) -> bool:
     datcore_adapter_settings = app[APP_CONFIG_KEY].DATCORE_ADAPTER
     url = datcore_adapter_settings.endpoint + "/ready"
     session: ClientSession = get_client_session(app)
     try:
         await session.get(url, raise_for_status=True)
-    except (TimeoutError, aiohttp.ClientError):
+    except (asyncio.TimeoutError, aiohttp.ClientError):
         return False
     return True
 
 
 async def check_user_can_connect(
-    app: aiohttp.web.Application, api_key: str, api_secret: str
+    app: web.Application, api_key: str, api_secret: str
 ) -> bool:
     try:
         await _request(app, api_key, api_secret, "GET", "/user/profile")
@@ -118,7 +121,7 @@ async def check_user_can_connect(
 
 
 async def list_all_datasets_files_metadatas(
-    app: aiohttp.web.Application, api_key: str, api_secret: str
+    app: web.Application, api_key: str, api_secret: str
 ) -> List[FileMetaDataEx]:
     all_datasets: List[DatasetMetaData] = await list_datasets(app, api_key, api_secret)
     get_dataset_files_tasks = [
@@ -133,7 +136,7 @@ async def list_all_datasets_files_metadatas(
 
 
 async def list_all_files_metadatas_in_dataset(
-    app: aiohttp.web.Application, api_key: str, api_secret: str, dataset_id: str
+    app: web.Application, api_key: str, api_secret: str, dataset_id: str
 ) -> List[FileMetaDataEx]:
     all_files: List[Dict[str, Any]] = cast(
         List[Dict[str, Any]],
@@ -166,7 +169,7 @@ async def list_all_files_metadatas_in_dataset(
 
 
 async def list_datasets(
-    app: aiohttp.web.Application, api_key: str, api_secret: str
+    app: web.Application, api_key: str, api_secret: str
 ) -> List[DatasetMetaData]:
     all_datasets: List[DatasetMetaData] = await _retrieve_all_pages(
         app,
@@ -182,7 +185,7 @@ async def list_datasets(
 
 
 async def get_file_download_presigned_link(
-    app: aiohttp.web.Application, api_key: str, api_secret: str, file_id: str
+    app: web.Application, api_key: str, api_secret: str, file_id: str
 ) -> URL:
     file_download_data = cast(
         Dict[str, Any],
@@ -192,6 +195,6 @@ async def get_file_download_presigned_link(
 
 
 async def delete_file(
-    app: aiohttp.web.Application, api_key: str, api_secret: str, file_id: str
+    app: web.Application, api_key: str, api_secret: str, file_id: str
 ):
     await _request(app, api_key, api_secret, "DELETE", f"/files/{file_id}")

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -164,7 +164,7 @@ class DataStorageManager:
             aws_secret_access_key=self.s3_client.secret_key,
         )
 
-    def _get_datcore_tokens(self, user_id: str) -> Tuple[str, str]:
+    def _get_datcore_tokens(self, user_id: str) -> Tuple[Optional[str], Optional[str]]:
         # pylint: disable=no-member
         token = self.datcore_tokens.get(user_id, DatCoreApiToken())
         return token.to_tuple()
@@ -175,11 +175,13 @@ class DataStorageManager:
         locs.append(simcore_s3)
 
         api_token, api_secret = self._get_datcore_tokens(user_id)
-        if await datcore_adapter.check_user_can_connect(
-            self.app, api_token, api_secret
-        ):
-            datcore = {"name": DATCORE_STR, "id": DATCORE_ID}
-            locs.append(datcore)
+
+        if api_token and api_secret and self.app:
+            if await datcore_adapter.check_user_can_connect(
+                self.app, api_token, api_secret
+            ):
+                datcore = {"name": DATCORE_STR, "id": DATCORE_ID}
+                locs.append(datcore)
 
         return locs
 

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -153,11 +153,12 @@ class DataStorageManager:
     datcore_tokens: Dict[str, DatCoreApiToken] = attr.Factory(dict)
     app: Optional[web.Application] = None
 
-    def _create_client_context(self) -> ClientCreatorContext:
+    def _create_aiobotocore_client_context(self) -> ClientCreatorContext:
         assert hasattr(self.session, "create_client")
         # pylint: disable=no-member
 
         # SEE API in https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html
+        # SEE https://aiobotocore.readthedocs.io/en/latest/index.html
         return self.session.create_client(
             "s3",
             endpoint_url=self.s3_client.endpoint_url,
@@ -420,14 +421,14 @@ class DataStorageManager:
         """
         current_iteraction = 0
 
-        async with self._create_client_context() as client:
+        async with self._create_aiobotocore_client_context() as aioboto_client:
             current_iteraction += 1
             continue_loop = True
             sleep_generator = expo()
             update_succeeded = False
 
             while continue_loop:
-                result = await client.list_objects_v2(
+                result = await aioboto_client.list_objects_v2(
                     Bucket=bucket_name, Prefix=object_name
                 )
                 sleep_amount = next(sleep_generator)
@@ -742,16 +743,30 @@ class DataStorageManager:
             if new_node_id is not None:
                 uuid_name_dict[new_node_id] = src_node["label"]
 
-        async with self._create_client_context() as client:
+        async with self._create_aiobotocore_client_context() as aioboto_client:
+
+            logger.debug(
+                "Listing all items under  %s:%s/",
+                self.simcore_bucket_name,
+                source_folder,
+            )
 
             # Step 1: List all objects for this project replace them with the destination object name
             # and do a copy at the same time collect some names
             # Note: the / at the end of the Prefix is VERY important, makes the listing several order of magnitudes faster
-            response = await client.list_objects_v2(
+            response = await aioboto_client.list_objects_v2(
                 Bucket=self.simcore_bucket_name, Prefix=f"{source_folder}/"
             )
 
-            for item in response.get("Contents", []):
+            contents: List = response.get("Contents", [])
+            logger.debug(
+                "Listed  %s items under %s:%s/",
+                len(contents),
+                self.simcore_bucket_name,
+                source_folder,
+            )
+
+            for item in contents:
                 source_object_name = item["Key"]
                 source_object_parts = Path(source_object_name).parts
 
@@ -772,7 +787,7 @@ class DataStorageManager:
                         Path(dest_folder) / new_node_id / old_filename
                     )
 
-                    await client.copy_object(
+                    copy_kwargs = dict(
                         CopySource={
                             "Bucket": self.simcore_bucket_name,
                             "Key": source_object_name,
@@ -780,6 +795,11 @@ class DataStorageManager:
                         Bucket=self.simcore_bucket_name,
                         Key=dest_object_name,
                     )
+                    logger.debug("Copying %s ...", copy_kwargs)
+
+                    # FIXME: if 5GB, it must use multipart upload Upload Part - Copy API
+                    # SEE https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.copy_object
+                    await aioboto_client.copy_object(**copy_kwargs)
 
         # Step 2: List all references in outputs that point to datcore and copy over
         for node_id, node in destination_project["workbench"].items():
@@ -808,11 +828,11 @@ class DataStorageManager:
                     output["path"] = destination
 
         fmds = []
-        async with self._create_client_context() as client:
+        async with self._create_aiobotocore_client_context() as aioboto_client:
 
             # step 3: list files first to create fmds
             # Note: the / at the end of the Prefix is VERY important, makes the listing several order of magnitudes faster
-            response = await client.list_objects_v2(
+            response = await aioboto_client.list_objects_v2(
                 Bucket=self.simcore_bucket_name, Prefix=f"{dest_folder}/"
             )
 
@@ -935,9 +955,9 @@ class DataStorageManager:
                 delete_me = delete_me.where(file_meta_data.c.node_id == node_id)
             await conn.execute(delete_me)
 
-        async with self._create_client_context() as client:
+        async with self._create_aiobotocore_client_context() as aioboto_client:
             # Note: the / at the end of the Prefix is VERY important, makes the listing several order of magnitudes faster
-            response = await client.list_objects_v2(
+            response = await aioboto_client.list_objects_v2(
                 Bucket=self.simcore_bucket_name,
                 Prefix=f"{project_id}/{node_id}/" if node_id else f"{project_id}/",
             )
@@ -947,7 +967,7 @@ class DataStorageManager:
                 objects_to_delete.append({"Key": f["Key"]})
 
             if objects_to_delete:
-                response = await client.delete_objects(
+                response = await aioboto_client.delete_objects(
                     Bucket=self.simcore_bucket_name,
                     Delete={"Objects": objects_to_delete},
                 )
@@ -1055,7 +1075,7 @@ class DataStorageManager:
                 "synchronisation of database/s3 storage started, this will take some time..."
             )
 
-            async with self.engine.acquire() as conn, self._create_client_context() as s3_client:
+            async with self.engine.acquire() as conn, self._create_aiobotocore_client_context() as aioboto_client:
 
                 number_of_rows_in_db = await conn.scalar(file_meta_data.count()) or 0
                 logger.warning(
@@ -1063,7 +1083,7 @@ class DataStorageManager:
                     number_of_rows_in_db,
                 )
 
-                assert isinstance(s3_client, AioBaseClient)  # nosec
+                assert isinstance(aioboto_client, AioBaseClient)  # nosec
 
                 async for row in conn.execute(
                     sa.select([file_meta_data.c.object_name])
@@ -1072,7 +1092,7 @@ class DataStorageManager:
 
                     # now check if the file exists in S3
                     # SEE https://www.peterbe.com/plog/fastest-way-to-find-out-if-a-file-exists-in-s3
-                    response = await s3_client.list_objects_v2(
+                    response = await aioboto_client.list_objects_v2(
                         Bucket=self.simcore_bucket_name, Prefix=s3_key
                     )
                     if response.get("KeyCount", 0) == 0:

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -549,7 +549,7 @@ class DataStorageManager:
             stmt = sa.select([file_meta_data.c.object_name]).where(
                 file_meta_data.c.file_uuid == file_uuid
             )
-            object_name: str = await conn.scalar(stmt)
+            object_name: Optional[str] = await conn.scalar(stmt)
 
             if object_name is None:
                 raise web.HTTPNotFound(

--- a/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
@@ -3,10 +3,11 @@
 """
 import logging
 import time
-from typing import Callable, Coroutine
+from asyncio.exceptions import CancelledError
 
 import prometheus_client
 from aiohttp import web
+from aiohttp.web_middlewares import _Handler, _Middleware
 from prometheus_client import CONTENT_TYPE_LATEST, Counter
 from prometheus_client.registry import CollectorRegistry
 from servicelib.aiohttp.monitor_services import add_instrumentation
@@ -58,13 +59,16 @@ async def metrics_handler(request: web.Request):
     return response
 
 
-def middleware_factory(app_name: str) -> Coroutine:
+def middleware_factory(app_name: str) -> _Middleware:
     @web.middleware
-    async def _middleware_handler(request: web.Request, handler: Callable):
+    async def _middleware_handler(request: web.Request, handler: _Handler):
         if request.rel_url.path == "/socket.io/":
             return await handler(request)
 
         log_exception = None
+        resp: web.StreamResponse = web.HTTPInternalServerError(
+            reason="Unexpected exception"
+        )
 
         try:
             request[kSTART_TIME] = time.time()
@@ -91,6 +95,11 @@ def middleware_factory(app_name: str) -> Coroutine:
             resp = web.HTTPInternalServerError(reason=str(exc))
             resp.__cause__ = exc
             log_exception = exc
+        except CancelledError as exc:
+            # Mostly for logging
+            resp = web.HTTPInternalServerError(reason=str(exc))
+            log_exception = exc
+            raise
 
         finally:
             resp_time_secs: float = time.time() - request[kSTART_TIME]

--- a/services/web/server/src/simcore_service_webserver/storage_api.py
+++ b/services/web/server/src/simcore_service_webserver/storage_api.py
@@ -28,10 +28,15 @@ def _get_storage_client(app: web.Application) -> Tuple[ClientSession, URL]:
 
 
 async def copy_data_folders_from_project(
-    app, source_project, destination_project, nodes_map, user_id
+    app: web.Application,
+    source_project: Dict,
+    destination_project: Dict,
+    nodes_map: Dict,
+    user_id: int,
 ):
     # TODO: optimize if project has actualy data or not before doing the call
     client, api_endpoint = _get_storage_client(app)
+    log.debug("Coying %d nodes", len(nodes_map))
 
     # /simcore-s3/folders:
     url = (api_endpoint / "simcore-s3/folders").with_query(user_id=user_id)
@@ -43,6 +48,8 @@ async def copy_data_folders_from_project(
             "nodes_map": nodes_map,
         },
         ssl=False,
+        # NOTE: extends time for copying operation
+        timeout=ClientTimeout(total=10 * 60),
     ) as resp:
         payload = await resp.json()
 

--- a/services/web/server/src/simcore_service_webserver/storage_api.py
+++ b/services/web/server/src/simcore_service_webserver/storage_api.py
@@ -14,6 +14,8 @@ from .storage_config import get_client_session, get_storage_config
 
 log = logging.getLogger(__name__)
 
+TOTAL_TIMEOUT_TO_COPY_DATA_SECS = 60 * 60
+
 
 def _get_storage_client(app: web.Application) -> Tuple[ClientSession, URL]:
     cfg = get_storage_config(app)
@@ -49,7 +51,7 @@ async def copy_data_folders_from_project(
         },
         ssl=False,
         # NOTE: extends time for copying operation
-        timeout=ClientTimeout(total=10 * 60),
+        timeout=ClientTimeout(total=TOTAL_TIMEOUT_TO_COPY_DATA_SECS),
     ) as resp:
         payload = await resp.json()
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?


Analyzed logs of ``webserver``, ``storage`` and ``datcoreadapter`` services.  Found and fix the folling issues:

#### webserver.storage_api call times out [``webserver``]
- Increases *total timeout* from **20 secs to 5 mins** so it takes time to copy 
```log
ERROR: aiohttp.server:log_exception(393) - Error handling request
Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/diagnostics_monitoring.py", line 72, in _middleware_handler
    resp = await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp_session/__init__.py", line 154, in factory
    response = await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/servicelib/rest_middlewares.py", line 67, in _middleware_handler
    return await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/servicelib/rest_middlewares.py", line 171, in _middleware_handler
    return await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/products.py", line 98, in discover_product_middleware
    response = await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/diagnostics_monitoring.py", line 53, in metrics_handler
    result = await request.loop.run_in_executor(
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 422, in _handle_request
    resp = await self._request_handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp/web_app.py", line 499, in _handle
    resp = await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/diagnostics_monitoring.py", line 112, in _middleware_handler
    app_name, request.method, request.path, resp.status, exc_name
UnboundLocalError: local variable 'resp' referenced before assignment

```

#### 🐛  Uncaught timeout exception [``storage``, ``datcore_adapter``]
 -  ``asyncio.TimeoutEror`` is not the same as built-in ``TimeoutError``
```log
2021-09-14T22:14:20.678026536Z ERROR:servicelib.rest_middlewares:Unexpected server error "<class 'asyncio.exceptions.TimeoutError'>" from access: 10.11.0.65 "GET /v0/locations". Responding with status 500
2021-09-14T22:14:20.678082623Z Traceback (most recent call last):
2021-09-14T22:14:20.678090699Z   File "/home/scu/.venv/lib/python3.8/site-packages/servicelib/rest_middlewares.py", line 71, in _middleware_handler
2021-09-14T22:14:20.678096383Z     response = await handler(request)
2021-09-14T22:14:20.678101270Z   File "/home/scu/.venv/lib/python3.8/site-packages/servicelib/rest_middlewares.py", line 173, in _middleware_handler
2021-09-14T22:14:20.678106510Z     resp = await handler(request)
2021-09-14T22:14:20.678111943Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_storage/handlers.py", line 88, in get_storage_locations
2021-09-14T22:14:20.678117341Z     locs = await dsm.locations(user_id)
2021-09-14T22:14:20.678122041Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_storage/dsm.py", line 178, in locations
2021-09-14T22:14:20.678126944Z     if await datcore_adapter.check_user_can_connect(
2021-09-14T22:14:20.678131916Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_storage/datcore_adapter/datcore_adapter.py", line 114, in check_user_can_connect
2021-09-14T22:14:20.678136952Z     await _request(app, api_key, api_secret, "GET", "/user/profile")
2021-09-14T22:14:20.678141983Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_storage/datcore_adapter/datcore_adapter.py", line 47, in _request
2021-09-14T22:14:20.678147319Z     async with session.request(
2021-09-14T22:14:20.678152001Z   File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp/client.py", line 1117, in __aenter__
2021-09-14T22:14:20.678157021Z     self._resp = await self._coro
2021-09-14T22:14:20.678161660Z   File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp/client.py", line 544, in _request
2021-09-14T22:14:20.678166751Z     await resp.start(conn)
2021-09-14T22:14:20.678171923Z   File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp/client_reqrep.py", line 905, in start
2021-09-14T22:14:20.678176933Z     self._continue = None
2021-09-14T22:14:20.678181458Z   File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp/helpers.py", line 656, in __exit__
2021-09-14T22:14:20.678186230Z     raise asyncio.TimeoutError from None
2021-09-14T22:14:20.678190862Z asyncio.exceptions.TimeoutError
2021-09-14T22:14:20.678195598Z Stack (most recent call last):
```
- Timeout is produced when storage checks for datcore credentials. Speedup by avoiding check if no tokens available. Can read a lot of
```log
INFO:     10.0.44.4:54464 - "GET /v0/user/profile HTTP/1.1" 401 Unauthorized
INFO:     10.0.44.4:54466 - "GET /v0/user/profile HTTP/1.1" 401 Unauthorized
```
#### 🐛 Fixes ``UnboundLocalError`` reraised while handling ``CancelledError`` [``webserver``]
```log
ERROR: aiohttp.server:log_exception(393) - Error handling request
Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/diagnostics_monitoring.py", line 72, in _middleware_handler
    resp = await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp_session/__init__.py", line 154, in factory
    response = await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/servicelib/rest_middlewares.py", line 67, in _middleware_handler
    return await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/servicelib/rest_middlewares.py", line 171, in _middleware_handler
    return await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/products.py", line 98, in discover_product_middleware
    response = await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/diagnostics_monitoring.py", line 53, in metrics_handler
    result = await request.loop.run_in_executor(
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp/web_protocol.py", line 422, in _handle_request
    resp = await self._request_handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp/web_app.py", line 499, in _handle
    resp = await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/diagnostics_monitoring.py", line 112, in _middleware_handler
    app_name, request.method, request.path, resp.status, exc_name
UnboundLocalError: local variable 'resp' referenced before assignment

```

#### future exception un retrieved [``storage``]

```logs
ERROR:asyncio:Future exception was never retrieved
future: <Future finished exception=UniqueViolation('duplicate key value violates unique constraint "file_meta_data_pkey"\nDETAIL:  Key (file_uuid)=(c892d04c-1241-11ec-93d1-02420a0b1572/59333091-4d54-54ff-92be-bfe7139e0ee2/TheNumber.txt) already exists.\n')>
Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.8/site-packages/tenacity/_asyncio.py", line 41, in __call__
    result = await fn(*args, **kwargs)
  File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_storage/dsm.py", line 505, in _init_metadata
    await conn.execute(ins)
  File "/home/scu/.venv/lib/python3.8/site-packages/aiopg/sa/connection.py", line 168, in _execute
    await cursor.execute(str(compiled), post_processed_params[0])
  File "/home/scu/.venv/lib/python3.8/site-packages/aiopg/connection.py", line 426, in execute
    await self._conn._poll(waiter, timeout)
  File "/home/scu/.venv/lib/python3.8/site-packages/aiopg/connection.py", line 881, in _poll
    await asyncio.wait_for(self._waiter, timeout)
  File "/usr/local/lib/python3.8/asyncio/tasks.py", line 494, in wait_for
    return fut.result()
  File "/home/scu/.venv/lib/python3.8/site-packages/aiopg/connection.py", line 788, in _ready
    state = self._conn.poll()
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "file_meta_data_pkey"
DETAIL:  Key (file_uuid)=(c892d04c-1241-11ec-93d1-02420a0b1572/59333091-4d54-54ff-92be-bfe7139e0ee2/TheNumber.txt) already exists.

```
## Related issue/s

-  ITISFoundation/osparc-issues#542


