### PR TITLE
⬆️ Upgrades api-server requirements

### DIFF
--- a/services/api-server/requirements/_base.in
+++ b/services/api-server/requirements/_base.in
@@ -15,22 +15,14 @@
 --requirement ../../../packages/service-library/requirements/_base.in
 --requirement ../../../packages/service-library/requirements/_fastapi.in
 
-
-# fastapi and extensions
-fastapi[all]
-
-# data models
-pydantic[dotenv]
-
-# database
+aiofiles
 aiopg[sa]
-
-# web client
-httpx
-
-#
-importlib_resources
-attrs
-tenacity
 cryptography
+fastapi[all]
+httpx
+orjson
 packaging
+pydantic[dotenv]
+pyyaml
+tenacity
+typer

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -15,6 +15,7 @@ aiofiles==0.8.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
+    #   -r requirements/_base.in
 aiohttp==3.8.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -53,8 +54,8 @@ attrs==20.3.0
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
-    #   -r requirements/_base.in
     #   aiohttp
+    #   jsonschema
 certifi==2021.10.8
     # via
     #   httpcore
@@ -62,12 +63,12 @@ certifi==2021.10.8
     #   requests
 cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via
     #   aiohttp
     #   httpx
     #   requests
-click==8.0.3
+click==8.0.4
     # via
     #   typer
     #   uvicorn
@@ -90,7 +91,7 @@ email-validator==1.1.3
     # via
     #   fastapi
     #   pydantic
-fastapi==0.73.0
+fastapi==0.74.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
@@ -125,7 +126,7 @@ idna==2.10
     #   requests
     #   rfc3986
     #   yarl
-importlib-metadata==4.11.0
+importlib-metadata==4.11.2
     # via alembic
 importlib-resources==5.4.0 ; python_version < "3.9"
     # via
@@ -139,9 +140,8 @@ importlib-resources==5.4.0 ; python_version < "3.9"
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
-    #   -r requirements/_base.in
     #   alembic
-itsdangerous==2.0.1
+itsdangerous==2.1.0
     # via fastapi
 jaeger-client==4.8.0
     # via fastapi-contrib
@@ -158,9 +158,15 @@ jinja2==3.0.3
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   fastapi
+jsonschema==3.2.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 mako==1.1.6
     # via alembic
-markupsafe==2.0.1
+markupsafe==2.1.0
     # via
     #   jinja2
     #   mako
@@ -172,8 +178,10 @@ opentracing==2.4.0
     # via
     #   fastapi-contrib
     #   jaeger-client
-orjson==3.6.6
-    # via fastapi
+orjson==3.6.7
+    # via
+    #   -r requirements/_base.in
+    #   fastapi
 packaging==21.3
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
@@ -212,6 +220,8 @@ pyinstrument==4.1.1
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 pyparsing==3.0.7
     # via packaging
+pyrsistent==0.18.1
+    # via jsonschema
 python-dotenv==0.19.2
     # via
     #   pydantic
@@ -236,6 +246,7 @@ pyyaml==5.4.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
     #   fastapi
     #   uvicorn
 requests==2.27.1
@@ -244,6 +255,7 @@ rfc3986==1.5.0
     # via httpx
 six==1.16.0
     # via
+    #   jsonschema
     #   python-multipart
     #   thrift
 sniffio==1.2.0
@@ -284,11 +296,13 @@ tornado==6.1
     # via
     #   jaeger-client
     #   threadloop
-tqdm==4.62.3
+tqdm==4.63.0
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 typer==0.4.0
-    # via -r requirements/../../../packages/settings-library/requirements/_base.in
-typing-extensions==4.0.1
+    # via
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/_base.in
+typing-extensions==4.1.1
     # via
     #   aiodebug
     #   pydantic
@@ -313,7 +327,7 @@ uvloop==0.16.0
     # via uvicorn
 watchgod==0.7
     # via uvicorn
-websockets==10.1
+websockets==10.2
     # via uvicorn
 yarl==1.7.2
     # via
@@ -324,3 +338,6 @@ zipp==3.7.0
     # via
     #   importlib-metadata
     #   importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -4,18 +4,18 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-aiodebug==1.1.2
+aiodebug==2.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-aiofiles==0.5.0
+aiofiles==0.8.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-aiohttp==3.7.4.post0
+aiohttp==3.8.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -27,13 +27,14 @@ aiohttp==3.7.4.post0
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
-    #   -c requirements/./constraints.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-aiopg==1.2.1
+aiopg==1.3.3
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-alembic==1.7.4
+aiosignal==1.2.0
+    # via aiohttp
+alembic==1.7.6
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
@@ -41,9 +42,9 @@ anyio==3.5.0
     # via
     #   httpcore
     #   starlette
-asgiref==3.4.1
+asgiref==3.5.0
     # via uvicorn
-async-timeout==3.0.1
+async-timeout==4.0.2
     # via
     #   aiohttp
     #   aiopg
@@ -54,24 +55,23 @@ attrs==20.3.0
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -r requirements/_base.in
     #   aiohttp
-certifi==2020.12.5
+certifi==2021.10.8
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==1.14.5
+cffi==1.15.0
     # via cryptography
-chardet==4.0.0
+charset-normalizer==2.0.11
     # via
     #   aiohttp
+    #   httpx
     #   requests
-charset-normalizer==2.0.10
-    # via httpx
 click==8.0.3
     # via
     #   typer
     #   uvicorn
-cryptography==3.4.7
+cryptography==36.0.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -84,28 +84,32 @@ cryptography==3.4.7
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
-dnspython==2.1.0
+dnspython==2.2.0
     # via email-validator
-email-validator==1.1.2
+email-validator==1.1.3
     # via
     #   fastapi
     #   pydantic
-fastapi==0.71.0
+fastapi==0.73.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   fastapi-contrib
 fastapi-contrib==0.2.11
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
+frozenlist==1.3.0
+    # via
+    #   aiohttp
+    #   aiosignal
 h11==0.12.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==0.14.4
+httpcore==0.14.7
     # via httpx
 httptools==0.2.0
     # via uvicorn
-httpx==0.21.3
+httpx==0.22.0
     # via -r requirements/_base.in
 idna==2.10
     # via
@@ -121,9 +125,9 @@ idna==2.10
     #   requests
     #   rfc3986
     #   yarl
-importlib-metadata==4.8.1
+importlib-metadata==4.11.0
     # via alembic
-importlib-resources==5.3.0 ; python_version < "3.9"
+importlib-resources==5.4.0 ; python_version < "3.9"
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -137,11 +141,11 @@ importlib-resources==5.3.0 ; python_version < "3.9"
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
     #   alembic
-itsdangerous==1.1.0
+itsdangerous==2.0.1
     # via fastapi
 jaeger-client==4.8.0
     # via fastapi-contrib
-jinja2==2.11.3
+jinja2==3.0.3
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -154,13 +158,13 @@ jinja2==2.11.3
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   fastapi
-mako==1.1.5
+mako==1.1.6
     # via alembic
 markupsafe==2.0.1
     # via
     #   jinja2
     #   mako
-multidict==5.1.0
+multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
@@ -168,17 +172,17 @@ opentracing==2.4.0
     # via
     #   fastapi-contrib
     #   jaeger-client
-orjson==3.5.2
+orjson==3.6.6
     # via fastapi
-packaging==20.9
+packaging==21.3
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-psycopg2-binary==2.9.1
+psycopg2-binary==2.9.3
     # via
     #   aiopg
     #   sqlalchemy
-pycparser==2.20
+pycparser==2.21
     # via cffi
 pydantic==1.9.0
     # via
@@ -201,16 +205,14 @@ pydantic==1.9.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
     #   fastapi
-pyinstrument==3.4.2
+pyinstrument==4.1.1
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-pyinstrument-cext==0.2.4
-    # via pyinstrument
-pyparsing==2.4.7
+pyparsing==3.0.7
     # via packaging
-python-dotenv==0.17.1
+python-dotenv==0.19.2
     # via
     #   pydantic
     #   uvicorn
@@ -236,14 +238,13 @@ pyyaml==5.4.1
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   fastapi
     #   uvicorn
-requests==2.25.1
+requests==2.27.1
     # via fastapi
 rfc3986==1.5.0
     # via httpx
 six==1.16.0
     # via
     #   python-multipart
-    #   tenacity
     #   thrift
 sniffio==1.2.0
     # via
@@ -268,7 +269,7 @@ sqlalchemy==1.3.24
     #   alembic
 starlette==0.17.1
     # via fastapi
-tenacity==7.0.0
+tenacity==8.0.1
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -277,23 +278,23 @@ tenacity==7.0.0
     #   -r requirements/_base.in
 threadloop==1.0.2
     # via jaeger-client
-thrift==0.13.0
+thrift==0.15.0
     # via jaeger-client
 tornado==6.1
     # via
     #   jaeger-client
     #   threadloop
-tqdm==4.60.0
+tqdm==4.62.3
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 typer==0.4.0
     # via -r requirements/../../../packages/settings-library/requirements/_base.in
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via
-    #   aiohttp
+    #   aiodebug
     #   pydantic
-ujson==4.0.2
+ujson==4.3.0
     # via fastapi
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -308,18 +309,18 @@ urllib3==1.26.7
     #   requests
 uvicorn==0.15.0
     # via fastapi
-uvloop==0.14.0
+uvloop==0.16.0
     # via uvicorn
 watchgod==0.7
     # via uvicorn
 websockets==10.1
     # via uvicorn
-yarl==1.6.3
+yarl==1.7.2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
     #   aiohttp
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -83,7 +83,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==12.1.0
+faker==12.3.0
     # via -r requirements/_test.in
 h11==0.12.0
     # via
@@ -176,7 +176,7 @@ pytest==6.2.5
     #   pytest-cov
     #   pytest-docker
     #   pytest-mock
-pytest-asyncio==0.18.0
+pytest-asyncio==0.18.1
     # via -r requirements/_test.in
 pytest-cov==3.0.0
     # via -r requirements/_test.in

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-alembic==1.7.4
+alembic==1.7.6
     # via
     #   -c requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -27,26 +27,23 @@ bcrypt==3.2.0
     # via
     #   paramiko
     #   passlib
-certifi==2020.12.5
+certifi==2021.10.8
     # via
     #   -c requirements/_base.txt
     #   httpcore
     #   httpx
     #   requests
-cffi==1.14.5
+cffi==1.15.0
     # via
     #   -c requirements/_base.txt
     #   bcrypt
     #   cryptography
     #   pynacl
-chardet==4.0.0
-    # via
-    #   -c requirements/_base.txt
-    #   requests
-charset-normalizer==2.0.10
+charset-normalizer==2.0.11
     # via
     #   -c requirements/_base.txt
     #   httpx
+    #   requests
 click==8.0.3
     # via
     #   -c requirements/_base.txt
@@ -60,7 +57,7 @@ coverage==6.3.1
     #   pytest-cov
 coveralls==3.3.1
     # via -r requirements/_test.in
-cryptography==3.4.7
+cryptography==36.0.1
     # via
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -89,11 +86,11 @@ h11==0.12.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==0.14.4
+httpcore==0.14.7
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.21.3
+httpx==0.22.0
     # via
     #   -c requirements/_base.txt
     #   respx
@@ -105,11 +102,11 @@ idna==2.10
     #   requests
     #   rfc3986
     #   yarl
-importlib-metadata==4.8.1
+importlib-metadata==4.11.0
     # via
     #   -c requirements/_base.txt
     #   alembic
-importlib-resources==5.3.0 ; python_version < "3.9"
+importlib-resources==5.4.0 ; python_version < "3.9"
     # via
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -123,7 +120,7 @@ jsonschema==3.2.0
     # via docker-compose
 lazy-object-proxy==1.7.1
     # via astroid
-mako==1.1.5
+mako==1.1.6
     # via
     #   -c requirements/_base.txt
     #   alembic
@@ -133,11 +130,11 @@ markupsafe==2.0.1
     #   mako
 mccabe==0.6.1
     # via pylint
-multidict==5.1.0
+multidict==6.0.2
     # via
     #   -c requirements/_base.txt
     #   yarl
-packaging==20.9
+packaging==21.3
     # via
     #   -c requirements/_base.txt
     #   pytest
@@ -149,13 +146,13 @@ platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via pytest
-psycopg2-binary==2.9.1
+psycopg2-binary==2.9.3
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
 py==1.11.0
     # via pytest
-pycparser==2.20
+pycparser==2.21
     # via
     #   -c requirements/_base.txt
     #   cffi
@@ -163,7 +160,7 @@ pylint==2.12.2
     # via -r requirements/_test.in
 pynacl==1.5.0
     # via paramiko
-pyparsing==2.4.7
+pyparsing==3.0.7
     # via
     #   -c requirements/_base.txt
     #   packaging
@@ -188,7 +185,7 @@ pytest-runner==5.3.1
     # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via faker
-python-dotenv==0.17.1
+python-dotenv==0.19.2
     # via
     #   -c requirements/_base.txt
     #   docker-compose
@@ -198,7 +195,7 @@ pyyaml==5.4.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   docker-compose
-requests==2.25.1
+requests==2.27.1
     # via
     #   -c requirements/_base.txt
     #   codecov
@@ -218,7 +215,6 @@ six==1.16.0
     #   dockerpty
     #   jsonschema
     #   python-dateutil
-    #   tenacity
     #   websocket-client
 sniffio==1.2.0
     # via
@@ -234,7 +230,7 @@ sqlalchemy==1.3.24
     #   -c requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   alembic
-tenacity==7.0.0
+tenacity==8.0.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -249,12 +245,12 @@ tomli==1.2.3
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   coverage
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   pylint
-urllib3==1.26.7
+urllib3==1.26.8
     # via
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -266,11 +262,11 @@ websocket-client==0.59.0
     #   docker-compose
 wrapt==1.13.3
     # via astroid
-yarl==1.6.3
+yarl==1.7.2
     # via
     #   -c requirements/_base.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   -c requirements/_base.txt
     #   importlib-metadata

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -39,18 +39,18 @@ cffi==1.15.0
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via
     #   -c requirements/_base.txt
     #   httpx
     #   requests
-click==8.0.3
+click==8.0.4
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
 codecov==2.1.12
     # via -r requirements/_test.in
-coverage==6.3.1
+coverage==6.3.2
     # via
     #   codecov
     #   coveralls
@@ -63,7 +63,7 @@ cryptography==36.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   paramiko
-distro==1.6.0
+distro==1.7.0
     # via docker-compose
 docker==5.0.3
     # via
@@ -80,7 +80,7 @@ docopt==0.6.2
     # via
     #   coveralls
     #   docker-compose
-faker==12.3.0
+faker==13.3.0
     # via -r requirements/_test.in
 h11==0.12.0
     # via
@@ -102,7 +102,7 @@ idna==2.10
     #   requests
     #   rfc3986
     #   yarl
-importlib-metadata==4.11.0
+importlib-metadata==4.11.2
     # via
     #   -c requirements/_base.txt
     #   alembic
@@ -117,14 +117,16 @@ iniconfig==1.1.1
 isort==5.10.1
     # via pylint
 jsonschema==3.2.0
-    # via docker-compose
+    # via
+    #   -c requirements/_base.txt
+    #   docker-compose
 lazy-object-proxy==1.7.1
     # via astroid
 mako==1.1.6
     # via
     #   -c requirements/_base.txt
     #   alembic
-markupsafe==2.0.1
+markupsafe==2.1.0
     # via
     #   -c requirements/_base.txt
     #   mako
@@ -142,7 +144,7 @@ paramiko==2.9.2
     # via docker
 passlib==1.7.4
     # via -r requirements/_test.in
-platformdirs==2.5.0
+platformdirs==2.5.1
     # via pylint
 pluggy==1.0.0
     # via pytest
@@ -165,7 +167,9 @@ pyparsing==3.0.7
     #   -c requirements/_base.txt
     #   packaging
 pyrsistent==0.18.1
-    # via jsonschema
+    # via
+    #   -c requirements/_base.txt
+    #   jsonschema
 pytest==6.2.5
     # via
     #   -r requirements/_test.in
@@ -181,7 +185,7 @@ pytest-docker==0.10.3
     # via -r requirements/_test.in
 pytest-mock==3.7.0
     # via -r requirements/_test.in
-pytest-runner==5.3.1
+pytest-runner==6.0.0
     # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via faker
@@ -245,7 +249,7 @@ tomli==1.2.3
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   coverage
-typing-extensions==4.0.1
+typing-extensions==4.1.1
     # via
     #   -c requirements/_base.txt
     #   astroid

--- a/services/api-server/requirements/_tools.txt
+++ b/services/api-server/requirements/_tools.txt
@@ -12,7 +12,7 @@ cfgv==3.3.1
     # via pre-commit
 change-case==0.5.2
     # via -r requirements/_tools.in
-click==8.0.3
+click==8.0.4
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -20,9 +20,9 @@ click==8.0.3
     #   pip-tools
 distlib==0.3.4
     # via virtualenv
-filelock==3.4.2
+filelock==3.6.0
     # via virtualenv
-identify==2.4.9
+identify==2.4.11
     # via pre-commit
 isort==5.10.1
     # via
@@ -33,7 +33,7 @@ jinja2==3.0.3
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_tools.in
-markupsafe==2.0.1
+markupsafe==2.1.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -48,7 +48,7 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.5.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.5.0
+platformdirs==2.5.1
     # via
     #   -c requirements/_test.txt
     #   black
@@ -79,12 +79,12 @@ tomli==1.2.3
     #   -c requirements/_test.txt
     #   black
     #   pep517
-typing-extensions==4.0.1
+typing-extensions==4.1.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.13.1
+virtualenv==20.13.2
     # via pre-commit
 watchdog==2.1.6
     # via -r requirements/_tools.in

--- a/services/api-server/requirements/_tools.txt
+++ b/services/api-server/requirements/_tools.txt
@@ -28,7 +28,7 @@ isort==5.10.1
     # via
     #   -c requirements/_test.txt
     #   -r requirements/../../../requirements/devenv.txt
-jinja2==2.11.3
+jinja2==3.0.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -79,7 +79,7 @@ tomli==1.2.3
     #   -c requirements/_test.txt
     #   black
     #   pep517
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt

--- a/services/api-server/requirements/constraints.txt
+++ b/services/api-server/requirements/constraints.txt
@@ -1,8 +1,1 @@
-
-
-# There are incompatible versions in the resolved dependencies:
-#   async-timeout<5.0,>=4.0.0a3 (from aiohttp==3.8.1)
-#   async-timeout<4.0,>=3.0 (from aiopg[sa]==1.2.1->-r requirements/_base.in (line 25))
-# NOTE: All services with aiopg and aiohttp will have this conflict.
-#       Need to wait until aiopg releases and removes this constraint
-aiohttp<3.8.0
+# Add here ONLY this package's constraints

--- a/services/api-server/src/simcore_service_api_server/modules/webserver.py
+++ b/services/api-server/src/simcore_service_api_server/modules/webserver.py
@@ -3,10 +3,10 @@ import json
 import logging
 from collections import deque
 from contextlib import suppress
+from dataclasses import dataclass
 from typing import Deque, Dict, List, Optional
 from uuid import UUID
 
-import attr
 from cryptography import fernet
 from fastapi import FastAPI, HTTPException
 from httpx import AsyncClient, Response, codes
@@ -21,7 +21,7 @@ from ..utils.client_base import BaseServiceClientApi, setup_client_instance
 logger = logging.getLogger(__name__)
 
 
-@attr.s(auto_attribs=True)
+@dataclass
 class AuthSession:
     """
     - wrapper around thin-client to simplify webserver's API
@@ -35,7 +35,7 @@ class AuthSession:
 
     client: AsyncClient  # Its lifetime is attached to app
     vtag: str
-    session_cookies: Dict = None
+    session_cookies: Optional[Dict] = None
 
     @classmethod
     def create(cls, app: FastAPI, session_cookies: Dict):


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

In preparation for new features, we upgrade api-server requirements.

- Removed local constraints
- Pruned dependencies
- full upgrade base.in, tests.in and tools.in

#### base requirements
- #packages before: 44
- #packages after : 46

|#|name|before|after|upgrade| count|
|-|----|------|-----|-------|------|
|  1 | aiodebug                  | 1.1.2           | 2.3.0      | **MAJOR**  | 1 |
|  2 | aiofiles                  | 0.5.0           | 0.8.0      | *minor*    | 1 |
|  3 | aiohttp                   | 3.7.4.post0     | 3.8.1      | *minor*    | 1 |
|  4 | aiopg                     | 1.2.1           | 1.3.3      | *minor*    | 1 |
|  5 | alembic                   | 1.7.4           | 1.7.6      |            | 1 |
|  6 | asgiref                   | 3.4.1           | 3.5.0      | *minor*    | 1 |
|  7 | async-timeout             | 3.0.1           | 4.0.2      | **MAJOR**  | 1 |
|  8 | certifi                   | 2020.12.5       | 2021.10.8  | **MAJOR**  | 1 |
|  9 | cffi                      | 1.14.5          | 1.15.0     | *minor*    | 1 |
| 10 | chardet                   | 4.0.0           | removed    |  | 1 |
| 11 | charset-normalizer        | 2.0.10          | 2.0.12     |            | 1 |
| 12 | click                     | 8.0.3           | 8.0.4      |            | 1 |
| 13 | cryptography              | 3.4.7           | 36.0.1     | **MAJOR**  | 1 |
| 14 | dnspython                 | 2.1.0           | 2.2.0      | *minor*    | 1 |
| 15 | email-validator           | 1.1.2           | 1.1.3      |            | 1 |
| 16 | fastapi                   | 0.71.0          | 0.74.1     | *minor*    | 1 |
| 17 | httpcore                  | 0.14.4          | 0.14.7     |            | 1 |
| 18 | httpx                     | 0.21.3          | 0.22.0     | *minor*    | 1 |
| 19 | importlib-metadata        | 4.8.1           | 4.11.2     | *minor*    | 1 |
| 20 | importlib-resources       | 5.3.0           | 5.4.0      | *minor*    | 1 |
| 21 | itsdangerous              | 1.1.0           | 2.1.0      | **MAJOR**  | 1 |
| 22 | jinja2                    | 2.11.3          | 3.0.3      | **MAJOR**  | 1 |
| 23 | mako                      | 1.1.5           | 1.1.6      |            | 1 |
| 24 | markupsafe                | 2.0.1           | 2.1.0      | *minor*    | 1 |
| 25 | multidict                 | 5.1.0           | 6.0.2      | **MAJOR**  | 1 |
| 26 | orjson                    | 3.5.2           | 3.6.7      | *minor*    | 1 |
| 27 | packaging                 | 20.9            | 21.3       | **MAJOR**  | 1 |
| 28 | psycopg2-binary           | 2.9.1           | 2.9.3      |            | 1 |
| 29 | pycparser                 | 2.20            | 2.21       | *minor*    | 1 |
| 30 | pyinstrument              | 3.4.2           | 4.1.1      | **MAJOR**  | 1 |
| 31 | pyinstrument-cext         | 0.2.4           | removed    |  | 1 |
| 32 | pyparsing                 | 2.4.7           | 3.0.7      | **MAJOR**  | 1 |
| 33 | python-dotenv             | 0.17.1          | 0.19.2     | *minor*    | 1 |
| 34 | requests                  | 2.25.1          | 2.27.1     | *minor*    | 1 |
| 35 | tenacity                  | 7.0.0           | 8.0.1      | **MAJOR**  | 1 |
| 36 | thrift                    | 0.13.0          | 0.15.0     | *minor*    | 1 |
| 37 | tqdm                      | 4.60.0          | 4.63.0     | *minor*    | 1 |
| 38 | typing-extensions         | 3.10.0.2        | 4.1.1      | **MAJOR**  | 1 |
| 39 | ujson                     | 4.0.2           | 4.3.0      | *minor*    | 1 |
| 40 | urllib3                   | 1.26.7          | 1.26.8     |            | 1 |
| 41 | uvloop                    | 0.14.0          | 0.16.0     | *minor*    | 1 |
| 42 | websockets                | 10.1            | 10.2       | *minor*    | 1 |
| 43 | yarl                      | 1.6.3           | 1.7.2      | *minor*    | 1 |
| 44 | zipp                      | 3.6.0           | 3.7.0      | *minor*    | 1 |

#### tests requirements

- #packages before: 31
- #packages after : 30

|#|name|before|after|upgrade| count|
|-|----|------|-----|-------|------|
|  1 | alembic                   | 1.7.4           | 1.7.6      |            | 1 |
|  2 | certifi                   | 2020.12.5       | 2021.10.8  | **MAJOR**  | 1 |
|  3 | cffi                      | 1.14.5          | 1.15.0     | *minor*    | 1 |
|  4 | chardet                   | 4.0.0           | removed    |  | 1 |
|  5 | charset-normalizer        | 2.0.10          | 2.0.12     |            | 1 |
|  6 | click                     | 8.0.3           | 8.0.4      |            | 1 |
|  7 | coverage                  | 6.3.1           | 6.3.2      |            | 1 |
|  8 | cryptography              | 3.4.7           | 36.0.1     | **MAJOR**  | 1 |
|  9 | distro                    | 1.6.0           | 1.7.0      | *minor*    | 1 |
| 10 | faker                     | 12.1.0          | 13.3.0     | **MAJOR**  | 1 |
| 11 | httpcore                  | 0.14.4          | 0.14.7     |            | 1 |
| 12 | httpx                     | 0.21.3          | 0.22.0     | *minor*    | 1 |
| 13 | importlib-metadata        | 4.8.1           | 4.11.2     | *minor*    | 1 |
| 14 | importlib-resources       | 5.3.0           | 5.4.0      | *minor*    | 1 |
| 15 | mako                      | 1.1.5           | 1.1.6      |            | 1 |
| 16 | markupsafe                | 2.0.1           | 2.1.0      | *minor*    | 1 |
| 17 | multidict                 | 5.1.0           | 6.0.2      | **MAJOR**  | 1 |
| 18 | packaging                 | 20.9            | 21.3       | **MAJOR**  | 1 |
| 19 | platformdirs              | 2.5.0           | 2.5.1      |            | 1 |
| 20 | psycopg2-binary           | 2.9.1           | 2.9.3      |            | 1 |
| 21 | pycparser                 | 2.20            | 2.21       | *minor*    | 1 |
| 22 | pyparsing                 | 2.4.7           | 3.0.7      | **MAJOR**  | 1 |
| 23 | pytest-asyncio            | 0.18.0          | 0.18.1     |            | 1 |
| 24 | pytest-runner             | 5.3.1           | 6.0.0      | **MAJOR**  | 1 |
| 25 | python-dotenv             | 0.17.1          | 0.19.2     | *minor*    | 1 |
| 26 | requests                  | 2.25.1          | 2.27.1     | *minor*    | 1 |
| 27 | tenacity                  | 7.0.0           | 8.0.1      | **MAJOR**  | 1 |
| 28 | typing-extensions         | 3.10.0.2        | 4.1.1      | **MAJOR**  | 1 |
| 29 | urllib3                   | 1.26.7          | 1.26.8     |            | 1 |
| 30 | yarl                      | 1.6.3           | 1.7.2      | *minor*    | 1 |
| 31 | zipp                      | 3.6.0           | 3.7.0      | *minor*    | 1 |

## Related issue/s

- ITISFoundation/osparc-issues#428
- ITISFoundation/osparc-issues#509

## How to test
- service (already in CI)
```cmd
cd services/api-server
make install-dev
make test-dev
```
- integration via client (already in CI)
```cmd
make build
cd tests/public-api
make install-ci
make test-dev
```
- pip-freeze check: verifies that ``_base.txt`` is indeed the dependencies installed in production. This is done by comparing these two files manually (for the moment)
```cmd
$ docker run -it local/api-server:production pip freeze > freeze-prod.ignore.txt
$ cat requirements/_base.txt | grep -v '#' > freeze-base.ignore.txt
```

## Checklist

- [x] Removed local constraints
- [x] Pruned dependencies
- [x] Full upgrade base.in, tests.in and tools.in
- [x] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
