### PR TITLE
✨Adds timestamps to sidecars (dynamic and computational)

### DIFF
--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
@@ -61,6 +61,10 @@ async def _wait_till_rabbit_responsive(url: str) -> None:
             await connection.close()
 
 
+def _get_utc_now() -> datetime.date:
+    return datetime.datetime.utcnow()
+
+
 class RabbitMQ:  # pylint: disable = too-many-instance-attributes
     CHANNEL_LOG = "logger"
 
@@ -170,7 +174,7 @@ class RabbitMQ:  # pylint: disable = too-many-instance-attributes
         if isinstance(log_msg, str):
             log_msg = [log_msg]
 
-        time_string = datetime.datetime.utcnow().strftime(LOG_DATETIME_FORMAT)
+        time_string = _get_utc_now().strftime(LOG_DATETIME_FORMAT)
         for message in log_msg:
             with_timestamp = f"{time_string} {message}"
             await self._channel_queues[self.CHANNEL_LOG].put(with_timestamp)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

To allow users to more easily figure out what is happening with the services, timestamps were added to the logs coming from sidecars.


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->

- closes https://github.com/ITISFoundation/osparc-issues/issues/591#issuecomment-1034693762

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
