### PR TITLE
Iframe lazy loading

### DIFF
--- a/services/web/client/source/class/osparc/component/widget/PersistentIframe.js
+++ b/services/web/client/source/class/osparc/component/widget/PersistentIframe.js
@@ -36,7 +36,9 @@ qx.Class.define("osparc.component.widget.PersistentIframe", {
 
     getMaximizeWidgetId: function(maximize) {
       return maximize ? "restoreBtn" : "maximizeBtn";
-    }
+    },
+
+    HIDDEN_TOP: -10000
   },
 
   properties: {
@@ -96,7 +98,7 @@ qx.Class.define("osparc.component.widget.PersistentIframe", {
       let standin = new qx.html.Element("div");
       let appRoot = this.getApplicationRoot();
       appRoot.add(iframe, {
-        top:-10000
+        top: this.self().HIDDEN_TOP
       });
       const restartButton = this.__restartButton = new qx.ui.form.Button(null, "@FontAwesome5Solid/redo-alt/14").set({
         zIndex: 20,
@@ -112,7 +114,7 @@ qx.Class.define("osparc.component.widget.PersistentIframe", {
       }, this);
       osparc.utils.Utils.setIdToWidget(restartButton, "iFrameRestartBtn");
       appRoot.add(restartButton, {
-        top:-10000
+        top: this.self().HIDDEN_TOP
       });
       let zoomButton = this.__zoomButton = new qx.ui.form.Button(null).set({
         icon: this.self().getZoomIcon(false),
@@ -122,7 +124,7 @@ qx.Class.define("osparc.component.widget.PersistentIframe", {
       });
       osparc.utils.Utils.setIdToWidget(zoomButton, this.self().getMaximizeWidgetId(false));
       appRoot.add(zoomButton, {
-        top:-10000
+        top: this.self().HIDDEN_TOP
       });
       zoomButton.addListener("execute", e => {
         this.maximizeIFrame(!this.hasState("maximized"));
@@ -133,13 +135,13 @@ qx.Class.define("osparc.component.widget.PersistentIframe", {
       });
       standin.addListener("disappear", e => {
         iframe.setLayoutProperties({
-          top: -10000
+          top: this.self().HIDDEN_TOP
         });
         restartButton.setLayoutProperties({
-          top: -10000
+          top: this.self().HIDDEN_TOP
         });
         zoomButton.setLayoutProperties({
-          top: -10000
+          top: this.self().HIDDEN_TOP
         });
       });
       this.addListener("move", e => {

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -888,16 +888,24 @@ qx.Class.define("osparc.data.model.Node", {
 
       const iframe = new osparc.component.widget.PersistentIframe();
       osparc.utils.Utils.setIdToWidget(iframe, "PersistentIframe");
-      iframe.addListener("restart", () => {
-        this.__restartIFrame();
-      }, this);
+      iframe.addListener("restart", () => this.__restartIFrame(), this);
       this.setIFrame(iframe);
     },
 
     __restartIFrame: function() {
       if (this.getServiceUrl() !== null) {
-        this.getIFrame().resetSource();
-        this.getIFrame().setSource(this.getServiceUrl());
+        const loadingPage = this.getLoadingPage();
+        const iframe = this.getIFrame();
+        if (loadingPage.getBounds() === null) {
+          // lazy loading
+          loadingPage.addListenerOnce("appear", () => {
+            iframe.resetSource();
+            iframe.setSource(this.getServiceUrl());
+          }, this);
+        } else {
+          iframe.resetSource();
+          iframe.setSource(this.getServiceUrl());
+        }
       }
     },
 

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -894,17 +894,21 @@ qx.Class.define("osparc.data.model.Node", {
 
     __restartIFrame: function() {
       if (this.getServiceUrl() !== null) {
+        const loadIframe = () => {
+          this.getIFrame().resetSource();
+          this.getIFrame().setSource(this.getServiceUrl());
+        };
+
         const loadingPage = this.getLoadingPage();
-        const iframe = this.getIFrame();
-        if (loadingPage.getBounds() === null) {
-          // lazy loading
-          loadingPage.addListenerOnce("appear", () => {
-            iframe.resetSource();
-            iframe.setSource(this.getServiceUrl());
-          }, this);
+        const bounds = loadingPage.getBounds();
+        const domEle = loadingPage.getContentElement().getDomElement();
+        const boundsCR = domEle ? domEle.getBoundingClientRect() : null;
+        if (bounds !== null && boundsCR && boundsCR.width > 0) {
+          loadIframe();
         } else {
-          iframe.resetSource();
-          iframe.setSource(this.getServiceUrl());
+          // lazy loading
+          console.debug("lazy load", this.getNodeId());
+          loadingPage.addListenerOnce("appear", () => loadIframe(), this);
         }
       }
     },

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -899,6 +899,11 @@ qx.Class.define("osparc.data.model.Node", {
           this.getIFrame().setSource(this.getServiceUrl());
         };
 
+        // restart button pushed
+        if (this.getIFrame().getSource().includes(this.getServiceUrl())) {
+          loadIframe();
+        }
+
         const loadingPage = this.getLoadingPage();
         const bounds = loadingPage.getBounds();
         const domEle = loadingPage.getContentElement().getDomElement();

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -897,33 +897,7 @@ qx.Class.define("osparc.data.model.Node", {
     __restartIFrame: function() {
       if (this.getServiceUrl() !== null) {
         this.getIFrame().resetSource();
-        if (this.getKey().includes("3d-viewer")) {
-          // HACK: add this argument to only load the defined colorMaps
-          // https://github.com/Kitware/visualizer/commit/197acaf
-          const srvUrl = this.getServiceUrl();
-          let arg = "?serverColorMaps";
-          if (srvUrl[srvUrl.length - 1] !== "/") {
-            arg = "/" + arg;
-          }
-          this.getIFrame().setSource(srvUrl + arg);
-        } else {
-          this.getIFrame().setSource(this.getServiceUrl());
-        }
-
-        if (this.getKey().includes("raw-graphs")) {
-          // Listen to the postMessage from RawGraphs, posting a new graph
-          window.addEventListener("message", e => {
-            const {
-              id,
-              imgData
-            } = e.data;
-            if (imgData && id === "svgChange") {
-              const img = document.createElement("img");
-              img.src = imgData;
-              this.setThumbnail(img.outerHTML);
-            }
-          }, false);
-        }
+        this.getIFrame().setSource(this.getServiceUrl());
       }
     },
 


### PR DESCRIPTION
## What do these changes do?
This PR makes the frontend nodes connect to their dynamic service's iframes on demand.

When opening studies with many dynamic services, all the iframes were connected and opened right away, creating hundreds of parallel requests, overloading the backend and the frontend. With these changes, dynamic services will be started, the ```/retrieve``` endpoint called, BUT the iframe will not be loaded until the user opens it.

Before:
![beforeNetwork](https://user-images.githubusercontent.com/33152403/152515077-5f34c078-d0db-418b-b508-7dc6dce1708f.gif)

After:
![afterNetwork](https://user-images.githubusercontent.com/33152403/152541838-625985eb-f7fa-412f-a822-e06b95a186c2.gif)


## Related issue/s
related to https://github.com/ITISFoundation/osparc-simcore/issues/2785

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
