### PR TITLE
update the ca in the e2e/p2e puppeteer image

### DIFF
--- a/tests/e2e/docker/Dockerfile
+++ b/tests/e2e/docker/Dockerfile
@@ -71,6 +71,11 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /
 RUN curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
   chmod +x /usr/local/bin/docker-compose
 
+# Certificate fix
+
+RUN sed -i 's|mozilla/DST_Root_CA_X3.crt|!mozilla/DST_Root_CA_X3.crt|' /etc/ca-certificates.conf
+RUN update-ca-certificates
+
 SHELL [ "/bin/bash", "-c" ]
 
 ENTRYPOINT []

--- a/tests/e2e/docker/Makefile
+++ b/tests/e2e/docker/Makefile
@@ -1,7 +1,7 @@
 DOCKER_REGISTRY ?= itisfoundation
 DOCKER_IMAGE_NAME ?= puppeteer
 # $(puppeteer-version)-$(our-version)
-DOCKER_IMAGE_TAG ?= 14-2
+DOCKER_IMAGE_TAG ?= 14-3
 
 # version control
 VCS_URL          := $(shell git config --get remote.origin.url)


### PR DESCRIPTION
## What do these changes do?

Modify a certificate in the puppeteer image used for testing

## Related issue/s


## How to test

The image is in use here: https://git.speag.com/oSparc/e2e-portal-testing/-/pipelines/194844


