### PR TITLE
🐛 Cluster credentials passed as *****

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
@@ -1,4 +1,5 @@
 import logging
+from asyncio.log import logger
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -148,13 +149,15 @@ async def get_default_cluster_details(
     clusters_repo: ClustersRepository = Depends(get_repository(ClustersRepository)),
     dask_clients_pool: DaskClientsPool = Depends(get_dask_clients_pool),
 ):
-    return await _get_cluster_details_with_id(
+    default_cluster = await _get_cluster_details_with_id(
         settings=settings,
         user_id=user_id,
         cluster_id=DEFAULT_CLUSTER_ID,
         clusters_repo=clusters_repo,
         dask_clients_pool=dask_clients_pool,
     )
+    logger.debug("found followind %s", f"{default_cluster=!r}")
+    return default_cluster
 
 
 @router.get(
@@ -170,13 +173,15 @@ async def get_cluster_details(
     clusters_repo: ClustersRepository = Depends(get_repository(ClustersRepository)),
     dask_clients_pool: DaskClientsPool = Depends(get_dask_clients_pool),
 ):
-    return await _get_cluster_details_with_id(
+    cluster_details = await _get_cluster_details_with_id(
         settings=settings,
         user_id=user_id,
         cluster_id=cluster_id,
         clusters_repo=clusters_repo,
         dask_clients_pool=dask_clients_pool,
     )
+    logger.debug("found followind %s", f"{cluster_details=!r}")
+    return cluster_details
 
 
 @router.post(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
creating a cluster or pinging it would use very nice password stars instead of the real password...

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
