### PR TITLE
🔒️ Adds codeql-analysis cron job

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,9 @@
+name: "ospac-simcore CodeQL config"
+
+disable-default-queries: false
+
+paths:
+  - '**/src/**'
+  - '**/source/**'
+paths-ignore:
+  - '**/tests/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,6 +1,8 @@
 name: "ospac-simcore CodeQL config"
 
 disable-default-queries: false
+#queries:
+#  - uses: security-and-quality
 
 paths:
   - packages/dask-task-models-library/src
@@ -10,7 +12,14 @@ paths:
   - packages/settings-library/src/settings_library
   - packages/models-library/src/models_library
   - packages/simcore-sdk/src/simcore_sdk
+  - services/storage/src/simcore_service_storage
+  - services/datcore-adapter/src/simcore_service_datcore_adapter
+  - services/dask-sidecar/src/simcore_service_dask_sidecar
+  - services/api-server/src/simcore_service_api_server
+  - services/director-v2/src/simcore_service_director_v2
   - services/web/server/src/simcore_service_webserver
+  - services/dynamic-sidecar/src/simcore_service_dynamic_sidecar
+  - services/catalog/src/simcore_service_catalog
   - "**/src"
   - "**/source"
 paths-ignore:

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,5 +5,6 @@ disable-default-queries: false
 paths:
   - '**/src'
   - '**/source'
+  - '../../services/web/server/src/simcore_service_webserver'
 paths-ignore:
   - '**/tests/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,8 +3,9 @@ name: "ospac-simcore CodeQL config"
 disable-default-queries: false
 
 paths:
-  - '**/src'
-  - '**/source'
-  - 'services/web/server/src/simcore_service_webserver'
+  - packages/settings-library
+  - services/web/server/src/simcore_service_webserver
+  - "**/src"
+  - "**/source"
 paths-ignore:
-  - '**/tests/**'
+  - "**/tests"

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,6 +5,6 @@ disable-default-queries: false
 paths:
   - '**/src'
   - '**/source'
-  - '../../services/web/server/src/simcore_service_webserver'
+  - 'services/web/server/src/simcore_service_webserver'
 paths-ignore:
   - '**/tests/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,7 +3,10 @@ name: "ospac-simcore CodeQL config"
 disable-default-queries: false
 
 paths:
+  - src
   - '**/src/**'
   - '**/source/**'
 paths-ignore:
+  - tests
+  - test
   - '**/tests/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -6,20 +6,20 @@ disable-default-queries: false
 
 paths:
   - packages/dask-task-models-library/src
-  - packages/service-integration/src/service_integration
+  - packages/models-library/src/models_library
   - packages/postgres-database/src/simcore_postgres_database
+  - packages/service-integration/src/service_integration
   - packages/service-library/src/servicelib
   - packages/settings-library/src/settings_library
-  - packages/models-library/src/models_library
   - packages/simcore-sdk/src/simcore_sdk
-  - services/storage/src/simcore_service_storage
-  - services/datcore-adapter/src/simcore_service_datcore_adapter
-  - services/dask-sidecar/src/simcore_service_dask_sidecar
   - services/api-server/src/simcore_service_api_server
-  - services/director-v2/src/simcore_service_director_v2
-  - services/web/server/src/simcore_service_webserver
-  - services/dynamic-sidecar/src/simcore_service_dynamic_sidecar
   - services/catalog/src/simcore_service_catalog
+  - services/dask-sidecar/src/simcore_service_dask_sidecar
+  - services/datcore-adapter/src/simcore_service_datcore_adapter
+  - services/director-v2/src/simcore_service_director_v2
+  - services/dynamic-sidecar/src/simcore_service_dynamic_sidecar
+  - services/storage/src/simcore_service_storage
+  - services/web/server/src/simcore_service_webserver
   - "**/src"
   - "**/source"
 paths-ignore:

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,10 +3,7 @@ name: "ospac-simcore CodeQL config"
 disable-default-queries: false
 
 paths:
-  - src
-  - '**/src/**'
-  - '**/source/**'
+  - '**/src'
+  - '**/source'
 paths-ignore:
-  - tests
-  - test
   - '**/tests/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -8,7 +8,7 @@ paths:
   - packages/dask-task-models-library/src
   - packages/service-integration/src/service_integration
   - packages/postgres-database/src/simcore_postgres_database
-  - packages/service-library/src/service_library
+  - packages/service-library/src/servicelib
   - packages/settings-library/src/settings_library
   - packages/models-library/src/models_library
   - packages/simcore-sdk/src/simcore_sdk

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,7 +3,13 @@ name: "ospac-simcore CodeQL config"
 disable-default-queries: false
 
 paths:
-  - packages/settings-library
+  - packages/dask-task-models-library/src
+  - packages/service-integration/src/service_integration
+  - packages/postgres-database/src/simcore_postgres_database
+  - packages/service-library/src/service_library
+  - packages/settings-library/src/settings_library
+  - packages/models-library/src/models_library
+  - packages/simcore-sdk/src/simcore_sdk
   - services/web/server/src/simcore_service_webserver
   - "**/src"
   - "**/source"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,3 @@
-#
 # codeQL    : https://codeql.github.com/docs/codeql-overview/
 # GH-Action : https://github.com/github/codeql-action
 # LGTM      : https://lgtm.com/#explore
@@ -12,6 +11,12 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+      - '**/*.json'
+      - '**/*.y*ml'
+
   schedule:
     - cron: '26 5 * * 1'
 
@@ -40,6 +45,7 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
+        config-file: ../codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,8 @@
-# codeQL    : https://codeql.github.com/docs/codeql-overview/
-# GH-Action : https://github.com/github/codeql-action
-# LGTM      : https://lgtm.com/#explore
+#
+# codeQL       : https://codeql.github.com/docs/codeql-overview/
+# GH-Action    : https://github.com/github/codeql-action
+# LGTM         : https://lgtm.com/#explore
+# codeql-config: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-a-custom-configuration-file
 #
 name: "CodeQL"
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,24 +7,12 @@
 name: "CodeQL"
 
 on:
-  # TODO: disable in push and pull_request. Keep only in schedule
-  push:
-    branches: [ master ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
-      - '**/*.json'
-      - '**/*.y*ml'
-
   schedule:
-    - cron: '26 5 * * 1'
+    - cron: "26 5 * * 1"
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze Code
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -34,40 +22,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'python' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        language: ["javascript", "python"]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        config-file: ./.github/codeql/codeql-config.yml
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      - name: Initialize CodeQL tools for scanning
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,64 @@
+#
+# codeQL    : https://codeql.github.com/docs/codeql-overview/
+# GH-Action : https://github.com/github/codeql-action
+# LGTM      : https://lgtm.com/#explore
+#
+name: "CodeQL"
+
+on:
+  #push:
+  #  branches: [ master ]
+  #pull_request:
+    # The branches below must be a subset of the branches above
+  #  branches: [ master ]
+  schedule:
+    - cron: '26 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript', 'python' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
-        config-file: ../codeql/codeql-config.yml
+        config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,11 +6,12 @@
 name: "CodeQL"
 
 on:
-  #push:
-  #  branches: [ master ]
-  #pull_request:
+  # TODO: disable in push and pull_request. Keep only in schedule
+  push:
+    branches: [ master ]
+  pull_request:
     # The branches below must be a subset of the branches above
-  #  branches: [ master ]
+    branches: [ master ]
   schedule:
     - cron: '26 5 * * 1'
 

--- a/services/datcore-adapter/src/simcore_service_datcore_adapter/modules/pennsieve.py
+++ b/services/datcore-adapter/src/simcore_service_datcore_adapter/modules/pennsieve.py
@@ -23,7 +23,6 @@ Total = int
 # NOTE: each pennsieve client seems to be about 8MB. so let's keep max 32
 @lru_cache(maxsize=32)
 def _create_pennsieve_client(api_key: str, api_secret: str) -> Pennsieve:
-    logger.debug("creating new client for key/secret [%s/%s]", api_key, api_secret)
     return Pennsieve(api_token=api_key, api_secret=api_secret)
 
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/sidecar.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/sidecar.py
@@ -129,7 +129,7 @@ def get_dynamic_sidecar_spec(
                 )
             )
 
-    endpint_spec = {}
+    endpoint_spec = {}
 
     if dynamic_sidecar_settings.DYNAMIC_SIDECAR_MOUNT_PATH_DEV is not None:
         dynamic_sidecar_path = dynamic_sidecar_settings.DYNAMIC_SIDECAR_MOUNT_PATH_DEV
@@ -163,7 +163,7 @@ def get_dynamic_sidecar_spec(
             )
     # expose this service on an empty port
     if dynamic_sidecar_settings.DYNAMIC_SIDECAR_EXPOSE_PORT:
-        endpint_spec["Ports"] = [
+        endpoint_spec["Ports"] = [
             {
                 "Protocol": "tcp",
                 "TargetPort": dynamic_sidecar_settings.DYNAMIC_SIDECAR_PORT,
@@ -171,7 +171,7 @@ def get_dynamic_sidecar_spec(
         ]
 
     create_service_params = {
-        "endpoint_spec": endpint_spec,
+        "endpoint_spec": endpoint_spec,
         "labels": {
             # TODO: let's use a pydantic model with descriptions
             "io.simcore.zone": scheduler_data.simcore_traefik_zone,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
@@ -155,6 +155,11 @@ class CreateSidecars(DynamicSchedulerEvent):
         swarm_network_name: str = swarm_network["Name"]
 
         # start dynamic-sidecar and run the proxy on the same node
+
+        # WARNING: do NOT log, this structure has secrets in the open
+        # If you want to log, please use an obfuscator
+        dynamic_sidecar_create_service_params: Dict[str, Any]
+
         dynamic_sidecar_create_service_params = get_dynamic_sidecar_spec(
             scheduler_data=scheduler_data,
             dynamic_sidecar_settings=dynamic_sidecar_settings,
@@ -162,10 +167,6 @@ class CreateSidecars(DynamicSchedulerEvent):
             swarm_network_id=swarm_network_id,
             settings=settings,
             app_settings=app.state.settings,
-        )
-        logger.debug(
-            "dynamic-sidecar create_service_params %s",
-            json_dumps(dynamic_sidecar_create_service_params),
         )
 
         dynamic_sidecar_id = await create_service_and_get_id(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

- Activates cron job that analyzes repo code for vulnerabilities (every monday at 5:26am)
- Fixes two clear-text logging of sensitive info 
   -  NOTE: as a good practice always use ``SecretStr`` in pydantic models for objects that are logged

More details:
- [codeQL]( https://codeql.github.com/docs/codeql-overview/)
- [GH-Action](https://github.com/github/codeql-action)
- [LGTM](https://lgtm.com/#explore)
- [codeql-config](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-a-custom-configuration-file)

To see some of the job runs, check the ["Actions" tab and select CodeQL workflow](https://github.com/ITISFoundation/osparc-simcore/actions/workflows/codeql-analysis.yml) 

<img width="1216" alt="Screen Shot 2022-03-15 at 22 56 00" src="https://user-images.githubusercontent.com/32402063/158479192-e3ff14bb-bca8-42f1-869c-1c1429f3ff37.png">

## Related issue/s

- ITISFoundation/osparc-issues#509



## Checklist

- [x] scan only src/ folders
- [x] leave only cron-job and disable push+pull-request
- [x] analyze code and apply fixes
- [x] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)

