### PR TITLE
✅ Improving CI tests: web/server/tests/integration/02/test_rabbit.py

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/websocket_client.py
+++ b/packages/pytest-simcore/src/pytest_simcore/websocket_client.py
@@ -3,7 +3,7 @@
 # pylint:disable=redefined-outer-name
 
 import logging
-from typing import AsyncIterable, Awaitable, Callable, Optional
+from typing import AsyncIterable, Awaitable, Callable, List, Optional
 from uuid import uuid4
 
 import pytest
@@ -62,7 +62,7 @@ async def socketio_client_factory(
 ) -> AsyncIterable[
     Callable[[Optional[str], Optional[TestClient]], Awaitable[socketio.AsyncClient]]
 ]:
-    clients = []
+    clients: List[socketio.AsyncClient] = []
 
     async def _connect(
         client_session_id: Optional[str] = None, client: Optional[TestClient] = None
@@ -98,4 +98,6 @@ async def socketio_client_factory(
         if sio.connected:
             logger.debug("Disconnecting socketio client %s", sio)
             await sio.disconnect()
+            await sio.wait()
+
         assert not sio.sid

--- a/services/web/server/src/simcore_service_webserver/groups_api.py
+++ b/services/web/server/src/simcore_service_webserver/groups_api.py
@@ -18,6 +18,7 @@ from .groups_exceptions import (
     UserInGroupNotFoundError,
 )
 from .groups_utils import (
+    AccessRightsDict,
     check_group_permissions,
     convert_groups_db_to_schema,
     convert_groups_schema_to_db,
@@ -28,8 +29,17 @@ from .users_exceptions import UserNotFoundError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_GROUP_READ_ACCESS_RIGHTS = {"read": True, "write": False, "delete": False}
-DEFAULT_GROUP_OWNER_ACCESS_RIGHTS = {"read": True, "write": True, "delete": True}
+
+DEFAULT_GROUP_READ_ACCESS_RIGHTS: AccessRightsDict = {
+    "read": True,
+    "write": False,
+    "delete": False,
+}
+DEFAULT_GROUP_OWNER_ACCESS_RIGHTS: AccessRightsDict = {
+    "read": True,
+    "write": True,
+    "delete": True,
+}
 
 
 async def list_user_groups(
@@ -222,7 +232,7 @@ async def add_user_in_group(
     *,
     new_user_id: Optional[int] = None,
     new_user_email: Optional[str] = None,
-    access_rights: Optional[Dict[str, bool]] = None,
+    access_rights: Optional[AccessRightsDict] = None,
 ) -> None:
     """
     adds new_user (either by id or email) in group (with gid) owned by user_id
@@ -321,9 +331,9 @@ async def update_user_in_group(
                 )
             )
         )
-        the_user = dict(the_user)
-        the_user.update(**new_db_values)
-        return convert_user_in_group_to_schema(the_user)
+        user = dict(the_user)
+        user.update(**new_db_values)
+        return convert_user_in_group_to_schema(user)
 
 
 async def delete_user_in_group(

--- a/services/web/server/src/simcore_service_webserver/groups_utils.py
+++ b/services/web/server/src/simcore_service_webserver/groups_utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Mapping, Optional, TypedDict
 
 from aiopg.sa.result import RowProxy
 
@@ -16,6 +16,12 @@ GROUPS_SCHEMA_TO_DB = {
     "accessRights": "access_rights",
     "inclusionRules": "inclusion_rules",
 }
+
+
+class AccessRightsDict(TypedDict):
+    read: bool
+    write: bool
+    delete: bool
 
 
 def check_group_permissions(
@@ -47,9 +53,9 @@ def convert_groups_schema_to_db(schema: Dict) -> Dict:
     }
 
 
-def convert_user_in_group_to_schema(row: Union[RowProxy, Dict]) -> Dict[str, str]:
-    group_user = convert_user_db_to_schema(row)
+def convert_user_in_group_to_schema(user: Mapping[str, Any]) -> Dict[str, str]:
+    group_user = convert_user_db_to_schema(user)
     group_user.pop("role")
-    group_user["accessRights"] = row["access_rights"]
-    group_user["gid"] = row["primary_gid"]
+    group_user["accessRights"] = user["access_rights"]
+    group_user["gid"] = user["primary_gid"]
     return group_user

--- a/services/web/server/src/simcore_service_webserver/socketio/handlers_utils.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/handlers_utils.py
@@ -44,6 +44,7 @@ def register_handlers(app: web.Application, module: ModuleType):
         socket_io_handler(app)(func_handler) for func_handler in member_fcts
     ]
     app[APP_CLIENT_SOCKET_DECORATED_HANDLERS_KEY] = partial_fcts
+
     # register the fcts
     for func in partial_fcts:
         sio.on(func.__name__, handler=func)

--- a/services/web/server/src/simcore_service_webserver/socketio/module_setup.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/module_setup.py
@@ -5,9 +5,8 @@
 import logging
 
 from aiohttp import web
-from socketio import AsyncServer
-
 from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
+from socketio import AsyncServer
 
 from . import handlers, handlers_utils
 from .config import APP_CLIENT_SOCKET_SERVER_KEY, assert_valid_config
@@ -15,15 +14,21 @@ from .config import APP_CLIENT_SOCKET_SERVER_KEY, assert_valid_config
 log = logging.getLogger(__name__)
 
 
-@app_module_setup("simcore_service_webserver.socketio", ModuleCategory.SYSTEM, logger=log)
+@app_module_setup(
+    "simcore_service_webserver.socketio", ModuleCategory.SYSTEM, logger=log
+)
 def setup_socketio(app: web.Application):
     # ----------------------------------------------
     # TODO: temporary, just to check compatibility between
     # trafaret and pydantic schemas
     assert_valid_config(app)
     # ---------------------------------------------
-    mgr = None
-    sio = AsyncServer(async_mode="aiohttp", client_manager=mgr, logging=log)
+
+    # SEE https://github.com/miguelgrinberg/python-socketio/blob/v4.6.1/docs/server.rst#aiohttp
+    sio = AsyncServer(async_mode="aiohttp", client_manager=None, logging=log)
     sio.attach(app)
+
+    # FIXME: cleanup sio??
+
     app[APP_CLIENT_SOCKET_SERVER_KEY] = sio
     handlers_utils.register_handlers(app, handlers)

--- a/services/web/server/src/simcore_service_webserver/socketio/module_setup.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/module_setup.py
@@ -25,10 +25,10 @@ def setup_socketio(app: web.Application):
     # ---------------------------------------------
 
     # SEE https://github.com/miguelgrinberg/python-socketio/blob/v4.6.1/docs/server.rst#aiohttp
-    sio = AsyncServer(async_mode="aiohttp", client_manager=None, logging=log)
+    # TODO: ujson to speed up?
+    # TODO: client_manager= to socketio.AsyncRedisManager/AsyncAioPikaManager for horizontal scaling (shared sessions)
+    sio = AsyncServer(async_mode="aiohttp", logger=log, engineio_logger=False)
     sio.attach(app)
-
-    # FIXME: cleanup sio??
 
     app[APP_CLIENT_SOCKET_SERVER_KEY] = sio
     handlers_utils.register_handlers(app, handlers)

--- a/services/web/server/src/simcore_service_webserver/users_utils.py
+++ b/services/web/server/src/simcore_service_webserver/users_utils.py
@@ -1,7 +1,5 @@
 import logging
-from typing import Dict, Optional
-
-from aiopg.sa.result import RowProxy
+from typing import Any, Dict, Mapping, Optional
 
 from .utils import gravatar_hash
 
@@ -9,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def convert_user_db_to_schema(
-    row: RowProxy, prefix: Optional[str] = ""
+    row: Mapping[str, Any], prefix: Optional[str] = ""
 ) -> Dict[str, str]:
     parts = row[f"{prefix}name"].split(".") + [""]
     return {

--- a/services/web/server/tests/integration/02/test_rabbit.py
+++ b/services/web/server/tests/integration/02/test_rabbit.py
@@ -1,18 +1,15 @@
-# pylint:disable=unused-variable
-# pylint:disable=unused-argument
-# pylint:disable=redefined-outer-name
-# pylint:disable=too-many-arguments
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
 import json
 import logging
-import time
 from asyncio import sleep
 from typing import Any, Callable, Dict, List, Tuple
-from unittest import mock
 from unittest.mock import call
 from uuid import uuid4
 
 import aio_pika
-import aioresponses
 import pytest
 import sqlalchemy as sa
 from models_library.settings.rabbit import RabbitConfig
@@ -32,13 +29,10 @@ from simcore_service_webserver.security import setup_security
 from simcore_service_webserver.security_roles import UserRole
 from simcore_service_webserver.session import setup_session
 from simcore_service_webserver.socketio.module_setup import setup_socketio
-from tenacity import before_sleep
 from tenacity._asyncio import AsyncRetrying
 from tenacity.before_sleep import before_sleep_log
 from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_fixed
-
-API_VERSION = "v0"
 
 # Selection of core and tool services started in this swarm fixture (integration)
 pytest_simcore_core_services_selection = [
@@ -50,86 +44,50 @@ pytest_simcore_core_services_selection = [
 pytest_simcore_ops_services_selection = []
 
 
-@pytest.fixture
-def client(
-    loop,
-    aiohttp_client,
-    app_config,  ## waits until swarm with *_services are up
-    rabbit_service: RabbitConfig,  ## waits until rabbit is responsive
-    postgres_db: sa.engine.Engine,
-):
-    assert app_config["rest"]["version"] == API_VERSION
+# HELPERS ------------------------------------------------------------------------------------
 
-    app_config["storage"]["enabled"] = False
+logger = logging.getLogger(__name__)
 
-    # fake config
-    app = create_safe_application()
-    app[APP_CONFIG_KEY] = app_config
+UUIDStr = str
 
-    setup_db(app)
-    setup_session(app)
-    setup_security(app)
-    setup_rest(app)
-    setup_login(app)
-    setup_projects(app)
-    setup_computation(app)
-    setup_director_v2(app)
-    setup_socketio(app)
-    setup_resource_manager(app)
-
-    yield loop.run_until_complete(
-        aiohttp_client(
-            app,
-            server_kwargs={
-                "port": app_config["main"]["port"],
-                "host": app_config["main"]["host"],
-            },
-        )
-    )
+RabbitMessage = Dict[str, Any]
+LogMessages = List[RabbitMessage]
+InstrumMessages = List[RabbitMessage]
+ProgressMessages = List[RabbitMessage]
 
 
-# ------------------------------------------
-
-
-def _create_rabbit_message(
-    message_name: str, node_uuid: str, user_id: int, project_id: str, param: Any
-) -> Dict[str, Any]:
-    message = {
-        "channel": message_name,
-        "node_id": node_uuid,
-        "user_id": f"{user_id}",
-        "project_id": project_id,
-    }
-
-    if message_name == "log":
-        message["messages"] = param
-    if message_name == "progress":
-        message["progress"] = param
-    return message
-
-
-@pytest.fixture
-def client_session_id() -> str:
-    return str(uuid4())
-
-
-async def _publish_messages(
-    num_messages: int,
-    node_uuid: str,
+async def _publish_in_rabbit(
     user_id: int,
-    project_id: str,
+    project_id: UUIDStr,
+    node_uuid: UUIDStr,
+    num_messages: int,
     rabbit_exchange: Tuple[aio_pika.Exchange, aio_pika.Exchange],
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+) -> Tuple[LogMessages, ProgressMessages, InstrumMessages]:
+    def _msg(
+        message_name: str, node_uuid: str, user_id: int, project_id: str, param: Any
+    ) -> RabbitMessage:
+        message = {
+            "channel": message_name,
+            "node_id": node_uuid,
+            "user_id": f"{user_id}",
+            "project_id": project_id,
+        }
+
+        if message_name == "log":
+            message["messages"] = param
+        if message_name == "progress":
+            message["progress"] = param
+
+        return message
+
+    # -----
+
     log_messages = [
-        _create_rabbit_message(
-            "logger", node_uuid, user_id, project_id, f"log number {n}"
-        )
+        _msg("logger", node_uuid, user_id, project_id, f"log number {n}")
         for n in range(num_messages)
     ]
     progress_messages = [
-        _create_rabbit_message(
-            "progress", node_uuid, user_id, project_id, n / num_messages
-        )
+        _msg("progress", node_uuid, user_id, project_id, n / num_messages)
         for n in range(num_messages)
     ]
     # send the messages over rabbit
@@ -186,112 +144,271 @@ async def _publish_messages(
     return (log_messages, progress_messages, instrumentation_messages)
 
 
-logger = logging.getLogger(__name__)
+# FIXTURES ------------------------------------------------------------------------------------
 
 
-async def _wait_until(pred: Callable, timeout: int):
-    async for attempt in AsyncRetrying(
-        stop=stop_after_delay(timeout),
-        wait=wait_fixed(1),
-        before_sleep=before_sleep_log(logger, log_level=logging.WARNING),
-        reraise=True,
-    ):
-        with attempt:
-            print(
-                f"attempt {attempt.retry_state.attempt_number}, waiting for predicate to become true"
-            )
-            if pred():
-                return
-            raise AssertionError("waited too long!")
-
-
-@pytest.mark.parametrize(
-    "user_role",
-    [
-        (UserRole.GUEST),
-        (UserRole.USER),
-        (UserRole.TESTER),
-    ],
-)
-async def test_rabbit_websocket_computation(
-    director_v2_service_mock: aioresponses.aioresponses,
-    mock_orphaned_services: mock.Mock,
-    logged_user: Dict[str, Any],
-    user_project: Dict[str, Any],
-    socketio_client_factory: Callable,
-    client_session_id: str,
-    mocker: MockerFixture,
-    rabbit_exchange: Tuple[aio_pika.Exchange, aio_pika.Exchange],
-    node_uuid: str,
-    user_id: int,
-    project_id: str,
+@pytest.fixture
+def client(
+    loop,
+    aiohttp_client,
+    app_config,  ## waits until swarm with *_services are up
+    rabbit_service: RabbitConfig,  ## waits until rabbit is responsive and set env vars
+    postgres_db: sa.engine.Engine,
+    mocker,
 ):
+    app_config["storage"]["enabled"] = False
 
-    # corresponding websocket event names
-    websocket_log_event = "logger"
-    websocket_node_update_event = "nodeUpdated"
-    # connect websocket
-    sio = await socketio_client_factory(client_session_id)
-    # register mock websocket handler functions
-    mock_log_handler_fct = mocker.Mock()
-    mock_node_update_handler_fct = mocker.Mock()
-    sio.on(websocket_log_event, handler=mock_log_handler_fct)
-    sio.on(websocket_node_update_event, handler=mock_node_update_handler_fct)
-    # publish messages with wrong user id
-    NUMBER_OF_MESSAGES = 1
-    TIMEOUT_S = 20
-    await _publish_messages(
-        NUMBER_OF_MESSAGES, node_uuid, user_id, project_id, rabbit_exchange
+    # fake config
+    app = create_safe_application()
+    app[APP_CONFIG_KEY] = app_config
+
+    setup_db(app)
+    setup_session(app)
+    setup_security(app)
+    setup_rest(app)
+    setup_login(app)
+    setup_projects(app)
+    setup_computation(app)
+    setup_director_v2(app)
+    setup_socketio(app)
+
+    # GC not relevant for these test-suite,
+    mocker.patch(
+        "simcore_service_webserver.resource_manager.module_setup.setup_garbage_collector",
+        side_effect=lambda app: print(
+            f"PATCH @{__name__}:"
+            "Garbage collector disabled."
+            "Mock bypasses setup_garbage_collector to skip initializing the GC"
+        ),
     )
-    await sleep(1)
-    mock_log_handler_fct.assert_not_called()
-    mock_node_update_handler_fct.assert_not_called()
+    setup_resource_manager(app)
+
+    yield loop.run_until_complete(
+        aiohttp_client(
+            app,
+            server_kwargs={
+                "port": app_config["main"]["port"],
+                "host": app_config["main"]["host"],
+            },
+        )
+    )
+
+
+@pytest.fixture
+def client_session_id() -> UUIDStr:
+    return str(uuid4())
+
+
+@pytest.fixture
+def other_user_id(user_id, logged_user):
+    other = user_id
+    assert logged_user["id"] != other
+    return other
+
+
+@pytest.fixture
+def other_project_id(project_id, user_project):
+    other = project_id
+    assert user_project["uuid"] != other
+    return other
+
+
+@pytest.fixture
+def other_node_uuid(node_uuid, user_project):
+    other = node_uuid
+    node_uuid = list(user_project["workbench"])[0]
+    assert node_uuid != other
+    return other
+
+
+@pytest.fixture
+async def socketio_subscriber_handlers(
+    socketio_client_factory: Callable,
+    client_session_id: UUIDStr,
+    mocker: MockerFixture,
+):
+    """socketio SUBSCRIBER
+
+    Somehow this emulates the logic of the front-end:
+    it connects to a session (client_session_id) and
+    registers two event handlers that are be called
+    when a message is received
+    """
+    # connect to websocket session
+    sio = await socketio_client_factory(client_session_id)
+
+    WEBSOCKET_LOG_EVENTNAME = "logger"
+    # called when log messages are received
+    mock_log_handler = mocker.Mock()
+    sio.on(WEBSOCKET_LOG_EVENTNAME, handler=mock_log_handler)
+
+    WEBSOCKET_NODE_UPDATE_EVENTNAME = "nodeUpdated"
+    # called when a node was updated (e.g. progress)
+    mock_node_update_handler = mocker.Mock()
+    sio.on(WEBSOCKET_NODE_UPDATE_EVENTNAME, handler=mock_node_update_handler)
+
+    return mock_log_handler, mock_node_update_handler
+
+
+@pytest.fixture
+def publish_some_messages_in_rabbit(
+    rabbit_exchange: Tuple[aio_pika.Exchange, aio_pika.Exchange],
+):
+    """rabbitMQ PUBLISHER"""
+
+    async def _do(
+        user_id: int,
+        project_id: str,
+        node_uuid: str,
+        num_messages: int,
+    ):
+        return await _publish_in_rabbit(
+            user_id, project_id, node_uuid, num_messages, rabbit_exchange
+        )
+
+    return _do
+
+
+def test_it(client, socketio_subscriber_handlers):
+    print("foo")
+    import pdb
+
+    pdb.set_trace()
+    mock_log_handler, mock_node_update_handler = socketio_subscriber_handlers
+    assert True
+
+
+# TESTS ------------------------------------------------------------------------------------
+#
+#   publisher ---> (rabbitMQ)  ---> webserver --- (socketio) ---> front-end pages
+#
+# - logs, instrumentation and progress are set to rabbitMQ messages
+# - webserver consumes these messages and forwards them to the front-end broadcasting them to socketio
+# - all front-end insteances connected to these channes will get notified when new messages are directed
+#   to them
+#
+
+POLLING_TIME = 0.2
+TIMEOUT_S = 1
+RETRY_POLICY = dict(
+    wait=wait_fixed(POLLING_TIME),
+    stop=stop_after_delay(TIMEOUT_S),
+    before_sleep=before_sleep_log(logger, log_level=logging.WARNING),
+    reraise=True,
+)
+NUMBER_OF_MESSAGES = 1
+USER_ROLES = [
+    UserRole.GUEST,
+    UserRole.USER,
+    UserRole.TESTER,
+]
+
+
+@pytest.mark.parametrize("user_role", USER_ROLES)
+async def test_publish_to_other_user(
+    other_user_id,
+    other_project_id,
+    other_node_uuid,
+    #
+    socketio_subscriber_handlers,
+    publish_some_messages_in_rabbit,
+):
+    mock_log_handler, mock_node_update_handler = socketio_subscriber_handlers
+
+    # Some other client publishes messages with wrong user id
+    await publish_some_messages_in_rabbit(
+        other_user_id,
+        other_project_id,
+        other_node_uuid,
+        NUMBER_OF_MESSAGES,
+    )
+    await sleep(TIMEOUT_S)
+
+    mock_log_handler.assert_not_called()
+    mock_node_update_handler.assert_not_called()
+
+
+@pytest.mark.parametrize("user_role", USER_ROLES)
+async def test_publish_to_user(
+    logged_user: Dict[str, Any],
+    other_project_id,
+    other_node_uuid,
+    #
+    socketio_subscriber_handlers,
+    publish_some_messages_in_rabbit,
+):
+    mock_log_handler, mock_node_update_handler = socketio_subscriber_handlers
 
     # publish messages with correct user id, but no project
-    log_messages, _, _ = await _publish_messages(
-        NUMBER_OF_MESSAGES, node_uuid, logged_user["id"], project_id, rabbit_exchange
+    log_messages, _, _ = await publish_some_messages_in_rabbit(
+        logged_user["id"],
+        other_project_id,
+        other_node_uuid,
+        NUMBER_OF_MESSAGES,
     )
 
-    def predicate() -> bool:
-        return mock_log_handler_fct.call_count == (NUMBER_OF_MESSAGES)
+    async for attempt in AsyncRetrying(**RETRY_POLICY):
+        with attempt:
+            assert mock_log_handler.call_count == (NUMBER_OF_MESSAGES)
 
-    await _wait_until(predicate, TIMEOUT_S)
     log_calls = [call(json.dumps(message)) for message in log_messages]
-    mock_log_handler_fct.assert_has_calls(log_calls, any_order=True)
-    mock_node_update_handler_fct.assert_not_called()
+    mock_log_handler.assert_has_calls(log_calls, any_order=True)
+    mock_node_update_handler.assert_not_called()
+
+
+@pytest.mark.parametrize("user_role", USER_ROLES)
+async def test_publish_about_users_project(
+    logged_user: Dict[str, Any],
+    user_project: Dict[str, Any],
+    other_node_uuid,
+    #
+    socketio_subscriber_handlers,
+    publish_some_messages_in_rabbit,
+):
+    mock_log_handler, mock_node_update_handler = socketio_subscriber_handlers
+
     # publish message with correct user id, project but not node
-    mock_log_handler_fct.reset_mock()
-    log_messages, _, _ = await _publish_messages(
-        NUMBER_OF_MESSAGES,
-        node_uuid,
+    log_messages, _, _ = await publish_some_messages_in_rabbit(
         logged_user["id"],
         user_project["uuid"],
-        rabbit_exchange,
+        other_node_uuid,
+        NUMBER_OF_MESSAGES,
     )
-    await _wait_until(predicate, TIMEOUT_S)
+
+    async for attempt in AsyncRetrying(**RETRY_POLICY):
+        with attempt:
+            assert mock_log_handler.call_count == (NUMBER_OF_MESSAGES)
+
     log_calls = [call(json.dumps(message)) for message in log_messages]
-    mock_log_handler_fct.assert_has_calls(log_calls, any_order=True)
-    mock_node_update_handler_fct.assert_not_called()
-    mock_log_handler_fct.reset_mock()
+    mock_log_handler.assert_has_calls(log_calls, any_order=True)
+    mock_node_update_handler.assert_not_called()
+
+
+@pytest.mark.parametrize("user_role", USER_ROLES)
+async def test_publish_about_users_projects_node(
+    logged_user: Dict[str, Any],
+    user_project: Dict[str, Any],
+    #
+    socketio_subscriber_handlers,
+    publish_some_messages_in_rabbit,
+):
+    mock_log_handler, mock_node_update_handler = socketio_subscriber_handlers
 
     # publish message with correct user id, project node
-    mock_log_handler_fct.reset_mock()
     node_uuid = list(user_project["workbench"])[0]
-    log_messages, _, _ = await _publish_messages(
-        NUMBER_OF_MESSAGES,
-        node_uuid,
+    log_messages, _, _ = await publish_some_messages_in_rabbit(
         logged_user["id"],
         user_project["uuid"],
-        rabbit_exchange,
+        node_uuid,
+        NUMBER_OF_MESSAGES,
     )
 
-    def predicate2() -> bool:
-        return mock_log_handler_fct.call_count == (
-            NUMBER_OF_MESSAGES
-        ) and mock_node_update_handler_fct.call_count == (NUMBER_OF_MESSAGES)
+    async for attempt in AsyncRetrying(**RETRY_POLICY):
+        with attempt:
+            assert mock_log_handler.call_count == (NUMBER_OF_MESSAGES)
+            assert mock_node_update_handler.call_count == (NUMBER_OF_MESSAGES)
 
-    await _wait_until(predicate2, TIMEOUT_S)
     log_calls = [call(json.dumps(message)) for message in log_messages]
-    mock_log_handler_fct.assert_has_calls(log_calls, any_order=True)
-    mock_node_update_handler_fct.assert_called()
-    assert mock_node_update_handler_fct.call_count == (NUMBER_OF_MESSAGES)
+    mock_log_handler.assert_has_calls(log_calls, any_order=True)
+    mock_node_update_handler.assert_called()
+    assert mock_node_update_handler.call_count == (NUMBER_OF_MESSAGES)

--- a/services/web/server/tests/integration/02/test_rabbit.py
+++ b/services/web/server/tests/integration/02/test_rabbit.py
@@ -269,15 +269,6 @@ def publish_some_messages_in_rabbit(
     return _do
 
 
-def test_it(client, socketio_subscriber_handlers):
-    print("foo")
-    import pdb
-
-    pdb.set_trace()
-    mock_log_handler, mock_node_update_handler = socketio_subscriber_handlers
-    assert True
-
-
 # TESTS ------------------------------------------------------------------------------------
 #
 #   publisher ---> (rabbitMQ)  ---> webserver --- (socketio) ---> front-end pages

--- a/services/web/server/tests/integration/conftest.py
+++ b/services/web/server/tests/integration/conftest.py
@@ -25,7 +25,7 @@ import trafaret_config
 import yaml
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers import FIXTURE_CONFIG_CORE_SERVICES_SELECTION
-from pytest_simcore.helpers.utils_docker import get_ip, get_service_published_port
+from pytest_simcore.helpers.utils_docker import get_service_published_port
 from pytest_simcore.helpers.utils_login import NewUser
 from simcore_service_webserver.application_config import app_schema
 from simcore_service_webserver.cli import create_environ
@@ -106,8 +106,8 @@ def webserver_environ(
         assert port_key in environ
 
         # to swarm boundary since webserver is installed in the host and therefore outside the swarm's network
-        published_port = get_service_published_port(name, int(environ.get(port_key)))
-        environ[host_key] = get_ip()
+        published_port = get_service_published_port(name, int(environ[port_key]))
+        environ[host_key] = "127.0.0.1"
         environ[port_key] = published_port
 
     pprint(environ)  # NOTE: displayed only if error
@@ -129,7 +129,7 @@ def _webserver_dev_config(webserver_environ: Dict, docker_stack: Dict) -> Dict:
     with app_resources.stream("config/server-docker-dev.yaml") as f:
         cfg = yaml.safe_load(f)
         # test webserver works in host
-        cfg["main"]["host"] = get_ip()
+        cfg["main"]["host"] = "127.0.0.1"
 
     with config_file_path.open("wt") as f:
         yaml.dump(cfg, f, default_flow_style=False)

--- a/services/web/server/tests/integration/conftest.py
+++ b/services/web/server/tests/integration/conftest.py
@@ -8,9 +8,9 @@
   NOTE: services/web/server/tests/conftest.py is pre-loaded
 
 """
+# pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
-# pylint: disable=bare-except
-# pylint:disable=redefined-outer-name
+# pylint: disable=unused-variable
 
 import logging
 import sys
@@ -25,7 +25,7 @@ import trafaret_config
 import yaml
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers import FIXTURE_CONFIG_CORE_SERVICES_SELECTION
-from pytest_simcore.helpers.utils_docker import get_service_published_port
+from pytest_simcore.helpers.utils_docker import get_ip, get_service_published_port
 from pytest_simcore.helpers.utils_login import NewUser
 from simcore_service_webserver.application_config import app_schema
 from simcore_service_webserver.cli import create_environ
@@ -37,7 +37,7 @@ from simcore_service_webserver.groups_api import (
 )
 from simcore_service_webserver.resources import resources as app_resources
 
-current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
+CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
 # imports the fixtures for the integration tests
 pytest_plugins = [
@@ -107,7 +107,7 @@ def webserver_environ(
 
         # to swarm boundary since webserver is installed in the host and therefore outside the swarm's network
         published_port = get_service_published_port(name, int(environ.get(port_key)))
-        environ[host_key] = "127.0.0.1"
+        environ[host_key] = get_ip()
         environ[port_key] = published_port
 
     pprint(environ)  # NOTE: displayed only if error
@@ -123,13 +123,13 @@ def _webserver_dev_config(webserver_environ: Dict, docker_stack: Dict) -> Dict:
 
     NOTE: Prefer using 'app_config' below instead of this as a function-scoped fixture
     """
-    config_file_path = current_dir / "webserver_dev_config.yaml"
+    config_file_path = CURRENT_DIR / "webserver_dev_config.ignore.yaml"
 
     # recreate config-file
     with app_resources.stream("config/server-docker-dev.yaml") as f:
         cfg = yaml.safe_load(f)
         # test webserver works in host
-        cfg["main"]["host"] = "127.0.0.1"
+        cfg["main"]["host"] = get_ip()
 
     with config_file_path.open("wt") as f:
         yaml.dump(cfg, f, default_flow_style=False)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

✅ This PR aims to fix the flaky ``services/web/server/tests/integration/02/test_rabbit.py`` test-suite and improve the CI stability.

- ♻️ split single ``test_rabbit_websocket_computation `` into smaller independent ``tests_`` cases
- ♻️ cleaned up pytest-simcore fixtures used in this test-suite
- ♻️ cleaned up some of the web-server's modules used in this test

## Related issue/s

Reviewing flaky integration tests in CI

## How to test

```
make devenv
source .venv/bin/activate
cd services/web/server
make install-dev
pytest -vv tests/integration/02/test_rabbit.py
```
