### PR TITLE
🐛 Enabling auto reload for uvicorn in development mode

### DIFF
--- a/services/api-server/docker/boot.sh
+++ b/services/api-server/docker/boot.sh
@@ -27,12 +27,16 @@ fi
 
 # RUNNING application ----------------------------------------
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
-  # NOTE: ptvsd is programmatically enabled inside of the service
-  # this way we can have reload in place as well
-  exec uvicorn simcore_service_api_server.main:the_app \
-    --reload \
-    --host 0.0.0.0 \
-    --reload-dir services/api-server/src/simcore_service_api_server
+  reload_dir_packages=$(find /devel/packages -maxdepth 3 -type d -path "*/src/*" ! -path "*.*" -exec echo '--reload-dir {} \' \;)
+
+  exec sh -c "
+    cd services/api-server/src/simcore_service_api_server && \
+    uvicorn main:the_app \
+      --host 0.0.0.0 \
+      --reload \
+      $reload_dir_packages
+      --reload-dir .
+  "
 else
   exec uvicorn simcore_service_api_server.main:the_app \
     --host 0.0.0.0

--- a/services/catalog/docker/boot.sh
+++ b/services/catalog/docker/boot.sh
@@ -27,12 +27,16 @@ fi
 
 # RUNNING application ----------------------------------------
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
-  # NOTE: ptvsd is programmatically enabled inside of the service
-  # this way we can have reload in place as well
-  exec uvicorn simcore_service_catalog.main:the_app \
-    --reload \
-    --host 0.0.0.0 \
-    --reload-dir services/catalog/src/simcore_service_catalog
+  reload_dir_packages=$(find /devel/packages -maxdepth 3 -type d -path "*/src/*" ! -path "*.*" -exec echo '--reload-dir {} \' \;)
+
+  exec sh -c "
+    cd services/catalog/src/simcore_service_catalog && \
+    uvicorn main:the_app \
+      --host 0.0.0.0 \
+      --reload \
+      $reload_dir_packages
+      --reload-dir .
+  "
 else
   exec uvicorn simcore_service_catalog.main:the_app \
     --host 0.0.0.0

--- a/services/datcore-adapter/docker/boot.sh
+++ b/services/datcore-adapter/docker/boot.sh
@@ -34,12 +34,16 @@ fi
 # RUNNING application
 #
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
-  # NOTE: ptvsd is programmatically enabled inside of the service
-  # this way we can have reload in place as well
-  exec uvicorn simcore_service_datcore_adapter.main:the_app \
-    --reload \
-    --host 0.0.0.0 \
-    --reload-dir services/datcore-adapter/src/simcore_service_datcore_adapter
+  reload_dir_packages=$(find /devel/packages -maxdepth 3 -type d -path "*/src/*" ! -path "*.*" -exec echo '--reload-dir {} \' \;)
+
+  exec sh -c "
+    cd services/datcore-adapter/src/simcore_service_datcore_adapter && \
+    uvicorn main:the_app \
+      --host 0.0.0.0 \
+      --reload \
+      $reload_dir_packages
+      --reload-dir .
+  "
 else
   exec uvicorn simcore_service_datcore_adapter.main:the_app \
     --host 0.0.0.0

--- a/services/director-v2/docker/boot.sh
+++ b/services/director-v2/docker/boot.sh
@@ -34,19 +34,16 @@ fi
 # RUNNING application
 #
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
-  # NOTE: ptvsd is programmatically enabled inside of the service
-  # this way we can have reload in place as well
-  reload_dir_packages=$(find packages -maxdepth 3 -type d -path "*/src/*" ! -path "*.*" -exec echo --reload-dir {} \;)
+  reload_dir_packages=$(find /devel/packages -maxdepth 3 -type d -path "*/src/*" ! -path "*.*" -exec echo '--reload-dir {} \' \;)
 
-  # NOTE: keep the reload_dir_package as un-quoted as the IFS (internal field separators works only this way. any SH shell guru is welcome to enhance this!
-  # FIXME: when uvicorn >0.15.0 comes in, replace it with --reload-include '*.py'
-  IFS=$(printf ' \n\t');
-  #shellcheck disable=SC2086
-  exec uvicorn simcore_service_director_v2.main:the_app \
-    --host 0.0.0.0 \
-    --reload \
-    $reload_dir_packages \
-    --reload-dir services/director-v2/src/simcore_service_director_v2
+  exec sh -c "
+    cd services/director-v2/src/simcore_service_director_v2 && \
+    uvicorn main:the_app \
+      --host 0.0.0.0 \
+      --reload \
+      $reload_dir_packages
+      --reload-dir .
+  "
 else
   exec uvicorn simcore_service_director_v2.main:the_app \
     --host 0.0.0.0

--- a/services/dynamic-sidecar/docker/boot.sh
+++ b/services/dynamic-sidecar/docker/boot.sh
@@ -27,12 +27,16 @@ fi
 
 # RUNNING application ----------------------------------------
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
-  # NOTE: ptvsd is programmatically enabled inside of the service
-  # this way we can have reload in place as well
-  exec uvicorn simcore_service_dynamic_sidecar.main:app \
-    --reload \
-    --host 0.0.0.0 \
-    --reload-dir services/dynamic-sidecar/src/simcore_service_dynamic_sidecar
+  reload_dir_packages=$(find /devel/packages -maxdepth 3 -type d -path "*/src/*" ! -path "*.*" -exec echo '--reload-dir {} \' \;)
+
+  exec sh -c "
+    cd services/dynamic-sidecar/src/simcore_service_dynamic_sidecar && \
+    uvicorn main:app \
+      --host 0.0.0.0 \
+      --reload \
+      $reload_dir_packages
+      --reload-dir .
+  "
 else
   exec uvicorn simcore_service_dynamic_sidecar.main:app \
     --host 0.0.0.0


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Fixes an annoying issue with uvicorn. If the working directory does not coincide with the directory from where the "app" is loaded, auto reload will not be working.

All uvicorn services will reload on changes applied to packages.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->
- https://github.com/encode/uvicorn/issues/1289

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
