### PR TITLE
🐛 #2758 exclusive queue cannot be reacquired

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ printf "$$rows" Redis 'http://$(get_my_ip).nip.io:18081';\
 printf "$$rows" 'Docker Registry' $${REGISTRY_URL} $${REGISTRY_USER} $${REGISTRY_PW};\
 printf "$$rows" "Dask Dashboard" "http://$(get_my_ip).nip.io:8787";
 printf "$$rows" "Traefik Dashboard" "http://$(get_my_ip).nip.io:8080/dashboard/";
+printf "$$rows" "Rabbit Dashboard" "http://$(get_my_ip).nip.io:15762" admin adminadmin;
 printf "\n%s\n" "⚠️ if a DNS is not used (as displayed above), the interactive services started via dynamic-sidecar";\
 echo "⚠️ will not be shown. The frontend accesses them via the uuid.services.YOUR_IP.nip.io:9081";
 endef

--- a/services/web/server/src/simcore_service_webserver/computation_subscribe.py
+++ b/services/web/server/src/simcore_service_webserver/computation_subscribe.py
@@ -172,15 +172,12 @@ async def setup_rabbitmq_consumer(app: web.Application) -> AsyncIterator[None]:
                     # Declaring queue
                     queue = await channel.declare_queue(
                         f"webserver_{exchange_name}_{socket.gethostname()}_{os.getpid()}",
-                        exclusive=True,
                         arguments={"x-message-ttl": 60000},
                     )
                     # Binding the queue to the exchange
                     await queue.bind(exchange)
                     # process
-                    async with queue.iterator(
-                        exclusive=True, **consumer_kwargs
-                    ) as queue_iter:
+                    async with queue.iterator(**consumer_kwargs) as queue_iter:
                         async for message in queue_iter:
                             log.debug(
                                 "Received message from exchange %s", exchange_name


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
This PR changes how RabbitMQ queues are declared.
Before PR: queue set as "exclusive" (e.g. (used by only one connection and the queue will be deleted when that connection closes)
After PR: queue is not exclusive

This has the following implication:
- when a webserver is restarted, for about 5-10 seconds it is a 2nd instance and it has issues accessing the queue (as explained [here](https://www.rabbitmq.com/queues.html) there can be a race condition and client side communication might ensure issues... that is what we are seeing)
- since the queue is not deleted now when the webserver goes down, it *could* generate issues but I don't see any at the moment since the messages have a TTL of 60000 seconds, so they will be deleted anyhow.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->
fixes #2758

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
