### PR TITLE
Bugfix/storage lazy update of files

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/ports_mapping.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/ports_mapping.py
@@ -18,7 +18,7 @@ class BasePortsMapping(BaseModel):
                 key = list(self.__root__.keys())[key]
         if not key in self.__root__:
             raise UnboundPortError(key)
-        assert isinstance(key, str)  # no sec
+        assert isinstance(key, str)  # nosec
         return self.__root__[key]
 
     def __iter__(self) -> Iterator[PortKey]:

--- a/scripts/maintenance/check_consistency_data.py
+++ b/scripts/maintenance/check_consistency_data.py
@@ -16,7 +16,10 @@ from typing import Any, Dict, List, Set, Tuple
 import aiopg
 import typer
 from dateutil import parser
-from tenacity import after_log, retry, stop_after_attempt, wait_random
+from tenacity import retry
+from tenacity.after import after_log
+from tenacity.stop import stop_after_attempt
+from tenacity.wait import wait_random
 
 log = logging.getLogger(__name__)
 

--- a/scripts/maintenance/check_consistency_data.py
+++ b/scripts/maintenance/check_consistency_data.py
@@ -32,8 +32,8 @@ async def managed_docker_compose(
     compose_file = Path.cwd() / "consistency" / "docker-compose.yml"
     try:
         subprocess.run(
-            f"docker-compose --file {compose_file} up --detach",
-            shell=True,
+            ["docker-compose", "--file", compose_file, "up", "--detach"],
+            shell=False,
             check=True,
             cwd=compose_file.parent,
             env={**os.environ, **{"POSTGRES_DATA_VOLUME": postgres_volume_name}},
@@ -59,8 +59,8 @@ async def managed_docker_compose(
         yield
     finally:
         subprocess.run(
-            f"docker-compose --file {compose_file} down",
-            shell=True,
+            ["docker-compose", "--file", compose_file, "down"],
+            shell=False,
             check=True,
             cwd=compose_file.parent,
         )

--- a/scripts/maintenance/check_consistency_data.py
+++ b/scripts/maintenance/check_consistency_data.py
@@ -1,15 +1,6 @@
 #! /usr/bin/env python3
 
-"""Script to check consistency of the file storage backend in oSparc.
 
-
-
-    1. From an osparc database, go over all projects, get the project IDs and Node IDs
-    2. From the same database, now get all the files listed like projectID/nodeID from 1.
-    3. We get a list of files that are needed for the current projects
-    4. connect to the S3 backend, check that these files exist
-    5. generate a report with: project uuid, owner, files missing in S3
-"""
 import asyncio
 import csv
 import logging
@@ -336,6 +327,21 @@ def main(
     s3_secret: str,
     s3_bucket: str,
 ):
+    """Script to check consistency of the file storage backend in oSparc.
+
+    requirements:
+    - local docker volume containing a database from a deployment (see make import-db-from-docker-volume in /packages/postgres-database)
+
+    1. From an osparc database, go over all projects, get the project IDs and Node IDs
+
+    2. From the same database, now get all the files listed like projectID/nodeID from 1.
+
+    3. We get a list of files that are needed for the current projects
+
+    4. connect to the S3 backend, check that these files exist
+
+    5. generate a report with: project uuid, owner, files missing in S3"""
+
     asyncio.run(
         main_async(
             postgres_volume_name,

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
@@ -118,7 +118,7 @@ async def push_file_to_remote(
                     None, zfp.write, src_path, src_path.name
                 )
             logger.debug("%s created.", archive_file_path)
-            assert archive_file_path.exists()  # no sec
+            assert archive_file_path.exists()  # nosec
             file_to_upload = archive_file_path
             await log_publishing_cb(
                 f"Compression of '{src_path.name}' to '{archive_file_path.name}' complete."

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
@@ -89,7 +89,7 @@ class DaskScheduler(BaseCompScheduler):
             event.job_id
         )
 
-        assert event.state in COMPLETED_STATES  # no sec
+        assert event.state in COMPLETED_STATES  # nosec
 
         logger.info(
             "task %s completed with state: %s",
@@ -98,7 +98,7 @@ class DaskScheduler(BaseCompScheduler):
         )
         if event.state == RunningState.SUCCESS:
             # we need to parse the results
-            assert event.msg  # no sec
+            assert event.msg  # nosec
             await parse_output_data(
                 self.db_engine,
                 event.job_id,

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -225,7 +225,7 @@ def done_dask_callback(
         # remove the future from the dict to remove any handle to the future, so the worker can free the memory
         task_to_future_map.pop(job_id)
         logger.debug("dispatching callback to finish task '%s'", job_id)
-        assert event_data  # no sec
+        assert event_data  # nosec
         try:
             asyncio.run_coroutine_threadsafe(user_callback(event_data), main_loop)
         except Exception:  # pylint: disable=broad-except

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -154,7 +154,7 @@ class DataStorageManager:  # pylint: disable=too-many-public-methods
     app: Optional[web.Application] = None
 
     def _create_aiobotocore_client_context(self) -> ClientCreatorContext:
-        assert hasattr(self.session, "create_client")
+        assert hasattr(self.session, "create_client")  # nosec
         # pylint: disable=no-member
 
         # SEE API in https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html
@@ -289,9 +289,9 @@ class DataStorageManager:  # pylint: disable=too-many-public-methods
 
         elif location == DATCORE_STR:
             api_token, api_secret = self._get_datcore_tokens(user_id)
-            assert self.app  # no sec
-            assert api_secret  # no sec
-            assert api_token  # no sec
+            assert self.app  # nosec
+            assert api_secret  # nosec
+            assert api_token  # nosec
             return await datcore_adapter.list_all_datasets_files_metadatas(
                 self.app, api_token, api_secret
             )
@@ -334,9 +334,9 @@ class DataStorageManager:  # pylint: disable=too-many-public-methods
         elif location == DATCORE_STR:
             api_token, api_secret = self._get_datcore_tokens(user_id)
             # lists all the files inside the dataset
-            assert self.app  # no sec
-            assert api_secret  # no sec
-            assert api_token  # no sec
+            assert self.app  # nosec
+            assert api_secret  # nosec
+            assert api_token  # nosec
             return await datcore_adapter.list_all_files_metadatas_in_dataset(
                 self.app, api_token, api_secret, dataset_id
             )
@@ -375,9 +375,9 @@ class DataStorageManager:  # pylint: disable=too-many-public-methods
 
         elif location == DATCORE_STR:
             api_token, api_secret = self._get_datcore_tokens(user_id)
-            assert self.app  # no sec
-            assert api_secret  # no sec
-            assert api_token  # no sec
+            assert self.app  # nosec
+            assert api_secret  # nosec
+            assert api_token  # nosec
             return await datcore_adapter.list_datasets(self.app, api_token, api_secret)
 
         return data
@@ -584,9 +584,9 @@ class DataStorageManager:  # pylint: disable=too-many-public-methods
 
     async def download_link_datcore(self, user_id: str, file_id: str) -> URL:
         api_token, api_secret = self._get_datcore_tokens(user_id)
-        assert self.app  # no sec
-        assert api_secret  # no sec
-        assert api_token  # no sec
+        assert self.app  # nosec
+        assert api_secret  # nosec
+        assert api_token  # nosec
         return await datcore_adapter.get_file_download_presigned_link(
             self.app, api_token, api_secret, file_id
         )
@@ -942,9 +942,9 @@ class DataStorageManager:  # pylint: disable=too-many-public-methods
         elif location == DATCORE_STR:
             # FIXME: review return inconsistencies
             api_token, api_secret = self._get_datcore_tokens(user_id)
-            assert self.app  # no sec
-            assert api_secret  # no sec
-            assert api_token  # no sec
+            assert self.app  # nosec
+            assert api_secret  # nosec
+            assert api_token  # nosec
             await datcore_adapter.delete_file(
                 self.app, api_token, api_secret, file_uuid
             )

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -212,18 +212,14 @@ class DataStorageManager:  # pylint: disable=too-many-public-methods
                 accesible_projects_ids = await get_readable_project_ids(
                     conn, int(user_id)
                 )
-                has_read_access = (
+                where_statement = (
                     file_meta_data.c.user_id == user_id
                 ) | file_meta_data.c.project_id.in_(accesible_projects_ids)
                 if uuid_filter:
-                    accesible_projects_ids = list(
-                        filter(
-                            lambda p_id: uuid_filter in f"{p_id}",
-                            accesible_projects_ids,
-                        )
+                    where_statement &= file_meta_data.c.file_uuid.ilike(
+                        f"%{uuid_filter}%"
                     )
-
-                query = sa.select([file_meta_data]).where(has_read_access)
+                query = sa.select([file_meta_data]).where(where_statement)
 
                 async for row in conn.execute(query):
                     dex = to_meta_data_extended(row)

--- a/services/storage/src/simcore_service_storage/models.py
+++ b/services/storage/src/simcore_service_storage/models.py
@@ -2,6 +2,7 @@
 
 """
 import datetime
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Tuple, Union
 from uuid import UUID
@@ -48,7 +49,7 @@ def get_location_from_id(location_id: Union[str, int]) -> str:
         return UNDEFINED_LOCATION_TAG
 
 
-@attr.s(auto_attribs=True)
+@dataclass
 class DatasetMetaData:
     dataset_id: str = ""
     display_name: str = ""
@@ -155,7 +156,7 @@ attr.s(
 )(FileMetaData)
 
 
-@attr.s(auto_attribs=True)
+@dataclass
 class FileMetaDataEx:
     """Extend the base type by some additional attributes that shall not end up in the db"""
 

--- a/services/storage/src/simcore_service_storage/s3wrapper/s3_client.py
+++ b/services/storage/src/simcore_service_storage/s3wrapper/s3_client.py
@@ -114,7 +114,7 @@ class MinioClientWrapper:
     def get_metadata(self, bucket_name, object_name):
         try:
             obj = self._minio.stat_object(bucket_name, object_name)
-            assert obj.metadata  # no sec
+            assert obj.metadata  # nosec
             return dict(obj.metadata)
 
         except MinioException:

--- a/services/storage/src/simcore_service_storage/s3wrapper/s3_client.py
+++ b/services/storage/src/simcore_service_storage/s3wrapper/s3_client.py
@@ -2,7 +2,6 @@
 # SEE https://docs.min.io/docs/python-client-api-reference.html
 #
 import logging
-import re
 from datetime import timedelta
 from typing import Iterator, List, Optional
 
@@ -78,14 +77,6 @@ class MinioClientWrapper:
 
         return False
 
-    def list_buckets(self):
-        try:
-            return self._minio.list_buckets()
-        except MinioException:
-            logging.exception("Could not list bucket")
-
-        return []
-
     def upload_file(self, bucket_name, object_name, filepath, metadata=None):
         """Note
 
@@ -123,12 +114,8 @@ class MinioClientWrapper:
     def get_metadata(self, bucket_name, object_name):
         try:
             obj = self._minio.stat_object(bucket_name, object_name)
-            _metadata = obj.metadata
-            metadata = {}
-            for key in _metadata.keys():
-                _key = key[len(self.__metadata_prefix) :]
-                metadata[_key] = _metadata[key]
-            return metadata
+            assert obj.metadata  # no sec
+            return dict(obj.metadata)
 
         except MinioException:
             logging.exception("Could not get metadata")
@@ -177,28 +164,6 @@ class MinioClientWrapper:
             logging.exception("Could check object for existence")
             return False
         return False
-
-    def search(self, bucket_name, query, recursive=True, include_metadata=False):
-        results = []
-
-        _query = re.compile(query, re.IGNORECASE)
-
-        for obj in self.list_objects(bucket_name, recursive=recursive):
-            if _query.search(obj.object_name):
-                results.append(obj)
-            if include_metadata:
-                metadata = self.get_metadata(bucket_name, obj.object_name)
-                for key in metadata.keys():
-                    if _query.search(key) or _query.search(metadata[key]):
-                        results.append(obj)
-
-        for r in results:
-            msg = "Object {} in bucket {} matches query {}".format(
-                r.object_name, r.bucket_name, query
-            )
-            log.debug(msg)
-
-        return results
 
     def create_presigned_put_url(self, bucket_name, object_name, dt=timedelta(days=3)):
         try:

--- a/services/storage/src/simcore_service_storage/utils.py
+++ b/services/storage/src/simcore_service_storage/utils.py
@@ -9,7 +9,10 @@ import aiofiles
 import tenacity
 from aiohttp import ClientSession
 from aiohttp.typedefs import StrOrURL
+from aiopg.sa.result import ResultProxy, RowProxy
 from yarl import URL
+
+from .models import FileMetaData, FileMetaDataEx
 
 logger = logging.getLogger(__name__)
 
@@ -92,3 +95,13 @@ def create_reverse_dns(*resource_name_parts) -> str:
 def create_resource_uuid(*resource_name_parts) -> UUID:
     revers_dns = create_reverse_dns(*resource_name_parts)
     return uuid.uuid5(uuid.NAMESPACE_DNS, revers_dns)
+
+
+def to_meta_data_extended(row: Union[ResultProxy, RowProxy]) -> FileMetaDataEx:
+    assert row
+    meta = FileMetaData(**dict(row))  # type: ignore
+    meta_extended = FileMetaDataEx(
+        fmd=meta,
+        parent_id=str(Path(meta.object_name).parent),
+    )  # type: ignore
+    return meta_extended

--- a/services/storage/src/simcore_service_storage/utils.py
+++ b/services/storage/src/simcore_service_storage/utils.py
@@ -105,3 +105,11 @@ def to_meta_data_extended(row: Union[ResultProxy, RowProxy]) -> FileMetaDataEx:
         parent_id=str(Path(meta.object_name).parent),
     )  # type: ignore
     return meta_extended
+
+
+def is_file_entry_valid(file_metadata: FileMetaData) -> bool:
+    return (
+        file_metadata.entity_tag is not None
+        and file_metadata.file_size is not None
+        and file_metadata.file_size > 0
+    )

--- a/services/storage/src/simcore_service_storage/utils.py
+++ b/services/storage/src/simcore_service_storage/utils.py
@@ -98,7 +98,7 @@ def create_resource_uuid(*resource_name_parts) -> UUID:
 
 
 def to_meta_data_extended(row: Union[ResultProxy, RowProxy]) -> FileMetaDataEx:
-    assert row
+    assert row  # nosec
     meta = FileMetaData(**dict(row))  # type: ignore
     meta_extended = FileMetaDataEx(
         fmd=meta,

--- a/services/storage/tests/docker-compose.yml
+++ b/services/storage/tests/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     #   - net.ipv4.tcp_keepalive_time=600
     command: postgres -c tcp_keepalives_idle=600 -c tcp_keepalives_interval=600 -c tcp_keepalives_count=5
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2020-05-16T01-33-21Z
     environment:
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:-12345678}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-12345678}

--- a/services/storage/tests/unit/s3wrapper/test_s3_client.py
+++ b/services/storage/tests/unit/s3wrapper/test_s3_client.py
@@ -141,37 +141,6 @@ def test_sub_folders(s3_client, bucket, text_files_factory):
         counter += 1
 
 
-def test_search(s3_client, bucket, text_files_factory):
-    metadata = [{"User": "alpha"}, {"User": "beta"}, {"User": "gamma"}]
-
-    for i in range(3):
-        bucket_sub_folder = "Folder" + str(i + 1)
-
-        filepaths = text_files_factory(3)
-        counter = 0
-        for f in filepaths:
-            object_name = bucket_sub_folder + "/" + "Data" + str(counter)
-            assert s3_client.upload_file(
-                bucket, object_name, f, metadata=metadata[counter]
-            )
-            counter += 1
-
-    query = "DATA1"
-    results = s3_client.search(bucket, query, recursive=False, include_metadata=False)
-    assert not results
-
-    results = s3_client.search(bucket, query, recursive=True, include_metadata=False)
-    assert len(results) == 3
-
-    query = "alpha"
-    results = s3_client.search(bucket, query, recursive=True, include_metadata=True)
-    assert len(results) == 3
-
-    query = "dat*"
-    results = s3_client.search(bucket, query, recursive=True, include_metadata=False)
-    assert len(results) == 9
-
-
 def test_presigned_put(s3_client, bucket, text_files_factory):
     filepath = text_files_factory(1)[0]
     object_name = "my_file"

--- a/services/storage/tests/unit/s3wrapper/test_s3_client.py
+++ b/services/storage/tests/unit/s3wrapper/test_s3_client.py
@@ -126,9 +126,9 @@ def test_file_upload_meta_data(s3_client, bucket, text_files_factory):
 
     metadata2 = s3_client.get_metadata(bucket, object_name)
 
-    assert metadata2["user"] == "guidon"
-    assert metadata2["node_id"] == str(_id)
-    assert metadata2["boom-boom"] == str(42.0)
+    assert metadata2["X-Amz-Meta-User"] == "guidon"
+    assert metadata2["X-Amz-Meta-Node_id"] == str(_id)
+    assert metadata2["X-Amz-Meta-Boom-Boom"] == str(42.0)
 
 
 def test_sub_folders(s3_client, bucket, text_files_factory):

--- a/services/storage/tests/unit/test_dsm.py
+++ b/services/storage/tests/unit/test_dsm.py
@@ -9,16 +9,13 @@
 import copy
 import datetime
 import filecmp
-import io
-import json
 import os
-import urllib
+import urllib.request
 import uuid
 from pathlib import Path
 from shutil import copyfile
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-import attr
 import pytest
 import tests.utils
 from simcore_service_storage.access_layer import InvalidFileIdentifier
@@ -29,11 +26,9 @@ from simcore_service_storage.s3wrapper.s3_client import MinioClientWrapper
 from tests.utils import BUCKET_NAME, USER_ID, has_datcore_tokens
 
 
-def test_mockup(dsm_mockup_db):
-    assert len(dsm_mockup_db) == 100
-
-
-async def test_dsm_s3(dsm_mockup_db, dsm_fixture):
+async def test_dsm_s3(
+    dsm_mockup_db: Dict[str, FileMetaData], dsm_fixture: DataStorageManager
+):
     id_name_map = {}
     id_file_count = {}
     for d in dsm_mockup_db.keys():
@@ -46,25 +41,15 @@ async def test_dsm_s3(dsm_mockup_db, dsm_fixture):
 
     dsm = dsm_fixture
 
-    data_as_dict = []
-    write_data = False
     # list files for every user
     for _id in id_file_count:
         data = await dsm.list_files(user_id=_id, location=SIMCORE_S3_STR)
         assert len(data) == id_file_count[_id]
-        if write_data:
-            for dx in data:
-                d = dx.fmd
-                data_as_dict.append(attr.asdict(d))
-
-    if write_data:
-        with open("example.json", "w") as _f:
-            json.dump(data_as_dict, _f)
 
     # Get files from bob from the project biology
     bob_id = 0
-    for _id in id_name_map.keys():
-        if id_name_map[_id] == "bob":
+    for _id, _name in id_name_map.items():
+        if _name == "bob":
             bob_id = _id
             break
     assert not bob_id == 0
@@ -111,14 +96,14 @@ async def test_dsm_s3(dsm_mockup_db, dsm_fixture):
 
 
 def _create_file_meta_for_s3(
-    postgres_url: str, s3_client: MinioClientWrapper, tmp_file: str
+    postgres_url: str, s3_client: MinioClientWrapper, tmp_file: Path
 ) -> FileMetaData:
 
     bucket_name = BUCKET_NAME
     s3_client.create_bucket(bucket_name, delete_contents_if_exists=True)
 
     # create file and upload
-    filename = os.path.basename(tmp_file)
+    filename = tmp_file.name
     project_id = "api"  # "357879cc-f65d-48b2-ad6c-074e2b9aa1c7"
     project_name = "battlestar"
     node_name = "galactica"
@@ -127,7 +112,7 @@ def _create_file_meta_for_s3(
     file_uuid = os.path.join(str(project_id), str(node_id), str(file_name))
     display_name = os.path.join(str(project_name), str(node_name), str(file_name))
     created_at = str(datetime.datetime.now())
-    file_size = Path(tmp_file).stat().st_size
+    file_size = tmp_file.stat().st_size
 
     d = {
         "object_name": os.path.join(str(project_id), str(node_id), str(file_name)),
@@ -173,7 +158,7 @@ async def _upload_file(
 async def test_update_metadata_from_storage(
     postgres_service_url: str,
     s3_client: MinioClientWrapper,
-    mock_files_factory: Callable[[int], List[str]],
+    mock_files_factory: Callable[[int], List[Path]],
     dsm_fixture: DataStorageManager,
 ):
     tmp_file = mock_files_factory(1)[0]
@@ -183,21 +168,21 @@ async def test_update_metadata_from_storage(
     fmd = await _upload_file(dsm_fixture, fmd, Path(tmp_file))
 
     assert (
-        await dsm_fixture.update_database_from_storage(  # pylint: disable=protected-access
+        await dsm_fixture.try_update_database_from_storage(  # pylint: disable=protected-access
             "some_fake_uuid", fmd.bucket_name, fmd.object_name
         )
         is None
     )
 
     assert (
-        await dsm_fixture.update_database_from_storage(  # pylint: disable=protected-access
+        await dsm_fixture.try_update_database_from_storage(  # pylint: disable=protected-access
             fmd.file_uuid, "some_fake_bucket", fmd.object_name
         )
         is None
     )
 
     assert (
-        await dsm_fixture.update_database_from_storage(  # pylint: disable=protected-access
+        await dsm_fixture.try_update_database_from_storage(  # pylint: disable=protected-access
             fmd.file_uuid, fmd.bucket_name, "some_fake_object"
         )
         is None
@@ -205,7 +190,7 @@ async def test_update_metadata_from_storage(
 
     file_metadata: Optional[
         FileMetaDataEx
-    ] = await dsm_fixture.update_database_from_storage(  # pylint: disable=protected-access
+    ] = await dsm_fixture.try_update_database_from_storage(  # pylint: disable=protected-access
         fmd.file_uuid, fmd.bucket_name, fmd.object_name
     )
     assert file_metadata is not None
@@ -216,7 +201,7 @@ async def test_update_metadata_from_storage(
 async def test_links_s3(
     postgres_service_url: str,
     s3_client: MinioClientWrapper,
-    mock_files_factory: Callable[[int], List[str]],
+    mock_files_factory: Callable[[int], List[Path]],
     dsm_fixture: DataStorageManager,
 ):
 
@@ -267,7 +252,7 @@ async def test_links_s3(
                     field.name
                 ), f"{field.name}: expected {fmd.__getattribute__(field.name)} vs {file_metadata.fmd.__getattribute__(field.name)}"
 
-    tmp_file2 = tmp_file + ".rec"
+    tmp_file2 = f"{tmp_file}.rec"
     user_id = 0
     down_url = await dsm.download_link_s3(fmd.file_uuid, user_id)
 
@@ -277,7 +262,10 @@ async def test_links_s3(
 
 
 async def test_copy_s3_s3(
-    postgres_service_url, s3_client, mock_files_factory, dsm_fixture
+    postgres_service_url: str,
+    s3_client: MinioClientWrapper,
+    mock_files_factory: Callable[[int], List[Path]],
+    dsm_fixture: DataStorageManager,
 ):
 
     tmp_file = mock_files_factory(1)[0]
@@ -289,7 +277,7 @@ async def test_copy_s3_s3(
 
     # upload the file
     up_url = await dsm.upload_link(fmd.user_id, fmd.file_uuid)
-    with io.open(tmp_file, "rb") as fp:
+    with tmp_file.open("rb") as fp:
         d = fp.read()
         req = urllib.request.Request(up_url, data=d, method="PUT")
         with urllib.request.urlopen(req) as _f:
@@ -350,11 +338,11 @@ async def test_dsm_datcore(
 
 @pytest.mark.skipif(not has_datcore_tokens(), reason="no datcore tokens")
 async def test_dsm_s3_to_datcore(
-    postgres_service_url,
-    s3_client,
-    mock_files_factory,
-    dsm_fixture,
-    datcore_structured_testbucket,
+    postgres_service_url: str,
+    s3_client: MinioClientWrapper,
+    mock_files_factory: Callable[[int], List[Path]],
+    dsm_fixture: DataStorageManager,
+    datcore_structured_testbucket: str,
 ):
     tmp_file = mock_files_factory(1)[0]
 
@@ -363,14 +351,14 @@ async def test_dsm_s3_to_datcore(
     dsm = dsm_fixture
 
     up_url = await dsm.upload_link(fmd.user_id, fmd.file_uuid)
-    with io.open(tmp_file, "rb") as fp:
+    with tmp_file.open("rb") as fp:
         d = fp.read()
         req = urllib.request.Request(up_url, data=d, method="PUT")
         with urllib.request.urlopen(req) as _f:
             pass
 
     # given the fmd, upload to datcore
-    tmp_file2 = tmp_file + ".fordatcore"
+    tmp_file2 = f"{tmp_file}.fordatcore"
     user_id = USER_ID
     down_url = await dsm.download_link_s3(fmd.file_uuid)
     urllib.request.urlretrieve(down_url, tmp_file2)
@@ -402,7 +390,10 @@ async def test_dsm_s3_to_datcore(
 
 @pytest.mark.skipif(not has_datcore_tokens(), reason="no datcore tokens")
 async def test_dsm_datcore_to_local(
-    postgres_service_url, dsm_fixture, mock_files_factory, datcore_structured_testbucket
+    postgres_service_url,
+    dsm_fixture: DataStorageManager,
+    mock_files_factory: Callable[[int], List[Path]],
+    datcore_structured_testbucket,
 ):
 
     dsm = dsm_fixture
@@ -417,7 +408,7 @@ async def test_dsm_datcore_to_local(
     )
 
     tmp_file = mock_files_factory(1)[0]
-    tmp_file2 = tmp_file + ".fromdatcore"
+    tmp_file2 = f"{tmp_file}.fromdatcore"
 
     urllib.request.urlretrieve(url, tmp_file2)
 
@@ -426,11 +417,11 @@ async def test_dsm_datcore_to_local(
 
 @pytest.mark.skipif(not has_datcore_tokens(), reason="no datcore tokens")
 async def test_dsm_datcore_to_S3(
-    postgres_service_url,
-    s3_client,
-    dsm_fixture,
-    mock_files_factory,
-    datcore_structured_testbucket,
+    postgres_service_url: str,
+    s3_client: MinioClientWrapper,
+    dsm_fixture: DataStorageManager,
+    mock_files_factory: Callable[[int], List[Path]],
+    datcore_structured_testbucket: str,
 ):
     # create temporary file
     tmp_file = mock_files_factory(1)[0]
@@ -461,14 +452,14 @@ async def test_dsm_datcore_to_S3(
     assert len(s3_data) == 1
 
     # now download the original file
-    tmp_file1 = tmp_file + ".fromdatcore"
+    tmp_file1 = f"{tmp_file}.fromdatcore"
     down_url_dc, filename = await dsm.download_link_datcore(
         user_id, datcore_structured_testbucket["file_id1"]
     )
     urllib.request.urlretrieve(down_url_dc, tmp_file1)
 
     # and the one on s3
-    tmp_file2 = tmp_file + ".fromS3"
+    tmp_file2 = f"{tmp_file}.fromS3"
     down_url_s3 = await dsm.download_link_s3(dest_uuid)
     urllib.request.urlretrieve(down_url_s3, tmp_file2)
 
@@ -477,11 +468,11 @@ async def test_dsm_datcore_to_S3(
 
 @pytest.mark.skipif(not has_datcore_tokens(), reason="no datcore tokens")
 async def test_copy_datcore(
-    postgres_service_url,
-    s3_client,
-    dsm_fixture,
-    mock_files_factory,
-    datcore_structured_testbucket,
+    postgres_service_url: str,
+    s3_client: MinioClientWrapper,
+    dsm_fixture: DataStorageManager,
+    mock_files_factory: Callable[[int], List[Path]],
+    datcore_structured_testbucket: str,
 ):
     # the fixture should provide 3 files
     dsm = dsm_fixture
@@ -496,7 +487,7 @@ async def test_copy_datcore(
     fmd = _create_file_meta_for_s3(postgres_service_url, s3_client, tmp_file)
 
     up_url = await dsm.upload_link(fmd.user_id, fmd.file_uuid)
-    with io.open(tmp_file, "rb") as fp:
+    with tmp_file.open("rb") as fp:
         d = fp.read()
         req = urllib.request.Request(up_url, data=d, method="PUT")
         with urllib.request.urlopen(req) as _f:
@@ -548,7 +539,10 @@ def test_fmd_build():
     assert fmd.bucket_name == "test-bucket"
 
 
-async def test_dsm_complete_db(dsm_fixture, dsm_mockup_complete_db):
+async def test_dsm_complete_db(
+    dsm_fixture: DataStorageManager,
+    dsm_mockup_complete_db: Tuple[Dict[str, str], Dict[str, str]],
+):
     dsm = dsm_fixture
     _id = "21"
     dsm.has_project_db = True
@@ -563,7 +557,10 @@ async def test_dsm_complete_db(dsm_fixture, dsm_mockup_complete_db):
         assert d.raw_file_path
 
 
-async def test_delete_data_folders(dsm_fixture, dsm_mockup_complete_db):
+async def test_delete_data_folders(
+    dsm_fixture: DataStorageManager,
+    dsm_mockup_complete_db: Tuple[Dict[str, str], Dict[str, str]],
+):
     file_1, file_2 = dsm_mockup_complete_db
     _id = "21"
     data = await dsm_fixture.list_files(user_id=_id, location=SIMCORE_S3_STR)
@@ -733,14 +730,19 @@ async def test_sync_table_meta_data(
 
 
 @pytest.mark.skipif(not has_datcore_tokens(), reason="no datcore tokens")
-async def test_dsm_list_datasets_datcore(dsm_fixture, datcore_structured_testbucket):
+async def test_dsm_list_datasets_datcore(
+    dsm_fixture: DataStorageManager, datcore_structured_testbucket: str
+):
     datasets = await dsm_fixture.list_datasets(user_id=USER_ID, location=DATCORE_STR)
 
     assert len(datasets)
     assert any(BUCKET_NAME in d.display_name for d in datasets)
 
 
-async def test_dsm_list_dataset_files_s3(dsm_fixture, dsm_mockup_complete_db):
+async def test_dsm_list_dataset_files_s3(
+    dsm_fixture: DataStorageManager,
+    dsm_mockup_complete_db: Tuple[Dict[str, str], Dict[str, str]],
+):
     dsm_fixture.has_project_db = True
 
     datasets = await dsm_fixture.list_datasets(user_id="21", location=SIMCORE_S3_STR)
@@ -771,7 +773,7 @@ async def test_dsm_list_dataset_files_s3(dsm_fixture, dsm_mockup_complete_db):
 
 @pytest.mark.skipif(not has_datcore_tokens(), reason="no datcore tokens")
 async def test_dsm_list_dataset_files_datcore(
-    dsm_fixture, datcore_structured_testbucket
+    dsm_fixture: DataStorageManager, datcore_structured_testbucket: str
 ):
     datasets = await dsm_fixture.list_datasets(user_id=USER_ID, location=DATCORE_STR)
 
@@ -789,12 +791,14 @@ async def test_dsm_list_dataset_files_datcore(
 @pytest.mark.skip(reason="develop only")
 @pytest.mark.skipif(not has_datcore_tokens(), reason="no datcore tokens")
 async def test_download_links(
-    datcore_structured_testbucket, s3_client, mock_files_factory
+    datcore_structured_testbucket: str,
+    s3_client: MinioClientWrapper,
+    mock_files_factory: Callable[[int], List[Path]],
 ):
     s3_client.create_bucket(BUCKET_NAME, delete_contents_if_exists=True)
-    _file = mock_files_factory(count=1)[0]
+    _file = mock_files_factory(1)[0]
 
-    s3_client.upload_file(BUCKET_NAME, "test.txt", _file)
+    s3_client.upload_file(BUCKET_NAME, "test.txt", f"{_file}")
     link = s3_client.create_presigned_get_url(BUCKET_NAME, "test.txt")
     print(link)
 
@@ -804,7 +808,6 @@ async def test_download_links(
     counter = 1
     for e in endings:
         file_name = "test{}.{}".format(counter, e)
-        file2 = str(Path(_file).parent / file_name)
         copyfile(_file, file_name)
         dataset_id = datcore_structured_testbucket["dataset_id"]
         file_id = await dcw.upload_file_to_id(dataset_id, file_name)

--- a/services/storage/tests/unit/test_dsm_soft_links.py
+++ b/services/storage/tests/unit/test_dsm_soft_links.py
@@ -42,6 +42,7 @@ async def output_file(
         f"{project_id}/{node_id}/filename.txt", bucket_name="master-simcore"
     )
     file.entity_tag = "df9d868b94e53d18009066ca5cd90e9f"
+    file.file_size = 12
     file.user_name = "test"
     file.user_id = str(user_id)
 

--- a/services/storage/tests/unit/test_utils.py
+++ b/services/storage/tests/unit/test_utils.py
@@ -1,7 +1,15 @@
+import random
 from pathlib import Path
+from typing import Optional
 
+import pytest
 from aiohttp import ClientSession
-from simcore_service_storage.utils import MAX_CHUNK_SIZE, download_to_file_or_raise
+from simcore_service_storage.models import FileMetaData
+from simcore_service_storage.utils import (
+    MAX_CHUNK_SIZE,
+    download_to_file_or_raise,
+    is_file_entry_valid,
+)
 
 
 async def test_download_files(tmpdir):
@@ -16,3 +24,23 @@ async def test_download_files(tmpdir):
         assert destination.exists()
         assert expected_size == total_size
         assert destination.stat().st_size == total_size
+
+
+@pytest.mark.parametrize(
+    "file_size, entity_tag, expected_validity",
+    [
+        (None, None, False),
+        (-1, None, False),
+        (0, None, False),
+        (random.randint(1, 1000000), None, False),
+        (None, "some_valid_entity_tag", False),
+        (-1, "some_valid_entity_tag", False),
+        (0, "some_valid_entity_tag", False),
+        (random.randint(1, 1000000), "some_valid_entity_tag", True),
+    ],
+)
+def test_file_entry_valid(
+    file_size: Optional[int], entity_tag: Optional[str], expected_validity: bool
+):
+    file_meta_data = FileMetaData(file_size=file_size, entity_tag=entity_tag)
+    assert is_file_entry_valid(file_meta_data) == expected_validity


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Since commit [21a15b3dba89e6214c02e7dda3d4a41d70ccbb2a](https://github.com/ITISFoundation/osparc-simcore/commit/21a15b3dba89e6214c02e7dda3d4a41d70ccbb2a) storage would lazily update its database when a file there would miss informations about its file size and/or entity tag. When this happens, it means the database is not in sync with the S3 backend.

Alas, when the frontend asks for the file of a node, this enters the in a very old part of storage micro-service that went through all the files a user may own. Therefore triggering a high load of requests to S3 to check look for files that may or may not exist. Therefore the webserver request would time out, and return an empty list of files to the frontend.

This PR changes this by making the DB request a bit more smart and filtering by the node uuid. Thus this reduce the calls to S3 by a huge amount and seems to pass the webserver time outs...

Nevertheless, I think we should clean the file_meta_data table. Since the presigned links are anyway only valid for 3 days... I guess any entry in the file_meta_data table that is older than that should be deleted. (added to [#2396](https://github.com/ITISFoundation/osparc-simcore/issues/2396))

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
