### PR TITLE
✨ Cache list service request in catalog

### DIFF
--- a/packages/settings-library/src/settings_library/postgres.py
+++ b/packages/settings-library/src/settings_library/postgres.py
@@ -64,7 +64,14 @@ class PostgresSettings(BaseCustomSettings):
 
     @cached_property
     def dsn_with_async_sqlalchemy(self) -> str:
-        dsn = self.dsn.replace("postgresql", "postgresql+asyncpg")
+        dsn: str = PostgresDsn.build(
+            scheme="postgresql+asyncpg",
+            user=self.POSTGRES_USER,
+            password=self.POSTGRES_PASSWORD.get_secret_value(),
+            host=self.POSTGRES_HOST,
+            port=f"{self.POSTGRES_PORT}",
+            path=f"/{self.POSTGRES_DB}",
+        )
         return dsn
 
     @cached_property

--- a/services/catalog/src/simcore_service_catalog/api/routes/services.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services.py
@@ -39,6 +39,7 @@ RESPONSE_MODEL_POLICY = {
 }
 
 DIRECTOR_CACHING_TTL = 5 * MINUTE
+LIST_SERVICES_CACHING_TTL = 30
 
 
 def _prepare_service_details(
@@ -69,8 +70,19 @@ def _prepare_service_details(
     return validated_service
 
 
+def _build_cache_key(fct, *_, **kwargs):
+    return f"{fct.__name__}_{kwargs['user_id']}_{kwargs['x_simcore_products_name']}_{kwargs['details']}"
+
+
+# NOTE: this call is pretty expensive and can be called several times
+# (when e2e runs or by the webserver when listing projects) therefore
+# a cache is setup here
 @router.get("", response_model=List[ServiceOut], **RESPONSE_MODEL_POLICY)
 @cancellable_request
+@cached(
+    ttl=LIST_SERVICES_CACHING_TTL,
+    key_builder=_build_cache_key,
+)
 async def list_services(
     request: Request,  # pylint:disable=unused-argument
     user_id: PositiveInt,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
This PR follows #2869 and the idea is to provide caching of the request listing services from the catalog using for now a simple cache mechanism through [aiocache](https://github.com/aio-libs/aiocache) library.
This library could allow caching through Redis if need be. for now it caches in memory for a 30 seconds time.

The requests per seconds doubles using that mechanism, during the 30seconds the cache lives.


Without cache:
```
------------------------------------------------------------------------------------------------ benchmark: 2 tests ------------------------------------------------------------------------------------------------
  Name (time in ms)                             Min                   Max                  Mean             StdDev                Median                 IQR            Outliers     OPS            Rounds  Iterations
  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  test_list_services_without_details       620.0175 (1.0)        748.3653 (1.0)        666.8922 (1.0)      63.0435 (1.05)       623.8694 (1.0)      108.3981 (1.07)          1;0  1.4995 (1.0)           5           1
  test_list_services_with_details        1,270.5686 (2.05)     1,403.4215 (1.88)     1,348.9908 (2.02)     60.2470 (1.0)      1,384.6504 (2.22)     100.8497 (1.0)           1;0  0.7413 (0.49)          5           1
  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
With cache:
```
-------------------------------------------------------------------------------------------- benchmark: 2 tests -------------------------------------------------------------------------------------------
  Name (time in ms)                           Min                 Max                Mean             StdDev              Median                IQR            Outliers     OPS            Rounds  Iterations
  -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  test_list_services_without_details     676.1354 (1.0)      787.9862 (1.0)      716.5263 (1.0)      42.6909 (1.24)     705.7252 (1.0)      44.0494 (1.50)          1;0  1.3956 (1.0)           5           1
  test_list_services_with_details        756.4908 (1.12)     843.0671 (1.07)     782.8207 (1.09)     34.4919 (1.0)      771.2704 (1.09)     29.3169 (1.0)           1;1  1.2774 (0.92)          5           1
  -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
