### PR TITLE
🐛 bugfix: Copy thumbnail only if exists

### DIFF
--- a/services/web/client/source/class/osparc/data/Permissions.js
+++ b/services/web/client/source/class/osparc/data/Permissions.js
@@ -165,6 +165,7 @@ qx.Class.define("osparc.data.Permissions", {
           "user.role.update",
           "user.clusters.create",
           "study.service.update",
+          "study.snapshot.read",
           "study.snapshot.create",
           "study.nodestree.uuid.read",
           "study.filestree.uuid.read",

--- a/services/web/client/source/class/osparc/data/model/Study.js
+++ b/services/web/client/source/class/osparc/data/model/Study.js
@@ -232,6 +232,10 @@ qx.Class.define("osparc.data.model.Study", {
 
     getSnapshots: function(studyId) {
       return new Promise((resolve, reject) => {
+        if (!osparc.data.Permissions.getInstance().canDo("study.snapshot.read")) {
+          reject();
+          return;
+        }
         const params = {
           url: {
             "studyId": studyId
@@ -254,9 +258,8 @@ qx.Class.define("osparc.data.model.Study", {
           .then(snapshots => {
             resolve(Boolean(snapshots.length));
           })
-          .catch(err => {
-            console.error(err);
-            reject(err);
+          .catch(() => {
+            resolve(false);
           });
       });
     }

--- a/services/web/client/source/class/osparc/utils/Study.js
+++ b/services/web/client/source/class/osparc/utils/Study.js
@@ -41,7 +41,9 @@ qx.Class.define("osparc.utils.Study", {
               const newUuid = osparc.utils.Utils.uuidv4();
               const minStudyData = osparc.data.model.Study.createMyNewStudyObject();
               minStudyData["name"] = service["name"];
-              minStudyData["thumbnail"] = service["thumbnail"];
+              if (service["thumbnail"]) {
+                minStudyData["thumbnail"] = service["thumbnail"];
+              }
               minStudyData["workbench"][newUuid] = {
                 "key": service["key"],
                 "version": service["version"],


### PR DESCRIPTION
## What do these changes do?

Copy thumbnail only if exists

Bonus
- [x] Ask for checkpoints only if can read

Before:
![before](https://user-images.githubusercontent.com/33152403/134327508-e0cf8e50-ae09-4bfc-b564-2ea9165a3bf4.gif)

After:
![after](https://user-images.githubusercontent.com/33152403/134327605-b0ec5eae-fc46-4e66-82fe-6a75db6eb830.gif)

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
