### PR TITLE
e2e fix: Wait for iframe after opening node

### DIFF
--- a/tests/e2e/portal/2D_Plot.js
+++ b/tests/e2e/portal/2D_Plot.js
@@ -1,7 +1,6 @@
 // node 2D_Plot.js [url_prefix] [template_uuid] [--demo]
 
 const tutorialBase = require('../tutorials/tutorialBase');
-const auto = require('../utils/auto');
 const utils = require('../utils/utils');
 
 const args = process.argv.slice(2);

--- a/tests/e2e/portal/2D_Plot.js
+++ b/tests/e2e/portal/2D_Plot.js
@@ -30,8 +30,7 @@ async function runTutorial () {
     await tutorial.waitFor(5000, 'Some time for starting the service');
     await utils.takeScreenshot(page, screenshotPrefix + 'service_started');
 
-    // await tutorial.openNode(1);
-    auto.openNode(page, 1);
+    await tutorial.openNode(1);
 
     await tutorial.waitFor(2000);
     await utils.takeScreenshot(page, screenshotPrefix + 'iFrame0');

--- a/tests/e2e/portal/Kember.js
+++ b/tests/e2e/portal/Kember.js
@@ -41,7 +41,7 @@ async function runTutorial () {
 
 
     // open kember viewer
-    auto.openNode(page, 1);
+    await tutorial.openNode(1);
 
     await tutorial.waitFor(2000);
     await utils.takeScreenshot(page, screenshotPrefix + 'iFrame0');

--- a/tests/e2e/portal/Kember.js
+++ b/tests/e2e/portal/Kember.js
@@ -1,7 +1,6 @@
 // node kember.js [url_prefix] [template_uuid] [--demo]
 
 const tutorialBase = require('../tutorials/tutorialBase');
-const auto = require('../utils/auto');
 const utils = require('../utils/utils');
 
 const args = process.argv.slice(2);

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -406,7 +406,7 @@ class TutorialBase {
   }
 
   async removeStudy(studyId) {
-    await this.waitFor(5000, 'Wait for to be unlocked');
+    await this.waitFor(5000, 'Wait to be unlocked');
     await this.takeScreenshot("deleteFirstStudy_before");
     try {
       // await this.waitForStudyUnlocked(studyId);

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -321,6 +321,8 @@ class TutorialBase {
 
   async openNode(nodePosInTree = 0) {
     await auto.openNode(this.__page, nodePosInTree);
+    // Iframes get loaded on demand, wait 2"
+    await this.waitFor(2000);
     await this.takeScreenshot('openNode_' + nodePosInTree);
   }
 

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -321,8 +321,8 @@ class TutorialBase {
 
   async openNode(nodePosInTree = 0) {
     await auto.openNode(this.__page, nodePosInTree);
-    // Iframes get loaded on demand, wait 2"
-    await this.waitFor(2000);
+    // Iframes get loaded on demand, wait 5"
+    await this.waitFor(5000);
     await this.takeScreenshot('openNode_' + nodePosInTree);
   }
 

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -406,6 +406,7 @@ class TutorialBase {
   }
 
   async removeStudy(studyId) {
+    await this.waitFor(5000, 'Wait for to be unlocked');
     await this.takeScreenshot("deleteFirstStudy_before");
     try {
       // await this.waitForStudyUnlocked(studyId);


### PR DESCRIPTION
## What do these changes do?

Since iframes are loaded on demand, to be on the safe side, wait 5 seconds after opening the node.