### PR TITLE
🐛 Bugfix: properly handle timeout when copying project

### DIFF
--- a/api/specs/webserver/openapi-projects.yaml
+++ b/api/specs/webserver/openapi-projects.yaml
@@ -61,6 +61,12 @@ paths:
           schema:
             type: string
           description: "Option to create a template from existing project: as_template={study_uuid}"
+        - name: copy_data
+          in: query
+          schema:
+            type: boolean
+            default: True
+          description: "Option to copy data when creating from an existing template or as a template, defaults to True"
         - name: hidden
           in: query
           schema:

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -6887,6 +6887,12 @@ paths:
           schema:
             type: string
           description: 'Option to create a template from existing project: as_template={study_uuid}'
+        - name: copy_data
+          in: query
+          schema:
+            type: boolean
+            default: true
+          description: 'Option to copy data when creating from an existing template or as a template, defaults to True'
         - name: hidden
           in: query
           schema:

--- a/services/web/server/src/simcore_service_webserver/projects/project_lock.py
+++ b/services/web/server/src/simcore_service_webserver/projects/project_lock.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 import aioredlock
 from aiohttp import web

--- a/services/web/server/src/simcore_service_webserver/projects/project_lock.py
+++ b/services/web/server/src/simcore_service_webserver/projects/project_lock.py
@@ -9,6 +9,8 @@ from simcore_service_webserver.resource_manager.redis import (
     get_redis_lock_manager_client,
 )
 
+from ..users_api import UserNameDict
+
 PROJECT_REDIS_LOCK_KEY: str = "project:{}"
 
 ProjectLock = aioredlock.Lock
@@ -20,7 +22,7 @@ async def lock_project(
     project_uuid: Union[str, ProjectID],
     status: ProjectStatus,
     user_id: int,
-    user_name: Dict[str, str],
+    user_name: UserNameDict,
 ) -> ProjectLock:
     """returns a distributed redis lock on the project defined by its UUID.
     NOTE: can be used as a context manager

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -8,6 +8,7 @@
 """
 # pylint: disable=too-many-arguments
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -70,9 +71,11 @@ def _is_node_dynamic(node_key: str) -> bool:
     return "/dynamic/" in node_key
 
 
-def validate_project(app: web.Application, project: Dict):
+async def validate_project(app: web.Application, project: Dict):
     project_schema = app[APP_JSONSCHEMA_SPECS_KEY][CONFIG_SECTION_NAME]
-    validate_instance(project, project_schema)  # TODO: handl
+    await asyncio.get_event_loop().run_in_executor(
+        None, validate_instance, project, project_schema
+    )
 
 
 async def get_project_for_user(
@@ -107,7 +110,7 @@ async def get_project_for_user(
 
     # TODO: how to handle when database has an invalid project schema???
     # Notice that db model does not include a check on project schema.
-    validate_project(app, project)
+    await validate_project(app, project)
     return project
 
 

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -769,7 +769,7 @@ async def _get_project_lock_state(
         project_uuid,
         set_user_ids,
     )
-    usernames: List[Dict[str, str]] = [
+    usernames: List[UserNameDict] = [
         await get_user_name(app, uid) for uid in set_user_ids
     ]
     # let's check if the project is opened by the same user, maybe already opened or closed in a orphaned session

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -251,6 +251,10 @@ async def lock_with_notification(
                     user_id, project_uuid, app
                 )
             yield
+            log.debug(
+                "Project [%s] lock released",
+                project_uuid,
+            )
     except ProjectLockError:
         # someone else has already the lock?
         prj_states: ProjectState = await get_project_states_for_user(

--- a/services/web/server/src/simcore_service_webserver/projects/projects_db.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_db.py
@@ -22,7 +22,7 @@ from aiopg.sa import Engine
 from aiopg.sa.connection import SAConnection
 from aiopg.sa.result import RowProxy
 from change_case import ChangeCase
-from models_library.projects import ProjectAtDB
+from models_library.projects import ProjectAtDB, ProjectIDStr
 from pydantic import ValidationError
 from pydantic.types import PositiveInt
 from servicelib.aiohttp.application_keys import APP_DB_ENGINE_KEY
@@ -816,7 +816,11 @@ class ProjectDBAPI:
             return list(result)
 
     async def update_project_without_checking_permissions(
-        self, project_data: Dict, project_uuid: str, hidden: Optional[bool] = None
+        self,
+        project_data: Dict,
+        project_uuid: ProjectIDStr,
+        *,
+        hidden: Optional[bool] = None,
     ) -> bool:
         """The garbage collector needs to alter the row without passing through the
         permissions layer."""

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -62,6 +62,7 @@ async def create_projects(
 
     template_uuid = request.query.get("from_template")
     as_template = request.query.get("as_template")
+    copy_data = request.query.get("copy_data", True)
     hidden: bool = bool(request.query.get("hidden", False))
 
     new_project = {}
@@ -94,8 +95,12 @@ async def create_projects(
                 new_project["accessRights"] = {}
             # the project is to be hidden until the data is copied
             hidden = True
-            clone_data_coro = copy_data_folders_from_project(
-                request.app, source_project, new_project, nodes_map, user_id
+            clone_data_coro = (
+                copy_data_folders_from_project(
+                    request.app, source_project, new_project, nodes_map, user_id
+                )
+                if copy_data
+                else None
             )
             # FIXME: parameterized inputs should get defaults provided by service
 

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -153,6 +153,7 @@ async def create_projects(request: web.Request):
     except asyncio.CancelledError:
         log.warning("cancelled creation of project, cleaning up")
         await projects_api.delete_project(request.app, new_project["uuid"], user_id)
+        raise
     else:
         raise web.HTTPCreated(
             text=json.dumps(new_project), content_type="application/json"

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -59,7 +59,6 @@ async def create_projects(
 ):  # pylint: disable=too-many-branches, too-many-statements
     user_id: int = request[RQT_USERID_KEY]
     db: ProjectDBAPI = request.config_dict[APP_PROJECT_DBAPI]
-
     template_uuid = request.query.get("from_template")
     as_template = request.query.get("as_template")
     copy_data: bool = bool(

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -166,16 +166,15 @@ async def create_projects(
         )
 
     except ValidationError as exc:
-        log.debug("project validation error")
         raise web.HTTPBadRequest(reason="Invalid project data") from exc
     except ProjectNotFoundError as exc:
-        log.debug("project not found error")
         raise web.HTTPNotFound(reason="Project not found") from exc
     except ProjectInvalidRightsError as exc:
-        log.debug("project invalid rights error")
         raise web.HTTPUnauthorized from exc
     except asyncio.CancelledError:
-        log.warning("cancelled creation of project, cleaning up")
+        log.warning(
+            "cancelled creation of project for user '%s', cleaning up", f"{user_id=}"
+        )
         await projects_api.delete_project(request.app, new_project["uuid"], user_id)
         raise
     else:

--- a/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
@@ -73,7 +73,7 @@ def clone_project_document(
         if "mode" in project_copy["ui"]:
             project_copy["ui"]["mode"] = project_copy["ui"]["mode"]
     if clean_output_data:
-        FIELDS_TO_DELETE = ["outputs", "progress", "runHash"]
+        FIELDS_TO_DELETE = ("outputs", "progress", "runHash")
         for node_data in project_copy.get("workbench", {}).values():
             for field in FIELDS_TO_DELETE:
                 node_data.pop(field, None)

--- a/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
@@ -73,10 +73,10 @@ def clone_project_document(
         if "mode" in project_copy["ui"]:
             project_copy["ui"]["mode"] = project_copy["ui"]["mode"]
     if clean_output_data:
+        FIELDS_TO_DELETE = ["outputs", "progress", "runHash"]
         for node_data in project_copy.get("workbench", {}).values():
-            node_data["outputs"] = {}
-            node_data["progress"] = 0
-            node_data["runHash"] = ""
+            for field in FIELDS_TO_DELETE:
+                node_data.pop(field, None)
     return project_copy, nodes_map
 
 

--- a/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from copy import deepcopy
-from typing import Any, AnyStr, Dict, List, Match, Optional, Set, Tuple
+from typing import Any, AnyStr, Dict, List, Match, Optional, Set, Tuple, Union
 from uuid import UUID, uuid1, uuid5
 
 from servicelib.decorators import safe_return
@@ -12,7 +12,10 @@ variable_pattern = re.compile(r"^{{\W*(\w+)\W*}}$")
 
 
 def clone_project_document(
-    project: Dict, *, forced_copy_project_id: Optional[UUID] = None
+    project: Dict,
+    *,
+    forced_copy_project_id: Optional[UUID] = None,
+    clean_output_data: bool = False,
 ) -> Tuple[Dict, Dict]:
     project_copy = deepcopy(project)
 
@@ -38,7 +41,7 @@ def clone_project_document(
 
     project_map = {project["uuid"]: project_copy["uuid"]}
 
-    def _replace_uuids(node):
+    def _replace_uuids(node: Union[str, List, Dict]) -> Union[str, List, Dict]:
         if isinstance(node, str):
             # NOTE: for datasets we get something like project_uuid/node_uuid/file_id
             if "/" in node:
@@ -69,6 +72,11 @@ def clone_project_document(
         )
         if "mode" in project_copy["ui"]:
             project_copy["ui"]["mode"] = project_copy["ui"]["mode"]
+    if clean_output_data:
+        for node_data in project_copy.get("workbench", {}).values():
+            node_data["outputs"] = {}
+            node_data["progress"] = 0
+            node_data["runHash"] = ""
     return project_copy, nodes_map
 
 

--- a/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
@@ -15,7 +15,7 @@ from ..db_models import GroupType
 from ..director.director_exceptions import DirectorException, ServiceNotFoundError
 from ..groups_api import get_group_from_gid
 from ..projects.projects_api import (
-    delete_project_from_db,
+    delete_project,
     get_project_for_user,
     get_workbench_node_ids_from_project_uuid,
     is_node_id_present_in_any_project_workbench,
@@ -563,7 +563,7 @@ async def remove_all_projects_for_user(app: web.Application, user_id: int) -> No
                 "The project can be removed as is not shared with write access with other users"
             )
             try:
-                await delete_project_from_db(app, project_uuid, user_id)
+                await delete_project(app, project_uuid, user_id)
             except ProjectNotFoundError:
                 logging.warning(
                     "Project '%s' not found, skipping removal", project_uuid

--- a/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
@@ -272,7 +272,12 @@ async def remove_disconnected_user_resources(
                             user_id=int(dead_key["user_id"]),
                             project_uuid=resource_value,
                             app=app,
+                            user_name={
+                                "first_name": "garbage",
+                                "last_name": "collector",
+                            },
                         )
+
                     except ProjectNotFoundError as err:
                         logger.warning(
                             (
@@ -714,7 +719,7 @@ async def replace_current_owner(
 
     # syncing back project data
     try:
-        await app[APP_PROJECT_DBAPI].update_project_without_enforcing_checks(
+        await app[APP_PROJECT_DBAPI].update_project_without_checking_permissions(
             project_data=project,
             project_uuid=project_uuid,
         )

--- a/services/web/server/src/simcore_service_webserver/users_api.py
+++ b/services/web/server/src/simcore_service_webserver/users_api.py
@@ -6,7 +6,7 @@
 
 import logging
 from collections import deque
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, TypedDict
 
 import sqlalchemy as sa
 from aiohttp import web
@@ -153,7 +153,12 @@ async def delete_user(app: web.Application, user_id: int) -> None:
     clean_auth_policy_cache(app)
 
 
-async def get_user_name(app: web.Application, user_id: int) -> Dict[str, str]:
+class UserNameDict(TypedDict):
+    first_name: str
+    last_name: str
+
+
+async def get_user_name(app: web.Application, user_id: int) -> UserNameDict:
     engine = app[APP_DB_ENGINE_KEY]
     async with engine.acquire() as conn:
         user_name = await conn.scalar(
@@ -162,7 +167,7 @@ async def get_user_name(app: web.Application, user_id: int) -> Dict[str, str]:
         if not user_name:
             raise UserNotFoundError(uid=user_id)
         parts = user_name.split(".") + [""]
-        return dict(first_name=parts[0], last_name=parts[1])
+        return UserNameDict(first_name=parts[0], last_name=parts[1])
 
 
 async def get_user(app: web.Application, user_id: int) -> Dict:

--- a/services/web/server/tests/unit/isolated/test_studies_dispatcher_core.py
+++ b/services/web/server/tests/unit/isolated/test_studies_dispatcher_core.py
@@ -56,7 +56,7 @@ def test_download_link_validators():
 
 
 @pytest.mark.parametrize("view", list_fake_file_consumers())
-def test_create_project_with_viewer(project_jsonschema, view):
+async def test_create_project_with_viewer(project_jsonschema, view):
 
     view["label"] = view.pop("display_name")
     viewer = ViewerInfo(**view)
@@ -82,7 +82,7 @@ def test_create_project_with_viewer(project_jsonschema, view):
     print(json.dumps(project_in, indent=2))
 
     # This operation is done exactly before adding to the database in projects_handlers.create_projects
-    projects_api.validate_project(
+    await projects_api.validate_project(
         app={APP_JSONSCHEMA_SPECS_KEY: {"projects": project_jsonschema}},
         project=project_in,
     )

--- a/services/web/server/tests/unit/with_dbs/02/test_access_to_studies.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_access_to_studies.py
@@ -11,7 +11,7 @@ import logging
 import re
 from copy import deepcopy
 from pprint import pprint
-from typing import Dict
+from typing import AsyncIterator, Dict
 
 import pytest
 from aiohttp import ClientResponse, ClientSession, web
@@ -24,7 +24,7 @@ from pytest_simcore.helpers.utils_projects import NewProject, delete_all_project
 from servicelib.aiohttp.rest_responses import unwrap_envelope
 from simcore_service_webserver import catalog
 from simcore_service_webserver.log import setup_logging
-from simcore_service_webserver.projects.projects_api import delete_project_from_db
+from simcore_service_webserver.projects.projects_api import delete_project
 from simcore_service_webserver.users_api import delete_user, is_user_guest
 
 SHARED_STUDY_UUID = "e2e38eee-c569-4e55-b104-70d159e49c87"
@@ -110,7 +110,7 @@ async def unpublished_project(client, fake_project):
 
 
 @pytest.fixture(autouse=True)
-async def director_v2_mock(director_v2_service_mock) -> aioresponses:
+async def director_v2_mock(director_v2_service_mock) -> AsyncIterator[aioresponses]:
     yield director_v2_service_mock
 
 
@@ -286,7 +286,7 @@ async def test_access_study_anonymously(
 
 
 @pytest.fixture
-async def auto_delete_projects(client) -> None:
+async def auto_delete_projects(client) -> AsyncIterator[None]:
     yield
     await delete_all_projects(client.app)
 
@@ -351,7 +351,7 @@ async def test_access_cookie_of_expired_user(
         assert len(projects) == 1
 
         prj_id = projects[0]["uuid"]
-        await delete_project_from_db(app, prj_id, uid)
+        await delete_project(app, prj_id, uid)
         await delete_user(app, uid)
         return uid
 

--- a/services/web/server/tests/unit/with_dbs/09/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/09/conftest.py
@@ -4,7 +4,7 @@
 # pylint: disable=unused-variable
 
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, AsyncIterable, Callable, Dict, List, Optional, Type, Union
 
 import pytest
 from aiohttp import web
@@ -151,7 +151,7 @@ async def shared_project(client, fake_project, logged_user, all_group):
 @pytest.fixture
 async def template_project(
     client, fake_project, logged_user, all_group: Dict[str, str]
-):
+) -> AsyncIterable[Dict[str, Any]]:
     project_data = deepcopy(fake_project)
     project_data["name"] = "Fake template"
     project_data["uuid"] = "d4d0eca3-d210-4db6-84f9-63670b07176b"

--- a/services/web/server/tests/unit/with_dbs/09/test_projects_cancellations.py
+++ b/services/web/server/tests/unit/with_dbs/09/test_projects_cancellations.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, List, Tuple
 from unittest import mock
 
 import pytest
-from _helpers import ExpectedResponse, standard_role_response
+from _helpers import ExpectedResponse, standard_role_response  # type: ignore
 from aiohttp.test_utils import TestClient
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.utils_assert import assert_status

--- a/services/web/server/tests/unit/with_dbs/09/test_projects_cancellations.py
+++ b/services/web/server/tests/unit/with_dbs/09/test_projects_cancellations.py
@@ -6,11 +6,9 @@ import asyncio
 from typing import Any, Callable, Dict, List, Tuple
 
 import pytest
-from _helpers import (  # type: ignore
-    ExpectedResponse,
-    MockedStorageSubsystem,
-    standard_role_response,
-)
+from _helpers import ExpectedResponse  # type: ignore
+from _helpers import MockedStorageSubsystem  # type: ignore
+from _helpers import standard_role_response  # type: ignore
 from aiohttp.test_utils import TestClient
 from pytest_simcore.helpers.utils_assert import assert_status
 from simcore_postgres_database.models.users import UserRole

--- a/services/web/server/tests/unit/with_dbs/09/test_projects_cancellations.py
+++ b/services/web/server/tests/unit/with_dbs/09/test_projects_cancellations.py
@@ -1,0 +1,81 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List
+from unittest import mock
+
+import pytest
+from _helpers import ExpectedResponse, standard_role_response
+from aiohttp.test_utils import TestClient
+from pytest_mock.plugin import MockerFixture
+from pytest_simcore.helpers.utils_assert import assert_status
+from simcore_service_webserver._meta import api_version_prefix
+
+API_PREFIX = "/" + api_version_prefix
+
+
+@dataclass
+class MockedStorageSubsystem:
+    copy_data_folders_from_project: mock.MagicMock
+    delete_data_folders_of_project: mock.MagicMock
+
+
+@pytest.fixture
+async def slow_storage_subsystem_mock(
+    loop: asyncio.AbstractEventLoop, mocker: MockerFixture
+) -> MockedStorageSubsystem:
+    # requests storage to copy data
+    async def _very_slow_copy_of_data(*args):
+        await asyncio.sleep(30)
+        return args[2]
+
+    mock = mocker.patch(
+        "simcore_service_webserver.projects.projects_handlers.copy_data_folders_from_project",
+        autospec=True,
+        side_effect=_very_slow_copy_of_data,
+    )
+
+    # requests storage to delete data
+    mock1 = mocker.patch(
+        "simcore_service_webserver.projects.projects_handlers.projects_api.delete_data_folders_of_project",
+        autospec=True,
+        return_value="",
+    )
+    return MockedStorageSubsystem(mock, mock1)
+
+
+@pytest.mark.parametrize("copy_query_param", ["from_template"])
+@pytest.mark.parametrize(*standard_role_response())
+async def test_creating_new_project_and_disconnecting_does_not_create_project(
+    client: TestClient,
+    logged_user: Dict[str, Any],
+    primary_group: Dict[str, str],
+    standard_groups: List[Dict[str, str]],
+    template_project: Dict[str, Any],
+    expected: ExpectedResponse,
+    catalog_subsystem_mock: Callable,
+    slow_storage_subsystem_mock: MockedStorageSubsystem,
+    project_db_cleaner: None,
+    copy_query_param: str,
+):
+    catalog_subsystem_mock([template_project])
+    # create a project from another and disconnect while doing this by timing out
+    # POST /v0/projects
+    create_url = client.app.router["create_projects"].url_for()
+    assert str(create_url) == f"{API_PREFIX}/projects"
+    create_url = create_url.with_query(from_template=template_project["uuid"])
+    with pytest.raises(asyncio.TimeoutError):
+        await client.post(f"{create_url}", json={}, timeout=10)
+    # now check the project was not created
+    list_url = client.app.router["list_projects"].url_for()
+    assert str(list_url) == API_PREFIX + "/projects"
+    list_url = list_url.with_query(type="user")
+    resp = await client.get(f"{list_url}")
+    data, *_ = await assert_status(
+        resp,
+        expected.ok,
+    )
+    assert not data

--- a/services/web/server/tests/unit/with_dbs/09/test_projects_cancellations.py
+++ b/services/web/server/tests/unit/with_dbs/09/test_projects_cancellations.py
@@ -184,10 +184,10 @@ async def test_creating_new_project_from_template_without_copying_data_creates_s
     project_workbench = project["workbench"]
     assert project_workbench
     assert len(project_workbench) > 0
+    EXPECTED_DELETED_FIELDS = ["outputs", "progress", "runHash"]
     for node_data in project_workbench.values():
-        assert not node_data["outputs"]
-        assert not node_data["runHash"]
-        assert not node_data["progress"]
+        for field in EXPECTED_DELETED_FIELDS:
+            assert field not in node_data
 
 
 @pytest.mark.parametrize(*standard_user_role_response())
@@ -230,7 +230,7 @@ async def test_creating_new_project_as_template_without_copying_data_creates_ske
     project_workbench = project["workbench"]
     assert project_workbench
     assert len(project_workbench) > 0
+    EXPECTED_DELETED_FIELDS = ["outputs", "progress", "runHash"]
     for node_data in project_workbench.values():
-        assert not node_data["outputs"]
-        assert not node_data["runHash"]
-        assert not node_data["progress"]
+        for field in EXPECTED_DELETED_FIELDS:
+            assert field not in node_data

--- a/services/web/server/tests/unit/with_dbs/09/test_projects_cancellations.py
+++ b/services/web/server/tests/unit/with_dbs/09/test_projects_cancellations.py
@@ -42,10 +42,13 @@ async def slow_storage_subsystem_mock(
     )
 
     # requests storage to delete data
+    async def _very_slow_deletion_of_data(*args, **kwargs):
+        await asyncio.sleep(30)
+
     mock1 = mocker.patch(
         "simcore_service_webserver.projects.projects_handlers.projects_api.delete_data_folders_of_project",
         autospec=True,
-        return_value="",
+        side_effect=_very_slow_deletion_of_data,
     )
     return MockedStorageSubsystem(mock, mock1)
 

--- a/services/web/server/tests/unit/with_dbs/10/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/10/test_resource_manager.py
@@ -30,7 +30,7 @@ from simcore_service_webserver.director_v2 import setup_director_v2
 from simcore_service_webserver.login.module_setup import setup_login
 from simcore_service_webserver.projects.module_setup import setup_projects
 from simcore_service_webserver.projects.projects_api import (
-    delete_project_from_db,
+    delete_project,
     remove_project_interactive_services,
 )
 from simcore_service_webserver.projects.projects_exceptions import ProjectNotFoundError
@@ -737,12 +737,12 @@ async def test_websocket_disconnected_remove_or_maintain_files_based_on_role(
     mocked_director_v2_api["director_v2_core.stop_service"].assert_has_calls(calls)
 
     if expect_call:
-        # make sure `delete_project_from_db` is called
+        # make sure `delete_project` is called
         storage_subsystem_mock[1].assert_called_once()
         # make sure `delete_user` is called
         # asyncpg_storage_system_mock.assert_called_once()
     else:
-        # make sure `delete_project_from_db` not called
+        # make sure `delete_project` not called
         storage_subsystem_mock[1].assert_not_called()
         # make sure `delete_user` not called
         # asyncpg_storage_system_mock.assert_not_called()
@@ -759,7 +759,7 @@ async def test_regression_removing_unexisting_user(
     # regression test for https://github.com/ITISFoundation/osparc-simcore/issues/2504
 
     # remove project
-    await delete_project_from_db(
+    await delete_project(
         app=client.server.app,
         project_uuid=empty_user_project["uuid"],
         user_id=logged_user["id"],

--- a/services/web/server/tests/unit/with_dbs/_helpers.py
+++ b/services/web/server/tests/unit/with_dbs/_helpers.py
@@ -1,8 +1,8 @@
 from collections import namedtuple
-from typing import List, Tuple
+from typing import List, NamedTuple, Tuple
+from unittest import mock
 
 from aiohttp import web
-
 from simcore_service_webserver.projects.projects_handlers import HTTPLocked
 from simcore_service_webserver.security_roles import UserRole
 
@@ -66,3 +66,8 @@ def standard_role_response() -> Tuple[str, List[Tuple[UserRole, ExpectedResponse
             ),
         ],
     )
+
+
+class MockedStorageSubsystem(NamedTuple):
+    copy_data_folders_from_project: mock.MagicMock
+    delete_project: mock.MagicMock

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -14,7 +14,7 @@ import sys
 import textwrap
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List
+from typing import Any, AsyncIterator, Callable, Dict, Iterator, List
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -26,6 +26,7 @@ import simcore_service_webserver.db_models as orm
 import simcore_service_webserver.utils
 import sqlalchemy as sa
 import trafaret_config
+from _helpers import MockedStorageSubsystem
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 from pytest_simcore.helpers.utils_login import NewUser
@@ -210,29 +211,28 @@ def computational_system_mock(mocker):
 
 
 @pytest.fixture
-async def storage_subsystem_mock(loop, mocker):
+async def storage_subsystem_mock(loop, mocker) -> MockedStorageSubsystem:
     """
     Patches client calls to storage service
 
     Patched functions are exposed within projects but call storage subsystem
     """
-    # requests storage to copy data
-    mock = mocker.patch(
-        "simcore_service_webserver.projects.projects_handlers.copy_data_folders_from_project"
-    )
 
     async def _mock_copy_data_from_project(*args):
         return args[2]
 
-    mock.side_effect = _mock_copy_data_from_project
+    mock = mocker.patch(
+        "simcore_service_webserver.projects.projects_handlers.copy_data_folders_from_project",
+        autospec=True,
+        side_effect=_mock_copy_data_from_project,
+    )
 
-    # requests storage to delete data
     async_mock = mocker.AsyncMock(return_value="")
     mock1 = mocker.patch(
-        "simcore_service_webserver.projects.projects_handlers.projects_api.delete_data_folders_of_project",
+        "simcore_service_webserver.projects.projects_handlers.projects_api.delete_project",
         side_effect=async_mock,
     )
-    return mock, mock1
+    return MockedStorageSubsystem(mock, mock1)
 
 
 @pytest.fixture
@@ -401,7 +401,9 @@ async def primary_group(client, logged_user) -> Dict[str, str]:
 
 
 @pytest.fixture
-async def standard_groups(client, logged_user: Dict) -> List[Dict[str, str]]:
+async def standard_groups(
+    client, logged_user: Dict
+) -> AsyncIterator[List[Dict[str, str]]]:
     # create a separate admin account to create some standard groups for the logged user
     sparc_group = {
         "gid": "5",  # this will be replaced

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -26,7 +26,7 @@ import simcore_service_webserver.db_models as orm
 import simcore_service_webserver.utils
 import sqlalchemy as sa
 import trafaret_config
-from _helpers import MockedStorageSubsystem
+from _helpers import MockedStorageSubsystem  # type: ignore
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 from pytest_simcore.helpers.utils_login import NewUser
@@ -229,7 +229,7 @@ async def storage_subsystem_mock(loop, mocker) -> MockedStorageSubsystem:
 
     async_mock = mocker.AsyncMock(return_value="")
     mock1 = mocker.patch(
-        "simcore_service_webserver.projects.projects_handlers.projects_api.delete_project",
+        "simcore_service_webserver.projects.projects_handlers.projects_api.delete_data_folders_of_project",
         side_effect=async_mock,
     )
     return MockedStorageSubsystem(mock, mock1)

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -15,7 +15,7 @@ import textwrap
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, AsyncIterator, Callable, Dict, Iterator, List
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import aioredis
@@ -245,7 +245,7 @@ def asyncpg_storage_system_mock(mocker):
 
 
 @pytest.fixture
-async def mocked_director_v2_api(loop, mocker):
+async def mocked_director_v2_api(loop, mocker) -> Dict[str, MagicMock]:
     mock = {}
 
     #


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
When creating a project FROM a TEMPLATE or AS a TEMPLATE FROM a Study, the webserver does the following:
1. copies the project skeleton in a new project (with new uuids for project, nodes)
2. copies the data by calling into the storage API

In case 2. fails or times-out (due to the webserver or more often due to the webbrowser timing out), the project is still listed for the user, although it is not valid and in an undefined state.

This PR aims to fix this issue by creating the new project as hidden by default UNTIL all the data was completely copied. In case of time out or of disconnection, the handler is cancelled and that cancellation is now handled. This will in turn delete the project, thus cleaning up.

As users still need something akin to copying only the skeleton an additional optional query parameter has been added to the creation project endpoint such as:
POST /projects now takes as query parameters the following:
- as_template: optional to create a template from a study
- from_template: optional to create a study from a template
- copy_data: optional (defaults to true) but can be set to false to copy only the study/template skeleton (without outputs)

Bonus:
now lock the study when creating a template

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
