### PR TITLE
🐛 fixes schema-json in settings-CLI

### DIFF
--- a/packages/settings-library/src/settings_library/base.py
+++ b/packages/settings-library/src/settings_library/base.py
@@ -1,4 +1,3 @@
-import warnings
 from functools import cached_property
 from typing import Sequence, get_args
 
@@ -88,10 +87,10 @@ class BaseCustomSettings(BaseSettings):
                     assert field.field_info.default is Undefined
                     assert field.field_info.default_factory is None
 
+                    # Transform it into something like `Field(default_factory=create_settings_from_env(field))`
                     field.default_factory = create_settings_from_env(field)
                     field.default = None
-                    # Having a default value, makes this field automatically optional
-                    field.required = False
+                    field.required = False  # has a default now
 
             elif issubclass(field_type, BaseSettings):
                 raise ValueError(
@@ -106,10 +105,7 @@ class BaseCustomSettings(BaseSettings):
 
     @classmethod
     def create_from_envs(cls, **overrides):
-        # Kept for legacy
+        # Kept for legacy. Identical to the constructor.
         # Optional to use to make the code more readable
         # More explicit and pylance seems to get less confused
-        warnings.warn(
-            "please use constructor instead of `create_from_envs`", DeprecationWarning
-        )
         return cls(**overrides)

--- a/packages/settings-library/src/settings_library/base.py
+++ b/packages/settings-library/src/settings_library/base.py
@@ -1,5 +1,4 @@
 import warnings
-
 from functools import cached_property
 from typing import Sequence, get_args
 
@@ -90,6 +89,7 @@ class BaseCustomSettings(BaseSettings):
                     assert field.field_info.default_factory is None
 
                     field.default_factory = create_settings_from_env(field)
+                    field.default = None
                     # Having a default value, makes this field automatically optional
                     field.required = False
 

--- a/packages/settings-library/src/settings_library/utils_cli.py
+++ b/packages/settings-library/src/settings_library/utils_cli.py
@@ -73,7 +73,8 @@ def create_settings_command(
 
             assert logger is not None  # nosec
             logger.error(
-                "Invalid application settings. Typically an environment variable is missing or mistyped :\n%s",
+                "Invalid settings. "
+                "Typically this is due to an environment variable missing or misspelled :\n%s",
                 "\n".join(
                     [
                         HEADER_STR.format("detail"),

--- a/packages/settings-library/tests/test_utils_cli.py
+++ b/packages/settings-library/tests/test_utils_cli.py
@@ -99,19 +99,24 @@ def test_compose_commands(cli: typer.Typer, cli_runner: CliRunner):
 
 
 HELP = """
-    Usage: app settings [OPTIONS]
+Usage: app settings [OPTIONS]
 
-    Resolves settings and prints envfile
+  Resolves settings and prints envfile
 
-    Options:
-    --as-json / --no-as-json        [default: no-as-json]
-    --as-json-schema / --no-as-json-schema
-                                    [default: no-as-json-schema]
-    --compact / --no-compact        Print compact form  [default: no-compact]
-    --verbose / --no-verbose        [default: no-verbose]
-    --show-secrets / --no-show-secrets
-                                    [default: no-show-secrets]
-    --help                          Show this message and exit.
+Options:
+  --as-json / --no-as-json        [default: no-as-json]
+  --as-json-schema / --no-as-json-schema
+                                  [default: no-as-json-schema]
+  --compact / --no-compact        Print compact form  [default: no-compact]
+  --verbose / --no-verbose        [default: no-verbose]
+  --show-secrets / --no-show-secrets
+                                  [default: no-show-secrets]
+  --exclude-unset / --no-exclude-unset
+                                  displays settings that were explicitly setThis
+                                  represents current config (i.e. required+
+                                  defaults overriden).  [default: no-exclude-
+                                  unset]
+  --help                          Show this message and exit.
 """
 
 

--- a/packages/settings-library/tests/test_utils_cli.py
+++ b/packages/settings-library/tests/test_utils_cli.py
@@ -72,17 +72,20 @@ def fake_granular_env_file_content() -> str:
 
 
 def test_compose_commands(cli: typer.Typer, cli_runner: CliRunner):
-    result = cli_runner.invoke(cli, ["--help"])
+    # NOTE: this tests is mostly here to raise awareness about what options
+    # are exposed in the CLI so we can add tests if there is any update
+    #
+    result = cli_runner.invoke(cli, ["--help"], catch_exceptions=False)
     print(result.stdout)
     assert result.exit_code == 0, result
 
     # first command
-    result = cli_runner.invoke(cli, ["run", "--help"])
+    result = cli_runner.invoke(cli, ["run", "--help"], catch_exceptions=False)
     print(result.stdout)
     assert result.exit_code == 0, result
 
     # settings command
-    result = cli_runner.invoke(cli, ["settings", "--help"])
+    result = cli_runner.invoke(cli, ["settings", "--help"], catch_exceptions=False)
     print(result.stdout)
 
     assert "--compact" in result.stdout
@@ -113,15 +116,34 @@ HELP = """
 
 
 def test_settings_as_json(
-    cli: typer.Typer, fake_settings_class, mock_environment, cli_runner: CliRunner
+    cli: typer.Typer,
+    fake_settings_class: Type[BaseCustomSettings],
+    mock_environment,
+    cli_runner: CliRunner,
 ):
 
-    result = cli_runner.invoke(cli, ["settings", "--as-json"])
+    result = cli_runner.invoke(cli, ["settings", "--as-json"], catch_exceptions=False)
     print(result.stdout)
 
     # reuse resulting json to build settings
     settings: Dict = json.loads(result.stdout)
     assert fake_settings_class.parse_obj(settings)
+
+
+def test_settings_as_json_schema(
+    cli: typer.Typer,
+    fake_settings_class: Type[BaseCustomSettings],
+    mock_environment,
+    cli_runner: CliRunner,
+):
+
+    result = cli_runner.invoke(
+        cli, ["settings", "--as-json-schema"], catch_exceptions=False
+    )
+    print(result.stdout)
+
+    # reuse resulting json to build settings
+    settings_schema: Dict = json.loads(result.stdout)
 
 
 def test_cli_default_settings_envs(
@@ -139,6 +161,7 @@ def test_cli_default_settings_envs(
         cli_settings_output = cli_runner.invoke(
             cli,
             ["settings", "--show-secrets"],
+            catch_exceptions=False,
         ).stdout
 
     # now let's use these as env vars
@@ -207,6 +230,7 @@ def test_cli_compact_settings_envs(
         setting_env_content_compact = cli_runner.invoke(
             cli,
             ["settings", "--compact"],
+            catch_exceptions=False,
         ).stdout
 
     # now we use these as env vars


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

All services apps in the simcore-stack have now a CLI that allows displaying the app settings (associated to its env vars). This can help setup a reliable mechanism to catch up with changes in the configuration between the code and operations (⚠️ devops) 

- 🐛 Fixes problem with app's CLI  command ``settings --as-json-schema``
- ✨Adds flags to get different views (e.g. ``--exclude-unset``)


## Related issue/s

- Closes #2794 


## How to test

- build image, prepare envs and compose specs:
```cmd
make build
make .env
make .stack-simcore-production.yml
```
- get webserver's config values as json
```cmd
docker-compose -f .stack-simcore-production.yml run webserver \
   simcore-service-webserver settings --as-json  > webserver-settings.json
```
- get websercer's config **json-schema**
```cmd
docker-compose -f .stack-simcore-production.yml run webserver \
  simcore-service-webserver settings --as-json-schema  > webserver-settings-schema.json
```

NOTE: this test can also be done deploying the stack and executing ``simcore-service-webserver settings --help`` in the web-server (or any other service) (⚠️ devops).

## Checklist

- [x] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)

