### PR TITLE
🐛 fixes concurrency issue with directory-watcher

### DIFF
--- a/services/dynamic-sidecar/openapi.json
+++ b/services/dynamic-sidecar/openapi.json
@@ -382,7 +382,7 @@
           "containers"
         ],
         "summary": "Enable/disable directory-watcher event propagation",
-        "operationId": "disable_directory_watcher_v1_containers_directory_watcher_patch",
+        "operationId": "enabled_disable_directory_watcher_v1_containers_directory_watcher_patch",
         "requestBody": {
           "content": {
             "application/json": {

--- a/services/dynamic-sidecar/openapi.json
+++ b/services/dynamic-sidecar/openapi.json
@@ -382,7 +382,7 @@
           "containers"
         ],
         "summary": "Enable/disable directory-watcher event propagation",
-        "operationId": "enabled_disable_directory_watcher_v1_containers_directory_watcher_patch",
+        "operationId": "toggle_directory_watcher_v1_containers_directory_watcher_patch",
         "requestBody": {
           "content": {
             "application/json": {

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
@@ -132,7 +132,7 @@ async def pull_input_ports(
     response_class=Response,
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def enabled_disable_directory_watcher(
+async def toggle_directory_watcher(
     patch_directory_watcher_item: PatchDirectoryWatcherItem,
     app: FastAPI = Depends(get_application),
 ) -> None:

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
@@ -132,7 +132,7 @@ async def pull_input_ports(
     response_class=Response,
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def disable_directory_watcher(
+async def enabled_disable_directory_watcher(
     patch_directory_watcher_item: PatchDirectoryWatcherItem,
     app: FastAPI = Depends(get_application),
 ) -> None:

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/directory_watcher.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/directory_watcher.py
@@ -194,6 +194,7 @@ def setup_directory_watcher(app: FastAPI) -> None:
 
         app.state.dir_watcher = DirectoryWatcherObservers()
         app.state.dir_watcher.observe_directory(mounted_volumes.disk_outputs_path)
+        app.state.dir_watcher.disable_event_propagation()
         app.state.dir_watcher.start()
 
     async def on_shutdown() -> None:


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Directory watcher is now disabled when starting the dynamic-sidecar.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->

- [x] Unit tests for the changes exist
- [x] Runs in the swarm
