### PR TITLE
✨ Change default limit for computational services to 1 CPU

### DIFF
--- a/packages/settings-library/src/settings_library/comp_services.py
+++ b/packages/settings-library/src/settings_library/comp_services.py
@@ -1,15 +1,18 @@
 from pydantic import ByteSize, NonNegativeInt, validator
+from pydantic.tools import parse_raw_as
 from settings_library.base import BaseCustomSettings
 
 from .constants import GB
 
-_DEFAULT_MAX_NANO_CPUS_VALUE = 4 * pow(10, 9)
+_DEFAULT_MAX_NANO_CPUS_VALUE = 1 * pow(10, 9)
 _DEFAULT_MAX_MEMORY_VALUE = 2 * GB
 
 
 class ComputationalServices(BaseCustomSettings):
     DEFAULT_MAX_NANO_CPUS: NonNegativeInt = _DEFAULT_MAX_NANO_CPUS_VALUE
-    DEFAULT_MAX_MEMORY: ByteSize = _DEFAULT_MAX_MEMORY_VALUE
+    DEFAULT_MAX_MEMORY: ByteSize = parse_raw_as(
+        ByteSize, f"{_DEFAULT_MAX_MEMORY_VALUE}"
+    )
     DEFAULT_RUNTIME_TIMEOUT: NonNegativeInt = 0
 
     @validator("DEFAULT_MAX_NANO_CPUS", pre=True)

--- a/services/director/src/simcore_service_director/config.py
+++ b/services/director/src/simcore_service_director/config.py
@@ -33,7 +33,7 @@ def _from_env_with_default(env: str, python_type, default):
 
 # NOTE: these settings must be in sync with settings-library: comp_services.py (since the director is frozen)
 DEFAULT_MAX_NANO_CPUS: int = _from_env_with_default(
-    "DEFAULT_MAX_NANO_CPUS", int, 4 * pow(10, 9)
+    "DEFAULT_MAX_NANO_CPUS", int, 1 * pow(10, 9)
 )
 DEFAULT_MAX_MEMORY: int = _from_env_with_default(
     "DEFAULT_MAX_MEMORY", int, 2 * pow(1024, 3)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Changes the default (when no limit is set) on a computational service to use 1 CPU (and 2GB (unchanged))

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
