### PR TITLE
⬆️ adds constraint to pip~=21.3 util pip-tools issue resolved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ push-version: tag-version
 .venv:
 	python3 -m venv $@
 	$@/bin/pip3 --quiet install --upgrade \
-		pip \
+		pip~=21.3 \
 		wheel \
 		setuptools
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->


Prevents pip to upgrade to version 22 until jazzband/pip-tools#1558 is resolved

``Dockerfile`` are all synced to  ``pip~=21.3`` (See ``tests/environment-setup/test_used_python.py``)

