### PR TITLE
🐛 adds exception rules for legacy services (⚠️ devops)

### DIFF
--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -5,6 +5,7 @@ import re
 from datetime import datetime, timedelta
 from distutils.version import StrictVersion
 from enum import Enum
+from http import HTTPStatus
 from pprint import pformat
 from typing import Dict, List, Optional, Tuple
 
@@ -1023,18 +1024,22 @@ async def _save_service_state(service_host_name: str, session: aiohttp.ClientSes
         try:
             response.raise_for_status()
 
-        except (web.HTTPMethodNotAllowed, web.HTTPNotFound) as err:
-            # NOTE: Legacy Override. Some old services do not have a state entrypoint defined
-            # therefore we assume there is nothing to be saved and do not raise exception
-            # Responses found so far:
-            #   METHOD NOT ALLOWED https://httpstatuses.com/405
-            #   NOT FOUND https://httpstatuses.com/404
-            #
-            log.warning(
-                "Service '%s' does not seem to implement save state functionality: %s. Skipping save",
-                service_host_name,
-                err,
-            )
+        except ClientResponseError as err:
+            if err.status in (HTTPStatus.METHOD_NOT_ALLOWED, HTTPStatus.NOT_FOUND):
+                # NOTE: Legacy Override. Some old services do not have a state entrypoint defined
+                # therefore we assume there is nothing to be saved and do not raise exception
+                # Responses found so far:
+                #   METHOD NOT ALLOWED https://httpstatuses.com/405
+                #   NOT FOUND https://httpstatuses.com/404
+                #
+                log.warning(
+                    "Service '%s' does not seem to implement save state functionality: %s. Skipping save",
+                    service_host_name,
+                    err,
+                )
+            else:
+                # re-reaise
+                raise
         else:
             log.info(
                 "Service '%s' successfully saved its state: %s",
@@ -1045,7 +1050,10 @@ async def _save_service_state(service_host_name: str, session: aiohttp.ClientSes
 
 @run_sequentially_in_context(target_args=["node_uuid"])
 async def stop_service(app: web.Application, node_uuid: str, save_state: bool) -> None:
-    log.debug("stopping service with uuid %s", node_uuid)
+    log.debug(
+        "stopping service with node_uuid=%s, save_state=%s", node_uuid, save_state
+    )
+
     # get the docker client
     async with docker_utils.docker_client() as client:  # pylint: disable=not-async-context-manager
         try:

--- a/services/director/tests/test_producer.py
+++ b/services/director/tests/test_producer.py
@@ -96,9 +96,10 @@ async def run_services(
     # teardown stop the services
     for service in started_services:
         service_uuid = service["service_uuid"]
-        # NOTE: All fake services have no save-state entrypoint, but since save_state=True
-        #       the legacy rule will apply and save will be skipped.
-        await producer.stop_service(aiohttp_mock_app, service_uuid, save_state=True)
+        # NOTE: Fake services are not even web-services therefore we cannot
+        # even emulate a legacy dy-service that does not implement a save-state feature
+        # so here we must make save_state=False
+        await producer.stop_service(aiohttp_mock_app, service_uuid, save_state=False)
         with pytest.raises(exceptions.ServiceUUIDNotFoundError):
             await producer.get_service_details(aiohttp_mock_app, service_uuid)
 

--- a/services/director/tests/test_producer.py
+++ b/services/director/tests/test_producer.py
@@ -96,7 +96,9 @@ async def run_services(
     # teardown stop the services
     for service in started_services:
         service_uuid = service["service_uuid"]
-        await producer.stop_service(aiohttp_mock_app, service_uuid, save_state=False)
+        # NOTE: All fake services have no save-state entrypoint, but since save_state=True
+        #       the legacy rule will apply and save will be skipped.
+        await producer.stop_service(aiohttp_mock_app, service_uuid, save_state=True)
         with pytest.raises(exceptions.ServiceUUIDNotFoundError):
             await producer.get_service_details(aiohttp_mock_app, service_uuid)
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

This fix follows up from #2803 

After observing master, we noticed that the GC was failing to stop old services because they would not save their state. It happens that *some* old services do not add that functionality and threfore the new rule introduced in #2803 needs to introduce some exceptions to support this legacy.


NOTE1: that all this functionality will be taken over by the new side-car. 
NOTE2 (⚠️ devops):  #2803 must not be released alone but together with this PR. Otherwise, the GC will fail to close old services (mostly used in the e2e) and will collapse resources in the cluster (as observed in master)


## Related issue/s

#2803

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

- [x] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)

