### PR TITLE
♻️ New interfaces for webserver.director_v2 plugin

### DIFF
--- a/api/specs/webserver/openapi-services.yaml
+++ b/api/specs/webserver/openapi-services.yaml
@@ -17,7 +17,8 @@ paths:
                 force_restart:
                   type: boolean
                   default: false
-                  description: if true will force re-running all dependent nodes
+                  description: "DEPRECATED if true will force re-running all dependent nodes"
+                  deprecated: true
                 cluster_id:
                   type: integer
                   description: the computation shall use the cluster described by its id, 0 is the default cluster

--- a/packages/models-library/src/models_library/projects.py
+++ b/packages/models-library/src/models_library/projects.py
@@ -7,20 +7,22 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr, Extra, Field, HttpUrl, validator
+from pydantic import BaseModel, EmailStr, Extra, Field, HttpUrl, constr, validator
 
-from .basic_regex import DATE_RE
+from .basic_regex import DATE_RE, UUID_RE
 from .projects_access import AccessRights, GroupID
 from .projects_nodes import Node
-from .projects_nodes_io import NodeID_AsDictKey
+from .projects_nodes_io import NodeIDStr
 from .projects_state import ProjectState
 from .projects_ui import StudyUI
 
 ProjectID = UUID
+ProjectIDStr = constr(regex=UUID_RE)
+
 ClassifierID = str
 
 # TODO: for some reason class Workbench(BaseModel): __root__= does not work as I thought ... investigate!
-Workbench = Dict[NodeID_AsDictKey, Node]
+Workbench = Dict[NodeIDStr, Node]
 
 
 # NOTE: careful this is in sync with packages/postgres-database/src/simcore_postgres_database/models/projects.py!!!

--- a/packages/models-library/src/models_library/projects_nodes.py
+++ b/packages/models-library/src/models_library/projects_nodes.py
@@ -139,7 +139,6 @@ class Node(BaseModel):
     input_nodes: Optional[List[NodeID]] = Field(
         default_factory=list,
         description="node IDs of where the node is connected to",
-        examples=["nodeUuid1", "nodeUuid2"],
         alias="inputNodes",
     )
 
@@ -151,7 +150,6 @@ class Node(BaseModel):
     output_nodes: Optional[List[NodeID]] = Field(
         None,
         description="Used in group-nodes. Node IDs of those connected to the output",
-        examples=["nodeUuid1", "nodeUuid2"],
         alias="outputNodes",
     )
 
@@ -161,7 +159,11 @@ class Node(BaseModel):
     )
 
     # NOTE: use projects_ui.py
-    position: Optional[Position] = Field(None, deprecated=True)
+    position: Optional[Position] = Field(
+        None,
+        deprecated=True,
+        description="Use projects_ui.WorkbenchUI.position instead",
+    )
 
     state: Optional[NodeState] = Field(
         default_factory=NodeState, description="The node's state object"

--- a/packages/models-library/src/models_library/projects_nodes.py
+++ b/packages/models-library/src/models_library/projects_nodes.py
@@ -158,7 +158,6 @@ class Node(BaseModel):
         description="Parent's (group-nodes') node ID s. Used to group",
     )
 
-    # NOTE: use projects_ui.py
     position: Optional[Position] = Field(
         None,
         deprecated=True,

--- a/packages/models-library/src/models_library/projects_nodes_io.py
+++ b/packages/models-library/src/models_library/projects_nodes_io.py
@@ -17,7 +17,7 @@ NodeID = UUID
 UUID_REGEX = (
     r"^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}$"
 )
-NodeID_AsDictKey = constr(regex=UUID_REGEX)
+NodeIDStr = constr(regex=UUID_REGEX)
 
 
 class PortLink(BaseModel):

--- a/packages/models-library/src/models_library/projects_ui.py
+++ b/packages/models-library/src/models_library/projects_ui.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional
 
 from pydantic import BaseModel, Extra, Field
 
-from .projects_nodes_io import NodeID, NodeID_AsDictKey
+from .projects_nodes_io import NodeID, NodeIDStr
 from .projects_nodes_ui import Position
 
 
@@ -25,8 +25,8 @@ class Slideshow(BaseModel):
 
 
 class StudyUI(BaseModel):
-    workbench: Optional[Dict[NodeID_AsDictKey, WorkbenchUI]] = Field(None)
-    slideshow: Optional[Dict[NodeID_AsDictKey, Slideshow]]
+    workbench: Optional[Dict[NodeIDStr, WorkbenchUI]] = Field(None)
+    slideshow: Optional[Dict[NodeIDStr, Slideshow]]
     current_node_id: Optional[NodeID] = Field(alias="currentNodeId")
 
     class Config:

--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -2,7 +2,7 @@ import functools
 import inspect
 import logging
 from enum import Enum
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Protocol
 
 from aiohttp import web
 
@@ -11,6 +11,13 @@ from .application_keys import APP_CONFIG_KEY
 log = logging.getLogger(__name__)
 
 APP_SETUP_KEY = f"{__name__ }.setup"
+
+
+class _SetupFunc(Protocol):
+    __name__: str
+
+    def __call__(self, app: web.Application, *args: Any, **kwds: Any) -> bool:
+        ...
 
 
 class ModuleCategory(Enum):
@@ -95,7 +102,7 @@ def app_module_setup(
         # if passes config_enabled, invalidates info on section
         section = None
 
-    def _decorate(setup_func: Callable):
+    def _decorate(setup_func: _SetupFunc):
 
         if "setup" not in setup_func.__name__:
             logger.warning("Rename '%s' to contain 'setup'", setup_func.__name__)

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -6013,7 +6013,8 @@ paths:
                 force_restart:
                   type: boolean
                   default: false
-                  description: if true will force re-running all dependent nodes
+                  description: DEPRECATED if true will force re-running all dependent nodes
+                  deprecated: true
                 cluster_id:
                   type: integer
                   description: 'the computation shall use the cluster described by its id, 0 is the default cluster'

--- a/services/web/server/src/simcore_service_webserver/director_v2.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2.py
@@ -9,7 +9,7 @@ from servicelib.aiohttp.rest_routing import (
 
 from . import director_v2_handlers
 from .constants import APP_OPENAPI_SPECS_KEY
-from .director_v2_abc import set_run_policy
+from .director_v2_abc import set_project_run_policy
 from .director_v2_core import DefaultRunPolicy, DirectorV2ApiClient, set_client
 from .director_v2_settings import CONFIG_SECTION_NAME, create_settings
 
@@ -27,7 +27,7 @@ def setup_director_v2(app: web.Application):
     # create settings and injects in app
     create_settings(app)
 
-    set_run_policy(app, DefaultRunPolicy())
+    set_project_run_policy(app, DefaultRunPolicy())
 
     set_client(app, DirectorV2ApiClient(app))
 

--- a/services/web/server/src/simcore_service_webserver/director_v2.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2.py
@@ -10,7 +10,7 @@ from servicelib.aiohttp.rest_routing import (
 from . import director_v2_handlers
 from .constants import APP_OPENAPI_SPECS_KEY
 from .director_v2_abc import set_project_run_policy
-from .director_v2_core import DefaultRunPolicy, DirectorV2ApiClient, set_client
+from .director_v2_core import DefaultProjectRunPolicy, DirectorV2ApiClient, set_client
 from .director_v2_settings import CONFIG_SECTION_NAME, create_settings
 
 log = logging.getLogger(__file__)
@@ -27,7 +27,7 @@ def setup_director_v2(app: web.Application):
     # create settings and injects in app
     create_settings(app)
 
-    set_project_run_policy(app, DefaultRunPolicy())
+    set_project_run_policy(app, DefaultProjectRunPolicy())
 
     set_client(app, DirectorV2ApiClient(app))
 

--- a/services/web/server/src/simcore_service_webserver/director_v2.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2.py
@@ -9,6 +9,8 @@ from servicelib.aiohttp.rest_routing import (
 
 from . import director_v2_handlers
 from .constants import APP_OPENAPI_SPECS_KEY
+from .director_v2_abc import set_run_policy
+from .director_v2_core import DefaultRunPolicy, DirectorV2ApiClient, set_client
 from .director_v2_settings import CONFIG_SECTION_NAME, create_settings
 
 log = logging.getLogger(__file__)
@@ -24,6 +26,10 @@ log = logging.getLogger(__file__)
 def setup_director_v2(app: web.Application):
     # create settings and injects in app
     create_settings(app)
+
+    set_run_policy(app, DefaultRunPolicy())
+
+    set_client(app, DirectorV2ApiClient(app))
 
     if not APP_OPENAPI_SPECS_KEY in app:
         log.warning(
@@ -41,5 +47,5 @@ def setup_director_v2(app: web.Application):
         filter(lambda o: "computation" in o[1], iter_path_operations(specs)),
         strict=True,
     )
-    # FIXME:  app.router.add_routes(director_v2_handlers.routes)
+    # TODO:  app.router.add_routes(director_v2_handlers.routes) and corresponding tests
     app.router.add_routes(routes)

--- a/services/web/server/src/simcore_service_webserver/director_v2_abc.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_abc.py
@@ -46,9 +46,9 @@ class AbstractProjectRunPolicy(ABC):
         ...
 
 
-def get_run_policy(app: web.Application) -> Optional[AbstractProjectRunPolicy]:
+def get_project_run_policy(app: web.Application) -> Optional[AbstractProjectRunPolicy]:
     return app.get(f"{__name__}.ProjectRunPolicy")
 
 
-def set_run_policy(app: web.Application, policy_obj: AbstractProjectRunPolicy):
+def set_project_run_policy(app: web.Application, policy_obj: AbstractProjectRunPolicy):
     app[f"{__name__}.ProjectRunPolicy"] = policy_obj

--- a/services/web/server/src/simcore_service_webserver/director_v2_abc.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_abc.py
@@ -5,6 +5,7 @@ from aiohttp import web
 from models_library.projects import ProjectID
 
 CommitID = int
+_APP_PROJECT_RUN_POLICY_KEY = f"{__name__}.ProjectRunPolicy"
 
 
 class AbstractProjectRunPolicy(ABC):
@@ -47,8 +48,8 @@ class AbstractProjectRunPolicy(ABC):
 
 
 def get_project_run_policy(app: web.Application) -> Optional[AbstractProjectRunPolicy]:
-    return app.get(f"{__name__}.ProjectRunPolicy")
+    return app.get(_APP_PROJECT_RUN_POLICY_KEY)
 
 
 def set_project_run_policy(app: web.Application, policy_obj: AbstractProjectRunPolicy):
-    app[f"{__name__}.ProjectRunPolicy"] = policy_obj
+    app[_APP_PROJECT_RUN_POLICY_KEY] = policy_obj

--- a/services/web/server/src/simcore_service_webserver/director_v2_abc.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_abc.py
@@ -1,0 +1,40 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional, Tuple
+
+from aiohttp import web
+from models_library.projects import ProjectID
+
+CommitID = int
+
+
+class AbstractProjectRunPolicy(ABC):
+    # pylint: disable=unused-argument
+
+    @abstractmethod
+    async def get_runnable_projects_ids(
+        self,
+        request: web.Request,
+        project_uuid: ProjectID,
+    ) -> List[ProjectID]:
+        ...
+
+    @abstractmethod
+    async def get_or_create_runnable_projects(
+        self,
+        request: web.Request,
+        project_uuid: ProjectID,
+    ) -> Tuple[List[ProjectID], List[CommitID]]:
+        """
+        Returns ids and refid of projects that can run
+        If project_uuid is a std-project, then it returns itself
+        If project_uuid is a meta-project, then it returns iterations
+        """
+        ...
+
+
+def get_run_policy(app: web.Application) -> Optional[AbstractProjectRunPolicy]:
+    return app.get(f"{__name__}.ProjectRunPolicy")
+
+
+def set_run_policy(app: web.Application, policy_obj: AbstractProjectRunPolicy):
+    app[f"{__name__}.ProjectRunPolicy"] = policy_obj

--- a/services/web/server/src/simcore_service_webserver/director_v2_abc.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_abc.py
@@ -8,6 +8,24 @@ CommitID = int
 
 
 class AbstractProjectRunPolicy(ABC):
+    """
+    Since the introduction of meta-projects, not all
+    projects can be executed "as is". E.g. a meta-project
+    with an iterator needs to be converted to a project that
+    replaces the iterator node with a concrete
+    iteration value so it can be run.
+
+    This policy class intends to fill this gap by resolving which
+    runnable/s project/s are associated to a given project (by it's project_uuid)
+
+    For instance, if project_uuid is a standard project, then it returns itself
+    but if project_uuid is a meta-project, then it returns iterations
+
+    NOTE: this abstraction is used to change the functionality of
+    the ``director_v2`` app module while keeping it decoupled from
+    higher level add-ons like the ``meta`` app module
+    """
+
     # pylint: disable=unused-argument
 
     @abstractmethod
@@ -24,11 +42,7 @@ class AbstractProjectRunPolicy(ABC):
         request: web.Request,
         project_uuid: ProjectID,
     ) -> Tuple[List[ProjectID], List[CommitID]]:
-        """
-        Returns ids and refid of projects that can run
-        If project_uuid is a std-project, then it returns itself
-        If project_uuid is a meta-project, then it returns iterations
-        """
+
         ...
 
 

--- a/services/web/server/src/simcore_service_webserver/director_v2_api.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_api.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+from .director_v2_abc import AbstractProjectRunPolicy, get_run_policy, set_run_policy
 from .director_v2_core import (
     DirectorServiceError,
     create_or_update_pipeline,
@@ -17,15 +18,18 @@ from .director_v2_core import (
 
 # director-v2 module internal API
 __all__: Tuple[str, ...] = (
+    "AbstractProjectRunPolicy",
     "create_or_update_pipeline",
     "delete_pipeline",
     "DirectorServiceError",
     "get_computation_task",
+    "get_run_policy",
     "get_service_state",
     "get_services",
     "is_healthy",
     "request_retrieve_dyn_service",
     "retrieve",
+    "set_run_policy",
     "start_service",
     "stop_service",
     "stop_services",

--- a/services/web/server/src/simcore_service_webserver/director_v2_api.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_api.py
@@ -5,7 +5,11 @@ PLEASE avoid importing from any other module to access this plugin's functionali
 
 from typing import Tuple
 
-from .director_v2_abc import AbstractProjectRunPolicy, get_run_policy, set_run_policy
+from .director_v2_abc import (
+    AbstractProjectRunPolicy,
+    get_project_run_policy,
+    set_project_run_policy,
+)
 from .director_v2_core import (
     DirectorServiceError,
     create_or_update_pipeline,
@@ -28,13 +32,13 @@ __all__: Tuple[str, ...] = (
     "delete_pipeline",
     "DirectorServiceError",
     "get_computation_task",
-    "get_run_policy",
+    "get_project_run_policy",
     "get_service_state",
     "get_services",
     "is_healthy",
     "request_retrieve_dyn_service",
     "retrieve",
-    "set_run_policy",
+    "set_project_run_policy",
     "start_service",
     "stop_service",
     "stop_services",

--- a/services/web/server/src/simcore_service_webserver/director_v2_api.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_api.py
@@ -1,3 +1,8 @@
+""" plugin API
+
+PLEASE avoid importing from any other module to access this plugin's functionality
+"""
+
 from typing import Tuple
 
 from .director_v2_abc import AbstractProjectRunPolicy, get_run_policy, set_run_policy

--- a/services/web/server/src/simcore_service_webserver/director_v2_core.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_core.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from uuid import UUID
 
 import aiohttp
@@ -8,6 +8,7 @@ from aiohttp import ClientTimeout, web
 from models_library.projects import ProjectID
 from models_library.projects_pipeline import ComputationTask
 from models_library.settings.services_common import ServicesCommonSettings
+from models_library.users import UserID
 from pydantic.types import PositiveInt
 from servicelib.logging_utils import log_decorator
 from servicelib.utils import logged_gather
@@ -16,6 +17,7 @@ from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_exponential
 from yarl import URL
 
+from .director_v2_abc import AbstractProjectRunPolicy
 from .director_v2_settings import Directorv2Settings, get_client_session, get_settings
 
 log = logging.getLogger(__file__)
@@ -46,6 +48,41 @@ class DirectorServiceError(Exception):
 
 
 # base/HELPERS ------------------------------------------------
+
+
+class DirectorV2ApiClient:
+    def __init__(self, app: web.Application) -> None:
+        self._app = app
+        self._settings: Directorv2Settings = get_settings(app)
+        self._base_url = URL(self._settings.endpoint)
+
+    async def start(self, project_id: ProjectID, user_id: UserID, **options) -> str:
+        computation_task_out = await _request_director_v2(
+            self._app,
+            "POST",
+            self._base_url / "computations",
+            expected_status=web.HTTPCreated,
+            data={"user_id": user_id, "project_id": project_id, **options},
+        )
+        assert isinstance(computation_task_out, dict)  # nosec
+        return computation_task_out["id"]
+
+    async def stop(self, project_id: ProjectID, user_id: UserID):
+        await _request_director_v2(
+            self._app,
+            "POST",
+            self._base_url / "computations" / f"{project_id}:stop",
+            expected_status=web.HTTPAccepted,
+            data={"user_id": user_id},
+        )
+
+
+def get_client(app: web.Application) -> Optional[DirectorV2ApiClient]:
+    return app.get(f"{__name__}.DirectorV2ApiClient")
+
+
+def set_client(app: web.Application, obj: DirectorV2ApiClient):
+    app[f"{__name__}.DirectorV2ApiClient"] = obj
 
 
 async def _request_director_v2(
@@ -94,7 +131,38 @@ async def _request_director_v2(
         ) from err
 
 
-# CORE FUNCTIONALITY ------------------------------------------------
+# POLICY ------------------------------------------------
+class DefaultRunPolicy(AbstractProjectRunPolicy):
+    # pylint: disable=unused-argument
+
+    async def get_runnable_projects_ids(
+        self,
+        request: web.Request,
+        project_uuid: ProjectID,
+    ) -> List[ProjectID]:
+        return [
+            project_uuid,
+        ]
+
+    async def get_or_create_runnable_projects(
+        self,
+        request: web.Request,
+        project_uuid: ProjectID,
+    ) -> Tuple[List[ProjectID], List[int]]:
+        """
+        Returns ids and refid of projects that can run
+        If project_uuid is a std-project, then it returns itself
+        If project_uuid is a meta-project, then it returns iterations
+        """
+        return (
+            [
+                project_uuid,
+            ],
+            [],
+        )
+
+
+# calls to director-v2 API ------------------------------------------------
 
 
 async def is_healthy(app: web.Application) -> bool:

--- a/services/web/server/src/simcore_service_webserver/director_v2_core.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_core.py
@@ -22,6 +22,7 @@ from .director_v2_settings import Directorv2Settings, get_client_session, get_se
 
 log = logging.getLogger(__file__)
 
+_APP_DIRECTOR_V2_CLIENT_KEY = f"{__name__}.DirectorV2ApiClient"
 
 SERVICE_HEALTH_CHECK_TIMEOUT = ClientTimeout(total=2, connect=1)  # type:ignore
 SERVICE_RETRIEVE_HTTP_TIMEOUT = ClientTimeout(
@@ -78,11 +79,11 @@ class DirectorV2ApiClient:
 
 
 def get_client(app: web.Application) -> Optional[DirectorV2ApiClient]:
-    return app.get(f"{__name__}.DirectorV2ApiClient")
+    return app.get(_APP_DIRECTOR_V2_CLIENT_KEY)
 
 
 def set_client(app: web.Application, obj: DirectorV2ApiClient):
-    app[f"{__name__}.DirectorV2ApiClient"] = obj
+    app[_APP_DIRECTOR_V2_CLIENT_KEY] = obj
 
 
 async def _request_director_v2(
@@ -132,7 +133,7 @@ async def _request_director_v2(
 
 
 # POLICY ------------------------------------------------
-class DefaultRunPolicy(AbstractProjectRunPolicy):
+class DefaultProjectRunPolicy(AbstractProjectRunPolicy):
     # pylint: disable=unused-argument
 
     async def get_runnable_projects_ids(

--- a/services/web/server/src/simcore_service_webserver/director_v2_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_handlers.py
@@ -40,13 +40,13 @@ async def start_pipeline(request: web.Request) -> web.Response:
     project_id = UUID(request.match_info["project_id"])
 
     subgraph: Set[str] = set()
-    force_restart: bool = False
+    force_restart: bool = False  # TODO: deprecate this entry
     cluster_id: NonNegativeInt = 0
 
     if request.can_read_body:
         body = await request.json()
         subgraph = body.get("subgraph", [])
-        force_restart = bool(body.get("force_restart"))
+        force_restart = bool(body.get("force_restart", force_restart))
         cluster_id = body.get("cluster_id")
 
     options = {
@@ -109,7 +109,7 @@ async def stop_pipeline(request: web.Request) -> web.Response:
     assert run_policy  # nosec
 
     user_id = UserID(request[RQT_USERID_KEY])
-    project_id = UUID(request.match_info["project_id"])
+    project_id = ProjectID(request.match_info["project_id"])
 
     try:
         project_ids: List[ProjectID] = await run_policy.get_runnable_projects_ids(

--- a/services/web/server/src/simcore_service_webserver/director_v2_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_handlers.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from typing import Any, Dict, List, Set, Tuple
-from uuid import UUID
 
 from aiohttp import web
 from models_library.projects import ProjectID

--- a/services/web/server/src/simcore_service_webserver/director_v2_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_handlers.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import List, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 from uuid import UUID
 
 from aiohttp import web
@@ -77,13 +77,15 @@ async def start_pipeline(request: web.Request) -> web.Response:
 
         assert set(_started_pipelines_ids) == set(map(str, project_ids))  # nosec
 
+        data: Dict[str, Any] = {
+            "pipeline_id": project_id,
+        }
+        # Optional
+        if project_vc_commits:
+            data["ref_ids"] = project_vc_commits
+
         return web.json_response(
-            {
-                "data": {
-                    "pipeline_id": project_id,
-                    "ref_ids": project_vc_commits,
-                }
-            },
+            {"data": data},
             status=web.HTTPCreated.status_code,
             dumps=json_dumps,
         )

--- a/services/web/server/src/simcore_service_webserver/director_v2_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_handlers.py
@@ -12,7 +12,7 @@ from servicelib.json_serialization import json_dumps
 from servicelib.logging_utils import log_decorator
 
 from ._meta import api_version_prefix as VTAG
-from .director_v2_abc import get_run_policy
+from .director_v2_abc import get_project_run_policy
 from .director_v2_core import DirectorServiceError, DirectorV2ApiClient
 from .login.decorators import RQT_USERID_KEY, login_required
 from .security_decorators import permission_required
@@ -33,11 +33,11 @@ routes = web.RouteTableDef()
 async def start_pipeline(request: web.Request) -> web.Response:
     client = DirectorV2ApiClient(request.app)
 
-    run_policy = get_run_policy(request.app)
+    run_policy = get_project_run_policy(request.app)
     assert run_policy  # nosec
 
     user_id = UserID(request[RQT_USERID_KEY])
-    project_id = UUID(request.match_info["project_id"])
+    project_id = ProjectID(request.match_info["project_id"])
 
     subgraph: Set[str] = set()
     force_restart: bool = False  # TODO: deprecate this entry
@@ -105,7 +105,7 @@ async def start_pipeline(request: web.Request) -> web.Response:
 @log_decorator(logger=log)
 async def stop_pipeline(request: web.Request) -> web.Response:
     client = DirectorV2ApiClient(request.app)
-    run_policy = get_run_policy(request.app)
+    run_policy = get_project_run_policy(request.app)
     assert run_policy  # nosec
 
     user_id = UserID(request[RQT_USERID_KEY])


### PR DESCRIPTION

## What do these changes do?

A key requirement to implement the meta modeling in PR #2556 is to avoid coupling high-level functionality, like meta-modeling implemented in its own plugin (an ``addon`` in this case), from low-level functionality like the ``director-v2`` plugin. For that reason, this PR refactors ``webserver.director_v2``'s *plugin*  introducing:
  - ``director_v2_api``: new API module to reduce coupling with other plugins 
  - ``director_v2_abc``: new abstract class to allow external consumers (e.g. metamodeling addon) to customize run policies (``AbstractProjectRunPolicy``)

It also adds some minor cleanup and doc: 
 - improves type annotations
 - Naming convention for constraint types: 
    - It is an established practice to name constraint variants of builtin types appending suffix lik ``Str`` or ``Dict`` etc . Some common examples are ``AnyStr``, ``TypedDict``, etc.   In this PR i started by renaming ``NodeID_asDictKey = constr(...)`` which a string with a regex constraint as``NodeIDStr``. 
    - **I propose** that if any new constraint type (i.e. types built with ``constr``, ``conint``, .. etc) *whose name is not obvious as is and needs change* , it should append the corresponding base built-in type ,( i.e.``Str``, ``Int``, resp)


## Related issue/s

- prerequisite for PR #2556  which implements #2392



## How to test

standard ``services/web/server`` and ``packages/models-library`` tests
