### PR TITLE
♻️🐛 Maintenance: removed devel-prod dependency on static-webserver

### DIFF
--- a/services/static-webserver/Dockerfile
+++ b/services/static-webserver/Dockerfile
@@ -10,21 +10,21 @@ ENV SC_USER_ID=8004 \
 
 RUN adduser -D -u ${SC_USER_ID} -s /bin/sh -h /home/${SC_USER_NAME} ${SC_USER_NAME}
 
-# front-end client last (image name is the path to the Dockerfile)
-COPY --from=client/tools/qooxdoo-kit/builder:latest --chown=${SC_USER_NAME}:${SC_USER_NAME} \
-  /project/build-output "/static-content"
-
 # changing ownership of static-web-server files
-RUN chown -R ${SC_USER_NAME}:${SC_USER_NAME} /entrypoint.sh && \
-  chown -R ${SC_USER_NAME}:${SC_USER_NAME} /usr/local/bin/static-web-server && \
-  chown -R ${SC_USER_NAME}:${SC_USER_NAME} /public
+RUN chown -R "${SC_USER_NAME}:${SC_USER_NAME}" /entrypoint.sh && \
+  chown -R "${SC_USER_NAME}:${SC_USER_NAME}" /usr/local/bin/static-web-server && \
+  chown -R "${SC_USER_NAME}:${SC_USER_NAME}" /public
+
 
 USER ${SC_USER_NAME}
 
 FROM base as build
+# front-end client last (image name is the path to the Dockerfile)
+COPY --from=client/tools/qooxdoo-kit/builder:latest --chown=${SC_USER_NAME}:${SC_USER_NAME} \
+  /project/build-output "/static-content"
 ENV SC_BUILD_TARGET build
 
-FROM base as production
+FROM build as production
 ENV SC_BUILD_TARGET production
 
 FROM base as development


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
when issuing ```make build-devel``` on a clean machine it would fail because the static-webserver tries to copy from qooxdoo-kit image that does not exist.
This image only exist in the **production** environment, e.g. after ```make build``` was called.

This fixes the issue.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```
docker system prune -a
make build-devel
```

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
