### PR TITLE
🐛 Fixes wrong signature and adds tests

### DIFF
--- a/services/web/server/tests/unit/isolated/test_template_projects.py
+++ b/services/web/server/tests/unit/isolated/test_template_projects.py
@@ -10,8 +10,8 @@ import pytest
 from jsonschema import SchemaError
 from servicelib.aiohttp.jsonschema_specs import create_jsonschema_specs
 from simcore_service_webserver.projects.projects_utils import (
+    VARIABLE_PATTERN,
     substitute_parameterized_inputs,
-    variable_pattern,
 )
 from yarl import URL
 
@@ -35,8 +35,8 @@ def mock_parametrized_project(fake_data_dir):
 
     # check parameterized
     inputs = prj["workbench"]["de2578c5-431e-409d-998c-c1f04de67f8b"]["inputs"]
-    assert variable_pattern.match(inputs["Na"])
-    assert variable_pattern.match(inputs["BCL"])
+    assert VARIABLE_PATTERN.match(inputs["Na"])
+    assert VARIABLE_PATTERN.match(inputs["BCL"])
     return prj
 
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

Fixes wrong signature in ``project_utils`` (somehow was not caught by our linter! Follow up in  #2811 )
This could have been prevented if I would have not missed (forgot) the tests in PR #2797

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist


- [x] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
