### PR TITLE
Show "please wait" message when Nature services are starting

### DIFF
--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -872,14 +872,19 @@ qx.Class.define("osparc.data.model.Node", {
       return this.tr("Starting ") + label;
     },
 
+    __getExtraMessages: function() {
+      if (this.getKey() && this.getKey().includes("pub-nat-med")) {
+        return [
+          this.tr("This might take a couple of minutes")
+        ];
+      }
+      return [];
+    },
+
     __initLoadingIPage: function() {
-      const loadingPage = new osparc.ui.message.Loading(this.__getLoadingPageHeader(), [], true);
-      this.addListener("changeLabel", e => {
-        loadingPage.setHeader(this.__getLoadingPageHeader());
-      }, this);
-      this.getStatus().addListener("changeInteractive", e => {
-        loadingPage.setHeader(this.__getLoadingPageHeader());
-      }, this);
+      const loadingPage = new osparc.ui.message.Loading(this.__getLoadingPageHeader(), this.__getExtraMessages(), true);
+      this.addListener("changeLabel", () => loadingPage.setHeader(this.__getLoadingPageHeader()), this);
+      this.getStatus().addListener("changeInteractive", () => loadingPage.setHeader(this.__getLoadingPageHeader()), this);
       this.setLoadingPage(loadingPage);
     },
 

--- a/services/web/client/source/class/osparc/ui/message/Loading.js
+++ b/services/web/client/source/class/osparc/ui/message/Loading.js
@@ -91,7 +91,8 @@ qx.Class.define("osparc.ui.message.Loading", {
         icon: "@FontAwesome5Solid/circle-notch/32",
         font: "nav-bar-label",
         alignX: "center",
-        gap: 15
+        gap: 15,
+        allowGrowX: false
       });
       atom.getChildControl("icon").getContentElement().addClass("rotate");
 

--- a/services/web/client/source/class/osparc/ui/message/Loading.js
+++ b/services/web/client/source/class/osparc/ui/message/Loading.js
@@ -40,10 +40,17 @@ qx.Class.define("osparc.ui.message.Loading", {
     this.base(arguments);
     this._setLayout(new qx.ui.layout.HBox());
 
+    this.set({
+      alignX: "center"
+    });
     this.__buildLayout(showMaximize);
 
-    this.setHeader(header);
-    this.setMessages(messages);
+    if (header) {
+      this.setHeader(header);
+    }
+    if (messages.length) {
+      this.setMessages(messages);
+    }
   },
 
   properties: {
@@ -88,22 +95,19 @@ qx.Class.define("osparc.ui.message.Loading", {
       });
       atom.getChildControl("icon").getContentElement().addClass("rotate");
 
-      const messages = this.__messages = new qx.ui.container.Composite(new qx.ui.layout.VBox(10)).set({
+      const messages = this.__messages = new qx.ui.container.Composite(new qx.ui.layout.VBox(10).set({
+        alignX: "center"
+      })).set({
         padding: 20
       });
 
       const loadingWidget = new qx.ui.container.Composite(new qx.ui.layout.VBox().set({
+        alignX: "center",
         alignY: "middle"
       }));
-      loadingWidget.add(new qx.ui.core.Widget(), {
-        flex: 1
-      });
       loadingWidget.add(image);
       loadingWidget.add(atom);
       loadingWidget.add(messages);
-      loadingWidget.add(new qx.ui.core.Widget(), {
-        flex: 1
-      });
 
       this._add(new qx.ui.core.Widget(), {
         flex: 1


### PR DESCRIPTION
## What do these changes do?

Demo showing the message in the 2D plot service:
![MightTakeLong](https://user-images.githubusercontent.com/33152403/152780858-63293d7d-577c-401c-8d66-eef1e5899660.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
