### PR TITLE
Publish template with or without data

### DIFF
--- a/services/web/client/source/class/osparc/component/study/SaveAsTemplate.js
+++ b/services/web/client/source/class/osparc/component/study/SaveAsTemplate.js
@@ -25,35 +25,16 @@ qx.Class.define("osparc.component.study.SaveAsTemplate", {
   extend: qx.ui.core.Widget,
 
   /**
-   * @param studyId {String} Study Id
    * @param studyData {Object} Object containing part or the entire serialized Study Data
    */
-  construct: function(studyId, studyData) {
+  construct: function(studyData) {
     this.base(arguments);
 
     this._setLayout(new qx.ui.layout.VBox(5));
 
-    this.__studyId = studyId;
-    this.__formData = osparc.data.model.Study.deepCloneStudyObject(studyData);
+    this.__studyDataClone = osparc.data.model.Study.deepCloneStudyObject(studyData);
 
     this.__buildLayout();
-
-    this.setHeaderText(this.tr("Make Template accessible to"));
-    this.setButtonText(this.tr("Publish"));
-  },
-
-  properties: {
-    headerText: {
-      check: "String",
-      init: "",
-      event: "changeHeaderText"
-    },
-
-    buttonText: {
-      check: "String",
-      init: "",
-      event: "changeButtonText"
-    }
   },
 
   events: {
@@ -61,25 +42,28 @@ qx.Class.define("osparc.component.study.SaveAsTemplate", {
   },
 
   members: {
-    __studyId: null,
+    __studyDataClone: null,
     __shareWith: null,
-    __formData: null,
+    __copyWData: null,
 
     __buildLayout: function() {
       const shareWith = this.__shareWith = new osparc.component.permissions.ShareWith();
-      this.bind("headerText", shareWith, "legend");
+      shareWith.setLegend(this.tr("Make Template accessible to"));
       this._add(shareWith, {
         flex: 1
       });
 
+      const publishWithdData = this.__copyWData = new qx.ui.form.CheckBox(this.tr("Publish with data")).set({
+        value: true
+      });
+      this._add(publishWithdData);
+
       const shareResourceBtn = new osparc.ui.form.FetchButton().set({
+        label: this.tr("Publish"),
         allowGrowX: false,
         alignX: "right"
       });
-      this.bind("buttonText", shareResourceBtn, "label");
-      shareResourceBtn.addListener("execute", () => {
-        this.__shareResource(shareResourceBtn);
-      }, this);
+      shareResourceBtn.addListener("execute", () => this.__shareResource(shareResourceBtn), this);
       shareWith.bind("ready", shareResourceBtn, "enabled");
       this._add(shareResourceBtn);
     },
@@ -89,7 +73,7 @@ qx.Class.define("osparc.component.study.SaveAsTemplate", {
 
       const selectedGroupIDs = this.__shareWith.getSelectedGroups();
       selectedGroupIDs.forEach(gid => {
-        this.__formData["accessRights"][gid] = {
+        this.__studyDataClone["accessRights"][gid] = {
           "read": true,
           "write": false,
           "delete": false
@@ -98,9 +82,10 @@ qx.Class.define("osparc.component.study.SaveAsTemplate", {
 
       const params = {
         url: {
-          "study_id": this.__studyId
+          "study_id": this.__studyDataClone.uuid,
+          "copy_data": this.__copyWData.getValue()
         },
-        data: this.__formData
+        data: this.__studyDataClone
       };
       osparc.data.Resources.fetch("studies", "postToTemplate", params)
         .then(template => {

--- a/services/web/client/source/class/osparc/component/study/SaveAsTemplate.js
+++ b/services/web/client/source/class/osparc/component/study/SaveAsTemplate.js
@@ -48,7 +48,10 @@ qx.Class.define("osparc.component.study.SaveAsTemplate", {
 
     __buildLayout: function() {
       const shareWith = this.__shareWith = new osparc.component.permissions.ShareWith();
-      shareWith.setLegend(this.tr("Make Template accessible to"));
+      shareWith.getChildControl("legend").set({
+        label: this.tr("Make Template accessible to"),
+        font: "title-14"
+      });
       this._add(shareWith, {
         flex: 1
       });

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -669,7 +669,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     __getSaveAsTemplateMenuButton: function(studyData) {
       const saveAsTemplateButton = new qx.ui.menu.Button(this.tr("Publish as Template"));
       saveAsTemplateButton.addListener("execute", () => {
-        const saveAsTemplateView = new osparc.component.study.SaveAsTemplate(studyData.uuid, studyData);
+        const saveAsTemplateView = new osparc.component.study.SaveAsTemplate(studyData);
         const title = this.tr("Publish as Template");
         const window = osparc.ui.window.Window.popUpInWindow(saveAsTemplateView, title, 400, 300);
         saveAsTemplateView.addListener("finished", e => {

--- a/services/web/client/source/class/osparc/data/Resources.js
+++ b/services/web/client/source/class/osparc/data/Resources.js
@@ -92,7 +92,7 @@ qx.Class.define("osparc.data.Resources", {
           },
           postToTemplate: {
             method: "POST",
-            url: statics.API + "/projects?as_template={study_id}"
+            url: statics.API + "/projects?as_template={study_id}&copy_data={copy_data}"
           },
           open: {
             method: "POST",


### PR DESCRIPTION
## What do these changes do?

This PR implements the frontend part for publishing a template with or without data.

![PublishWData](https://user-images.githubusercontent.com/33152403/143474229-d21a58a4-456b-488c-9cd9-1e31d65615b1.gif)




## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
