### PR TITLE
✨ Enable/disable plugins marked as "under development" via env vars

### DIFF
--- a/services/web/server/src/simcore_service_webserver/application.py
+++ b/services/web/server/src/simcore_service_webserver/application.py
@@ -8,10 +8,9 @@ from typing import Any, Dict
 from aiohttp import web
 from servicelib.aiohttp.application import create_safe_application
 
-from ._constants import APP_SETTINGS_KEY
 from ._meta import WELCOME_MSG
 from .activity.module_setup import setup_activity
-from .application_settings import ApplicationSettings, setup_settings
+from .application_settings import setup_settings
 from .catalog import setup_catalog
 from .clusters.module_setup import setup_clusters
 from .computation import setup_computation
@@ -57,7 +56,6 @@ def create_application(config: Dict[str, Any]) -> web.Application:
     app = create_safe_application(config)
 
     setup_settings(app)
-    settings: ApplicationSettings = app[APP_SETTINGS_KEY]
 
     # WARNING: setup order matters
     # TODO: create dependency mechanism

--- a/services/web/server/src/simcore_service_webserver/application.py
+++ b/services/web/server/src/simcore_service_webserver/application.py
@@ -88,11 +88,8 @@ def create_application(config: Dict[str, Any]) -> web.Application:
     # projects
     setup_projects(app)
     # project add-ons
-    if settings.WEBSERVER_DEV_FEATURES_ENABLED:
-        setup_version_control(app)
-        setup_meta_modeling(app)
-    else:
-        log.info("Skipping add-ons under development: version-control and meta")
+    setup_version_control(app)
+    setup_meta_modeling(app)
 
     # TODO: classify
     setup_activity(app)

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -12,7 +12,6 @@ from models_library.basic_types import (
 )
 from pydantic import validator
 from pydantic.fields import Field
-from pydantic.types import SecretStr
 from settings_library.base import BaseCustomSettings
 from settings_library.email import SMTPSettings
 from settings_library.postgres import PostgresSettings
@@ -88,7 +87,8 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
     # PLUGINS ----------------
 
     WEBSERVER_ACTIVITY: Optional[PrometheusSettings] = Field(
-        auto_default_from_env=True, description="activity plugin"
+        auto_default_from_env=True,
+        description="activity plugin",
     )
     WEBSERVER_CATALOG: Optional[CatalogSettings] = Field(
         auto_default_from_env=True, description="catalog service client's plugin"
@@ -141,7 +141,7 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
         auto_default_from_env=True, description="tracing plugin"
     )
 
-    # enabled-like settings
+    # These plugins only require (for the moment) an entry to toggle between enabled/disabled
     WEBSERVER_CLUSTERS: bool = True
     WEBSERVER_GROUPS: bool = True
     WEBSERVER_META_MODELING: bool = True
@@ -185,7 +185,7 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
 
     def is_plugin(self, field_name: str) -> bool:
         if field := self.__fields__.get(field_name):
-            # TODO: more reliable definition of a "plugin" (extra var?)
+            # TODO: more reliable definition of a "plugin" (extra var? e.g. Field( ... , x_advertise_plugin=True))
             if (
                 "auto_default_from_env" in field.field_info.extra and field.allow_none
             ) or field.type_ == bool:
@@ -196,12 +196,12 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
         plugins_disabled = []
         # NOTE: this list is limited for security reasons. An unbounded list
         # might reveal critical info on the settings of a deploy to the client.
-        PUBLIC_PLUGIN_CANDIDATES = [
+        PUBLIC_PLUGIN_CANDIDATES = {
             "WEBSERVER_EXPORTER",
             "WEBSERVER_META_MODELING",
             "WEBSERVER_SCICRUNCH",
             "WEBSERVER_VERSION_CONTROL",
-        ]
+        }
         for field_name in PUBLIC_PLUGIN_CANDIDATES:
             if not self.is_enabled(field_name):
                 plugins_disabled.append(field_name)
@@ -248,267 +248,3 @@ def setup_settings(app: web.Application) -> ApplicationSettings:
 
 def get_settings(app: web.Application) -> ApplicationSettings:
     return app[APP_SETTINGS_KEY]
-
-
-def convert_to_app_config(app_settings: ApplicationSettings) -> Dict[str, Any]:
-    """Maps current ApplicationSettings object into former trafaret-based config"""
-
-    cfg = {
-        "version": "1.0",
-        "main": {
-            "host": "0.0.0.0",
-            "port": app_settings.WEBSERVER_PORT,
-            "log_level": f"{app_settings.WEBSERVER_LOG_LEVEL}",
-            "testing": False,  # TODO: deprecate!
-            "studies_access_enabled": 1
-            if app_settings.WEBSERVER_STUDIES_ACCESS_ENABLED
-            else 0,
-        },
-        "tracing": {
-            "enabled": 1 if app_settings.WEBSERVER_TRACING is not None else 0,
-            "zipkin_endpoint": f"{getattr(app_settings.WEBSERVER_TRACING, 'TRACING_ZIPKIN_ENDPOINT', None)}",
-        },
-        "socketio": {"enabled": app_settings.WEBSERVER_SOCKETIO},
-        "director": {
-            "enabled": app_settings.WEBSERVER_DIRECTOR is not None,
-            "host": getattr(app_settings.WEBSERVER_DIRECTOR, "DIRECTOR_HOST", None),
-            "port": getattr(app_settings.WEBSERVER_DIRECTOR, "DIRECTOR_PORT", None),
-            "version": getattr(app_settings.WEBSERVER_DIRECTOR, "DIRECTOR_VTAG", None),
-        },
-        "db": {
-            "postgres": {
-                "database": getattr(app_settings.WEBSERVER_DB, "POSTGRES_DB", None),
-                "endpoint": f"{getattr(app_settings.WEBSERVER_DB, 'POSTGRES_HOST', None)}:{getattr(app_settings.WEBSERVER_DB, 'POSTGRES_PORT', None)}",
-                "host": getattr(app_settings.WEBSERVER_DB, "POSTGRES_HOST", None),
-                "maxsize": getattr(app_settings.WEBSERVER_DB, "POSTGRES_MAXSIZE", None),
-                "minsize": getattr(app_settings.WEBSERVER_DB, "POSTGRES_MINSIZE", None),
-                "password": getattr(
-                    app_settings.WEBSERVER_DB, "POSTGRES_PASSWORD", SecretStr("")
-                ).get_secret_value(),
-                "port": getattr(app_settings.WEBSERVER_DB, "POSTGRES_PORT", None),
-                "user": getattr(app_settings.WEBSERVER_DB, "POSTGRES_USER", None),
-            },
-            "enabled": app_settings.WEBSERVER_DB is not None,
-        },
-        "resource_manager": {
-            "enabled": (
-                app_settings.WEBSERVER_REDIS is not None
-                and app_settings.WEBSERVER_RESOURCE_MANAGER is not None
-            ),
-            "resource_deletion_timeout_seconds": getattr(
-                app_settings.WEBSERVER_RESOURCE_MANAGER,
-                "RESOURCE_MANAGER_RESOURCE_TTL_S",
-                None,
-            ),
-            "garbage_collection_interval_seconds": getattr(
-                app_settings.WEBSERVER_RESOURCE_MANAGER,
-                "RESOURCE_MANAGER_GARBAGE_COLLECTION_INTERVAL_S",
-                None,
-            ),
-            "redis": {
-                "enabled": app_settings.WEBSERVER_REDIS is not None,
-                "host": getattr(app_settings.WEBSERVER_REDIS, "REDIS_HOST", None),
-                "port": getattr(app_settings.WEBSERVER_REDIS, "REDIS_PORT", None),
-            },
-        },
-        "login": {
-            "enabled": app_settings.WEBSERVER_LOGIN is not None,
-            "registration_invitation_required": 1
-            if getattr(
-                app_settings.WEBSERVER_LOGIN,
-                "LOGIN_REGISTRATION_INVITATION_REQUIRED",
-                None,
-            )
-            else 0,
-            "registration_confirmation_required": 1
-            if getattr(
-                app_settings.WEBSERVER_LOGIN,
-                "LOGIN_REGISTRATION_CONFIRMATION_REQUIRED",
-                None,
-            )
-            else 0,
-        },
-        "smtp": {
-            "sender": getattr(app_settings.WEBSERVER_EMAIL, "SMTP_SENDER", None),
-            "host": getattr(app_settings.WEBSERVER_EMAIL, "SMTP_HOST", None),
-            "port": getattr(app_settings.WEBSERVER_EMAIL, "SMTP_PORT", None),
-            "tls": int(getattr(app_settings.WEBSERVER_EMAIL, "SMTP_TLS_ENABLED", 0)),
-            "username": str(
-                getattr(app_settings.WEBSERVER_EMAIL, "SMTP_USERNAME", None)
-            ),
-            "password": str(
-                getattr(app_settings.WEBSERVER_EMAIL, "SMTP_PASSWORD", None)
-                and getattr(
-                    app_settings.WEBSERVER_EMAIL, "SMTP_PASSWORD", SecretStr("")
-                ).get_secret_value()
-            ),
-        },
-        "storage": {
-            "enabled": app_settings.WEBSERVER_STORAGE is not None,
-            "host": getattr(app_settings.WEBSERVER_STORAGE, "STORAGE_HOST", None),
-            "port": getattr(app_settings.WEBSERVER_STORAGE, "STORAGE_PORT", None),
-            "version": getattr(app_settings.WEBSERVER_STORAGE, "STORAGE_VTAG", None),
-        },
-        "catalog": {
-            "enabled": app_settings.WEBSERVER_CATALOG is not None,
-            "host": getattr(app_settings.WEBSERVER_CATALOG, "CATALOG_HOST", None),
-            "port": getattr(app_settings.WEBSERVER_CATALOG, "CATALOG_PORT", None),
-            "version": getattr(app_settings.WEBSERVER_CATALOG, "CATALOG_VTAG", None),
-        },
-        "rest": {
-            "version": app_settings.API_VTAG,
-            "enabled": app_settings.WEBSERVER_REST,
-        },
-        "projects": {"enabled": app_settings.WEBSERVER_PROJECTS},
-        "session": {
-            "secret_key": app_settings.WEBSERVER_SESSION.SESSION_SECRET_KEY.get_secret_value()
-        },
-        "activity": {
-            "enabled": app_settings.WEBSERVER_ACTIVITY is not None,
-            "prometheus_host": getattr(app_settings.WEBSERVER_ACTIVITY, "origin", None),
-            "prometheus_port": getattr(
-                app_settings.WEBSERVER_ACTIVITY, "PROMETHEUS_PORT", None
-            ),
-            "prometheus_api_version": getattr(
-                app_settings.WEBSERVER_ACTIVITY, "PROMETHEUS_VTAG", None
-            ),
-        },
-        "clusters": {"enabled": app_settings.WEBSERVER_CLUSTERS},
-        "computation": {"enabled": app_settings.is_enabled("WEBSERVER_COMPUTATION")},
-        "diagnostics": {"enabled": app_settings.is_enabled("WEBSERVER_DIAGNOSTICS")},
-        "director-v2": {"enabled": app_settings.is_enabled("WEBSERVER_DIRECTOR_V2")},
-        "exporter": {"enabled": app_settings.WEBSERVER_EXPORTER is not None},
-        "groups": {"enabled": app_settings.WEBSERVER_GROUPS},
-        "meta_modeling": {"enabled": app_settings.WEBSERVER_META_MODELING},
-        "products": {"enabled": app_settings.WEBSERVER_PRODUCTS},
-        "publications": {"enabled": app_settings.WEBSERVER_PUBLICATIONS},
-        "remote_debug": {"enabled": app_settings.WEBSERVER_REMOTE_DEBUG},
-        "security": {"enabled": True},
-        "statics": {
-            "enabled": app_settings.WEBSERVER_FRONTEND is not None
-            and app_settings.WEBSERVER_STATICWEB is not None
-        },
-        # NOTE:  app_settings.WEBSERVER_STUDIES_ACCESS_ENABLED did not apply
-        "studies_access": {"enabled": app_settings.WEBSERVER_STUDIES_ACCESS},
-        # NOTE  app_settings.WEBSERVER_STUDIES_ACCESS_ENABLED did not apply
-        "studies_dispatcher": {"enabled": app_settings.WEBSERVER_STUDIES_DISPATCHER},
-        "tags": {"enabled": app_settings.WEBSERVER_TAGS},
-        "users": {"enabled": app_settings.WEBSERVER_USERS},
-        "version_control": {"enabled": app_settings.WEBSERVER_VERSION_CONTROL},
-    }
-
-    return cfg
-
-
-def convert_to_environ_vars(cfg: Dict[str, Any]) -> Dict[str, Any]:
-    # NOTE: maily used for testing traferet vs settings_library
-    # pylint:disable=too-many-branches
-    # pylint:disable=too-many-statements
-    envs = {}
-
-    def _set_enable(section_name, section):
-        if not section.get("enabled"):
-            envs[section_name] = "null"
-
-    if main := cfg.get("main"):
-        envs["WEBSERVER_PORT"] = main.get("port")
-        envs["WEBSERVER_LOG_LEVEL"] = main.get("log_level")
-        envs["WEBSERVER_STUDIES_ACCESS_ENABLED"] = main.get("studies_access_enabled")
-
-    if section := cfg.get("tracing"):
-        _set_enable("WEBSERVER_TRACING", section)
-        envs["TRACING_ZIPKIN_ENDPOINT"] = section.get("zipkin_endpoint")
-
-    if section := cfg.get("director"):
-        _set_enable("WEBSERVER_DIRECTOR", section)
-        envs["DIRECTOR_HOST"] = section.get("host")
-        envs["DIRECTOR_PORT"] = section.get("port")
-        envs["DIRECTOR_VTAG"] = section.get("version")
-
-    if db := cfg.get("db"):
-        if section := db.get("postgres"):
-
-            envs["POSTGRES_DB"] = section.get("database")
-            envs["POSTGRES_HOST"] = section.get("host")
-            envs["POSTGRES_MAXSIZE"] = section.get("maxsize")
-            envs["POSTGRES_MINSIZE"] = section.get("minsize")
-            envs["POSTGRES_PASSWORD"] = section.get("password")
-            envs["POSTGRES_PORT"] = section.get("port")
-            envs["POSTGRES_USER"] = section.get("user")
-
-        _set_enable("WEBSERVER_DB", db)
-
-    if section := cfg.get("resource_manager"):
-        _set_enable("WEBSERVER_RESOURCE_MANAGER", section)
-
-        envs["WEBSERVER_RESOURCES_DELETION_TIMEOUT_SECONDS"] = section.get(
-            "resource_deletion_timeout_seconds"
-        )
-        envs["WEBSERVER_GARBAGE_COLLECTION_INTERVAL_SECONDS"] = section.get(
-            "garbage_collection_interval_seconds"
-        )
-
-        if section2 := section.get("redis"):
-            _set_enable("WEBSERVER_REDIS", section2)
-            envs["REDIS_HOST"] = section2.get("host")
-            envs["REDIS_PORT"] = section2.get("port")
-
-    if section := cfg.get("login"):
-        _set_enable("WEBSERVER_LOGIN", section)
-
-        envs["LOGIN_REGISTRATION_INVITATION_REQUIRED"] = section.get(
-            "registration_invitation_required"
-        )
-        envs["LOGIN_REGISTRATION_CONFIRMATION_REQUIRED"] = section.get(
-            "registration_confirmation_required"
-        )
-
-    if section := cfg.get("smtp"):
-        envs["SMTP_SENDER"] = section.get("sender")
-        envs["SMTP_HOST"] = section.get("host")
-        envs["SMTP_PORT"] = section.get("port")
-        envs["SMTP_TLS_ENABLED"] = section.get("tls")
-
-        envs["SMTP_USERNAME"] = section.get("username")
-        envs["SMTP_PASSWORD"] = section.get("password")
-
-    if section := cfg.get("storage"):
-        _set_enable("WEBSERVER_STORAGE", section)
-
-        envs["STORAGE_HOST"] = section.get("host")
-        envs["STORAGE_PORT"] = section.get("port")
-        envs["STORAGE_VTAG"] = section.get("version")
-
-    if section := cfg.get("catalog"):
-        _set_enable("WEBSERVER_CATALOG", section)
-
-        envs["CATALOG_HOST"] = section.get("host")
-        envs["CATALOG_PORT"] = section.get("port")
-        envs["CATALOG_VTAG"] = section.get("version")
-
-    if section := cfg.get("session"):
-        envs["SESSION_SECRET_KEY"] = section.get("secret_key")
-
-    if section := cfg.get("activity"):
-        _set_enable("WEBSERVER_ACTIVITY", section)
-
-        envs["PROMETHEUS_PORT"] = section.get("prometheus_port")
-        envs["PROMETHEUS_VTAG"] = section.get("prometheus_api_version")
-
-    if section := cfg.get("computation"):
-        _set_enable("COMPUTATION", section)
-
-    if section := cfg.get("diagnostics"):
-        _set_enable("DIAGNOSTICS", section)
-
-    if section := cfg.get("director-v2"):
-        _set_enable("DIRECTOR_V2", section)
-
-    if section := cfg.get("exporter"):
-        _set_enable("WEBSERVER_EXPORTER", section)
-
-    if section := cfg.get("statics"):
-        _set_enable("WEBSERVER_FRONTEND", section)
-        _set_enable("WEBSERVER_STATICWEB", section)
-
-    return {k: v for k, v in envs.items() if v is not None}

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -158,6 +158,9 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
     WEBSERVER_VERSION_CONTROL: bool = True
 
     @validator(
+        # List of plugins under-development (keep up-to-date)
+        # TODO: consider mark as dev-feature in field extras of Config attr.
+        # Then they can be automtically advertised
         "WEBSERVER_META_MODELING",
         "WEBSERVER_VERSION_CONTROL",
         "WEBSERVER_CLUSTERS",
@@ -166,8 +169,7 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
     )
     @classmethod
     def enable_only_if_dev_features_allowed(cls, v, values):
-        """Ensures that plugins under development get programatically disabled if WEBSERVER_DEV_FEATURES_ENABLED=False"""
-        # NOTE: keep the list of plugins under-develpment up-to-date
+        """Ensures that plugins 'under development' get programatically disabled if WEBSERVER_DEV_FEATURES_ENABLED=False"""
         if values["WEBSERVER_DEV_FEATURES_ENABLED"]:
             return v
         return False if isinstance(v, bool) else None

--- a/services/web/server/src/simcore_service_webserver/application_settings_utils.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings_utils.py
@@ -1,0 +1,272 @@
+import logging
+from typing import Any, Dict
+
+from pydantic.types import SecretStr
+
+from .application_settings import ApplicationSettings
+
+log = logging.getLogger(__name__)
+
+
+def convert_to_app_config(app_settings: ApplicationSettings) -> Dict[str, Any]:
+    """Maps current ApplicationSettings object into former trafaret-based config"""
+
+    cfg = {
+        "version": "1.0",
+        "main": {
+            "host": "0.0.0.0",
+            "port": app_settings.WEBSERVER_PORT,
+            "log_level": f"{app_settings.WEBSERVER_LOG_LEVEL}",
+            "testing": False,  # TODO: deprecate!
+            "studies_access_enabled": 1
+            if app_settings.WEBSERVER_STUDIES_ACCESS_ENABLED
+            else 0,
+        },
+        "tracing": {
+            "enabled": 1 if app_settings.WEBSERVER_TRACING is not None else 0,
+            "zipkin_endpoint": f"{getattr(app_settings.WEBSERVER_TRACING, 'TRACING_ZIPKIN_ENDPOINT', None)}",
+        },
+        "socketio": {"enabled": app_settings.WEBSERVER_SOCKETIO},
+        "director": {
+            "enabled": app_settings.WEBSERVER_DIRECTOR is not None,
+            "host": getattr(app_settings.WEBSERVER_DIRECTOR, "DIRECTOR_HOST", None),
+            "port": getattr(app_settings.WEBSERVER_DIRECTOR, "DIRECTOR_PORT", None),
+            "version": getattr(app_settings.WEBSERVER_DIRECTOR, "DIRECTOR_VTAG", None),
+        },
+        "db": {
+            "postgres": {
+                "database": getattr(app_settings.WEBSERVER_DB, "POSTGRES_DB", None),
+                "endpoint": f"{getattr(app_settings.WEBSERVER_DB, 'POSTGRES_HOST', None)}:{getattr(app_settings.WEBSERVER_DB, 'POSTGRES_PORT', None)}",
+                "host": getattr(app_settings.WEBSERVER_DB, "POSTGRES_HOST", None),
+                "maxsize": getattr(app_settings.WEBSERVER_DB, "POSTGRES_MAXSIZE", None),
+                "minsize": getattr(app_settings.WEBSERVER_DB, "POSTGRES_MINSIZE", None),
+                "password": getattr(
+                    app_settings.WEBSERVER_DB, "POSTGRES_PASSWORD", SecretStr("")
+                ).get_secret_value(),
+                "port": getattr(app_settings.WEBSERVER_DB, "POSTGRES_PORT", None),
+                "user": getattr(app_settings.WEBSERVER_DB, "POSTGRES_USER", None),
+            },
+            "enabled": app_settings.WEBSERVER_DB is not None,
+        },
+        "resource_manager": {
+            "enabled": (
+                app_settings.WEBSERVER_REDIS is not None
+                and app_settings.WEBSERVER_RESOURCE_MANAGER is not None
+            ),
+            "resource_deletion_timeout_seconds": getattr(
+                app_settings.WEBSERVER_RESOURCE_MANAGER,
+                "RESOURCE_MANAGER_RESOURCE_TTL_S",
+                None,
+            ),
+            "garbage_collection_interval_seconds": getattr(
+                app_settings.WEBSERVER_RESOURCE_MANAGER,
+                "RESOURCE_MANAGER_GARBAGE_COLLECTION_INTERVAL_S",
+                None,
+            ),
+            "redis": {
+                "enabled": app_settings.WEBSERVER_REDIS is not None,
+                "host": getattr(app_settings.WEBSERVER_REDIS, "REDIS_HOST", None),
+                "port": getattr(app_settings.WEBSERVER_REDIS, "REDIS_PORT", None),
+            },
+        },
+        "login": {
+            "enabled": app_settings.WEBSERVER_LOGIN is not None,
+            "registration_invitation_required": 1
+            if getattr(
+                app_settings.WEBSERVER_LOGIN,
+                "LOGIN_REGISTRATION_INVITATION_REQUIRED",
+                None,
+            )
+            else 0,
+            "registration_confirmation_required": 1
+            if getattr(
+                app_settings.WEBSERVER_LOGIN,
+                "LOGIN_REGISTRATION_CONFIRMATION_REQUIRED",
+                None,
+            )
+            else 0,
+        },
+        "smtp": {
+            "sender": getattr(app_settings.WEBSERVER_EMAIL, "SMTP_SENDER", None),
+            "host": getattr(app_settings.WEBSERVER_EMAIL, "SMTP_HOST", None),
+            "port": getattr(app_settings.WEBSERVER_EMAIL, "SMTP_PORT", None),
+            "tls": int(getattr(app_settings.WEBSERVER_EMAIL, "SMTP_TLS_ENABLED", 0)),
+            "username": str(
+                getattr(app_settings.WEBSERVER_EMAIL, "SMTP_USERNAME", None)
+            ),
+            "password": str(
+                getattr(app_settings.WEBSERVER_EMAIL, "SMTP_PASSWORD", None)
+                and getattr(
+                    app_settings.WEBSERVER_EMAIL, "SMTP_PASSWORD", SecretStr("")
+                ).get_secret_value()
+            ),
+        },
+        "storage": {
+            "enabled": app_settings.WEBSERVER_STORAGE is not None,
+            "host": getattr(app_settings.WEBSERVER_STORAGE, "STORAGE_HOST", None),
+            "port": getattr(app_settings.WEBSERVER_STORAGE, "STORAGE_PORT", None),
+            "version": getattr(app_settings.WEBSERVER_STORAGE, "STORAGE_VTAG", None),
+        },
+        "catalog": {
+            "enabled": app_settings.WEBSERVER_CATALOG is not None,
+            "host": getattr(app_settings.WEBSERVER_CATALOG, "CATALOG_HOST", None),
+            "port": getattr(app_settings.WEBSERVER_CATALOG, "CATALOG_PORT", None),
+            "version": getattr(app_settings.WEBSERVER_CATALOG, "CATALOG_VTAG", None),
+        },
+        "rest": {
+            "version": app_settings.API_VTAG,
+            "enabled": app_settings.WEBSERVER_REST,
+        },
+        "projects": {"enabled": app_settings.WEBSERVER_PROJECTS},
+        "session": {
+            "secret_key": app_settings.WEBSERVER_SESSION.SESSION_SECRET_KEY.get_secret_value()
+        },
+        "activity": {
+            "enabled": app_settings.WEBSERVER_ACTIVITY is not None,
+            "prometheus_host": getattr(app_settings.WEBSERVER_ACTIVITY, "origin", None),
+            "prometheus_port": getattr(
+                app_settings.WEBSERVER_ACTIVITY, "PROMETHEUS_PORT", None
+            ),
+            "prometheus_api_version": getattr(
+                app_settings.WEBSERVER_ACTIVITY, "PROMETHEUS_VTAG", None
+            ),
+        },
+        "clusters": {"enabled": app_settings.WEBSERVER_CLUSTERS},
+        "computation": {"enabled": app_settings.is_enabled("WEBSERVER_COMPUTATION")},
+        "diagnostics": {"enabled": app_settings.is_enabled("WEBSERVER_DIAGNOSTICS")},
+        "director-v2": {"enabled": app_settings.is_enabled("WEBSERVER_DIRECTOR_V2")},
+        "exporter": {"enabled": app_settings.WEBSERVER_EXPORTER is not None},
+        "groups": {"enabled": app_settings.WEBSERVER_GROUPS},
+        "meta_modeling": {"enabled": app_settings.WEBSERVER_META_MODELING},
+        "products": {"enabled": app_settings.WEBSERVER_PRODUCTS},
+        "publications": {"enabled": app_settings.WEBSERVER_PUBLICATIONS},
+        "remote_debug": {"enabled": app_settings.WEBSERVER_REMOTE_DEBUG},
+        "security": {"enabled": True},
+        "statics": {
+            "enabled": app_settings.WEBSERVER_FRONTEND is not None
+            and app_settings.WEBSERVER_STATICWEB is not None
+        },
+        # NOTE:  app_settings.WEBSERVER_STUDIES_ACCESS_ENABLED did not apply
+        "studies_access": {"enabled": app_settings.WEBSERVER_STUDIES_ACCESS},
+        # NOTE  app_settings.WEBSERVER_STUDIES_ACCESS_ENABLED did not apply
+        "studies_dispatcher": {"enabled": app_settings.WEBSERVER_STUDIES_DISPATCHER},
+        "tags": {"enabled": app_settings.WEBSERVER_TAGS},
+        "users": {"enabled": app_settings.WEBSERVER_USERS},
+        "version_control": {"enabled": app_settings.WEBSERVER_VERSION_CONTROL},
+    }
+
+    return cfg
+
+
+def convert_to_environ_vars(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    # NOTE: maily used for testing traferet vs settings_library
+    # pylint:disable=too-many-branches
+    # pylint:disable=too-many-statements
+    envs = {}
+
+    def _set_enable(section_name, section):
+        if not section.get("enabled"):
+            envs[section_name] = "null"
+
+    if main := cfg.get("main"):
+        envs["WEBSERVER_PORT"] = main.get("port")
+        envs["WEBSERVER_LOG_LEVEL"] = main.get("log_level")
+        envs["WEBSERVER_STUDIES_ACCESS_ENABLED"] = main.get("studies_access_enabled")
+
+    if section := cfg.get("tracing"):
+        _set_enable("WEBSERVER_TRACING", section)
+        envs["TRACING_ZIPKIN_ENDPOINT"] = section.get("zipkin_endpoint")
+
+    if section := cfg.get("director"):
+        _set_enable("WEBSERVER_DIRECTOR", section)
+        envs["DIRECTOR_HOST"] = section.get("host")
+        envs["DIRECTOR_PORT"] = section.get("port")
+        envs["DIRECTOR_VTAG"] = section.get("version")
+
+    if db := cfg.get("db"):
+        if section := db.get("postgres"):
+
+            envs["POSTGRES_DB"] = section.get("database")
+            envs["POSTGRES_HOST"] = section.get("host")
+            envs["POSTGRES_MAXSIZE"] = section.get("maxsize")
+            envs["POSTGRES_MINSIZE"] = section.get("minsize")
+            envs["POSTGRES_PASSWORD"] = section.get("password")
+            envs["POSTGRES_PORT"] = section.get("port")
+            envs["POSTGRES_USER"] = section.get("user")
+
+        _set_enable("WEBSERVER_DB", db)
+
+    if section := cfg.get("resource_manager"):
+        _set_enable("WEBSERVER_RESOURCE_MANAGER", section)
+
+        envs["WEBSERVER_RESOURCES_DELETION_TIMEOUT_SECONDS"] = section.get(
+            "resource_deletion_timeout_seconds"
+        )
+        envs["WEBSERVER_GARBAGE_COLLECTION_INTERVAL_SECONDS"] = section.get(
+            "garbage_collection_interval_seconds"
+        )
+
+        if section2 := section.get("redis"):
+            _set_enable("WEBSERVER_REDIS", section2)
+            envs["REDIS_HOST"] = section2.get("host")
+            envs["REDIS_PORT"] = section2.get("port")
+
+    if section := cfg.get("login"):
+        _set_enable("WEBSERVER_LOGIN", section)
+
+        envs["LOGIN_REGISTRATION_INVITATION_REQUIRED"] = section.get(
+            "registration_invitation_required"
+        )
+        envs["LOGIN_REGISTRATION_CONFIRMATION_REQUIRED"] = section.get(
+            "registration_confirmation_required"
+        )
+
+    if section := cfg.get("smtp"):
+        envs["SMTP_SENDER"] = section.get("sender")
+        envs["SMTP_HOST"] = section.get("host")
+        envs["SMTP_PORT"] = section.get("port")
+        envs["SMTP_TLS_ENABLED"] = section.get("tls")
+
+        envs["SMTP_USERNAME"] = section.get("username")
+        envs["SMTP_PASSWORD"] = section.get("password")
+
+    if section := cfg.get("storage"):
+        _set_enable("WEBSERVER_STORAGE", section)
+
+        envs["STORAGE_HOST"] = section.get("host")
+        envs["STORAGE_PORT"] = section.get("port")
+        envs["STORAGE_VTAG"] = section.get("version")
+
+    if section := cfg.get("catalog"):
+        _set_enable("WEBSERVER_CATALOG", section)
+
+        envs["CATALOG_HOST"] = section.get("host")
+        envs["CATALOG_PORT"] = section.get("port")
+        envs["CATALOG_VTAG"] = section.get("version")
+
+    if section := cfg.get("session"):
+        envs["SESSION_SECRET_KEY"] = section.get("secret_key")
+
+    if section := cfg.get("activity"):
+        _set_enable("WEBSERVER_ACTIVITY", section)
+
+        envs["PROMETHEUS_PORT"] = section.get("prometheus_port")
+        envs["PROMETHEUS_VTAG"] = section.get("prometheus_api_version")
+
+    if section := cfg.get("computation"):
+        _set_enable("COMPUTATION", section)
+
+    if section := cfg.get("diagnostics"):
+        _set_enable("DIAGNOSTICS", section)
+
+    if section := cfg.get("director-v2"):
+        _set_enable("DIRECTOR_V2", section)
+
+    if section := cfg.get("exporter"):
+        _set_enable("WEBSERVER_EXPORTER", section)
+
+    if section := cfg.get("statics"):
+        _set_enable("WEBSERVER_FRONTEND", section)
+        _set_enable("WEBSERVER_STATICWEB", section)
+
+    return {k: v for k, v in envs.items() if v is not None}

--- a/services/web/server/src/simcore_service_webserver/clusters/module_setup.py
+++ b/services/web/server/src/simcore_service_webserver/clusters/module_setup.py
@@ -16,7 +16,6 @@ from servicelib.aiohttp.application_setup import (
 )
 
 from .._constants import APP_SETTINGS_KEY
-from ..application_settings import ApplicationSettings
 from . import handlers
 
 log = logging.getLogger(__file__)
@@ -29,9 +28,10 @@ log = logging.getLogger(__file__)
     logger=log,
 )
 def setup_clusters(app: web.Application):
-    settings: ApplicationSettings = app[APP_SETTINGS_KEY]
-    if not settings.WEBSERVER_DEV_FEATURES_ENABLED:
-        raise SkipModuleSetup(reason="Development feature")
+    if not app[APP_SETTINGS_KEY].WEBSERVER_CLUSTERS:
+        raise SkipModuleSetup(
+            reason="{__name__} plugin was explictly disabled in the app settings"
+        )
 
     app.add_routes(handlers.routes)
 

--- a/services/web/server/src/simcore_service_webserver/meta_modeling.py
+++ b/services/web/server/src/simcore_service_webserver/meta_modeling.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
     ModuleCategory.ADDON,
     depends=[
         "simcore_service_webserver.projects",
-        "simcore_service_webserver.version_control",
+        ## FIXME: tmp disabled so it can start "simcore_service_webserver.version_control",
     ],
     logger=log,
 )

--- a/services/web/server/src/simcore_service_webserver/meta_modeling.py
+++ b/services/web/server/src/simcore_service_webserver/meta_modeling.py
@@ -6,9 +6,14 @@
 import logging
 
 from aiohttp import web
-from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
+from servicelib.aiohttp.application_setup import (
+    ModuleCategory,
+    SkipModuleSetup,
+    app_module_setup,
+)
 
 from . import meta_modeling_handlers
+from ._constants import APP_SETTINGS_KEY
 from .director_v2_api import get_project_run_policy, set_project_run_policy
 from .meta_modeling_projects import meta_project_policy, projects_redirection_middleware
 
@@ -25,6 +30,12 @@ log = logging.getLogger(__name__)
     logger=log,
 )
 def setup_meta_modeling(app: web.Application):
+
+    if not app[APP_SETTINGS_KEY].WEBSERVER_META_MODELING:
+        raise SkipModuleSetup(
+            reason="{__name__} plugin was explictly disabled in the app settings"
+        )
+
     app.add_routes(meta_modeling_handlers.routes)
     app.middlewares.append(projects_redirection_middleware)
 

--- a/services/web/server/src/simcore_service_webserver/version_control.py
+++ b/services/web/server/src/simcore_service_webserver/version_control.py
@@ -6,9 +6,14 @@
 import logging
 
 from aiohttp import web
-from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
+from servicelib.aiohttp.application_setup import (
+    ModuleCategory,
+    SkipModuleSetup,
+    app_module_setup,
+)
 
 from . import version_control_handlers
+from ._constants import APP_SETTINGS_KEY
 
 log = logging.getLogger(__name__)
 
@@ -22,5 +27,10 @@ log = logging.getLogger(__name__)
     logger=log,
 )
 def setup_version_control(app: web.Application):
+
+    if not app[APP_SETTINGS_KEY].WEBSERVER_META_MODELING:
+        raise SkipModuleSetup(
+            reason="{__name__} plugin was explictly disabled in the app settings"
+        )
 
     app.add_routes(version_control_handlers.routes)

--- a/services/web/server/tests/conftest.py
+++ b/services/web/server/tests/conftest.py
@@ -12,7 +12,7 @@ import pytest
 import simcore_service_webserver
 from pytest_simcore.helpers.utils_login import AUserDict, LoggedUser
 from servicelib.json_serialization import json_dumps
-from simcore_service_webserver.application_settings import convert_to_environ_vars
+from simcore_service_webserver.application_settings_utils import convert_to_environ_vars
 from simcore_service_webserver.db_models import UserRole
 
 CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -22,6 +22,17 @@ from simcore_service_webserver.cli import parse, setup_parser
 
 
 @pytest.fixture
+def mock_env_devel_environment(
+    mock_env_devel_environment: Dict[str, str], monkeypatch
+) -> Dict[str, str]:
+    # Overrides to ensure dev-features are enabled testings
+    # TODO: move this to the base conftest!
+    monkeypatch.setenv("WEBSERVER_DEV_FEATURES_ENABLED", "1")
+    mock_env_devel_environment["WEBSERVER_DEV_FEATURES_ENABLED"] = "1"
+    return mock_env_devel_environment
+
+
+@pytest.fixture
 def mock_env_makefile(monkeypatch):
     """envvars produced @Makefile (export)"""
 

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -231,6 +231,9 @@ def test_settings_to_client_statics_plugins(
     for name in disable_plugins:
         monkeypatch.setenv(name, "null")
 
+    monkeypatch.setenv("WEBSERVER_VERSION_CONTROL", "0")
+    disable_plugins.add("WEBSERVER_VERSION_CONTROL")
+
     settings = ApplicationSettings()
     statics = settings.to_client_statics()
 

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -13,9 +13,9 @@ from aiohttp import web
 from simcore_service_webserver.application_settings import (
     APP_SETTINGS_KEY,
     ApplicationSettings,
-    convert_to_app_config,
     setup_settings,
 )
+from simcore_service_webserver.application_settings_utils import convert_to_app_config
 from simcore_service_webserver.cli import parse, setup_parser
 
 # FIXTURES -----------------------------


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

Webserver plugins marked in the code as "under development" can be disabled via ``WEBSERVER_DEV_FEATURES_ENABLED=0`` and also get advertised in the front-end  statics under ``"pluginsDisabled"``.

Example of statics report sent to the front-end that shows four plugin disabled:
```json
{
 "apiVersion": "0.7.0",
 "appName": "simcore_service_webserver",
 "buildDate": "2022-01-09T12:26:29Z",
 "vcsRef": "dd536f998",
 "vcsUrl": "git@github.com:ITISFoundation/osparc-simcore.git",
 "stackName": "master-simcore",
 "pluginsDisabled": [
  "WEBSERVER_EXPORTER",
  "WEBSERVER_SCICRUNCH",
  "WEBSERVER_VERSION_CONTROL",
  "WEBSERVER_META_MODELING"
 ]
```
which would correspond to the following env vars in eht web-server (@mrnicegyu11 )
```cmd
WEBSERVER_DEV_FEATURES_ENABLED=0
WEBSERVER_EXPORTER=null
WEBSERVER_SCICRUNCH=null
```


@odeimaiz FYI: at this moment, the web-server plugins marked as "under development" are ``WEBSERVER_VERSION_CONTROL``, ``WEBSERVER_META_MODELING`` and ``WEBSERVER_CLUSTERS``.
@odeimaiz Just to clarify, this is how I see the mapping between the plugin variables ``WEBSERVER_VERSION_CONTROL`` and ``WEBSERVER_META_MODELING`` and the front-end features, right?

<img width="1183" alt="image" src="https://user-images.githubusercontent.com/32402063/153602881-14b68314-9204-46fe-ae2f-35e1af8a3398.png">

### Implementation details

- ✨ **every single plugin** has a field entry in ``ApplicationSettings`` in  ``WEBSERVER_${plugin-name}`` that can be used *both* to store settings and enable/disable the plugin (by setting it to None/False or Settings/True)
- ✨ Plugins marked under development are automatically disabled if ``WEBSERVER_DEV_FEATURES_ENABLED=0``.
- ♻️ moved helper functions from ``application_settings.py`` -> ``application_settings_utils.py``

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

- [x] ``WEBSERVER_VERSION_CONTROL=0`` and  ``WEBSERVER_META_MODELING=0`` as defaults until feature is fully released.
- [x] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)

