### PR TITLE
Fix: Search filters

### DIFF
--- a/services/web/client/source/class/osparc/dashboard/CardBase.js
+++ b/services/web/client/source/class/osparc/dashboard/CardBase.js
@@ -401,7 +401,8 @@ qx.Class.define("osparc.dashboard.CardBase", {
     },
 
     _shouldApplyFilter: function(data) {
-      data = "searchBarFilter" in data ? data["searchBarFilter"] : data;
+      const filterId = "searchBarFilter-" + this.getResourceType();
+      data = filterId in data ? data[filterId] : data;
       if (this._filterText(data.text)) {
         return true;
       }
@@ -415,7 +416,8 @@ qx.Class.define("osparc.dashboard.CardBase", {
     },
 
     _shouldReactToFilter: function(data) {
-      data = "searchBarFilter" in data ? data["searchBarFilter"] : data;
+      const filterId = "searchBarFilter-" + this.getResourceType();
+      data = filterId in data ? data[filterId] : data;
       if (data.text && data.text.length > 1) {
         return true;
       }

--- a/services/web/client/source/class/osparc/dashboard/ResourceBrowserBase.js
+++ b/services/web/client/source/class/osparc/dashboard/ResourceBrowserBase.js
@@ -140,7 +140,7 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
         alignY: "middle"
       });
 
-      const searchBarFilter = new osparc.dashboard.SearchBarFilter();
+      const searchBarFilter = new osparc.dashboard.SearchBarFilter(resourceType);
       const textField = searchBarFilter.getChildControl("text-field");
       osparc.utils.Utils.setIdToWidget(textField, resourceType ? "searchBarFilter-textField-"+resourceType : "searchBarFilter-textField");
       topBar.add(searchBarFilter, {

--- a/services/web/client/source/class/osparc/dashboard/SearchBarFilter.js
+++ b/services/web/client/source/class/osparc/dashboard/SearchBarFilter.js
@@ -18,8 +18,8 @@
 qx.Class.define("osparc.dashboard.SearchBarFilter", {
   extend: osparc.component.filter.UIFilter,
 
-  construct: function() {
-    this.base(arguments, "searchBarFilter", "searchBarFilter");
+  construct: function(resourceType) {
+    this.base(arguments, "searchBarFilter-"+resourceType, "searchBarFilter");
 
     this._setLayout(new qx.ui.layout.HBox(5));
 

--- a/services/web/client/source/class/osparc/dashboard/ServiceBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/ServiceBrowser.js
@@ -84,7 +84,7 @@ qx.Class.define("osparc.dashboard.ServiceBrowser", {
     },
 
     _createLayout: function() {
-      const servicesLayout = this._createResourcesLayout("services");
+      const servicesLayout = this._createResourcesLayout("service");
 
       this.__addNewServiceButtons();
 

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -127,7 +127,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     },
 
     _createLayout: function() {
-      const studiesLayout = this._createResourcesLayout("studies");
+      const studiesLayout = this._createResourcesLayout("study");
 
       const importStudyButton = this.__createImportButton();
       this._secondaryBar.add(importStudyButton);

--- a/services/web/client/source/class/osparc/dashboard/TemplateBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/TemplateBrowser.js
@@ -49,7 +49,7 @@ qx.Class.define("osparc.dashboard.TemplateBrowser", {
     },
 
     _createLayout: function() {
-      const templatesLayout = this._createResourcesLayout("templates");
+      const templatesLayout = this._createResourcesLayout("template");
 
       osparc.utils.Utils.setIdToWidget(this._resourcesContainer, "templatesList");
 

--- a/tests/e2e/tests/tags.test.js
+++ b/tests/e2e/tests/tags.test.js
@@ -91,7 +91,7 @@ describe('tags testing', () => {
 
   test('tag shows in filters', async () => {
     // Check that tag shows in filter
-    await waitAndClick(page, '[osparc-test-id="searchBarFilter-textField-studies"]');
+    await waitAndClick(page, '[osparc-test-id="searchBarFilter-textField-study"]');
     await waitAndClick(page, '[osparc-test-id="searchBarFilter-tags-button"]');
     const tagFilterMenu = await page.waitForSelector('[osparc-test-id="searchBarFilter-tags-menu"]:not([style*="display: none"])');
     expect(await tagFilterMenu.evaluate(el => el.innerText)).toContain(TAG_NAME);
@@ -136,7 +136,7 @@ describe('tags testing', () => {
     // Close properties
     await waitAndClick(page, '[osparc-test-id="preferencesWindowCloseBtn"]');
     // Check that tag name changed in filter and study list
-    await waitAndClick(page, '[osparc-test-id="searchBarFilter-textField-studies"]');
+    await waitAndClick(page, '[osparc-test-id="searchBarFilter-textField-study"]');
     await waitAndClick(page, '[osparc-test-id="searchBarFilter-tags-button"]');
     const tagFilterMenu = await page.waitForSelector('[osparc-test-id="searchBarFilter-tags-menu"]:not([style*="display: none"])');
     expect(await tagFilterMenu.evaluate(el => el.innerText)).toContain(TAG_NAME_2);

--- a/tests/e2e/utils/auto.js
+++ b/tests/e2e/utils/auto.js
@@ -177,17 +177,17 @@ async function dashboardOpenService(page, serviceName) {
 
 async function __filterStudiesByText(page, studyName) {
   await __dashboardStudiesBrowser(page);
-  await __typeInSearchBarFilter(page, "studies", studyName);
+  await __typeInSearchBarFilter(page, "study", studyName);
 }
 
 async function __filterTemplatesByText(page, templateName) {
   await __dashboardTemplatesBrowser(page);
-  await __typeInSearchBarFilter(page, "templates", templateName);
+  await __typeInSearchBarFilter(page, "template", templateName);
 }
 
 async function __filterServicesByText(page, serviceName) {
   await __dashboardServicesBrowser(page);
-  await __typeInSearchBarFilter(page, "services", serviceName);
+  await __typeInSearchBarFilter(page, "service", serviceName);
 }
 
 async function __typeInSearchBarFilter(page, resource, text) {


### PR DESCRIPTION
## What do these changes do?

Issue: Study/Template/Service cards were interacting with the search filters that didn't belong to their tab. This PR fixes that bug:
![filtering](https://user-images.githubusercontent.com/33152403/152994219-cff70f95-6337-4e2a-b911-d7671ecf54eb.gif)


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
