### PR TITLE
🐛 Check if connection with backend is still up

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/background_task.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/background_task.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Coroutine
 
 from fastapi import FastAPI
 
-from ...core.errors import ComputationalBackendNotConnectedError
 from . import factory
 
 logger = logging.getLogger(__name__)
@@ -27,9 +26,6 @@ async def scheduler_task(app: FastAPI) -> None:
         except CancelledError:
             logger.info("Computational scheduler task cancelled")
             raise
-        except ComputationalBackendNotConnectedError:
-            logger.info("trying to reconnect to computational backend...")
-            await scheduler.reconnect_backend()
         except Exception:  # pylint: disable=broad-except
             if not app.state.comp_scheduler_running:
                 logger.warning("Forced to stop computational scheduler")

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -368,7 +368,16 @@ def check_scheduler_is_still_the_same(
         )
 
 
-def check_client_can_connect_to_scheduler(client: distributed.Client):
+def check_communication_with_scheduler_is_open(client: distributed.Client):
+    if (
+        client.scheduler_comm
+        and client.scheduler_comm.comm is not None
+        and client.scheduler_comm.comm.closed()
+    ):
+        raise ComputationalBackendNotConnectedError()
+
+
+def check_scheduler_status(client: distributed.Client):
     client_status = client.status
     if client_status not in "running":
         logger.error(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

The Dask client internal heartbeat seems to lose the connection with the dask-scheduler after awhile. It is not clear why.
This check should allow detection of that fact.

Adds an yet an additional check when acquiring a client.

Not yet 100% foul proof but should already improve
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
