### PR TITLE
🐛 FIX issues with control networking

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
@@ -428,14 +428,14 @@ class AttachProjectsNetworks(DynamicSchedulerEvent):
             network_name,
             container_aliases,
         ) in projects_networks.networks_with_aliases.items():
-            for network_alias in container_aliases.values():
-                await dynamic_sidecar_client.attach_service_containers_to_project_network(
-                    dynamic_sidecar_endpoint=dynamic_sidecar_endpoint,
-                    dynamic_sidecar_network_name=scheduler_data.dynamic_sidecar_network_name,
-                    project_network=network_name,
-                    project_id=scheduler_data.project_id,
-                    network_alias=network_alias,
-                )
+            network_alias = container_aliases[f"{scheduler_data.node_uuid}"]
+            await dynamic_sidecar_client.attach_service_containers_to_project_network(
+                dynamic_sidecar_endpoint=dynamic_sidecar_endpoint,
+                dynamic_sidecar_network_name=scheduler_data.dynamic_sidecar_network_name,
+                project_network=network_name,
+                project_id=scheduler_data.project_id,
+                network_alias=network_alias,
+            )
 
         scheduler_data.dynamic_sidecar.is_project_network_attached = True
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
@@ -5,7 +5,7 @@ import logging
 from collections import deque
 from typing import Any, Awaitable, Deque, Dict, List, Optional, Set
 
-import aiodocker
+from aiodocker.networks import DockerNetwork
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Response, status
 from models_library.services import ServiceOutput
 from pydantic.main import BaseModel
@@ -281,14 +281,10 @@ async def attach_container_to_network(
             )
             return
 
-        try:
-            network = await docker.networks.get(item.network_id)
-        except aiodocker.docker.DockerError as e:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND,
-                detail=f"No network with id={item.network_id} found",
-            ) from e
-
+        # NOTE: Not querying for the network because it might not be on the host.
+        # Attaching it to a container will make the object appera on the host.
+        # This issue presents itself when dealing with worker nodes.
+        network = DockerNetwork(docker=docker, id_=item.network_id)
         await network.connect(
             {
                 "Container": id,
@@ -321,12 +317,8 @@ async def detach_container_from_network(
             )
             return
 
-        try:
-            network = await docker.networks.get(item.network_id)
-        except aiodocker.docker.DockerError as e:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND,
-                detail=f"No network with id={item.network_id} found",
-            ) from e
-
+        # NOTE: Not querying for the network because it might not be on the host.
+        # Attaching it to a container will make the object appera on the host.
+        # This issue presents itself when dealing with worker nodes.
+        network = DockerNetwork(docker=docker, id_=item.network_id)
         await network.disconnect({"Container": id})

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
@@ -286,7 +286,7 @@ async def attach_container_to_network(
         except aiodocker.docker.DockerError as e:
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND,
-                detail="No network with id={item.network_id} found",
+                detail=f"No network with id={item.network_id} found",
             ) from e
 
         await network.connect(
@@ -326,7 +326,7 @@ async def detach_container_from_network(
         except aiodocker.docker.DockerError as e:
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND,
-                detail="No network with id={item.network_id} found",
+                detail=f"No network with id={item.network_id} found",
             ) from e
 
         await network.disconnect({"Container": id})

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
@@ -281,9 +281,8 @@ async def attach_container_to_network(
             )
             return
 
-        # NOTE: Not querying for the network because it might not be on the host.
-        # Attaching it to a container will make the object appera on the host.
-        # This issue presents itself when dealing with worker nodes.
+        # NOTE: A docker network is only visible on a docker node when it is
+        # used by a container
         network = DockerNetwork(docker=docker, id_=item.network_id)
         await network.connect(
             {
@@ -317,8 +316,7 @@ async def detach_container_from_network(
             )
             return
 
-        # NOTE: Not querying for the network because it might not be on the host.
-        # Attaching it to a container will make the object appera on the host.
-        # This issue presents itself when dealing with worker nodes.
+        # NOTE: A docker network is only visible on a docker node when it is
+        # used by a container
         network = DockerNetwork(docker=docker, id_=item.network_id)
         await network.disconnect({"Container": id})


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

- When the dynamic-sidecar is attaching containers to a project-network it tried to fetch the network fist. 
That project network may not exist on the host (especially if a swarm worker node).
This fix will use the low level aiodocker object instead to bypass the issue.
- The same network alias was being attached for all containers when the project was started. Now the correct alias is being attached 

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

- fixes https://github.com/ITISFoundation/osparc-simcore/pull/2633


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

See `How to test` section from https://github.com/ITISFoundation/osparc-simcore/pull/2633

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist
- [x] Runs in the swarm 