### PR TITLE
App mode: Smarter Next button

### DIFF
--- a/services/web/client/source/class/osparc/component/node/NodeView.js
+++ b/services/web/client/source/class/osparc/component/node/NodeView.js
@@ -37,6 +37,8 @@ qx.Class.define("osparc.component.node.NodeView", {
   extend: osparc.component.node.BaseNodeView,
 
   statics: {
+    LOGGER_HEIGHT: 28,
+
     isPropsFormShowable: function(node) {
       if (node && ("getPropsForm" in node) && node.getPropsForm()) {
         return node.getPropsForm().hasVisibleInputs();
@@ -115,11 +117,12 @@ qx.Class.define("osparc.component.node.NodeView", {
       const loggerView = this.getNode().getLogger();
       loggerView.getChildControl("pin-node").exclude();
       const loggerPanel = this.__loggerPanel = new osparc.desktop.PanelView(this.tr("Logger"), loggerView).set({
-        minHeight: 24,
+        padding: 3,
+        minHeight: this.self().LOGGER_HEIGHT-1,
         collapsed: true
       });
       loggerPanel.bind("collapsed", loggerPanel, "maxHeight", {
-        converter: collapsed => collapsed ? 25 : null
+        converter: collapsed => collapsed ? this.self().LOGGER_HEIGHT : null
       });
       this.add(loggerPanel, 0);
     },

--- a/services/web/client/source/class/osparc/desktop/SlideshowView.js
+++ b/services/web/client/source/class/osparc/desktop/SlideshowView.js
@@ -234,13 +234,18 @@ qx.Class.define("osparc.desktop.SlideshowView", {
           maxWidth: node.isDynamic() ? null : 800,
           margin: this.self().CARD_MARGIN
         });
-        view.getMainView().set({
-          backgroundColor: "contrasted-background+",
-          padding: 10,
-          paddingBottom: 0
-        });
         if (node.isParameter()) {
           view.bind("backgroundColor", view.getChildControl("frame"), "backgroundColor");
+          view.set({
+            backgroundColor: "contrasted-background+",
+            padding: 10
+          });
+        } else {
+          view.getMainView().set({
+            backgroundColor: "contrasted-background+",
+            padding: 10,
+            paddingBottom: 0
+          });
         }
 
         // If the current node is moving forward do some run checks:

--- a/services/web/client/source/class/osparc/desktop/SlideshowView.js
+++ b/services/web/client/source/class/osparc/desktop/SlideshowView.js
@@ -272,6 +272,8 @@ qx.Class.define("osparc.desktop.SlideshowView", {
           }
         }
 
+        this.__prevNextButtons.setNode(node);
+
         if (view) {
           if (this.__nodeView && this.__mainView.getChildren().includes(this.__nodeView)) {
             this.__mainView.remove(this.__nodeView);

--- a/services/web/client/source/class/osparc/navigation/PrevNextButtons.js
+++ b/services/web/client/source/class/osparc/navigation/PrevNextButtons.js
@@ -41,6 +41,19 @@ qx.Class.define("osparc.navigation.PrevNextButtons", {
       check: "osparc.data.model.Study",
       apply: "__applyStudy",
       nullable: false
+    },
+
+    node: {
+      check: "osparc.data.model.Node",
+      apply: "__applyNode",
+      nullable: false
+    },
+
+    nextState: {
+      check: ["ready", "busy", "run", "select-file"],
+      apply: "__updateNextButtonState",
+      nullable: false,
+      init: null
     }
   },
 
@@ -59,14 +72,14 @@ qx.Class.define("osparc.navigation.PrevNextButtons", {
     __createButtons: function() {
       const prvsBtn = this.__prvsBtn = new qx.ui.form.Button().set({
         toolTipText: qx.locale.Manager.tr("Previous"),
-        icon: "@FontAwesome5Solid/arrow-left/24",
+        icon: "@FontAwesome5Solid/arrow-left/32",
         ...this.self().BUTTON_OPTIONS
       });
       prvsBtn.addListener("execute", () => this.__prevPressed(), this);
 
       const nextBtn = this.__nextBtn = new qx.ui.form.Button().set({
         toolTipText: qx.locale.Manager.tr("Next"),
-        icon: "@FontAwesome5Solid/arrow-right/24",
+        icon: "@FontAwesome5Solid/arrow-right/32",
         ...this.self().BUTTON_OPTIONS
       });
       nextBtn.addListener("execute", () => this.__nextPressed(), this);
@@ -77,6 +90,52 @@ qx.Class.define("osparc.navigation.PrevNextButtons", {
       study.getUi().addListener("changeCurrentNodeId", () => this.__updatePrevNextButtons(), this);
     },
 
+    __applyNode: function(node) {
+      this.__updatePrevNextButtons();
+      node.getStatus().addListener("changeRunning", () => this.__updatePrevNextButtons(), this);
+      node.getStatus().addListener("changeOutput", () => this.__updatePrevNextButtons(), this);
+    },
+
+    __updateNextButtonState: function(state) {
+      let icon = "@FontAwesome5Solid/arrow-right/32";
+      let toolTipText = qx.locale.Manager.tr("Next");
+      let textColor = "text";
+      let animate = false;
+      let enabled = true;
+      switch (state) {
+        case "run":
+          icon = "@FontAwesome5Solid/play/32";
+          toolTipText = qx.locale.Manager.tr("Run");
+          break;
+        case "select-file":
+          icon = "@FontAwesome5Solid/file-medical/32";
+          toolTipText = qx.locale.Manager.tr("Select File");
+          enabled = false;
+          break;
+        case "busy":
+          icon = "@FontAwesome5Solid/circle-notch/32";
+          toolTipText = qx.locale.Manager.tr("Running");
+          textColor = "busy-orange";
+          animate = true;
+          enabled = false;
+          break;
+      }
+      if (this.__nextBtn) {
+        this.__nextBtn.set({
+          icon,
+          toolTipText,
+          textColor,
+          enabled
+        });
+        const btnIcon = this.__nextBtn.getChildControl("icon").getContentElement();
+        if (animate) {
+          osparc.ui.basic.NodeStatusUI.addClass(btnIcon, "rotate");
+        } else {
+          osparc.ui.basic.NodeStatusUI.removeClass(btnIcon, "rotate");
+        }
+      }
+    },
+
     __updatePrevNextButtons: function() {
       const studyUI = this.getStudy().getUi();
       const currentNodeId = studyUI.getCurrentNodeId();
@@ -84,7 +143,24 @@ qx.Class.define("osparc.navigation.PrevNextButtons", {
       const currentIdx = nodesIds.indexOf(currentNodeId);
 
       this.__prvsBtn.setEnabled(currentIdx > 0);
-      this.__nextBtn.setEnabled(currentIdx < nodesIds.length-1);
+      // this.__nextBtn.setEnabled(currentIdx < nodesIds.length-1);
+
+      const currentNode = this.getStudy().getWorkbench().getNode(nodesIds[currentIdx]);
+      if (currentNode) {
+        const currentNodeStatus = currentNode.getStatus();
+        const currentNodeStatusOutput = currentNodeStatus.getOutput();
+        if (["busy"].includes(currentNodeStatusOutput)) {
+          this.setNextState("busy");
+        } else if (currentNode.isFilePicker() && ["not-available"].includes(currentNodeStatusOutput)) {
+          this.setNextState("select-file");
+        } else if (["not-available", "out-of-date"].includes(currentNodeStatusOutput)) {
+          this.setNextState("run");
+        } else {
+          this.setNextState("ready");
+        }
+      } else {
+        this.setNextState("ready");
+      }
     },
 
     __prevPressed: function() {

--- a/services/web/client/source/class/osparc/navigation/PrevNextButtons.js
+++ b/services/web/client/source/class/osparc/navigation/PrevNextButtons.js
@@ -153,7 +153,7 @@ qx.Class.define("osparc.navigation.PrevNextButtons", {
           this.setNextState("busy");
         } else if (currentNode.isFilePicker() && ["not-available"].includes(currentNodeStatusOutput)) {
           this.setNextState("select-file");
-        } else if (["not-available", "out-of-date"].includes(currentNodeStatusOutput)) {
+        } else if (currentNode.isComputational() && ["not-available", "out-of-date"].includes(currentNodeStatusOutput)) {
           this.setNextState("run");
         } else {
           this.setNextState("ready");

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -66,6 +66,10 @@ class TutorialBase {
 
     await auto.acceptCookies(this.__page);
     await this.takeScreenshot("postCookies_" + domain);
+
+    // eslint-disable-next-line no-undef
+    const commit = await this.__page.evaluate(() => qx.core.Environment.get("osparc.vcsRef"));
+    console.log("commit", commit);
   }
 
   async start() {


### PR DESCRIPTION
## What do these changes do?

Depending on the state of the current node's outputs ("not-available", "out-of-date", "busy", "up-to-date"), the Next button shows:
- "not-available" or "out-of-date": "Run" (Computational) or "Select-file" (File Picker)
- "busy": "Running"
- "up-to-date": "Arrow"

![NextButton](https://user-images.githubusercontent.com/33152403/147254543-3027152f-f752-46da-82fe-c92a71266cc0.gif)


### Bonus:
- [x] Print commit hash in the e2e

## Related issue/s
Related to https://github.com/ITISFoundation/osparc-simcore/issues/2661
If the last node is a computational one it can still be run

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
