### PR TITLE
Cluster resource details II

### DIFF
--- a/services/web/client/source/class/osparc/component/cluster/ClusterDetails.js
+++ b/services/web/client/source/class/osparc/component/cluster/ClusterDetails.js
@@ -62,7 +62,7 @@ qx.Class.define("osparc.component.cluster.ClusterDetails", {
           }
         }
       });
-      clusters.startFetchDetailsTimer(this.__clusterId);
+      clusters.startFetchingDetails(this.__clusterId);
     },
 
     __detailsCallFailed: function() {
@@ -193,6 +193,6 @@ qx.Class.define("osparc.component.cluster.ClusterDetails", {
   },
 
   destruct: function() {
-    osparc.utils.Clusters.getInstance().stopFetchDetailsTimer(this.__clusterId);
+    osparc.utils.Clusters.getInstance().stopFetchingDetails(this.__clusterId);
   }
 });

--- a/services/web/client/source/class/osparc/component/cluster/ClusterDetails.js
+++ b/services/web/client/source/class/osparc/component/cluster/ClusterDetails.js
@@ -27,7 +27,9 @@ qx.Class.define("osparc.component.cluster.ClusterDetails", {
     this._add(clusterDetailsLayout);
 
     const grid = new qx.ui.layout.Grid(5, 8);
-    grid.setColumnFlex(1, 1);
+    for (let i=0; i<Object.keys(this.self().GRID_POS).length; i++) {
+      grid.setColumnFlex(i, 1);
+    }
     const workersGrid = this.__workersGrid = new qx.ui.container.Composite(grid);
     this._add(workersGrid);
 
@@ -150,6 +152,7 @@ qx.Class.define("osparc.component.cluster.ClusterDetails", {
       };
 
       let row = 0;
+      const gridW = this.__computedLayout ? this.__computedLayout.width - 15 : 600;
       Object.keys(clusterDetails.scheduler.workers).forEach((workerUrl, idx) => {
         const worker = clusterDetails.scheduler.workers[workerUrl];
         row++;
@@ -179,9 +182,12 @@ qx.Class.define("osparc.component.cluster.ClusterDetails", {
           }
           const layout = osparc.wrapper.Plotly.getDefaultLayout();
           const plotId = "ClusterDetails_" + plotKey + "-" + row;
+          const w = parseInt(gridW/Object.keys(plots).length);
+          const h = parseInt(w*0.75);
+          console.log(gridW, w, h);
           const plot = new osparc.component.widget.PlotlyWidget(plotId, gaugeDatas, layout).set({
-            width: 200,
-            height: 160
+            width: w,
+            height: h
           });
           workersGrid.add(plot, {
             row,

--- a/services/web/client/source/class/osparc/component/cluster/ClusterMiniView.js
+++ b/services/web/client/source/class/osparc/component/cluster/ClusterMiniView.js
@@ -18,14 +18,12 @@
 qx.Class.define("osparc.component.cluster.ClusterMiniView", {
   extend: qx.ui.core.Widget,
 
-  construct: function(clusterId = 0) {
+  construct: function() {
     this.base(arguments);
 
     this._setLayout(new qx.ui.layout.VBox().set({
       alignY: "middle"
     }));
-
-    this.__clusterId = clusterId;
 
     const grid = new qx.ui.layout.Grid(2, 2);
     const miniGrid = this.__miniGrid = new qx.ui.container.Composite(grid).set({
@@ -33,7 +31,7 @@ qx.Class.define("osparc.component.cluster.ClusterMiniView", {
     });
     this._add(miniGrid);
 
-    this.__startFetchingDetails();
+    this.__listenToClusterDetails();
 
     this.set({
       cursor: "pointer"
@@ -75,22 +73,19 @@ qx.Class.define("osparc.component.cluster.ClusterMiniView", {
       clusters.startFetchingDetails(clusterId);
     },
 
-    __startFetchingDetails: function() {
-      // if (osparc.utils.Utils.checkIsOnScreen(this)) {
-        const clusters = osparc.utils.Clusters.getInstance();
-        clusters.addListener("clusterDetailsReceived", e => {
-          const data = e.getData();
-          if (this.__clusterId === data.clusterId) {
-            if ("error" in data) {
-              this.__detailsCallFailed();
-            } else {
-              const clusterDetails = data.clusterDetails;
-              this.__updateWorkersDetails(clusterDetails);
-            }
+    __listenToClusterDetails: function() {
+      const clusters = osparc.utils.Clusters.getInstance();
+      clusters.addListener("clusterDetailsReceived", e => {
+        const data = e.getData();
+        if (this.__clusterId === data.clusterId) {
+          if ("error" in data) {
+            this.__detailsCallFailed();
+          } else {
+            const clusterDetails = data.clusterDetails;
+            this.__updateWorkersDetails(clusterDetails);
           }
-        });
-        clusters.startFetchingDetails(this.__clusterId);
-      // }
+        }
+      });
     },
 
     __showFailedBulb: function() {

--- a/services/web/client/source/class/osparc/component/cluster/ClusterMiniView.js
+++ b/services/web/client/source/class/osparc/component/cluster/ClusterMiniView.js
@@ -33,12 +33,7 @@ qx.Class.define("osparc.component.cluster.ClusterMiniView", {
     });
     this._add(miniGrid);
 
-    this.__fetchDetails();
-    // Fecth every 3 seconds
-    const interval = 3000;
-    const timer = this.__timer = new qx.event.Timer(interval);
-    timer.addListener("interval", () => this.__fetchDetails(), this);
-    timer.start();
+    this.__startFetchingDetails();
 
     this.set({
       cursor: "pointer"
@@ -67,26 +62,35 @@ qx.Class.define("osparc.component.cluster.ClusterMiniView", {
 
   members: {
     __clusterId: null,
-    __timer: null,
     __clusterDetailsLayout: null,
     __miniGrid: null,
     __hint: null,
 
     setClusterId: function(clusterId) {
+      const clusters = osparc.utils.Clusters.getInstance();
+      if (this.__clusterId !== null) {
+        clusters.stopFetchDetailsTimer(this.__clusterId);
+      }
       this.__clusterId = clusterId;
+      clusters.startFetchDetailsTimer(clusterId);
     },
 
-    __fetchDetails: function() {
-      if (osparc.utils.Utils.checkIsOnScreen(this)) {
-        const params = {
-          url: {
-            "cid": this.__clusterId
+    __startFetchingDetails: function() {
+      // if (osparc.utils.Utils.checkIsOnScreen(this)) {
+        const clusters = osparc.utils.Clusters.getInstance();
+        clusters.addListener("clusterDetailsReceived", e => {
+          const data = e.getData();
+          if (this.__clusterId === data.clusterId) {
+            if ("error" in data) {
+              this.__detailsCallFailed();
+            } else {
+              const clusterDetails = data.clusterDetails;
+              this.__updateWorkersDetails(clusterDetails);
+            }
           }
-        };
-        osparc.data.Resources.get("clusterDetails", params)
-          .then(clusterDetails => this.__updateWorkersDetails(clusterDetails))
-          .catch(() => this.__detailsCallFailed());
-      }
+        });
+        clusters.startFetchDetailsTimer(this.__clusterId);
+      // }
     },
 
     __showFailedBulb: function() {
@@ -203,6 +207,6 @@ qx.Class.define("osparc.component.cluster.ClusterMiniView", {
   },
 
   destruct: function() {
-    this.__timer.stop();
+    osparc.utils.Clusters.getInstance().stopFetchDetailsTimer(this.__clusterId);
   }
 });

--- a/services/web/client/source/class/osparc/component/cluster/ClusterMiniView.js
+++ b/services/web/client/source/class/osparc/component/cluster/ClusterMiniView.js
@@ -69,10 +69,10 @@ qx.Class.define("osparc.component.cluster.ClusterMiniView", {
     setClusterId: function(clusterId) {
       const clusters = osparc.utils.Clusters.getInstance();
       if (this.__clusterId !== null) {
-        clusters.stopFetchDetailsTimer(this.__clusterId);
+        clusters.stopFetchingDetails(this.__clusterId);
       }
       this.__clusterId = clusterId;
-      clusters.startFetchDetailsTimer(clusterId);
+      clusters.startFetchingDetails(clusterId);
     },
 
     __startFetchingDetails: function() {
@@ -89,7 +89,7 @@ qx.Class.define("osparc.component.cluster.ClusterMiniView", {
             }
           }
         });
-        clusters.startFetchDetailsTimer(this.__clusterId);
+        clusters.startFetchingDetails(this.__clusterId);
       // }
     },
 
@@ -207,6 +207,6 @@ qx.Class.define("osparc.component.cluster.ClusterMiniView", {
   },
 
   destruct: function() {
-    osparc.utils.Clusters.getInstance().stopFetchDetailsTimer(this.__clusterId);
+    osparc.utils.Clusters.getInstance().stopFetchingDetails(this.__clusterId);
   }
 });

--- a/services/web/client/source/class/osparc/component/cluster/ClustersDetails.js
+++ b/services/web/client/source/class/osparc/component/cluster/ClustersDetails.js
@@ -55,6 +55,7 @@ qx.Class.define("osparc.component.cluster.ClustersDetails", {
           selectBox.setSelection([selectable]);
         }
       });
+      this.__updateClusterDetails(selectClusterId);
     },
 
     __updateClusterDetails: function(clusterId) {

--- a/services/web/client/source/class/osparc/component/form/Auto.js
+++ b/services/web/client/source/class/osparc/component/form/Auto.js
@@ -446,7 +446,6 @@ qx.Class.define("osparc.component.form.Auto", {
     __getField: function(s, key) {
       if (s.type === "ref_contentSchema") {
         Object.assign(s, s.contentSchema);
-        s.label = s.title;
       }
 
       if (s.defaultValue) {

--- a/services/web/client/source/class/osparc/component/permissions/Permissions.js
+++ b/services/web/client/source/class/osparc/component/permissions/Permissions.js
@@ -116,9 +116,7 @@ qx.Class.define("osparc.component.permissions.Permissions", {
         allowGrowY: false,
         enabled: false
       });
-      addCollaboratorBtn.addListener("execute", () => {
-        this._addCollaborator();
-      }, this);
+      addCollaboratorBtn.addListener("execute", () => this._addCollaborator(), this);
       qx.event.message.Bus.getInstance().subscribe("OrgAndMembPermsFilter", () => {
         const anySelected = Boolean(this.__organizationsAndMembers.getSelectedGIDs().length);
         addCollaboratorBtn.setEnabled(anySelected);

--- a/services/web/client/source/class/osparc/dashboard/ResourceMoreOptions.js
+++ b/services/web/client/source/class/osparc/dashboard/ResourceMoreOptions.js
@@ -52,20 +52,26 @@ qx.Class.define("osparc.dashboard.ResourceMoreOptions", {
     __qualityPage: null,
     __servicesUpdatePage: null,
 
+    __openPage: function(page) {
+      if (page) {
+        this.setSelection([page]);
+      }
+    },
+
     openAccessRights: function() {
-      this.setSelection([this.__permissionsPage]);
+      this.__openPage(this.__permissionsPage);
     },
 
     openClassifiers: function() {
-      this.setSelection([this.__classifiersPage]);
+      this.__openPage(this.__classifiersPage);
     },
 
     openQuality: function() {
-      this.setSelection([this.__qualityPage]);
+      this.__openPage(this.__qualityPage);
     },
 
     openUpdateServices: function() {
-      this.setSelection([this.__servicesUpdatePage]);
+      this.__openPage(this.__servicesUpdatePage);
     },
 
     __createServiceVersionSelector: function() {

--- a/services/web/client/source/class/osparc/desktop/StartStopButtons.js
+++ b/services/web/client/source/class/osparc/desktop/StartStopButtons.js
@@ -123,7 +123,6 @@ qx.Class.define("osparc.desktop.StartStopButtons", {
 
       const store = osparc.store.Store.getInstance();
       store.addListener("changeClusters", () => this.__populateClustersSelectBox(), this);
-      this.__populateClustersSelectBox();
 
       const clusterMiniView = new osparc.component.cluster.ClusterMiniView().set({
         alignY: "middle"

--- a/services/web/client/source/class/osparc/utils/Clusters.js
+++ b/services/web/client/source/class/osparc/utils/Clusters.js
@@ -27,6 +27,7 @@ qx.Class.define("osparc.utils.Clusters", {
 
   construct: function() {
     this.base(arguments);
+    this.__clusterIds = [];
     this.__fetchDetailsTimers = [];
   },
 
@@ -93,45 +94,60 @@ qx.Class.define("osparc.utils.Clusters", {
         });
       }
       return clusters;
-    },
+    }
+  },
 
-    fetchDetails: function(cid) {
+  events: {
+    "clusterDetailsReceived": "qx.event.type.Data"
+  },
+
+  members: {
+    __clusterIds: null,
+    __fetchDetailsTimers: null,
+
+    __fetchDetails: function(cid) {
       const params = {
         url: {
           cid
         }
       };
-      osparc.data.Resources.fetch("clusterDetails", params);
-    }
-  },
+      osparc.data.Resources.get("clusterDetails", params)
+        .then(clusterDetails => {
+          this.fireDataEvent("clusterDetailsReceived", {
+            clusterId: cid,
+            clusterDetails
+          });
+        })
+        .catch(err => {
+          console.error(err);
+          this.fireDataEvent("clusterDetailsReceived", {
+            clusterId: cid,
+            error: err
+          });
+        })
+        .finally(() => {
+          // keep asking?
+          if (this.__clusterIds.includes(cid)) {
+            const interval = 3000;
+            qx.event.Timer.once(() => this.__fetchDetails(cid), this, interval);
+          }
+        });
+    },
 
-  members: {
-    __fetchDetailsTimers: null,
-
-    startFetchDetailsTimer: function(clusterId, interval = 3000) {
-      const fetchDetailsTimer = this.__fetchDetailsTimers.find(timer => timer.clusterId === clusterId);
-      if (fetchDetailsTimer) {
-        fetchDetailsTimer.counter++;
-        return;
+    startFetchDetailsTimer: function(clusterId) {
+      console.log("startFetchDetailsTimer", clusterId, this.__clusterIds);
+      const found = this.__clusterIds.includes(clusterId);
+      this.__clusterIds.push(clusterId);
+      if (!found) {
+        console.log("start fetching", this.__clusterIds);
+        this.__fetchDetails(clusterId);
       }
-      this.self().fetchDetails(clusterId);
-      const timer = new qx.event.Timer(interval);
-      timer.clusterId = clusterId;
-      timer.counter = 1;
-      timer.addListener("interval", () => this.self().fetchDetails(clusterId), this);
-      timer.start();
-      this.__fetchDetailsTimers.push(timer);
     },
 
     stopFetchDetailsTimer: function(clusterId) {
-      const idx = this.__fetchDetailsTimers.findIndex(timer => timer.clusterId === clusterId);
-      if (idx > 1) {
-        const fetchDetailsTimer = this.__fetchDetailsTimers[idx];
-        fetchDetailsTimer.counter--;
-        if (fetchDetailsTimer.counter === 0) {
-          fetchDetailsTimer.stop();
-          this.__fetchDetailsTimers.splice(idx, 1);
-        }
+      const idx = this.__clusterIds.indexOf(clusterId);
+      if (idx > -1) {
+        this.__clusterIds.splice(idx, 1);
       }
     }
   }

--- a/services/web/client/source/class/osparc/utils/Clusters.js
+++ b/services/web/client/source/class/osparc/utils/Clusters.js
@@ -74,16 +74,7 @@ qx.Class.define("osparc.utils.Clusters", {
       const store = osparc.store.Store.getInstance();
       const clusters = store.getClusters();
       if (clusters) {
-        const itemDefault = new qx.ui.form.ListItem().set({
-          label: "default",
-          toolTipText: "default cluster"
-        });
-        itemDefault.id = 0;
-        clustersSelectBox.add(itemDefault);
         clusters.forEach(cluster => {
-          if (!("name" in cluster)) {
-            return;
-          }
           const item = new qx.ui.form.ListItem().set({
             label: cluster["name"],
             toolTipText: cluster["type"] + "\n" + cluster["description"],

--- a/services/web/client/source/class/osparc/utils/Clusters.js
+++ b/services/web/client/source/class/osparc/utils/Clusters.js
@@ -118,6 +118,7 @@ qx.Class.define("osparc.utils.Clusters", {
         })
         .finally(() => {
           // keep asking?
+          console.log("keep asking", this.__clusterIds);
           if (this.__clusterIds.includes(cid)) {
             const interval = 3000;
             qx.event.Timer.once(() => this.__fetchDetails(cid), this, interval);
@@ -125,8 +126,8 @@ qx.Class.define("osparc.utils.Clusters", {
         });
     },
 
-    startFetchDetailsTimer: function(clusterId) {
-      console.log("startFetchDetailsTimer", clusterId, this.__clusterIds);
+    startFetchingDetails: function(clusterId) {
+      console.log("startFetchingDetails", clusterId, this.__clusterIds);
       const found = this.__clusterIds.includes(clusterId);
       this.__clusterIds.push(clusterId);
       if (!found) {
@@ -135,7 +136,7 @@ qx.Class.define("osparc.utils.Clusters", {
       }
     },
 
-    stopFetchDetailsTimer: function(clusterId) {
+    stopFetchingDetails: function(clusterId) {
       const idx = this.__clusterIds.indexOf(clusterId);
       if (idx > -1) {
         this.__clusterIds.splice(idx, 1);

--- a/services/web/client/source/class/osparc/utils/Clusters.js
+++ b/services/web/client/source/class/osparc/utils/Clusters.js
@@ -117,8 +117,6 @@ qx.Class.define("osparc.utils.Clusters", {
           });
         })
         .finally(() => {
-          // keep asking?
-          console.log("keep asking", this.__clusterIds);
           if (this.__clusterIds.includes(cid)) {
             const interval = 3000;
             qx.event.Timer.once(() => this.__fetchDetails(cid), this, interval);
@@ -127,7 +125,6 @@ qx.Class.define("osparc.utils.Clusters", {
     },
 
     startFetchingDetails: function(clusterId) {
-      console.log("startFetchingDetails", clusterId, this.__clusterIds);
       const found = this.__clusterIds.includes(clusterId);
       this.__clusterIds.push(clusterId);
       if (!found) {


### PR DESCRIPTION
## What do these changes do?

- [x] Call optimization (fix): re-request details 3" after receiving the last request
- [x] Cluster Details view: all plots same size when resizing the window
- [x] Do not insert "default" cluster, backend already provides it in the clusters list

![ClustersII](https://user-images.githubusercontent.com/33152403/160618484-33b2866b-7b6e-4108-8e63-fc99633039f3.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
