### PR TITLE
🐛 In case RabbitMQ has unexpected error, wait before restarting it

### DIFF
--- a/services/web/server/src/simcore_service_webserver/computation_subscribe.py
+++ b/services/web/server/src/simcore_service_webserver/computation_subscribe.py
@@ -114,6 +114,7 @@ async def events_message_parser(app: web.Application, data: bytes) -> None:
 
 
 APP_RABBITMQ_POOL_KEY = f"{__name__}.pool"
+_RABBITMQ_INTERVAL_BEFORE_RESTARTING_CONSUMER_S = 2
 
 
 async def setup_rabbitmq_consumer(app: web.Application) -> AsyncIterator[None]:
@@ -196,6 +197,10 @@ async def setup_rabbitmq_consumer(app: web.Application) -> AsyncIterator[None]:
                     "restarting..." if consumer_running else "stopping",
                     exc_info=True,
                 )
+                if consumer_running:
+                    await asyncio.sleep(_RABBITMQ_INTERVAL_BEFORE_RESTARTING_CONSUMER_S)
+
+    # TODO
 
     consumer_tasks = []
     for exchange_name, message_parser, consumer_kwargs in [


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Problem:
- If for any reason the RabbitMQ communication fails and the consumer in the webserver raises exception, it tries right away to restart and if for some reason this not work it enters a loop, thus loading the webserver.

Fix:
- add a sleep interval of 2 seconds before restarting


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
