### PR TITLE
Start aiohttp services using gunicorn

### DIFF
--- a/packages/service-library/requirements/_aiohttp.in
+++ b/packages/service-library/requirements/_aiohttp.in
@@ -11,7 +11,6 @@ aiozipkin
 
 aiohttp
 aiopg[sa]
-nest_asyncio # used for aiozipkin initialization (we should move to OpenTelemetry) # see issue [#2715](https://github.com/ITISFoundation/osparc-simcore/issues/2715)
 jsonschema
 prometheus_client
 attrs

--- a/packages/service-library/requirements/_aiohttp.in
+++ b/packages/service-library/requirements/_aiohttp.in
@@ -7,7 +7,7 @@
 
 openapi-core==0.12.0     # frozen until https://github.com/ITISFoundation/osparc-simcore/pull/1396 is CLOSED
 lazy-object-proxy~=1.4.3 # cannot upgrade due to contraints in openapi-core
-
+aiozipkin
 
 aiohttp
 aiopg[sa]

--- a/packages/service-library/requirements/_aiohttp.in
+++ b/packages/service-library/requirements/_aiohttp.in
@@ -11,6 +11,7 @@ lazy-object-proxy~=1.4.3 # cannot upgrade due to contraints in openapi-core
 
 aiohttp
 aiopg[sa]
+nest_asyncio # used for aiozipkin initialization (we should move to OpenTelemetry)
 jsonschema
 prometheus_client
 attrs

--- a/packages/service-library/requirements/_aiohttp.in
+++ b/packages/service-library/requirements/_aiohttp.in
@@ -11,7 +11,7 @@ aiozipkin
 
 aiohttp
 aiopg[sa]
-nest_asyncio # used for aiozipkin initialization (we should move to OpenTelemetry)
+nest_asyncio # used for aiozipkin initialization (we should move to OpenTelemetry) # see issue [#2715](https://github.com/ITISFoundation/osparc-simcore/issues/2715)
 jsonschema
 prometheus_client
 attrs

--- a/packages/service-library/requirements/_aiohttp.in
+++ b/packages/service-library/requirements/_aiohttp.in
@@ -7,7 +7,6 @@
 
 openapi-core==0.12.0     # frozen until https://github.com/ITISFoundation/osparc-simcore/pull/1396 is CLOSED
 lazy-object-proxy~=1.4.3 # cannot upgrade due to contraints in openapi-core
-aiozipkin~=0.7.1         # 1.X has an issue with no content responses
 
 
 aiohttp

--- a/packages/service-library/requirements/_aiohttp.txt
+++ b/packages/service-library/requirements/_aiohttp.txt
@@ -8,10 +8,13 @@ aiohttp==3.8.1
     # via
     #   -c requirements/./../../../requirements/constraints.txt
     #   -r requirements/_aiohttp.in
+    #   aiozipkin
 aiopg==1.3.3
     # via -r requirements/_aiohttp.in
 aiosignal==1.2.0
     # via aiohttp
+aiozipkin==1.1.1
+    # via -r requirements/_aiohttp.in
 async-timeout==4.0.1
     # via
     #   aiohttp
@@ -53,8 +56,6 @@ multidict==5.2.0
     # via
     #   aiohttp
     #   yarl
-nest-asyncio==1.5.4
-    # via -r requirements/_aiohttp.in
 openapi-core==0.12.0
     # via -r requirements/_aiohttp.in
 openapi-schema-validator==0.1.5

--- a/packages/service-library/requirements/_aiohttp.txt
+++ b/packages/service-library/requirements/_aiohttp.txt
@@ -13,8 +13,7 @@ aiopg==1.3.3
     # via -r requirements/_aiohttp.in
 aiosignal==1.2.0
     # via aiohttp
-aiozipkin==0.7.1
-    # via -r requirements/_aiohttp.in
+aiozipkin==1.1.1
 async-timeout==4.0.1
     # via
     #   aiohttp

--- a/packages/service-library/requirements/_aiohttp.txt
+++ b/packages/service-library/requirements/_aiohttp.txt
@@ -8,12 +8,10 @@ aiohttp==3.8.1
     # via
     #   -c requirements/./../../../requirements/constraints.txt
     #   -r requirements/_aiohttp.in
-    #   aiozipkin
 aiopg==1.3.3
     # via -r requirements/_aiohttp.in
 aiosignal==1.2.0
     # via aiohttp
-aiozipkin==1.1.1
 async-timeout==4.0.1
     # via
     #   aiohttp
@@ -55,6 +53,8 @@ multidict==5.2.0
     # via
     #   aiohttp
     #   yarl
+nest-asyncio==1.5.4
+    # via -r requirements/_aiohttp.in
 openapi-core==0.12.0
     # via -r requirements/_aiohttp.in
 openapi-schema-validator==0.1.5

--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -2,6 +2,7 @@ import functools
 import inspect
 import logging
 from datetime import datetime
+from distutils.util import strtobool
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Protocol
 
@@ -42,14 +43,14 @@ class DependencyError(ApplicationSetupError):
 
 def _is_app_module_enabled(cfg: Dict, parts: List[str], section) -> bool:
     # navigates app_config (cfg) searching for section
+    enabled = False
     for part in parts:
         if section and part == "enabled":
             # if section exists, no need to explicitly enable it
-            cfg = cfg.get(part, True)
+            enabled = strtobool(f"{cfg.get(part, True)}")
         else:
-            cfg = cfg[part]
-    assert isinstance(cfg, bool)  # nosec
-    return cfg
+            enabled = cfg[part]
+    return enabled
 
 
 def app_module_setup(

--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 import logging
+from copy import deepcopy
 from datetime import datetime
 from distutils.util import strtobool
 from enum import Enum
@@ -43,14 +44,14 @@ class DependencyError(ApplicationSetupError):
 
 def _is_app_module_enabled(cfg: Dict, parts: List[str], section) -> bool:
     # navigates app_config (cfg) searching for section
-    enabled = False
+    searched_config = deepcopy(cfg)
     for part in parts:
         if section and part == "enabled":
             # if section exists, no need to explicitly enable it
-            enabled = strtobool(f"{cfg.get(part, True)}")
-        else:
-            enabled = cfg[part]
-    return enabled
+            return strtobool(f"{searched_config.get(part, True)}")
+        searched_config = searched_config[part]
+    assert isinstance(searched_config, bool)  # nosec
+    return searched_config
 
 
 def app_module_setup(

--- a/packages/service-library/src/servicelib/aiohttp/tracing.py
+++ b/packages/service-library/src/servicelib/aiohttp/tracing.py
@@ -14,13 +14,6 @@ from yarl import URL
 
 log = logging.getLogger(__name__)
 
-# TODO: This is currently used here in order to call an async function
-# inside the synchronous setup_tracing function.
-# WE should move to using OpenTelemetry instead (recommended by Jaeger, Zipkin, etc)
-# https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/asgi/asgi.html
-
-nest_asyncio.apply()
-
 
 def setup_tracing(
     app: web.Application,
@@ -47,6 +40,12 @@ def setup_tracing(
 
     endpoint = az.create_endpoint(service_name, ipv4=host, port=port)
 
+    # TODO: move away from aiozipkin to OpenTelemetrySDK
+    # TODO: This is currently used here in order to call an async function
+    # inside the synchronous setup_tracing function.
+    # WE should move to using OpenTelemetry instead (recommended by Jaeger, Zipkin, etc)
+    # https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/asgi/asgi.html
+    nest_asyncio.apply()
     tracer: Tracer = asyncio.get_event_loop().run_until_complete(
         az.create(f"{zipkin_address}", endpoint, sample_rate=1.0)
     )

--- a/packages/service-library/src/servicelib/aiohttp/tracing.py
+++ b/packages/service-library/src/servicelib/aiohttp/tracing.py
@@ -45,6 +45,7 @@ def setup_tracing(
     # inside the synchronous setup_tracing function.
     # WE should move to using OpenTelemetry instead (recommended by Jaeger, Zipkin, etc)
     # https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/asgi/asgi.html
+    # see issue [#2715](https://github.com/ITISFoundation/osparc-simcore/issues/2715)
     nest_asyncio.apply()
     tracer: Tracer = asyncio.get_event_loop().run_until_complete(
         az.create(f"{zipkin_address}", endpoint, sample_rate=1.0)

--- a/packages/service-library/src/servicelib/aiohttp/tracing.py
+++ b/packages/service-library/src/servicelib/aiohttp/tracing.py
@@ -6,12 +6,20 @@ import logging
 from typing import Iterable, Optional, Union
 
 import aiozipkin as az
+import nest_asyncio
 from aiohttp import web
 from aiohttp.web import AbstractRoute
 from aiozipkin.tracer import Tracer
 from yarl import URL
 
 log = logging.getLogger(__name__)
+
+# TODO: This is currently used here in order to call an async function
+# inside the synchronous setup_tracing function.
+# WE should move to using OpenTelemetry instead (recommended by Jaeger, Zipkin, etc)
+# https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/asgi/asgi.html
+
+nest_asyncio.apply()
 
 
 def setup_tracing(
@@ -30,7 +38,7 @@ def setup_tracing(
     zipkin_address = URL(f"{jaeger_base_url}") / "api/v2/spans"
 
     log.debug(
-        "Settings up tracing for %s at %s:%d -> %s",
+        "Setting up tracing for %s at %s:%d -> %s",
         service_name,
         host,
         port,

--- a/packages/service-library/tests/aiohttp/test_tracing.py
+++ b/packages/service-library/tests/aiohttp/test_tracing.py
@@ -73,8 +73,6 @@ def client(
 
 
 async def test_setup_tracing(client: TestClient):
-    # NOTE: version aiozipkin 1.1.0 did not pass this test
-
     res: ClientResponse
 
     # on error

--- a/services/director-v2/src/simcore_service_director_v2/core/application.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/application.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 def init_app(settings: Optional[AppSettings] = None) -> FastAPI:
     if settings is None:
         settings = AppSettings.create_from_envs()
-
+    assert settings  # nosec
     logging.basicConfig(level=settings.LOG_LEVEL.value)
     logging.root.setLevel(settings.LOG_LEVEL.value)
     logger.debug(settings.json(indent=2))

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -29,6 +29,7 @@ aiopg==1.3.1
     #   -r requirements/../../../packages/service-library/requirements/_aiohttp.in
     #   -r requirements/_base.in
 aiozipkin==1.1.1
+    # via -r requirements/../../../packages/service-library/requirements/_aiohttp.in
 alembic==1.7.4
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
 async-timeout==3.0.1
@@ -114,6 +115,8 @@ multidict==5.1.0
     # via
     #   aiohttp
     #   yarl
+nest-asyncio==1.5.4
+    # via -r requirements/../../../packages/service-library/requirements/_aiohttp.in
 openapi-core==0.12.0
     # via -r requirements/../../../packages/service-library/requirements/_aiohttp.in
 openapi-schema-validator==0.1.5

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -28,8 +28,7 @@ aiopg==1.3.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_aiohttp.in
     #   -r requirements/_base.in
-aiozipkin==0.7.1
-    # via -r requirements/../../../packages/service-library/requirements/_aiohttp.in
+aiozipkin==1.1.1
 alembic==1.7.4
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
 async-timeout==3.0.1

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -115,8 +115,6 @@ multidict==5.1.0
     # via
     #   aiohttp
     #   yarl
-nest-asyncio==1.5.4
-    # via -r requirements/../../../packages/service-library/requirements/_aiohttp.in
 openapi-core==0.12.0
     # via -r requirements/../../../packages/service-library/requirements/_aiohttp.in
 openapi-schema-validator==0.1.5

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -32,7 +32,9 @@ fi
 # RUNNING application ----------------------------------------
 echo "$INFO" "Selected config $APP_CONFIG"
 
-# NOTE: the number of workers ```(2 x $num_cores) + 1``` is the official recommendation [https://docs.gunicorn.org/en/latest/design.html#how-many-workers]
+# NOTE: the number of workers ```(2 x $num_cores) + 1``` is
+# the official recommendation [https://docs.gunicorn.org/en/latest/design.html#how-many-workers]
+# For now we set it to 1 to check what happens with websockets
 
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   # NOTE: ptvsd is programmatically enabled inside of the service

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -43,7 +43,7 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   exec gunicorn simcore_service_webserver.cli:app_factory \
       --bind 0.0.0.0:8080 \
       --worker-class aiohttp.GunicornWebWorker \
-      --workers=2
+      --workers="${WEBSERVER_GUNICORN_WORKERS:-1}"
     # simcore_service_webserver --config $APP_CONFIG
 
 else

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -39,8 +39,13 @@ echo "$INFO" "Selected config $APP_CONFIG"
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   # NOTE: needs ptvsd installed
   echo "$INFO" "PTVSD Debugger initializing in port 3000 with ${APP_CONFIG}"
-  eval "$entrypoint" python3 -m ptvsd --host 0.0.0.0 --port 3000 -m \
-    simcore_service_webserver --config $APP_CONFIG
+  # exec python3 -m ptvsd --host 0.0.0.0 --port 3000 -m \
+  exec gunicorn simcore_service_webserver.cli:app_factory \
+      --bind 0.0.0.0:8080 \
+      --worker-class aiohttp.GunicornWebWorker \
+      --workers=2
+    # simcore_service_webserver --config $APP_CONFIG
+
 else
   exec simcore-service-webserver --config $APP_CONFIG
 fi

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -46,8 +46,6 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
     --access-logfile='-' \
     --access-logformat='%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"' \
     --reload
-  #
-  # simcore_service_webserver --config $APP_CONFIG
 
 else
   exec gunicorn simcore_service_webserver.cli:app_factory \
@@ -58,5 +56,4 @@ else
     --log-level="${LOG_LEVEL:-warning}" \
     --access-logfile='-' \
     --access-logformat='%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"'
-  # exec simcore-service-webserver --config $APP_CONFIG
 fi

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -44,8 +44,11 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
     --worker-class aiohttp.GunicornWebWorker \
     --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
     --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$" \
+    --log-level="${LOG_LEVEL:-info}" \
+    --access-logfile='-' \
+    --access-logformat='%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"' \
     --reload
-
+  #
   # simcore_service_webserver --config $APP_CONFIG
 
 else
@@ -53,6 +56,9 @@ else
     --bind 0.0.0.0:8080 \
     --worker-class aiohttp.GunicornWebWorker \
     --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
-    --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$"
+    --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$" \
+    --log-level="${LOG_LEVEL:-info}" \
+    --access-logfile='-' \
+    --access-logformat='%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"'
   # exec simcore-service-webserver --config $APP_CONFIG
 fi

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -57,7 +57,7 @@ else
     --worker-class aiohttp.GunicornWebWorker \
     --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
     --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$" \
-    --log-level="${LOG_LEVEL:-info}" \
+    --log-level="${LOG_LEVEL:-warning}" \
     --access-logfile='-' \
     --access-logformat='%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"'
   # exec simcore-service-webserver --config $APP_CONFIG

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -32,22 +32,27 @@ fi
 # RUNNING application ----------------------------------------
 echo "$INFO" "Selected config $APP_CONFIG"
 
+# NOTE: the number of workers ```(2 x $num_cores) + 1``` is the official recommendation [https://docs.gunicorn.org/en/latest/design.html#how-many-workers]
+
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   # NOTE: needs ptvsd installed
   echo "$INFO" "PTVSD Debugger initializing in port 3000 with ${APP_CONFIG}"
   # exec python3 -m ptvsd --host 0.0.0.0 --port 3000 -m \
-  exec gunicorn simcore_service_webserver.cli:app_factory \
-      --bind 0.0.0.0:8080 \
-      --worker-class aiohttp.GunicornWebWorker \
-      --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
-      --reload
 
-    # simcore_service_webserver --config $APP_CONFIG
+  exec gunicorn simcore_service_webserver.cli:app_factory \
+    --bind 0.0.0.0:8080 \
+    --worker-class aiohttp.GunicornWebWorker \
+    --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
+    --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$" \
+    --reload
+
+  # simcore_service_webserver --config $APP_CONFIG
 
 else
   exec gunicorn simcore_service_webserver.cli:app_factory \
     --bind 0.0.0.0:8080 \
     --worker-class aiohttp.GunicornWebWorker \
-    --workers="${WEBSERVER_GUNICORN_WORKERS:-1}"
+    --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
+    --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$"
   # exec simcore-service-webserver --config $APP_CONFIG
 fi

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -35,10 +35,8 @@ echo "$INFO" "Selected config $APP_CONFIG"
 # NOTE: the number of workers ```(2 x $num_cores) + 1``` is the official recommendation [https://docs.gunicorn.org/en/latest/design.html#how-many-workers]
 
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
-  # NOTE: needs ptvsd installed
-  echo "$INFO" "PTVSD Debugger initializing in port 3000 with ${APP_CONFIG}"
-  # exec python3 -m ptvsd --host 0.0.0.0 --port 3000 -m \
-
+  # NOTE: ptvsd is programmatically enabled inside of the service
+  # this way we can have reload in place as well
   exec gunicorn simcore_service_webserver.cli:app_factory \
     --bind 0.0.0.0:8080 \
     --worker-class aiohttp.GunicornWebWorker \

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -25,12 +25,8 @@ if [ "${SC_BUILD_TARGET}" = "development" ]; then
   pip list | sed 's/^/    /'
 
   APP_CONFIG=server-docker-dev.yaml
-  echo "$INFO" "Setting entrypoint to use watchmedo autorestart..."
-  entrypoint='watchmedo auto-restart --recursive --pattern="*.py;*/src/*" --ignore-patterns="*test*;pytest_simcore/*;setup.py;*ignore*" --ignore-directories --'
-
 elif [ "${SC_BUILD_TARGET}" = "production" ]; then
   APP_CONFIG=server-docker-prod.yaml
-  entrypoint=""
 fi
 
 # RUNNING application ----------------------------------------
@@ -43,9 +39,15 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   exec gunicorn simcore_service_webserver.cli:app_factory \
       --bind 0.0.0.0:8080 \
       --worker-class aiohttp.GunicornWebWorker \
-      --workers="${WEBSERVER_GUNICORN_WORKERS:-1}"
+      --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
+      --reload
+
     # simcore_service_webserver --config $APP_CONFIG
 
 else
-  exec simcore-service-webserver --config $APP_CONFIG
+  exec gunicorn simcore_service_webserver.cli:app_factory \
+    --bind 0.0.0.0:8080 \
+    --worker-class aiohttp.GunicornWebWorker \
+    --workers="${WEBSERVER_GUNICORN_WORKERS:-1}"
+  # exec simcore-service-webserver --config $APP_CONFIG
 fi

--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -20,7 +20,7 @@ aiohttp_jinja2
 aiohttp_session[secure]
 aiohttp_security
 aiohttp-swagger[performance]
-gunicorn
+gunicorn[setproctitle]
 
 
 # web-sockets

--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -20,6 +20,7 @@ aiohttp_jinja2
 aiohttp_session[secure]
 aiohttp_security
 aiohttp-swagger[performance]
+gunicorn
 
 
 # web-sockets

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -63,6 +63,7 @@ asyncpg==0.23.0
     # via -r requirements/_base.in
 attrs==20.3.0
     # via
+    #   -c requirements/../../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/_aiohttp.in
     #   aiohttp
@@ -106,12 +107,15 @@ et-xmlfile==1.1.0
     # via openpyxl
 expiringdict==1.2.1
     # via -r requirements/_base.in
+gunicorn==20.1.0
+    # via -r requirements/_base.in
 hiredis==2.0.0
     # via aioredis
 idna==2.10
     # via
     #   -c requirements/../../../../packages/models-library/requirements/_base.in
     #   -c requirements/../../../../packages/postgres-database/requirements/_base.in
+    #   -c requirements/../../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/./constraints.txt
     #   email-validator
     #   yarl
@@ -183,6 +187,7 @@ pyyaml==5.4.1
     #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/./_base.in
     #   -c requirements/../../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/_base.in

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -197,6 +197,8 @@ redis==3.5.3
     # via celery
 semantic-version==2.8.5
     # via -r requirements/_base.in
+setproctitle==1.2.2
+    # via gunicorn
 six==1.16.0
     # via
     #   click-repl

--- a/services/web/server/requirements/_packages.txt
+++ b/services/web/server/requirements/_packages.txt
@@ -34,7 +34,7 @@ async-timeout==3.0.1
     #   aiopg
 attrs==20.3.0
     # via
-
+    #   -c requirements/../../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
@@ -55,7 +55,7 @@ email-validator==1.1.3
     #   pydantic
 idna==2.10
     # via
-
+    #   -c requirements/../../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/../../../../packages/models-library/requirements/_base.in
@@ -78,7 +78,7 @@ isodate==0.6.0
     #   openapi-schema-validator
 jsonschema==3.2.0
     # via
-
+    #   -c requirements/../../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/./constraints.txt
     #   -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
     #   openapi-schema-validator
@@ -137,6 +137,7 @@ pyyaml==5.4.1
     #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/./_base.in
     #   -c requirements/../../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../../requirements/constraints.txt

--- a/services/web/server/requirements/_packages.txt
+++ b/services/web/server/requirements/_packages.txt
@@ -98,8 +98,6 @@ multidict==5.1.0
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-nest-asyncio==1.5.4
-    # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
 openapi-core==0.12.0
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
 openapi-schema-validator==0.1.5

--- a/services/web/server/requirements/_packages.txt
+++ b/services/web/server/requirements/_packages.txt
@@ -24,6 +24,7 @@ aiopg==1.2.1
     #   -c requirements/_base.txt
     #   -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
 aiozipkin==1.1.1
+    # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
 alembic==1.7.4
     # via -r requirements/../../../../packages/postgres-database/requirements/_base.in
 async-timeout==3.0.1
@@ -97,6 +98,8 @@ multidict==5.1.0
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
+nest-asyncio==1.5.4
+    # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
 openapi-core==0.12.0
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
 openapi-schema-validator==0.1.5

--- a/services/web/server/requirements/_packages.txt
+++ b/services/web/server/requirements/_packages.txt
@@ -23,8 +23,7 @@ aiopg==1.2.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
-aiozipkin==0.7.1
-    # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
+aiozipkin==1.1.1
 alembic==1.7.4
     # via -r requirements/../../../../packages/postgres-database/requirements/_base.in
 async-timeout==3.0.1

--- a/services/web/server/requirements/_tools.in
+++ b/services/web/server/requirements/_tools.in
@@ -4,6 +4,3 @@
 --constraint _test.txt
 
 --requirement ../../../../requirements/devenv.txt
-
-# basic dev tools
-watchdog[watchmedo]

--- a/services/web/server/requirements/_tools.in
+++ b/services/web/server/requirements/_tools.in
@@ -4,3 +4,6 @@
 --constraint _test.txt
 
 --requirement ../../../../requirements/devenv.txt
+
+# for gunicorn reloading mechanism
+inotify

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -52,7 +52,6 @@ pyyaml==5.4.1
     #   -c requirements/_packages.txt
     #   -c requirements/_test.txt
     #   pre-commit
-    #   watchdog
 regex==2021.11.10
     # via black
 six==1.16.0
@@ -78,8 +77,6 @@ typing-extensions==3.10.0.2
     #   black
 virtualenv==20.10.0
     # via pre-commit
-watchdog==2.1.6
-    # via -r requirements/_tools.in
 wheel==0.37.0
     # via pip-tools
 

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -24,6 +24,8 @@ filelock==3.4.0
     # via virtualenv
 identify==2.4.0
     # via pre-commit
+inotify==0.2.10
+    # via -r requirements/_tools.in
 isort==5.10.1
     # via
     #   -c requirements/_test.txt
@@ -32,6 +34,8 @@ mypy-extensions==0.4.3
     # via black
 nodeenv==1.6.0
     # via pre-commit
+nose==1.3.7
+    # via inotify
 pathspec==0.9.0
     # via black
 pep517==0.12.0

--- a/services/web/server/src/simcore_service_webserver/application.py
+++ b/services/web/server/src/simcore_service_webserver/application.py
@@ -57,13 +57,13 @@ def create_application(config: Dict[str, Any]) -> web.Application:
     )
 
     app = create_safe_application(config)
-    setup_remote_debugging()
+
     setup_settings(app)
 
     # TODO: create dependency mechanism
     # and compute setup order https://github.com/ITISFoundation/osparc-simcore/issues/1142
     #
-
+    setup_remote_debugging(app)
     setup_app_tracing(app)  # WARNING: must be UPPERMOST middleware
     setup_statics(app)
     setup_db(app)

--- a/services/web/server/src/simcore_service_webserver/application.py
+++ b/services/web/server/src/simcore_service_webserver/application.py
@@ -93,27 +93,15 @@ def create_application(config: Dict[str, Any]) -> web.Application:
     setup_exporter(app)
     setup_clusters(app)
 
-    return app
-
-
-def create_app(config: Dict[str, Any]) -> web.Application:
-    app = create_application(config)
-
-    async def welcome_banner(_app: web.Application):
-        print(WELCOME_MSG, flush=True)
-
-    app.on_startup.append(welcome_banner)
-    return app
-
-
-def run_service(config: Dict[str, Any]):
-    app = create_application(config)
-
     async def welcome_banner(_app: web.Application):
         print(WELCOME_MSG, flush=True)
 
     app.on_startup.append(welcome_banner)
 
+    return app
+
+
+def run_service(app: web.Application, config: Dict[str, Any]):
     web.run_app(
         app,
         host=config["main"]["host"],

--- a/services/web/server/src/simcore_service_webserver/application.py
+++ b/services/web/server/src/simcore_service_webserver/application.py
@@ -117,7 +117,8 @@ def run_service(config: Dict[str, Any]):
         app,
         host=config["main"]["host"],
         port=config["main"]["port"],
-        access_log_format='%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"',
+        # this gets overriden by the gunicorn config if any
+        access_log_format='%a %t "%r" %s %b --- [%Dus] "%{Referer}i" "%{User-Agent}i"',
     )
 
 

--- a/services/web/server/src/simcore_service_webserver/application.py
+++ b/services/web/server/src/simcore_service_webserver/application.py
@@ -25,6 +25,7 @@ from .login.module_setup import setup_login
 from .products import setup_products
 from .projects.module_setup import setup_projects
 from .publications import setup_publications
+from .remote_debug import setup_remote_debugging
 from .resource_manager.module_setup import setup_resource_manager
 from .rest import setup_rest
 from .security import setup_security
@@ -56,7 +57,7 @@ def create_application(config: Dict[str, Any]) -> web.Application:
     )
 
     app = create_safe_application(config)
-
+    setup_remote_debugging()
     setup_settings(app)
 
     # TODO: create dependency mechanism

--- a/services/web/server/src/simcore_service_webserver/application.py
+++ b/services/web/server/src/simcore_service_webserver/application.py
@@ -95,6 +95,16 @@ def create_application(config: Dict[str, Any]) -> web.Application:
     return app
 
 
+def create_app(config: Dict[str, Any]) -> web.Application:
+    app = create_application(config)
+
+    async def welcome_banner(_app: web.Application):
+        print(WELCOME_MSG, flush=True)
+
+    app.on_startup.append(welcome_banner)
+    return app
+
+
 def run_service(config: Dict[str, Any]):
     app = create_application(config)
 

--- a/services/web/server/src/simcore_service_webserver/application_config.py
+++ b/services/web/server/src/simcore_service_webserver/application_config.py
@@ -91,6 +91,7 @@ def create_schema() -> T.Dict:
             addon_section("groups", optional=True): minimal_addon_schema(),
             addon_section("products", optional=True): minimal_addon_schema(),
             addon_section("publications", optional=True): minimal_addon_schema(),
+            addon_section("remote_debug", optional=True): minimal_addon_schema(),
             addon_section("security", optional=True): minimal_addon_schema(),
             addon_section("statics", optional=True): minimal_addon_schema(),
             addon_section("studies_access", optional=True): minimal_addon_schema(),

--- a/services/web/server/src/simcore_service_webserver/cli.py
+++ b/services/web/server/src/simcore_service_webserver/cli.py
@@ -21,6 +21,7 @@ from argparse import ArgumentParser
 from typing import Dict, List, Optional, Tuple
 
 from aiohttp import web
+from models_library.basic_types import BuildTargetEnum
 
 from .application import create_application, run_service
 from .application_config import CLI_DEFAULT_CONFIGFILE, app_schema
@@ -134,7 +135,7 @@ async def app_factory() -> web.Application:
     args = [
         "--config",
         "server-docker-dev.yaml"
-        if app_settings.build_target.lower() == "development"
+        if app_settings.boot_mode == BuildTargetEnum.DEVELOPMENT
         else "server-docker-prod.yaml",
     ]
     app, _ = _setup_app(args)

--- a/services/web/server/src/simcore_service_webserver/cli.py
+++ b/services/web/server/src/simcore_service_webserver/cli.py
@@ -26,6 +26,7 @@ from .application import create_application, run_service
 from .application_config import CLI_DEFAULT_CONFIGFILE, app_schema
 from .cli_config import add_cli_options, config_from_options
 from .log import setup_logging
+from .settings import ApplicationSettings
 from .utils import search_osparc_repo_dir
 
 # ptsvd cause issues with ProcessPoolExecutor
@@ -125,12 +126,17 @@ def main(args: Optional[List] = None):
     run_service(app, config)
 
 
-async def app_factory(args: Optional[List] = None) -> web.Application:
+async def app_factory() -> web.Application:
     # parse & config file
-    if not args:
-        args = []
-    log.debug("Received arguments: %s", f"{args=}")
-    args.extend(["--config", "server-docker-prod.yaml"])
+    app_settings = ApplicationSettings()
+    assert app_settings.build_target  # nosec
+    log.info("Application settings: %s", f"{app_settings.json(indent=2)}")
+    args = [
+        "--config",
+        "server-docker-dev.yaml"
+        if app_settings.build_target.lower() == "development"
+        else "server-docker-prod.yaml",
+    ]
     app, _ = _setup_app(args)
 
     return app

--- a/services/web/server/src/simcore_service_webserver/director_v2_core.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_core.py
@@ -134,6 +134,7 @@ async def _request_director_v2(
             web.HTTPServiceUnavailable.status_code,
             reason=f"request to director-v2 service unexpected error {err}",
         ) from err
+    log.error("Unexpected result calling %s, %s", f"{url=}", f"{method=}")
     raise DirectorServiceError(
         web.HTTPClientError.status_code, reason="Unexpected client error"
     )

--- a/services/web/server/src/simcore_service_webserver/remote_debug.py
+++ b/services/web/server/src/simcore_service_webserver/remote_debug.py
@@ -4,6 +4,7 @@
 import logging
 
 from aiohttp import web
+from models_library.basic_types import BootModeEnum
 from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
 
 from .constants import APP_SETTINGS_KEY
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 def setup_remote_debugging(app: web.Application):
     application_settings: ApplicationSettings = app[APP_SETTINGS_KEY]
     assert application_settings.boot_mode  # nosec
-    if "DEBUG" in application_settings.boot_mode.upper():
+    if application_settings.boot_mode == BootModeEnum.DEBUG:
         try:
             logger.debug("Enabling attach ptvsd ...")
             #

--- a/services/web/server/src/simcore_service_webserver/remote_debug.py
+++ b/services/web/server/src/simcore_service_webserver/remote_debug.py
@@ -3,24 +3,36 @@
 """
 import logging
 
+from aiohttp import web
+from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
+
+from .constants import APP_SETTINGS_KEY
+from .settings import ApplicationSettings
+
 logger = logging.getLogger(__name__)
 
 
-def setup_remote_debugging():
-    try:
-        logger.debug("Enabling attach ptvsd ...")
-        #
-        # SEE https://github.com/microsoft/ptvsd#enabling-debugging
-        #
-        import ptvsd
+@app_module_setup(__name__, ModuleCategory.ADDON, logger=logger, depends=[])
+def setup_remote_debugging(app: web.Application):
+    application_settings: ApplicationSettings = app[APP_SETTINGS_KEY]
+    assert application_settings.boot_mode  # nosec
+    if "DEBUG" in application_settings.boot_mode.upper():
+        try:
+            logger.debug("Enabling attach ptvsd ...")
+            #
+            # SEE https://github.com/microsoft/ptvsd#enabling-debugging
+            #
+            import ptvsd
 
-        REMOTE_DEBUGGING_PORT = 3000
-        ptvsd.enable_attach(
-            address=("0.0.0.0", REMOTE_DEBUGGING_PORT),
+            REMOTE_DEBUGGING_PORT = 3000
+            ptvsd.enable_attach(
+                address=("0.0.0.0", REMOTE_DEBUGGING_PORT),
+            )
+        except ImportError as err:
+            raise Exception(
+                "Cannot enable remote debugging. Please install ptvsd first"
+            ) from err
+
+        logger.info(
+            "Remote debugging enabled: listening port %s", REMOTE_DEBUGGING_PORT
         )
-    except ImportError as err:
-        raise Exception(
-            "Cannot enable remote debugging. Please install ptvsd first"
-        ) from err
-
-    logger.info("Remote debugging enabled: listening port %s", REMOTE_DEBUGGING_PORT)

--- a/services/web/server/src/simcore_service_webserver/remote_debug.py
+++ b/services/web/server/src/simcore_service_webserver/remote_debug.py
@@ -1,0 +1,26 @@
+""" Setup remote debugger with Python Tools for Visual Studio (PTVSD)
+
+"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def setup_remote_debugging():
+    try:
+        logger.debug("Enabling attach ptvsd ...")
+        #
+        # SEE https://github.com/microsoft/ptvsd#enabling-debugging
+        #
+        import ptvsd
+
+        REMOTE_DEBUGGING_PORT = 3000
+        ptvsd.enable_attach(
+            address=("0.0.0.0", REMOTE_DEBUGGING_PORT),
+        )
+    except ImportError as err:
+        raise Exception(
+            "Cannot enable remote debugging. Please install ptvsd first"
+        ) from err
+
+    logger.info("Remote debugging enabled: listening port %s", REMOTE_DEBUGGING_PORT)

--- a/services/web/server/src/simcore_service_webserver/settings.py
+++ b/services/web/server/src/simcore_service_webserver/settings.py
@@ -6,6 +6,7 @@ import logging
 from typing import Dict, Optional
 
 from aiohttp import web
+from models_library.basic_types import BootModeEnum, BuildTargetEnum
 from pydantic import BaseSettings, Field
 
 from ._meta import API_VERSION, APP_NAME
@@ -29,9 +30,13 @@ class ApplicationSettings(BaseSettings):
     vcs_url: Optional[str] = Field(None, env="SC_VCS_URL")
     vcs_ref: Optional[str] = Field(None, env="SC_VCS_REF")
     build_date: Optional[str] = Field(None, env="SC_BUILD_DATE")
-    build_target: Optional[str] = Field("production", env="SC_BUILD_TARGET")
+    build_target: Optional[BuildTargetEnum] = Field(
+        BuildTargetEnum.PRODUCTION, env="SC_BUILD_TARGET"
+    )
 
-    boot_mode: Optional[str] = Field("prod", env="SC_BOOT_MODE")
+    boot_mode: Optional[BootModeEnum] = Field(
+        BootModeEnum.PRODUCTION, env="SC_BOOT_MODE"
+    )
     user_name: Optional[str] = Field(None, env="SC_USER_NAME")
     user_id: Optional[int] = Field(None, env="SC_USER_ID")
 

--- a/services/web/server/src/simcore_service_webserver/settings.py
+++ b/services/web/server/src/simcore_service_webserver/settings.py
@@ -29,9 +29,9 @@ class ApplicationSettings(BaseSettings):
     vcs_url: Optional[str] = Field(None, env="SC_VCS_URL")
     vcs_ref: Optional[str] = Field(None, env="SC_VCS_REF")
     build_date: Optional[str] = Field(None, env="SC_BUILD_DATE")
-    build_target: Optional[str] = Field(None, env="SC_BUILD_TARGET")
+    build_target: Optional[str] = Field("production", env="SC_BUILD_TARGET")
 
-    boot_mode: Optional[str] = Field(None, env="SC_BOOT_MODE")
+    boot_mode: Optional[str] = Field("prod", env="SC_BOOT_MODE")
     user_name: Optional[str] = Field(None, env="SC_USER_NAME")
     user_id: Optional[int] = Field(None, env="SC_USER_ID")
 

--- a/tests/performance/Dockerfile
+++ b/tests/performance/Dockerfile
@@ -7,5 +7,5 @@ RUN pip3 --version && \
   pip3 install \
   faker \
   python-dotenv \
-  locust-plugins==1.2.0 &&\
+  locust-plugins==2.1.1 &&\
   pip3 freeze --verbose

--- a/tests/performance/Makefile
+++ b/tests/performance/Makefile
@@ -3,7 +3,7 @@
 #
 include ../../scripts/common.Makefile
 
-LOCUST_VERSION=1.5.3
+LOCUST_VERSION=2.5.1
 export LOCUST_VERSION
 # UTILS
 get_my_ip := $(shell hostname --all-ip-addresses | cut --delimiter=" " --fields=1)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Use [gunicorn](https://gunicorn.org/) to deploy aiohttp-based servers to boost response time and requests per seconds.

This is a proof that for the webserver application it is **NOT** the case.

Since the webserver handles a websocket, it is not possible to increase the number of worker processes gunicorn deploys.
For each request a worker process is assigned. Since the websocket is a kind of request that is kept it would need to be processed by the same worker. Gunicorn does not handle this case.

Nevertheless, using [gunicorn](https://docs.gunicorn.org/en/stable/index.html) is the recommended deployment of aiohttp (see [here](https://docs.aiohttp.org/en/stable/deployment.html)).

Integrating gunicorn implied some necessary changes:
- gunicorn handles reload without the need of watchdog (therefore it was removed)
- gunicorn does not pass the config file (therefore it was removed and is currently bypassed using ApplicationSettings)

Summary of performances:
- aiohttp standalone server handles ~900 requests per second
- gunicorn 1 worker handles ~750 requests per second
- gunicorn 3 workers (2X#CPUs+1) handles ~1850 requests per second (not applicable to websocket)
NOTE: for websocket the solution would be to keep 1 worker but scale the number of containers, then use the RabbitMQ to communicate among servers.

standalone aiohttp server:
![total_requests_per_second_1641299555](https://user-images.githubusercontent.com/35365065/148059619-c5374cd8-34b3-4e3c-a728-e2913b6f5e31.png)
![response_times_(ms)_1641299555](https://user-images.githubusercontent.com/35365065/148059631-65433b99-5bb0-45b3-ba13-b33765dd4eac.png)

gunicorn-1worker:
![total_requests_per_second_1641299445](https://user-images.githubusercontent.com/35365065/148059435-1f9bf855-93b0-4060-9f35-f27c57b081d1.png)
![response_times_(ms)_1641299445](https://user-images.githubusercontent.com/35365065/148059456-f94822a8-8405-414d-a187-887f713b268c.png)
![number_of_users_1641299445](https://user-images.githubusercontent.com/35365065/148059463-b75bca5f-9087-4d5c-bf37-3249210a3783.png)





## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
