### PR TITLE
Bugfix: Initialize Mardown element's height to minimum

### DIFF
--- a/services/web/client/source/class/osparc/ui/markdown/Markdown.js
+++ b/services/web/client/source/class/osparc/ui/markdown/Markdown.js
@@ -52,6 +52,8 @@ qx.Class.define("osparc.ui.markdown.Markdown", {
     ].forEach(event => {
       this.addListener(event, e => this.__resizeMe(), this);
     });
+
+    this.setHeight(1);
   },
 
   properties: {


### PR DESCRIPTION
## What do these changes do?

Initializes Mardown element's height to the minimum (1), and once it ```appear```s it will resize itself to whatever it takes.

![MinMarkdown](https://user-images.githubusercontent.com/33152403/153835563-99ad2f86-0726-4a81-a9ad-94bb0f4d9c6d.gif)

Check bug issue to see the **before**

## Related issue/s
closes https://github.com/ITISFoundation/osparc-issues/issues/598


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
