### PR TITLE
Fix: Range validation with prefix updated

### DIFF
--- a/services/web/client/source/class/osparc/component/editor/AnnotationEditor.js
+++ b/services/web/client/source/class/osparc/component/editor/AnnotationEditor.js
@@ -71,6 +71,20 @@ qx.Class.define("osparc.component.editor.AnnotationEditor", {
           row,
           column: 1
         });
+        row++;
+
+        this._add(new qx.ui.basic.Label(this.tr("Size")), {
+          row,
+          column: 0
+        });
+        console.log("attrs", annotation.getAttributes());
+        const fontSizeField = new qx.ui.form.Spinner(12);
+        fontSizeField.addListener("changeValue", e => annotation.setFontSize(e.getData()));
+        this._add(fontSizeField, {
+          row,
+          column: 1
+        });
+        row++;
       }
     }
   }

--- a/services/web/client/source/class/osparc/component/editor/AnnotationEditor.js
+++ b/services/web/client/source/class/osparc/component/editor/AnnotationEditor.js
@@ -61,11 +61,12 @@ qx.Class.define("osparc.component.editor.AnnotationEditor", {
       row++;
 
       if (annotation.getType() === "text") {
+        const attrs = annotation.getAttributes();
         this._add(new qx.ui.basic.Label(this.tr("Text")), {
           row,
           column: 0
         });
-        const textField = new qx.ui.form.TextField(annotation.getAttributes().text);
+        const textField = new qx.ui.form.TextField(attrs.text);
         textField.addListener("changeValue", e => annotation.setText(e.getData()));
         this._add(textField, {
           row,
@@ -77,8 +78,7 @@ qx.Class.define("osparc.component.editor.AnnotationEditor", {
           row,
           column: 0
         });
-        console.log("attrs", annotation.getAttributes());
-        const fontSizeField = new qx.ui.form.Spinner(12);
+        const fontSizeField = new qx.ui.form.Spinner(attrs.fontSize);
         fontSizeField.addListener("changeValue", e => annotation.setFontSize(e.getData()));
         this._add(fontSizeField, {
           row,

--- a/services/web/client/source/class/osparc/component/form/ColorPicker.js
+++ b/services/web/client/source/class/osparc/component/form/ColorPicker.js
@@ -14,7 +14,8 @@ qx.Class.define("osparc.component.form.ColorPicker", {
 
     this._setLayout(new qx.ui.layout.HBox());
 
-    this._add(this.getChildControl("color-button"));
+    this._add(this.getChildControl("random-button"));
+    this._add(this.getChildControl("selector-button"));
     this._add(this.getChildControl("color-input"));
   },
 
@@ -30,9 +31,17 @@ qx.Class.define("osparc.component.form.ColorPicker", {
     _createChildControlImpl: function(id) {
       let control;
       switch (id) {
-        case "color-button":
+        case "random-button":
           control = new qx.ui.form.Button(null, "@FontAwesome5Solid/sync-alt/12");
           control.addListener("execute", () => this.setColor(osparc.utils.Utils.getRandomColor()), this);
+          this.bind("color", control, "backgroundColor");
+          this.bind("color", control, "textColor", {
+            converter: value => osparc.utils.Utils.getContrastedTextColor(qx.theme.manager.Color.getInstance().resolve(value))
+          });
+          break;
+        case "selector-button":
+          control = new qx.ui.form.Button(null, "@FontAwesome5Solid/eye-dropper/12");
+          control.addListener("execute", () => this.__openColorSelector(), this);
           this.bind("color", control, "backgroundColor");
           this.bind("color", control, "textColor", {
             converter: value => osparc.utils.Utils.getContrastedTextColor(qx.theme.manager.Color.getInstance().resolve(value))
@@ -53,6 +62,16 @@ qx.Class.define("osparc.component.form.ColorPicker", {
           break;
       }
       return control || this.base(arguments, id);
+    },
+
+    __openColorSelector: function() {
+      const colorSelector = new qx.ui.control.ColorSelector();
+      const rgb = qx.util.ColorUtil.hexStringToRgb(this.getColor());
+      colorSelector.setRed(rgb[0]);
+      colorSelector.setGreen(rgb[1]);
+      colorSelector.setBlue(rgb[2]);
+      osparc.ui.window.Window.popUpInWindow(colorSelector, this.tr("Pick a color"), 590, 380);
+      colorSelector.addListener("changeValue", e => this.setColor(e.getData()));
     }
   }
 });

--- a/services/web/client/source/class/osparc/component/workbench/Annotation.js
+++ b/services/web/client/source/class/osparc/component/workbench/Annotation.js
@@ -95,7 +95,7 @@ qx.Class.define("osparc.component.workbench.Annotation", {
           representation = this.__svgLayer.drawAnnotationRect(attrs.width, attrs.height, attrs.x, attrs.y, this.getColor());
           break;
         case "text":
-          representation = this.__svgLayer.drawAnnotationText(attrs.x, attrs.y, attrs.text, this.getColor());
+          representation = this.__svgLayer.drawAnnotationText(attrs.x, attrs.y, attrs.text, this.getColor(), attrs.fontSize);
           break;
       }
       if (representation) {
@@ -164,6 +164,14 @@ qx.Class.define("osparc.component.workbench.Annotation", {
       const representation = this.getRepresentation();
       if (representation) {
         osparc.wrapper.Svg.updateText(representation, newText);
+      }
+    },
+
+    setFontSize: function(fontSize) {
+      this.getAttributes().fontSize = fontSize;
+      const representation = this.getRepresentation();
+      if (representation) {
+        osparc.wrapper.Svg.updateTextSize(representation, fontSize);
       }
     },
 

--- a/services/web/client/source/class/osparc/component/workbench/SvgWidget.js
+++ b/services/web/client/source/class/osparc/component/workbench/SvgWidget.js
@@ -93,8 +93,8 @@ qx.Class.define("osparc.component.workbench.SvgWidget", {
       return osparc.wrapper.Svg.drawCurve(this.__canvas, controls, dashed);
     },
 
-    drawAnnotationText: function(x, y, label, color) {
-      return osparc.wrapper.Svg.drawAnnotationText(this.__canvas, x, y, label, color);
+    drawAnnotationText: function(x, y, label, color, fontSize) {
+      return osparc.wrapper.Svg.drawAnnotationText(this.__canvas, x, y, label, color, fontSize);
     },
 
     drawAnnotationRect: function(width, height, x, y, color) {

--- a/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -1806,6 +1806,7 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
         titleEditor.addListener("labelChanged", e => {
           titleEditor.close();
           serializeData.attributes.text = e.getData()["newLabel"];
+          serializeData.attributes.fontSize = 12;
           this.__addAnnotation(serializeData);
         }, this);
         titleEditor.center();

--- a/services/web/client/source/class/osparc/desktop/WorkbenchView.js
+++ b/services/web/client/source/class/osparc/desktop/WorkbenchView.js
@@ -813,17 +813,23 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
         this.__studyOptionsPage.add(this.__getAnnotationsSection());
       }
 
+      const snaps = this.__getSnapshotsSection();
+      snaps.exclude();
+      this.__studyOptionsPage.add(snaps);
       osparc.utils.DisabledPlugins.isVersionControlDisabled()
         .then(isDisabled => {
           if (!isDisabled) {
-            this.__studyOptionsPage.add(this.__getSnapshotsSection());
+            snaps.show();
           }
         });
 
+      const iters = this.__getIterationsSection();
+      iters.exclude();
+      this.__studyOptionsPage.add(iters);
       osparc.utils.DisabledPlugins.isMetaModelingDisabled()
         .then(isDisabled => {
           if (!isDisabled) {
-            this.__studyOptionsPage.add(this.__getIterationsSection());
+            iters.show();
           }
         });
     },

--- a/services/web/client/source/class/osparc/ui/form/ContentSchemaHelper.js
+++ b/services/web/client/source/class/osparc/ui/form/ContentSchemaHelper.js
@@ -47,7 +47,10 @@ qx.Class.define("osparc.ui.form.ContentSchemaHelper", {
         let multiplier = 1;
         let invalidMessage = qx.locale.Manager.tr("Out of range");
         if ("x_unit" in s) {
-          multiplier = osparc.utils.Units.getMultiplier(s, control.unitPrefix, item.unitPrefix);
+          const {
+            unitPrefix
+          } = osparc.utils.Units.decomposeXUnit(s["x_unit"]);
+          multiplier = osparc.utils.Units.getMultiplier(unitPrefix, control.unitPrefix);
         }
         let valid = true;
         if ("minimum" in s && value < multiplier*(s.minimum)) {

--- a/services/web/client/source/class/osparc/utils/Clusters.js
+++ b/services/web/client/source/class/osparc/utils/Clusters.js
@@ -128,7 +128,6 @@ qx.Class.define("osparc.utils.Clusters", {
       const found = this.__clusterIds.includes(clusterId);
       this.__clusterIds.push(clusterId);
       if (!found) {
-        console.log("start fetching", this.__clusterIds);
         this.__fetchDetails(clusterId);
       }
     },

--- a/services/web/client/source/class/osparc/wrapper/Svg.js
+++ b/services/web/client/source/class/osparc/wrapper/Svg.js
@@ -141,12 +141,12 @@ qx.Class.define("osparc.wrapper.Svg", {
       };
     },
 
-    drawAnnotationText: function(draw, x, y, label, color) {
+    drawAnnotationText: function(draw, x, y, label, color, fontSize) {
       const text = draw.text(label)
         .font({
           fill: color,
-          family: "Roboto",
-          size: "12px"
+          size: (fontSize ? fontSize : 12) + "px",
+          family: "Roboto"
         })
         .style({
           cursor: "pointer"
@@ -243,6 +243,13 @@ qx.Class.define("osparc.wrapper.Svg", {
         fill: color
       });
     },
+
+    updateTextSize: function(text, size) {
+      text.font({
+        size: size + "px"
+      });
+    },
+
     updateCurveDashes: function(curve, dashed) {
       curve.attr({
         "stroke-dasharray": dashed ? 5 : 0


### PR DESCRIPTION
## What do these changes do?

Fixed:
![RangeValidation](https://user-images.githubusercontent.com/33152403/160859126-283b2a9e-820c-4be5-8305-e4ab6de352a5.gif)

## Bonus:
- Text annotation with font size


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
