### PR TITLE
🐛Fix storage service in local deployment with self signed SSL certificates

### DIFF
--- a/services/storage/docker/entrypoint.sh
+++ b/services/storage/docker/entrypoint.sh
@@ -8,6 +8,14 @@ INFO="INFO: [$(basename "$0")] "
 WARNING="WARNING: [$(basename "$0")] "
 ERROR="ERROR: [$(basename "$0")] "
 
+# Read self-signed SSH certificates (if applicable)
+#
+# In case the director must access a docker registry in a secure way using
+# non-standard certificates (e.g. such as self-signed certificates), this call is needed.
+# It needs to be executed as root.
+update-ca-certificates
+
+
 # This entrypoint script:
 #
 # - Executes *inside* of the container upon start as --user [default root]

--- a/services/storage/docker/entrypoint.sh
+++ b/services/storage/docker/entrypoint.sh
@@ -10,7 +10,7 @@ ERROR="ERROR: [$(basename "$0")] "
 
 # Read self-signed SSH certificates (if applicable)
 #
-# In case the director must access a docker registry in a secure way using
+# In case storage must access a docker registry in a secure way using
 # non-standard certificates (e.g. such as self-signed certificates), this call is needed.
 # It needs to be executed as root.
 update-ca-certificates


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

As in PR #2667 , we need to add a call to `update-ca-certificates` to make the local deployment work with self-signed SSL certificates.


## Related issue/s
No issue, but related PR is #2667 


## How to test

Merge and see, but as PR #2667 works this one-line code addition should as well. Tested locally manually calling `update-ca-certificates` , it worked.

