### PR TITLE
✨ Enhanced services catch all to only return 503 for services, 404 otherwise (⚠️ devops)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -17,7 +17,11 @@ services:
         # ssl header necessary so that socket.io upgrades correctly from polling to websocket mode. the middleware must be attached to the right connection.
         - traefik.enable=true
         - traefik.http.services.${SWARM_STACK_NAME}_api-server.loadbalancer.server.port=8000
+        - traefik.http.services.${SWARM_STACK_NAME}_api-server.loadbalancer.healthcheck.path=/
+        - traefik.http.services.${SWARM_STACK_NAME}_api-server.loadbalancer.healthcheck.interval=2000ms
+        - traefik.http.services.${SWARM_STACK_NAME}_api-server.loadbalancer.healthcheck.timeout=1000ms
         - traefik.http.routers.${SWARM_STACK_NAME}_api-server.rule=hostregexp(`{host:.+}`)
+          && (Path(`/`) ||  PathPrefix(`/v0`))
         - traefik.http.routers.${SWARM_STACK_NAME}_api-server.entrypoints=simcore_api
         - traefik.http.routers.${SWARM_STACK_NAME}_api-server.priority=1
         - traefik.http.routers.${SWARM_STACK_NAME}_api-server.middlewares=${SWARM_STACK_NAME}_gzip@docker,ratelimit-${SWARM_STACK_NAME}_api-server

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -148,11 +148,34 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_static_webserver.loadbalancer.healthcheck.timeout=1000ms
         - traefik.http.middlewares.${SWARM_STACK_NAME}_static_webserver_retry.retry.attempts=2
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.rule=hostregexp(`{host:.+}`)
-          && (PathPrefix(`/osparc`) || PathPrefix(`/s4l`) || PathPrefix(`/tis`)
-          || PathPrefix(`/transpiled`) || PathPrefix(`/resource`))
+          && (PathPrefix(`/osparc`,`/s4l`,`/tis`,`/transpiled`,`/resource`))
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.priority=2
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.middlewares=${SWARM_STACK_NAME}_gzip@docker,${SWARM_STACK_NAME}_static_webserver_retry
+        # catchall for legacy services (this happens if a backend disappears and a frontend tries to reconnect, the right return value is a 503)
+        - traefik.http.routers.${SWARM_STACK_NAME}_legacy_services_catchall.service=${SWARM_STACK_NAME}_legacy_services_catchall
+        - traefik.http.routers.${SWARM_STACK_NAME}_legacy_services_catchall.priority=1
+        - traefik.http.routers.${SWARM_STACK_NAME}_legacy_services_catchall.entrypoints=http
+        - traefik.http.routers.${SWARM_STACK_NAME}_legacy_services_catchall.rule=hostregexp(`{host:.+}`)
+          && PathPrefix(`/x`)
+        # this tricks traefik into a 502 since the service does not exist on this port
+        - traefik.http.services.${SWARM_STACK_NAME}_legacy_services_catchall.loadbalancer.server.port=0
+        # this tricks traefik into returning a 503 since the healthcheck will always return false
+        - traefik.http.services.${SWARM_STACK_NAME}_legacy_services_catchall.loadbalancer.healthcheck.path=/some/invalid/path/to/generate/a/503
+        - traefik.http.services.${SWARM_STACK_NAME}_legacy_services_catchall.loadbalancer.healthcheck.interval=500s
+        - traefik.http.services.${SWARM_STACK_NAME}_legacy_services_catchall.loadbalancer.healthcheck.timeout=1ms
+        # catchall for modern services (this happens if a backend disappears and a frontend tries to reconnect, the right return value is a 503)
+        - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.service=${SWARM_STACK_NAME}_modern_services_catchall
+        - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.priority=1
+        - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.entrypoints=http
+        - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.rule=hostregexp(`{host:.+}`)
+          && PathPrefix(`/x`)
+        # this tricks traefik into a 502 since the service does not exist on this port
+        - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.server.port=0
+        # this tricks traefik into returning a 503 since the healthcheck will always return false
+        - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.path=/some/invalid/path/to/generate/a/503
+        - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.interval=500s
+        - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.timeout=1ms
     networks:
       - default
 
@@ -434,16 +457,7 @@ services:
         - traefik.http.middlewares.ratelimit-${SWARM_STACK_NAME}_api-server.ratelimit.burst=10
         # X-Forwarded-For header extracts second IP from the right, count starts at one
         - traefik.http.middlewares.ratelimit-${SWARM_STACK_NAME}_api-server.ratelimit.sourcecriterion.ipstrategy.depth=2
-        # catchall service
-        - traefik.http.routers.${SWARM_STACK_NAME}_catchall.service=${SWARM_STACK_NAME}_catchall
-        - traefik.http.routers.${SWARM_STACK_NAME}_catchall.priority=1
-        - traefik.http.routers.${SWARM_STACK_NAME}_catchall.entrypoints=http
-        - traefik.http.routers.${SWARM_STACK_NAME}_catchall.rule=hostregexp(`{host:.+}`)
-          && PathPrefix(`/`)
-        - traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.server.port=0
-        - traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.healthcheck.path=/some/invalid/path/to/generate/a/503
-        - traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.healthcheck.interval=500s
-        - traefik.http.services.${SWARM_STACK_NAME}_catchall.loadbalancer.healthcheck.timeout=1ms
+
     networks:
       - default
       - interactive_services_subnet

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -158,9 +158,9 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_legacy_services_catchall.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_legacy_services_catchall.rule=hostregexp(`{host:.+}`)
           && PathPrefix(`/x`)
-        # this tricks traefik into a 502 since the service does not exist on this port
+        # this tricks traefik into a 502 (bad gateway) since the service does not exist on this port
         - traefik.http.services.${SWARM_STACK_NAME}_legacy_services_catchall.loadbalancer.server.port=0
-        # this tricks traefik into returning a 503 since the healthcheck will always return false
+        # this tricks traefik into returning a 503 (service unavailable) since the healthcheck will always return false
         - traefik.http.services.${SWARM_STACK_NAME}_legacy_services_catchall.loadbalancer.healthcheck.path=/some/invalid/path/to/generate/a/503
         - traefik.http.services.${SWARM_STACK_NAME}_legacy_services_catchall.loadbalancer.healthcheck.interval=500s
         - traefik.http.services.${SWARM_STACK_NAME}_legacy_services_catchall.loadbalancer.healthcheck.timeout=1ms
@@ -172,9 +172,9 @@ services:
         # - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.entrypoints=http
         # - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.rule=hostregexp(`{host:.+}`)
         #   && PathPrefix(`/x`)
-        # # this tricks traefik into a 502 since the service does not exist on this port
+        # this tricks traefik into a 502 (bad gateway) since the service does not exist on this port
         # - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.server.port=0
-        # # this tricks traefik into returning a 503 since the healthcheck will always return false
+        # this tricks traefik into returning a 503 (service unavailable) since the healthcheck will always return false
         # - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.path=/some/invalid/path/to/generate/a/503
         # - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.interval=500s
         # - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.timeout=1ms

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -164,18 +164,20 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_legacy_services_catchall.loadbalancer.healthcheck.path=/some/invalid/path/to/generate/a/503
         - traefik.http.services.${SWARM_STACK_NAME}_legacy_services_catchall.loadbalancer.healthcheck.interval=500s
         - traefik.http.services.${SWARM_STACK_NAME}_legacy_services_catchall.loadbalancer.healthcheck.timeout=1ms
+        # TODO: ANE once the dynamic sidecar powered jupyter lab is around we can activate this
+        # see [#2718](https://github.com/ITISFoundation/osparc-simcore/issues/2718)
         # catchall for modern services (this happens if a backend disappears and a frontend tries to reconnect, the right return value is a 503)
-        - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.service=${SWARM_STACK_NAME}_modern_services_catchall
-        - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.priority=1
-        - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.entrypoints=http
-        - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.rule=hostregexp(`{host:.+}`)
-          && PathPrefix(`/x`)
-        # this tricks traefik into a 502 since the service does not exist on this port
-        - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.server.port=0
-        # this tricks traefik into returning a 503 since the healthcheck will always return false
-        - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.path=/some/invalid/path/to/generate/a/503
-        - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.interval=500s
-        - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.timeout=1ms
+        # - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.service=${SWARM_STACK_NAME}_modern_services_catchall
+        # - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.priority=1
+        # - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.entrypoints=http
+        # - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.rule=hostregexp(`{host:.+}`)
+        #   && PathPrefix(`/x`)
+        # # this tricks traefik into a 502 since the service does not exist on this port
+        # - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.server.port=0
+        # # this tricks traefik into returning a 503 since the healthcheck will always return false
+        # - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.path=/some/invalid/path/to/generate/a/503
+        # - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.interval=500s
+        # - traefik.http.services.${SWARM_STACK_NAME}_modern_services_catchall.loadbalancer.healthcheck.timeout=1ms
     networks:
       - default
 

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -148,7 +148,8 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_static_webserver.loadbalancer.healthcheck.timeout=1000ms
         - traefik.http.middlewares.${SWARM_STACK_NAME}_static_webserver_retry.retry.attempts=2
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.rule=hostregexp(`{host:.+}`)
-          && (PathPrefix(`/osparc`,`/s4l`,`/tis`,`/transpiled`,`/resource`))
+          && PathPrefix(`/osparc`,`/s4l`,`/tis`,`/transpiled`,`/resource`)
+        - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.service=${SWARM_STACK_NAME}_static_webserver
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.priority=2
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.middlewares=${SWARM_STACK_NAME}_gzip@docker,${SWARM_STACK_NAME}_static_webserver_retry


### PR DESCRIPTION
⚠️ devops: remove the catchall from ```services/simcore/docker-compose.yml``` under treafik


A catch all service was introduced lately that would return a 503 for any invalid entrypoint.
This is too much.

Now a more selective catchall will return a 503 in case of accessing if it does not exists for any reason:
- /x/{UUID} this is the access of a legacy service backend
- uuid.services.OSPARC this is the access of a modern backend

Everything else will return a 404 which is traefik defaults behaviour.


This has the side effect of changing the ```Directory Not Found``` error of the jupyter lab service into the following much less agressive and more understandable:
![image](https://user-images.githubusercontent.com/35365065/148093546-45bc8f58-3bb7-4787-b637-8d4eabb81929.png)

## Bonuses:
- api-server is now also only served if the access is done with ```/``` or ```/v0```

<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
