### PR TITLE
e2e: get timeouts from cli arguments

### DIFF
--- a/tests/e2e/portal-files/VTK_file.js
+++ b/tests/e2e/portal-files/VTK_file.js
@@ -8,6 +8,7 @@ const args = process.argv.slice(2);
 const {
   urlPrefix,
   params,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArgumentsStudyDispatcherParams(args);
 
@@ -39,7 +40,7 @@ async function runTutorial () {
 
     const workbenchData = utils.extractWorkbenchData(studyData["data"]);
     const nodeIdViewer = workbenchData["nodeIds"][1];
-    await tutorial.waitForServices(workbenchData["studyId"], [nodeIdViewer]);
+    await tutorial.waitForServices(workbenchData["studyId"], [nodeIdViewer], startTimeout);
     await utils.takeScreenshot(page, screenshotPrefix + 'service_started');
 
     // Some time for setting up service's frontend

--- a/tests/e2e/portal/2D_Plot.js
+++ b/tests/e2e/portal/2D_Plot.js
@@ -8,6 +8,7 @@ const args = process.argv.slice(2);
 const {
   urlPrefix,
   templateUuid,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArgumentsTemplate(args);
 
@@ -26,7 +27,7 @@ async function runTutorial () {
 
     const workbenchData = utils.extractWorkbenchData(studyData["data"]);
     const nodeIdViewer = workbenchData["nodeIds"][1];
-    await tutorial.waitForServices(workbenchData["studyId"], [nodeIdViewer]);
+    await tutorial.waitForServices(workbenchData["studyId"], [nodeIdViewer], startTimeout);
 
     await tutorial.waitFor(5000, 'Some time for starting the service');
     await utils.takeScreenshot(page, screenshotPrefix + 'service_started');

--- a/tests/e2e/portal/3D_Anatomical.js
+++ b/tests/e2e/portal/3D_Anatomical.js
@@ -7,6 +7,7 @@ const args = process.argv.slice(2);
 const {
   urlPrefix,
   templateUuid,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArgumentsTemplate(args);
 
@@ -24,7 +25,7 @@ async function runTutorial () {
     console.log("Study ID:", studyId);
 
     const workbenchData = utils.extractWorkbenchData(studyData["data"]);
-    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][1]]);
+    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][1]], startTimeout);
 
     await tutorial.waitFor(10000, 'Some time for starting the service');
     await utils.takeScreenshot(page, screenshotPrefix + 'service_started');

--- a/tests/e2e/portal/3D_EM.js
+++ b/tests/e2e/portal/3D_EM.js
@@ -7,6 +7,7 @@ const args = process.argv.slice(2);
 const {
   urlPrefix,
   templateUuid,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArgumentsTemplate(args);
 
@@ -24,7 +25,7 @@ async function runTutorial () {
     console.log("Study ID:", studyId);
 
     const workbenchData = utils.extractWorkbenchData(studyData["data"]);
-    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][2]]);
+    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][2]], startTimeout);
 
     await tutorial.waitFor(10000, 'Some time for starting the service');
     await utils.takeScreenshot(page, screenshotPrefix + 'service_started');

--- a/tests/e2e/portal/Bornstein.js
+++ b/tests/e2e/portal/Bornstein.js
@@ -7,6 +7,7 @@ const args = process.argv.slice(2);
 const {
   urlPrefix,
   templateUuid,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArgumentsTemplate(args);
 
@@ -24,7 +25,7 @@ async function runTutorial () {
     console.log("Study ID:", studyId);
 
     const workbenchData = utils.extractWorkbenchData(studyData["data"]);
-    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][0]]);
+    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][0]], startTimeout);
 
     await tutorial.waitFor(60000, 'Some time for starting the service');
     await utils.takeScreenshot(page, screenshotPrefix + 'service_started');

--- a/tests/e2e/portal/CC_Human.js
+++ b/tests/e2e/portal/CC_Human.js
@@ -7,6 +7,7 @@ const args = process.argv.slice(2);
 const {
   urlPrefix,
   templateUuid,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArgumentsTemplate(args);
 
@@ -27,7 +28,7 @@ async function runTutorial () {
     await utils.takeScreenshot(page, screenshotPrefix + 'workbench_loaded');
 
     await tutorial.runPipeline();
-    await tutorial.waitForStudyDone(studyId, 1800000);
+    await tutorial.waitForStudyDone(studyId, startTimeout);
 
     const outFiles0 = [
       "vm_1Hz.txt",

--- a/tests/e2e/portal/CC_Rabbit.js
+++ b/tests/e2e/portal/CC_Rabbit.js
@@ -7,6 +7,7 @@ const args = process.argv.slice(2);
 const {
   urlPrefix,
   templateUuid,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArgumentsTemplate(args);
 
@@ -27,7 +28,7 @@ async function runTutorial () {
     await utils.takeScreenshot(page, screenshotPrefix + 'workbench_loaded');
 
     await tutorial.runPipeline();
-    await tutorial.waitForStudyDone(studyId, 1500000);
+    await tutorial.waitForStudyDone(studyId, startTimeout);
 
     const outFiles0 = [
       "logs.zip",

--- a/tests/e2e/portal/Kember.js
+++ b/tests/e2e/portal/Kember.js
@@ -8,6 +8,7 @@ const args = process.argv.slice(2);
 const {
   urlPrefix,
   templateUuid,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArgumentsTemplate(args);
 
@@ -31,7 +32,7 @@ async function runTutorial () {
     await utils.takeScreenshot(page, screenshotPrefix + 'workbench_loaded');
 
     await tutorial.runPipeline();
-    await tutorial.waitForStudyDone(studyId, 120000);
+    await tutorial.waitForStudyDone(studyId, startTimeout);
 
     const outFiles = [
       "logs.zip",

--- a/tests/e2e/portal/Mattward.js
+++ b/tests/e2e/portal/Mattward.js
@@ -7,6 +7,7 @@ const args = process.argv.slice(2);
 const {
   urlPrefix,
   templateUuid,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArgumentsTemplate(args);
 
@@ -24,7 +25,7 @@ async function runTutorial () {
     console.log("Study ID:", studyId);
 
     const workbenchData = utils.extractWorkbenchData(studyData["data"]);
-    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][0]]);
+    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][0]], startTimeout);
 
     await tutorial.waitFor(20000, 'Some time for starting the service');
     await utils.takeScreenshot(page, screenshotPrefix + 'service_started');

--- a/tests/e2e/portal/Voila.js
+++ b/tests/e2e/portal/Voila.js
@@ -7,6 +7,7 @@ const args = process.argv.slice(2);
 const {
   urlPrefix,
   templateUuid,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArgumentsTemplate(args);
 
@@ -26,7 +27,7 @@ async function runTutorial () {
     const workbenchData = utils.extractWorkbenchData(studyData["data"]);
     console.log("Workbench Data:", workbenchData);
     const voilaIdViewer = workbenchData["nodeIds"][0];
-    await tutorial.waitForServices(workbenchData["studyId"], [voilaIdViewer]);
+    await tutorial.waitForServices(workbenchData["studyId"], [voilaIdViewer], startTimeout);
 
     await tutorial.waitFor(40000, 'Some time for starting the service');
     await utils.takeScreenshot(page, screenshotPrefix + 'service_started');

--- a/tests/e2e/portal/opencor.js
+++ b/tests/e2e/portal/opencor.js
@@ -7,6 +7,7 @@ const args = process.argv.slice(2);
 const {
   urlPrefix,
   templateUuid,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArgumentsTemplate(args);
 
@@ -27,7 +28,7 @@ async function runTutorial () {
     await utils.takeScreenshot(page, screenshotPrefix + 'workbench_loaded');
 
     await tutorial.runPipeline();
-    await tutorial.waitForStudyDone(studyId, 30000);
+    await tutorial.waitForStudyDone(studyId, startTimeout);
 
     const outFiles = [
       "results.json",

--- a/tests/e2e/tutorials/isolve-gpu.js
+++ b/tests/e2e/tutorials/isolve-gpu.js
@@ -11,6 +11,7 @@ const {
   user,
   pass,
   newUser,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
@@ -28,7 +29,7 @@ async function runTutorial() {
     await tutorial.waitFor(5000, 'Some time for loading the workbench');
 
     await tutorial.runPipeline();
-    await tutorial.waitForStudyDone(studyId, 30000);
+    await tutorial.waitForStudyDone(studyId, startTimeout);
 
     const outFiles = [
       "logs.zip",

--- a/tests/e2e/tutorials/isolve-mpi.js
+++ b/tests/e2e/tutorials/isolve-mpi.js
@@ -9,6 +9,7 @@ const {
   user,
   pass,
   newUser,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
@@ -26,7 +27,7 @@ async function runTutorial() {
     await tutorial.waitFor(5000, 'Some time for loading the workbench');
 
     await tutorial.runPipeline();
-    await tutorial.waitForStudyDone(studyId, 120000);
+    await tutorial.waitForStudyDone(studyId, startTimeout);
 
     const outFiles = [
       "logs.zip",

--- a/tests/e2e/tutorials/jupyters.js
+++ b/tests/e2e/tutorials/jupyters.js
@@ -9,6 +9,7 @@ const {
   user,
   pass,
   newUser,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
@@ -24,7 +25,7 @@ async function runTutorial() {
     console.log("Study ID:", studyId);
 
     const workbenchData = utils.extractWorkbenchData(studyData["data"]);
-    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][1], workbenchData["nodeIds"][2]]);
+    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][1], workbenchData["nodeIds"][2]], startTimeout);
     await tutorial.waitFor(2000);
 
     // open jupyterNB

--- a/tests/e2e/tutorials/mattward.js
+++ b/tests/e2e/tutorials/mattward.js
@@ -9,6 +9,7 @@ const {
   user,
   pass,
   newUser,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
@@ -24,7 +25,7 @@ async function runTutorial() {
     console.log("Study ID:", studyId);
 
     const workbenchData = utils.extractWorkbenchData(studyData["data"]);
-    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][0]]);
+    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][0]], startTimeout);
 
     await tutorial.waitFor(30000, 'Wait for the output files to be pushed');
 

--- a/tests/e2e/tutorials/sim4life.js
+++ b/tests/e2e/tutorials/sim4life.js
@@ -9,6 +9,7 @@ const {
   user,
   pass,
   newUser,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
@@ -27,7 +28,7 @@ async function runTutorial() {
 
     const workbenchData = utils.extractWorkbenchData(studyData["data"]);
     console.log(workbenchData);
-    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][0]], 20000);
+    await tutorial.waitForServices(workbenchData["studyId"], [workbenchData["nodeIds"][0]], startTimeout);
 
     await tutorial.waitFor(12000, 'Wait for some time');
   }

--- a/tests/e2e/tutorials/sleepers.js
+++ b/tests/e2e/tutorials/sleepers.js
@@ -9,6 +9,7 @@ const {
   user,
   pass,
   newUser,
+  startTimeout,
   enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
@@ -26,7 +27,7 @@ async function runTutorial() {
     await tutorial.waitFor(5000, 'Some time for loading the workbench');
 
     await tutorial.runPipeline();
-    await tutorial.waitForStudyDone(studyId, 60000);
+    await tutorial.waitForStudyDone(studyId, startTimeout);
 
     const outFiles = [
       "logs.zip",

--- a/tests/e2e/utils/utils.js
+++ b/tests/e2e/utils/utils.js
@@ -2,6 +2,7 @@ const pathLib = require('path');
 const URL = require('url').URL;
 
 const SCREENSHOTS_DIR = "../screenshots/";
+const DEFAULT_TIMEOUT = 60000;
 
 function parseCommandLineArguments(args) {
   // node $tutorial.js [url] [user] [password] [--demo]
@@ -17,7 +18,7 @@ function parseCommandLineArguments(args) {
     pass,
     newUser
   } = getUserAndPass(args);
-  const startTimeout = args.length > 3 ? args[3] : ourTimeout;
+  const startTimeout = args.length > 3 ? args[3] : DEFAULT_TIMEOUT;
   const enableDemoMode = args.includes("--demo");
 
   return {

--- a/tests/e2e/utils/utils.js
+++ b/tests/e2e/utils/utils.js
@@ -12,13 +12,13 @@ function parseCommandLineArguments(args) {
   }
 
   const url = args[0];
-  const enableDemoMode = args.includes("--demo");
   const {
     user,
     pass,
     newUser
   } = getUserAndPass(args);
-  const startTimeout = args[3];
+  const startTimeout = args.length > 3 ? args[3] : ourTimeout;
+  const enableDemoMode = args.includes("--demo");
 
   return {
     url,

--- a/tests/e2e/utils/utils.js
+++ b/tests/e2e/utils/utils.js
@@ -7,7 +7,7 @@ function parseCommandLineArguments(args) {
   // node $tutorial.js [url] [user] [password] [--demo]
 
   if (args.length < 1) {
-    console.log('More arguments expected:  $tutorial.js [url] [user] [password] [--demo]');
+    console.log('More arguments expected:  $tutorial.js [url] [user] [password] [start_timeout] [--demo]');
     process.exit(1);
   }
 
@@ -18,12 +18,14 @@ function parseCommandLineArguments(args) {
     pass,
     newUser
   } = getUserAndPass(args);
+  const startTimeout = args[3];
 
   return {
     url,
     user,
     pass,
     newUser,
+    startTimeout,
     enableDemoMode
   }
 }
@@ -31,18 +33,20 @@ function parseCommandLineArguments(args) {
 function parseCommandLineArgumentsTemplate(args) {
   // node $template.js [url] [template_uuid] [--demo]
 
-  if (args.length < 2) {
-    console.log('More arguments expected: $template.js [url_prefix] [template_uuid] [--demo]');
+  if (args.length < 3) {
+    console.log('More arguments expected: $template.js [url_prefix] [template_uuid] [start_timeout] [--demo]');
     process.exit(1);
   }
 
   const urlPrefix = args[0];
   const templateUuid = args[1];
+  const startTimeout = args[2];
   const enableDemoMode = args.includes("--demo");
 
   return {
     urlPrefix,
     templateUuid,
+    startTimeout,
     enableDemoMode
   }
 }
@@ -50,8 +54,8 @@ function parseCommandLineArgumentsTemplate(args) {
 function parseCommandLineArgumentsStudyDispatcherParams(args) {
   // [url] [download_link] [file_size] [--demo]
 
-  if (args.length < 3) {
-    console.log('More arguments expected: [url] [download_link] [file_size] [--demo]');
+  if (args.length < 4) {
+    console.log('More arguments expected: [url] [download_link] [file_size] [start_timeout] [--demo]');
     process.exit(1);
   }
 
@@ -59,11 +63,13 @@ function parseCommandLineArgumentsStudyDispatcherParams(args) {
   const params = {};
   params["download_link"] = args[1];
   params["file_size"] = args[2];
+  const startTimeout = args[2];
   const enableDemoMode = args.includes("--demo");
 
   return {
     urlPrefix,
     params,
+    startTimeout,
     enableDemoMode
   }
 }


### PR DESCRIPTION
## What do these changes do?

In order to make service start timeouts more flexible, it will have to be provided with the cli arguments


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
