### PR TITLE
WIP: ⬆️ vulnerability upgrade ujson -> fastapi

### DIFF
--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -107,7 +107,9 @@ termcolor==1.1.0
 toml==0.10.2
     # via pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c ../../requirements/constraints.txt
+    #   coverage
 typing-extensions==4.0.0
     # via async-timeout
 werkzeug==2.0.2

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -123,7 +123,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==4.0.0 ; python_version < "3.9"
     # via
     #   -c requirements/_base.txt

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -60,6 +60,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -143,7 +143,10 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==4.0.0
     # via
     #   -c requirements/_base.txt

--- a/packages/models-library/requirements/_tools.txt
+++ b/packages/models-library/requirements/_tools.txt
@@ -59,6 +59,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -176,7 +176,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==4.0.0
     # via
     #   astroid

--- a/packages/postgres-database/requirements/_tools.txt
+++ b/packages/postgres-database/requirements/_tools.txt
@@ -58,6 +58,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/packages/service-integration/requirements/_test.txt
+++ b/packages/service-integration/requirements/_test.txt
@@ -89,7 +89,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==4.0.0
     # via
     #   -c requirements/_base.txt

--- a/packages/service-integration/requirements/_tools.txt
+++ b/packages/service-integration/requirements/_tools.txt
@@ -175,6 +175,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -198,7 +198,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==4.0.0
     # via
     #   -c requirements/_aiohttp.txt

--- a/packages/service-library/requirements/_tools.txt
+++ b/packages/service-library/requirements/_tools.txt
@@ -59,6 +59,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/packages/settings-library/requirements/_test.txt
+++ b/packages/settings-library/requirements/_test.txt
@@ -73,7 +73,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==4.0.0
     # via
     #   -c requirements/_base.txt

--- a/packages/settings-library/requirements/_tools.txt
+++ b/packages/settings-library/requirements/_tools.txt
@@ -56,6 +56,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -185,7 +185,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==4.0.0
     # via
     #   -c requirements/_base.txt

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -59,6 +59,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,7 +16,7 @@ pyyaml>=5.4                                   # https://github.com/advisories/GH
 sqlalchemy[postgresql_psycopg2binary]>=1.3.3  # https://nvd.nist.gov/vuln/detail/CVE-2019-7164
 sqlalchemy>=1.3.3                             # https://nvd.nist.gov/vuln/detail/CVE-2019-7164
 urllib3>=1.26.5                               # https://github.com/advisories/GHSA-q2q7-5pp4-w6pg
-
+ujson>=5.1.0                                  # https://github.com/advisories/GHSA-fh56-85cw-5pq6
 
 #
 # Breaking changes

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -239,7 +239,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==3.10.0.2
     # via
     #   -c requirements/_base.txt

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -170,7 +170,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==3.10.0.2 ; python_version < "3.9"
     # via
     #   -c requirements/_base.txt

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -64,6 +64,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/services/datcore-adapter/requirements/_test.txt
+++ b/services/datcore-adapter/requirements/_test.txt
@@ -156,7 +156,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==3.10.0.2
     # via
     #   -c requirements/_base.txt

--- a/services/datcore-adapter/requirements/_tools.txt
+++ b/services/datcore-adapter/requirements/_tools.txt
@@ -61,6 +61,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -305,7 +305,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 tornado==6.1
     # via
     #   -c requirements/_base.txt

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -62,6 +62,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/services/dynamic-sidecar/requirements/_test.txt
+++ b/services/dynamic-sidecar/requirements/_test.txt
@@ -71,7 +71,9 @@ text-unidecode==1.3
 toml==0.10.2
     # via pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 types-aiofiles==0.8.2
     # via -r requirements/_test.in
 types-pkg-resources==0.1.3

--- a/services/dynamic-sidecar/requirements/_tools.txt
+++ b/services/dynamic-sidecar/requirements/_tools.txt
@@ -77,6 +77,7 @@ toml==0.10.2
     #   pylint
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -212,8 +212,15 @@ typing-extensions==3.10.0.2
     #   aiodebug
     #   aiohttp
     #   pydantic
-ujson==4.0.2
-    # via aiohttp-swagger
+ujson==5.1.0
+    # via
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   aiohttp-swagger
 urllib3==1.26.7
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -195,7 +195,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==3.10.0.2
     # via
     #   -c requirements/_base.txt

--- a/services/storage/requirements/_tools.txt
+++ b/services/storage/requirements/_tools.txt
@@ -62,6 +62,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -287,8 +287,15 @@ typing-extensions==3.10.0.2
     #   aiohttp
     #   aiohttp-jinja2
     #   pydantic
-ujson==4.0.2
-    # via aiohttp-swagger
+ujson==5.1.0
+    # via
+    #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../requirements/constraints.txt
+    #   aiohttp-swagger
 werkzeug==2.0.2
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
 yarl==1.5.1

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -252,7 +252,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==3.10.0.2
     # via
     #   -c requirements/_base.txt

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -64,6 +64,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/tests/public-api/requirements/_test.txt
+++ b/tests/public-api/requirements/_test.txt
@@ -108,7 +108,9 @@ text-unidecode==1.3
 toml==0.10.2
     # via pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==4.0.0
     # via async-timeout
 urllib3==1.26.7

--- a/tests/public-api/requirements/_tools.txt
+++ b/tests/public-api/requirements/_tools.txt
@@ -55,6 +55,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -244,7 +244,15 @@ termcolor==1.1.0
 toml==0.10.2
     # via pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 tqdm==4.62.3
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 typing-extensions==4.0.0

--- a/tests/swarm-deploy/requirements/_tools.txt
+++ b/tests/swarm-deploy/requirements/_tools.txt
@@ -57,6 +57,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

CVE-2021-45958
High severity
Vulnerable versions: >= 4.0.2, < 5.1.0
Patched version: 5.1.0
UltraJSON (aka ujson) 4.0.2 through 5.0.0 has a stack-based buffer overflow in Buffer_AppendIndentUnchecked (called from encode).

- cannot upgrade all repo due to constraints in fastapi.
- Waiting for fastapi to upgrade constraint on ujson (https://github.com/tiangolo/fastapi/blob/master/pyproject.toml#L62)
- cleanup reqs comments

## Related issue/s

CVE-2021-45958


## How to test

all tests shall pass

## Checklist


- [ ] upgrade repo-wide fastapi when ujson constraint is removed
- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
