### PR TITLE
Bug fix: Draw connection to existing parameter

### DIFF
--- a/services/web/client/source/class/osparc/component/form/renderer/PropForm.js
+++ b/services/web/client/source/class/osparc/component/form/renderer/PropForm.js
@@ -199,7 +199,12 @@ qx.Class.define("osparc.component.form.renderer.PropForm", {
               });
               paramButton.addListener("execute", () => {
                 this.getNode().addInputNode(inputNodeId);
-                this.getNode().addPortLink(targetPortId, inputNodeId, outputKey);
+                this.getNode().addPortLink(targetPortId, inputNodeId, outputKey)
+                  .then(connected => {
+                    if (connected) {
+                      this.getNode().fireEvent("reloadModel");
+                    }
+                  });
               }, this);
               menu.add(paramButton);
               osparc.utils.Ports.arePortsCompatible(inputNode, outputKey, this.getNode(), targetPortId)
@@ -269,7 +274,12 @@ qx.Class.define("osparc.component.form.renderer.PropForm", {
                 const paramButton = new qx.ui.menu.Button(inputNode.getOutput(outputKey).label);
                 paramButton.addListener("execute", () => {
                   this.getNode().addInputNode(inputNodeId);
-                  this.getNode().addPortLink(targetPortId, inputNodeId, outputKey);
+                  this.getNode().addPortLink(targetPortId, inputNodeId, outputKey)
+                    .then(connected => {
+                      if (connected) {
+                        this.getNode().fireEvent("reloadModel");
+                      }
+                    });
                 }, this);
                 menu.add(paramButton);
                 menuBtn.show();
@@ -295,7 +305,12 @@ qx.Class.define("osparc.component.form.renderer.PropForm", {
               paramNode.bind("label", paramButton, "label");
               paramButton.addListener("execute", () => {
                 this.getNode().addInputNode(inputNodeId);
-                this.getNode().addPortLink(targetPortId, inputNodeId, outputKey);
+                this.getNode().addPortLink(targetPortId, inputNodeId, outputKey)
+                  .then(connected => {
+                    if (connected) {
+                      this.getNode().fireEvent("reloadModel");
+                    }
+                  });
               }, this);
               if (!menu.getChildren().some(child => child.nodeId === paramButton.nodeId)) {
                 menu.add(paramButton);

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -210,6 +210,7 @@ qx.Class.define("osparc.data.model.Node", {
   },
 
   events: {
+    "reloadModel": "qx.event.type.Event",
     "retrieveInputs": "qx.event.type.Data",
     "fileRequested": "qx.event.type.Data",
     "parameterRequested": "qx.event.type.Data",

--- a/services/web/client/source/class/osparc/data/model/Workbench.js
+++ b/services/web/client/source/class/osparc/data/model/Workbench.js
@@ -257,6 +257,7 @@ qx.Class.define("osparc.data.model.Workbench", {
     __createNode: function(study, key, version, uuid) {
       const node = new osparc.data.model.Node(study, key, version, uuid);
       node.addListener("changeInputNodes", () => this.fireDataEvent("pipelineChanged"), this);
+      node.addListener("reloadModel", () => this.fireEvent("reloadModel"), this);
       return node;
     },
 


### PR DESCRIPTION
## What do these changes do?

Fix: Connection to existing parameter not drawn bug

![ConnectExistingParameter](https://user-images.githubusercontent.com/33152403/147094582-ed3d63dd-b0fa-4fa8-a4aa-5c51e3cc108c.gif)


## Related issue/s

closes https://github.com/ITISFoundation/osparc-simcore/issues/2705


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
