### PR TITLE
ensure director has started before getting services

### DIFF
--- a/services/catalog/src/simcore_service_catalog/core/background_tasks.py
+++ b/services/catalog/src/simcore_service_catalog/core/background_tasks.py
@@ -211,7 +211,9 @@ async def sync_registry_task(app: FastAPI) -> None:
                 "Unexpected error while syncing registry entries, restarting now..."
             )
             # wait a bit before retrying, so it does not block everything until the director is up
-            await asyncio.sleep(app.state.settings.BACKGROUND_TASK_WAIT_AFTER_FAILURE)
+            await asyncio.sleep(
+                app.state.settings.CATALOG_BACKGROUND_TASK_WAIT_AFTER_FAILURE
+            )
 
 
 async def start_registry_sync_task(app: FastAPI) -> None:

--- a/services/catalog/tests/unit/with_dbs/conftest.py
+++ b/services/catalog/tests/unit/with_dbs/conftest.py
@@ -5,7 +5,7 @@
 
 import itertools
 import random
-from typing import Any, Callable, Dict, Iterator, List, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Tuple
 
 import pytest
 import respx
@@ -34,14 +34,14 @@ def app(
     service_test_environ: None,
     postgres_db: sa.engine.Engine,
     postgres_host_config: Dict[str, str],
-) -> FastAPI:
+) -> Iterable[FastAPI]:
     monkeypatch.setenv("CATALOG_TRACING", "null")
     app = init_app()
     yield app
 
 
 @pytest.fixture
-def client(app: FastAPI) -> TestClient:
+def client(app: FastAPI) -> Iterable[TestClient]:
     with TestClient(app) as cli:
         # Note: this way we ensure the events are run in the application
         yield cli


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

- ensures that the director-v0 is ready for receiving requests before the catalog says he is ready to get the services
Should fix the instabilities in the CI for at least e2e testing
## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
