### PR TITLE
WIP: ✨ Adding mechanism to manually create multi-platform dask-sidecar

### DIFF
--- a/.github/workflows/ci-arm-dask-sidecar.yml
+++ b/.github/workflows/ci-arm-dask-sidecar.yml
@@ -13,19 +13,16 @@ env:
   DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
   DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  DOCKER_IMAGE_TAG: multi-platform
 
 jobs:
   build-deploy-images:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python: [3.8]
+        python: [3.9.9]
         os: [ubuntu-20.04]
         docker_buildx: [v0.5.1]
-        docker_compose: [1.29.1]
-        include:
-          - docker_compose: 1.29.1
-            docker_compose_sha: 8097769d32e34314125847333593c8edb0dfc4a5b350e4839bef8c2fe8d09de7
       fail-fast: false
     name: "[build/deploy] dask-sidecar multiplatform docker images"
     steps:
@@ -49,13 +46,13 @@ jobs:
         if: github.event_name == "pull_request"
         env:
           DOCKER_TARGET_PLATFORM: ${{ github.event.inputs.platforms }}
-        run: |
-          pushd services/dask-sidecar
-          make build
+          DEBIAN_VERSION: bullseye
+          PYTHON_VERSION: ${{ matrix.python }}
+        run: make build target=dask-sidecar
       - name: build/deploy multi-platform images
         if: github.event_name == "push"
         env:
           DOCKER_TARGET_PLATFORM: ${{ github.event.inputs.platforms }}
-        run: |
-          pushd services/dask-sidecar
-          make build push=1
+          DEBIAN_VERSION: bullseye
+          PYTHON_VERSION: ${{ matrix.python }}
+        run: make build target=dask-sidecar push=1

--- a/.github/workflows/ci-arm-dask-sidecar.yml
+++ b/.github/workflows/ci-arm-dask-sidecar.yml
@@ -27,7 +27,7 @@ jobs:
           - docker_compose: 1.29.1
             docker_compose_sha: 8097769d32e34314125847333593c8edb0dfc4a5b350e4839bef8c2fe8d09de7
       fail-fast: false
-    name: "[build/deploy] docker images"
+    name: "[build/deploy] dask-sidecar multiplatform docker images"
     steps:
       - uses: actions/checkout@v2
       - name: setup docker buildx

--- a/.github/workflows/ci-arm-dask-sidecar.yml
+++ b/.github/workflows/ci-arm-dask-sidecar.yml
@@ -1,0 +1,59 @@
+name: Create multi-platform dask-sidecar
+
+on:
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Platforms"
+        required: true
+        default: "linux/arm/v7,linux/arm64,linux/amd64"
+
+env:
+  # secrets can be set in settings/secrets on github
+  DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+  DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+jobs:
+  build-deploy-images:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python: [3.8]
+        os: [ubuntu-20.04]
+        docker_buildx: [v0.5.1]
+        docker_compose: [1.29.1]
+        include:
+          - docker_compose: 1.29.1
+            docker_compose_sha: 8097769d32e34314125847333593c8edb0dfc4a5b350e4839bef8c2fe8d09de7
+      fail-fast: false
+    name: "[build/deploy] docker images"
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup docker buildx
+        if: github.event_name == 'push'
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: ${{ matrix.docker_buildx }}
+          driver: docker
+      - name: setup docker-compose
+        if: github.event_name == 'push'
+        run: sudo ./ci/github/helpers/setup_docker_compose.bash ${{ matrix.docker_compose }} ${{ matrix.docker_compose_sha }}
+      - name: show system environs
+        if: github.event_name == 'push'
+        run: ./ci/helpers/show_system_versions.bash
+      - name: build multi-platform images
+        if: github.event_name == "pull_request"
+        env:
+          DOCKER_TARGET_PLATFORM: ${{ github.event.inputs.platforms }}
+        run: |
+          pushd services/dask-sidecar
+          make build
+      - name: build/deploy multi-platform images
+        if: github.event_name == "push"
+        env:
+          DOCKER_TARGET_PLATFORM: ${{ github.event.inputs.platforms }}
+        run: |
+          pushd services/dask-sidecar
+          make build push=1

--- a/.github/workflows/ci-arm-dask-sidecar.yml
+++ b/.github/workflows/ci-arm-dask-sidecar.yml
@@ -30,16 +30,18 @@ jobs:
     name: "[build/deploy] dask-sidecar multiplatform docker images"
     steps:
       - uses: actions/checkout@v2
+      - name: set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
       - name: setup docker buildx
-        if: github.event_name == 'push'
         id: buildx
         uses: docker/setup-buildx-action@v1
         with:
           version: ${{ matrix.docker_buildx }}
-          driver: docker
-      - name: setup docker-compose
-        if: github.event_name == 'push'
-        run: sudo ./ci/github/helpers/setup_docker_compose.bash ${{ matrix.docker_compose }} ${{ matrix.docker_compose_sha }}
+          driver: docker-container # a must for multi-arch buildsplatform
       - name: show system environs
         if: github.event_name == 'push'
         run: ./ci/helpers/show_system_versions.bash

--- a/scripts/common-service.Makefile
+++ b/scripts/common-service.Makefile
@@ -61,7 +61,7 @@ test-ci: test-ci-unit test-ci-integration ## runs unit and integration tests for
 .PHONY: build build-nc build-devel build-devel-nc
 build build-nc build-devel build-devel-nc: ## builds docker image in many flavours
 	# Building docker image for ${APP_NAME} ...
-	@$(MAKE_C) ${REPO_BASE_DIR} $@ target=${APP_NAME}
+	@$(MAKE_C) ${REPO_BASE_DIR} $@ target=${APP_NAME} push=$(push)
 
 
 .PHONY: shell

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.8.10"
-FROM --platform=${TARGETPLATFORM} python:${PYTHON_VERSION}-slim-buster as base
+ARG DEBIAN_VERSION="buster"
+FROM --platform=${TARGETPLATFORM} python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION} as base
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /log

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -174,7 +174,7 @@ packaging==20.4
     #   bleach
     #   bokeh
     #   dask
-pandas==1.2.4
+pandas==1.4.0
     # via
     #   -r requirements/_base.in
     #   dask

--- a/services/dask-sidecar/requirements/_dask-complete.txt
+++ b/services/dask-sidecar/requirements/_dask-complete.txt
@@ -63,7 +63,7 @@ packaging==20.4
     #   -c requirements/./_base.txt
     #   bokeh
     #   dask
-pandas==1.2.4
+pandas==1.4.0
     # via
     #   -c requirements/./_base.txt
     #   dask

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -170,7 +170,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==3.10.0.2 ; python_version < "3.9"
     # via
     #   -c requirements/_base.txt

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -64,6 +64,7 @@ toml==0.10.2
     #   pre-commit
 tomli==1.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517

--- a/services/docker-compose-build.yml
+++ b/services/docker-compose-build.yml
@@ -61,7 +61,8 @@ services:
         org.label-schema.vcs-ref: "${VCS_REF}"
         io.osparc.api-version: "${DIRECTOR_API_VERSION}"
 
-  dask-sidecar: &build-dask-sidecar
+  dask-sidecar:
+    &build-dask-sidecar
     image: local/dask-sidecar:${BUILD_TARGET:?build_target_required}
     build:
       context: ../
@@ -77,6 +78,9 @@ services:
         org.label-schema.build-date: "${BUILD_DATE}"
         org.label-schema.vcs-url: "${VCS_URL}"
         org.label-schema.vcs-ref: "${VCS_REF}"
+      args:
+        - PYTHON_VERSION=${PYTHON_VERSION:-3.8.10}
+        - DEBIAN_VERSION=${DEBIAN_VERSION:-buster}
 
   dask-scheduler: *build-dask-sidecar
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?
This PR shall allow a maintainer to manually build and deploy multi-platform dask-sidecar.

When doing multi-platform deployment to ARM(64) the dask-sidecar must use python 3.9 and bullseye image (in AMD64 we currently use python 3.8 and buster image)
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
