### PR TITLE
✨ Performance testing: allow for auth calls

### DIFF
--- a/tests/performance/docker-compose.yml
+++ b/tests/performance/docker-compose.yml
@@ -4,19 +4,19 @@ services:
   master:
     image: itisfoundation/locust:${LOCUST_VERSION}
     ports:
-     - "8089:8089"
+      - "8089:8089"
     volumes:
       - ./locust_files:/mnt/locust
       - ./locust_report:/reporting
     command: >
-      -f /mnt/locust/${LOCUST_FILE}
-      --host ${TARGET_URL}
-      --html /reporting/locust_html.html
-      ${LOCUST_OPTIONS}
-      --master
+      -f /mnt/locust/${LOCUST_FILE} --host ${TARGET_URL} --html
+      /reporting/locust_html.html ${LOCUST_OPTIONS} --master
 
   worker:
     image: itisfoundation/locust:${LOCUST_VERSION}
     volumes:
       - ./locust_files:/mnt/locust
     command: -f /mnt/locust/${LOCUST_FILE} --worker --master-host master
+    environment:
+      - SC_USER_NAME=${SC_USER_NAME}
+      - SC_PASSWORD=${SC_PASSWORD}

--- a/tests/performance/locust_files/platform_ping_test.py
+++ b/tests/performance/locust_files/platform_ping_test.py
@@ -3,6 +3,10 @@
 #
 
 import logging
+import os
+from functools import cached_property
+from re import L
+from typing import NamedTuple
 
 import locust_plugins
 from dotenv import load_dotenv
@@ -14,28 +18,34 @@ logging.basicConfig(level=logging.INFO)
 
 load_dotenv()  # take environment variables from .env
 
+_UNDEFINED = "undefined"
+
+
+class LocustAuth(NamedTuple):
+    username: str = os.environ.get("USER_NAME", _UNDEFINED)
+    password: str = os.environ.get("PASSWORD", _UNDEFINED)
+
+    @cached_property
+    def defined(self) -> bool:
+        return _UNDEFINED not in (self.username, self.password)
+
 
 class WebApiUser(FastHttpUser):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.auth = LocustAuth()
 
     @task(10)
     def get_root(self):
-        self.client.get(
-            "",
-        )
+        self.client.get("", auth=AUTH)
 
     @task(10)
     def get_root_slash(self):
-        self.client.get(
-            "/",
-        )
+        self.client.get("/", auth=AUTH)
 
     @task(1)
     def get_health(self):
-        self.client.get(
-            "/v0/health",
-        )
+        self.client.get("/v0/health", auth=AUTH)
 
     def on_start(self):
         print("Created locust user")


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- allows the locust to send authenticated calls when going through some kind of authentication

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```console
cd tests/performance
make build
export SC_USER_NAME=blahblah
export SC_PASSWORD=blahblahandblah
make up target=platform_ping_test.py host=OSPARC_HOST_TO_TEST
make down
## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
