### PR TITLE
🐛 #2923 - sharing not possible

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -321,7 +321,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=psycopg2.errors
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/services/catalog/src/simcore_service_catalog/db/events.py
+++ b/services/catalog/src/simcore_service_catalog/db/events.py
@@ -27,6 +27,7 @@ async def connect_to_db(app: FastAPI) -> None:
             "server_settings": {"application_name": cfg.POSTGRES_CLIENT_NAME}
         },
         pool_pre_ping=True,  # https://docs.sqlalchemy.org/en/14/core/pooling.html#dealing-with-disconnects
+        future=True,
     )
 
     logger.debug("Connected to %s", engine.url)  # pylint: disable=no-member

--- a/services/catalog/src/simcore_service_catalog/db/events.py
+++ b/services/catalog/src/simcore_service_catalog/db/events.py
@@ -27,7 +27,7 @@ async def connect_to_db(app: FastAPI) -> None:
             "server_settings": {"application_name": cfg.POSTGRES_CLIENT_NAME}
         },
         pool_pre_ping=True,  # https://docs.sqlalchemy.org/en/14/core/pooling.html#dealing-with-disconnects
-        future=True,
+        future=True,  # this uses sqlalchemy 2.0 API, shall be removed when sqlalchemy 2.0 is released
     )
 
     logger.debug("Connected to %s", engine.url)  # pylint: disable=no-member


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
The change in the catalog to async SQLAlchemy brought these:
- autocommit is disabled by default
- when modifying the database one need to use the explicit transaction context manager:
  ```python
  with engine.begin() as conn:
    conn.insert(...)
  ```
or
```python
with engine.connect() as conn:
  conn.insert(...)
  conn.commit()
```

a lot of information may be found [here](https://python-gino.org/docs/en/1.1b2/explanation/sa20.html)

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->
fixes #2923 

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
