### PR TITLE
✨ Enhancement/provide default cluster info

### DIFF
--- a/packages/models-library/src/models_library/clusters.py
+++ b/packages/models-library/src/models_library/clusters.py
@@ -1,4 +1,4 @@
-from typing import Dict, Literal, Optional, Union
+from typing import Dict, Final, Literal, Optional, Union
 
 from pydantic import AnyUrl, BaseModel, Extra, Field, HttpUrl, SecretStr, root_validator
 from pydantic.types import NonNegativeInt
@@ -107,16 +107,17 @@ class BaseCluster(BaseModel):
 
 
 ClusterID = NonNegativeInt
+DEFAULT_CLUSTER_ID: Final[NonNegativeInt] = 0
 
 
 class Cluster(BaseCluster):
-    id: Union[ClusterID, Literal["default"]] = Field(..., description="The cluster ID")
+    id: ClusterID = Field(..., description="The cluster ID")
 
     class Config(BaseCluster.Config):
         schema_extra = {
             "examples": [
                 {
-                    "id": "default",
+                    "id": DEFAULT_CLUSTER_ID,
                     "name": "The default cluster",
                     "type": ClusterType.ON_PREMISE,
                     "owner": 1456,
@@ -176,7 +177,7 @@ class Cluster(BaseCluster):
     @root_validator(pre=True)
     @classmethod
     def check_owner_has_access_rights(cls, values):
-        is_default_cluster = bool(values["id"] == "default")
+        is_default_cluster = bool(values["id"] == DEFAULT_CLUSTER_ID)
         owner_gid = values["owner"]
 
         # check owner is in the access rights, if not add it

--- a/packages/models-library/src/models_library/clusters.py
+++ b/packages/models-library/src/models_library/clusters.py
@@ -106,7 +106,7 @@ class BaseCluster(BaseModel):
         use_enum_values = True
 
 
-ClusterID = NonNegativeInt
+ClusterID = Union[NonNegativeInt, Literal["default"]]
 
 
 class Cluster(BaseCluster):
@@ -115,6 +115,18 @@ class Cluster(BaseCluster):
     class Config(BaseCluster.Config):
         schema_extra = {
             "examples": [
+                {
+                    "id": "default",
+                    "name": "The default cluster",
+                    "type": ClusterType.ON_PREMISE,
+                    "owner": 1456,
+                    "endpoint": "tcp://default-dask-scheduler:8786",
+                    "authentication": {
+                        "type": "simple",
+                        "username": "someuser",
+                        "password": "somepassword",
+                    },
+                },
                 {
                     "id": 432,
                     "name": "My awesome cluster",

--- a/packages/models-library/src/models_library/clusters.py
+++ b/packages/models-library/src/models_library/clusters.py
@@ -180,7 +180,7 @@ class Cluster(BaseCluster):
             return values
         owner_gid = values["owner"]
         # check owner is in the access rights, if not add it
-        access_rights = values.get("access_rights", values.get("accessRights"))
+        access_rights = values.get("access_rights", values.get("accessRights", {}))
         if owner_gid not in access_rights:
             access_rights[owner_gid] = CLUSTER_ADMIN_RIGHTS
         # check owner has full access

--- a/packages/models-library/src/models_library/clusters.py
+++ b/packages/models-library/src/models_library/clusters.py
@@ -197,5 +197,7 @@ class DefaultCluster(Cluster):
     id: Literal["default"] = "default"
     name: Literal["Default cluster"] = "Default cluster"
     type: ClusterType = ClusterType.ON_PREMISE
-    owner: GroupID = 1
+    owner: GroupID = (
+        1  # NOTE: This group ID 1 is 99% of the time equivalent to the Everyone group
+    )
     access_rights: Dict[GroupID, ClusterAccessRights] = {1: CLUSTER_USER_RIGHTS}

--- a/packages/models-library/src/models_library/clusters.py
+++ b/packages/models-library/src/models_library/clusters.py
@@ -180,7 +180,7 @@ class Cluster(BaseCluster):
             return values
         owner_gid = values["owner"]
         # check owner is in the access rights, if not add it
-        access_rights = values["access_rights"]
+        access_rights = values.get("access_rights", values.get("accessRights"))
         if owner_gid not in access_rights:
             access_rights[owner_gid] = CLUSTER_ADMIN_RIGHTS
         # check owner has full access

--- a/packages/models-library/tests/test_clusters.py
+++ b/packages/models-library/tests/test_clusters.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from typing import Any, Dict, Type
 
 import pytest
+from faker import Faker
 from models_library.clusters import (
     CLUSTER_ADMIN_RIGHTS,
     CLUSTER_MANAGER_RIGHTS,
@@ -25,18 +26,24 @@ def test_cluster_access_rights_correctly_created_when_owner_access_rights_not_pr
         modified_example.get("access_rights", {}).pop(owner_gid, None)
 
         instance = model_cls(**modified_example)
-        assert instance.access_rights[owner_gid] == CLUSTER_ADMIN_RIGHTS  # type: ignore
+        if instance.id != "default":
+            assert instance.access_rights[owner_gid] == CLUSTER_ADMIN_RIGHTS  # type: ignore
+        else:
+            assert instance.access_rights[owner_gid] == CLUSTER_USER_RIGHTS  # type: ignore
 
 
 @pytest.mark.parametrize(
     "model_cls",
     (Cluster,),
 )
-def test_cluster_fails_when_owner_has_no_admin_rights(
-    model_cls: Type[BaseModel], model_cls_examples: Dict[str, Dict[str, Any]]
+def test_cluster_fails_when_owner_has_no_admin_rights_unless_default_cluster(
+    model_cls: Type[BaseModel],
+    model_cls_examples: Dict[str, Dict[str, Any]],
+    faker: Faker,
 ):
     for example in model_cls_examples.values():
         modified_example = deepcopy(example)
+        modified_example["id"] = faker.pyint(min_value=1)
         owner_gid = modified_example["owner"]
         # ensure there are access rights
         modified_example.setdefault("access_rights", {})
@@ -47,5 +54,30 @@ def test_cluster_fails_when_owner_has_no_admin_rights(
 
         # set the owner with user rights
         modified_example["access_rights"][owner_gid] = CLUSTER_USER_RIGHTS
+        with pytest.raises(ValidationError):
+            model_cls(**modified_example)
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    (Cluster,),
+)
+def test_cluster_fails_when_owner_has_no_user_rights_if_default_cluster(
+    model_cls: Type[BaseModel],
+    model_cls_examples: Dict[str, Dict[str, Any]],
+):
+    for example in model_cls_examples.values():
+        modified_example = deepcopy(example)
+        modified_example["id"] = "default"
+        owner_gid = modified_example["owner"]
+        # ensure there are access rights
+        modified_example.setdefault("access_rights", {})
+        # set the owner with manager rights
+        modified_example["access_rights"][owner_gid] = CLUSTER_MANAGER_RIGHTS
+        with pytest.raises(ValidationError):
+            model_cls(**modified_example)
+
+        # set the owner with user rights
+        modified_example["access_rights"][owner_gid] = CLUSTER_ADMIN_RIGHTS
         with pytest.raises(ValidationError):
             model_cls(**modified_example)

--- a/packages/models-library/tests/test_clusters.py
+++ b/packages/models-library/tests/test_clusters.py
@@ -7,6 +7,7 @@ from models_library.clusters import (
     CLUSTER_ADMIN_RIGHTS,
     CLUSTER_MANAGER_RIGHTS,
     CLUSTER_USER_RIGHTS,
+    DEFAULT_CLUSTER_ID,
     Cluster,
 )
 from pydantic import BaseModel, ValidationError
@@ -26,7 +27,7 @@ def test_cluster_access_rights_correctly_created_when_owner_access_rights_not_pr
         modified_example.get("access_rights", {}).pop(owner_gid, None)
 
         instance = model_cls(**modified_example)
-        if instance.id != "default":
+        if instance.id != DEFAULT_CLUSTER_ID:
             assert instance.access_rights[owner_gid] == CLUSTER_ADMIN_RIGHTS  # type: ignore
         else:
             assert instance.access_rights[owner_gid] == CLUSTER_USER_RIGHTS  # type: ignore
@@ -68,7 +69,7 @@ def test_cluster_fails_when_owner_has_no_user_rights_if_default_cluster(
 ):
     for example in model_cls_examples.values():
         modified_example = deepcopy(example)
-        modified_example["id"] = "default"
+        modified_example["id"] = DEFAULT_CLUSTER_ID
         owner_gid = modified_example["owner"]
         # ensure there are access rights
         modified_example.setdefault("access_rights", {})

--- a/packages/pytest-simcore/src/pytest_simcore/db_entries_mocks.py
+++ b/packages/pytest-simcore/src/pytest_simcore/db_entries_mocks.py
@@ -37,6 +37,7 @@ def registered_user(
             )
             user = result.first()
             assert user
+            print(f"--> created {user=}")
             created_user_ids.append(user["id"])
         return dict(user)
 
@@ -44,6 +45,7 @@ def registered_user(
 
     with postgres_db.connect() as con:
         con.execute(users.delete().where(users.c.id.in_(created_user_ids)))
+    print(f"<-- deleted users {created_user_ids=}")
 
 
 @pytest.fixture
@@ -74,11 +76,12 @@ def project(
             )
 
             inserted_project = ProjectAtDB.parse_obj(result.first())
-            created_project_ids.append(f"{inserted_project.uuid}")
-            return inserted_project
+        created_project_ids.append(f"{inserted_project.uuid}")
+        return inserted_project
 
     yield creator
 
     # cleanup
     with postgres_db.connect() as con:
         con.execute(projects.delete().where(projects.c.uuid.in_(created_project_ids)))
+    print(f"<-- delete projects {created_project_ids=}")

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
@@ -38,7 +38,7 @@ async def _get_cluster_details_with_id(
     dask_clients_pool: DaskClientsPool,
 ) -> ClusterDetailsGet:
     log.debug("Getting details for cluster '%s'", cluster_id)
-    cluster: Cluster = dask_clients_pool.default_cluster(settings)
+    cluster: Cluster = settings.default_cluster
     if cluster_id != settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID:
         cluster = await clusters_repo.get_cluster(user_id, cluster_id)
     async with dask_clients_pool.acquire(cluster) as client:
@@ -72,9 +72,8 @@ async def list_clusters(
     user_id: UserID,
     clusters_repo: ClustersRepository = Depends(get_repository(ClustersRepository)),
     settings: ComputationalBackendSettings = Depends(get_scheduler_settings),
-    dask_clients_pool: DaskClientsPool = Depends(get_dask_clients_pool),
 ):
-    default_cluster = dask_clients_pool.default_cluster(settings)
+    default_cluster = settings.default_cluster
     return [default_cluster] + await clusters_repo.list_clusters(user_id)
 
 
@@ -86,10 +85,9 @@ async def list_clusters(
 )
 async def get_default_cluster(
     settings: ComputationalBackendSettings = Depends(get_scheduler_settings),
-    dask_clients_pool: DaskClientsPool = Depends(get_dask_clients_pool),
 ):
     assert settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID is not None  # nosec
-    cluster = dask_clients_pool.default_cluster(settings)
+    cluster = settings.default_cluster
     return cluster
 
 
@@ -211,9 +209,8 @@ async def test_cluster_connection(
 )
 async def test_default_cluster_connection(
     settings: ComputationalBackendSettings = Depends(get_scheduler_settings),
-    dask_clients_pool: DaskClientsPool = Depends(get_dask_clients_pool),
 ):
-    cluster = dask_clients_pool.default_cluster(settings)
+    cluster = settings.default_cluster
     return await test_scheduler_endpoint(
         endpoint=cluster.endpoint, authentication=cluster.authentication
     )

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
@@ -83,9 +83,11 @@ async def list_clusters(
 )
 async def get_default_cluster(
     settings: ComputationalBackendSettings = Depends(get_scheduler_settings),
+    dask_clients_pool: DaskClientsPool = Depends(get_dask_clients_pool),
 ):
     assert settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID is not None  # nosec
-    raise NotImplementedError("dev in progress")
+    cluster = dask_clients_pool.default_cluster(settings)
+    return cluster
 
 
 @router.get(

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
-from models_library.clusters import Cluster, ClusterID
+from models_library.clusters import DEFAULT_CLUSTER_ID, Cluster, ClusterID
 from models_library.users import UserID
 from pydantic import AnyUrl, parse_obj_as
 from simcore_service_director_v2.api.dependencies.scheduler import (
@@ -39,7 +39,7 @@ async def _get_cluster_details_with_id(
 ) -> ClusterDetailsGet:
     log.debug("Getting details for cluster '%s'", cluster_id)
     cluster: Cluster = settings.default_cluster
-    if cluster_id != settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID:
+    if cluster_id != DEFAULT_CLUSTER_ID:
         cluster = await clusters_repo.get_cluster(user_id, cluster_id)
     async with dask_clients_pool.acquire(cluster) as client:
         scheduler_info = client.dask_subsystem.client.scheduler_info()
@@ -86,7 +86,6 @@ async def list_clusters(
 async def get_default_cluster(
     settings: ComputationalBackendSettings = Depends(get_scheduler_settings),
 ):
-    assert settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID is not None  # nosec
     cluster = settings.default_cluster
     return cluster
 
@@ -149,11 +148,10 @@ async def get_default_cluster_details(
     clusters_repo: ClustersRepository = Depends(get_repository(ClustersRepository)),
     dask_clients_pool: DaskClientsPool = Depends(get_dask_clients_pool),
 ):
-    assert settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID is not None  # nosec
     return await _get_cluster_details_with_id(
         settings=settings,
         user_id=user_id,
-        cluster_id=settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
+        cluster_id=DEFAULT_CLUSTER_ID,
         clusters_repo=clusters_repo,
         dask_clients_pool=dask_clients_pool,
     )

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
@@ -71,8 +71,11 @@ async def create_cluster(
 async def list_clusters(
     user_id: UserID,
     clusters_repo: ClustersRepository = Depends(get_repository(ClustersRepository)),
+    settings: ComputationalBackendSettings = Depends(get_scheduler_settings),
+    dask_clients_pool: DaskClientsPool = Depends(get_dask_clients_pool),
 ):
-    return await clusters_repo.list_clusters(user_id)
+    default_cluster = dask_clients_pool.default_cluster(settings)
+    return [default_cluster] + await clusters_repo.list_clusters(user_id)
 
 
 @router.get(

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -5,6 +5,7 @@ from typing import Any, List
 
 import networkx as nx
 from fastapi import APIRouter, Depends, HTTPException
+from models_library.clusters import DEFAULT_CLUSTER_ID
 from models_library.projects import ProjectAtDB, ProjectID
 from models_library.users import UserID
 from servicelib.async_utils import run_sequentially_in_context
@@ -138,8 +139,7 @@ async def create_computation(
             await scheduler.run_new_pipeline(
                 job.user_id,
                 job.project_id,
-                job.cluster_id
-                or request.app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
+                job.cluster_id or DEFAULT_CLUSTER_ID,
             )
 
         # filter the tasks by the effective pipeline

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -311,7 +311,7 @@ class ComputationalBackendSettings(BaseCustomSettings):
     @cached_property
     def default_cluster(self):
         return Cluster(
-            id="default",
+            id=self.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
             name="Default cluster",
             endpoint=self.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_URL,
             authentication=self.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_AUTH,

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -14,9 +14,9 @@ from models_library.basic_types import (
     VersionTag,
 )
 from models_library.clusters import (
+    DEFAULT_CLUSTER_ID,
     Cluster,
     ClusterAuthentication,
-    ClusterID,
     NoAuthentication,
 )
 from models_library.projects_networks import SERVICE_NETWORK_RE
@@ -304,14 +304,11 @@ class ComputationalBackendSettings(BaseCustomSettings):
         description="Empty for the internal cluster, must be one "
         "of simple/kerberos/jupyterhub for the osparc-dask-gateway",
     )
-    COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID: Optional[ClusterID] = Field(
-        0, description="This defines the default cluster id when none is defined"
-    )
 
     @cached_property
     def default_cluster(self):
         return Cluster(
-            id=self.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
+            id=DEFAULT_CLUSTER_ID,
             name="Default cluster",
             endpoint=self.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_URL,
             authentication=self.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_AUTH,

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -13,7 +13,12 @@ from models_library.basic_types import (
     PortInt,
     VersionTag,
 )
-from models_library.clusters import ClusterAuthentication, ClusterID, NoAuthentication
+from models_library.clusters import (
+    Cluster,
+    ClusterAuthentication,
+    ClusterID,
+    NoAuthentication,
+)
 from models_library.projects_networks import SERVICE_NETWORK_RE
 from pydantic import AnyHttpUrl, AnyUrl, Field, PositiveFloat, PositiveInt, validator
 from settings_library.base import BaseCustomSettings
@@ -24,6 +29,7 @@ from settings_library.rabbit import RabbitSettings
 from settings_library.s3 import S3Settings
 from settings_library.tracing import TracingSettings
 from settings_library.utils_logging import MixinLoggingSettings
+from simcore_postgres_database.models.clusters import ClusterType
 
 from ..meta import API_VTAG
 from ..models.schemas.constants import DYNAMIC_SIDECAR_DOCKER_IMAGE_RE
@@ -301,6 +307,17 @@ class ComputationalBackendSettings(BaseCustomSettings):
     COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID: Optional[ClusterID] = Field(
         0, description="This defines the default cluster id when none is defined"
     )
+
+    @cached_property
+    def default_cluster(self):
+        return Cluster(
+            id="default",
+            name="Default cluster",
+            endpoint=self.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_URL,
+            authentication=self.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_AUTH,
+            owner=1,  # NOTE: currently this is a soft hack (the group of everyone is the group 1)
+            type=ClusterType.ON_PREMISE,
+        )  # type: ignore
 
     @validator("COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_AUTH", pre=True)
     def empty_auth_is_none(v):

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
@@ -13,7 +13,7 @@ from models_library.clusters import (
 )
 from models_library.generics import DictModel
 from models_library.users import GroupID
-from pydantic import AnyHttpUrl, BaseModel, Field, HttpUrl, validator
+from pydantic import AnyHttpUrl, BaseModel, Field, HttpUrl, root_validator, validator
 from pydantic.networks import AnyUrl
 from pydantic.types import ByteSize, PositiveFloat
 
@@ -52,6 +52,14 @@ class ClusterGet(Cluster):
 
     class Config(Cluster.Config):
         allow_population_by_field_name = True
+
+    @root_validator(pre=True)
+    @classmethod
+    def ensure_access_rights_converted(cls, values):
+        if "access_rights" in values:
+            access_rights = values.pop("access_rights")
+            values["accessRights"] = access_rights
+        return values
 
 
 class ClusterDetailsGet(BaseModel):

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
@@ -60,7 +60,6 @@ class BaseCompScheduler(ABC):
     ]
     db_engine: Engine
     wake_up_event: asyncio.Event = field(default_factory=asyncio.Event, init=False)
-    default_cluster_id: ClusterID
 
     async def run_new_pipeline(
         self, user_id: UserID, project_id: ProjectID, cluster_id: ClusterID
@@ -84,7 +83,6 @@ class BaseCompScheduler(ABC):
             user_id=user_id,
             project_id=project_id,
             cluster_id=cluster_id,
-            default_cluster_id=self.default_cluster_id,
         )
         self.scheduled_pipelines[
             (user_id, project_id, new_run.iteration)

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 async def _cluster_dask_client(
     user_id: UserID, cluster_id: ClusterID, scheduler: "DaskScheduler"
 ) -> AsyncIterator[DaskClient]:
-    cluster: Cluster = scheduler.dask_clients_pool.default_cluster(scheduler.settings)
+    cluster: Cluster = scheduler.settings.default_cluster
     if cluster_id != scheduler.settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID:
         clusters_repo: ClustersRepository = get_repository(
             scheduler.db_engine, ClustersRepository

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
@@ -11,7 +11,7 @@ from dask_task_models_library.container_tasks.events import (
     TaskStateEvent,
 )
 from dask_task_models_library.container_tasks.io import TaskOutputData
-from models_library.clusters import Cluster, ClusterID
+from models_library.clusters import DEFAULT_CLUSTER_ID, Cluster, ClusterID
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.projects_state import RunningState
@@ -46,7 +46,7 @@ async def _cluster_dask_client(
     user_id: UserID, cluster_id: ClusterID, scheduler: "DaskScheduler"
 ) -> AsyncIterator[DaskClient]:
     cluster: Cluster = scheduler.settings.default_cluster
-    if cluster_id != scheduler.settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID:
+    if cluster_id != DEFAULT_CLUSTER_ID:
         clusters_repo: ClustersRepository = get_repository(
             scheduler.db_engine, ClustersRepository
         )  # type: ignore

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/factory.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/factory.py
@@ -2,6 +2,7 @@ import logging
 from typing import List, cast
 
 from fastapi import FastAPI
+from models_library.clusters import DEFAULT_CLUSTER_ID
 from simcore_service_director_v2.modules.dask_clients_pool import DaskClientsPool
 
 from ...core.errors import ConfigurationError
@@ -41,12 +42,11 @@ async def create_from_db(app: FastAPI) -> BaseCompScheduler:
         dask_clients_pool=DaskClientsPool.instance(app),
         rabbitmq_client=RabbitMQClient.instance(app),
         db_engine=db_engine,
-        default_cluster_id=app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
         scheduled_pipelines={
             (r.user_id, r.project_uuid, r.iteration): ScheduledPipelineParams(
                 cluster_id=r.cluster_id
                 if r.cluster_id is not None
-                else app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
+                else DEFAULT_CLUSTER_ID,
                 mark_for_cancellation=False,
             )
             for r in runs

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_clients_pool.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_clients_pool.py
@@ -5,8 +5,7 @@ from dataclasses import dataclass, field
 from typing import AsyncIterator, Dict, Optional
 
 from fastapi import FastAPI
-from models_library.clusters import Cluster, ClusterID
-from simcore_postgres_database.models.clusters import ClusterType
+from models_library.clusters import Cluster, ClusterID, DefaultCluster
 
 from ..core.errors import (
     ComputationalBackendNotConnectedError,
@@ -34,13 +33,9 @@ class DaskClientsPool:
 
     @staticmethod
     def default_cluster(settings: ComputationalBackendSettings):
-        return Cluster(
-            id=settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
-            name="Default cluster",
-            type=ClusterType.ON_PREMISE,
+        return DefaultCluster.construct(
             endpoint=settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_URL,
             authentication=settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_AUTH,
-            owner=1,  # FIXME: that is usually the everyone's group... but we do not know nor care about it in director-v2...
         )  # type: ignore
 
     def register_handlers(self, task_handlers: TaskHandlers) -> None:

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Set
 
 import sqlalchemy as sa
 from aiopg.sa.result import RowProxy
-from models_library.clusters import ClusterID
+from models_library.clusters import DEFAULT_CLUSTER_ID, ClusterID
 from models_library.projects import ProjectID
 from models_library.projects_state import RunningState
 from models_library.users import UserID
@@ -24,8 +24,10 @@ logger = logging.getLogger(__name__)
 
 class CompRunsRepository(BaseRepository):
     async def list(
-        self, filter_by_state: Set[RunningState] = None
+        self, filter_by_state: Optional[Set[RunningState]] = None
     ) -> List[CompRunsAtDB]:
+        if not filter_by_state:
+            filter_by_state = set()
         runs_in_db = deque()
         async with self.db_engine.acquire() as conn:
             async for row in conn.execute(
@@ -46,7 +48,6 @@ class CompRunsRepository(BaseRepository):
         user_id: UserID,
         project_id: ProjectID,
         cluster_id: ClusterID,
-        default_cluster_id: ClusterID,
         iteration: Optional[PositiveInt] = None,
     ) -> CompRunsAtDB:
         async with self.db_engine.acquire() as conn:
@@ -67,7 +68,7 @@ class CompRunsRepository(BaseRepository):
                 .values(
                     user_id=user_id,
                     project_uuid=f"{project_id}",
-                    cluster_id=cluster_id if cluster_id != default_cluster_id else None,
+                    cluster_id=cluster_id if cluster_id != DEFAULT_CLUSTER_ID else None,
                     iteration=iteration,
                     result=RUNNING_STATE_TO_DB[RunningState.PUBLISHED],
                     started=datetime.utcnow(),

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask_client_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask_client_utils.py
@@ -196,6 +196,7 @@ async def get_gateway_auth_from_params(
 
 
 _PING_TIMEOUT_S: Final[int] = 5
+_DASK_SCHEDULER_RUNNING_STATE: Final[str] = "running"
 
 
 async def test_scheduler_endpoint(
@@ -210,7 +211,7 @@ async def test_scheduler_endpoint(
             async with distributed.Client(
                 address=endpoint, timeout=_PING_TIMEOUT_S, asynchronous=True
             ) as dask_client:
-                if not dask_client.status == "running":
+                if not dask_client.status == _DASK_SCHEDULER_RUNNING_STATE:
                     raise SchedulerError("internal scheduler is not running!")
 
         else:

--- a/services/director-v2/tests/unit/test_modules_dask_clients_pool.py
+++ b/services/director-v2/tests/unit/test_modules_dask_clients_pool.py
@@ -228,7 +228,7 @@ def test_default_cluster_correctly_initialized(
     dask_scheduler_settings = (
         client.app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND
     )
-    default_cluster = DaskClientsPool.default_cluster(dask_scheduler_settings)
+    default_cluster = dask_scheduler_settings.default_cluster
     assert default_cluster
     assert (
         default_cluster.endpoint
@@ -263,7 +263,7 @@ async def test_acquire_default_cluster(
     dask_scheduler_settings = (
         client.app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND
     )
-    default_cluster = DaskClientsPool.default_cluster(dask_scheduler_settings)
+    default_cluster = dask_scheduler_settings.default_cluster
     assert default_cluster
     async with dask_clients_pool.acquire(default_cluster) as dask_client:
 

--- a/services/director-v2/tests/unit/test_modules_dask_clients_pool.py
+++ b/services/director-v2/tests/unit/test_modules_dask_clients_pool.py
@@ -13,6 +13,7 @@ from _pytest.monkeypatch import MonkeyPatch
 from distributed.deploy.spec import SpecCluster
 from faker import Faker
 from models_library.clusters import (
+    DEFAULT_CLUSTER_ID,
     Cluster,
     ClusterAuthentication,
     JupyterHubTokenAuthentication,
@@ -235,10 +236,7 @@ def test_default_cluster_correctly_initialized(
         == dask_scheduler_settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_URL
     )
 
-    assert (
-        default_cluster.id
-        == dask_scheduler_settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID
-    )
+    assert default_cluster.id == DEFAULT_CLUSTER_ID
     assert isinstance(default_cluster.authentication, get_args(ClusterAuthentication))
 
 

--- a/services/director-v2/tests/unit/with_dbs/conftest.py
+++ b/services/director-v2/tests/unit/with_dbs/conftest.py
@@ -167,7 +167,7 @@ def cluster(
     created_cluster_ids: List[str] = []
 
     def creator(user: Dict[str, Any], **cluster_kwargs) -> Cluster:
-        cluster_config = Cluster.Config.schema_extra["examples"][0]
+        cluster_config = Cluster.Config.schema_extra["examples"][1]
         cluster_config["owner"] = user["primary_gid"]
         cluster_config.update(**cluster_kwargs)
         new_cluster = Cluster.parse_obj(cluster_config)
@@ -218,6 +218,7 @@ def cluster(
                 endpoint=created_cluster.endpoint,
                 authentication=created_cluster.authentication,
                 access_rights=access_rights_in_db,
+                thumbnail=None,
             )
 
     yield creator

--- a/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
@@ -28,6 +28,7 @@ from dask.distributed import SpecCluster
 from dask_task_models_library.container_tasks.errors import TaskCancelledError
 from dask_task_models_library.container_tasks.io import TaskOutputData
 from fastapi.applications import FastAPI
+from models_library.clusters import DEFAULT_CLUSTER_ID
 from models_library.projects import ProjectAtDB
 from models_library.projects_state import RunningState
 from pytest_mock.plugin import MockerFixture
@@ -189,7 +190,7 @@ async def test_empty_pipeline_is_not_scheduled(
         await scheduler.run_new_pipeline(
             user_id=user["id"],
             project_id=empty_project.uuid,
-            cluster_id=minimal_app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
+            cluster_id=DEFAULT_CLUSTER_ID,
         )
     # create the empty pipeline now
     _empty_pipeline = pipeline(project_id=f"{empty_project.uuid}")
@@ -198,7 +199,7 @@ async def test_empty_pipeline_is_not_scheduled(
     await scheduler.run_new_pipeline(
         user_id=user["id"],
         project_id=empty_project.uuid,
-        cluster_id=minimal_app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
+        cluster_id=DEFAULT_CLUSTER_ID,
     )
     assert len(scheduler.scheduled_pipelines) == 0
     assert (
@@ -238,7 +239,7 @@ async def test_misconfigured_pipeline_is_not_scheduled(
     await scheduler.run_new_pipeline(
         user_id=user["id"],
         project_id=sleepers_project.uuid,
-        cluster_id=minimal_app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
+        cluster_id=DEFAULT_CLUSTER_ID,
     )
     assert len(scheduler.scheduled_pipelines) == 1
     assert (
@@ -287,7 +288,7 @@ async def test_proper_pipeline_is_scheduled(
     await scheduler.run_new_pipeline(
         user_id=published_project.project.prj_owner,
         project_id=published_project.project.uuid,
-        cluster_id=minimal_app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
+        cluster_id=DEFAULT_CLUSTER_ID,
     )
     assert len(scheduler.scheduled_pipelines) == 1, "the pipeline is not scheduled!"
     assert (
@@ -335,7 +336,7 @@ async def test_proper_pipeline_is_scheduled(
             mock.call(
                 published_project.project.prj_owner,
                 project_id=published_project.project.uuid,
-                cluster_id=minimal_app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
+                cluster_id=DEFAULT_CLUSTER_ID,
                 tasks={f"{p.node_id}": p.image},
                 callback=scheduler._wake_up_scheduler_now,
             )
@@ -416,7 +417,7 @@ async def test_proper_pipeline_is_scheduled(
     mocked_dask_client.send_computation_tasks.assert_called_once_with(
         user_id=published_project.project.prj_owner,
         project_id=published_project.project.uuid,
-        cluster_id=minimal_app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
+        cluster_id=DEFAULT_CLUSTER_ID,
         tasks={
             f"{next_published_task.node_id}": next_published_task.image,
         },
@@ -524,7 +525,7 @@ async def test_handling_of_disconnected_dask_scheduler(
     await scheduler.run_new_pipeline(
         user_id=published_project.project.prj_owner,
         project_id=published_project.project.uuid,
-        cluster_id=minimal_app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_ID,
+        cluster_id=DEFAULT_CLUSTER_ID,
     )
 
     # since there is no cluster, there is no dask-scheduler,

--- a/services/director-v2/tests/unit/with_dbs/test_route_clusters.py
+++ b/services/director-v2/tests/unit/with_dbs/test_route_clusters.py
@@ -604,6 +604,7 @@ async def test_update_another_cluster(
 
 async def test_delete_cluster(
     clusters_config: None,
+    cluster: Callable[..., Cluster],
     registered_user: Callable[..., Dict],
     async_client: httpx.AsyncClient,
 ):

--- a/services/director-v2/tests/unit/with_dbs/test_route_clusters.py
+++ b/services/director-v2/tests/unit/with_dbs/test_route_clusters.py
@@ -244,11 +244,18 @@ async def test_get_another_cluster(
     ), f"received {response.text}"
 
 
+@pytest.mark.parametrize("with_query", [True, False])
 async def test_get_default_cluster(
     clusters_config: None,
+    registered_user: Callable[..., Dict],
     async_client: httpx.AsyncClient,
+    with_query: bool,
 ):
+    user_1 = registered_user()
+
     get_cluster_url = URL("/v2/clusters/default")
+    if with_query:
+        get_cluster_url = URL(f"/v2/clusters/default?user_id={user_1['id']}")
     response = await async_client.get(get_cluster_url)
     assert response.status_code == status.HTTP_200_OK, f"received {response.text}"
     returned_cluster = parse_obj_as(ClusterGet, response.json())

--- a/services/director-v2/tests/unit/with_dbs/test_route_clusters.py
+++ b/services/director-v2/tests/unit/with_dbs/test_route_clusters.py
@@ -244,22 +244,16 @@ async def test_get_another_cluster(
     ), f"received {response.text}"
 
 
-@pytest.mark.xfail(reason="This needs another iteration and will be tackled next")
 async def test_get_default_cluster(
     clusters_config: None,
-    registered_user: Callable[..., Dict],
-    cluster: Callable[..., Cluster],
     async_client: httpx.AsyncClient,
 ):
-    user_1 = registered_user()
-    # NOTE: we should not need the user id for default right?
-    # NOTE: it should be accessible to everyone to run, and only a handful of elected
-    # people shall be able to administer it
     get_cluster_url = URL("/v2/clusters/default")
     response = await async_client.get(get_cluster_url)
     assert response.status_code == status.HTTP_200_OK, f"received {response.text}"
     returned_cluster = parse_obj_as(ClusterGet, response.json())
     assert returned_cluster
+    assert returned_cluster.id == "default"
     assert returned_cluster.name == "Default cluster"
     assert 1 in returned_cluster.access_rights  # everyone group is always 1
     assert returned_cluster.access_rights[1] == CLUSTER_USER_RIGHTS

--- a/services/director-v2/tests/unit/with_dbs/test_route_clusters.py
+++ b/services/director-v2/tests/unit/with_dbs/test_route_clusters.py
@@ -91,7 +91,7 @@ async def test_list_clusters(
         len(returned_clusters_list) == 1
     ), f"no default cluster in {returned_clusters_list=}"
     assert (
-        returned_clusters_list[0].id == "default"
+        returned_clusters_list[0].id == 0
     ), "default cluster id is not the one expected"
 
     # let's create some clusters
@@ -106,7 +106,7 @@ async def test_list_clusters(
         len(returned_clusters_list) == NUM_CLUSTERS + 1
     )  # the default cluster comes on top of the NUM_CLUSTERS
     assert (
-        returned_clusters_list[0].id == "default"
+        returned_clusters_list[0].id == 0
     ), "the first cluster shall be the platform default cluster"
 
     # now create a second user and check the clusters are not seen by it BUT the default one
@@ -118,7 +118,7 @@ async def test_list_clusters(
         len(returned_clusters_list) == 1
     ), f"no default cluster in {returned_clusters_list=}"
     assert (
-        returned_clusters_list[0].id == "default"
+        returned_clusters_list[0].id == 0
     ), "default cluster id is not the one expected"
 
     # let's create a few more clusters owned by user_1 with specific rights
@@ -277,7 +277,7 @@ async def test_get_default_cluster(
     assert response.status_code == status.HTTP_200_OK, f"received {response.text}"
     returned_cluster = parse_obj_as(ClusterGet, response.json())
     assert returned_cluster
-    assert returned_cluster.id == "default"
+    assert returned_cluster.id == 0
     assert returned_cluster.name == "Default cluster"
     assert 1 in returned_cluster.access_rights  # everyone group is always 1
     assert returned_cluster.access_rights[1] == CLUSTER_USER_RIGHTS

--- a/services/director-v2/tests/unit/with_dbs/test_route_clusters.py
+++ b/services/director-v2/tests/unit/with_dbs/test_route_clusters.py
@@ -789,3 +789,16 @@ async def test_ping_specific_cluster(
     )
     response.raise_for_status()
     assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+async def test_ping_default_cluster(
+    clusters_config: None,
+    registered_user: Callable[..., Dict],
+    async_client: httpx.AsyncClient,
+):
+    user_1 = registered_user()
+    # try to ping one that does not exist
+    response = await async_client.post(
+        f"/v2/clusters/default:ping?user_id={user_1['id']}"
+    )
+    assert response.status_code == status.HTTP_204_NO_CONTENT


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->


This PR adds the following specific entrypoints:

- GET ```/clusters/default``` returns the default cluster
- GET ```/clusters``` now also returns the default cluster as the first element of the list
- - GET ```/clusters/default/details``` now also returns the default cluster details
- POST ```clusters/default:ping``` allows to ping the default cluster


As a summary, the default cluster is the cluster available to everyone, defined by the ENV ```COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_URL```. It can be either a dask-scheduler (as is usual at the moment) or a osparc-dask-gateway.

The default cluster is available to any user, albeit in USE mode only (one cannot change the parameters of the default cluster)

![image](https://user-images.githubusercontent.com/35365065/160354840-c9d71bfa-cfeb-4189-8271-deb1ea5458ca.png)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
