### PR TITLE
🐛 Fix email sending issue missing "From" field

### DIFF
--- a/services/director-v2/tests/unit/test_modules_project_networks.py
+++ b/services/director-v2/tests/unit/test_modules_project_networks.py
@@ -62,9 +62,7 @@ def _network_name(number: int) -> str:
 
 
 @pytest.fixture
-def examples_factory(
-    mock_scheduler: AsyncMock, project_id: ProjectID
-) -> List[Example]:
+def examples_factory(mock_scheduler: AsyncMock, project_id: ProjectID) -> List[Example]:
     return [
         # nothing exists
         Example.using(

--- a/services/web/server/src/simcore_service_webserver/login/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/login/plugin.py
@@ -54,7 +54,7 @@ def setup_login_storage(app: web.Application):
 def _setup_login_options(app: web.Application):
     settings: SMTPSettings = get_email_plugin_settings(app)
 
-    cfg = settings.dict(exclude_unset=True)
+    cfg = settings.dict(exclude_none=True)
     if INDEX_RESOURCE_NAME in app.router:
         cfg["LOGIN_REDIRECT"] = f"{app.router[INDEX_RESOURCE_NAME].url_for()}"
 

--- a/services/web/server/src/simcore_service_webserver/login/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/login/plugin.py
@@ -54,7 +54,7 @@ def setup_login_storage(app: web.Application):
 def _setup_login_options(app: web.Application):
     settings: SMTPSettings = get_email_plugin_settings(app)
 
-    cfg = settings.dict(exclude_none=True)
+    cfg = settings.dict()
     if INDEX_RESOURCE_NAME in app.router:
         cfg["LOGIN_REDIRECT"] = f"{app.router[INDEX_RESOURCE_NAME].url_for()}"
 

--- a/services/web/server/src/simcore_service_webserver/login/settings.py
+++ b/services/web/server/src/simcore_service_webserver/login/settings.py
@@ -46,8 +46,8 @@ class LoginOptions(BaseModel):
     SMTP_HOST: str
     SMTP_PORT: int
     SMTP_TLS_ENABLED: bool
-    SMTP_USERNAME: Optional[str]
-    SMTP_PASSWORD: Optional[SecretStr]
+    SMTP_USERNAME: Optional[str] = Field(...)
+    SMTP_PASSWORD: Optional[SecretStr] = Field(...)
 
     # lifetime limits are in days
     REGISTRATION_CONFIRMATION_LIFETIME: PositiveFloat = 5 * _DAYS

--- a/services/web/server/src/simcore_service_webserver/login/settings.py
+++ b/services/web/server/src/simcore_service_webserver/login/settings.py
@@ -42,12 +42,12 @@ class LoginOptions(BaseModel):
     LOGIN_REDIRECT: str = "/"
     LOGOUT_REDIRECT: str = "/"
 
-    SMTP_SENDER: Optional[str] = None
+    SMTP_SENDER: str
     SMTP_HOST: str
     SMTP_PORT: int
-    SMTP_TLS_ENABLED: bool = False
-    SMTP_USERNAME: Optional[str] = None
-    SMTP_PASSWORD: Optional[SecretStr] = None
+    SMTP_TLS_ENABLED: bool
+    SMTP_USERNAME: Optional[str]
+    SMTP_PASSWORD: Optional[SecretStr]
 
     # lifetime limits are in days
     REGISTRATION_CONFIRMATION_LIFETIME: PositiveFloat = 5 * _DAYS

--- a/services/web/server/src/simcore_service_webserver/login/utils.py
+++ b/services/web/server/src/simcore_service_webserver/login/utils.py
@@ -118,6 +118,7 @@ def flash_response(msg: str, level: str = "INFO") -> web.Response:
 
 async def send_mail(app: web.Application, msg: MIMEText):
     cfg: LoginOptions = get_plugin_options(app)
+    log.debug("Email configuration %s", cfg)
 
     msg["From"] = cfg.SMTP_SENDER
     smtp_args = dict(

--- a/services/web/server/tests/unit/isolated/test_login_plugin.py
+++ b/services/web/server/tests/unit/isolated/test_login_plugin.py
@@ -1,0 +1,23 @@
+# pylint: disable=unused-argument
+import os
+from typing import Any, Dict
+
+from settings_library.email import SMTPSettings
+from simcore_service_webserver.login.plugin import LoginOptions
+
+
+def test_smtp_settings(mock_env_devel_environment: Dict[str, Any]):
+
+    settings = SMTPSettings()
+
+    cfg = settings.dict(exclude_unset=True)
+
+    for env_name in cfg:
+        assert env_name in os.environ
+
+    cfg = settings.dict()
+
+    config = LoginOptions(**cfg)
+    print(config.json(indent=1))
+
+    assert config.SMTP_SENDER is not None


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

The "From" field was not found during the sending of the email. Turns out the wrong parameter to parse the pedantic model was used.
This fixes the issue and allows for emails to get sent once again.

Extra:

- Fixes warnings with a test case in director-v2
## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

- closes https://github.com/ITISFoundation/osparc-simcore/issues/2882

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
