### PR TITLE
Support ContentSchema (array) input/output port type

### DIFF
--- a/services/web/client/source/class/osparc/component/form/Auto.js
+++ b/services/web/client/source/class/osparc/component/form/Auto.js
@@ -413,6 +413,10 @@ qx.Class.define("osparc.component.form.Auto", {
         }
       );
     },
+    __setupContentSchema: function(s, key, control) {
+      control.setContentSchema(s.contentSchema);
+    },
+
     __addField: function(s, key) {
       const control = this.__getField(s, key);
 
@@ -440,7 +444,8 @@ qx.Class.define("osparc.component.form.Auto", {
             integer: "Spinner",
             number: "Number",
             boolean: "CheckBox",
-            data: "FileButton"
+            data: "FileButton",
+            "ref_contentSchema": "ContentSchema"
           }[type]
         };
       }
@@ -490,6 +495,10 @@ qx.Class.define("osparc.component.form.Auto", {
         case "FileButton":
           control = new qx.ui.form.TextField();
           setup = this.__setupFileButton;
+          break;
+        case "ContentSchema":
+          control = new osparc.ui.form.ContentSchemaField();
+          setup = this.__setupContentSchema;
           break;
         default:
           throw new Error("unknown widget type " + s.widget.type);

--- a/services/web/client/source/class/osparc/component/widget/inputs/NodeOutputTreeItem.js
+++ b/services/web/client/source/class/osparc/component/widget/inputs/NodeOutputTreeItem.js
@@ -90,6 +90,10 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
 
     isArray: function(n) {
       return Array.isArray(n);
+    },
+
+    isQxArray: function(n) {
+      return n instanceof qx.data.Array;
     }
   },
 
@@ -191,6 +195,9 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
       }
       if (this.self().isArray(value)) {
         return JSON.stringify(value);
+      }
+      if (this.self().isQxArray(value)) {
+        return JSON.stringify(value.toArray());
       }
       return value;
     }

--- a/services/web/client/source/class/osparc/component/widget/inputs/NodeOutputTreeItem.js
+++ b/services/web/client/source/class/osparc/component/widget/inputs/NodeOutputTreeItem.js
@@ -86,6 +86,10 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
 
     isBoolean: function(n) {
       return typeof n == "boolean";
+    },
+
+    isArray: function(n) {
+      return Array.isArray(n);
     }
   },
 
@@ -184,6 +188,9 @@ qx.Class.define("osparc.component.widget.inputs.NodeOutputTreeItem", {
       }
       if (this.self().isNumber(value) || this.self().isBoolean(value)) {
         return value.toString();
+      }
+      if (this.self().isArray(value)) {
+        return JSON.stringify(value);
       }
       return value;
     }

--- a/services/web/client/source/class/osparc/ui/form/ContentSchemaField.js
+++ b/services/web/client/source/class/osparc/ui/form/ContentSchemaField.js
@@ -41,7 +41,7 @@ qx.Class.define("osparc.ui.form.ContentSchemaField", {
       const cSchema = this.getContentSchema();
       if (cSchema) {
         if (cSchema.type === "array") {
-          value = this.__addArrayCharacters(value);
+          value = this.__addArrayBrackets(value);
         }
       }
       return value;
@@ -52,13 +52,13 @@ qx.Class.define("osparc.ui.form.ContentSchemaField", {
       const cSchema = this.getContentSchema();
       if (cSchema) {
         if (cSchema.type === "array") {
-          value = this.__addArrayCharacters(value);
+          value = this.__addArrayBrackets(value);
         }
       }
       this.base(arguments, value);
     },
 
-    __addArrayCharacters: function(label) {
+    __addArrayBrackets: function(label) {
       if (label.charAt(0) !== "[") {
         label = "[" + label;
       }

--- a/services/web/client/source/class/osparc/ui/form/ContentSchemaField.js
+++ b/services/web/client/source/class/osparc/ui/form/ContentSchemaField.js
@@ -41,7 +41,7 @@ qx.Class.define("osparc.ui.form.ContentSchemaField", {
       const cSchema = this.getContentSchema();
       if (cSchema) {
         if (cSchema.type === "array") {
-          this.__addArrayCharacters(value);
+          value = this.__addArrayCharacters(value);
         }
       }
       return value;
@@ -52,7 +52,7 @@ qx.Class.define("osparc.ui.form.ContentSchemaField", {
       const cSchema = this.getContentSchema();
       if (cSchema) {
         if (cSchema.type === "array") {
-          this.__addArrayCharacters(value);
+          value = this.__addArrayCharacters(value);
         }
       }
       this.base(arguments, value);
@@ -65,6 +65,7 @@ qx.Class.define("osparc.ui.form.ContentSchemaField", {
       if (label.charAt(label.length-1) !== "]") {
         label += "]";
       }
+      return label;
     }
   }
 });

--- a/services/web/client/source/class/osparc/ui/form/ContentSchemaField.js
+++ b/services/web/client/source/class/osparc/ui/form/ContentSchemaField.js
@@ -38,6 +38,9 @@ qx.Class.define("osparc.ui.form.ContentSchemaField", {
     // overrriden
     getValue: function() {
       let value = this.base(arguments);
+      if (value === null) {
+        value = "";
+      }
       const cSchema = this.getContentSchema();
       if (cSchema) {
         if (cSchema.type === "array") {

--- a/services/web/client/source/class/osparc/ui/form/ContentSchemaField.js
+++ b/services/web/client/source/class/osparc/ui/form/ContentSchemaField.js
@@ -55,6 +55,9 @@ qx.Class.define("osparc.ui.form.ContentSchemaField", {
       const cSchema = this.getContentSchema();
       if (cSchema) {
         if (cSchema.type === "array") {
+          if (Array.isArray(value)) {
+            value = JSON.stringify(value);
+          }
           value = this.__addArrayBrackets(value);
         }
       }

--- a/services/web/client/source/class/osparc/ui/form/ContentSchemaField.js
+++ b/services/web/client/source/class/osparc/ui/form/ContentSchemaField.js
@@ -1,0 +1,70 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2022 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+qx.Class.define("osparc.ui.form.ContentSchemaField", {
+  extend: qx.ui.form.TextField,
+
+  construct: function(contentSchema) {
+    this.base(arguments);
+
+    if (contentSchema) {
+      this.setContentSchema(contentSchema);
+    }
+  },
+
+  properties: {
+    contentSchema: {
+      check: "Object",
+      init: null,
+      nullable: true
+    }
+  },
+
+  members: {
+    // overrriden
+    getValue: function() {
+      let value = this.base(arguments);
+      const cSchema = this.getContentSchema();
+      if (cSchema) {
+        if (cSchema.type === "array") {
+          this.__addArrayCharacters(value);
+        }
+      }
+      return value;
+    },
+
+    // overrriden
+    setValue: function(value) {
+      const cSchema = this.getContentSchema();
+      if (cSchema) {
+        if (cSchema.type === "array") {
+          this.__addArrayCharacters(value);
+        }
+      }
+      this.base(arguments, value);
+    },
+
+    __addArrayCharacters: function(label) {
+      if (label.charAt(0) !== "[") {
+        label = "[" + label;
+      }
+      if (label.charAt(label.length-1) !== "]") {
+        label += "]";
+      }
+    }
+  }
+});


### PR DESCRIPTION
## What do these changes do?

This PR brings a new widget (TextField like) that supports the Content Schema input port type that comes in https://github.com/ITISFoundation/osparc-simcore/pull/2756.

For now, only the ```array``` type is supported



## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
