### PR TITLE
✨ Handling of staging hotfixes

### DIFF
--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -27,10 +27,15 @@ jobs:
             docker_compose_sha: 8097769d32e34314125847333593c8edb0dfc4a5b350e4839bef8c2fe8d09de7
       fail-fast: false
     env:
-      FROM_TAG_PREFIX: master-github
       TO_TAG_PREFIX: staging-github
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: set target variable
+        run: |
+          target=$(git name-rev --refs="refs/remotes/origin/*" --name-only ${GITHUB_SHA})
+          echo "TARGET=${target}" >> $GITHUB_ENV
       - name: setup docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
@@ -43,5 +48,13 @@ jobs:
         run: echo "OWNER=${GITHUB_REPOSITORY%/*}" >> $GITHUB_ENV
       - name: set git tag
         run: echo "GIT_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
-      - name: deploy
+      - if: contains(env.TARGET, 'remotes/origin/master')
+        env:
+          FROM_TAG_PREFIX: master-github
+        name: deploy from master to staging
+        run: ./ci/deploy/dockerhub-tag-version.bash
+      - if: contains(env.TARGET, 'remotes/origin/hotfix_staging_')
+        env:
+          FROM_TAG_PREFIX: hotfix-staging-github
+        name: deploy from hotfix staging to staging
         run: ./ci/deploy/dockerhub-tag-version.bash

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -2439,13 +2439,18 @@ jobs:
         run: sudo ./ci/github/helpers/setup_docker_compose.bash ${{ matrix.docker_compose }} ${{ matrix.docker_compose_sha }}
       - name: set owner variable
         run: echo "OWNER=${GITHUB_REPOSITORY%/*}" >> $GITHUB_ENV
-      - name: deploy master
-        if: github.ref == 'refs/heads/master'
+      - if: github.ref == 'refs/heads/master'
+        name: deploy master image
         env:
           TAG_PREFIX: master-github
         run: ./ci/deploy/dockerhub-deploy.bash
-      - name: deploy hotfix
-        if: contains(github.ref, 'refs/heads/hotfix_v')
+      - if: contains(github.ref, 'refs/heads/hotfix_v')
+        name: deploy release hotfix image
         env:
           TAG_PREFIX: hotfix-github
+        run: ./ci/deploy/dockerhub-deploy.bash
+      - if: contains(github.ref, 'refs/heads/hotfix_staging_')
+        name: deploy staging hotfix image
+        env:
+          TAG_PREFIX: hotfix-staging-github
         run: ./ci/deploy/dockerhub-deploy.bash

--- a/Makefile
+++ b/Makefile
@@ -616,14 +616,13 @@ endef
 _git_get_repo_orga_name = $(shell git config --get remote.origin.url | \
 							grep --perl-regexp --only-matching "((?<=git@github\.com:)|(?<=https:\/\/github\.com\/))(.*?)(?=.git)")
 
-.PHONY: .check-master-branch
-.check-master-branch:
+.PHONY: .check-on-master-branch .create_github_release_url
+.check-on-master-branch:
 	@if [ "$(_git_get_current_branch)" != "master" ]; then\
 		echo -e "\e[91mcurrent branch is not master branch."; exit 1;\
 	fi
 
-.PHONY: release-staging release-prod
-release-staging release-prod: .check-master-branch ## Helper to create a staging or production release in Github (usage: make release-staging name=sprint version=1 git_sha=optional or make release-prod version=1.2.3 git_sha=optional)
+.create_github_release_url:
 	# ensure tags are uptodate
 	@git pull --tags
 	@echo -e "\e[33mOpen the following link to create the $(if $(findstring -staging, $@),staging,production) release:";
@@ -631,10 +630,8 @@ release-staging release-prod: .check-master-branch ## Helper to create a staging
 	@echo -e "\e[33mOr open the following link to create the $(if $(findstring -staging, $@),staging,production) release and paste the logs:";
 	@echo -e "\e[32mhttps://github.com/$(_git_get_repo_orga_name)/releases/new?prerelease=$(if $(findstring -staging, $@),1,0)&target=$(_url_encoded_target)&tag=$(_url_encoded_tag)&title=$(_url_encoded_title)";
 	@echo -e "\e[34m$(_prettify_logs)"
+.PHONY: release-staging release-prod
+release-staging release-prod: .check-on-master-branch .create_github_release_url ## Helper to create a staging or production release in Github (usage: make release-staging name=sprint version=1 git_sha=optional or make release-prod version=1.2.3 git_sha=optional)
 
-.PHONY: release-hotfix
-release-hotfix: ## Helper to create a hotfix release in Github (usage: make release-hotfix version=1.2.4 git_sha=optional)
-	# ensure tags are uptodate
-	@git pull --tags
-	@echo -e "\e[33mOpen the following link to create the $(if $(findstring -staging, $@),staging,production) release:";
-	@echo -e "\e[32mhttps://github.com/$(_git_get_repo_orga_name)/releases/new?prerelease=$(if $(findstring -staging, $@),1,0)&target=$(_url_encoded_target)&tag=$(_url_encoded_tag)&title=$(_url_encoded_title)&body=$(_url_encoded_logs)";
+.PHONY: release-hotfix release-staging-hotfix
+release-hotfix release-staging-hotfix: .create_github_release_url## Helper to create a hotfix release in Github (usage: make release-hotfix version=1.2.4 git_sha=optional or make release-staging-hotfix name=Sprint version=2)

--- a/docs/releasing-workflow-instructions.md
+++ b/docs/releasing-workflow-instructions.md
@@ -156,3 +156,32 @@ make release-hotfix version=MAJ.MIN.PATCH (git_sha=OPTIONAL)
 6. The branch can be safely deleted afterwards
 
 See ![img/git-hotfix-workflow.svg](img/git-hotfix-workflow.svg)
+
+### Instructions to generate a hotfix for staging
+
+1. Generate *Github*  release tag
+
+```bash
+git clone https://github.com/ITISFoundation/osparc-simcore.git
+cd osparc-simcore
+# let's checkout the release with the issue, typically a staging tag such as staging_Meerkat1
+git checkout VERSION_TAG_FOR_HOTFIXING
+# create the hotfix branch, the name must follow the hotfix__stagingX convention, X is just a number
+git checkout -b hotfix_stagingX
+# develop the fix here, git commit, git push, have someone review your code
+
+git commit -m "this is my awsome fix for this problematic issue"
+git push --set-upstream origin/hotfix_stagingX
+
+# - NO NEED to pull request
+# - WAIT until the CI completed the its run (going through ALL the tests and generating the docker images)
+# - once ALL the images are in dockerhub, create the new version
+
+make release-staging-hotfix name=SPRINT version=VERSION (git_sha=OPTIONAL)
+```
+
+2. Adjust the list of changes if needed
+3. Press the **Publish release** button
+4. The CI will be automatically triggered and will deploy the staging release
+5. **Once the deploy was successfully done: create a PR from that branch to the master branch if it applies
+6. The branch can be safely deleted afterwards

--- a/docs/releasing-workflow-instructions.md
+++ b/docs/releasing-workflow-instructions.md
@@ -57,15 +57,15 @@ then after the review we do a couple of additions and re-release staging ``DAJIA
 
 1. Generate *Github*  release tag
 
-  ```bash
-  git clone https://github.com/ITISFoundation/osparc-simcore.git
-  cd osparc-simcore
-  make release-staging name=SPRINTNAME version=VERSION (git_sha=OPTIONAL)
-  ```
+    ```bash
+    git clone https://github.com/ITISFoundation/osparc-simcore.git
+    cd osparc-simcore
+    make release-staging name=SPRINTNAME version=VERSION (git_sha=OPTIONAL)
+    ```
+
 2. Adjust the list of changes if needed
 3. Press the **Publish release** button
 4. The CI will be automatically triggered and will deploy the staging release
-
 
 ## Release process
 
@@ -95,11 +95,11 @@ The team decides to release to production the lastest staging version of ``DAJIA
 
 1. Generate *Github*  release tag
 
-  ```bash
-  git clone https://github.com/ITISFoundation/osparc-simcore.git
-  cd osparc-simcore
-  make release-prod version=MAJ.MIN.PATCH git_sha=SHA_OF_THE_WANTED_STAGING_RELEASE
-  ```
+    ```bash
+    git clone https://github.com/ITISFoundation/osparc-simcore.git
+    cd osparc-simcore
+    make release-prod version=MAJ.MIN.PATCH git_sha=SHA_OF_THE_WANTED_STAGING_RELEASE
+    ```
 
 2. Adjust the list of changes if needed
 3. Press the **Publish release** button
@@ -130,24 +130,24 @@ A bug was found in version 1.2.0 of the simcore stack. The team decides to fix i
 
 1. Generate *Github*  release tag
 
-```bash
-git clone https://github.com/ITISFoundation/osparc-simcore.git
-cd osparc-simcore
-# let's checkout the release with the issue, typically a release tag such as v1.4.5
-git checkout VERSION_TAG_FOR_HOTFIXING
-# create the hotfix branch, the name must follow the hotfix_v* convention, what lies after v is free
-git checkout -b hotfix_v1_4_x
-# develop the fix here, git commit, git push, have someone review your code
+    ```bash
+    git clone https://github.com/ITISFoundation/osparc-simcore.git
+    cd osparc-simcore
+    # let's checkout the release with the issue, typically a release tag such as v1.4.5
+    git checkout VERSION_TAG_FOR_HOTFIXING
+    # create the hotfix branch, the name must follow the hotfix_v* convention, what lies after v is free
+    git checkout -b hotfix_v1_4_x
+    # develop the fix here, git commit, git push, have someone review your code
 
-git commit -m "this is my awsome fix for this problematic issue"
-git push --set-upstream origin/hotfix_v1_4_x
+    git commit -m "this is my awsome fix for this problematic issue"
+    git push --set-upstream origin/hotfix_v1_4_x
 
-# - NO NEED to pull request
-# - WAIT until the CI completed the its run (going through ALL the tests and generating the docker images)
-# - once ALL the images are in dockerhub, create the new version
+    # - NO NEED to pull request
+    # - WAIT until the CI completed the its run (going through ALL the tests and generating the docker images)
+    # - once ALL the images are in dockerhub, create the new version
 
-make release-hotfix version=MAJ.MIN.PATCH (git_sha=OPTIONAL)
-```
+    make release-hotfix version=MAJ.MIN.PATCH (git_sha=OPTIONAL)
+    ```
 
 2. Adjust the list of changes if needed
 3. Press the **Publish release** button
@@ -161,24 +161,23 @@ See ![img/git-hotfix-workflow.svg](img/git-hotfix-workflow.svg)
 
 1. Generate *Github*  release tag
 
-```bash
-git clone https://github.com/ITISFoundation/osparc-simcore.git
-cd osparc-simcore
-# let's checkout the release with the issue, typically a staging tag such as staging_Meerkat1
-git checkout VERSION_TAG_FOR_HOTFIXING
-# create the hotfix branch, the name must follow the hotfix__stagingX convention, X is just a number
-git checkout -b hotfix_stagingX
-# develop the fix here, git commit, git push, have someone review your code
+    ```bash
+    git clone https://github.com/ITISFoundation/osparc-simcore.git
+    cd osparc-simcore
+    # let's checkout the release with the issue, typically a staging tag such as staging_Meerkat1
+    git checkout VERSION_TAG_FOR_HOTFIXING
+    # create the hotfix branch, the name must follow the hotfix__stagingX convention, X is just a number
+    git checkout -b hotfix_stagingX
+    # develop the fix here, git commit, git push, have someone review your code
 
-git commit -m "this is my awsome fix for this problematic issue"
-git push --set-upstream origin/hotfix_stagingX
+    git commit -m "this is my awsome fix for this problematic issue"
+    git push --set-upstream origin/hotfix_stagingX
 
-# - NO NEED to pull request
-# - WAIT until the CI completed the its run (going through ALL the tests and generating the docker images)
-# - once ALL the images are in dockerhub, create the new version
-
-make release-staging-hotfix name=SPRINT version=VERSION (git_sha=OPTIONAL)
-```
+    # - NO NEED to pull request
+    # - WAIT until the CI completed the its run (going through ALL the tests and generating the docker images)
+    # - once ALL the images are in dockerhub, create the new version
+    make release-staging-hotfix name=SPRINT version=VERSION (git_sha=OPTIONAL)
+    ```
 
 2. Adjust the list of changes if needed
 3. Press the **Publish release** button


### PR DESCRIPTION


<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Adds the option to create a staging-hotfix release by following the same rules as for release-hotfixes:
- create a branch named such as staging_meerkat2
- wait for the CI to complete the normal build -> will generate images named such as webserver:hotfix-staging-github-latest and webserver:hotfix-staging-github-DATE-SHA
- if ok, then using ```make release-hotfix-staging``` creates a TAG that the github CI will pickup
- the CI will then rename the previously created images to staging-github-latest so that it gets deployed

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
