### PR TITLE
🐛 Bugfix: ensure rebooting of director-v2 is only checking the python code

### DIFF
--- a/services/director-v2/docker/boot.sh
+++ b/services/director-v2/docker/boot.sh
@@ -43,7 +43,6 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
     --reload-dir packages/postgres-database/src/simcore_postgres_database \
     --reload-dir packages/service-library/src/servicelib \
     --reload-dir packages/settings-library/src/settings_library \
-    --reload-dir packages/settings-library/src/settings_library \
     --reload-dir packages/simcore-sdk/src/simcore_sdk \
     --reload-dir services/director-v2/src/simcore_service_director_v2
 else


### PR DESCRIPTION


<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

the auto-reload of director-v2 was set to check everything in the packages folder, which is a bit too much.
now only looks into the python code changes in the folder since there is no filter possible in uvicorn for now.

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
