### PR TITLE
⬆️ Maintenance/week 05: test and tooling libs

### DIFF
--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -11,23 +11,23 @@ aiohttp==3.8.1
     #   pytest-aiohttp
 aiosignal==1.2.0
     # via aiohttp
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via aiohttp
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   aiohttp
     #   jsonschema
     #   openapi-core
     #   pytest
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via aiohttp
-coverage[toml]==6.1.2
+coverage[toml]==6.3.1
     # via
     #   -r requirements.in
     #   pytest-cov
 dictpath==0.1.3
     # via openapi-core
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
@@ -39,29 +39,27 @@ importlib-resources==5.4.0 ; python_version < "3.9"
     #   jsonschema
 iniconfig==1.1.1
     # via pytest
-isodate==0.6.0
-    # via
-    #   openapi-core
-    #   openapi-schema-validator
-jsonschema==4.2.1
+isodate==0.6.1
+    # via openapi-core
+jsonschema==4.4.0
     # via
     #   openapi-schema-validator
     #   openapi-spec-validator
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via openapi-core
 more-itertools==8.12.0
     # via openapi-core
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
 openapi-core==0.14.2
     # via -r requirements.in
-openapi-schema-validator==0.1.5
+openapi-schema-validator==0.2.3
     # via
     #   openapi-core
     #   openapi-spec-validator
-openapi-spec-validator==0.3.1
+openapi-spec-validator==0.4.0
     # via openapi-core
 packaging==21.3
     # via
@@ -73,19 +71,22 @@ pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r requirements.in
     #   pytest-aiohttp
+    #   pytest-asyncio
     #   pytest-cov
     #   pytest-instafail
     #   pytest-sugar
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.0.3
     # via -r requirements.in
+pytest-asyncio==0.18.0
+    # via pytest-aiohttp
 pytest-cov==3.0.0
     # via -r requirements.in
 pytest-instafail==0.4.2
@@ -100,19 +101,19 @@ six==1.16.0
     # via
     #   isodate
     #   openapi-core
-    #   openapi-schema-validator
-    #   openapi-spec-validator
 termcolor==1.1.0
     # via pytest-sugar
-toml==0.10.2
-    # via pytest
-tomli==1.2.2
-    # via coverage
-typing-extensions==4.0.0
-    # via async-timeout
-werkzeug==2.0.2
+tomli==1.2.3
+    # via
+    #   -c ../../requirements/constraints.txt
+    #   coverage
+    #   pytest
+werkzeug==2.0.3
     # via openapi-core
 yarl==1.7.2
     # via aiohttp
-zipp==3.6.0
+zipp==3.7.0
     # via importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/ci/helpers/requirements.txt
+++ b/ci/helpers/requirements.txt
@@ -8,23 +8,23 @@ aiohttp==3.8.1
     # via -r requirements.in
 aiosignal==1.2.0
     # via aiohttp
-anyio==3.4.0
+anyio==3.5.0
     # via starlette
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via aiohttp
-attrs==21.2.0
+attrs==21.4.0
     # via aiohttp
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via
     #   aiohttp
     #   requests
 docker==5.0.3
     # via -r requirements.in
-fastapi==0.70.0
+fastapi==0.73.0
     # via -r requirements.in
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
@@ -33,7 +33,7 @@ idna==3.3
     #   anyio
     #   requests
     #   yarl
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
@@ -41,19 +41,17 @@ pydantic==1.9.0
     # via fastapi
 pyjwt==2.3.0
     # via -r requirements.in
-requests==2.26.0
+requests==2.27.1
     # via docker
 sniffio==1.2.0
     # via anyio
-starlette==0.16.0
+starlette==0.17.1
     # via fastapi
-typing-extensions==4.0.0
-    # via
-    #   async-timeout
-    #   pydantic
-urllib3==1.26.7
+typing-extensions==4.0.1
+    # via pydantic
+urllib3==1.26.8
     # via requests
-websocket-client==1.2.1
+websocket-client==1.2.3
     # via docker
 yarl==1.7.2
     # via aiohttp

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -10,17 +10,17 @@ cloudpickle==2.0.0
     # via
     #   dask
     #   distributed
-dask==2021.12.0
+dask==2022.01.1
     # via
     #   -r requirements/_base.in
     #   distributed
-distributed==2021.12.0
+distributed==2022.01.1
     # via dask
-dnspython==2.1.0
+dnspython==2.2.0
     # via email-validator
 email-validator==1.1.3
     # via pydantic
-fsspec==2021.11.0
+fsspec==2022.1.0
     # via dask
 heapdict==1.0.1
     # via zict
@@ -41,10 +41,12 @@ markupsafe==2.0.1
 msgpack==1.0.3
     # via distributed
 packaging==21.3
-    # via dask
+    # via
+    #   dask
+    #   distributed
 partd==1.2.0
     # via dask
-psutil==5.8.0
+psutil==5.9.0
     # via distributed
 pydantic==1.9.0
     # via
@@ -52,7 +54,7 @@ pydantic==1.9.0
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/_base.in
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 pyyaml==6.0
     # via
@@ -71,7 +73,7 @@ toolz==0.11.2
     #   partd
 tornado==6.1
     # via distributed
-typing-extensions==4.0.0 ; python_version < "3.9"
+typing-extensions==4.0.1 ; python_version < "3.9"
     # via
     #   -r requirements/_base.in
     #   pydantic

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -10,21 +10,21 @@ aiohttp==3.8.1
     #   pytest-aiohttp
 aiosignal==1.2.0
     # via aiohttp
-astroid==2.9.0
+astroid==2.9.3
     # via pylint
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via aiohttp
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   aiohttp
     #   pytest
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via
     #   aiohttp
     #   requests
-coverage==6.1.2
+coverage==6.3.1
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -33,9 +33,9 @@ coveralls==3.3.1
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
-faker==9.8.3
+faker==12.1.0
     # via -r requirements/_test.in
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
@@ -50,11 +50,11 @@ iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via pylint
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 mccabe==0.6.1
     # via pylint
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
@@ -66,7 +66,7 @@ packaging==21.3
     #   pytest-sugar
 pint==0.18
     # via -r requirements/_test.in
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via pylint
 pluggy==1.0.0
     # via pytest
@@ -74,30 +74,33 @@ pprintpp==0.4.0
     # via pytest-icdiff
 py==1.11.0
     # via pytest
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements/_test.in
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via
     #   -c requirements/_base.txt
     #   packaging
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
+    #   pytest-asyncio
     #   pytest-cov
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
     #   pytest-sugar
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.0.3
     # via -r requirements/_test.in
+pytest-asyncio==0.18.0
+    # via pytest-aiohttp
 pytest-cov==3.0.0
     # via -r requirements/_test.in
 pytest-icdiff==0.5
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements/_test.in
 pytest-runner==5.3.1
     # via -r requirements/_test.in
@@ -110,27 +113,25 @@ pyyaml==6.0
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-requests==2.26.0
+requests==2.27.1
     # via coveralls
 six==1.16.0
     # via python-dateutil
 termcolor==1.1.0
     # via pytest-sugar
-text-unidecode==1.3
-    # via faker
 toml==0.10.2
+    # via pylint
+tomli==1.2.3
     # via
-    #   pylint
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
     #   pytest
-tomli==1.2.2
-    # via coverage
-typing-extensions==4.0.0 ; python_version < "3.9"
+typing-extensions==4.0.1 ; python_version < "3.9"
     # via
     #   -c requirements/_base.txt
     #   astroid
-    #   async-timeout
     #   pylint
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   requests

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -66,7 +66,7 @@ packaging==21.3
     #   pytest-sugar
 pint==0.18
     # via -r requirements/_test.in
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via pytest

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -4,9 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
-black==21.12b0
+black==22.1.0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -17,11 +15,11 @@ click==8.0.3
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.4.2
     # via virtualenv
-identify==2.4.0
+identify==2.4.8
     # via pre-commit
 isort==5.10.1
     # via
@@ -35,14 +33,14 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via
     #   -c requirements/_test.txt
     #   black
     #   virtualenv
-pre-commit==2.15.0
+pre-commit==2.17.0
     # via -r requirements/../../../requirements/devenv.txt
 pyyaml==6.0
     # via
@@ -58,19 +56,20 @@ toml==0.10.2
     # via
     #   -c requirements/_test.txt
     #   pre-commit
-tomli==1.2.2
+tomli==1.2.3
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517
-typing-extensions==4.0.0 ; python_version < "3.9"
+typing-extensions==4.0.1 ; python_version < "3.9"
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.10.0
+virtualenv==20.13.1
     # via pre-commit
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -19,7 +19,7 @@ distlib==0.3.4
     # via virtualenv
 filelock==3.4.2
     # via virtualenv
-identify==2.4.8
+identify==2.4.9
     # via pre-commit
 isort==5.10.1
     # via
@@ -35,7 +35,7 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via
     #   -c requirements/_test.txt
     #   black

--- a/packages/models-library/requirements/_base.txt
+++ b/packages/models-library/requirements/_base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-dnspython==2.1.0
+dnspython==2.2.0
     # via email-validator
 email-validator==1.1.3
     # via pydantic
@@ -16,5 +16,5 @@ pydantic==1.9.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via pydantic

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -80,7 +80,7 @@ packaging==21.3
     #   pytest-sugar
 pint==0.18
     # via -r requirements/_test.in
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via pytest

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -11,23 +11,23 @@ aiohttp==3.8.1
     #   pytest-aiohttp
 aiosignal==1.2.0
     # via aiohttp
-alembic==1.7.5
+alembic==1.7.6
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
-astroid==2.9.0
+astroid==2.9.3
     # via pylint
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via aiohttp
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   aiohttp
     #   pytest
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via
     #   aiohttp
     #   requests
-coverage==6.1.2
+coverage==6.3.1
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -36,9 +36,9 @@ coveralls==3.3.1
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
-faker==9.8.3
+faker==12.1.0
     # via -r requirements/_test.in
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
@@ -50,7 +50,7 @@ idna==2.10
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   requests
     #   yarl
-importlib-metadata==4.8.2
+importlib-metadata==4.10.1
     # via alembic
 importlib-resources==5.4.0 ; python_version < "3.9"
     # via
@@ -61,7 +61,7 @@ iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via pylint
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 mako==1.1.6
     # via alembic
@@ -69,7 +69,7 @@ markupsafe==2.0.1
     # via mako
 mccabe==0.6.1
     # via pylint
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
@@ -80,38 +80,41 @@ packaging==21.3
     #   pytest-sugar
 pint==0.18
     # via -r requirements/_test.in
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via pylint
 pluggy==1.0.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-psycopg2-binary==2.9.2
+psycopg2-binary==2.9.3
     # via sqlalchemy
 py==1.11.0
     # via pytest
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements/_test.in
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
+    #   pytest-asyncio
     #   pytest-cov
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
     #   pytest-sugar
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.0.3
     # via -r requirements/_test.in
+pytest-asyncio==0.18.0
+    # via pytest-aiohttp
 pytest-cov==3.0.0
     # via -r requirements/_test.in
 pytest-icdiff==0.5
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements/_test.in
 pytest-runner==5.3.1
     # via -r requirements/_test.in
@@ -124,7 +127,7 @@ pyyaml==6.0
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-requests==2.26.0
+requests==2.27.1
     # via coveralls
 six==1.16.0
     # via python-dateutil
@@ -136,21 +139,20 @@ sqlalchemy==1.3.24
     #   alembic
 termcolor==1.1.0
     # via pytest-sugar
-text-unidecode==1.3
-    # via faker
 toml==0.10.2
+    # via pylint
+tomli==1.2.3
     # via
-    #   pylint
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
     #   pytest
-tomli==1.2.2
-    # via coverage
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
     #   -c requirements/_base.txt
     #   astroid
-    #   async-timeout
     #   pylint
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -161,7 +163,7 @@ yarl==1.7.2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   aiohttp
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/packages/models-library/requirements/_tools.txt
+++ b/packages/models-library/requirements/_tools.txt
@@ -4,9 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
-black==21.12b0
+black==22.1.0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -17,11 +15,11 @@ click==8.0.3
     #   black
     #   pip-tools
     #   typer
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.4.2
     # via virtualenv
-identify==2.4.0
+identify==2.4.8
     # via pre-commit
 isort==5.10.1
     # via
@@ -35,14 +33,14 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via
     #   -c requirements/_test.txt
     #   black
     #   virtualenv
-pre-commit==2.15.0
+pre-commit==2.17.0
     # via -r requirements/../../../requirements/devenv.txt
 pyyaml==6.0
     # via
@@ -57,21 +55,22 @@ toml==0.10.2
     # via
     #   -c requirements/_test.txt
     #   pre-commit
-tomli==1.2.2
+tomli==1.2.3
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517
 typer==0.4.0
     # via -r requirements/_tools.in
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.10.0
+virtualenv==20.13.1
     # via pre-commit
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/packages/models-library/requirements/_tools.txt
+++ b/packages/models-library/requirements/_tools.txt
@@ -19,7 +19,7 @@ distlib==0.3.4
     # via virtualenv
 filelock==3.4.2
     # via virtualenv
-identify==2.4.8
+identify==2.4.9
     # via pre-commit
 isort==5.10.1
     # via
@@ -35,7 +35,7 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via
     #   -c requirements/_test.txt
     #   black

--- a/packages/postgres-database/requirements/_base.txt
+++ b/packages/postgres-database/requirements/_base.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-alembic==1.7.5
+alembic==1.7.6
     # via -r requirements/_base.in
 idna==2.10
     # via
     #   -r requirements/_base.in
     #   yarl
-importlib-metadata==4.8.2
+importlib-metadata==4.10.1
     # via alembic
 importlib-resources==5.4.0 ; python_version < "3.9"
     # via
@@ -20,9 +20,9 @@ mako==1.1.6
     # via alembic
 markupsafe==2.0.1
     # via mako
-multidict==5.2.0
+multidict==6.0.2
     # via yarl
-psycopg2-binary==2.9.2
+psycopg2-binary==2.9.3
     # via sqlalchemy
 sqlalchemy==1.3.24
     # via
@@ -31,7 +31,7 @@ sqlalchemy==1.3.24
     #   alembic
 yarl==1.7.2
     # via -r requirements/_base.in
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/packages/postgres-database/requirements/_migration.txt
+++ b/packages/postgres-database/requirements/_migration.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=requirements/_migration.txt --strip-extras requirements/_migration.in
 #
-alembic==1.7.5
+alembic==1.7.6
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_migration.in
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via requests
 click==8.0.3
     # via -r requirements/_migration.in
@@ -20,7 +20,7 @@ idna==2.10
     # via
     #   -c requirements/_base.txt
     #   requests
-importlib-metadata==4.8.2
+importlib-metadata==4.10.1
     # via
     #   -c requirements/_base.txt
     #   alembic
@@ -37,11 +37,11 @@ markupsafe==2.0.1
     # via
     #   -c requirements/_base.txt
     #   mako
-psycopg2-binary==2.9.2
+psycopg2-binary==2.9.3
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
-requests==2.26.0
+requests==2.27.1
     # via docker
 six==1.16.0
     # via websocket-client
@@ -52,7 +52,7 @@ sqlalchemy==1.3.24
     #   alembic
 tenacity==8.0.1
     # via -r requirements/_migration.in
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_migration.in
@@ -61,7 +61,7 @@ websocket-client==0.59.0
     # via
     #   -r requirements/_migration.in
     #   docker
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   -c requirements/_base.txt
     #   importlib-metadata

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -98,7 +98,7 @@ packaging==21.3
     # via pytest
 paramiko==2.9.2
     # via docker
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via pytest

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -12,13 +12,13 @@ aiopg==1.3.3
     # via -r requirements/_test.in
 aiosignal==1.2.0
     # via aiohttp
-astroid==2.9.0
+astroid==2.9.3
     # via pylint
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via
     #   aiohttp
     #   aiopg
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   aiohttp
     #   jsonschema
@@ -35,19 +35,19 @@ cffi==1.15.0
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via
     #   -c requirements/_migration.txt
     #   aiohttp
     #   requests
-coverage==6.1.2
+coverage==6.3.1
     # via
     #   -r requirements/_test.in
     #   coveralls
     #   pytest-cov
 coveralls==3.3.1
     # via -r requirements/_test.in
-cryptography==36.0.0
+cryptography==36.0.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   paramiko
@@ -67,9 +67,9 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==9.8.3
+faker==12.1.0
     # via -r requirements/_test.in
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
@@ -85,24 +85,24 @@ isort==5.10.1
     # via pylint
 jsonschema==3.2.0
     # via docker-compose
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 mccabe==0.6.1
     # via pylint
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
 packaging==21.3
     # via pytest
-paramiko==2.8.0
+paramiko==2.9.2
     # via docker
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via pylint
 pluggy==1.0.0
     # via pytest
-psycopg2-binary==2.9.2
+psycopg2-binary==2.9.3
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_migration.txt
@@ -112,23 +112,26 @@ py==1.11.0
     # via pytest
 pycparser==2.21
     # via cffi
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements/_test.in
-pynacl==1.4.0
+pynacl==1.5.0
     # via paramiko
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
 pytest==6.2.5
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
+    #   pytest-asyncio
     #   pytest-cov
     #   pytest-docker
     #   pytest-instafail
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.0.3
     # via -r requirements/_test.in
+pytest-asyncio==0.18.0
+    # via pytest-aiohttp
 pytest-cov==3.0.0
     # via -r requirements/_test.in
 pytest-docker==0.10.3
@@ -146,7 +149,7 @@ pyyaml==5.4.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
     #   docker-compose
-requests==2.26.0
+requests==2.27.1
     # via
     #   -c requirements/_migration.txt
     #   coveralls
@@ -158,7 +161,6 @@ six==1.16.0
     #   bcrypt
     #   dockerpty
     #   jsonschema
-    #   pynacl
     #   python-dateutil
     #   websocket-client
 sqlalchemy==1.3.24
@@ -167,22 +169,21 @@ sqlalchemy==1.3.24
     #   -c requirements/_base.txt
     #   -c requirements/_migration.txt
     #   aiopg
-text-unidecode==1.3
-    # via faker
 texttable==1.6.4
     # via docker-compose
 toml==0.10.2
     # via
     #   pylint
     #   pytest
-tomli==1.2.2
-    # via coverage
-typing-extensions==4.0.0
+tomli==1.2.3
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
+typing-extensions==4.0.1
     # via
     #   astroid
-    #   async-timeout
     #   pylint
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_migration.txt

--- a/packages/postgres-database/requirements/_tools.txt
+++ b/packages/postgres-database/requirements/_tools.txt
@@ -18,7 +18,7 @@ distlib==0.3.4
     # via virtualenv
 filelock==3.4.2
     # via virtualenv
-identify==2.4.8
+identify==2.4.9
     # via pre-commit
 isort==5.10.1
     # via
@@ -34,7 +34,7 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via
     #   -c requirements/_test.txt
     #   black

--- a/packages/postgres-database/requirements/_tools.txt
+++ b/packages/postgres-database/requirements/_tools.txt
@@ -4,9 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
-black==21.12b0
+black==22.1.0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -16,11 +14,11 @@ click==8.0.3
     # via
     #   black
     #   pip-tools
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.4.2
     # via virtualenv
-identify==2.4.0
+identify==2.4.8
     # via pre-commit
 isort==5.10.1
     # via
@@ -34,14 +32,14 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via
     #   -c requirements/_test.txt
     #   black
     #   virtualenv
-pre-commit==2.15.0
+pre-commit==2.17.0
     # via -r requirements/../../../requirements/devenv.txt
 pyyaml==5.4.1
     # via
@@ -56,18 +54,19 @@ toml==0.10.2
     # via
     #   -c requirements/_test.txt
     #   pre-commit
-tomli==1.2.2
+tomli==1.2.3
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.10.0
+virtualenv==20.13.1
     # via pre-commit
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/packages/service-integration/requirements/_base.txt
+++ b/packages/service-integration/requirements/_base.txt
@@ -4,17 +4,17 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   jsonschema
     #   pytest
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via requests
 click==8.0.3
     # via -r requirements/_base.in
-dnspython==2.1.0
+dnspython==2.2.0
     # via email-validator
 docker==5.0.3
     # via -r requirements/_base.in
@@ -32,7 +32,7 @@ importlib-resources==5.4.0 ; python_version < "3.9"
     #   jsonschema
 iniconfig==1.1.1
     # via pytest
-jsonschema==4.2.1
+jsonschema==4.4.0
     # via -r requirements/_base.in
 packaging==21.3
     # via pytest
@@ -45,29 +45,32 @@ pydantic==1.9.0
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
-pytest==6.2.5
+pytest==7.0.0
     # via -r requirements/_base.in
 pyyaml==6.0
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
-requests==2.26.0
+requests==2.27.1
     # via docker
-toml==0.10.2
-    # via pytest
-typing-extensions==4.0.0
+tomli==1.2.3
+    # via
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   pytest
+typing-extensions==4.0.1
     # via pydantic
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-websocket-client==1.2.1
+websocket-client==1.2.3
     # via docker
-zipp==3.6.0
+zipp==3.7.0
     # via importlib-resources

--- a/packages/service-integration/requirements/_test.txt
+++ b/packages/service-integration/requirements/_test.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-astroid==2.9.0
+astroid==2.9.3
     # via pylint
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   -c requirements/_base.txt
     #   pytest
@@ -14,11 +14,11 @@ certifi==2021.10.8
     # via
     #   -c requirements/_base.txt
     #   requests
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via
     #   -c requirements/_base.txt
     #   requests
-coverage==6.1.2
+coverage==6.3.1
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -37,7 +37,7 @@ iniconfig==1.1.1
     #   pytest
 isort==5.10.1
     # via pylint
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 mccabe==0.6.1
     # via pylint
@@ -46,7 +46,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   pytest
     #   pytest-sugar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via pylint
 pluggy==1.0.0
     # via
@@ -56,13 +56,13 @@ py==1.11.0
     # via
     #   -c requirements/_base.txt
     #   pytest
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements/_test.in
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via
     #   -c requirements/_base.txt
     #   packaging
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -77,25 +77,26 @@ pytest-runner==5.3.1
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
-requests==2.26.0
+requests==2.27.1
     # via
     #   -c requirements/_base.txt
     #   coveralls
 termcolor==1.1.0
     # via pytest-sugar
 toml==0.10.2
+    # via pylint
+tomli==1.2.3
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
-    #   pylint
+    #   coverage
     #   pytest
-tomli==1.2.2
-    # via coverage
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   pylint
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/packages/service-integration/requirements/_test.txt
+++ b/packages/service-integration/requirements/_test.txt
@@ -46,7 +46,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   pytest
     #   pytest-sugar
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via

--- a/packages/service-library/requirements/_aiohttp.txt
+++ b/packages/service-library/requirements/_aiohttp.txt
@@ -15,7 +15,7 @@ aiosignal==1.2.0
     # via aiohttp
 aiozipkin==1.1.1
     # via -r requirements/_aiohttp.in
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via
     #   aiohttp
     #   aiopg
@@ -26,9 +26,9 @@ attrs==20.3.0
     #   aiohttp
     #   jsonschema
     #   openapi-core
-charset-normalizer==2.0.7
+charset-normalizer==2.0.11
     # via aiohttp
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
@@ -38,10 +38,8 @@ idna==2.10
     # via
     #   -c requirements/././constraints.txt
     #   yarl
-isodate==0.6.0
-    # via
-    #   openapi-core
-    #   openapi-schema-validator
+isodate==0.6.1
+    # via openapi-core
 jsonschema==3.2.0
     # via
     #   -c requirements/././constraints.txt
@@ -52,23 +50,23 @@ lazy-object-proxy==1.4.3
     # via
     #   -r requirements/_aiohttp.in
     #   openapi-core
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
 openapi-core==0.12.0
     # via -r requirements/_aiohttp.in
-openapi-schema-validator==0.1.5
+openapi-schema-validator==0.2.3
     # via openapi-spec-validator
-openapi-spec-validator==0.3.1
+openapi-spec-validator==0.4.0
     # via openapi-core
-prometheus-client==0.12.0
+prometheus-client==0.13.1
     # via -r requirements/_aiohttp.in
-psycopg2-binary==2.9.2
+psycopg2-binary==2.9.3
     # via
     #   aiopg
     #   sqlalchemy
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
 pyyaml==5.4.1
     # via
@@ -81,17 +79,13 @@ six==1.16.0
     #   isodate
     #   jsonschema
     #   openapi-core
-    #   openapi-schema-validator
-    #   openapi-spec-validator
-sqlalchemy==1.4.27
+sqlalchemy==1.4.31
     # via
     #   -c requirements/./../../../requirements/constraints.txt
     #   aiopg
 strict-rfc3339==0.7
     # via openapi-core
-typing-extensions==4.0.0
-    # via async-timeout
-werkzeug==2.0.2
+werkzeug==2.0.3
     # via -r requirements/_aiohttp.in
 yarl==1.7.2
     # via aiohttp

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-aiodebug==1.1.2
+aiodebug==2.3.0
     # via -r requirements/_base.in
 aiofiles==0.8.0
     # via -r requirements/_base.in
@@ -21,5 +21,7 @@ pyyaml==5.4.1
     #   -r requirements/_base.in
 tenacity==8.0.1
     # via -r requirements/_base.in
-typing-extensions==4.0.0
-    # via pydantic
+typing-extensions==4.0.1
+    # via
+    #   aiodebug
+    #   pydantic

--- a/packages/service-library/requirements/_fastapi.txt
+++ b/packages/service-library/requirements/_fastapi.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=requirements/_fastapi.txt --strip-extras requirements/_fastapi.in
 #
-anyio==3.3.4
+anyio==3.5.0
     # via starlette
-fastapi==0.71.0
+fastapi==0.73.0
     # via
     #   -r requirements/_fastapi.in
     #   fastapi-contrib
@@ -41,5 +41,5 @@ tornado==6.1
     # via
     #   jaeger-client
     #   threadloop
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via pydantic

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -13,9 +13,9 @@ aiosignal==1.2.0
     # via
     #   -c requirements/_aiohttp.txt
     #   aiohttp
-astroid==2.9.0
+astroid==2.9.3
     # via pylint
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via
     #   -c requirements/_aiohttp.txt
     #   aiohttp
@@ -35,19 +35,19 @@ cffi==1.15.0
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.7
+charset-normalizer==2.0.11
     # via
     #   -c requirements/_aiohttp.txt
     #   aiohttp
     #   requests
-coverage==6.1.2
+coverage==6.3.1
     # via
     #   -r requirements/_test.in
     #   coveralls
     #   pytest-cov
 coveralls==3.3.1
     # via -r requirements/_test.in
-cryptography==36.0.0
+cryptography==36.0.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   paramiko
@@ -65,9 +65,9 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==9.8.3
+faker==12.1.0
     # via -r requirements/_test.in
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   -c requirements/_aiohttp.txt
     #   aiohttp
@@ -80,10 +80,6 @@ idna==2.10
     #   yarl
 iniconfig==1.1.1
     # via pytest
-isodate==0.6.0
-    # via
-    #   -c requirements/_aiohttp.txt
-    #   openapi-schema-validator
 isort==5.10.1
     # via pylint
 jsonschema==3.2.0
@@ -98,16 +94,16 @@ lazy-object-proxy==1.4.3
     #   astroid
 mccabe==0.6.1
     # via pylint
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   -c requirements/_aiohttp.txt
     #   aiohttp
     #   yarl
-openapi-schema-validator==0.1.5
+openapi-schema-validator==0.2.3
     # via
     #   -c requirements/_aiohttp.txt
     #   openapi-spec-validator
-openapi-spec-validator==0.3.1
+openapi-spec-validator==0.4.0
     # via
     #   -c requirements/_aiohttp.txt
     #   -r requirements/_test.in
@@ -115,9 +111,9 @@ packaging==21.3
     # via
     #   pytest
     #   pytest-sugar
-paramiko==2.8.0
+paramiko==2.9.2
     # via docker
-platformdirs==2.4.0
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via pytest
@@ -125,13 +121,13 @@ py==1.11.0
     # via pytest
 pycparser==2.21
     # via cffi
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements/_test.in
-pynacl==1.4.0
+pynacl==1.5.0
     # via paramiko
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via
     #   -c requirements/_aiohttp.txt
     #   jsonschema
@@ -139,20 +135,23 @@ pytest==6.2.5
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
+    #   pytest-asyncio
     #   pytest-cov
     #   pytest-docker
     #   pytest-instafail
     #   pytest-mock
     #   pytest-sugar
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.0.3
     # via -r requirements/_test.in
+pytest-asyncio==0.18.0
+    # via pytest-aiohttp
 pytest-cov==3.0.0
     # via -r requirements/_test.in
 pytest-docker==0.10.3
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements/_test.in
 pytest-runner==5.3.1
     # via -r requirements/_test.in
@@ -169,7 +168,7 @@ pyyaml==5.4.1
     #   -c requirements/_base.txt
     #   docker-compose
     #   openapi-spec-validator
-requests==2.26.0
+requests==2.27.1
     # via
     #   coveralls
     #   docker
@@ -180,34 +179,28 @@ six==1.16.0
     #   -c requirements/_fastapi.txt
     #   bcrypt
     #   dockerpty
-    #   isodate
     #   jsonschema
-    #   openapi-schema-validator
-    #   openapi-spec-validator
-    #   pynacl
     #   python-dateutil
     #   websocket-client
 termcolor==1.1.0
     # via pytest-sugar
-text-unidecode==1.3
-    # via faker
 texttable==1.6.4
     # via docker-compose
 toml==0.10.2
     # via
     #   pylint
     #   pytest
-tomli==1.2.2
-    # via coverage
-typing-extensions==4.0.0
+tomli==1.2.3
     # via
-    #   -c requirements/_aiohttp.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
+typing-extensions==4.0.1
+    # via
     #   -c requirements/_base.txt
     #   -c requirements/_fastapi.txt
     #   astroid
-    #   async-timeout
     #   pylint
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   requests

--- a/packages/service-library/requirements/_tools.txt
+++ b/packages/service-library/requirements/_tools.txt
@@ -4,9 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
-black==21.12b0
+black==22.1.0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -16,11 +14,11 @@ click==8.0.3
     # via
     #   black
     #   pip-tools
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.4.2
     # via virtualenv
-identify==2.4.0
+identify==2.4.9
     # via pre-commit
 isort==5.10.1
     # via
@@ -34,14 +32,14 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.0
+platformdirs==2.5.0
     # via
     #   -c requirements/_test.txt
     #   black
     #   virtualenv
-pre-commit==2.15.0
+pre-commit==2.17.0
     # via -r requirements/../../../requirements/devenv.txt
 pyyaml==5.4.1
     # via
@@ -57,19 +55,20 @@ toml==0.10.2
     # via
     #   -c requirements/_test.txt
     #   pre-commit
-tomli==1.2.2
+tomli==1.2.3
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.10.0
+virtualenv==20.13.1
     # via pre-commit
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/packages/settings-library/requirements/_base.txt
+++ b/packages/settings-library/requirements/_base.txt
@@ -12,5 +12,5 @@ pydantic==1.9.0
     #   -r requirements/_base.in
 typer==0.4.0
     # via -r requirements/_base.in
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via pydantic

--- a/packages/settings-library/requirements/_test.txt
+++ b/packages/settings-library/requirements/_test.txt
@@ -35,7 +35,7 @@ packaging==21.3
     # via
     #   pytest
     #   pytest-sugar
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via pytest

--- a/packages/settings-library/requirements/_test.txt
+++ b/packages/settings-library/requirements/_test.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-astroid==2.9.0
+astroid==2.9.3
     # via pylint
-attrs==21.2.0
+attrs==21.4.0
     # via pytest
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via requests
-coverage==6.1.2
+coverage==6.3.1
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -27,7 +27,7 @@ iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via pylint
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 mccabe==0.6.1
     # via pylint
@@ -35,17 +35,17 @@ packaging==21.3
     # via
     #   pytest
     #   pytest-sugar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via pylint
 pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements/_test.in
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r requirements/_test.in
     #   pytest-cov
@@ -56,7 +56,7 @@ pytest-cov==3.0.0
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements/_test.in
 pytest-runner==5.3.1
     # via -r requirements/_test.in
@@ -64,22 +64,23 @@ pytest-sugar==0.9.4
     # via -r requirements/_test.in
 python-dotenv==0.19.2
     # via -r requirements/_test.in
-requests==2.26.0
+requests==2.27.1
     # via coveralls
 termcolor==1.1.0
     # via pytest-sugar
 toml==0.10.2
+    # via pylint
+tomli==1.2.3
     # via
-    #   pylint
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
     #   pytest
-tomli==1.2.2
-    # via coverage
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   pylint
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   requests

--- a/packages/settings-library/requirements/_tools.txt
+++ b/packages/settings-library/requirements/_tools.txt
@@ -4,9 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
-black==21.12b0
+black==22.1.0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -17,11 +15,11 @@ click==8.0.3
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.4.2
     # via virtualenv
-identify==2.4.0
+identify==2.4.8
     # via pre-commit
 isort==5.10.1
     # via
@@ -35,14 +33,14 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via
     #   -c requirements/_test.txt
     #   black
     #   virtualenv
-pre-commit==2.15.0
+pre-commit==2.17.0
     # via -r requirements/../../../requirements/devenv.txt
 pyyaml==6.0
     # via
@@ -54,19 +52,20 @@ toml==0.10.2
     # via
     #   -c requirements/_test.txt
     #   pre-commit
-tomli==1.2.2
+tomli==1.2.3
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.10.0
+virtualenv==20.13.1
     # via pre-commit
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/packages/settings-library/requirements/_tools.txt
+++ b/packages/settings-library/requirements/_tools.txt
@@ -19,7 +19,7 @@ distlib==0.3.4
     # via virtualenv
 filelock==3.4.2
     # via virtualenv
-identify==2.4.8
+identify==2.4.9
     # via pre-commit
 isort==5.10.1
     # via
@@ -35,7 +35,7 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via
     #   -c requirements/_test.txt
     #   black

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-aiodebug==1.1.2
+aiodebug==2.3.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiofiles==0.8.0
     # via
@@ -21,9 +21,9 @@ aiopg==1.3.3
     # via -r requirements/_base.in
 aiosignal==1.2.0
     # via aiohttp
-alembic==1.7.5
+alembic==1.7.6
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via
     #   aiohttp
     #   aiopg
@@ -31,13 +31,13 @@ attrs==20.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   aiohttp
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via aiohttp
-dnspython==2.1.0
+dnspython==2.2.0
     # via email-validator
 email-validator==1.1.3
     # via pydantic
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
@@ -48,7 +48,7 @@ idna==2.10
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   email-validator
     #   yarl
-importlib-metadata==4.8.2
+importlib-metadata==4.10.1
     # via alembic
 importlib-resources==5.4.0 ; python_version < "3.9"
     # via
@@ -61,13 +61,13 @@ mako==1.1.6
     # via alembic
 markupsafe==2.0.1
     # via mako
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
 packaging==21.3
     # via -r requirements/_base.in
-psycopg2-binary==2.9.2
+psycopg2-binary==2.9.3
     # via
     #   aiopg
     #   sqlalchemy
@@ -82,7 +82,7 @@ pydantic==1.9.0
     #   -r requirements/_base.in
 pyinstrument==4.1.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 pyyaml==5.4.1
     # via
@@ -107,15 +107,15 @@ tenacity==8.0.1
     #   -r requirements/_base.in
 tqdm==4.62.3
     # via -r requirements/_base.in
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
-    #   async-timeout
+    #   aiodebug
     #   pydantic
 yarl==1.7.2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   aiohttp
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -108,7 +108,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   pytest
     #   pytest-sugar
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via pytest

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -10,19 +10,19 @@ aiohttp==3.8.1
     #   -c requirements/_base.txt
     #   aioresponses
     #   pytest-aiohttp
-aioresponses==0.7.2
+aioresponses==0.7.3
     # via -r requirements/_test.in
 aiosignal==1.2.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-alembic==1.7.5
+alembic==1.7.6
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-astroid==2.9.0
+astroid==2.9.3
     # via pylint
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -35,14 +35,14 @@ certifi==2021.10.8
     # via
     #   minio
     #   requests
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   requests
 click==8.0.3
     # via -r requirements/_test.in
-coverage==6.1.2
+coverage==6.3.1
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -55,9 +55,9 @@ docopt==0.6.2
     # via coveralls
 execnet==1.9.0
     # via pytest-xdist
-faker==9.8.3
+faker==12.1.0
     # via -r requirements/_test.in
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -69,7 +69,7 @@ idna==2.10
     #   -c requirements/_base.txt
     #   requests
     #   yarl
-importlib-metadata==4.8.2
+importlib-metadata==4.10.1
     # via
     #   -c requirements/_base.txt
     #   alembic
@@ -82,7 +82,7 @@ iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via pylint
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 mako==1.1.6
     # via
@@ -98,7 +98,7 @@ minio==7.0.4
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -108,13 +108,13 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   pytest
     #   pytest-sugar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via pylint
 pluggy==1.0.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-psycopg2-binary==2.9.2
+psycopg2-binary==2.9.3
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
@@ -122,16 +122,17 @@ py==1.11.0
     # via
     #   pytest
     #   pytest-forked
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements/_test.in
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via
     #   -c requirements/_base.txt
     #   packaging
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
+    #   pytest-asyncio
     #   pytest-cov
     #   pytest-forked
     #   pytest-icdiff
@@ -140,11 +141,13 @@ pytest==6.2.5
     #   pytest-mock
     #   pytest-sugar
     #   pytest-xdist
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.0.3
     # via -r requirements/_test.in
+pytest-asyncio==0.18.0
+    # via pytest-aiohttp
 pytest-cov==3.0.0
     # via -r requirements/_test.in
-pytest-forked==1.3.0
+pytest-forked==1.4.0
     # via pytest-xdist
 pytest-icdiff==0.5
     # via -r requirements/_test.in
@@ -152,19 +155,19 @@ pytest-instafail==0.4.2
     # via -r requirements/_test.in
 pytest-lazy-fixture==0.6.3
     # via -r requirements/_test.in
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements/_test.in
 pytest-runner==5.3.1
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
-pytest-xdist==2.4.0
+pytest-xdist==2.5.0
     # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via faker
 python-dotenv==0.19.2
     # via -r requirements/_test.in
-requests==2.26.0
+requests==2.27.1
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -178,26 +181,24 @@ sqlalchemy==1.3.24
     #   alembic
 termcolor==1.1.0
     # via pytest-sugar
-text-unidecode==1.3
-    # via faker
 toml==0.10.2
+    # via pylint
+tomli==1.2.3
     # via
-    #   pylint
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
     #   pytest
-tomli==1.2.2
-    # via coverage
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
     #   -c requirements/_base.txt
     #   astroid
-    #   async-timeout
     #   pylint
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   minio
     #   requests
-websocket-client==1.2.1
+websocket-client==1.2.3
     # via docker
 wrapt==1.13.3
     # via astroid
@@ -205,7 +206,7 @@ yarl==1.7.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   -c requirements/_base.txt
     #   importlib-metadata

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -4,9 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
-black==21.12b0
+black==22.1.0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -17,11 +15,11 @@ click==8.0.3
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.4.2
     # via virtualenv
-identify==2.4.0
+identify==2.4.8
     # via pre-commit
 isort==5.10.1
     # via
@@ -35,14 +33,14 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via
     #   -c requirements/_test.txt
     #   black
     #   virtualenv
-pre-commit==2.15.0
+pre-commit==2.17.0
     # via -r requirements/../../../requirements/devenv.txt
 pyyaml==5.4.1
     # via
@@ -57,19 +55,20 @@ toml==0.10.2
     # via
     #   -c requirements/_test.txt
     #   pre-commit
-tomli==1.2.2
+tomli==1.2.3
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.10.0
+virtualenv==20.13.1
     # via pre-commit
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -19,7 +19,7 @@ distlib==0.3.4
     # via virtualenv
 filelock==3.4.2
     # via virtualenv
-identify==2.4.8
+identify==2.4.9
     # via pre-commit
 isort==5.10.1
     # via
@@ -35,7 +35,7 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via
     #   -c requirements/_test.txt
     #   black

--- a/requirements/tools/Makefile
+++ b/requirements/tools/Makefile
@@ -74,7 +74,10 @@ reqs-all: guard-UPGRADE_OPTION ## updates a give package repository-wise (e.g. m
 	# Upgrading $(upgrade) ALL requirements
 	@$(foreach p,${_inputs-all},echo Touching $(p);touch $(p);$(MAKE_C) $(dir $(p)) reqs $(UPGRADE_OPTION);)
 
-
+reqs-ci: ## upgrades requirements for pylint recipe in CI
+	cd $(REPODIR)/ci/helpers \
+	&& rm requirements.txt \
+	&& pip-compile --output-file=requirements.txt requirements.in
 
 IMAGE_NAME:=local/python-devkit:${PYTHON_VERSION}
 

--- a/requirements/tools/check_changes.py
+++ b/requirements/tools/check_changes.py
@@ -1,0 +1,79 @@
+import re
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+
+from packaging.version import Version
+
+BEFORE_PATTERN = re.compile(r"^-([\w-]+)==([0-9\.]+)")
+AFTER_PATTERN = re.compile(r"^\+([\w-]+)==([0-9\.]+)")
+
+
+def dump_changes(filename: Path):
+    subprocess.run(f"git --no-pager diff > {filename}", shell=True, check=True)
+
+
+def tag_upgrade(from_version: Version, to_version: Version):
+    assert from_version < to_version
+    if from_version.major < to_version.major:
+        return "**MAJOR**"
+    if from_version.minor < to_version.minor:
+        return "*minor*"
+    return ""
+
+
+def parse_changes(filename: Path):
+
+    before = defaultdict(list)
+    after = defaultdict(list)
+    with filename.open() as fh:
+        for line in fh:
+            if match := BEFORE_PATTERN.match(line):
+                name, version = match.groups()
+                before[name].append(Version(version))
+            elif match := AFTER_PATTERN.match(line):
+                name, version = match.groups()
+                after[name].append(Version(version))
+    return before, after
+
+
+def main():
+
+    filepath = Path("changes.ignore.keep.log")
+    if not filepath.exists():
+        dump_changes(filepath)
+
+    before, after = parse_changes(filepath)
+
+    # format
+    print("before", len(before))
+    print("after", len(after))
+
+    print("| | name | before | after| upgrade |\n |--|--|--|--|--|")
+    for i, name in enumerate(sorted(before.keys()), start=1):
+        # TODO: where are these libraries?
+        # TODO: are they first dependencies?
+        # TODO: if major, get link to release notes
+        from_versions = set(str(v) for v in before[name])
+        to_versions = set(str(v) for v in after[name])
+
+        print(
+            "|",
+            f"{i:2d}",
+            "|",
+            f"{name:25s}",
+            "|",
+            f'{", ".join(from_versions):15s}',
+            "|",
+            f'{",".join(to_versions) if to_versions else "removed":10s}',
+            "|",
+            # how big the version change is
+            f"{tag_upgrade(sorted(set(before[name]))[-1], sorted(set(after[name]))[-1]):10s}"
+            if to_versions
+            else "",
+            "|",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements/tools/check_changes.py
+++ b/requirements/tools/check_changes.py
@@ -46,10 +46,15 @@ def main():
     before, after = parse_changes(filepath)
 
     # format
-    print("before", len(before))
-    print("after", len(after))
+    print("Stats")
+    print("- #packages before:", len(before))
+    print("- #packages after :", len(after))
+    print()
 
-    print("| | name | before | after| upgrade |\n |--|--|--|--|--|")
+    COLUMNS = ["#", "name", "before", "after", "upgrade"]
+
+    print("|" + "|".join(COLUMNS) + "|")
+    print("|" + "|".join(["-" * len(c) for c in COLUMNS]) + "|")
     for i, name in enumerate(sorted(before.keys()), start=1):
         # TODO: where are these libraries?
         # TODO: are they first dependencies?

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -67,7 +67,7 @@ chardet==4.0.0
     #   requests
 charset-normalizer==2.0.10
     # via httpx
-click==7.1.2
+click==8.0.3
     # via
     #   typer
     #   uvicorn

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -15,7 +15,7 @@ anyio==3.5.0
     #   httpcore
 asgi-lifespan==1.0.1
     # via -r requirements/_test.in
-astroid==2.9.0
+astroid==2.9.3
     # via pylint
 attrs==20.3.0
     # via
@@ -53,7 +53,7 @@ click==7.1.2
     #   -r requirements/_test.in
 codecov==2.1.12
     # via -r requirements/_test.in
-coverage==6.1.2
+coverage==6.3.1
     # via
     #   codecov
     #   coveralls
@@ -83,7 +83,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==9.8.3
+faker==12.1.0
     # via -r requirements/_test.in
 h11==0.12.0
     # via
@@ -121,7 +121,7 @@ isort==5.10.1
     # via pylint
 jsonschema==3.2.0
     # via docker-compose
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 mako==1.1.5
     # via
@@ -141,11 +141,11 @@ packaging==20.9
     # via
     #   -c requirements/_base.txt
     #   pytest
-paramiko==2.8.0
+paramiko==2.9.2
     # via docker
 passlib==1.7.4
     # via -r requirements/_test.in
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via pylint
 pluggy==1.0.0
     # via pytest
@@ -159,15 +159,15 @@ pycparser==2.20
     # via
     #   -c requirements/_base.txt
     #   cffi
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements/_test.in
-pynacl==1.4.0
+pynacl==1.5.0
     # via paramiko
 pyparsing==2.4.7
     # via
     #   -c requirements/_base.txt
     #   packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
 pytest==6.2.5
     # via
@@ -176,13 +176,13 @@ pytest==6.2.5
     #   pytest-cov
     #   pytest-docker
     #   pytest-mock
-pytest-asyncio==0.16.0
+pytest-asyncio==0.18.0
     # via -r requirements/_test.in
 pytest-cov==3.0.0
     # via -r requirements/_test.in
 pytest-docker==0.10.3
     # via -r requirements/_test.in
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements/_test.in
 pytest-runner==5.3.1
     # via -r requirements/_test.in
@@ -205,7 +205,7 @@ requests==2.25.1
     #   coveralls
     #   docker
     #   docker-compose
-respx==0.19.1
+respx==0.19.2
     # via -r requirements/_test.in
 rfc3986==1.5.0
     # via
@@ -217,7 +217,6 @@ six==1.16.0
     #   bcrypt
     #   dockerpty
     #   jsonschema
-    #   pynacl
     #   python-dateutil
     #   tenacity
     #   websocket-client
@@ -239,15 +238,13 @@ tenacity==7.0.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-text-unidecode==1.3
-    # via faker
 texttable==1.6.4
     # via docker-compose
 toml==0.10.2
     # via
     #   pylint
     #   pytest
-tomli==1.2.2
+tomli==1.2.3
     # via
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -47,7 +47,7 @@ charset-normalizer==2.0.10
     # via
     #   -c requirements/_base.txt
     #   httpx
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -145,7 +145,7 @@ paramiko==2.9.2
     # via docker
 passlib==1.7.4
     # via -r requirements/_test.in
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via pytest

--- a/services/api-server/requirements/_tools.txt
+++ b/services/api-server/requirements/_tools.txt
@@ -4,9 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
-black==21.12b0
+black==22.1.0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -14,17 +12,17 @@ cfgv==3.3.1
     # via pre-commit
 change-case==0.5.2
     # via -r requirements/_tools.in
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.4.2
     # via virtualenv
-identify==2.4.0
+identify==2.4.9
     # via pre-commit
 isort==5.10.1
     # via
@@ -48,14 +46,14 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.0
+platformdirs==2.5.0
     # via
     #   -c requirements/_test.txt
     #   black
     #   virtualenv
-pre-commit==2.15.0
+pre-commit==2.17.0
     # via -r requirements/../../../requirements/devenv.txt
 ptvsd==4.3.2
     # via -r requirements/_tools.in
@@ -75,7 +73,7 @@ toml==0.10.2
     # via
     #   -c requirements/_test.txt
     #   pre-commit
-tomli==1.2.2
+tomli==1.2.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
@@ -86,11 +84,11 @@ typing-extensions==3.10.0.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.10.0
+virtualenv==20.13.1
     # via pre-commit
 watchdog==2.1.6
     # via -r requirements/_tools.in
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -7,7 +7,6 @@
 aiohttp==3.7.4.post0
     # via
     #   -c requirements/../../../requirements/constraints.txt
-    #   -c requirements/constraints.txt
     #   pytest-aiohttp
 alembic==1.7.4
     # via
@@ -239,7 +238,9 @@ toml==0.10.2
     #   pylint
     #   pytest
 tomli==1.2.2
-    # via coverage
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
 typing-extensions==3.10.0.2
     # via
     #   -c requirements/_base.txt

--- a/services/catalog/requirements/constraints.txt
+++ b/services/catalog/requirements/constraints.txt
@@ -1,7 +1,1 @@
-# Could not find a version that matches async-timeout<5.0,==3.0.1,>=4.0.0a3 (from -c requirements/_base.txt (line 23))
-# Tried: 1.0.0, 1.0.0, 1.1.0, 1.1.0, 1.2.0, 1.2.0, 1.2.1, 1.2.1, 1.3.0, 1.3.0, 1.4.0, 1.4.0, 2.0.0, 2.0.0, 2.0.1, 2.0.1, 3.0.0, 3.0.0, 3.0.1, 3.0.1, 4.0.0, 4.0.0, 4.0.1, 4.0.1
-# Skipped pre-versions: 4.0.0a0, 4.0.0a0, 4.0.0a1, 4.0.0a1, 4.0.0a2, 4.0.0a2, 4.0.0a3, 4.0.0a3
-# There are incompatible versions in the resolved dependencies:
-#   async-timeout==3.0.1 (from -c requirements/_base.txt (line 23))
-#   async-timeout<5.0,>=4.0.0a3 (from aiohttp==3.8.1->-c requirements/../../../requirements/constraints.txt (line 11))
-aiohttp~=3.7.4
+# Add here ONLY this package's constraints

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -13,7 +13,7 @@ aiosignal==1.2.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-astroid==2.9.0
+astroid==2.9.3
     # via pylint
 async-timeout==4.0.1
     # via
@@ -38,14 +38,14 @@ charset-normalizer==2.0.6
     #   -c requirements/_base.txt
     #   aiohttp
     #   requests
-coverage==6.1.2
+coverage==6.3.1
     # via
     #   -r requirements/_test.in
     #   coveralls
     #   pytest-cov
 coveralls==3.3.1
     # via -r requirements/_test.in
-cryptography==36.0.0
+cryptography==36.0.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   pyopenssl
@@ -53,7 +53,7 @@ docker==5.0.3
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
-faker==9.8.3
+faker==12.1.0
     # via -r requirements/_test.in
 frozenlist==1.2.0
     # via
@@ -72,7 +72,7 @@ iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via pylint
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 mccabe==0.6.1
     # via pylint
@@ -91,7 +91,7 @@ packaging==20.4
     #   -c requirements/_packages.txt
     #   pytest
     #   pytest-sugar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via pylint
 pluggy==1.0.0
     # via pytest
@@ -107,27 +107,30 @@ pycparser==2.20
     #   cffi
 pyftpdlib==1.5.6
     # via pytest-localftpserver
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements/_test.in
-pyopenssl==21.0.0
+pyopenssl==22.0.0
     # via pytest-localftpserver
 pyparsing==2.4.7
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_packages.txt
     #   packaging
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
+    #   pytest-asyncio
     #   pytest-cov
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-localftpserver
     #   pytest-mock
     #   pytest-sugar
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.0.3
     # via -r requirements/_test.in
+pytest-asyncio==0.18.0
+    # via pytest-aiohttp
 pytest-cov==3.0.0
     # via -r requirements/_test.in
 pytest-icdiff==0.5
@@ -136,7 +139,7 @@ pytest-instafail==0.4.2
     # via -r requirements/_test.in
 pytest-localftpserver==1.1.3
     # via -r requirements/_test.in
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
@@ -158,19 +161,17 @@ six==1.15.0
     #   -c requirements/_base.txt
     #   -c requirements/_packages.txt
     #   packaging
-    #   pyopenssl
     #   python-dateutil
     #   websocket-client
 termcolor==1.1.0
     # via pytest-sugar
-text-unidecode==1.3
-    # via faker
 toml==0.10.2
+    # via pylint
+tomli==1.2.3
     # via
-    #   pylint
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
     #   pytest
-tomli==1.2.2
-    # via coverage
 typing-extensions==3.10.0.2 ; python_version < "3.9"
     # via
     #   -c requirements/_base.txt

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -91,7 +91,7 @@ packaging==20.4
     #   -c requirements/_packages.txt
     #   pytest
     #   pytest-sugar
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via pytest

--- a/services/datcore-adapter/requirements/_test.txt
+++ b/services/datcore-adapter/requirements/_test.txt
@@ -10,9 +10,9 @@ anyio==3.2.1
     #   httpcore
 asgi-lifespan==1.0.1
     # via -r requirements/_test.in
-astroid==2.9.0
+astroid==2.9.3
     # via pylint
-attrs==21.2.0
+attrs==21.4.0
     # via pytest
 certifi==2021.5.30
     # via
@@ -30,7 +30,7 @@ charset-normalizer==2.0.10
     #   httpx
 codecov==2.1.12
     # via -r requirements/_test.in
-coverage==6.1.2
+coverage==6.3.1
     # via
     #   -r requirements/_test.in
     #   codecov
@@ -44,7 +44,7 @@ docopt==0.6.2
     #   coveralls
 execnet==1.9.0
     # via pytest-xdist
-faker==9.8.3
+faker==12.1.0
     # via -r requirements/_test.in
 h11==0.12.0
     # via
@@ -70,7 +70,7 @@ iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via pylint
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 mccabe==0.6.1
     # via pylint
@@ -78,7 +78,7 @@ packaging==21.3
     # via
     #   pytest
     #   pytest-sugar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via pylint
 pluggy==1.0.0
     # via pytest
@@ -88,11 +88,11 @@ py==1.11.0
     # via
     #   pytest
     #   pytest-forked
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements/_test.in
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio
@@ -103,23 +103,23 @@ pytest==6.2.5
     #   pytest-mock
     #   pytest-sugar
     #   pytest-xdist
-pytest-asyncio==0.16.0
+pytest-asyncio==0.18.0
     # via -r requirements/_test.in
 pytest-cov==3.0.0
     # via -r requirements/_test.in
-pytest-forked==1.3.0
+pytest-forked==1.4.0
     # via pytest-xdist
 pytest-icdiff==0.5
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements/_test.in
 pytest-runner==5.3.1
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in
-pytest-xdist==2.4.0
+pytest-xdist==2.5.0
     # via -r requirements/_test.in
 python-dateutil==2.8.1
     # via
@@ -130,7 +130,7 @@ requests==2.25.1
     #   -c requirements/_base.txt
     #   codecov
     #   coveralls
-respx==0.19.1
+respx==0.19.2
     # via -r requirements/_test.in
 rfc3986==1.5.0
     # via
@@ -149,14 +149,13 @@ sniffio==1.2.0
     #   httpx
 termcolor==1.1.0
     # via pytest-sugar
-text-unidecode==1.3
-    # via faker
 toml==0.10.2
+    # via pylint
+tomli==1.2.3
     # via
-    #   pylint
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
     #   pytest
-tomli==1.2.2
-    # via coverage
 typing-extensions==3.10.0.2
     # via
     #   -c requirements/_base.txt

--- a/services/datcore-adapter/requirements/_test.txt
+++ b/services/datcore-adapter/requirements/_test.txt
@@ -78,7 +78,7 @@ packaging==21.3
     # via
     #   pytest
     #   pytest-sugar
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via pytest

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -81,7 +81,7 @@ chardet==4.0.0
     #   requests
 charset-normalizer==2.0.7
     # via httpx
-click==7.1.2
+click==8.0.3
     # via
     #   typer
     #   uvicorn

--- a/services/dynamic-sidecar/requirements/_test.txt
+++ b/services/dynamic-sidecar/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-async-asgi-testclient==1.4.7
+async-asgi-testclient==1.4.9
     # via -r requirements/_test.in
 attrs==20.3.0
     # via
@@ -18,9 +18,9 @@ chardet==4.0.0
     # via
     #   -c requirements/_base.txt
     #   requests
-coverage==6.1.2
+coverage==6.3.1
     # via pytest-cov
-faker==9.8.3
+faker==12.1.0
     # via -r requirements/_test.in
 idna==2.10
     # via
@@ -44,17 +44,17 @@ pyparsing==2.4.7
     # via
     #   -c requirements/_base.txt
     #   packaging
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
-pytest-asyncio==0.16.0
+pytest-asyncio==0.18.0
     # via -r requirements/_test.in
 pytest-cov==3.0.0
     # via -r requirements/_test.in
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via faker
@@ -66,19 +66,16 @@ six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil
-text-unidecode==1.3
-    # via faker
-toml==0.10.2
-    # via pytest
-tomli==1.2.2
+tomli==1.2.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   coverage
-types-aiofiles==0.8.2
+    #   pytest
+types-aiofiles==0.8.3
     # via -r requirements/_test.in
 types-pkg-resources==0.1.3
     # via -r requirements/_test.in
-types-pyyaml==6.0.1
+types-pyyaml==6.0.4
     # via -r requirements/_test.in
 urllib3==1.26.6
     # via

--- a/services/dynamic-sidecar/requirements/_tools.txt
+++ b/services/dynamic-sidecar/requirements/_tools.txt
@@ -4,11 +4,9 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==2.9.0
+astroid==2.9.3
     # via pylint
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
-black==21.12b0
+black==22.1.0
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   -r requirements/_tools.in
@@ -16,27 +14,27 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.3.1
     # via pre-commit
-click==7.1.2
+click==8.0.3
     # via
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.4.2
     # via virtualenv
-identify==2.4.0
+identify==2.4.9
     # via pre-commit
 isort==5.10.1
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   -r requirements/_tools.in
     #   pylint
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
 mccabe==0.6.1
     # via pylint
-mypy==0.910
+mypy==0.931
     # via -r requirements/_tools.in
 mypy-extensions==0.4.3
     # via
@@ -48,16 +46,16 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.0
+platformdirs==2.5.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==2.15.0
+pre-commit==2.17.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements/_tools.in
 pyyaml==5.4.1
     # via
@@ -71,15 +69,14 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via
-    #   -c requirements/_test.txt
-    #   mypy
     #   pre-commit
     #   pylint
-tomli==1.2.2
+tomli==1.2.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
+    #   mypy
     #   pep517
 typing-extensions==3.10.0.2
     # via
@@ -88,9 +85,9 @@ typing-extensions==3.10.0.2
     #   black
     #   mypy
     #   pylint
-virtualenv==20.10.0
+virtualenv==20.13.1
     # via pre-commit
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 wrapt==1.13.3
     # via astroid

--- a/tests/e2e/requirements/requirements.txt
+++ b/tests/e2e/requirements/requirements.txt
@@ -6,7 +6,7 @@
 #
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via requests
 docker==5.0.3
     # via -r requirements.in

--- a/tests/environment-setup/requirements/requirements.txt
+++ b/tests/environment-setup/requirements/requirements.txt
@@ -12,16 +12,16 @@ aiohttp==3.8.1
     #   pytest-aiohttp
 aiosignal==1.2.0
     # via aiohttp
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via aiohttp
 attrs==20.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   aiohttp
     #   pytest
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via aiohttp
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
@@ -31,7 +31,7 @@ idna==2.10
     #   yarl
 iniconfig==1.1.1
     # via pytest
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
@@ -51,16 +51,19 @@ pydantic==1.9.0
     #   -c requirements/../../../packages/settings-library/requirements/_base.in
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/requirements.in
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r requirements/requirements.in
     #   pytest-aiohttp
+    #   pytest-asyncio
     #   pytest-instafail
     #   pytest-sugar
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.0.3
     # via -r requirements/requirements.in
+pytest-asyncio==0.18.0
+    # via pytest-aiohttp
 pytest-instafail==0.4.2
     # via -r requirements/requirements.in
 pytest-runner==5.3.1
@@ -77,11 +80,13 @@ pyyaml==5.4.1
     #   -r requirements/requirements.in
 termcolor==1.1.0
     # via pytest-sugar
-toml==0.10.2
-    # via pytest
-typing-extensions==4.0.0
+tomli==1.2.3
     # via
-    #   async-timeout
-    #   pydantic
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   pytest
+typing-extensions==4.0.1
+    # via pydantic
 yarl==1.7.2
     # via aiohttp

--- a/tests/public-api/requirements/_test.txt
+++ b/tests/public-api/requirements/_test.txt
@@ -10,11 +10,11 @@ aiohttp==3.8.1
     #   -r requirements/_test.in
 aiosignal==1.2.0
     # via aiohttp
-anyio==3.4.0
+anyio==3.5.0
     # via httpcore
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via aiohttp
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   aiohttp
     #   jsonschema
@@ -24,26 +24,26 @@ certifi==2021.10.8
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via
     #   aiohttp
     #   httpx
     #   requests
-coverage==6.1.2
+coverage==6.3.1
     # via pytest-cov
 docker==5.0.3
     # via -r requirements/_test.in
-faker==9.8.3
+faker==12.1.0
     # via -r requirements/_test.in
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
 h11==0.12.0
     # via httpcore
-httpcore==0.14.3
+httpcore==0.14.7
     # via httpx
-httpx==0.21.3
+httpx==0.22.0
     # via -r requirements/_test.in
 idna==3.3
     # via
@@ -57,9 +57,9 @@ importlib-resources==5.4.0 ; python_version < "3.9"
     #   jsonschema
 iniconfig==1.1.1
     # via pytest
-jsonschema==4.2.1
+jsonschema==4.4.0
     # via -r requirements/_test.in
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
@@ -69,16 +69,16 @@ pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio
     #   pytest-cov
-pytest-asyncio==0.16.0
+pytest-asyncio==0.18.0
     # via -r requirements/_test.in
 pytest-cov==3.0.0
     # via -r requirements/_test.in
@@ -90,7 +90,7 @@ pyyaml==6.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-requests==2.26.0
+requests==2.27.1
     # via docker
 rfc3986==1.5.0
     # via httpx
@@ -103,21 +103,18 @@ sniffio==1.2.0
     #   httpx
 tenacity==8.0.1
     # via -r requirements/_test.in
-text-unidecode==1.3
-    # via faker
-toml==0.10.2
-    # via pytest
-tomli==1.2.2
-    # via coverage
-typing-extensions==4.0.0
-    # via async-timeout
-urllib3==1.26.7
+tomli==1.2.3
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
+    #   pytest
+urllib3==1.26.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-websocket-client==1.2.1
+websocket-client==1.2.3
     # via docker
 yarl==1.7.2
     # via aiohttp
-zipp==3.6.0
+zipp==3.7.0
     # via importlib-resources

--- a/tests/public-api/requirements/_tools.txt
+++ b/tests/public-api/requirements/_tools.txt
@@ -4,9 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
-black==21.12b0
+black==22.1.0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -16,11 +14,11 @@ click==8.0.3
     # via
     #   black
     #   pip-tools
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.4.2
     # via virtualenv
-identify==2.4.0
+identify==2.4.8
     # via pre-commit
 isort==5.10.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -32,13 +30,13 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via
     #   black
     #   virtualenv
-pre-commit==2.15.0
+pre-commit==2.17.0
     # via -r requirements/../../../requirements/devenv.txt
 pyyaml==6.0
     # via
@@ -50,21 +48,18 @@ six==1.16.0
     #   -c requirements/_test.txt
     #   virtualenv
 toml==0.10.2
+    # via pre-commit
+tomli==1.2.3
     # via
-    #   -c requirements/_test.txt
-    #   pre-commit
-tomli==1.2.2
-    # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517
-typing-extensions==4.0.0
-    # via
-    #   -c requirements/_test.txt
-    #   black
-virtualenv==20.10.0
+typing-extensions==4.0.1
+    # via black
+virtualenv==20.13.1
     # via pre-commit
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tests/public-api/requirements/_tools.txt
+++ b/tests/public-api/requirements/_tools.txt
@@ -18,7 +18,7 @@ distlib==0.3.4
     # via virtualenv
 filelock==3.4.2
     # via virtualenv
-identify==2.4.8
+identify==2.4.9
     # via pre-commit
 isort==5.10.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -32,7 +32,7 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via
     #   black
     #   virtualenv

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-aio-pika==6.8.0
+aio-pika==6.8.2
     # via -r requirements/_test.in
-aiodebug==1.1.2
+aiodebug==2.3.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -35,12 +35,12 @@ aiormq==3.3.1
     # via aio-pika
 aiosignal==1.2.0
     # via aiohttp
-alembic==1.7.5
+alembic==1.7.6
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/_test.in
-async-timeout==4.0.1
+async-timeout==4.0.2
     # via
     #   aiohttp
     #   aiopg
@@ -56,7 +56,7 @@ certifi==2021.10.8
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   minio
     #   requests
-charset-normalizer==2.0.8
+charset-normalizer==2.0.11
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   aiohttp
@@ -65,11 +65,11 @@ click==8.0.3
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/_test.in
-coverage==6.1.2
+coverage==6.3.1
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-dnspython==2.1.0
+dnspython==2.2.0
     # via email-validator
 docker==5.0.3
     # via
@@ -77,7 +77,7 @@ docker==5.0.3
     #   -r requirements/_test.in
 email-validator==1.1.3
     # via pydantic
-frozenlist==1.2.0
+frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
@@ -92,7 +92,7 @@ idna==2.10
     #   email-validator
     #   requests
     #   yarl
-importlib-metadata==4.8.2
+importlib-metadata==4.10.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   alembic
@@ -132,7 +132,7 @@ minio==7.0.4
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-multidict==5.2.0
+multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
@@ -145,7 +145,7 @@ pamqp==2.3.0
     # via aiormq
 pluggy==1.0.0
     # via pytest
-psycopg2-binary==2.9.2
+psycopg2-binary==2.9.3
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   aiopg
@@ -170,25 +170,28 @@ pyinstrument==4.1.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
-pytest==6.2.5
+pytest==7.0.0
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
+    #   pytest-asyncio
     #   pytest-cov
     #   pytest-instafail
     #   pytest-mock
     #   pytest-sugar
-pytest-aiohttp==0.3.0
+pytest-aiohttp==1.0.3
     # via -r requirements/_test.in
+pytest-asyncio==0.18.0
+    # via pytest-aiohttp
 pytest-cov==3.0.0
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.6.1
+pytest-mock==3.7.0
     # via -r requirements/_test.in
 pytest-runner==5.3.1
     # via -r requirements/_test.in
@@ -210,7 +213,7 @@ pyyaml==5.4.1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_test.in
-requests==2.26.0
+requests==2.27.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   docker
@@ -241,18 +244,25 @@ tenacity==8.0.1
     #   -r requirements/_test.in
 termcolor==1.1.0
     # via pytest-sugar
-toml==0.10.2
-    # via pytest
-tomli==1.2.2
-    # via coverage
+tomli==1.2.3
+    # via
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   coverage
+    #   pytest
 tqdm==4.62.3
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
+    #   aiodebug
     #   aiodocker
-    #   async-timeout
     #   pydantic
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
@@ -274,7 +284,7 @@ yarl==1.7.2
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   importlib-metadata

--- a/tests/swarm-deploy/requirements/_tools.txt
+++ b/tests/swarm-deploy/requirements/_tools.txt
@@ -19,7 +19,7 @@ distlib==0.3.4
     # via virtualenv
 filelock==3.4.2
     # via virtualenv
-identify==2.4.8
+identify==2.4.9
     # via pre-commit
 isort==5.10.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -33,7 +33,7 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via
     #   black
     #   virtualenv

--- a/tests/swarm-deploy/requirements/_tools.txt
+++ b/tests/swarm-deploy/requirements/_tools.txt
@@ -4,9 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
-black==21.12b0
+black==22.1.0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -17,11 +15,11 @@ click==8.0.3
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.4.2
     # via virtualenv
-identify==2.4.0
+identify==2.4.8
     # via pre-commit
 isort==5.10.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -33,13 +31,13 @@ pathspec==0.9.0
     # via black
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via
     #   black
     #   virtualenv
-pre-commit==2.15.0
+pre-commit==2.17.0
     # via -r requirements/../../../requirements/devenv.txt
 pyyaml==5.4.1
     # via
@@ -52,23 +50,22 @@ six==1.16.0
     #   -c requirements/_test.txt
     #   virtualenv
 toml==0.10.2
+    # via pre-commit
+tomli==1.2.3
     # via
-    #   -c requirements/_test.txt
-    #   pre-commit
-tomli==1.2.2
-    # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   black
     #   pep517
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.10.0
+virtualenv==20.13.1
     # via pre-commit
 watchdog==2.1.6
     # via -r requirements/_tools.in
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## What do these changes do?

- Updates ONLY **test and tooling** dependencies repo-wide. 
- New table that highlights major & minor upgrades
   - highlights major upgraded libraries
   - spots how this upgrade unifies versions repo-wide ( see many *before* -> one *after*)
   
@GitHK we have to discuss about how to upgrade constraints more reliably since now many of the services upgrades are blocked because upstream constraints were not enforced downstream.

### Summary

NOTE that all these libraries are used for testing or tools. Those upgraded from service base requirements are marked with * (this is sometimes necesssary because previous commits with changes in uppermost constraints were not enforced downstream and therefore test upgrades are block by some frozen version sin the ``base.txt``)

- #packages before: 68
- #packages after : 66 (2 removed)

| #   | name                     | before               | after    | upgrade   |
| --- | ------------------------ | -------------------- | -------- | --------- |
| 1   | aio-pika                 | 6.8.0                | 6.8.2    |           |
| 2   | aiodebug                 | 1.1.2                | 2.3.0    | **MAJOR** |
| 3   | aioresponses             | 0.7.2                | 0.7.3    |           |
| 4   | alembic                  | 1.7.5                | 1.7.6    |           |
| 5   | anyio                    | 3.4.0, 3.3.4         | 3.5.0    | *minor*   |
| 6   | astroid                  | 2.9.0                | 2.9.3    |           |
| 7   | async-asgi-testclient    | 1.4.7                | 1.4.9    |           |
| 8   | async-timeout            | 4.0.1                | 4.0.2    |           |
| 9   | attrs                    | 21.2.0               | 21.4.0   | *minor*   |
| 10  | black                    | 21.12                | 22.1.0   | **MAJOR** |
| 11  | charset-normalizer       | 2.0.8, 2.0.7, 2.0.10 | 2.0.11   |           |
| 12* | click                    | 7.1.2                | 8.0.3    | **MAJOR** |
| 13  | coverage                 | 6.1.2                | 6.3.1    | *minor*   |
| 14  | cryptography             | 36.0.0               | 36.0.1   |           |
| 15  | dask                     | 2021.12.0            | 2022.1.1 | **MAJOR** |
| 16  | distlib                  | 0.3.3                | 0.3.4    |           |
| 17  | distributed              | 2021.12.0            | 2022.1.1 | **MAJOR** |
| 18  | dnspython                | 2.1.0                | 2.2.0    | *minor*   |
| 19  | faker                    | 9.8.3                | 12.1.0   | **MAJOR** |
| 20  | fastapi                  | 0.70.0, 0.71.0       | 0.73.0   | *minor*   |
| 21  | filelock                 | 3.4.0                | 3.4.2    |           |
| 22  | frozenlist               | 1.2.0                | 1.3.0    | *minor*   |
| 23  | fsspec                   | 2021.11.0            | 2022.1.0 | **MAJOR** |
| 24  | httpcore                 | 0.14.3               | 0.14.7   |           |
| 25  | httpx                    | 0.21.3               | 0.22.0   | *minor*   |
| 26  | identify                 | 2.4.0                | 2.4.9    |           |
| 27  | importlib-metadata       | 4.8.2                | 4.10.1   | *minor*   |
| 28  | isodate                  | 0.6.0                | 0.6.1    |           |
| 29  | jsonschema               | 4.2.1                | 4.4.0    | *minor*   |
| 30  | lazy-object-proxy        | 1.6.0                | 1.7.1    | *minor*   |
| 31  | multidict                | 5.2.0                | 6.0.2    | **MAJOR** |
| 32  | mypy                     | 0.910                | 0.931    | *minor*   |
| 33  | openapi-schema-validator | 0.1.5                | 0.2.3    | *minor*   |
| 34  | openapi-spec-validator   | 0.3.1                | 0.4.0    | *minor*   |
| 35  | paramiko                 | 2.8.0                | 2.9.2    | *minor*   |
| 36  | pip-tools                | 6.4.0                | 6.5.1    | *minor*   |
| 37  | platformdirs             | 2.4.0                | 2.5.0    | *minor*   |
| 38  | pre-commit               | 2.15.0               | 2.17.0   | *minor*   |
| 39  | prometheus-client        | 0.12.0               | 0.13.1   | *minor*   |
| 40  | psutil                   | 5.8.0                | 5.9.0    | *minor*   |
| 41  | psycopg2-binary          | 2.9.2                | 2.9.3    |           |
| 42  | pylint                   | 2.12.1               | 2.12.2   |           |
| 43  | pynacl                   | 1.4.0                | 1.5.0    | *minor*   |
| 44  | pyopenssl                | 21.0.0               | 22.0.0   | **MAJOR** |
| 45  | pyparsing                | 3.0.6                | 3.0.7    |           |
| 46  | pyrsistent               | 0.18.0               | 0.18.1   |           |
| 47  | pytest                   | 6.2.5                | 7.0.0    | **MAJOR** |
| 48  | pytest-aiohttp           | 0.3.0                | 1.0.3    | **MAJOR** |
| 49  | pytest-asyncio           | 0.16.0               | 0.18.0   | *minor*   |
| 50  | pytest-forked            | 1.3.0                | 1.4.0    | *minor*   |
| 51  | pytest-mock              | 3.6.1                | 3.7.0    | *minor*   |
| 52  | pytest-xdist             | 2.4.0                | 2.5.0    | *minor*   |
| 53  | requests                 | 2.26.0               | 2.27.1   | *minor*   |
| 54  | respx                    | 0.19.1               | 0.19.2   |           |
| 55  | sqlalchemy               | 1.4.27               | 1.4.31   |           |
| 56  | starlette                | 0.16.0               | 0.17.1   | *minor*   |
| 57  | text-unidecode           | 1.3                  | removed  |           |
| 58  | toml                     | 0.10.2               | removed  |           |
| 59  | tomli                    | 1.2.2                | 1.2.3    |           |
| 60  | types-aiofiles           | 0.8.2                | 0.8.3    |           |
| 61  | types-pyyaml             | 6.0.1                | 6.0.4    |           |
| 62  | typing-extensions        | 4.0.0                | 4.0.1    |           |
| 63  | urllib3                  | 1.26.7               | 1.26.8   |           |
| 64  | virtualenv               | 20.10.0              | 20.13.1  | *minor*   |
| 65  | websocket-client         | 1.2.1                | 1.2.3    |           |
| 66  | werkzeug                 | 2.0.2                | 2.0.3    |           |
| 67  | wheel                    | 0.37.0               | 0.37.1   |           |
| 68  | zipp                     | 3.6.0                | 3.7.0    | *minor*   |


## Related issue/s

weekly maintenance of test and tooling libraries


## How to test

all tests 

## Checklist

- [x] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
