### PR TITLE
🐛 Fixes: python runner fails raising FileNotFoundError

### DIFF
--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/io.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/io.py
@@ -141,11 +141,14 @@ class TaskOutputData(DictModel[PortKey, PortValue]):
 
         for output_key, output_params in schema.items():
             if isinstance(output_params, FilePortSchema):
-                file_path = output_folder / (output_params.mapping or output_key)
+                file_relpath = output_params.mapping or output_key
+                # TODO: file_path is built here, saved truncated in file_mapping and
+                # then rebuild again int _retrieve_output_data. Review.
+                file_path = output_folder / file_relpath
                 if file_path.exists():
                     data[output_key] = {
                         "url": f"{output_params.url}",
-                        "file_mapping": file_path.name,
+                        "file_mapping": file_relpath,
                     }
                 elif output_params.required:
                     raise ValueError(

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/io.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/io.py
@@ -57,7 +57,10 @@ class FilePortSchema(PortSchema):
 
 class FileUrl(BaseModel):
     url: AnyUrl
-    file_mapping: Optional[str] = None
+    file_mapping: Optional[str] = Field(
+        None,
+        description="Local file relpath name (if given), otherwise it takes the url filename",
+    )
 
     class Config:
         extra = Extra.forbid
@@ -73,7 +76,6 @@ class FileUrl(BaseModel):
 
 PortKey = Annotated[str, Field(regex=PROPERTY_KEY_RE)]
 PortValue = Union[StrictBool, StrictInt, StrictFloat, StrictStr, FileUrl, None]
-PortSchemaValue = Union[PortSchema, FilePortSchema]
 
 
 class TaskInputData(DictModel[PortKey, PortValue]):
@@ -91,7 +93,12 @@ class TaskInputData(DictModel[PortKey, PortValue]):
         }
 
 
+PortSchemaValue = Union[PortSchema, FilePortSchema]
+
+
 class TaskOutputDataSchema(DictModel[PortKey, PortSchemaValue]):
+    # This describes
+    #
     class Config(DictModel.Config):
         schema_extra = {
             "examples": [

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/io.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/io.py
@@ -97,7 +97,11 @@ PortSchemaValue = Union[PortSchema, FilePortSchema]
 
 
 class TaskOutputDataSchema(DictModel[PortKey, PortSchemaValue]):
-    # This describes
+    #
+    # NOTE: Expected output data is only determined at runtime. A possibility
+    # would be to create pydantic models dynamically but dask serialization
+    # does not work well in that case. For that reason, the schema is
+    # sent as a json-schema instead of with a dynamically-created model class
     #
     class Config(DictModel.Config):
         schema_extra = {

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -87,9 +87,6 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
                     input_params.file_mapping
                     or Path(URL(input_params.url).path.strip("/")).name
                 )
-                assert (  # nosec
-                    len(URL(input_params.url).path.strip("/").split("/")) == 4
-                ), f"{URL(input_params.url).path=} expected bucket/project/node/filename.ext"
 
                 destination_path = task_volumes.inputs_folder / file_name
 
@@ -139,10 +136,11 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
             upload_tasks = []
             for output_params in output_data.values():
                 if isinstance(output_params, FileUrl):
-                    src_path = task_volumes.outputs_folder / (
+                    assert (  # nosec
                         output_params.file_mapping
-                        or Path(URL(output_params.url).path.strip("/")).name
-                    )
+                    ), f"{output_params.json(indent=1)} expected resolved in TaskOutputData.from_task_output"
+
+                    src_path = task_volumes.outputs_folder / output_params.file_mapping
                     upload_tasks.append(
                         push_file_to_remote(
                             src_path, output_params.url, self._publish_sidecar_log

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -85,6 +85,8 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
                 destination_path = task_volumes.inputs_folder / (
                     input_params.file_mapping or URL(input_params.url).path.strip("/")
                 )
+                # NOTE: only 'task_volumes.inputs_folder' part of 'destination_path' is guaranteed
+                destination_path.parent.mkdir(parents=True, exist_ok=True)
                 download_tasks.append(
                     pull_file_from_remote(
                         input_params.url, destination_path, self._publish_sidecar_log

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/task_shared_volume.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/task_shared_volume.py
@@ -30,10 +30,14 @@ class TaskSharedVolumes:
                     "The path %s already exists. It will be wiped out now.", folder_path
                 )
                 shutil.rmtree(folder_path, onerror=_log_error)
+            # NOTE: PC->SAN: if rmtree fails, there is a risk of rewriting i/os that can start from here
+            # we should guarantee at this point that these folders exists and are empty
             folder_path.mkdir(parents=True, exist_ok=True)
             logger.debug(
-                "created inputs,outputs,logs folders in %s",
-                self.base_path,
+                "created %s in %s [%s]",
+                f"{folder=}",
+                f"{self.base_path=}",
+                f"{folder_path.exists()=}",
             )
 
     @property

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
@@ -46,6 +46,17 @@ async def pull_file_from_remote(
     await log_publishing_cb(
         f"Downloading '{src_url.path.strip('/')}' into local file '{dst_path.name}'..."
     )
+    logger.debug(
+        "Pulling file from %s -> %s [%s]",
+        f"{src_url=}",
+        f"{dst_path=}",
+        f"{dst_path.parent.exists()=}",
+    )
+    if not dst_path.parent.exists():
+        raise ValueError(
+            f"{dst_path.parent=} does not exist. It must be created by the caller"
+        )
+
     src_mime_type, _ = mimetypes.guess_type(f"{src_url.path}")
     dst_mime_type, _ = mimetypes.guess_type(dst_path)
 

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -151,6 +151,12 @@ def ubuntu_task(request: FixtureRequest, ftp_server: List[URL]) -> ServiceExampl
                 f"some_file_input_{index+1}": FileUrl(url=f"{file}")
                 for index, file in enumerate(ftp_server)
             },
+            **{
+                f"some_file_input_with_mapping{index+1}": FileUrl(
+                    url=f"{file}", file_mapping=f"{index+1}/some_file_input"
+                )
+                for index, file in enumerate(ftp_server)
+            },
         }
     )
     # check in the console that the expected files are present in the expected INPUT folder (set as ${INPUT_FOLDER} in the service)
@@ -158,11 +164,11 @@ def ubuntu_task(request: FixtureRequest, ftp_server: List[URL]) -> ServiceExampl
     list_of_commands = [
         "echo User: $(id $(whoami))",
         "echo Inputs:",
-        "ls -tlah ${INPUT_FOLDER}",
+        "ls -tlah -R ${INPUT_FOLDER}",
         "echo Outputs:",
-        "ls -tlah ${OUTPUT_FOLDER}",
+        "ls -tlah -R ${OUTPUT_FOLDER}",
         "echo Logs:",
-        "ls -tlah ${LOG_FOLDER}",
+        "ls -tlah -R ${LOG_FOLDER}",
     ]
     list_of_commands += [
         f"(test -f ${{INPUT_FOLDER}}/{file} || (echo ${{INPUT_FOLDER}}/{file} does not exists && exit 1))"
@@ -197,7 +203,12 @@ def ubuntu_task(request: FixtureRequest, ftp_server: List[URL]) -> ServiceExampl
                     "required": True,
                     "mapping": "a_outputfile",
                     "url": f"{output_file_url}",
-                }
+                },
+                "pytest_file_with_mapping": {
+                    "required": True,
+                    "mapping": "subfolder/a_outputfile",
+                    "url": f"{output_file_url}",
+                },
             },
         }
     )
@@ -208,7 +219,11 @@ def ubuntu_task(request: FixtureRequest, ftp_server: List[URL]) -> ServiceExampl
                 "pytest_file": {
                     "url": f"{output_file_url}",
                     "file_mapping": "a_outputfile",
-                }
+                },
+                "pytest_file_with_mapping": {
+                    "url": f"{output_file_url}",
+                    "file_mapping": "subfolder/a_outputfile",
+                },
             },
         }
     )

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -248,6 +248,8 @@ def ubuntu_task(request: FixtureRequest, ftp_server: List[URL]) -> ServiceExampl
     list_of_commands += [
         f"echo {jsonized_outputs} > ${{OUTPUT_FOLDER}}/{output_json_file_name}",
         "echo 'some data for the output file' > ${OUTPUT_FOLDER}/a_outputfile",
+        "mkdir -p ${OUTPUT_FOLDER}/subfolder",
+        "echo 'some data for the output file' > ${OUTPUT_FOLDER}/subfolder/a_outputfile",
     ]
 
     log_file_url = parse_obj_as(
@@ -258,8 +260,8 @@ def ubuntu_task(request: FixtureRequest, ftp_server: List[URL]) -> ServiceExampl
         docker_basic_auth=DockerBasicAuth(
             server_address="docker.io", username="pytest", password=""
         ),
-        service_key="ubuntu",
-        service_version="latest",
+        service_key="itisfoundation/sleeper",
+        service_version="2.1.2",
         command=[
             "/bin/bash",
             "-c",

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -260,6 +260,11 @@ def ubuntu_task(request: FixtureRequest, ftp_server: List[URL]) -> ServiceExampl
         docker_basic_auth=DockerBasicAuth(
             server_address="docker.io", username="pytest", password=""
         ),
+        #
+        # NOTE: we use sleeper because it defines a user
+        # that can write in outputs and the
+        # sidecar can remove the outputs dirs
+        #
         service_key="itisfoundation/sleeper",
         service_version="2.1.2",
         command=[


### PR DESCRIPTION
## What do these changes do?

Fixes running python-runner error due to missing folder when pulling inputs to the service. 

This bug is also found in production. Hotfix required.

### Steps
1. create a ``main.py`` with
```python
print("hello world")
```
2. connect to a python runner and run as
![image](https://user-images.githubusercontent.com/32402063/146242536-5bae881c-d50d-4b47-bc3a-722dc8defd3a.png)

This run would fail with the following log
![image](https://user-images.githubusercontent.com/32402063/146243009-e4a0a0f1-ad09-4aab-9ed3-ee6b471abdb2.png)

since the routine ``pull_file_from_remote`` would raise ``FileNotFoundError`` because the folders for the destination path do not exist.

The design guarantees (by ``TaskSharedVolumes.__post_init__``) that the input/outputs and logs folders exist (although not that they are empty!). The problem is that  ``destination_path = task_volumes.inputs_folder / something_else`` and `something_else`` path might have some extra sub-folders.

This PR provides a temporary fix but IMO is not fully satisfactory since ``destination_path``
- upon creation we ignore if the folder already exists and contains previous results (by setting ``exists_ok=True``)
- ~~does not define a clear lifetime: i.e. a clean creation/deletion context~~ -> ``TaskSharedVolumes`` provides a context manager but does not guarantee ``cleanup``.


## Related issue/s



## How to test

- tests input/output files with subfolders
```command
cd services/dask-sidecar
make install-dev
pytest --pdb -vv tests/unit/test_tasks.py
```
