### PR TITLE
🐛 add update certificates call to dask sidecar

### DIFF
--- a/services/dask-sidecar/docker/entrypoint.sh
+++ b/services/dask-sidecar/docker/entrypoint.sh
@@ -8,6 +8,13 @@ INFO="INFO: [$(basename "$0")] "
 WARNING="WARNING: [$(basename "$0")] "
 ERROR="ERROR: [$(basename "$0")] "
 
+# Read self-signed SSH certificates (if applicable)
+#
+# In case storage must access a docker registry in a secure way using
+# non-standard certificates (e.g. such as self-signed certificates), this call is needed.
+# It needs to be executed as root.
+update-ca-certificates
+
 # This entrypoint script:
 #
 # - Executes *inside* of the container upon start as --user [default root]


### PR DESCRIPTION
For the local deployment of oSparc, we need to point the dask-sidecar to the self-signed certificate in order to connect to storage. While the certificates are handled in the docker-compose file for the local deployment in the ops-repo, we need to call 'update-ca-certificates' in order to read them (as root!, at the right place). If the deployment is non-local
(i.e. the regular docker-compose files from the ops-repo are used or simcore is built 'vanilla' without the ops repo) nothing will happen. These changes have been tested locally and it looks good from my side currently.