### PR TITLE
🐛 Check dask scheduler ID in cluster, if it changes raise an exception

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/core/errors.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/errors.py
@@ -122,26 +122,14 @@ class InsuficientComputationalResourcesError(TaskSchedulingError):
         super().__init__(node_id, msg=msg)
 
 
-class ComputationalSchedulerChangedError(SchedulerError):
-    """The dask client is not connected to the same scheduler as at creation"""
-
-    def __init__(
-        self,
-        original_scheduler_id: str,
-        current_scheduler_id,
-        msg: Optional[str] = None,
-    ):
-        super().__init__(
-            msg=msg
-            or f"The scheduler changed from '{original_scheduler_id}' to '{current_scheduler_id}'"
-        )
+class ComputationalSchedulerChangedError(PydanticErrorMixin, SchedulerError):
+    code = "computational_backend.scheduler_changed"
+    msg_template = "The dask scheduler ID changed from '{original_scheduler_id}' to '{current_scheduler_id}'"
 
 
-class ComputationalBackendNotConnectedError(SchedulerError):
-    """The dask client is not connected to the dask-scheduler"""
-
-    def __init__(self, msg: Optional[str] = None):
-        super().__init__(msg=msg)
+class ComputationalBackendNotConnectedError(PydanticErrorMixin, SchedulerError):
+    code = "computational_backend.not_connected"
+    msg_template = "The dask computational backend is not connected"
 
 
 class ConfigurationError(DirectorException):

--- a/services/director-v2/src/simcore_service_director_v2/core/errors.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/errors.py
@@ -122,6 +122,21 @@ class InsuficientComputationalResourcesError(TaskSchedulingError):
         super().__init__(node_id, msg=msg)
 
 
+class ComputationalSchedulerChangedError(SchedulerError):
+    """The dask client is not connected to the same scheduler as at creation"""
+
+    def __init__(
+        self,
+        original_scheduler_id: str,
+        current_scheduler_id,
+        msg: Optional[str] = None,
+    ):
+        super().__init__(
+            msg=msg
+            or f"The scheduler changed from '{original_scheduler_id}' to '{current_scheduler_id}'"
+        )
+
+
 class ComputationalBackendNotConnectedError(SchedulerError):
     """The dask client is not connected to the dask-scheduler"""
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -150,7 +150,7 @@ async def _connect_with_gateway_and_create_cluster(
         assert client  # nosec
         return DaskSubSystem(
             client=client,
-            scheduler_id=client.scheduler_info["id"],  # type: ignore
+            scheduler_id=client.scheduler_info()["id"],
             gateway=gateway,
             gateway_cluster=cluster,
         )

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_clients_pool.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_clients_pool.py
@@ -98,11 +98,6 @@ class DaskClientsPool:
                     )
 
                 assert dask_client  # nosec
-                logger.debug(
-                    "returning %s, connected to %s",
-                    f"{dask_client=}",
-                    f"{dask_client.dask_subsystem.client.scheduler_info()=}",
-                )
                 return dask_client
 
         try:

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -363,7 +363,8 @@ def check_scheduler_is_still_the_same(
     if current_scheduler_id != original_scheduler_id:
         logger.error("The computational backend changed!")
         raise ComputationalSchedulerChangedError(
-            original_scheduler_id, current_scheduler_id
+            original_scheduler_id=original_scheduler_id,
+            current_scheduler_id=current_scheduler_id,
         )
 
 

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -40,6 +40,7 @@ from simcore_sdk.node_ports_v2 import links, port_utils
 
 from ..core.errors import (
     ComputationalBackendNotConnectedError,
+    ComputationalSchedulerChangedError,
     InsuficientComputationalResourcesError,
     MissingComputationalResourcesError,
 )
@@ -328,16 +329,18 @@ async def dask_sub_consumer_task(
     while True:
         try:
             logger.info(
-                "starting consumer task for topic '%s'", task_event.topic_name()
+                "starting dask consumer task for topic '%s'", task_event.topic_name()
             )
             await dask_sub_consumer(task_event, handler, dask_client)
         except asyncio.CancelledError:
-            logger.info("stopped consumer task for topic '%s'", task_event.topic_name())
+            logger.info(
+                "stopped dask consumer task for topic '%s'", task_event.topic_name()
+            )
             raise
         except Exception:  # pylint: disable=broad-except
             _REST_TIMEOUT_S: Final[int] = 1
             logger.exception(
-                "unknown exception in consumer task for topic '%s', restarting task in %s sec...",
+                "unknown exception in dask consumer task for topic '%s', restarting task in %s sec...",
                 task_event.topic_name(),
                 _REST_TIMEOUT_S,
             )
@@ -351,6 +354,17 @@ def from_node_reqs_to_dask_resources(
     dask_resources = node_reqs.dict(exclude_unset=True, by_alias=True)
     logger.debug("transformed to dask resources: %s", dask_resources)
     return dask_resources
+
+
+def check_scheduler_is_still_the_same(
+    original_scheduler_id: str, client: distributed.Client
+):
+    current_scheduler_id = client.scheduler_info()["id"]
+    if current_scheduler_id != original_scheduler_id:
+        logger.error("The computational backend changed!")
+        raise ComputationalSchedulerChangedError(
+            original_scheduler_id, current_scheduler_id
+        )
 
 
 def check_client_can_connect_to_scheduler(client: distributed.Client):

--- a/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
@@ -474,7 +474,8 @@ async def test_proper_pipeline_is_scheduled(
     [
         ComputationalBackendNotConnectedError(msg="faked disconnected backend"),
         ComputationalSchedulerChangedError(
-            "some_old_scheduler_id", "some_new_scheduler_id"
+            original_scheduler_id="some_old_scheduler_id",
+            current_scheduler_id="some_new_scheduler_id",
         ),
     ],
 )

--- a/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
@@ -33,8 +33,10 @@ from simcore_postgres_database.models.comp_tasks import NodeClass
 from simcore_service_director_v2.core.application import init_app
 from simcore_service_director_v2.core.errors import (
     ComputationalBackendNotConnectedError,
+    ComputationalSchedulerChangedError,
     ConfigurationError,
     PipelineNotFoundError,
+    SchedulerError,
 )
 from simcore_service_director_v2.core.settings import AppSettings
 from simcore_service_director_v2.models.domains.comp_pipelines import CompPipelineAtDB
@@ -467,6 +469,15 @@ async def test_proper_pipeline_is_scheduled(
     assert scheduler.scheduled_pipelines == {}
 
 
+@pytest.mark.parametrize(
+    "backend_error",
+    [
+        ComputationalBackendNotConnectedError(msg="faked disconnected backend"),
+        ComputationalSchedulerChangedError(
+            "some_old_scheduler_id", "some_new_scheduler_id"
+        ),
+    ],
+)
 async def test_handling_of_disconnected_dask_scheduler(
     mocked_scheduler_task: None,
     dask_spec_local_cluster: SpecCluster,
@@ -476,13 +487,12 @@ async def test_handling_of_disconnected_dask_scheduler(
     aiopg_engine: Iterator[aiopg.sa.engine.Engine],  # type: ignore
     mocker: MockerFixture,
     published_project: PublishedProject,
+    backend_error: SchedulerError,
 ):
     # this will create a non connected backend issue that will trigger re-connection
     mocked_dask_client_send_task = mocker.patch(
         "simcore_service_director_v2.modules.comp_scheduler.dask_scheduler.DaskClient.send_computation_tasks",
-        side_effect=ComputationalBackendNotConnectedError(
-            msg="faked disconnected backend"
-        ),
+        side_effect=backend_error,
     )
 
     # running the pipeline will now raise and the tasks are set back to PUBLISHED


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
The dask client automatically reconnects when a dask-scheduler restarts for whatever reason. That is nice, but it is NOT the case of all the Pub/Sub machinery used for:
- getting logs
- getting progress
- getting state changes
- cancelling tasks

This PR aims to detect when the original scheduler changed by checking its ID. If the ID changes, an exception is raised, catched and the dask-client is completely re-instantiated, guaranteeing that all the machinery is on par.

This should fix the issues **related to dask** where the logs are missing.

It is still an open question as if the dask-workers are correctly reconnecting. But this might come in another PR.

## Related issue/s
fixes #2787 
<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
