### PR TITLE
🐛 Is2800/fix director0 lost connection

### DIFF
--- a/.env-devel
+++ b/.env-devel
@@ -81,9 +81,9 @@ WEBSERVER_DEV_FEATURES_ENABLED=0
 WEBSERVER_HOST=webserver
 WEBSERVER_LOGIN_REGISTRATION_CONFIRMATION_REQUIRED=0
 WEBSERVER_LOGIN_REGISTRATION_INVITATION_REQUIRED=0
-WEBSERVER_FEEDBACK_FORM_URL='https://docs.google.com/forms/d/e/1FAIpQLSe232bTigsM2zV97Kjp2OhCenl6o9gNGcDFt2kO_dfkIjtQAQ/viewform?usp=sf_link'
+WEBSERVER_FEEDBACK_FORM_URL=https://docs.google.com/forms/d/e/1FAIpQLSe232bTigsM2zV97Kjp2OhCenl6o9gNGcDFt2kO_dfkIjtQAQ/viewform?usp=sf_link
 WEBSERVER_FOGBUGZ_LOGIN_URL=https://z43.manuscript.com/login
-WEBSERVER_FOGBUGZ_NEWCASE_URL='https://z43.manuscript.com/f/cases/new?command=new&pg=pgEditBug&ixProject=45&ixArea=449'
+WEBSERVER_FOGBUGZ_NEWCASE_URL=https://z43.manuscript.com/f/cases/new?command=new&pg=pgEditBug&ixProject=45&ixArea=449
 WEBSERVER_GARBAGE_COLLECTION_INTERVAL_SECONDS=30
 WEBSERVER_MANUAL_EXTRA_URL=https://itisfoundation.github.io/osparc-manual-z43/
 WEBSERVER_MANUAL_MAIN_URL=http://docs.osparc.io/
@@ -91,11 +91,10 @@ WEBSERVER_PROMETHEUS_API_VERSION=v1
 WEBSERVER_PROMETHEUS_HOST=http://prometheus
 WEBSERVER_PROMETHEUS_PORT=9090
 WEBSERVER_RESOURCES_DELETION_TIMEOUT_SECONDS=900
-WEBSERVER_S4L_FOGBUGZ_NEWCASE_URL='https://z43.manuscript.com/f/cases/new?command=new&pg=pgEditBug&ixProject=45&ixArea=458'
+WEBSERVER_S4L_FOGBUGZ_NEWCASE_URL=https://z43.manuscript.com/f/cases/new?command=new&pg=pgEditBug&ixProject=45&ixArea=458
 WEBSERVER_SESSION_SECRET_KEY='REPLACE_ME_with_result__Fernet_generate_key='
 WEBSERVER_STUDIES_ACCESS_ENABLED=0
-WEBSERVER_TIS_FOGBUGZ_NEWCASE_URL='https://z43.manuscript.com/f/cases/new?command=new&pg=pgEditBug&ixProject=45&ixArea=459'
-
+WEBSERVER_TIS_FOGBUGZ_NEWCASE_URL=https://z43.manuscript.com/f/cases/new?command=new&pg=pgEditBug&ixProject=45&ixArea=459
 # for debugging
 # PYTHONTRACEMALLOC=1
 # PYTHONASYNCIODEBUG=1

--- a/services/director/Makefile
+++ b/services/director/Makefile
@@ -5,6 +5,11 @@ include ../../scripts/common.Makefile
 include ../../scripts/common-service.Makefile
 
 
+_check_python_version:
+	# Checking that runs with correct python version
+	@python3 -c "import sys; current_version=[int(d) for d in '3.6'.split('.')]; assert sys.version_info[:2]==tuple(current_version[:2]), f'Expected python $(EXPECTED_PYTHON_VERSION), got {sys.version_info}'"
+
+
 .PHONY: openapi-specs
 openapi-specs: ## updates and validates openapi specifications
 	$(MAKE) -C $(CURDIR)/src/simcore_service_${APP_NAME}/api $@

--- a/services/director/src/simcore_service_director/exceptions.py
+++ b/services/director/src/simcore_service_director/exceptions.py
@@ -65,6 +65,12 @@ class ServiceUUIDInUseError(DirectorException):
         self.service_uuid = service_uuid
 
 
+class ServiceStateSaveError(DirectorException):
+    def __init__(self, service_uuid: str, reason: str):
+        super().__init__(f"Failed to save state of service {service_uuid}: {reason}")
+        self.service_uuid = service_uuid
+
+
 class RegistryConnectionError(DirectorException):
     """Error while connecting to the docker regitry"""
 

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -12,7 +12,13 @@ from typing import Dict, List, Optional, Tuple
 
 import aiodocker
 import tenacity
-from aiohttp import ClientConnectionError, ClientSession, web
+from aiohttp import (
+    ClientConnectionError,
+    ClientError,
+    ClientResponseError,
+    ClientSession,
+    web,
+)
 from servicelib.async_utils import (  # pylint: disable=no-name-in-module
     run_sequentially_in_context,
 )
@@ -20,6 +26,10 @@ from servicelib.monitor_services import (  # pylint: disable=no-name-in-module
     service_started,
     service_stopped,
 )
+from tenacity._asyncio import AsyncRetrying
+from tenacity.retry import retry_if_exception_type
+from tenacity.stop import stop_after_delay
+from tenacity.wait import wait_fixed
 
 from . import config, docker_utils, exceptions, registry_proxy
 from .config import (
@@ -27,6 +37,7 @@ from .config import (
     CPU_RESOURCE_LIMIT_KEY,
     MEM_RESOURCE_LIMIT_KEY,
 )
+from .exceptions import ServiceStateSaveError
 from .services_common import ServicesCommonSettings
 from .system_utils import get_system_extra_hosts_raw
 from .utils import parse_as_datetime
@@ -1020,7 +1031,9 @@ async def stop_service(app: web.Application, node_uuid: str, save_state: bool) -
         # error if no service with such an id exists
         if not list_running_services_with_uuid:
             raise exceptions.ServiceUUIDNotFoundError(node_uuid)
+
         log.debug("found service(s) with uuid %s", list_running_services_with_uuid)
+
         # save the state of the main service if it can
         service_details = await get_service_details(app, node_uuid)
         # FIXME: the exception for the 3d-viewer shall be removed once the dy-sidecar comes in
@@ -1033,42 +1046,57 @@ async def stop_service(app: web.Application, node_uuid: str, save_state: bool) -
             if not "3d-viewer" in service_details["service_host"]
             else "",
         )
-        log.debug("saving state of service %s...", service_host_name)
+
+        # If state save is enforced, it will fail if not completed
         if save_state:
+            log.debug("saving state of service %s...", service_host_name)
             try:
-                session = app[APP_CLIENT_SESSION_KEY]
-                service_url = "http://" + service_host_name + "/" + "state"
-                async with session.post(
-                    service_url,
-                    timeout=ServicesCommonSettings().director_dynamic_service_save_timeout,
-                ) as response:
-                    if 199 < response.status < 300:
-                        log.debug(
-                            "service %s successfully saved its state", service_host_name
-                        )
-                    else:
-                        log.warning(
-                            "service %s does not allow saving state, answered %s",
-                            service_host_name,
-                            await response.text(),
-                        )
-            except ClientConnectionError:
-                log.warning(
-                    "service %s could not be contacted, state not saved",
-                    service_host_name,
-                )
+                async for attempt in AsyncRetrying(
+                    wait=wait_fixed(2),
+                    stop=stop_after_delay(10),
+                    reraise=True,
+                    retry=retry_if_exception_type(ClientConnectionError),
+                ):
+                    with attempt:
+                        session = app[APP_CLIENT_SESSION_KEY]
+                        service_url = "http://{service_host_name}/state"
+                        async with session.post(
+                            service_url,
+                            timeout=ServicesCommonSettings().director_dynamic_service_save_timeout,
+                            raise_for_status=True,
+                        ) as response:
+                            log.info(
+                                "Service '%s' successfully saved its state: %s",
+                                service_host_name,
+                                f"{response}",
+                            )
+
+            except ClientResponseError as err:
+                raise ServiceStateSaveError(
+                    node_uuid,
+                    reason=f"service {service_host_name} rejected to save state, "
+                    f"responded {err.message} (status {err.status})",
+                ) from err
+
+            except ClientError as err:
+                raise ServiceStateSaveError(
+                    node_uuid, reason=f"service {service_host_name} unreachable [{err}]"
+                ) from err
 
         # remove the services
         try:
-            log.debug("removing services...")
+            log.debug("removing services ...")
             for service in list_running_services_with_uuid:
+                log.debug("removing %s", service["Spec"]["Name"])
                 await client.services.delete(service["Spec"]["Name"])
-            log.debug("removed services, now removing network...")
+
         except aiodocker.exceptions.DockerError as err:
             raise exceptions.GenericDockerError(
                 "Error while removing services", err
             ) from err
+
         # remove network(s)
+        log.debug("removed services, now removing network...")
         await _remove_overlay_network_of_swarm(client, node_uuid)
         log.debug("removed network")
 

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -28,7 +28,7 @@ from servicelib.monitor_services import (  # pylint: disable=no-name-in-module
 )
 from tenacity import retry
 from tenacity.retry import retry_if_exception_type
-from tenacity.stop import stop_after_delay
+from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
 
 from . import config, docker_utils, exceptions, registry_proxy
@@ -1010,7 +1010,7 @@ async def get_service_details(app: web.Application, node_uuid: str) -> Dict:
 
 @retry(
     wait=wait_fixed(2),
-    stop=stop_after_delay(10),
+    stop=stop_after_attempt(3),
     reraise=True,
     retry=retry_if_exception_type(ClientConnectionError),
 )

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -14,6 +14,7 @@ import tenacity
 from aiohttp import (
     ClientConnectionError,
     ClientError,
+    ClientResponse,
     ClientResponseError,
     ClientSession,
     web,
@@ -1014,12 +1015,12 @@ async def get_service_details(app: web.Application, node_uuid: str) -> Dict:
     retry=retry_if_exception_type(ClientConnectionError),
 )
 async def _save_service_state(service_host_name: str, session: aiohttp.ClientSession):
-    service_url = "http://{service_host_name}/state"
+    response: ClientResponse
     async with session.post(
-        service_url,
+        url="http://{service_host_name}/state",
         timeout=ServicesCommonSettings().director_dynamic_service_save_timeout,
-        raise_for_status=True,
     ) as response:
+        response.raise_for_status()
         log.info(
             "Service '%s' successfully saved its state: %s",
             service_host_name,

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -1017,7 +1017,7 @@ async def get_service_details(app: web.Application, node_uuid: str) -> Dict:
 async def _save_service_state(service_host_name: str, session: aiohttp.ClientSession):
     response: ClientResponse
     async with session.post(
-        url="http://{service_host_name}/state",
+        url=f"http://{service_host_name}/state",
         timeout=ServicesCommonSettings().director_dynamic_service_save_timeout,
     ) as response:
         response.raise_for_status()

--- a/services/director/src/simcore_service_director/rest/handlers.py
+++ b/services/director/src/simcore_service_director/rest/handlers.py
@@ -213,9 +213,16 @@ async def running_interactive_services_delete(
     )
     try:
         await producer.stop_service(request.app, service_uuid, save_state)
+
     except exceptions.ServiceUUIDNotFoundError as err:
         raise web_exceptions.HTTPNotFound(reason=str(err))
     except Exception as err:
+        # server errors are logged (>=500)
+        log.exception(
+            "Failed to delete dynamic service %s (save_state=%s)",
+            service_uuid,
+            save_state,
+        )
         raise web_exceptions.HTTPInternalServerError(reason=str(err))
 
     return web.json_response(status=204)

--- a/services/director/tests/test_handlers.py
+++ b/services/director/tests/test_handlers.py
@@ -13,11 +13,9 @@ from urllib.parse import quote
 import pytest
 from aioresponses.core import CallbackResult, aioresponses
 from helpers import json_schema_validator
-
 from servicelib.rest_responses import (  # pylint: disable=no-name-in-module
     unwrap_envelope,
 )
-
 from simcore_service_director import main, resources, rest
 
 
@@ -226,7 +224,7 @@ async def _start_get_stop_services(
     project_id,
     api_version_prefix: str,
     save_state: Optional[bool],
-    exp_save_state_call: bool,
+    expected_save_state_call: bool,
     mocker,
 ):
     params = {}
@@ -370,7 +368,7 @@ async def _start_get_stop_services(
                 f"/{api_version_prefix}/running_interactive_services/{params['service_uuid']}",
                 params=query_params,
             )
-            if exp_save_state_call:
+            if expected_save_state_call:
                 mocked_save_state_cb.assert_called_once()
 
         text = await web_response.text()
@@ -405,7 +403,7 @@ async def test_running_services_post_and_delete_no_swarm(
 
 
 @pytest.mark.parametrize(
-    "save_state, exp_save_state_call", [(True, True), (False, False), (None, True)]
+    "save_state, expected_save_state_call", [(True, True), (False, False), (None, True)]
 )
 async def test_running_services_post_and_delete(
     configure_swarm_stack_name,
@@ -416,7 +414,7 @@ async def test_running_services_post_and_delete(
     project_id,
     api_version_prefix,
     save_state: Optional[bool],
-    exp_save_state_call: bool,
+    expected_save_state_call: bool,
     mocker,
 ):
     await _start_get_stop_services(
@@ -426,7 +424,7 @@ async def test_running_services_post_and_delete(
         project_id,
         api_version_prefix,
         save_state,
-        exp_save_state_call,
+        expected_save_state_call,
         mocker,
     )
 

--- a/services/director/tests/test_producer.py
+++ b/services/director/tests/test_producer.py
@@ -1,13 +1,14 @@
-# pylint:disable=unused-variable
-# pylint:disable=unused-argument
+# pylint:disable=protected-access
 # pylint:disable=redefined-outer-name
 # pylint:disable=too-many-arguments
-# pylint:disable=protected-access
+# pylint:disable=unused-argument
+# pylint:disable=unused-variable
 
 import asyncio
 import time
 import uuid
 from dataclasses import dataclass
+from typing import Callable
 
 import docker
 import pytest
@@ -23,10 +24,10 @@ async def run_services(
     docker_swarm,
     user_id,
     project_id,
-):
+) -> Callable:
     started_services = []
 
-    async def push_start_services(number_comp, number_dyn, dependant=False):
+    async def push_start_services(number_comp: int, number_dyn: int, dependant=False):
         pushed_services = await push_services(
             number_comp, number_dyn, inter_dependent_services=dependant
         )
@@ -95,7 +96,7 @@ async def run_services(
     # teardown stop the services
     for service in started_services:
         service_uuid = service["service_uuid"]
-        await producer.stop_service(aiohttp_mock_app, service_uuid, True)
+        await producer.stop_service(aiohttp_mock_app, service_uuid, save_state=False)
         with pytest.raises(exceptions.ServiceUUIDNotFoundError):
             await producer.get_service_details(aiohttp_mock_app, service_uuid)
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

When a dynamic service is stopped, it will save its state first by default. Up to now, this operation was not guaranteed which would lead to situations in which services were removed even if their state was not saved. This would in many cases result in serious data loss as reported in #2800 .

Here the stop request will fail if the save state operation fails which will avoid deleting services until its state save is guaranteed. To force stop w/o saving the state can still be achieved by passing ``save_state=False``. This is e.g. used in the GC.

We are aware that this modification partially solves the problem since there is still a chance that the GC might delete a service that failed a state save. Nonetheless, its gives a chance to the client to reconnect to an unstop service and therefore recover the state data in place.

Further improvements will follow that shall guarantee the state data in a dynamic service upon close (either because it finished or as a result of a kill signal by the swarm manager/OS)


## Related issue/s

This PR partially resolves the issue reported in #2800.

## How to test

director/tests/test_handlers covers this functionality
