### PR TITLE
🐛 Avoids locking the dynamic-sidecar in an error state

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
@@ -428,7 +428,7 @@ class AttachProjectsNetworks(DynamicSchedulerEvent):
             network_name,
             container_aliases,
         ) in projects_networks.networks_with_aliases.items():
-            network_alias = container_aliases.get(f"{scheduler_data.node_uuid}", None)
+            network_alias = container_aliases.get(f"{scheduler_data.node_uuid}")
             if network_alias is not None:
                 await dynamic_sidecar_client.attach_service_containers_to_project_network(
                     dynamic_sidecar_endpoint=dynamic_sidecar_endpoint,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
@@ -428,14 +428,14 @@ class AttachProjectsNetworks(DynamicSchedulerEvent):
             network_name,
             container_aliases,
         ) in projects_networks.networks_with_aliases.items():
-            for network_alias in container_aliases.values():
-                await dynamic_sidecar_client.attach_service_containers_to_project_network(
-                    dynamic_sidecar_endpoint=dynamic_sidecar_endpoint,
-                    dynamic_sidecar_network_name=scheduler_data.dynamic_sidecar_network_name,
-                    project_network=network_name,
-                    project_id=scheduler_data.project_id,
-                    network_alias=network_alias,
-                )
+            network_alias = container_aliases[f"{scheduler_data.node_uuid}"]
+            await dynamic_sidecar_client.attach_service_containers_to_project_network(
+                dynamic_sidecar_endpoint=dynamic_sidecar_endpoint,
+                dynamic_sidecar_network_name=scheduler_data.dynamic_sidecar_network_name,
+                project_network=network_name,
+                project_id=scheduler_data.project_id,
+                network_alias=network_alias,
+            )
 
         scheduler_data.dynamic_sidecar.is_project_network_attached = True
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
@@ -428,14 +428,15 @@ class AttachProjectsNetworks(DynamicSchedulerEvent):
             network_name,
             container_aliases,
         ) in projects_networks.networks_with_aliases.items():
-            network_alias = container_aliases[f"{scheduler_data.node_uuid}"]
-            await dynamic_sidecar_client.attach_service_containers_to_project_network(
-                dynamic_sidecar_endpoint=dynamic_sidecar_endpoint,
-                dynamic_sidecar_network_name=scheduler_data.dynamic_sidecar_network_name,
-                project_network=network_name,
-                project_id=scheduler_data.project_id,
-                network_alias=network_alias,
-            )
+            network_alias = container_aliases.get(f"{scheduler_data.node_uuid}", None)
+            if network_alias is not None:
+                await dynamic_sidecar_client.attach_service_containers_to_project_network(
+                    dynamic_sidecar_endpoint=dynamic_sidecar_endpoint,
+                    dynamic_sidecar_network_name=scheduler_data.dynamic_sidecar_network_name,
+                    project_network=network_name,
+                    project_id=scheduler_data.project_id,
+                    network_alias=network_alias,
+                )
 
         scheduler_data.dynamic_sidecar.is_project_network_attached = True
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Fixes an issue where the director-v2 cannot find the node in the network aliases.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
