### PR TITLE
⬆️ prune dependencies of simcore-sdk package and downstream services

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -190,7 +190,7 @@ def app_module_setup(
                 "%s %s [Elapsed: %3.1f secs]",
                 head_msg,
                 "completed" if completed else "skipped",
-                elapsed,
+                elapsed.total_seconds(),
             )
             return completed
 

--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 import logging
+from datetime import datetime
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Protocol
 
@@ -120,8 +121,13 @@ def app_module_setup(
         @functools.wraps(setup_func)
         def _wrapper(app: web.Application, *args, **kargs) -> bool:
             # pre-setup
-            logger.debug(
-                "Setting up '%s' [%s; %s] ... ", module_name, category.name, depends
+            head_msg = f"Setup of {module_name}"
+            started = datetime.now()
+            logger.info(
+                "%s (%s, %s) started ... ",
+                head_msg,
+                f"{category.name=}",
+                f"{depends}",
             )
 
             if APP_SETUP_KEY not in app:
@@ -179,8 +185,12 @@ def app_module_setup(
                 logger.warning("Skipping '%s' setup: %s", module_name, exc.reason)
                 completed = False
 
-            logger.debug(
-                "'%s' setup %s", module_name, "completed" if completed else "skipped"
+            elapsed = datetime.now() - started
+            logger.info(
+                "%s %s [Elapsed: %3.1f secs]",
+                head_msg,
+                "completed" if completed else "skipped",
+                elapsed,
             )
             return completed
 

--- a/packages/simcore-sdk/requirements/_base.in
+++ b/packages/simcore-sdk/requirements/_base.in
@@ -3,15 +3,13 @@
 #
 --constraint ../../../requirements/constraints.txt
 --requirement ../../../packages/postgres-database/requirements/_base.in
---requirement ../../../packages/postgres-database/requirements/_migration.in
 --requirement ../../../packages/service-library/requirements/_base.in
 --requirement ../../../packages/models-library/requirements/_base.in
 
 aiofiles
 aiohttp
 aiopg[sa]
-networkx
-psycopg2-binary
+
 pydantic[email]
 tenacity
 tqdm

--- a/packages/simcore-sdk/requirements/_base.in
+++ b/packages/simcore-sdk/requirements/_base.in
@@ -9,11 +9,8 @@
 aiofiles
 aiohttp
 aiopg[sa]
-
+packaging
 pydantic[email]
 tenacity
 tqdm
 trafaret-config
-
-attrs
-packaging

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -28,7 +28,6 @@ async-timeout==4.0.1
 attrs==20.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
-    #   -r requirements/_base.in
     #   aiohttp
 charset-normalizer==2.0.8
     # via aiohttp

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -20,10 +20,7 @@ aiopg==1.3.3
 aiosignal==1.2.0
     # via aiohttp
 alembic==1.7.5
-    # via
-    #   -c requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   -r requirements/../../../packages/postgres-database/requirements/_base.in
-    #   -r requirements/../../../packages/postgres-database/requirements/_migration.in
+    # via -r requirements/../../../packages/postgres-database/requirements/_base.in
 async-timeout==4.0.1
     # via
     #   aiohttp
@@ -33,18 +30,10 @@ attrs==20.3.0
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -r requirements/_base.in
     #   aiohttp
-certifi==2021.10.8
-    # via requests
 charset-normalizer==2.0.8
-    # via
-    #   aiohttp
-    #   requests
-click==8.0.3
-    # via -r requirements/../../../packages/postgres-database/requirements/_migration.in
+    # via aiohttp
 dnspython==2.1.0
     # via email-validator
-docker==5.0.3
-    # via -r requirements/../../../packages/postgres-database/requirements/_migration.in
 email-validator==1.1.3
     # via pydantic
 frozenlist==1.2.0
@@ -53,46 +42,32 @@ frozenlist==1.2.0
     #   aiosignal
 idna==2.10
     # via
-    #   -c requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   email-validator
-    #   requests
     #   yarl
 importlib-metadata==4.8.2
-    # via
-    #   -c requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   alembic
+    # via alembic
 importlib-resources==5.4.0 ; python_version < "3.9"
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   alembic
 mako==1.1.6
-    # via
-    #   -c requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   alembic
+    # via alembic
 markupsafe==2.0.1
-    # via
-    #   -c requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   mako
+    # via mako
 multidict==5.2.0
     # via
-    #   -c requirements/../../../packages/postgres-database/requirements/_base.txt
     #   aiohttp
     #   yarl
-networkx==2.6.3
-    # via -r requirements/_base.in
 packaging==21.3
     # via -r requirements/_base.in
 psycopg2-binary==2.9.2
     # via
-    #   -c requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   -r requirements/_base.in
     #   aiopg
     #   sqlalchemy
 pydantic==1.8.2
@@ -117,15 +92,10 @@ pyyaml==5.4.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   trafaret-config
-requests==2.26.0
-    # via docker
-six==1.16.0
-    # via websocket-client
 sqlalchemy==1.3.24
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -133,7 +103,6 @@ sqlalchemy==1.3.24
     #   alembic
 tenacity==8.0.1
     # via
-    #   -r requirements/../../../packages/postgres-database/requirements/_migration.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
 tqdm==4.62.3
@@ -146,25 +115,11 @@ typing-extensions==4.0.0
     # via
     #   async-timeout
     #   pydantic
-urllib3==1.26.7
-    # via
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   -r requirements/../../../packages/postgres-database/requirements/_migration.in
-    #   requests
-websocket-client==0.59.0
-    # via
-    #   -r requirements/../../../packages/postgres-database/requirements/_migration.in
-    #   docker
 yarl==1.7.2
     # via
-    #   -c requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   aiohttp
 zipp==3.6.0
     # via
-    #   -c requirements/../../../packages/postgres-database/requirements/_base.txt
     #   importlib-metadata
     #   importlib-resources

--- a/packages/simcore-sdk/requirements/_test.in
+++ b/packages/simcore-sdk/requirements/_test.in
@@ -21,13 +21,14 @@ pytest-xdist
 pytest-lazy-fixture
 
 # mockups/fixtures
-alembic
 aioresponses
-requests
+alembic
+click
 docker
-python-dotenv
 faker
 minio
+python-dotenv
+requests
 
 # tools for CI
 pylint

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -40,6 +40,8 @@ charset-normalizer==2.0.8
     #   -c requirements/_base.txt
     #   aiohttp
     #   requests
+click==8.0.3
+    # via -r requirements/_test.in
 coverage==6.1.2
     # via
     #   -r requirements/_test.in

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -33,7 +33,6 @@ attrs==20.3.0
     #   pytest
 certifi==2021.10.8
     # via
-    #   -c requirements/_base.txt
     #   minio
     #   requests
 charset-normalizer==2.0.8
@@ -49,9 +48,7 @@ coverage==6.1.2
 coveralls==3.3.1
     # via -r requirements/_test.in
 docker==5.0.3
-    # via
-    #   -c requirements/_base.txt
-    #   -r requirements/_test.in
+    # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
 execnet==1.9.0
@@ -167,15 +164,11 @@ python-dotenv==0.19.2
     # via -r requirements/_test.in
 requests==2.26.0
     # via
-    #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   coveralls
     #   docker
 six==1.16.0
-    # via
-    #   -c requirements/_base.txt
-    #   python-dateutil
-    #   websocket-client
+    # via python-dateutil
 sqlalchemy==1.3.24
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -200,13 +193,10 @@ typing-extensions==4.0.0
 urllib3==1.26.7
     # via
     #   -c requirements/../../../requirements/constraints.txt
-    #   -c requirements/_base.txt
     #   minio
     #   requests
-websocket-client==0.59.0
-    # via
-    #   -c requirements/_base.txt
-    #   docker
+websocket-client==1.2.1
+    # via docker
 wrapt==1.13.3
     # via astroid
 yarl==1.7.2

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -14,7 +14,6 @@ cfgv==3.3.1
     # via pre-commit
 click==8.0.3
     # via
-    #   -c requirements/_base.txt
     #   black
     #   pip-tools
 distlib==0.3.3
@@ -53,7 +52,6 @@ regex==2021.11.10
     # via black
 six==1.16.0
     # via
-    #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   virtualenv
 toml==0.10.2

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -14,6 +14,7 @@ cfgv==3.3.1
     # via pre-commit
 click==8.0.3
     # via
+    #   -c requirements/_test.txt
     #   black
     #   pip-tools
 distlib==0.3.3

--- a/packages/simcore-sdk/requirements/ci.txt
+++ b/packages/simcore-sdk/requirements/ci.txt
@@ -11,7 +11,7 @@
 --requirement _test.txt
 
 # installs this repo's packages
-../postgres-database/[migration]
+../postgres-database
 ../pytest-simcore/
 ../models-library/
 

--- a/packages/simcore-sdk/requirements/dev.txt
+++ b/packages/simcore-sdk/requirements/dev.txt
@@ -14,7 +14,7 @@
 # installs this repo's packages
 --editable ../pytest-simcore/
 
---editable ../postgres-database/[migration]
+--editable ../postgres-database
 --editable ../models-library/
 
 # FIXME: these dependencies should be removed

--- a/packages/simcore-sdk/setup.py
+++ b/packages/simcore-sdk/setup.py
@@ -15,7 +15,7 @@ def read_reqs(reqs_path: Path):
 
 install_requirements = read_reqs(here / "requirements" / "_base.in")
 test_requirements = read_reqs(here / "requirements" / "_test.txt") + [
-    "simcore-postgres-database[migration]",
+    "simcore-postgres-database",
     "simcore-service-library",
     "simcore-models-library",
 ]

--- a/requirements/how-to-prune-requirements.md
+++ b/requirements/how-to-prune-requirements.md
@@ -1,0 +1,40 @@
+
+# Steps to prune a library and all services downstream
+
+
+Libraries evolve and some of the dependencies are not anymore in use but remain listed in their requirements file. These are the steps to prune unused dependencies in a library and all services downstream.
+
+For the sake of simplicity, let's assume we want to prune requirements of the library ``simcore-sdk`` (it should be analogous for any other package in the repository).
+
+
+First we need to find which dependencies are not anymore used. For that we run [pipreqs](https://github.com/bndr/pipreqs) which will create a list of requirements that the target library is importing. Then, we can compare against the base requirements ``simcore-sdk/requirements/_base.in`` to figure out which have to be pruned from the list. Once the ``_base.in`` has been modified, we can full upgrade the requirements.
+
+
+1. ``pip install pipreqs``
+1. find dependencies in use: ``pipreqs packages/simcore-sdk/src/simcore_sdk`` produces a ``requirements.txt`` file
+1. compare this file with ``packages/simcore-sdk/requirements/_base.in`` and remove unused libraries.
+1. dependencies with other libraries in the repo under ``packages`` has to be reviewed manually
+1. make full upgrade of reqs : ``make touch reqs``
+
+
+At this point ``simcore-sdk``'s requirement are up-to-date. Now, we need to propagate the changes to the services and libraries that include this library. Notice that during this update, *we should not update any other dependencies other than those added by ``simcore-sdk``*.
+
+
+6. Find packages that use the library : check for ``/packages/simcore-sdk/requirements/_base.in`` in all the repo including only ``*.in`` files:
+  ```bash
+  cd osparc-simcore
+  grep --include=\*.in -rnw -e 'packages/simcore-sdk/requirements/_base.in' .
+  ```
+7. Go to those services ``requirements`` folder
+1. We want to **selectively upgrade** the dependencies pulled by the upstream library in this service. We can do that by selective upgrade each of the libraries that ``simcore-sdk`` lists. Checking ``/packages/simcore-sdk/requirements/_base.in`` , we select e.g. ``aiohttp`` and proceed with a selective upgrade using our tooling:
+```
+make touch
+make reqs upgrade=aiohttp
+```
+9. Check changes in the ``requirements`` folder. It should have only a partial upgrade
+
+
+
+----
+
+NOTE: An example can be found in PR [#2664](https://github.com/ITISFoundation/osparc-simcore/pull/2664)

--- a/services/api-server/requirements/_base.in
+++ b/services/api-server/requirements/_base.in
@@ -4,6 +4,7 @@
 # NOTE: ALL version constraints MUST be commented
 # intra-repo constraints
 --constraint ../../../requirements/constraints.txt
+--constraint ./constraints.txt
 
 # intra-repo required dependencies
 --requirement ../../../packages/models-library/requirements/_base.in

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -25,6 +25,7 @@ aiohttp==3.7.4.post0
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/./constraints.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 aiopg==1.2.1
     # via
@@ -32,10 +33,8 @@ aiopg==1.2.1
     #   -r requirements/_base.in
 alembic==1.7.4
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
 aniso8601==7.0.0
     # via graphene
 async-exit-stack==1.0.1
@@ -66,7 +65,6 @@ chardet==4.0.0
     #   requests
 click==7.1.2
     # via
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   typer
     #   uvicorn
 cryptography==3.4.7
@@ -82,12 +80,8 @@ cryptography==3.4.7
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
-decorator==4.4.2
-    # via networkx
 dnspython==2.1.0
     # via email-validator
-docker==5.0.2
-    # via -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
 email-validator==1.1.2
     # via
     #   fastapi
@@ -121,7 +115,6 @@ idna==2.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -132,9 +125,7 @@ idna==2.10
     #   rfc3986
     #   yarl
 importlib-metadata==4.8.1
-    # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   alembic
+    # via alembic
 importlib-resources==5.3.0 ; python_version < "3.9"
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -144,7 +135,6 @@ importlib-resources==5.3.0 ; python_version < "3.9"
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -168,21 +158,15 @@ jinja2==2.11.3
     #   -c requirements/../../../requirements/constraints.txt
     #   fastapi
 mako==1.1.5
-    # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   alembic
+    # via alembic
 markupsafe==2.0.1
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   jinja2
     #   mako
 multidict==5.1.0
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   aiohttp
     #   yarl
-networkx==2.5.1
-    # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 opentracing==2.4.0
     # via
     #   fastapi-contrib
@@ -199,8 +183,6 @@ promise==2.3
     #   graphql-relay
 psycopg2-binary==2.9.1
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiopg
     #   sqlalchemy
 pycparser==2.20
@@ -247,11 +229,14 @@ pyyaml==5.4.1
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -260,9 +245,7 @@ pyyaml==5.4.1
     #   trafaret-config
     #   uvicorn
 requests==2.25.1
-    # via
-    #   docker
-    #   fastapi
+    # via fastapi
 rfc3986==1.5.0
     # via httpx
 rx==1.6.1
@@ -275,7 +258,6 @@ six==1.16.0
     #   python-multipart
     #   tenacity
     #   thrift
-    #   websocket-client
 sniffio==1.2.0
     # via
     #   httpcore
@@ -289,7 +271,6 @@ sqlalchemy==1.3.24
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -303,7 +284,6 @@ tenacity==7.0.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
@@ -329,7 +309,7 @@ typing-extensions==3.10.0.2
     #   pydantic
 ujson==4.0.2
     # via fastapi
-urllib3==1.26.5
+urllib3==1.26.7
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -341,7 +321,6 @@ urllib3==1.26.5
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   requests
 uvicorn==0.13.4
     # via
@@ -360,20 +339,14 @@ uvloop==0.14.0
     # via uvicorn
 watchgod==0.7
     # via uvicorn
-websocket-client==0.59.0
-    # via
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
-    #   docker
 websockets==8.1
     # via uvicorn
 yarl==1.6.3
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
     #   aiohttp
 zipp==3.6.0
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   importlib-metadata
     #   importlib-resources

--- a/services/api-server/requirements/_test.in
+++ b/services/api-server/requirements/_test.in
@@ -3,6 +3,8 @@
 #  both for unit and integration tests!!
 #
 --constraint ../../../requirements/constraints.txt
+--constraint ./constraints.txt
+
 # Adds base AS CONSTRAINT specs, not requirement.
 #  - Resulting _text.txt is a frozen list of EXTRA packages for testing, besides _base.txt
 #

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -61,7 +61,6 @@ distro==1.6.0
     # via docker-compose
 docker==5.0.2
     # via
-    #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   docker-compose
 docker-compose==1.29.1
@@ -247,7 +246,7 @@ typing-extensions==3.10.0.2
     #   -c requirements/_base.txt
     #   astroid
     #   pylint
-urllib3==1.26.5
+urllib3==1.26.7
     # via
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -255,7 +254,6 @@ urllib3==1.26.5
     #   requests
 websocket-client==0.59.0
     # via
-    #   -c requirements/_base.txt
     #   docker
     #   docker-compose
 wrapt==1.13.3

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -59,7 +59,7 @@ cryptography==3.4.7
     #   paramiko
 distro==1.6.0
     # via docker-compose
-docker==5.0.2
+docker==5.0.3
     # via
     #   -r requirements/_test.in
     #   docker-compose

--- a/services/api-server/requirements/constraints.txt
+++ b/services/api-server/requirements/constraints.txt
@@ -1,0 +1,8 @@
+
+
+# There are incompatible versions in the resolved dependencies:
+#   async-timeout<5.0,>=4.0.0a3 (from aiohttp==3.8.1)
+#   async-timeout<4.0,>=3.0 (from aiopg[sa]==1.2.1->-r requirements/_base.in (line 25))
+# NOTE: All services with aiopg and aiohttp will have this conflict.
+#       Need to wait until aiopg releases and removes this constraint
+aiohttp<3.8.0

--- a/services/director-v2/requirements/_base.in
+++ b/services/director-v2/requirements/_base.in
@@ -3,6 +3,7 @@
 #
 # NOTE: ALL version constraints MUST be commented
 --constraint ../../../requirements/constraints.txt
+--constraint ./constraints.txt
 
 --requirement ../../../packages/dask-task-models-library/requirements/_base.in
 --requirement ../../../packages/models-library/requirements/_base.in

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -31,6 +31,7 @@ aiohttp==3.7.4.post0
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/./constraints.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiodocker
 aiopg==1.2.1
@@ -41,10 +42,8 @@ aiormq==3.3.1
     # via aio-pika
 alembic==1.7.4
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
 amqp==5.0.6
     # via kombu
 aniso8601==7.0.0
@@ -80,7 +79,6 @@ chardet==4.0.0
     #   requests
 click==7.1.2
     # via
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   celery
     #   click-didyoumean
@@ -113,8 +111,6 @@ distributed==2021.10.0
     #   dask
 dnspython==2.1.0
     # via email-validator
-docker==5.0.2
-    # via -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
 email-validator==1.1.3
     # via
     #   fastapi
@@ -156,7 +152,6 @@ idna==2.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
@@ -170,9 +165,7 @@ idna==2.10
     #   rfc3986
     #   yarl
 importlib-metadata==4.8.1
-    # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   alembic
+    # via alembic
 importlib-resources==5.3.0 ; python_version < "3.9"
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -184,7 +177,6 @@ importlib-resources==5.3.0 ; python_version < "3.9"
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -217,12 +209,9 @@ locket==0.2.1
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   partd
 mako==1.1.5
-    # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   alembic
+    # via alembic
 markupsafe==2.0.1
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   jinja2
     #   mako
@@ -232,13 +221,10 @@ msgpack==1.0.2
     #   distributed
 multidict==5.1.0
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   aiohttp
     #   yarl
 networkx==2.5.1
-    # via
-    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-    #   -r requirements/_base.in
+    # via -r requirements/_base.in
 opentracing==2.4.0
     # via
     #   fastapi-contrib
@@ -270,8 +256,6 @@ psutil==5.8.0
     #   distributed
 psycopg2-binary==2.9.1
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiopg
     #   sqlalchemy
 pydantic==1.8.2
@@ -324,11 +308,14 @@ pyyaml==5.4.1
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -342,9 +329,7 @@ pyyaml==5.4.1
 redis==3.5.3
     # via celery
 requests==2.25.1
-    # via
-    #   docker
-    #   fastapi
+    # via fastapi
 rfc3986==1.4.0
     # via httpx
 rx==1.6.1
@@ -360,7 +345,6 @@ six==1.15.0
     #   python-multipart
     #   tenacity
     #   thrift
-    #   websocket-client
 sniffio==1.2.0
     # via
     #   anyio
@@ -381,7 +365,6 @@ sqlalchemy==1.3.24
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -399,7 +382,6 @@ tenacity==7.0.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
@@ -449,7 +431,6 @@ urllib3==1.26.6
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   requests
 uvicorn==0.13.4
     # via
@@ -477,15 +458,10 @@ watchgod==0.7
     # via uvicorn
 wcwidth==0.2.5
     # via prompt-toolkit
-websocket-client==0.59.0
-    # via
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
-    #   docker
 websockets==8.1
     # via uvicorn
 yarl==1.6.3
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
     #   aio-pika
@@ -497,7 +473,6 @@ zict==2.0.0
     #   distributed
 zipp==3.6.0
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   importlib-metadata
     #   importlib-resources
 

--- a/services/director-v2/requirements/_test.in
+++ b/services/director-v2/requirements/_test.in
@@ -2,6 +2,7 @@
 # Specifies dependencies required to run 'services/director-v2/test' both for unit and integration tests!!
 #
 --constraint ../../../requirements/constraints.txt
+--constraint ./constraints.txt
 
 # Adds base AS CONSTRAINT specs, not requirement.
 #  - Resulting _text.txt is a frozen list of EXTRA packages for testing, besides _base.txt

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -112,7 +112,7 @@ cryptography==36.0.0
     #   paramiko
 distro==1.6.0
     # via docker-compose
-docker==5.0.2
+docker==5.0.3
     # via
     #   -r requirements/_test.in
     #   docker-compose

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -11,6 +11,7 @@ aio-pika==6.8.0
 aiohttp==3.7.4.post0
     # via
     #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/./constraints.txt
     #   -c requirements/_base.txt
     #   pytest-aiohttp
 aioredis==1.3.1
@@ -113,7 +114,6 @@ distro==1.6.0
     # via docker-compose
 docker==5.0.2
     # via
-    #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   docker-compose
 docker-compose==1.29.1
@@ -357,7 +357,6 @@ wcwidth==0.2.5
     #   prompt-toolkit
 websocket-client==0.59.0
     # via
-    #   -c requirements/_base.txt
     #   docker
     #   docker-compose
 wrapt==1.13.3

--- a/services/director-v2/requirements/constraints.txt
+++ b/services/director-v2/requirements/constraints.txt
@@ -1,0 +1,8 @@
+
+
+# There are incompatible versions in the resolved dependencies:
+#   async-timeout<5.0,>=4.0.0a3 (from aiohttp==3.8.1)
+#   async-timeout<4.0,>=3.0 (from aiopg[sa]==1.2.1->-r requirements/_base.in (line 25))
+# NOTE: All services with aiopg and aiohttp will have this conflict.
+#       Need to wait until aiopg releases and removes this constraint
+aiohttp<3.8.0

--- a/services/dynamic-sidecar/requirements/_base.in
+++ b/services/dynamic-sidecar/requirements/_base.in
@@ -3,6 +3,7 @@
 #
 # NOTE: ALL version constraints MUST be commented
 --constraint ../../../requirements/constraints.txt
+--constraint ./constraints.txt
 
 # NOTE: These input-requirements under packages are tested using latest updates
 --requirement ../../../packages/models-library/requirements/_base.in

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -29,6 +29,7 @@ aiohttp==3.7.4.post0
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/./constraints.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiodocker
 aiopg==1.3.1
@@ -37,10 +38,8 @@ aiormq==3.3.1
     # via aio-pika
 alembic==1.7.4
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
 anyio==3.3.4
     # via httpcore
 async-generator==1.10
@@ -77,7 +76,6 @@ charset-normalizer==2.0.7
     # via httpx
 click==7.1.2
     # via
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   typer
     #   uvicorn
 cryptography==3.4.7
@@ -98,9 +96,7 @@ distro==1.5.0
 dnspython==2.1.0
     # via email-validator
 docker==5.0.2
-    # via
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
-    #   docker-compose
+    # via docker-compose
 docker-compose==1.29.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -139,7 +135,6 @@ idna==2.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -151,9 +146,7 @@ idna==2.10
     #   rfc3986
     #   yarl
 importlib-metadata==4.8.1
-    # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   alembic
+    # via alembic
 importlib-resources==5.3.0 ; python_version < "3.9"
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -163,7 +156,6 @@ importlib-resources==5.3.0 ; python_version < "3.9"
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -171,22 +163,19 @@ importlib-resources==5.3.0 ; python_version < "3.9"
 jaeger-client==4.8.0
     # via fastapi-contrib
 jsonschema==3.2.0
-    # via docker-compose
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
+    #   docker-compose
 mako==1.1.5
-    # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   alembic
+    # via alembic
 markupsafe==2.0.1
-    # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   mako
+    # via mako
 multidict==5.1.0
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   aiohttp
     #   yarl
-networkx==2.6.3
-    # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 opentracing==2.4.0
     # via
     #   fastapi-contrib
@@ -199,8 +188,6 @@ paramiko==2.7.2
     # via docker
 psycopg2-binary==2.9.1
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiopg
     #   sqlalchemy
 pycparser==2.20
@@ -245,11 +232,14 @@ pyyaml==5.4.1
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -285,7 +275,6 @@ sqlalchemy==1.3.24
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -299,7 +288,6 @@ tenacity==8.0.1
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 texttable==1.6.3
@@ -337,7 +325,6 @@ urllib3==1.26.6
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   requests
 uvicorn==0.13.4
     # via
@@ -356,12 +343,10 @@ watchdog==2.1.5
     # via -r requirements/_base.in
 websocket-client==0.59.0
     # via
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   docker
     #   docker-compose
 yarl==1.6.3
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
     #   aio-pika
@@ -369,7 +354,6 @@ yarl==1.6.3
     #   aiormq
 zipp==3.6.0
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   importlib-metadata
     #   importlib-resources
 

--- a/services/dynamic-sidecar/requirements/_test.in
+++ b/services/dynamic-sidecar/requirements/_test.in
@@ -1,4 +1,5 @@
 --constraint ../../../requirements/constraints.txt
+--constraint ./constraints.txt
 --constraint _base.txt
 
 pytest

--- a/services/dynamic-sidecar/requirements/constraints.txt
+++ b/services/dynamic-sidecar/requirements/constraints.txt
@@ -1,0 +1,8 @@
+
+
+# There are incompatible versions in the resolved dependencies:
+#   async-timeout<5.0,>=4.0.0a3 (from aiohttp==3.8.1)
+#   async-timeout<4.0,>=3.0 (from aiopg[sa]==1.2.1->-r requirements/_base.in (line 25))
+# NOTE: All services with aiopg and aiohttp will have this conflict.
+#       Need to wait until aiopg releases and removes this constraint
+aiohttp<3.8.0

--- a/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/garbage_collector.py
@@ -317,7 +317,8 @@ async def remove_users_manually_marked_as_guests(
     registry: RedisResourceRegistry, app: web.Application
 ) -> None:
     """
-    Removes all the projects associated with GUEST users in the system.
+    Removes all the projects MANUALLY marked as GUEST users in the system (i.e. does not include
+    those accessing via the front-end).
     If the user defined a TEMPLATE, this one also gets removed.
     """
     lock_manager: Aioredlock = get_redis_lock_manager(app)
@@ -325,22 +326,24 @@ async def remove_users_manually_marked_as_guests(
     # collects all users with registed sessions
     alive_keys, dead_keys = await registry.get_all_resource_keys()
 
-    user_ids_to_ignore = set()
+    skip_users = set()
     for entry in chain(alive_keys, dead_keys):
-        user_ids_to_ignore.add(int(entry["user_id"]))
+        skip_users.add(int(entry["user_id"]))
 
     # Prevent creating this list if a guest user
     guest_users: List[Tuple[int, str]] = await get_guest_user_ids_and_names(app)
-    logger.info("GUEST user candidates to clean %s", guest_users)
 
     for guest_user_id, guest_user_name in guest_users:
-        if guest_user_id in user_ids_to_ignore:
-            logger.info(
-                "Ignoring user '%s' as it previously had alive or dead resource keys ",
-                guest_user_id,
+        # Prevents removing GUEST users that were automatically (NOT manually) created
+        # from the front-end
+        if guest_user_id in skip_users:
+            logger.debug(
+                "Skipping garbage-collecting GUEST user with %s since it still has resources in use",
+                f"{guest_user_id=}",
             )
             continue
 
+        # Prevents removing GUEST users that are initializating
         lock_during_construction: bool = await lock_manager.is_locked(
             GUEST_USER_RC_LOCK_FORMAT.format(user_id=guest_user_name)
         )
@@ -351,12 +354,18 @@ async def remove_users_manually_marked_as_guests(
 
         if lock_during_construction or lock_during_initialization:
             logger.debug(
-                "Skipping garbage-collecting user '%s','%s' since it is still locked",
-                guest_user_id,
-                guest_user_name,
+                "Skipping garbage-collecting GUEST user with %s and %s since it is still locked",
+                f"{guest_user_id=}",
+                f"{guest_user_name=}",
             )
             continue
 
+        # Removing
+        logger.info(
+            "Removing user %s and %s with all its resources because it was MARKED as GUEST",
+            f"{guest_user_id=}",
+            f"{guest_user_name=}",
+        )
         await remove_guest_user_with_all_its_resources(
             app=app,
             user_id=guest_user_id,
@@ -485,19 +494,26 @@ async def remove_guest_user_with_all_its_resources(
     """Removes a GUEST user with all its associated projects and S3/MinIO files"""
 
     try:
-        logger.debug("Will try to remove resources for user '%s' if GUEST", user_id)
         if not await is_user_guest(app, user_id):
-            logger.debug("User is not GUEST, skipping cleanup")
             return
 
+        logger.debug(
+            "Deleting all projects of user with %s because it is a GUEST",
+            f"{user_id=}",
+        )
         await remove_all_projects_for_user(app=app, user_id=user_id)
+
+        logger.debug(
+            "Deleting user %s because it is a GUEST",
+            f"{user_id=}",
+        )
         await remove_user(app=app, user_id=user_id)
 
-    except database_errors as err:
+    except database_errors as error:
         logger.warning(
-            "Could not remove GUEST with id=%s. Check the logs above for details [%s]",
-            user_id,
-            err,
+            "Failure in database while removing user (%s) and its resources with %s",
+            f"{user_id=}",
+            f"{error}",
         )
 
 

--- a/services/web/server/tests/integration/02/test_computation.py
+++ b/services/web/server/tests/integration/02/test_computation.py
@@ -4,21 +4,9 @@
 import asyncio
 import json
 from pathlib import Path
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    NamedTuple,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, Callable, Dict, List, NamedTuple, Tuple, Type, Union
 
 import pytest
-import socketio
 import sqlalchemy as sa
 from aiohttp import web
 from aiohttp.test_utils import TestClient
@@ -48,7 +36,6 @@ from simcore_service_webserver.security_roles import UserRole
 from simcore_service_webserver.session import setup_session
 from simcore_service_webserver.socketio.module_setup import setup_socketio
 from simcore_service_webserver.users import setup_users
-from socketio.exceptions import ConnectionError as SocketConnectionError
 from tenacity import retry
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
@@ -97,6 +84,10 @@ class ExpectedResponse(NamedTuple):
     accepted: Union[
         Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[web.HTTPAccepted]
     ]
+
+    def __str__(self) -> str:
+        items = ", ".join(f"{k}={v.__name__}" for k, v in self._asdict().items())
+        return f"{self.__class__.__name__}({items})"
 
 
 def standard_role_response() -> Tuple[str, List[Tuple[UserRole, ExpectedResponse]]]:
@@ -184,7 +175,7 @@ def client(
     setup_computation(app)
     setup_director_v2(app)
 
-    # GC not relevant for these test-suite,
+    # GC not included in this test-suite,
     mocker.patch(
         "simcore_service_webserver.resource_manager.module_setup.setup_garbage_collector",
         side_effect=lambda app: print(
@@ -328,9 +319,7 @@ def _assert_sleeper_services_completed(
 
 
 # TESTS ------------------------------------------
-@pytest.mark.parametrize(
-    *standard_role_response(),
-)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
 async def test_start_pipeline(
     sleeper_service: Dict[str, str],
     postgres_session: sa.orm.session.Session,

--- a/services/web/server/tests/unit/with_dbs/02/clusters/test_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/clusters/test_handlers.py
@@ -125,9 +125,7 @@ async def second_user(
         yield user
 
 
-@pytest.mark.parametrize(
-    *standard_role_response(),
-)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
 async def test_list_clusters(
     enable_dev_features: None,
     client: TestClient,
@@ -201,9 +199,7 @@ async def test_list_clusters(
         {"type": "jupyterhub"},
     ],
 )
-@pytest.mark.parametrize(
-    *standard_role_response(),
-)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
 async def test_create_cluster(
     enable_dev_features: None,
     client: TestClient,
@@ -264,9 +260,7 @@ async def test_create_cluster(
     postgres_db.execute(clusters.delete().where(clusters.c.id == row[clusters.c.id]))
 
 
-@pytest.mark.parametrize(
-    *standard_role_response(),
-)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
 async def test_get_cluster(
     enable_dev_features: None,
     client: TestClient,
@@ -336,9 +330,7 @@ async def test_get_cluster(
         data, error = await assert_status(rsp, expected.forbidden)
 
 
-@pytest.mark.parametrize(
-    *standard_role_response(),
-)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
 async def test_update_cluster(
     enable_dev_features: None,
     client: TestClient,
@@ -553,9 +545,7 @@ async def test_update_cluster(
         data, error = await assert_status(rsp, expected.forbidden)
 
 
-@pytest.mark.parametrize(
-    *standard_role_response(),
-)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
 async def test_delete_cluster(
     enable_dev_features: None,
     client: TestClient,

--- a/services/web/server/tests/unit/with_dbs/03/test_director_v2.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_director_v2.py
@@ -35,9 +35,7 @@ def project_id() -> UUID:
     return uuid4()
 
 
-@pytest.mark.parametrize(
-    *standard_role_response(),
-)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
 async def test_start_pipeline(
     client,
     logged_user: Dict,
@@ -60,9 +58,7 @@ async def test_start_pipeline(
         ), f"received pipeline id: {data['pipeline_id']}, expected {project_id}"
 
 
-@pytest.mark.parametrize(
-    *standard_role_response(),
-)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
 async def test_start_partial_pipeline(
     client,
     logged_user: Dict,
@@ -87,9 +83,7 @@ async def test_start_partial_pipeline(
         ), f"received pipeline id: {data['pipeline_id']}, expected {project_id}"
 
 
-@pytest.mark.parametrize(
-    *standard_role_response(),
-)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
 async def test_stop_pipeline(
     client,
     logged_user: Dict,

--- a/services/web/server/tests/unit/with_dbs/08/test_groups.py
+++ b/services/web/server/tests/unit/with_dbs/08/test_groups.py
@@ -89,9 +89,7 @@ def _assert__group_user(
     assert "gid" in actual_user
 
 
-@pytest.mark.parametrize(
-    *standard_role_response(),
-)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
 async def test_list_groups(
     client,
     logged_user,

--- a/services/web/server/tests/unit/with_dbs/_helpers.py
+++ b/services/web/server/tests/unit/with_dbs/_helpers.py
@@ -1,15 +1,41 @@
-from collections import namedtuple
-from typing import List, NamedTuple, Tuple
+from typing import List, NamedTuple, Tuple, Type, Union
 from unittest import mock
 
 from aiohttp import web
 from simcore_service_webserver.projects.projects_handlers import HTTPLocked
 from simcore_service_webserver.security_roles import UserRole
 
-ExpectedResponse = namedtuple(
-    "ExpectedResponse",
-    ["ok", "created", "no_content", "not_found", "forbidden", "locked", "accepted"],
-)
+
+class ExpectedResponse(NamedTuple):
+    """
+    Stores respons status to an API request in function of the user
+
+    e.g. for a request that normally returns OK, a non-authorized user
+    will have no access, therefore ExpectedResponse.ok = HTTPUnauthorized
+    """
+
+    ok: Union[Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[web.HTTPOk]]
+    created: Union[
+        Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[web.HTTPCreated]
+    ]
+    no_content: Union[
+        Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[web.HTTPNoContent]
+    ]
+    not_found: Union[
+        Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[web.HTTPNotFound]
+    ]
+    forbidden: Union[
+        Type[web.HTTPUnauthorized],
+        Type[web.HTTPForbidden],
+    ]
+    locked: Union[Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[HTTPLocked]]
+    accepted: Union[
+        Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[web.HTTPAccepted]
+    ]
+
+    def __str__(self) -> str:
+        items = ",".join(f"{k}={v.__name__}" for k, v in self._asdict().items())
+        return f"{self.__class__.__name__}({items})"
 
 
 def standard_role_response() -> Tuple[str, List[Tuple[UserRole, ExpectedResponse]]]:
@@ -19,49 +45,49 @@ def standard_role_response() -> Tuple[str, List[Tuple[UserRole, ExpectedResponse
             (
                 UserRole.ANONYMOUS,
                 ExpectedResponse(
-                    web.HTTPUnauthorized,
-                    web.HTTPUnauthorized,
-                    web.HTTPUnauthorized,
-                    web.HTTPUnauthorized,
-                    web.HTTPUnauthorized,
-                    web.HTTPUnauthorized,
-                    web.HTTPUnauthorized,
+                    ok=web.HTTPUnauthorized,
+                    created=web.HTTPUnauthorized,
+                    no_content=web.HTTPUnauthorized,
+                    not_found=web.HTTPUnauthorized,
+                    forbidden=web.HTTPUnauthorized,
+                    locked=web.HTTPUnauthorized,
+                    accepted=web.HTTPUnauthorized,
                 ),
             ),
             (
                 UserRole.GUEST,
                 ExpectedResponse(
-                    web.HTTPForbidden,
-                    web.HTTPForbidden,
-                    web.HTTPForbidden,
-                    web.HTTPForbidden,
-                    web.HTTPForbidden,
-                    web.HTTPForbidden,
-                    web.HTTPForbidden,
+                    ok=web.HTTPForbidden,
+                    created=web.HTTPForbidden,
+                    no_content=web.HTTPForbidden,
+                    not_found=web.HTTPForbidden,
+                    forbidden=web.HTTPForbidden,
+                    locked=web.HTTPForbidden,
+                    accepted=web.HTTPForbidden,
                 ),
             ),
             (
                 UserRole.USER,
                 ExpectedResponse(
-                    web.HTTPOk,
-                    web.HTTPCreated,
-                    web.HTTPNoContent,
-                    web.HTTPNotFound,
-                    web.HTTPForbidden,
-                    HTTPLocked,
-                    web.HTTPAccepted,
+                    ok=web.HTTPOk,
+                    created=web.HTTPCreated,
+                    no_content=web.HTTPNoContent,
+                    not_found=web.HTTPNotFound,
+                    forbidden=web.HTTPForbidden,
+                    locked=HTTPLocked,
+                    accepted=web.HTTPAccepted,
                 ),
             ),
             (
                 UserRole.TESTER,
                 ExpectedResponse(
-                    web.HTTPOk,
-                    web.HTTPCreated,
-                    web.HTTPNoContent,
-                    web.HTTPNotFound,
-                    web.HTTPForbidden,
-                    HTTPLocked,
-                    web.HTTPAccepted,
+                    ok=web.HTTPOk,
+                    created=web.HTTPCreated,
+                    no_content=web.HTTPNoContent,
+                    not_found=web.HTTPNotFound,
+                    forbidden=web.HTTPForbidden,
+                    locked=HTTPLocked,
+                    accepted=web.HTTPAccepted,
                 ),
             ),
         ],

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -45,7 +45,6 @@ attrs==20.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiohttp
     #   jsonschema
     #   pytest

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -34,10 +34,8 @@ aiosignal==1.2.0
     # via aiohttp
 alembic==1.7.5
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   -r requirements/_test.in
 async-timeout==4.0.1
     # via
@@ -64,7 +62,6 @@ charset-normalizer==2.0.8
 click==8.0.3
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   -r requirements/_test.in
 coverage==6.1.2
     # via
@@ -75,7 +72,6 @@ dnspython==2.1.0
 docker==5.0.3
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   -r requirements/_test.in
 email-validator==1.1.3
     # via pydantic
@@ -86,7 +82,6 @@ frozenlist==1.2.0
 idna==2.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
@@ -97,7 +92,6 @@ idna==2.10
     #   yarl
 importlib-metadata==4.8.2
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   alembic
 importlib-resources==5.4.0 ; python_version < "3.9"
@@ -106,7 +100,6 @@ importlib-resources==5.4.0 ; python_version < "3.9"
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -121,12 +114,10 @@ jsonschema==3.2.0
     #   -r requirements/_test.in
 mako==1.1.6
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   alembic
 markupsafe==2.0.1
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   mako
 minio==7.0.4
@@ -141,11 +132,8 @@ minio==7.0.4
     #   -r requirements/_test.in
 multidict==5.2.0
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   aiohttp
     #   yarl
-networkx==2.6.3
-    # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 packaging==21.3
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
@@ -157,9 +145,7 @@ pluggy==1.0.0
     # via pytest
 psycopg2-binary==2.9.2
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiopg
     #   sqlalchemy
 py==1.11.0
@@ -238,7 +224,6 @@ sqlalchemy==1.3.24
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -250,7 +235,6 @@ tenacity==8.0.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_test.in
@@ -281,24 +265,20 @@ urllib3==1.26.7
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   minio
     #   requests
 websocket-client==0.59.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_migration.in
     #   docker
 yarl==1.7.2
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
     #   aio-pika
     #   aiohttp
     #   aiormq
 zipp==3.6.0
     # via
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   importlib-metadata
     #   importlib-resources


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

Libraries evolve ans some of the dependencies are not anymore in use but remain listed in their requirements file. This is one of many maintenance PR to prune these deprecated dependencies.

We start with ``packages/simcore-sdk``.  With the help of [pipreqs](https://github.com/bndr/pipreqs) we discover which dependencies are actually in use ``simcore-sdk`` and comparing with ``packages/simcore-sdk/requirements/_base.in`` revealed deprecated ones (see changes in ``_base.in`` to detect which were actually pruned)
Then  ``simcore-sdk``'s pruned reqs was propagated downstream (only the changes in simcore-sdk!) to services like
- api-server
- director-v2
- dynamic-sidecar
- swarm-deploy

This exercised also revealed:
- that some repo constraints (i.e. ``requirements/constraints.txt``) were added and not propagated downstream. For that reason, some of the services above added some more changes. Among them, an incompatibility between the latest ``aiohttp`` and ``aiopg`` due to impossible constraints on the ``async-timeout`` library. Added to ``constraint.txt`` to all services using both libraries.
- ♻️ refactored 
  -   removed gc from ``tests/integration/02/test_computation.py::test_start_pipeline``
  -   added more log info to gc

### Steps to prune a package and all services downstream

- ``pip install pipreqs``
- find dependencies in use: ``pipreqs packages/simcore-sdk/src/simcore_sdk`` produces a ``requirements.txt`` file
- compare this file with ``packages/simcore-sdk/requirements/_base.in`` and remove unused libraries. 
- dependencies with other libraries in the repo under ``packages`` has to be reviewed manually
- make full upgrade of reqs : ``make touch reqs``
- Now it is time to check downstream dependencies : check for ``/packages/simcore-sdk/requirements/_base.in`` in all the repo including only ``*.in`` files.
- Go to those services requirements folder
- We want to selectively upgrade the pruning of the upstream library in this service. For that, we need to do a selective upgrade on any of the libraries that the upstream dependency includes, e.g. ``aiohttp`` for this example. 
```
make touch 
make reqs upgrade=aiohttp
```
- That should do a selective upgrade of the service



## Related issue/s

ITISFoundation/osparc-issues#428

## How to test

all tests affected

