### PR TITLE
Enable/disable Export and Duplicate

### DIFF
--- a/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -435,7 +435,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       const renameStudyButton = this.__getRenameStudyMenuButton(studyData);
       menu.add(renameStudyButton);
 
-      const duplicateStudyButton = this.__getDuplicateStudyMenuButton(studyData);
+      const duplicateStudyButton = this.__getDuplicateMenuButton(studyData);
       menu.add(duplicateStudyButton);
 
       const exportButton = this.__getExportMenuButton(studyData);
@@ -497,17 +497,26 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         });
     },
 
-    __getDuplicateStudyMenuButton: function(studyData) {
-      const duplicateStudyButton = new qx.ui.menu.Button(this.tr("Duplicate"));
-      osparc.utils.Utils.setIdToWidget(duplicateStudyButton, "duplicateStudy");
-      duplicateStudyButton.addListener("execute", () => {
+    __getDuplicateMenuButton: function(studyData) {
+      const duplicateButton = new qx.ui.menu.Button(this.tr("Duplicate"));
+      duplicateButton.exclude();
+      osparc.utils.DisabledPlugins.isDuplicateDisabled()
+        .then(isDisabled => {
+          duplicateButton.setVisibility(isDisabled ? "excluded" : "visible");
+        });
+      duplicateButton.addListener("execute", () => {
         this.__duplicateStudy(studyData);
       }, this);
-      return duplicateStudyButton;
+      return duplicateButton;
     },
 
     __getExportMenuButton: function(studyData) {
       const exportButton = new qx.ui.menu.Button(this.tr("Export"));
+      exportButton.exclude();
+      osparc.utils.DisabledPlugins.isExportDisabled()
+        .then(isDisabled => {
+          exportButton.setVisibility(isDisabled ? "excluded" : "visible");
+        });
       exportButton.addListener("execute", () => {
         this.__exportStudy(studyData);
       }, this);

--- a/services/web/client/source/class/osparc/utils/DisabledPlugins.js
+++ b/services/web/client/source/class/osparc/utils/DisabledPlugins.js
@@ -1,0 +1,55 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2022 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+/**
+ * Collection of methods for studies
+ */
+
+qx.Class.define("osparc.utils.DisabledPlugins", {
+  type: "static",
+
+  statics: {
+    EXPORT: "WEBSERVER_EXPORTER",
+    DUPLICATE: "WEBSERVER_EXPORTER",
+    SCICRUNCH: "WEBSERVER_SCICRUNCH",
+
+    isExportDisabled: function() {
+      return this.self().isPluginDisabled(this.self().EXPORT);
+    },
+
+    isDuplicateDisabled: function() {
+      return this.self().isPluginDisabled(this.self().EXPORT);
+    },
+
+    isScicrunchDisabled: function() {
+      return this.self().isPluginDisabled(this.self().SCICRUNCH);
+    },
+
+    isPluginDisabled: function(key) {
+      return new Promise((resolve, reject) => {
+        osparc.data.Resources.get("statics")
+          .then(statics => {
+            if ("pluginsDisabled" in statics) {
+              resolve(statics["pluginsDisabled"].includes(key));
+            }
+            resolve(false);
+          })
+          .catch(err => reject(err));
+      });
+    }
+  }
+});


### PR DESCRIPTION
## What do these changes do?
Following https://github.com/ITISFoundation/osparc-simcore/pull/2814

Check statics from webserver to enable/disable Export and Duplicate.

The animation was paused in order to add the ```WEBSERVER_EXPORT``` variable and restart the webserver:
![ExportDisabled](https://user-images.githubusercontent.com/33152403/153557503-9f8955d9-78ca-48a5-a761-cf0a033b2c3d.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
