### PR TITLE
🐛 Retrieving service key/version from running service to use regex instead of split

### DIFF
--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -9,7 +9,7 @@ from distutils.version import StrictVersion
 from enum import Enum
 from pprint import pformat
 from typing import Dict, List, Optional, Tuple
-import re
+
 import aiodocker
 import tenacity
 from aiohttp import ClientConnectionError, ClientSession, web

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -818,18 +818,17 @@ async def _get_service_key_version_from_docker_service(
     service_full_name = str(service["Spec"]["TaskTemplate"]["ContainerSpec"]["Image"])
     if not service_full_name.startswith(config.REGISTRY_PATH):
         raise exceptions.DirectorException(
-            msg="Invalid service {}".format(service_full_name)
+            msg=f"Invalid service '{service_full_name}', it is missing {config.REGISTRY_PATH}"
         )
 
     service_full_name = service_full_name[len(config.REGISTRY_PATH) :].strip("/")
     service_re_match = _SERVICE_KEY_REGEX.match(service_full_name)
     if not service_re_match:
         raise exceptions.DirectorException(
-            msg=f"service {service_full_name} does not contain valid simcore key"
+            msg=f"Invalid service '{service_full_name}', it does not follow pattern '{_SERVICE_KEY_REGEX.pattern}'"
         )
     service_key = service_re_match.group(1)
     service_tag = service_re_match.group(4)
-    # FIXME: service_key:service_tag@sha256:230498230492834
     return service_key, service_tag
 
 

--- a/services/director/tests/test_producer.py
+++ b/services/director/tests/test_producer.py
@@ -8,7 +8,6 @@ import asyncio
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Dict
 
 import docker
 import pytest

--- a/services/director/tests/test_producer.py
+++ b/services/director/tests/test_producer.py
@@ -78,7 +78,7 @@ async def run_services(
             start_time = time.perf_counter()
             max_time = 2 * 60
             while node_details["service_state"] != "running":
-                asyncio.sleep(2)
+                await asyncio.sleep(2)
                 if (time.perf_counter() - start_time) > max_time:
                     assert True, "waiting too long to start service"
                 node_details = await producer.get_service_details(
@@ -268,12 +268,12 @@ class FakeDockerService:
     "fake_service",
     [
         FakeDockerService(
-            f"{config.REGISTRY_PATH}/simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214",
+            f"{config.REGISTRY_URL}/simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214",
             "simcore/services/dynamic/some/sub/folder/my_service-key",
             "123.456.3214",
         ),
         FakeDockerService(
-            f"{config.REGISTRY_PATH}/simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
+            f"{config.REGISTRY_URL}/simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
             "simcore/services/dynamic/some/sub/folder/my_service-key",
             "123.456.3214",
         ),
@@ -299,11 +299,11 @@ async def test_get_service_key_version_from_docker_service(
     "fake_service_str",
     [
         "postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
-        f"{config.REGISTRY_PATH}/simcore/postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
+        f"{config.REGISTRY_URL}/simcore/postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
         "itisfoundation/postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
-        f"{config.REGISTRY_PATH}/simcore/services/stuff/postgres:10.11",
-        f"{config.REGISTRY_PATH}/simcore/services/dynamic/postgres:10.11",
-        f"{config.REGISTRY_PATH}/simcore/services/dynamic/postgres:10",
+        f"{config.REGISTRY_URL}/simcore/services/stuff/postgres:10.11",
+        f"{config.REGISTRY_URL}/simcore/services/dynamic/postgres:10.11",
+        f"{config.REGISTRY_URL}/simcore/services/dynamic/postgres:10",
     ],
 )
 async def test_get_service_key_version_from_docker_service_except_invalid_keys(

--- a/services/director/tests/test_producer.py
+++ b/services/director/tests/test_producer.py
@@ -268,12 +268,12 @@ class FakeDockerService:
     "fake_service",
     [
         FakeDockerService(
-            f"{config.REGISTRY_URL}/simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214",
+            "/simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214",
             "simcore/services/dynamic/some/sub/folder/my_service-key",
             "123.456.3214",
         ),
         FakeDockerService(
-            f"{config.REGISTRY_URL}/simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
+            "/simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
             "simcore/services/dynamic/some/sub/folder/my_service-key",
             "123.456.3214",
         ),
@@ -283,7 +283,13 @@ async def test_get_service_key_version_from_docker_service(
     fake_service: FakeDockerService,
 ):
     docker_service_partial_inspect = {
-        "Spec": {"TaskTemplate": {"ContainerSpec": {"Image": fake_service.service_str}}}
+        "Spec": {
+            "TaskTemplate": {
+                "ContainerSpec": {
+                    "Image": f"{config.REGISTRY_PATH}{fake_service.service_str}"
+                }
+            }
+        }
     }
     (
         service_key,
@@ -299,18 +305,24 @@ async def test_get_service_key_version_from_docker_service(
     "fake_service_str",
     [
         "postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
-        f"{config.REGISTRY_URL}/simcore/postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
+        "/simcore/postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
         "itisfoundation/postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
-        f"{config.REGISTRY_URL}/simcore/services/stuff/postgres:10.11",
-        f"{config.REGISTRY_URL}/simcore/services/dynamic/postgres:10.11",
-        f"{config.REGISTRY_URL}/simcore/services/dynamic/postgres:10",
+        "/simcore/services/stuff/postgres:10.11",
+        "/simcore/services/dynamic/postgres:10.11",
+        "/simcore/services/dynamic/postgres:10",
     ],
 )
 async def test_get_service_key_version_from_docker_service_except_invalid_keys(
     fake_service_str: str,
 ):
     docker_service_partial_inspect = {
-        "Spec": {"TaskTemplate": {"ContainerSpec": {"Image": fake_service_str}}}
+        "Spec": {
+            "TaskTemplate": {
+                "ContainerSpec": {
+                    "Image": f"{config.REGISTRY_PATH if fake_service_str.startswith('/') else ''}{fake_service_str}"
+                }
+            }
+        }
     }
     with pytest.raises(exceptions.DirectorException):
         await producer._get_service_key_version_from_docker_service(

--- a/services/director/tests/test_producer.py
+++ b/services/director/tests/test_producer.py
@@ -7,6 +7,8 @@
 import asyncio
 import time
 import uuid
+from dataclasses import dataclass
+from typing import Dict
 
 import docker
 import pytest
@@ -256,11 +258,6 @@ async def test_dependent_services_have_common_network(run_services):
         )
 
 
-from typing import Dict
-
-from dataclasses import dataclass
-
-
 @dataclass
 class FakeDockerService:
     service_str: str
@@ -272,12 +269,12 @@ class FakeDockerService:
     "fake_service",
     [
         FakeDockerService(
-            "simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214",
+            f"{config.REGISTRY_PATH}/simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214",
             "simcore/services/dynamic/some/sub/folder/my_service-key",
             "123.456.3214",
         ),
         FakeDockerService(
-            "simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
+            f"{config.REGISTRY_PATH}/simcore/services/dynamic/some/sub/folder/my_service-key:123.456.3214@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
             "simcore/services/dynamic/some/sub/folder/my_service-key",
             "123.456.3214",
         ),
@@ -303,11 +300,11 @@ async def test_get_service_key_version_from_docker_service(
     "fake_service_str",
     [
         "postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
-        "simcore/postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
+        f"{config.REGISTRY_PATH}/simcore/postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
         "itisfoundation/postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f",
-        "simcore/services/stuff/postgres:10.11",
-        "simcore/services/dynamic/postgres:10.11",
-        "simcore/services/dynamic/postgres:10",
+        f"{config.REGISTRY_PATH}/simcore/services/stuff/postgres:10.11",
+        f"{config.REGISTRY_PATH}/simcore/services/dynamic/postgres:10.11",
+        f"{config.REGISTRY_PATH}/simcore/services/dynamic/postgres:10",
     ],
 )
 async def test_get_service_key_version_from_docker_service_except_invalid_keys(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- an issue arose where an image name used in a dynamic service was not following the conventions but of the type ```simcore/services/dynamic/jupyter-smash:2.5.8@sha256:lksdfjhlskfjsdlfksdjflgsdkjhgfsd123eu210```, this triggered a weird situation where the director-v0 was not able to stop the service, and letting a study as un-closed.

This PR fixes this problem.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
