### PR TITLE
✨ Improve Traefik rules (⚠️ devops)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -191,11 +191,12 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.interval=2000ms
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.timeout=1000ms
         - traefik.http.middlewares.${SWARM_STACK_NAME}_webserver_retry.retry.attempts=2
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.service=${SWARM_STACK_NAME}_webserver
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.rule=hostregexp(`{host:.+}`)
           && (Path(`/`)
           ||  PathPrefix(`/v0`,`/socket.io`,`/static-frontend-data.json`))
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.entrypoints=http
-        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.priority=1
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.priority=2
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.middlewares=${SWARM_STACK_NAME}_gzip@docker,
           ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader@docker,
           ${SWARM_STACK_NAME}_webserver_retry
@@ -433,6 +434,16 @@ services:
         - traefik.http.middlewares.ratelimit-${SWARM_STACK_NAME}_api-server.ratelimit.burst=10
         # X-Forwarded-For header extracts second IP from the right, count starts at one
         - traefik.http.middlewares.ratelimit-${SWARM_STACK_NAME}_api-server.ratelimit.sourcecriterion.ipstrategy.depth=2
+        # catchall service
+        - traefik.http.routers.${SWARM_STACK_NAME}_catchall.service=${SWARM_STACK_NAME}_catchall
+        - traefik.http.routers.${SWARM_STACK_NAME}_catchall.priority=1
+        - traefik.http.routers.${SWARM_STACK_NAME}_catchall.entrypoints=http
+        - traefik.http.routers.${SWARM_STACK_NAME}_catchall.rule=hostregexp(`{host:.+}`)
+          && PathPrefix(`/`)
+        - traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.server.port=0
+        - traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.healthcheck.path=/some/invalid/path/to/generate/a/503
+        - traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.healthcheck.interval=500s
+        - traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.healthcheck.timeout=1ms
     networks:
       - default
       - interactive_services_subnet

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -147,7 +147,9 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_static_webserver.loadbalancer.healthcheck.interval=2000ms
         - traefik.http.services.${SWARM_STACK_NAME}_static_webserver.loadbalancer.healthcheck.timeout=1000ms
         - traefik.http.middlewares.${SWARM_STACK_NAME}_static_webserver_retry.retry.attempts=2
-        - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.rule=hostregexp(`{host:.+}`) && (PathPrefix(`/osparc`) || PathPrefix(`/s4l`) || PathPrefix(`/tis`) || PathPrefix(`/transpiled`) || PathPrefix(`/resource`))
+        - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.rule=hostregexp(`{host:.+}`)
+          && (PathPrefix(`/osparc`) || PathPrefix(`/s4l`) || PathPrefix(`/tis`)
+          || PathPrefix(`/transpiled`) || PathPrefix(`/resource`))
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.priority=2
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.middlewares=${SWARM_STACK_NAME}_gzip@docker,${SWARM_STACK_NAME}_static_webserver_retry
@@ -189,10 +191,12 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.interval=2000ms
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.timeout=1000ms
         - traefik.http.middlewares.${SWARM_STACK_NAME}_webserver_retry.retry.attempts=2
-        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.rule=hostregexp(`{host:.+}`) && (PathPrefix(`/`) || PathPrefix(`/v0`) || PathPrefix(`/socket.io`) || PathPrefix(`/static-frontend-data.json`))
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.rule=hostregexp(`{host:.+}`) && (Path(`/`) ||  PathPrefix(`/v0`,`/socket.io`,`/static-frontend-data.json`))
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.priority=1
-        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.middlewares=${SWARM_STACK_NAME}_gzip@docker, ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader@docker, ${SWARM_STACK_NAME}_webserver_retry
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.middlewares=${SWARM_STACK_NAME}_gzip@docker,
+          ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader@docker,
+          ${SWARM_STACK_NAME}_webserver_retry
     networks:
       - default
       - interactive_services_subnet
@@ -307,7 +311,8 @@ services:
       - default
 
   postgres:
-    image: "postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f"
+    image: "postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27\
+      c02d8adb8feb20f"
     init: true
     hostname: "{{.Node.Hostname}}-{{.Service.Name}}-{{.Task.Slot}}"
     environment:
@@ -362,7 +367,8 @@ services:
       ]
 
   redis:
-    image: "redis:5.0.9-alpine@sha256:b011c1ca7fa97ed92d6c5995e5dd752dc37fe157c1b60ce96a6e35701851dabc"
+    image: "redis:5.0.9-alpine@sha256:b011c1ca7fa97ed92d6c5995e5dd752dc37fe157c1b60\
+      ce96a6e35701851dabc"
     init: true
     hostname: "{{.Node.Hostname}}-{{.Service.Name}}-{{.Task.Slot}}"
     networks:
@@ -384,8 +390,8 @@ services:
       - "--ping=true"
       - "--entryPoints.ping.address=:9082"
       - "--ping.entryPoint=ping"
-      - "--log.level=WARNING"
-      - "--accesslog=false"
+      - "--log.level=DEBUG"
+      - "--accesslog=true"
       - "--metrics.prometheus=true"
       - "--metrics.prometheus.addEntryPointsLabels=true"
       - "--metrics.prometheus.addServicesLabels=true"
@@ -403,7 +409,8 @@ services:
       # https://github.com/traefik/traefik/issues/7886
       - "--providers.docker.swarmModeRefreshSeconds=1"
       - "--providers.docker.exposedByDefault=false"
-      - "--providers.docker.constraints=Label(`io.simcore.zone`, `${TRAEFIK_SIMCORE_ZONE}`)"
+      - "--providers.docker.constraints=Label(`io.simcore.zone`,
+        `${TRAEFIK_SIMCORE_ZONE}`)"
       - "--tracing=true"
       - "--tracing.jaeger=true"
       - "--tracing.jaeger.samplingServerURL=http://jaeger:5778/sampling"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -191,7 +191,9 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.interval=2000ms
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.timeout=1000ms
         - traefik.http.middlewares.${SWARM_STACK_NAME}_webserver_retry.retry.attempts=2
-        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.rule=hostregexp(`{host:.+}`) && (Path(`/`) ||  PathPrefix(`/v0`,`/socket.io`,`/static-frontend-data.json`))
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.rule=hostregexp(`{host:.+}`)
+          && (Path(`/`)
+          ||  PathPrefix(`/v0`,`/socket.io`,`/static-frontend-data.json`))
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.priority=1
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.middlewares=${SWARM_STACK_NAME}_gzip@docker,
@@ -381,7 +383,7 @@ services:
       retries: 50
 
   traefik:
-    image: traefik:v2.4.13
+    image: traefik:v2.5.6
     init: true
     hostname: "{{.Node.Hostname}}-{{.Service.Name}}-{{.Task.Slot}}"
     command:
@@ -390,8 +392,8 @@ services:
       - "--ping=true"
       - "--entryPoints.ping.address=:9082"
       - "--ping.entryPoint=ping"
-      - "--log.level=DEBUG"
-      - "--accesslog=true"
+      - "--log.level=WARNING"
+      - "--accesslog=false"
       - "--metrics.prometheus=true"
       - "--metrics.prometheus.addEntryPointsLabels=true"
       - "--metrics.prometheus.addServicesLabels=true"


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Several issues were identified with the current configuration of traefik with regards to dynamic services (legacy ones).
## Problem
- When the legacy service is removed (for example, if the service was forcefully removed, or the user disconnected for some reason and comes back later), the frontend of that service would try to reconnect with its backend (as for any socket.io based services).
In the current configuration, all the calls to /x/UUID were redirected to the webserver, which would rightfully answer with a 404 - NOT FOUND. This would trigger an infinite loop where the frontend tries to re-connect with its lost backend (and also triggers the Directory Not Found error in Jupyter lab).

## Solution
- The new settings changes how the webserver traefik rules are set by changing it to take: Only ```/``` or anything that starts with ```/v0``` or ```/socket.io``` or ```/static-frontend-data.json``` instead of anything with ```/``` --> in any case a /x/UUID will end its life in Traefik thus relieving the webserver from handling this request.
- The new settings define a ```catch all``` service that will return a 503 (service unavalaible) instead of a 404, which calms down jupyter lab

## Bonus
- upgraded Traefik to 2.5.6
## Related issue/s


⚠️ devops: The part modified in docker-compose under traefik service MUST BE taken in the OPS deployment so that the catch all service also exists there. In particular:
```yml
# catchall service
- traefik.http.routers.${SWARM_STACK_NAME}_catchall.service=${SWARM_STACK_NAME}_catchall
- traefik.http.routers.${SWARM_STACK_NAME}_catchall.priority=1
- traefik.http.routers.${SWARM_STACK_NAME}_catchall.entrypoints=http
- traefik.http.routers.${SWARM_STACK_NAME}_catchall.rule=hostregexp(`{host:.+}`)
  && PathPrefix(`/`)
- traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.server.port=0
- traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.healthcheck.path=/some/invalid/path/to/generate/a/503
- traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.healthcheck.interval=500s
- traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.healthcheck.timeout=1ms
```

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
