### PR TITLE
♻️ Improve metrics generation

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/monitor_services.py
+++ b/packages/service-library/src/servicelib/aiohttp/monitor_services.py
@@ -22,23 +22,18 @@ from prometheus_client.registry import CollectorRegistry
 # https://grafana.com/docs/grafana-cloud/how-do-i/control-prometheus-metrics-usage/usage-analysis-explore/
 #
 
-# TODO: the user_id label on the http_requests_total Counter is a candidate to be removed. as endpoints also contain all kind of UUIDs
 
 kSERVICE_STARTED = f"{__name__}.services_started"
 kSERVICE_STOPPED = f"{__name__}.services_stopped"
 
 SERVICE_STARTED_LABELS: List[str] = [
-    "user_id",
     "service_key",
     "service_tag",
-    "service_type",
 ]
 
 SERVICE_STOPPED_LABELS: List[str] = [
-    "user_id",
     "service_key",
     "service_tag",
-    "service_type",
     "result",
 ]
 
@@ -79,32 +74,24 @@ class ServiceType(Enum):
 def service_started(
     # pylint: disable=too-many-arguments
     app: web.Application,
-    user_id: str,
     service_key: str,
     service_tag: str,
-    service_type: Union[ServiceType, str],
 ) -> None:
     app[kSERVICE_STARTED].labels(
-        user_id=user_id,
         service_key=service_key,
         service_tag=service_tag,
-        service_type=service_type,
     ).inc()
 
 
 def service_stopped(
     # pylint: disable=too-many-arguments
     app: web.Application,
-    user_id: str,
     service_key: str,
     service_tag: str,
-    service_type: Union[ServiceType, str],
     result: Union[ServiceResult, str],
 ) -> None:
     app[kSERVICE_STOPPED].labels(
-        user_id=user_id,
         service_key=service_key,
         service_tag=service_tag,
-        service_type=service_type,
         result=result.name if isinstance(result, ServiceResult) else result,
     ).inc()

--- a/packages/service-library/src/servicelib/aiohttp/monitoring.py
+++ b/packages/service-library/src/servicelib/aiohttp/monitoring.py
@@ -21,7 +21,7 @@ from prometheus_client import (
 from prometheus_client.registry import CollectorRegistry
 from servicelib.aiohttp.typing_extension import Handler
 
-from ..logging_utils import catch_log_exceptions
+from ..logging_utils import log_catch
 
 log = logging.getLogger(__name__)
 
@@ -156,7 +156,7 @@ def middleware_factory(
         try:
             log.debug("ENTERING monitoring middleware for %s", f"{request=}")
             if enter_middleware_cb:
-                with catch_log_exceptions(logger=log, reraise=False):
+                with log_catch(logger=log, reraise=False):
                     await enter_middleware_cb(request)
 
             in_flight_gauge = request.app[kINFLIGHTREQUESTS]
@@ -209,7 +209,7 @@ def middleware_factory(
             ).inc()
 
             if exit_middleware_cb:
-                with catch_log_exceptions(logger=log, reraise=False):
+                with log_catch(logger=log, reraise=False):
                     await exit_middleware_cb(request, resp)
 
             if log_exception:

--- a/packages/service-library/src/servicelib/aiohttp/monitoring.py
+++ b/packages/service-library/src/servicelib/aiohttp/monitoring.py
@@ -92,7 +92,10 @@ def middleware_factory(app_name):
             log.debug("REQUEST RESPONSE %s", f"{resp=}")
             if resp is not None:
                 request.app["REQUEST_COUNT"].labels(
-                    app_name, request.method, request.path, resp.status
+                    app_name,
+                    request.method,
+                    request.match_info.get_info().get("formatter", "undef"),
+                    resp.status,
                 ).inc()
 
         return resp

--- a/packages/service-library/src/servicelib/aiohttp/monitoring.py
+++ b/packages/service-library/src/servicelib/aiohttp/monitoring.py
@@ -87,6 +87,9 @@ def middleware_factory(
         resp: web.StreamResponse = web.HTTPInternalServerError(
             reason="Unexpected exception"
         )
+        # NOTE: a canonical endpoint is `/v0/projects/{project_id}/node/{node_uuid}``
+        # vs a resolved endpoint `/v0/projects/51e4bdf4-2cc7-43be-85a6-627a4c0afb77/nodes/51e4bdf4-2cc7-43be-85a6-627a4c0afb77`
+        # which would create way to many different endpoints for monitoring!
         canonical_endpoint = request.path
         if request.match_info.route.resource:
             canonical_endpoint = request.match_info.route.resource.canonical

--- a/packages/service-library/src/servicelib/aiohttp/monitoring.py
+++ b/packages/service-library/src/servicelib/aiohttp/monitoring.py
@@ -55,9 +55,15 @@ def middleware_factory(app_name):
         # See https://prometheus.io/docs/concepts/metric_types
         resp = None
         try:
+            log.debug("ENTERING monitoring middleware for %s", f"{request=}")
             request["start_time"] = time.time()
 
             resp = await handler(request)
+            log.debug(
+                "EXITING monitoring middleware for %s with %s",
+                f"{request=}",
+                f"{resp=}",
+            )
 
         except web.HTTPException as exc:
             # Captures raised reponses (success/failures accounted with resp.status)
@@ -83,7 +89,8 @@ def middleware_factory(app_name):
 
         finally:
             # metrics on the same request
-            if resp:
+            log.debug("REQUEST RESPONSE %s", f"{resp=}")
+            if resp is not None:
                 request.app["REQUEST_COUNT"].labels(
                     app_name, request.method, request.path, resp.status
                 ).inc()

--- a/packages/service-library/src/servicelib/aiohttp/monitoring.py
+++ b/packages/service-library/src/servicelib/aiohttp/monitoring.py
@@ -5,7 +5,7 @@
 import asyncio
 import logging
 import time
-from typing import Awaitable, Callable, Dict, Optional
+from typing import Awaitable, Callable, Optional
 
 import prometheus_client
 from aiohttp import web

--- a/packages/service-library/src/servicelib/aiohttp/monitoring.py
+++ b/packages/service-library/src/servicelib/aiohttp/monitoring.py
@@ -5,7 +5,7 @@
 import asyncio
 import logging
 import time
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Dict, Optional
 
 import prometheus_client
 from aiohttp import web
@@ -42,6 +42,65 @@ log = logging.getLogger(__name__)
 # https://promcon.io/2019-munich/slides/containing-your-cardinality.pdf
 # https://grafana.com/docs/grafana-cloud/how-do-i/control-prometheus-metrics-usage/usage-analysis-explore/
 #
+
+
+# This creates the following basic metrics:
+# # HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# # TYPE process_virtual_memory_bytes gauge
+# process_virtual_memory_bytes 8.12425216e+08
+# # HELP process_resident_memory_bytes Resident memory size in bytes.
+# # TYPE process_resident_memory_bytes gauge
+# process_resident_memory_bytes 1.2986368e+08
+# # HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# # TYPE process_start_time_seconds gauge
+# process_start_time_seconds 1.6418063518e+09
+# # HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# # TYPE process_cpu_seconds_total counter
+# process_cpu_seconds_total 9.049999999999999
+# # HELP process_open_fds Number of open file descriptors.
+# # TYPE process_open_fds gauge
+# process_open_fds 29.0
+# # HELP process_max_fds Maximum number of open file descriptors.
+# # TYPE process_max_fds gauge
+# process_max_fds 1.048576e+06
+# # HELP python_info Python platform information
+# # TYPE python_info gauge
+# python_info{implementation="CPython",major="3",minor="8",patchlevel="10",version="3.8.10"} 1.0
+# # HELP python_gc_objects_collected_total Objects collected during gc
+# # TYPE python_gc_objects_collected_total counter
+# python_gc_objects_collected_total{generation="0"} 7328.0
+# python_gc_objects_collected_total{generation="1"} 614.0
+# python_gc_objects_collected_total{generation="2"} 0.0
+# # HELP python_gc_objects_uncollectable_total Uncollectable object found during GC
+# # TYPE python_gc_objects_uncollectable_total counter
+# python_gc_objects_uncollectable_total{generation="0"} 0.0
+# python_gc_objects_uncollectable_total{generation="1"} 0.0
+# python_gc_objects_uncollectable_total{generation="2"} 0.0
+# # HELP python_gc_collections_total Number of times this generation was collected
+# # TYPE python_gc_collections_total counter
+# python_gc_collections_total{generation="0"} 628.0
+# python_gc_collections_total{generation="1"} 57.0
+# python_gc_collections_total{generation="2"} 5.0
+# # HELP http_requests_total Total requests count
+# # TYPE http_requests_total counter
+# http_requests_total{app_name="simcore_service_webserver",endpoint="/v0/",http_status="200",method="GET"} 15.0
+# # HELP http_requests_created Total requests count
+# # TYPE http_requests_created gauge
+# http_requests_created{app_name="simcore_service_webserver",endpoint="/v0/",http_status="200",method="GET"} 1.6418063614890063e+09
+# # HELP http_in_flight_requests Number of requests in process
+# # TYPE http_in_flight_requests gauge
+# http_in_flight_requests{app_name="simcore_service_webserver",endpoint="/v0/",method="GET"} 0.0
+# http_in_flight_requests{app_name="simcore_service_webserver",endpoint="/metrics",method="GET"} 1.0
+# # HELP http_request_latency_seconds Time processing a request
+# # TYPE http_request_latency_seconds summary
+# http_request_latency_seconds_count{app_name="simcore_service_webserver",endpoint="/v0/",method="GET"} 15.0
+# http_request_latency_seconds_sum{app_name="simcore_service_webserver",endpoint="/v0/",method="GET"} 0.007384857000033662
+# http_request_latency_seconds_count{app_name="simcore_service_webserver",endpoint="/metrics",method="GET"} 0.0
+# http_request_latency_seconds_sum{app_name="simcore_service_webserver",endpoint="/metrics",method="GET"} 0.0
+# # HELP http_request_latency_seconds_created Time processing a request
+# # TYPE http_request_latency_seconds_created gauge
+# http_request_latency_seconds_created{app_name="simcore_service_webserver",endpoint="/v0/",method="GET"} 1.6418063614873598e+09
+# http_request_latency_seconds_created{app_name="simcore_service_webserver",endpoint="/metrics",method="GET"} 1.641806371709292e+09
 
 
 kREQUEST_COUNT = f"{__name__}.request_count"
@@ -178,12 +237,16 @@ def middleware_factory(
 def setup_monitoring(
     app: web.Application,
     app_name: str,
+    *,
     enter_middleware_cb: Optional[EnterMiddlewareCB] = None,
     exit_middleware_cb: Optional[ExitMiddlewareCB] = None,
+    **app_info_kwargs,
 ):
     # app-scope registry
+    target_info = {"application name": app_name}
+    target_info.update(app_info_kwargs)
     app[kCOLLECTOR_REGISTRY] = reg = CollectorRegistry(
-        auto_describe=False, target_info={"name": app_name}
+        auto_describe=False, target_info=target_info
     )
     # automatically collects process metrics see [https://github.com/prometheus/client_python]
     app[kPROCESS_COLLECTOR] = ProcessCollector(registry=reg)

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -1,11 +1,13 @@
 """
 This codes originates from this article (https://medium.com/swlh/add-log-decorators-to-your-python-project-84094f832181)
 """
+import asyncio
 import functools
 import logging
 import os
 import sys
 from asyncio import iscoroutinefunction
+from contextlib import contextmanager
 from inspect import getframeinfo, stack
 from typing import Callable, Dict, Optional
 
@@ -171,3 +173,16 @@ def log_decorator(logger=None, level: int = logging.DEBUG):
         return log_decorator_wrapper
 
     return log_decorator_info
+
+
+@contextmanager
+def catch_log_exceptions(logger: logging.Logger, reraise: bool = True):
+    try:
+        yield
+    except asyncio.CancelledError:
+        logger.debug("call was cancelled")
+        raise
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.error("Unhandled exception: %s", f"{exc}", exc_info=True)
+        if reraise:
+            raise exc from exc

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -176,7 +176,7 @@ def log_decorator(logger=None, level: int = logging.DEBUG):
 
 
 @contextmanager
-def catch_log_exceptions(logger: logging.Logger, reraise: bool = True):
+def log_catch(logger: logging.Logger, reraise: bool = True):
     try:
         yield
     except asyncio.CancelledError:

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -869,7 +869,7 @@ async def start_service(
         if config.MONITORING_ENABLED:
             service_started(
                 app,
-                user_id,
+                "undefined_user",  # NOTE: to prevent high cardinality metrics this is disabled
                 service_key,
                 service_tag,
                 "DYNAMIC",

--- a/services/storage/src/simcore_service_storage/application.py
+++ b/services/storage/src/simcore_service_storage/application.py
@@ -10,7 +10,7 @@ from servicelib.aiohttp.application import APP_CONFIG_KEY, create_safe_applicati
 from servicelib.aiohttp.monitoring import setup_monitoring
 from servicelib.aiohttp.tracing import setup_tracing
 
-from ._meta import WELCOME_MSG
+from ._meta import WELCOME_MSG, app_name, version
 from .db import setup_db
 from .dsm import setup_dsm
 from .rest import setup_rest
@@ -46,7 +46,7 @@ def create(settings: Settings) -> web.Application:
     setup_rest(app)  # lastly, we expose API to the world
 
     if settings.STORAGE_MONITORING_ENABLED:
-        setup_monitoring(app, "simcore_service_storage")
+        setup_monitoring(app, app_name, version=f"{version}")
 
     return app
 

--- a/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
@@ -3,14 +3,11 @@
 """
 import logging
 import time
-from asyncio.exceptions import CancelledError
 
-import prometheus_client
 from aiohttp import web
-from prometheus_client import CONTENT_TYPE_LATEST, Counter
-from prometheus_client.registry import CollectorRegistry
-from servicelib.aiohttp.monitor_services import add_instrumentation
-from servicelib.aiohttp.typing_extension import Handler, Middleware
+from servicelib.aiohttp import monitor_services
+from servicelib.aiohttp.monitoring import get_collector_registry
+from servicelib.aiohttp.monitoring import setup_monitoring as service_lib_setup
 
 from .diagnostics_core import DelayWindowProbe, is_sensing_enabled, kLATENCY_PROBE
 
@@ -43,140 +40,31 @@ kCANCEL_COUNT = f"{__name__}.cancel_count"
 kCOLLECTOR_REGISTRY = f"{__name__}.collector_registry"
 
 
-def get_collector_registry(app: web.Application) -> CollectorRegistry:
-    return app[kCOLLECTOR_REGISTRY]
+async def enter_middleware_cb(request: web.Request):
+    request[kSTART_TIME] = time.time()
 
 
-async def metrics_handler(request: web.Request):
-    registry = get_collector_registry(request.app)
-
-    # NOTE: Cannot use ProcessPoolExecutor because registry is not pickable
-    result = await request.loop.run_in_executor(
-        None, prometheus_client.generate_latest, registry
-    )
-    response = web.Response(body=result)
-    response.content_type = CONTENT_TYPE_LATEST
-    return response
-
-
-def middleware_factory(app_name: str) -> Middleware:
-    @web.middleware
-    async def _middleware_handler(request: web.Request, handler: Handler):
-        if request.rel_url.path == "/socket.io/":
-            return await handler(request)
-
-        log_exception = None
-        resp: web.StreamResponse = web.HTTPInternalServerError(
-            reason="Unexpected exception"
-        )
-
-        try:
-            request[kSTART_TIME] = time.time()
-
-            resp = await handler(request)
-
-            assert isinstance(  # nosec
-                resp, web.StreamResponse
-            ), "Forgot envelope middleware?"
-
-        except web.HTTPServerError as exc:
-            # Transforms exception into response object and log exception
-            resp = exc
-            log_exception = exc
-
-        except web.HTTPException as exc:
-            # Transforms non-HTTPServerError exceptions into response object
-            resp = exc
-            log_exception = None
-
-        except Exception as exc:  # pylint: disable=broad-except
-            # Transforms unhandled exceptions into responses with status 500
-            # NOTE: Prevents issue #1025
-            resp = web.HTTPInternalServerError(reason=str(exc))
-            resp.__cause__ = exc
-            log_exception = exc
-
-        except CancelledError as exc:
-            # Mostly for logging
-            resp = web.HTTPInternalServerError(reason=str(exc))
-            log_exception = exc
-            raise
-
-        finally:
-            resp_time_secs: float = time.time() - request[kSTART_TIME]
-
-            exc_name = ""
-            if log_exception:
-                exc_name: str = log_exception.__class__.__name__
-
-            # Probes request latency
-            # NOTE: sockets connection is long
-            # FIXME: tmp by hand, add filters directly in probe
-            if not str(request.path).startswith("/socket.io") and is_sensing_enabled(
-                request.app
-            ):
-                request.app[kLATENCY_PROBE].observe(resp_time_secs)
-
-            # prometheus probes
-            request.app[kREQUEST_COUNT].labels(
-                app_name, request.method, request.path, resp.status, exc_name
-            ).inc()
-
-            if log_exception:
-                log.error(
-                    'Unexpected server error "%s" from access: %s "%s %s" done in %3.2f secs. Responding with status %s',
-                    type(log_exception),
-                    request.remote,
-                    request.method,
-                    request.path,
-                    resp_time_secs,
-                    resp.status,
-                    exc_info=log_exception,
-                    stack_info=True,
-                )
-
-        return resp
-
-    # adds identifier
-    _middleware_handler.__middleware_name__ = f"{__name__}.monitor_{app_name}"
-
-    return _middleware_handler
+async def exit_middleware_cb(request: web.Request, response: web.StreamResponse):
+    resp_time_secs: float = time.time() - request[kSTART_TIME]
+    if not str(request.path).startswith("/socket.io") and is_sensing_enabled(
+        request.app
+    ):
+        request.app[kLATENCY_PROBE].observe(resp_time_secs)
 
 
 def setup_monitoring(app: web.Application):
-    # app-scope registry
-    app[kCOLLECTOR_REGISTRY] = reg = CollectorRegistry(auto_describe=True)
-
-    # Total number of requests processed
-    app[kREQUEST_COUNT] = Counter(
-        name="http_requests_total",
-        documentation="Total Request Count",
-        labelnames=["app_name", "method", "endpoint", "http_status", "exception"],
-        registry=reg,
+    service_lib_setup(
+        app,
+        "simcore_service_webserver",
+        enter_middleware_cb=enter_middleware_cb,
+        exit_middleware_cb=exit_middleware_cb,
     )
 
-    add_instrumentation(app, get_collector_registry(app), "simcore_service_webserver")
+    monitor_services.add_instrumentation(
+        app, get_collector_registry(app), "simcore_service_webserver"
+    )
 
     # on-the fly stats
     app[kLATENCY_PROBE] = DelayWindowProbe()
-
-    # WARNING: ensure ERROR middleware is over this one
-    #
-    # non-API request/response (e.g /metrics, /x/*  ...)
-    #                                 |
-    # API request/response (/v0/*)    |
-    #       |                         |
-    #       |                         |
-    #       v                         |
-    # ===== monitoring-middleware =====
-    # == rest-error-middlewarer ====  |
-    # ==           ...            ==  |
-    # == rest-envelope-middleware ==  v
-    #
-    #
-    app.middlewares.insert(0, middleware_factory("simcore_service_webserver"))
-
-    # TODO: in production, it should only be accessible to backend services
-    app.router.add_get("/metrics", metrics_handler)
 
     return True

--- a/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
@@ -9,10 +9,10 @@ from servicelib.aiohttp import monitor_services
 from servicelib.aiohttp.monitoring import get_collector_registry
 from servicelib.aiohttp.monitoring import setup_monitoring as service_lib_setup
 
+from . import _meta
 from .diagnostics_core import DelayWindowProbe, is_sensing_enabled, kLATENCY_PROBE
 
 log = logging.getLogger(__name__)
-
 
 #
 # CAUTION CAUTION CAUTION NOTE:
@@ -50,13 +50,14 @@ async def exit_middleware_cb(request: web.Request, _response: web.StreamResponse
 def setup_monitoring(app: web.Application):
     service_lib_setup(
         app,
-        "simcore_service_webserver",
+        _meta.APP_NAME,
         enter_middleware_cb=enter_middleware_cb,
         exit_middleware_cb=exit_middleware_cb,
+        version=f"{_meta.version}",
     )
 
     monitor_services.add_instrumentation(
-        app, get_collector_registry(app), "simcore_service_webserver"
+        app, get_collector_registry(app), _meta.APP_NAME
     )
 
     # on-the fly stats

--- a/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics_monitoring.py
@@ -31,20 +31,15 @@ log = logging.getLogger(__name__)
 # https://grafana.com/docs/grafana-cloud/how-do-i/control-prometheus-metrics-usage/usage-analysis-explore/
 #
 
-# TODO: the endpoint label on the http_requests_total Counter is a candidate to be removed. as endpoints also contain all kind of UUIDs
 
 kSTART_TIME = f"{__name__}.start_time"
-kREQUEST_COUNT = f"{__name__}.request_count"
-kCANCEL_COUNT = f"{__name__}.cancel_count"
-
-kCOLLECTOR_REGISTRY = f"{__name__}.collector_registry"
 
 
 async def enter_middleware_cb(request: web.Request):
     request[kSTART_TIME] = time.time()
 
 
-async def exit_middleware_cb(request: web.Request, response: web.StreamResponse):
+async def exit_middleware_cb(request: web.Request, _response: web.StreamResponse):
     resp_time_secs: float = time.time() - request[kSTART_TIME]
     if not str(request.path).startswith("/socket.io") and is_sensing_enabled(
         request.app


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

- removed high cardinality metrics in storage and webserver by replacing all metrics that used endpoints with UUIDs inside with the "canonical" path. This translates into endpoint of the form
-```http_requests_total{app_name="simcore_service_webserver",endpoint="/v0/projects/{project_id}:open",http_status="200",method="POST"} 1.0```
as defined in their respective openapi.

Therefore the number of timeseries for an application can be calculated with: APP_NAMEs x ENDPOINTs x RESPONSE_STATUS x METHOD. ENDPOINT is constrained to the amount of entrypoints in the API. Before it was unconstrained since endpoints were created dynamically with UUIDs.

Also, storage and webserver use the same base module.



Additionally we have the following new metrics:
- platform metrics (defaults from the prometheus client)
- python GC metrics (defaults from the prometheus client)
- process metrics (defaults from the prometheus client)
- number of requests currently in process (http_in_flight_requests)
- number/sum of time of time taken to complete requests (http_request_latency_seconds)
Please note that the prometheus_client auto-creates a gauge metrics see this [issue](https://github.com/prometheus/client_python/issues/438), but it seems this gets compressed and should not be a hurdle... let's hope that is true.



## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```
make build
make up-prod
# find the port for webserver/storage
curl WEBSERVER/metrics
curl STORAGE/metrics
```

## Detailed metrics

Platform + GC + Process
```
# TYPE process_open_fds gauge
process_open_fds 30.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="8",patchlevel="10",version="3.8.10"} 1.0
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 7438.0
python_gc_objects_collected_total{generation="1"} 1783.0
python_gc_objects_collected_total{generation="2"} 0.0
# HELP python_gc_objects_uncollectable_total Uncollectable object found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 630.0
python_gc_collections_total{generation="1"} 57.0
python_gc_collections_total{generation="2"} 5.0
```

Example metrics webserver:
```
# HELP http_requests_total Total requests count
# TYPE http_requests_total counter
http_requests_total{app_name="simcore_service_webserver",endpoint="/v0/",http_status="200",method="GET"} 37.0
http_requests_total{app_name="simcore_service_webserver",endpoint="/socket.io/",http_status="200",method="GET"} 5.0
http_requests_total{app_name="simcore_service_webserver",endpoint="/v0/projects/active",http_status="200",method="GET"} 4.0
# HELP http_requests_created Total requests count
# TYPE http_requests_created gauge
http_requests_created{app_name="simcore_service_webserver",endpoint="/v0/",http_status="200",method="GET"} 1.6415744037080317e+09
http_requests_created{app_name="simcore_service_webserver",endpoint="/socket.io/",http_status="200",method="GET"} 1.6415744055034618e+09
http_requests_created{app_name="simcore_service_webserver",endpoint="/v0/projects/active",http_status="200",method="GET"} 1.6415744055948822e+09
# HELP http_in_flight_requests Number of requests in process
# TYPE http_in_flight_requests gauge
http_in_flight_requests{app_name="simcore_service_webserver",endpoint="/v0/",method="GET"} 0.0
http_in_flight_requests{app_name="simcore_service_webserver",endpoint="/socket.io/",method="GET"} 2.0
http_in_flight_requests{app_name="simcore_service_webserver",endpoint="/v0/projects/active",method="GET"} 0.0
http_in_flight_requests{app_name="simcore_service_webserver",endpoint="/metrics",method="GET"} 1.0
# HELP http_request_latency_seconds Time processing a request
# TYPE http_request_latency_seconds summary
http_request_latency_seconds_count{app_name="simcore_service_webserver",endpoint="/v0/",method="GET"} 37.0
http_request_latency_seconds_sum{app_name="simcore_service_webserver",endpoint="/v0/",method="GET"} 0.027914400037843734
http_request_latency_seconds_count{app_name="simcore_service_webserver",endpoint="/socket.io/",method="GET"} 5.0
http_request_latency_seconds_sum{app_name="simcore_service_webserver",endpoint="/socket.io/",method="GET"} 0.2476124000386335
http_request_latency_seconds_count{app_name="simcore_service_webserver",endpoint="/v0/projects/active",method="GET"} 4.0
http_request_latency_seconds_sum{app_name="simcore_service_webserver",endpoint="/v0/projects/active",method="GET"} 0.025529100035782903
http_request_latency_seconds_count{app_name="simcore_service_webserver",endpoint="/metrics",method="GET"} 0.0
http_request_latency_seconds_sum{app_name="simcore_service_webserver",endpoint="/metrics",method="GET"} 0.0
# HELP http_request_latency_seconds_created Time processing a request
# TYPE http_request_latency_seconds_created gauge
http_request_latency_seconds_created{app_name="simcore_service_webserver",endpoint="/v0/",method="GET"} 1.6415744037050257e+09
http_request_latency_seconds_created{app_name="simcore_service_webserver",endpoint="/socket.io/",method="GET"} 1.6415744054753144e+09
http_request_latency_seconds_created{app_name="simcore_service_webserver",endpoint="/v0/projects/active",method="GET"} 1.6415744055896983e+09
http_request_latency_seconds_created{app_name="simcore_service_webserver",endpoint="/metrics",method="GET"} 1.641574434527328e+09
# HELP simcore_simcore_service_webserver_services_started_total Counts the services started
# TYPE simcore_simcore_service_webserver_services_started_total counter
# HELP simcore_simcore_service_webserver_services_stopped_total Counts the services stopped
# TYPE simcore_simcore_service_webserver_services_stopped_total counter
```

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
