### PR TITLE
♻️ Maintenance: refactors guest user and save-state logic to improve flaky tests

### DIFF
--- a/packages/models-library/src/models_library/projects.py
+++ b/packages/models-library/src/models_library/projects.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from pydantic import BaseModel, EmailStr, Extra, Field, HttpUrl, constr, validator
 
 from .basic_regex import DATE_RE, UUID_RE
-from .projects_access import AccessRights, GroupID
+from .projects_access import AccessRights, GroupIDStr
 from .projects_nodes import Node
 from .projects_nodes_io import NodeIDStr
 from .projects_state import ProjectState
@@ -121,7 +121,7 @@ class Project(BaseProjectModel):
         examples=["2018-07-01T11:13:43Z"],
         alias="lastChangeDate",
     )
-    access_rights: Dict[GroupID, AccessRights] = Field(
+    access_rights: Dict[GroupIDStr, AccessRights] = Field(
         ...,
         description="object containing the GroupID as key and read/write/execution permissions as value",
         alias="accessRights",

--- a/packages/models-library/src/models_library/projects_access.py
+++ b/packages/models-library/src/models_library/projects_access.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pydantic import BaseModel, Extra, Field, constr
 from pydantic.types import PositiveInt
 
-GroupID = constr(regex=r"^\S+$")
+GroupIDStr = constr(regex=r"^\S+$")
 
 
 class AccessEnum(str, Enum):

--- a/packages/postgres-database/src/simcore_postgres_database/models/users.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/users.py
@@ -45,12 +45,14 @@ class UserRole(Enum):
     TESTER = "TESTER"
     ADMIN = "ADMIN"
 
-    def as_level(self) -> int:
+    @property
+    def privilege_level(self) -> int:
         return _USER_ROLE_TO_LEVEL[self.name]
 
-    def __lt__(self, other):
+    def __lt__(self, other) -> bool:
         if self.__class__ is other.__class__:
-            return self.as_level() < other.as_level()
+            return self.privilege_level < other.privilege_level
+        return NotImplemented
 
 
 class UserStatus(Enum):

--- a/packages/postgres-database/src/simcore_postgres_database/models/users.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/users.py
@@ -36,10 +36,6 @@ class UserRole(Enum):
     TESTER = "TESTER"
     ADMIN = "ADMIN"
 
-    @classmethod
-    def super_users(cls):
-        return list(itertools.takewhile(lambda e: e != cls.USER, cls))
-
     # TODO: add comparison https://portingguide.readthedocs.io/en/latest/comparisons.html
 
 

--- a/packages/postgres-database/src/simcore_postgres_database/models/users.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/users.py
@@ -4,15 +4,24 @@
     - Users they have a role within the framework that provides
     them different access levels to it
 """
-import itertools
 from enum import Enum
+from functools import total_ordering
 
 import sqlalchemy as sa
 from sqlalchemy.sql import func
 
 from .base import metadata
 
+_USER_ROLE_TO_LEVEL = {
+    "ANONYMOUS": 0,
+    "GUEST": 10,
+    "USER": 20,
+    "TESTER": 30,
+    "ADMIN": 100,
+}
 
+
+@total_ordering
 class UserRole(Enum):
     """SORTED enumeration of user roles
 
@@ -36,7 +45,12 @@ class UserRole(Enum):
     TESTER = "TESTER"
     ADMIN = "ADMIN"
 
-    # TODO: add comparison https://portingguide.readthedocs.io/en/latest/comparisons.html
+    def as_level(self) -> int:
+        return _USER_ROLE_TO_LEVEL[self.name]
+
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.as_level() < other.as_level()
 
 
 class UserStatus(Enum):

--- a/packages/postgres-database/tests/test_users.py
+++ b/packages/postgres-database/tests/test_users.py
@@ -1,0 +1,50 @@
+from simcore_postgres_database.models.users import _USER_ROLE_TO_LEVEL, UserRole
+
+
+def test_user_role_to_level_map_in_sync():
+    # If fails, then update _USER_ROLE_TO_LEVEL map
+    assert set(_USER_ROLE_TO_LEVEL.keys()) == set(UserRole.__members__.keys())
+
+
+def test_user_role_comparison():
+
+    assert UserRole.ANONYMOUS < UserRole.ADMIN
+    assert UserRole.GUEST < UserRole.ADMIN
+    assert UserRole.USER < UserRole.ADMIN
+    assert UserRole.TESTER < UserRole.ADMIN
+    assert UserRole.ADMIN == UserRole.ADMIN
+
+    assert UserRole.ANONYMOUS < UserRole.TESTER
+    assert UserRole.GUEST < UserRole.TESTER
+    assert UserRole.USER < UserRole.TESTER
+    assert UserRole.TESTER == UserRole.TESTER
+    assert UserRole.ADMIN > UserRole.TESTER
+
+    assert UserRole.ANONYMOUS < UserRole.USER
+    assert UserRole.GUEST < UserRole.USER
+    assert UserRole.USER == UserRole.USER
+    assert UserRole.TESTER > UserRole.USER
+    assert UserRole.ADMIN > UserRole.USER
+
+    assert UserRole.ANONYMOUS < UserRole.GUEST
+    assert UserRole.GUEST == UserRole.GUEST
+    assert UserRole.USER > UserRole.GUEST
+    assert UserRole.TESTER > UserRole.GUEST
+    assert UserRole.ADMIN > UserRole.GUEST
+
+    assert UserRole.ANONYMOUS == UserRole.ANONYMOUS
+    assert UserRole.GUEST > UserRole.ANONYMOUS
+    assert UserRole.USER > UserRole.ANONYMOUS
+    assert UserRole.TESTER > UserRole.ANONYMOUS
+    assert UserRole.ADMIN > UserRole.ANONYMOUS
+
+    # < and >
+    assert UserRole.TESTER < UserRole.ADMIN
+    assert UserRole.ADMIN > UserRole.TESTER
+
+    # >=, == and <=
+    assert UserRole.TESTER <= UserRole.ADMIN
+    assert UserRole.ADMIN >= UserRole.TESTER
+
+    assert UserRole.ADMIN <= UserRole.ADMIN
+    assert UserRole.ADMIN == UserRole.ADMIN

--- a/services/web/server/src/simcore_service_webserver/catalog_client.py
+++ b/services/web/server/src/simcore_service_webserver/catalog_client.py
@@ -4,7 +4,7 @@
 import asyncio
 import logging
 import urllib.parse
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from aiohttp import ClientSession, ClientTimeout, web
 from aiohttp.client_exceptions import (
@@ -60,7 +60,7 @@ async def make_request_and_envelope_response(
     app: web.Application,
     method: str,
     url: URL,
-    headers: Optional[Dict[str, str]] = None,
+    headers: Optional[Mapping[str, str]] = None,
     data: Optional[bytes] = None,
 ) -> web.Response:
     """

--- a/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
@@ -429,10 +429,6 @@ async def remove_guest_user_with_all_its_resources(
 
     try:
         user_role: Optional[UserRole] = await get_user_role(app, user_id)
-        assert (  # nosec
-            user_role is None
-        ), "Should have never been called w/o registered user"
-
         if user_role is None or user_role > UserRole.GUEST:
             # NOTE: This acts as a protection barrier to avoid removing resources to more
             # priviledge users

--- a/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
@@ -12,6 +12,7 @@ from aiopg.sa.result import RowProxy
 from aioredlock import Aioredlock
 from servicelib.utils import logged_gather
 from simcore_postgres_database.errors import DatabaseError
+from simcore_postgres_database.models.users import UserRole
 
 from . import director_v2_api, users_exceptions
 from .db_models import GroupType
@@ -34,8 +35,9 @@ from .users_api import (
     get_guest_user_ids_and_names,
     get_user,
     get_user_id_from_gid,
-    is_user_guest,
+    get_user_role,
 )
+from .users_exceptions import UserNotFoundError
 from .users_to_groups_api import get_users_for_gid
 
 _DATABASE_ERRORS = (
@@ -349,12 +351,21 @@ async def _remove_single_orphaned_service(
             # let's be conservative here.
             # 1. opened project disappeared from redis?
             # 2. something bad happened when closing a project?
-            user_id = int(interactive_service.get("user_id", -1))
-            is_invalid_user_id = user_id <= 0
-            save_state = True
 
-            if is_invalid_user_id or await is_user_guest(app, user_id):
+            # TODO: logic around save_state is not ideal, but it remains
+            # with the same logic as before until it is properly refactored
+            user_role: Optional[UserRole]
+            try:
+                user_role = await get_user_role(
+                    app, user_id=int(interactive_service.get("user_id", -1))
+                )
+            except UserNotFoundError:
+                user_role = None
+
+            save_state = True
+            if user_role is None or user_role <= UserRole.GUEST:
                 save_state = False
+            # -------------------------------------------
 
             await director_v2_api.stop_service(app, service_uuid, save_state)
 
@@ -423,7 +434,14 @@ async def remove_guest_user_with_all_its_resources(
     """Removes a GUEST user with all its associated projects and S3/MinIO files"""
 
     try:
-        if not await is_user_guest(app, user_id):
+        user_role: Optional[UserRole] = await get_user_role(app, user_id)
+        assert (  # nosec
+            user_role is None
+        ), "Should have never been called w/o registered user"
+
+        if user_role is None or user_role > UserRole.GUEST:
+            # NOTE: This acts as a protection barrier to avoid removing resources to more
+            # priviledge users
             return
 
         logger.debug(

--- a/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
@@ -423,8 +423,8 @@ async def remove_guest_user_with_all_its_resources(
     """Removes a GUEST user with all its associated projects and S3/MinIO files"""
 
     try:
-        user_role: Optional[UserRole] = await get_user_role(app, user_id)
-        if user_role is None or user_role > UserRole.GUEST:
+        user_role: UserRole = await get_user_role(app, user_id)
+        if user_role > UserRole.GUEST:
             # NOTE: This acts as a protection barrier to avoid removing resources to more
             # priviledge users
             return

--- a/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
@@ -8,17 +8,19 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 import asyncpg.exceptions
 from aiohttp import web
-from aiopg.sa.result import RowProxy
 from aioredlock import Aioredlock
 from servicelib.utils import logged_gather
 from simcore_postgres_database.errors import DatabaseError
 from simcore_postgres_database.models.users import UserRole
 
 from . import director_v2_api, users_exceptions
-from .db_models import GroupType
 from .director.director_exceptions import DirectorException, ServiceNotFoundError
 from .garbage_collector_settings import GUEST_USER_RC_LOCK_FORMAT
-from .groups_api import get_group_from_gid
+from .garbage_collector_utils import (
+    get_new_project_owner_gid,
+    remove_user,
+    replace_current_owner,
+)
 from .projects.projects_api import (
     delete_project,
     get_project_for_user,
@@ -26,19 +28,12 @@ from .projects.projects_api import (
     is_node_id_present_in_any_project_workbench,
     remove_project_interactive_services,
 )
-from .projects.projects_db import APP_PROJECT_DBAPI, ProjectAccessRights
+from .projects.projects_db import APP_PROJECT_DBAPI
 from .projects.projects_exceptions import ProjectNotFoundError
 from .redis import get_redis_lock_manager
 from .resource_manager.registry import RedisResourceRegistry, get_registry
-from .users_api import (
-    delete_user,
-    get_guest_user_ids_and_names,
-    get_user,
-    get_user_id_from_gid,
-    get_user_role,
-)
+from .users_api import get_guest_user_ids_and_names, get_user, get_user_role
 from .users_exceptions import UserNotFoundError
-from .users_to_groups_api import get_users_for_gid
 
 logger = logging.getLogger(__name__)
 
@@ -556,173 +551,3 @@ async def remove_all_projects_for_user(app: web.Application, user_id: int) -> No
                 new_project_owner_gid=new_project_owner_gid,
                 project=project,
             )
-
-
-async def get_new_project_owner_gid(
-    app: web.Application,
-    project_uuid: str,
-    user_id: int,
-    user_primary_gid: int,
-    project: Dict,
-) -> Optional[int]:
-    """Goes through the access rights and tries to find a new suitable owner.
-    The first viable user is selected as a new owner.
-    In order to become a new owner the user must have write access right.
-    """
-
-    access_rights = project["accessRights"]
-    # A Set[str] is prefered over Set[int] because access_writes
-    # is a Dict with only key,valus in {str, None}
-    other_users_access_rights: Set[str] = set(access_rights.keys()) - {
-        str(user_primary_gid)
-    }
-    logger.debug(
-        "Processing other user and groups access rights '%s'",
-        other_users_access_rights,
-    )
-
-    # Selecting a new project owner
-    # divide permissions between types of groups
-    standard_groups = {}  # groups of users, multiple users can be part of this
-    primary_groups = {}  # each individual user has a unique primary group
-    for other_gid in other_users_access_rights:
-        group: Optional[RowProxy] = await get_group_from_gid(
-            app=app, gid=int(other_gid)
-        )
-
-        # only process for users and groups with write access right
-        if group is None:
-            continue
-        if access_rights[other_gid]["write"] is not True:
-            continue
-
-        if group.type == GroupType.STANDARD:
-            standard_groups[other_gid] = access_rights[other_gid]
-        elif group.type == GroupType.PRIMARY:
-            primary_groups[other_gid] = access_rights[other_gid]
-
-    logger.debug(
-        "Possible new owner groups: standard='%s', primary='%s'",
-        standard_groups,
-        primary_groups,
-    )
-
-    new_project_owner_gid = None
-    # the primary group contains the users which which the project was directly shared
-    if len(primary_groups) > 0:
-        # fetch directly from the direct users with which the project is shared with
-        new_project_owner_gid = int(list(primary_groups.keys())[0])
-    # fallback to the groups search if the user does not exist
-    if len(standard_groups) > 0 and new_project_owner_gid is None:
-        new_project_owner_gid = await fetch_new_project_owner_from_groups(
-            app=app,
-            standard_groups=standard_groups,
-            user_id=user_id,
-        )
-
-    logger.info(
-        "Will move project '%s' to user with gid '%s', if user exists",
-        project_uuid,
-        new_project_owner_gid,
-    )
-
-    return new_project_owner_gid
-
-
-async def fetch_new_project_owner_from_groups(
-    app: web.Application, standard_groups: Dict, user_id: int
-) -> Optional[int]:
-    """Iterate over all the users in a group and if the users exists in the db
-    return its gid"""
-
-    # fetch all users in the group and then get their gid to put in here
-    # go through user_to_groups table and fetch all uid for matching gid
-    for group_gid in standard_groups.keys():
-        # remove the current owner from the bunch
-        target_group_users = await get_users_for_gid(app=app, gid=group_gid) - {user_id}
-        logger.error("Found group users '%s'", target_group_users)
-
-        for possible_user_id in target_group_users:
-            # check if the possible_user is still present in the db
-            try:
-                possible_user = await get_user(app=app, user_id=possible_user_id)
-                return int(possible_user["primary_gid"])
-            except users_exceptions.UserNotFoundError:
-                logger.warning(
-                    "Could not find new owner '%s' will try a new one",
-                    possible_user_id,
-                )
-
-        return None
-
-
-async def replace_current_owner(
-    app: web.Application,
-    project_uuid: str,
-    user_primary_gid: int,
-    new_project_owner_gid: int,
-    project: Dict,
-) -> None:
-    try:
-        new_project_owner_id = await get_user_id_from_gid(
-            app=app, primary_gid=new_project_owner_gid
-        )
-
-    except (
-        DatabaseError,
-        asyncpg.exceptions.PostgresError,
-        ProjectNotFoundError,
-        UserNotFoundError,
-    ):
-        logger.exception(
-            "Could not recover new user id from gid %s", new_project_owner_gid
-        )
-        return
-
-    # the result might me none
-    if new_project_owner_id is None:
-        logger.warning(
-            "Could not recover a new user id from gid %s", new_project_owner_gid
-        )
-        return
-
-    # unseting the project owner and saving the project back
-    project["prj_owner"] = int(new_project_owner_id)
-    # removing access rights entry
-    del project["accessRights"][str(user_primary_gid)]
-    project["accessRights"][
-        str(new_project_owner_gid)
-    ] = ProjectAccessRights.OWNER.value
-    logger.error("Syncing back project %s", project)
-
-    # syncing back project data
-    try:
-        await app[APP_PROJECT_DBAPI].update_project_without_checking_permissions(
-            project_data=project,
-            project_uuid=project_uuid,
-        )
-    except (
-        DatabaseError,
-        asyncpg.exceptions.PostgresError,
-        ProjectNotFoundError,
-        UserNotFoundError,
-    ):
-        logger.exception(
-            "Could not remove old owner and replaced it with user %s",
-            new_project_owner_id,
-        )
-
-
-async def remove_user(app: web.Application, user_id: int) -> None:
-    """Tries to remove a user, if the users still exists a warning message will be displayed"""
-    try:
-        await delete_user(app, user_id)
-    except (
-        DatabaseError,
-        asyncpg.exceptions.PostgresError,
-        ProjectNotFoundError,
-        UserNotFoundError,
-    ) as err:
-        logger.warning(
-            "User '%s' still has some projects, could not be deleted [%s]", user_id, err
-        )

--- a/services/web/server/src/simcore_service_webserver/garbage_collector_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_utils.py
@@ -49,7 +49,7 @@ async def fetch_new_project_owner_from_groups(
 async def get_new_project_owner_gid(
     app: web.Application,
     project_uuid: str,
-    user_id: int,
+    user_id: UserID,
     user_primary_gid: int,
     project: Dict,
 ) -> Optional[int]:

--- a/services/web/server/src/simcore_service_webserver/garbage_collector_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_utils.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 async def fetch_new_project_owner_from_groups(
     app: web.Application, standard_groups: Dict, user_id: int
-) -> Optional[int]:
+) -> Optional[UserID]:
     """Iterate over all the users in a group and if the users exists in the db
     return its gid
     """

--- a/services/web/server/src/simcore_service_webserver/garbage_collector_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_utils.py
@@ -1,0 +1,189 @@
+import logging
+from typing import Dict, Optional, Set
+
+import asyncpg.exceptions
+from aiohttp import web
+from aiopg.sa.result import RowProxy
+from simcore_postgres_database.errors import DatabaseError
+
+from . import users_exceptions
+from .db_models import GroupType
+from .groups_api import get_group_from_gid
+from .projects.projects_db import APP_PROJECT_DBAPI, ProjectAccessRights
+from .projects.projects_exceptions import ProjectNotFoundError
+from .users_api import delete_user, get_user, get_user_id_from_gid
+from .users_exceptions import UserNotFoundError
+from .users_to_groups_api import get_users_for_gid
+
+logger = logging.getLogger(__name__)
+
+
+async def fetch_new_project_owner_from_groups(
+    app: web.Application, standard_groups: Dict, user_id: int
+) -> Optional[int]:
+    """Iterate over all the users in a group and if the users exists in the db
+    return its gid
+    """
+
+    # fetch all users in the group and then get their gid to put in here
+    # go through user_to_groups table and fetch all uid for matching gid
+    for group_gid in standard_groups.keys():
+        # remove the current owner from the bunch
+        target_group_users = await get_users_for_gid(app=app, gid=group_gid) - {user_id}
+        logger.error("Found group users '%s'", target_group_users)
+
+        for possible_user_id in target_group_users:
+            # check if the possible_user is still present in the db
+            try:
+                possible_user = await get_user(app=app, user_id=possible_user_id)
+                return int(possible_user["primary_gid"])
+            except users_exceptions.UserNotFoundError:
+                logger.warning(
+                    "Could not find new owner '%s' will try a new one",
+                    possible_user_id,
+                )
+
+        return None
+
+
+async def get_new_project_owner_gid(
+    app: web.Application,
+    project_uuid: str,
+    user_id: int,
+    user_primary_gid: int,
+    project: Dict,
+) -> Optional[int]:
+    """Goes through the access rights and tries to find a new suitable owner.
+    The first viable user is selected as a new owner.
+    In order to become a new owner the user must have write access right.
+    """
+
+    access_rights = project["accessRights"]
+    # A Set[str] is prefered over Set[int] because access_writes
+    # is a Dict with only key,valus in {str, None}
+    other_users_access_rights: Set[str] = set(access_rights.keys()) - {
+        str(user_primary_gid)
+    }
+    logger.debug(
+        "Processing other user and groups access rights '%s'",
+        other_users_access_rights,
+    )
+
+    # Selecting a new project owner
+    # divide permissions between types of groups
+    standard_groups = {}  # groups of users, multiple users can be part of this
+    primary_groups = {}  # each individual user has a unique primary group
+    for other_gid in other_users_access_rights:
+        group: Optional[RowProxy] = await get_group_from_gid(
+            app=app, gid=int(other_gid)
+        )
+
+        # only process for users and groups with write access right
+        if group is None:
+            continue
+        if access_rights[other_gid]["write"] is not True:
+            continue
+
+        if group.type == GroupType.STANDARD:
+            standard_groups[other_gid] = access_rights[other_gid]
+        elif group.type == GroupType.PRIMARY:
+            primary_groups[other_gid] = access_rights[other_gid]
+
+    logger.debug(
+        "Possible new owner groups: standard='%s', primary='%s'",
+        standard_groups,
+        primary_groups,
+    )
+
+    new_project_owner_gid = None
+    # the primary group contains the users which which the project was directly shared
+    if len(primary_groups) > 0:
+        # fetch directly from the direct users with which the project is shared with
+        new_project_owner_gid = int(list(primary_groups.keys())[0])
+    # fallback to the groups search if the user does not exist
+    if len(standard_groups) > 0 and new_project_owner_gid is None:
+        new_project_owner_gid = await fetch_new_project_owner_from_groups(
+            app=app,
+            standard_groups=standard_groups,
+            user_id=user_id,
+        )
+
+    logger.info(
+        "Will move project '%s' to user with gid '%s', if user exists",
+        project_uuid,
+        new_project_owner_gid,
+    )
+
+    return new_project_owner_gid
+
+
+async def replace_current_owner(
+    app: web.Application,
+    project_uuid: str,
+    user_primary_gid: int,
+    new_project_owner_gid: int,
+    project: Dict,
+) -> None:
+    try:
+        new_project_owner_id = await get_user_id_from_gid(
+            app=app, primary_gid=new_project_owner_gid
+        )
+
+    except (
+        DatabaseError,
+        asyncpg.exceptions.PostgresError,
+        ProjectNotFoundError,
+        UserNotFoundError,
+    ):
+        logger.exception(
+            "Could not recover new user id from gid %s", new_project_owner_gid
+        )
+        return
+
+    # the result might me none
+    if new_project_owner_id is None:
+        logger.warning(
+            "Could not recover a new user id from gid %s", new_project_owner_gid
+        )
+        return
+
+    # unseting the project owner and saving the project back
+    project["prj_owner"] = int(new_project_owner_id)
+    # removing access rights entry
+    del project["accessRights"][str(user_primary_gid)]
+    project["accessRights"][
+        str(new_project_owner_gid)
+    ] = ProjectAccessRights.OWNER.value
+    logger.error("Syncing back project %s", project)
+
+    # syncing back project data
+    try:
+        await app[APP_PROJECT_DBAPI].update_project_without_checking_permissions(
+            project_data=project,
+            project_uuid=project_uuid,
+        )
+    except (
+        DatabaseError,
+        asyncpg.exceptions.PostgresError,
+        ProjectNotFoundError,
+        UserNotFoundError,
+    ):
+        logger.exception(
+            "Could not remove old owner and replaced it with user %s",
+            new_project_owner_id,
+        )
+
+
+async def remove_user(app: web.Application, user_id: int) -> None:
+    """Tries to remove a user, if the users still exists a warning message will be displayed"""
+    try:
+        await delete_user(app, user_id)
+    except (
+        DatabaseError,
+        asyncpg.exceptions.PostgresError,
+        ProjectNotFoundError,
+        UserNotFoundError,
+    ) as err:
+        logger.warning(
+            "User '%s' still has some projects, could not be deleted [%s]", user_id, err
+        )

--- a/services/web/server/src/simcore_service_webserver/garbage_collector_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_utils.py
@@ -50,7 +50,7 @@ async def get_new_project_owner_gid(
     app: web.Application,
     project_uuid: str,
     user_id: UserID,
-    user_primary_gid: int,
+    user_primary_gid: GroupID,
     project: Dict,
 ) -> Optional[int]:
     """Goes through the access rights and tries to find a new suitable owner.

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -284,6 +284,11 @@ async def remove_project_interactive_services(
     notify_users: bool = True,
     user_name: Optional[UserNameDict] = None,
 ) -> None:
+    """
+
+    :raises UserNotFoundError:
+    """
+
     # NOTE: during the closing process, which might take awhile,
     # the project is locked so no one opens it at the same time
     log.debug(
@@ -296,7 +301,7 @@ async def remove_project_interactive_services(
 
         # TODO: logic around save_state is not ideal, but it remains with the same logic
         # as before until it is properly refactored
-        user_role: Optional[UserRole]
+        user_role: Optional[UserRole] = None
         try:
             user_role = await get_user_role(app, user_id)
         except UserNotFoundError:

--- a/services/web/server/src/simcore_service_webserver/security_api.py
+++ b/services/web/server/src/simcore_service_webserver/security_api.py
@@ -37,7 +37,7 @@ async def check_credentials(engine: Engine, email: str, password: str) -> bool:
 
 
 def encrypt_password(password: str) -> str:
-    return passlib.hash.sha256_crypt.encrypt(password, rounds=1000)
+    return passlib.hash.sha256_crypt.hash(password, rounds=1000)
 
 
 def check_password(password: str, password_hash: str) -> bool:

--- a/services/web/server/src/simcore_service_webserver/users_api.py
+++ b/services/web/server/src/simcore_service_webserver/users_api.py
@@ -12,6 +12,7 @@ import sqlalchemy as sa
 from aiohttp import web
 from aiopg.sa.engine import Engine
 from aiopg.sa.result import RowProxy
+from models_library.users import UserID
 from servicelib.aiohttp.application_keys import APP_DB_ENGINE_KEY
 from simcore_postgres_database.models.users import UserRole
 from sqlalchemy import and_, literal_column

--- a/services/web/server/src/simcore_service_webserver/users_api.py
+++ b/services/web/server/src/simcore_service_webserver/users_api.py
@@ -42,7 +42,7 @@ def _parse_as_user(user_id: Any) -> int:
 # USERS  API ----------------------------------------------------------------------------
 
 
-async def get_user_profile(app: web.Application, user_id: int) -> Dict[str, Any]:
+async def get_user_profile(app: web.Application, user_id: UserID) -> Dict[str, Any]:
     """
     :raises UserNotFoundError:
     """

--- a/services/web/server/src/simcore_service_webserver/users_api.py
+++ b/services/web/server/src/simcore_service_webserver/users_api.py
@@ -133,7 +133,7 @@ async def update_user_profile(
         assert resp.rowcount == 1  # nosec
 
 
-async def get_user_role(app: web.Application, user_id: int) -> UserRole:
+async def get_user_role(app: web.Application, user_id: UserID) -> UserRole:
     """
     :raises UserNotFoundError:
     """

--- a/services/web/server/src/simcore_service_webserver/users_api.py
+++ b/services/web/server/src/simcore_service_webserver/users_api.py
@@ -26,7 +26,7 @@ from .users_utils import convert_user_db_to_schema
 logger = logging.getLogger(__name__)
 
 
-def _parse_as_user(user_id: Any) -> int:
+def _parse_as_user(user_id: Any) -> UserID:
     # analogous to pydantic.parse_obj_as(PositiveInt, user_id) but lighter and
     # raise UserNotFoundError instead of ValidationError
     try:

--- a/services/web/server/tests/conftest.py
+++ b/services/web/server/tests/conftest.py
@@ -12,7 +12,7 @@ from uuid import UUID
 import pytest
 import simcore_service_webserver
 from _pytest.monkeypatch import MonkeyPatch
-from pytest_simcore.helpers.utils_login import AUserDict, LoggedUser
+from pytest_simcore.helpers.utils_login import LoggedUser, UserInfoDict
 from servicelib.json_serialization import json_dumps
 from simcore_service_webserver.application_settings_utils import convert_to_environ_vars
 from simcore_service_webserver.db_models import UserRole
@@ -97,7 +97,7 @@ def fake_project(tests_data_dir: Path) -> ProjectDict:
 
 
 @pytest.fixture()
-async def logged_user(client, user_role: UserRole) -> AsyncIterator[AUserDict]:
+async def logged_user(client, user_role: UserRole) -> AsyncIterator[UserInfoDict]:
     """adds a user in db and logs in with client
 
     NOTE: `user_role` fixture is defined as a parametrization below!!!

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -17,7 +17,7 @@ import pytest
 from aiohttp.test_utils import TestClient
 from aioresponses import aioresponses
 from models_library.projects_state import RunningState
-from pytest_simcore.helpers.utils_login import AUserDict, log_client_in
+from pytest_simcore.helpers.utils_login import UserInfoDict, log_client_in
 from pytest_simcore.helpers.utils_projects import create_project, empty_project_data
 from servicelib.aiohttp.application import create_safe_application
 from settings_library.redis import RedisSettings
@@ -181,7 +181,7 @@ async def login_guest_user(client: TestClient):
 
 async def new_project(
     client: TestClient,
-    user: AUserDict,
+    user: UserInfoDict,
     tests_data_dir: Path,
     access_rights: Optional[Dict[str, Any]] = None,
 ):
@@ -200,7 +200,7 @@ async def new_project(
 
 async def get_template_project(
     client: TestClient,
-    user: AUserDict,
+    user: UserInfoDict,
     project_data: ProjectDict,
     access_rights=None,
 ):

--- a/services/web/server/tests/integration/conftest.py
+++ b/services/web/server/tests/integration/conftest.py
@@ -27,7 +27,7 @@ from pytest_mock import MockerFixture
 from pytest_simcore.helpers import FIXTURE_CONFIG_CORE_SERVICES_SELECTION
 from pytest_simcore.helpers.utils_dict import ConfigDict
 from pytest_simcore.helpers.utils_docker import get_service_published_port
-from pytest_simcore.helpers.utils_login import AUserDict, NewUser
+from pytest_simcore.helpers.utils_login import NewUser, UserInfoDict
 from simcore_service_webserver.groups_api import (
     add_user_in_group,
     create_user_group,
@@ -176,14 +176,14 @@ def mock_orphaned_services(mocker: MockerFixture) -> mock.Mock:
 
 
 @pytest.fixture
-async def primary_group(client, logged_user: AUserDict) -> Dict[str, str]:
+async def primary_group(client, logged_user: UserInfoDict) -> Dict[str, str]:
     primary_group, _, _ = await list_user_groups(client.app, logged_user["id"])
     return primary_group
 
 
 @pytest.fixture
 async def standard_groups(
-    client, logged_user: AUserDict
+    client, logged_user: UserInfoDict
 ) -> AsyncIterable[List[Dict[str, str]]]:
     # create a separate admin account to create some standard groups for the logged user
     sparc_group = {

--- a/services/web/server/tests/unit/isolated/test_security_access_model.py
+++ b/services/web/server/tests/unit/isolated/test_security_access_model.py
@@ -85,13 +85,6 @@ def access_model() -> RoleBasedAccessModel:
 # TESTS -------------------------------------------------------------------------
 
 
-def test_roles():
-    super_users = UserRole.super_users()
-    assert super_users
-    assert UserRole.USER not in super_users
-    assert all(r in UserRole for r in super_users)
-
-
 def test_unique_permissions():
     # Limit for scalability. Test that unnecessary resources and/or actions are used
     # Enforce reusable permission layouts

--- a/services/web/server/tests/unit/with_dbs/01/test_studies_dispatcher_studies_access.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_studies_dispatcher_studies_access.py
@@ -27,7 +27,7 @@ from servicelib.aiohttp.rest_responses import unwrap_envelope
 from simcore_service_webserver import catalog
 from simcore_service_webserver.log import setup_logging
 from simcore_service_webserver.projects.projects_api import delete_project
-from simcore_service_webserver.users_api import delete_user, is_user_guest
+from simcore_service_webserver.users_api import delete_user, get_user_role
 from yarl import URL
 
 SHARED_STUDY_UUID = "e2e38eee-c569-4e55-b104-70d159e49c87"
@@ -351,14 +351,14 @@ async def test_access_cookie_of_expired_user(
     resp = await client.get(me_url)
 
     data, _ = await assert_status(resp, web.HTTPOk)
-    assert await is_user_guest(app, data["id"])
+    assert await get_user_role(app, data["id"]) == UserRole.GUEST
 
     async def enforce_garbage_collect_guest(uid):
         # Emulates garbage collector:
         #   - GUEST user expired, cleaning it up
         #   - client still holds cookie with its identifier nonetheless
         #
-        assert await is_user_guest(app, uid)
+        assert await get_user_role(app, uid) == UserRole.GUEST
         projects = await _get_user_projects(client)
         assert len(projects) == 1
 
@@ -381,7 +381,7 @@ async def test_access_cookie_of_expired_user(
     # as a guest user
     resp = await client.get(me_url)
     data, _ = await assert_status(resp, web.HTTPOk)
-    assert await is_user_guest(app, data["id"])
+    assert await get_user_role(app, data["id"]) == UserRole.GUEST
 
     # But I am another user
     assert data["id"] != user_id

--- a/services/web/server/tests/unit/with_dbs/03/meta_modeling/test_meta_modeling_iterations.py
+++ b/services/web/server/tests/unit/with_dbs/03/meta_modeling/test_meta_modeling_iterations.py
@@ -10,7 +10,7 @@ from aiohttp.test_utils import TestClient
 from faker import Faker
 from models_library.projects import Project
 from pytest_simcore.helpers.utils_assert import assert_status
-from pytest_simcore.helpers.utils_login import AUserDict
+from pytest_simcore.helpers.utils_login import UserInfoDict
 from pytest_simcore.simcore_webserver_projects_rest_api import (
     NEW_PROJECT,
     REPLACE_PROJECT_ON_MODIFIED,
@@ -42,7 +42,7 @@ REQUEST_MODEL_POLICY = {
 
 
 @pytest.fixture
-async def context_with_logged_user(client: TestClient, logged_user: AUserDict):
+async def context_with_logged_user(client: TestClient, logged_user: UserInfoDict):
 
     yield
 

--- a/services/web/server/tests/unit/with_dbs/03/version_control/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/03/version_control/conftest.py
@@ -15,7 +15,7 @@ from faker import Faker
 from models_library.projects import ProjectID
 from models_library.users import UserID
 from pytest_simcore.helpers.rawdata_fakers import random_project
-from pytest_simcore.helpers.utils_login import AUserDict
+from pytest_simcore.helpers.utils_login import UserInfoDict
 from pytest_simcore.helpers.utils_projects import NewProject
 from simcore_postgres_database.models.projects_version_control import (
     projects_vc_repos,
@@ -132,7 +132,7 @@ def app_cfg(
 
 
 @pytest.fixture
-async def user_id(logged_user: AUserDict) -> UserID:
+async def user_id(logged_user: UserInfoDict) -> UserID:
     return logged_user["id"]
 
 
@@ -164,7 +164,7 @@ async def user_project(
 
 @pytest.fixture
 def do_update_user_project(
-    logged_user: AUserDict, client: TestClient, faker: Faker
+    logged_user: UserInfoDict, client: TestClient, faker: Faker
 ) -> Callable[[UUID], Awaitable]:
     async def _doit(project_uuid: UUID) -> None:
         resp: aiohttp.ClientResponse = await client.get(f"{VX}/projects/{project_uuid}")
@@ -191,7 +191,7 @@ def do_update_user_project(
 
 @pytest.fixture
 def do_delete_user_project(
-    logged_user: AUserDict, client: TestClient, mocker
+    logged_user: UserInfoDict, client: TestClient, mocker
 ) -> Callable[[UUID], Awaitable]:
     mocker.patch(
         "simcore_service_webserver.projects.projects_api.director_v2_api.delete_pipeline",


### PR DESCRIPTION
- ✨ adds ``UserRole`` comparison operators
- 🔥 rm ``users_api.is_guest_user`` and creates instead ``users_api.get_user_role``
- ♻️ ``save_state`` flag logic: Using ``UserRole`` comparison instead of ``is_guest_user`` to check whether the state shall be saved or not.
- ♻️ cleanup ``pytest_simcore.helpers.utils_login`` by adding ``TypedDict`` to datastructures
- ♻️ splits gc-core module in two: codeclimate error ``garbage_collector_core.py has 508 lines of code (exceeds 500)``
- 🗑️  Updates to fix ``DeprecationWarning: the method passlib.handlers.sha2_crypt.sha256_crypt.encrypt() is deprecated as of Passlib 1.7, and will be removed in Passlib 2.0, use .hash() instead.``

## Related issue/s

This PR is a part split from #2867 which will be closed w/o merge.


## How to test

Refactoring supported by tests in web-server and simcore_postgres_database packages