### PR TITLE
 🐛Fix save state for non-responsive services

### DIFF
--- a/services/director-v2/requirements/_test.in
+++ b/services/director-v2/requirements/_test.in
@@ -11,33 +11,36 @@
 
 
 # testing
-asgi_lifespan
+flaky
 pytest
 pytest-aiohttp
 pytest-cov
+pytest-docker
+pytest-icdiff
 pytest-mock
 pytest-runner
-pytest-docker
 pytest-xdist
-pytest-icdiff
-async-asgi-testclient
-minio
-aioboto3
 
 # fixtures
+asgi_lifespan
 Faker
 
+# helpers
+aioboto3
+async-asgi-testclient
+minio
+
+
 # migration due to pytest_simcore.postgres_service2
-alembic
 aio_pika
 aioredis
+alembic
 bokeh
 dask-gateway-server[local]
 docker
 respx
 
 # tools
-pylint
-coveralls
 codecov
-ptvsd
+coveralls
+pylint

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-aio_pika==6.8.0
+aio-pika==6.8.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -129,6 +129,8 @@ execnet==1.9.0
     # via pytest-xdist
 faker==9.8.3
     # via -r requirements/_test.in
+flaky==3.7.0
+    # via -r requirements/_test.in
 frozenlist==1.3.0
     # via
     #   -c requirements/_base.txt
@@ -235,8 +237,6 @@ psycopg2-binary==2.9.2
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
-ptvsd==4.3.2
-    # via -r requirements/_test.in
 py==1.11.0
     # via
     #   pytest

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-backports.entry-points-selectable==1.1.1
+backports-entry-points-selectable==1.1.1
     # via virtualenv
 black==21.12b0
     # via -r requirements/../../../requirements/devenv.txt

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -641,6 +641,7 @@ async def test_abort_computation_tasks(
     )
 
 
+@pytest.mark.flaky
 async def test_failed_task_returns_exceptions(
     dask_client: DaskClient,
     user_id: UserID,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

@sanderegg detected in master deploy that many services were never stopped because the new save-state-first policy (that prevents stopping a service until the state data save is granted) would not allow it. 
```log
ERROR: simcore_service_webserver.director_v2_core:stop_service(145) - Exception: forwarded call failed with status 500, reason {'data': {'status': 500, 'message': 'Failed to save state of service 39af424f-803e-4cc9-89d2-11f1b07d8aeb: service sim4life_39af424f-803e-4cc9-89d2-11f1b07d8aeb:80/x/39af424f-803e-4cc9-89d2-11f1b07d8aeb unreachable [Cannot connect to host sim4life_39af424f-803e-4cc9-89d2-11f1b07d8aeb:80 ssl:None [Name or service not known]]'}}
ERROR: simcore_service_webserver.director_v2_core:stop_service(145) - Exception: forwarded call failed with status 500, reason {'data': {'status': 500, 'message': 'Failed to save state of service 2a64b9a4-943f-4965-89af-076f20ea2ba0: service sim4life_2a64b9a4-943f-4965-89af-076f20ea2ba0:80/x/2a64b9a4-943f-4965-89af-076f20ea2ba0 unreachable [Cannot connect to host sim4life_2a64b9a4-943f-4965-89af-076f20ea2ba0:80 ssl:None [Name or service not known]]'}}
ERROR: simcore_service_webserver.director_v2_core:stop_service(145) - Exception: forwarded call failed with status 500, reason {'data': {'status': 500, 'message': 'Failed to save state of service 1316e834-b496-5f57-bdb2-bc44f04d8ea0: service jupyter-base-notebook_1316e834-b496-5f57-bdb2-bc44f04d8ea0:8888/x/1316e834-b496-5f57-bdb2-bc44f04d8ea0 unreachable [Cannot connect to host jupyter-base-notebook_1316e834-b496-5f57-bdb2-bc44f04d8ea0:8888 ssl:None [Name or service not known]]'}}
ERROR: simcore_service_webserver.director_v2_core:stop_service(145) - Exception: forwarded call failed with status 500, reason {'data': {'status': 500, 'message': 'Failed to save state of service 5c5654a6-beba-583c-b517-198c5dee491f: service 3d-viewer-gpu_5c5654a6-beba-583c-b517-198c5dee491f:80 unreachable [Cannot connect to host 3d-viewer-gpu_5c5654a6-beba-583c-b517-198c5dee491f:80 ssl:None [Name or service not known]]'}}
ERROR: simcore_service_webserver.director_v2_core:stop_service(145) - Exception: forwarded call failed with status 500, reason {'data': {'status': 500, 'message': 'Failed to save state of service 83b1fa30-b9e7-5f7d-92b3-d9ccbdc3317b: service jupyter-octave-python-math_83b1fa30-b9e7-5f7d-92b3-d9ccbdc3317b:8888/x/83b1fa30-b9e7-5f7d-92b3-d9ccbdc3317b unreachable [Cannot connect to host jupyter-octave-python-math_83b1fa30-b9e7-5f7d-92b3-d9ccbdc3317b:8888 ssl:None [Name or service not known]]'}}

```

A flaw in this policy is not considering the case in which the service failed to start in the first place, like here
![Image Pasted at 2022-3-11 09-25](https://user-images.githubusercontent.com/32402063/157840041-c63018e6-4cf7-4b0e-9cc2-455d37b3af8c.png)

This scenario can never save a state because the container is not reachable. In that case, we should resume stop and completely remove the service.

In addition, a 502 (not implemented) was also added to the list of responses that interpret that the save functionality is not implemented in the service.

## Related issue/s

- Follow up from fix #2813

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
