### PR TITLE
Fix: Stop requesting cluster details

### DIFF
--- a/services/web/client/source/class/osparc/component/cluster/ClusterMiniView.js
+++ b/services/web/client/source/class/osparc/component/cluster/ClusterMiniView.js
@@ -70,7 +70,9 @@ qx.Class.define("osparc.component.cluster.ClusterMiniView", {
         clusters.stopFetchingDetails(this.__clusterId);
       }
       this.__clusterId = clusterId;
-      clusters.startFetchingDetails(clusterId);
+      if (clusterId) {
+        clusters.startFetchingDetails(clusterId);
+      }
     },
 
     __listenToClusterDetails: function() {

--- a/services/web/client/source/class/osparc/component/cluster/ClusterMiniView.js
+++ b/services/web/client/source/class/osparc/component/cluster/ClusterMiniView.js
@@ -70,7 +70,7 @@ qx.Class.define("osparc.component.cluster.ClusterMiniView", {
         clusters.stopFetchingDetails(this.__clusterId);
       }
       this.__clusterId = clusterId;
-      if (clusterId) {
+      if (clusterId !== null) {
         clusters.startFetchingDetails(clusterId);
       }
     },

--- a/services/web/client/source/class/osparc/desktop/StartStopButtons.js
+++ b/services/web/client/source/class/osparc/desktop/StartStopButtons.js
@@ -57,6 +57,7 @@ qx.Class.define("osparc.desktop.StartStopButtons", {
   members: {
     __clustersLayout: null,
     __clustersSelectBox: null,
+    __clusterMiniView: null,
     __startButton: null,
     __startSelectionButton: null,
     __startAllButton: null,
@@ -124,7 +125,7 @@ qx.Class.define("osparc.desktop.StartStopButtons", {
       const store = osparc.store.Store.getInstance();
       store.addListener("changeClusters", () => this.__populateClustersSelectBox(), this);
 
-      const clusterMiniView = new osparc.component.cluster.ClusterMiniView().set({
+      const clusterMiniView = this.__clusterMiniView = new osparc.component.cluster.ClusterMiniView().set({
         alignY: "middle"
       });
       selectBox.addListener("changeSelection", e => {
@@ -148,6 +149,10 @@ qx.Class.define("osparc.desktop.StartStopButtons", {
         return this.__clustersSelectBox.getSelection()[0].id;
       }
       return null;
+    },
+
+    getClusterMiniView: function() {
+      return this.__clusterMiniView;
     },
 
     __createStartButton: function() {

--- a/services/web/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/web/client/source/class/osparc/desktop/StudyEditor.js
@@ -616,6 +616,10 @@ qx.Class.define("osparc.desktop.StudyEditor", {
       if (this.getStudy()) {
         this.getStudy().stopStudy();
       }
+      const clusterMiniView = this.__workbenchView.getStartStopButtons().getClusterMiniView();
+      if (clusterMiniView) {
+        clusterMiniView.setClusterId(null);
+      }
     },
 
     /**


### PR DESCRIPTION
## What do these changes do?

After closing the study, the Cluster Mini VIew has to stop asking for cluster details


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
