### PR TITLE
🐛 Bugfix: handle error when webserver disconnects an already disconnected socket

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
@@ -172,11 +172,11 @@ async def project_uses_available_services(
     }
 
     # get available services
-    available_services: Set[Tuple[str, str]] = {
+    available_services_set: Set[Tuple[str, str]] = {
         (s["key"], s["version"]) for s in available_services
     }
 
-    return needed_services.issubset(available_services)
+    return needed_services.issubset(available_services_set)
 
 
 def get_project_unavailable_services(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

The following error was spotted while debugging issues with parallel testing of jupyters.
now a proper warning message is created and the error is not raising uncontrolled.

```console
021-09-23T06:59:52.764498729Z ERROR: /home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/resource_manager/websocket_manager.py:managed_resource(180) - Error in web-socket for user:20159, session:328d7423-8413-467c-8cd1-d4474ff64c85
2021-09-23T06:59:52.764538763Z Traceback (most recent call last):
2021-09-23T06:59:52.764548797Z   File "/home/scu/.venv/lib/python3.8/site-packages/engineio/server.py", line 604, in _get_socket
2021-09-23T06:59:52.764557145Z     s = self.sockets[sid]
2021-09-23T06:59:52.764564040Z KeyError: '93b1c8c8939b4671b580b401d55a0511'
2021-09-23T06:59:52.764585166Z 
2021-09-23T06:59:52.764593645Z During handling of the above exception, another exception occurred:
2021-09-23T06:59:52.764600157Z 
2021-09-23T06:59:52.764605857Z Traceback (most recent call last):
2021-09-23T06:59:52.764611519Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/resource_manager/websocket_manager.py", line 178, in managed_resource
2021-09-23T06:59:52.764618354Z     yield registry
2021-09-23T06:59:52.764624349Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/socketio/handlers.py", line 127, in on_user_logout
2021-09-23T06:59:52.764630664Z     await sio.disconnect(sid=socket_id)
2021-09-23T06:59:52.764636359Z   File "/home/scu/.venv/lib/python3.8/site-packages/socketio/asyncio_server.py", line 343, in disconnect
2021-09-23T06:59:52.764643293Z     await self._trigger_event('disconnect', namespace, sid)
2021-09-23T06:59:52.764649569Z   File "/home/scu/.venv/lib/python3.8/site-packages/socketio/asyncio_server.py", line 504, in _trigger_event
2021-09-23T06:59:52.764656052Z     ret = await self.handlers[namespace][event](*args)
2021-09-23T06:59:52.764662555Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/socketio/handlers_utils.py", line 22, in wrapped
2021-09-23T06:59:52.764669083Z     return await func(*args, **kwargs, app=app)
2021-09-23T06:59:52.764675237Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/socketio/handlers.py", line 160, in disconnect
2021-09-23T06:59:52.764682551Z     log.error(
2021-09-23T06:59:52.764688809Z   File "/home/scu/.venv/lib/python3.8/site-packages/socketio/asyncio_server.py", line 314, in __aexit__
2021-09-23T06:59:52.764695364Z     await self.server.save_session(sid, self.session,
2021-09-23T06:59:52.764701770Z   File "/home/scu/.venv/lib/python3.8/site-packages/socketio/asyncio_server.py", line 276, in save_session
2021-09-23T06:59:52.764710008Z     eio_session = await self.eio.get_session(sid)
2021-09-23T06:59:52.764716496Z   File "/home/scu/.venv/lib/python3.8/site-packages/engineio/asyncio_server.py", line 107, in get_session
2021-09-23T06:59:52.764723089Z     socket = self._get_socket(sid)
2021-09-23T06:59:52.764730150Z   File "/home/scu/.venv/lib/python3.8/site-packages/engineio/server.py", line 606, in _get_socket
2021-09-23T06:59:52.764737592Z     raise KeyError('Session not found')
2021-09-23T06:59:52.764744034Z KeyError: 'Session not found'
2021-09-23T06:59:52.765118757Z WARNING: servicelib.utils:logged_gather(116) - Error in 1-th concurrent task <coroutine object on_user_logout at 0x7fb09da012c0>: 'Session not found'
2021-09-23T06:59:52.767678530Z ERROR: simcore_service_webserver.diagnostics_monitoring:_middleware_handler(125) - Unexpected server error "<class 'aiohttp.web_exceptions.HTTPInternalServerError'>" from access: 10.5.103.78 "POST /v0/auth/logout" done in 0.10 secs. Responding with status 500
2021-09-23T06:59:52.767702239Z Traceback (most recent call last):
2021-09-23T06:59:52.767708611Z   File "/home/scu/.venv/lib/python3.8/site-packages/engineio/server.py", line 604, in _get_socket
2021-09-23T06:59:52.767716309Z     s = self.sockets[sid]
2021-09-23T06:59:52.767722455Z KeyError: '93b1c8c8939b4671b580b401d55a0511'
2021-09-23T06:59:52.767726647Z 
2021-09-23T06:59:52.767730291Z During handling of the above exception, another exception occurred:
2021-09-23T06:59:52.767734215Z 
2021-09-23T06:59:52.767738270Z Traceback (most recent call last):
2021-09-23T06:59:52.767741963Z   File "/home/scu/.venv/lib/python3.8/site-packages/servicelib/aiohttp/rest_middlewares.py", line 71, in _middleware_handler
2021-09-23T06:59:52.767745931Z     response = await handler(request)
2021-09-23T06:59:52.767749531Z   File "/home/scu/.venv/lib/python3.8/site-packages/servicelib/aiohttp/rest_middlewares.py", line 186, in _middleware_handler
2021-09-23T06:59:52.767753446Z     resp = await handler(request)
2021-09-23T06:59:52.767757840Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/products.py", line 98, in discover_product_middleware
2021-09-23T06:59:52.767761779Z     response = await handler(request)
2021-09-23T06:59:52.767765310Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/login/decorators.py", line 20, in wrapped
2021-09-23T06:59:52.767769179Z     ret = await handler(*args, **kwargs)
2021-09-23T06:59:52.767772679Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/login/handlers.py", line 172, in logout
2021-09-23T06:59:52.767776618Z     await observer.emit("SIGNAL_USER_LOGOUT", user_id, client_session_id, request.app)
2021-09-23T06:59:52.767780451Z   File "/home/scu/.venv/lib/python3.8/site-packages/servicelib/observer.py", line 23, in emit
2021-09-23T06:59:52.767784207Z     await logged_gather(*coroutines)
2021-09-23T06:59:52.767787738Z   File "/home/scu/.venv/lib/python3.8/site-packages/servicelib/utils.py", line 128, in logged_gather
2021-09-23T06:59:52.767791580Z     raise error
2021-09-23T06:59:52.767795140Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/socketio/handlers.py", line 127, in on_user_logout
2021-09-23T06:59:52.767799020Z     await sio.disconnect(sid=socket_id)
2021-09-23T06:59:52.767802520Z   File "/home/scu/.venv/lib/python3.8/site-packages/socketio/asyncio_server.py", line 343, in disconnect
2021-09-23T06:59:52.767806332Z     await self._trigger_event('disconnect', namespace, sid)
2021-09-23T06:59:52.767810913Z   File "/home/scu/.venv/lib/python3.8/site-packages/socketio/asyncio_server.py", line 504, in _trigger_event
2021-09-23T06:59:52.767815367Z     ret = await self.handlers[namespace][event](*args)
2021-09-23T06:59:52.767823275Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/socketio/handlers_utils.py", line 22, in wrapped
2021-09-23T06:59:52.767838614Z     return await func(*args, **kwargs, app=app)
2021-09-23T06:59:52.767843671Z   File "/home/scu/.venv/lib/python3.8/site-packages/simcore_service_webserver/socketio/handlers.py", line 160, in disconnect
2021-09-23T06:59:52.767847704Z     log.error(
2021-09-23T06:59:52.767851329Z   File "/home/scu/.venv/lib/python3.8/site-packages/socketio/asyncio_server.py", line 314, in __aexit__
2021-09-23T06:59:52.767855260Z     await self.server.save_session(sid, self.session,
2021-09-23T06:59:52.767858901Z   File "/home/scu/.venv/lib/python3.8/site-packages/socketio/asyncio_server.py", line 276, in save_session
2021-09-23T06:59:52.767862799Z     eio_session = await self.eio.get_session(sid)
2021-09-23T06:59:52.767869405Z   File "/home/scu/.venv/lib/python3.8/site-packages/engineio/asyncio_server.py", line 107, in get_session
2021-09-23T06:59:52.767878868Z     socket = self._get_socket(sid)
2021-09-23T06:59:52.767883745Z   File "/home/scu/.venv/lib/python3.8/site-packages/engineio/server.py", line 606, in _get_socket
2021-09-23T06:59:52.767887844Z     raise KeyError('Session not found')
2021-09-23T06:59:52.767891624Z KeyError: 'Session not found'
```
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
