### PR TITLE
🐛 Sometimes the workers object is empty

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
@@ -48,7 +48,7 @@ class Scheduler(BaseModel):
     @classmethod
     def ensure_workers_is_empty_dict(cls, v):
         if v is None:
-            return dict()
+            return {}
         return v
 
 

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
@@ -42,7 +42,7 @@ class WorkersDict(DictModel[AnyUrl, Worker]):
 
 class Scheduler(BaseModel):
     status: str = Field(..., description="The running status of the scheduler")
-    workers: WorkersDict
+    workers: Optional[WorkersDict] = Field(default_factory=dict)
 
 
 class ClusterGet(Cluster):

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
@@ -44,6 +44,13 @@ class Scheduler(BaseModel):
     status: str = Field(..., description="The running status of the scheduler")
     workers: Optional[WorkersDict] = Field(default_factory=dict)
 
+    @validator("workers", pre=True, always=True)
+    @classmethod
+    def ensure_workers_is_empty_dict(cls, v):
+        if v is None:
+            return dict()
+        return v
+
 
 class ClusterGet(Cluster):
     access_rights: Dict[GroupID, ClusterAccessRights] = Field(

--- a/services/director-v2/tests/unit/test_models_clusters.py
+++ b/services/director-v2/tests/unit/test_models_clusters.py
@@ -2,10 +2,13 @@ from pprint import pformat
 from typing import Any, Dict, Type
 
 import pytest
+from faker import Faker
 from pydantic import BaseModel
 from simcore_service_director_v2.models.schemas.clusters import (
     ClusterCreate,
     ClusterPatch,
+    Scheduler,
+    WorkersDict,
 )
 
 
@@ -37,3 +40,15 @@ def test_cluster_creation_brings_default_thumbail(
         instance = model_cls(**example)
         assert instance
         assert instance.thumbnail
+
+
+def test_scheduler_constructor_with_default_has_correct_dict(faker: Faker):
+    scheduler = Scheduler(status=faker.text())
+    assert isinstance(scheduler.workers, WorkersDict)
+    assert len(scheduler.workers) == 0
+
+
+def test_scheduler_constructor_with_no_workers_has_correct_dict(faker: Faker):
+    scheduler = Scheduler(status=faker.text(), workers=None)
+    assert isinstance(scheduler.workers, WorkersDict)
+    assert len(scheduler.workers) == 0


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
The workers object is sometimes null.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
