### PR TITLE
🐛Fix blocking call in the garbage collector

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -512,8 +512,8 @@ async def get_workbench_node_ids_from_project_uuid(
     project_uuid: str,
 ) -> Set[str]:
     """Returns a set with all the node_ids from a project's workbench"""
-    db = app[APP_PROJECT_DBAPI]
-    return await db.get_all_node_ids_from_workbenches(project_uuid)
+    db: ProjectDBAPI = app[APP_PROJECT_DBAPI]
+    return await db.get_node_ids_from_project(project_uuid)
 
 
 async def is_node_id_present_in_any_project_workbench(
@@ -521,8 +521,8 @@ async def is_node_id_present_in_any_project_workbench(
     node_id: str,
 ) -> bool:
     """If the node_id is presnet in one of the projects' workbenche returns True"""
-    db = app[APP_PROJECT_DBAPI]
-    return node_id in await db.get_all_node_ids_from_workbenches()
+    db: ProjectDBAPI = app[APP_PROJECT_DBAPI]
+    return await db.node_id_exists(node_id)
 
 
 async def notify_project_state_update(

--- a/services/web/server/src/simcore_service_webserver/projects/projects_db.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_db.py
@@ -821,29 +821,14 @@ class ProjectDBAPI:
 
     async def get_node_ids_from_project(self, project_uuid: str) -> Set[str]:
         """Returns a set containing all the node_ids from project with project_uuid"""
-
-        # if project_uuid is None:
-        #     # this can return a tremendous amount of node IDs !!!!
-        #     # TODO: this should be the fix!
-        #     # SELECT *
-        #     # FROM "projects"
-        #     # WHERE workbench ->> '0b6b8423-c9e9-4d4c-9c59-a5eef6508ba5' IS NOT NULL
-        #     # or
-        #     # SELECT *
-        #     # FROM "projects"
-        #     # WHERE CAST("workbench" AS text) LIKE '%0b6b8423-c9e9-4d4c-9c59-a5eef6508ba5%'
-        #     query = "SELECT json_object_keys(projects.workbench) FROM projects"
-        # else:
-        #     query = f"SELECT json_object_keys(projects.workbench) FROM projects WHERE projects.uuid = '{project_uuid}'"
-
         result = set()
         async with self.engine.acquire() as conn:
             async for row in conn.execute(
-                sa.select([func.json_object_keys(projects.c.worbench)]).where(
-                    projects.c.uuid == f"{project_uuid}"
+                sa.DDL(
+                    f"SELECT json_object_keys(projects.workbench) FROM projects WHERE projects.uuid = '{project_uuid}'"
                 )
             ):
-                result.update(set(row.values()))
+                result.update(row.as_tuple())  # type: ignore
         return result
 
     async def list_all_projects_by_uuid_for_user(self, user_id: int) -> List[str]:

--- a/services/web/server/src/simcore_service_webserver/projects/projects_db.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_db.py
@@ -824,9 +824,9 @@ class ProjectDBAPI:
         result = set()
         async with self.engine.acquire() as conn:
             async for row in conn.execute(
-                sa.DDL(
-                    f"SELECT json_object_keys(projects.workbench) FROM projects WHERE projects.uuid = '{project_uuid}'"
-                )
+                sa.select([sa.func.json_object_keys(projects.c.workbench)])
+                .select_from(projects)
+                .where(projects.c.uuid == f"{project_uuid}")
             ):
                 result.update(row.as_tuple())  # type: ignore
         return result

--- a/services/web/server/src/simcore_service_webserver/projects/projects_db.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_db.py
@@ -225,7 +225,7 @@ class ProjectDBAPI:
     async def add_project(
         self,
         prj: Dict[str, Any],
-        user_id: int,
+        user_id: Optional[int],
         *,
         force_project_uuid: bool = False,
         force_as_template: bool = False,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/

and append (⚠️ devops) if changes in devops configuration required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

This PR optimizes a call to the database used by the **G**arbage **C**ollector that is asking:
- for all running services, find the one that are not in the database

To this end it was calling a SQL that would return all the nodeID in all the projects in the table. In master alone this would return >7000 entries. Times the number of running services.
Then this would be passed into a python Set, which is a blocking call twice.

This PR adds a function ```node_id_exists``` that runs a pSQL call that checks in the workbench field whether a specific nodeID exists. The computation happens on the postgres server and returns a yes/no type entry.

```BEFORE: 4.5s to call on about >1000 projects with 23-1434 nodes each```
```AFTER: 0.87s```




Bonus: 2 new tests

## Related issue/s
fixes #2399 
<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
