### PR TITLE
⬆️ udpates datcore-adapter service dependencies

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,10 +13,10 @@ cryptography>=3.3.2                           # https://github.com/advisories/GH
 jinja2>=2.11.3                                # https://github.com/advisories/GHSA-g3rq-g295-4j3m
 pydantic>=1.8.2                               # https://github.com/advisories/GHSA-5jqp-qgf6-3pvh
 pyyaml>=5.4                                   # https://github.com/advisories/GHSA-8q59-q68h-6hv4
+rsa>=4.1                                      # https://github.com/advisories/GHSA-537h-rv9q-vvph
 sqlalchemy[postgresql_psycopg2binary]>=1.3.3  # https://nvd.nist.gov/vuln/detail/CVE-2019-7164
 sqlalchemy>=1.3.3                             # https://nvd.nist.gov/vuln/detail/CVE-2019-7164
 urllib3>=1.26.5                               # https://github.com/advisories/GHSA-q2q7-5pp4-w6pg
-
 
 #
 # Breaking changes

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-aiodebug==1.1.2
+aiodebug==2.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -13,36 +13,37 @@ aiofiles==0.8.0
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-anyio==3.2.1
+anyio==3.5.0
     # via
     #   httpcore
     #   starlette
-asgiref==3.4.1
+    #   watchgod
+asgiref==3.5.0
     # via uvicorn
-boto3==1.17.104
+boto3==1.21.33
     # via pennsieve
-botocore==1.20.104
+botocore==1.24.33
     # via
     #   boto3
     #   s3transfer
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   httpcore
     #   httpx
     #   requests
-chardet==4.0.0
-    # via requests
-charset-normalizer==2.0.10
-    # via httpx
-click==8.0.3
+charset-normalizer==2.0.12
+    # via
+    #   httpx
+    #   requests
+click==8.1.2
     # via
     #   typer
     #   uvicorn
-configparser==5.0.2
+configparser==5.2.0
     # via pennsieve
-deprecated==1.2.12
+deprecated==1.2.13
     # via pennsieve
-dnspython==2.1.0
+dnspython==2.2.1
     # via email-validator
 docopt==0.6.2
     # via pennsieve
@@ -50,7 +51,7 @@ ecdsa==0.14.1
     # via python-jose
 email-validator==1.1.3
     # via pydantic
-fastapi==0.71.0
+fastapi==0.75.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
@@ -58,40 +59,37 @@ fastapi==0.71.0
     #   fastapi-pagination
 fastapi-contrib==0.2.11
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-fastapi-pagination==0.8.0
+fastapi-pagination==0.9.1
     # via -r requirements/_base.in
 future==0.18.2
     # via pennsieve
-futures==3.1.1
+futures==3.0.5
     # via pennsieve
 h11==0.12.0
     # via
     #   httpcore
     #   uvicorn
-h2==3.2.0
+h2==4.1.0
     # via httpx
-hpack==3.0.0
+hpack==4.0.0
     # via h2
-httpcore==0.14.4
+httpcore==0.14.7
     # via httpx
-httptools==0.3.0
+httptools==0.4.0
     # via uvicorn
-httpx==0.21.3
+httpx==0.22.0
     # via -r requirements/_base.in
-hyperframe==5.2.0
+hyperframe==6.0.1
     # via h2
-idna==2.10
+idna==3.3
     # via
-    #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
-    #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   anyio
     #   email-validator
     #   requests
     #   rfc3986
 jaeger-client==4.8.0
     # via fastapi-contrib
-jmespath==0.10.0
+jmespath==1.0.0
     # via
     #   boto3
     #   botocore
@@ -101,9 +99,9 @@ opentracing==2.4.0
     #   jaeger-client
 pennsieve==6.1.2
     # via -r requirements/_base.in
-protobuf==3.17.3
+protobuf==3.20.0
     # via pennsieve
-psutil==5.8.0
+psutil==5.9.0
     # via pennsieve
 pyasn1==0.4.8
     # via
@@ -123,21 +121,21 @@ pydantic==1.9.0
     #   -r requirements/_base.in
     #   fastapi
     #   fastapi-pagination
-pyinstrument==4.0.3
+pyinstrument==4.1.1
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   botocore
     #   pennsieve
-python-dotenv==0.18.0
+python-dotenv==0.20.0
     # via uvicorn
 python-jose==3.2.0
     # via pennsieve
 python-multipart==0.0.5
     # via -r requirements/_base.in
-pytz==2021.1
+pytz==2022.1
     # via pennsieve
 pyyaml==5.4.1
     # via
@@ -151,7 +149,7 @@ pyyaml==5.4.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   uvicorn
-requests==2.25.1
+requests==2.27.1
     # via pennsieve
 rfc3986==1.5.0
     # via httpx
@@ -159,14 +157,13 @@ rsa==4.0
     # via
     #   pennsieve
     #   python-jose
-s3transfer==0.4.2
+s3transfer==0.5.2
     # via boto3
 semver==2.13.0
     # via pennsieve
 six==1.16.0
     # via
     #   ecdsa
-    #   protobuf
     #   python-dateutil
     #   python-jose
     #   python-multipart
@@ -184,19 +181,19 @@ tenacity==8.0.1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 threadloop==1.0.2
     # via jaeger-client
-thrift==0.13.0
+thrift==0.16.0
     # via jaeger-client
 tornado==6.1
     # via
     #   jaeger-client
     #   threadloop
-typer==0.4.0
+typer==0.4.1
     # via -r requirements/../../../packages/settings-library/requirements/_base.in
-typing-extensions==3.10.0.2
+typing-extensions==4.1.1
     # via
-    #   fastapi-pagination
+    #   aiodebug
     #   pydantic
-urllib3==1.26.7
+urllib3==1.26.9
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
@@ -205,15 +202,15 @@ urllib3==1.26.7
     #   -c requirements/../../../requirements/constraints.txt
     #   botocore
     #   requests
-uvicorn==0.17.0
+uvicorn==0.17.6
     # via -r requirements/_base.in
-uvloop==0.15.2
+uvloop==0.16.0
     # via uvicorn
-watchgod==0.7
+watchgod==0.8.2
     # via uvicorn
-websocket-client==1.1.0
+websocket-client==1.3.2
     # via pennsieve
-websockets==10.1
+websockets==10.2
     # via uvicorn
-wrapt==1.12.1
+wrapt==1.14.0
     # via deprecated

--- a/services/datcore-adapter/requirements/_test.txt
+++ b/services/datcore-adapter/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-anyio==3.2.1
+anyio==3.5.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
@@ -14,20 +14,17 @@ astroid==2.11.2
     # via pylint
 attrs==21.4.0
     # via pytest
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -c requirements/_base.txt
     #   httpcore
     #   httpx
     #   requests
-chardet==4.0.0
-    # via
-    #   -c requirements/_base.txt
-    #   requests
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via
     #   -c requirements/_base.txt
     #   httpx
+    #   requests
 codecov==2.1.12
     # via -r requirements/_test.in
 coverage==6.3.2
@@ -46,23 +43,23 @@ docopt==0.6.2
     #   coveralls
 execnet==1.9.0
     # via pytest-xdist
-faker==13.3.3
+faker==13.3.4
     # via -r requirements/_test.in
 h11==0.12.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==0.14.4
+httpcore==0.14.7
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.21.3
+httpx==0.22.0
     # via
     #   -c requirements/_base.txt
     #   respx
 icdiff==2.0.4
     # via pytest-icdiff
-idna==2.10
+idna==3.3
     # via
     #   -c requirements/_base.txt
     #   anyio
@@ -90,7 +87,7 @@ py==1.11.0
     # via
     #   pytest
     #   pytest-forked
-pylint==2.13.2
+pylint==2.13.4
     # via -r requirements/_test.in
 pyparsing==3.0.7
     # via packaging
@@ -123,11 +120,11 @@ pytest-sugar==0.9.4
     # via -r requirements/_test.in
 pytest-xdist==2.5.0
     # via -r requirements/_test.in
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -c requirements/_base.txt
     #   faker
-requests==2.25.1
+requests==2.27.1
     # via
     #   -c requirements/_base.txt
     #   codecov
@@ -156,17 +153,17 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-typing-extensions==3.10.0.2
+typing-extensions==4.1.1
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   pylint
-urllib3==1.26.7
+urllib3==1.26.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   requests
-wrapt==1.12.1
+wrapt==1.14.0
     # via
     #   -c requirements/_base.txt
     #   astroid

--- a/services/datcore-adapter/requirements/_tools.txt
+++ b/services/datcore-adapter/requirements/_tools.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.1.0
+black==22.3.0
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.3.1
     # via pre-commit
-click==8.0.3
+click==8.1.2
     # via
     #   -c requirements/_base.txt
     #   black
@@ -40,7 +40,7 @@ platformdirs==2.5.1
     #   -c requirements/_test.txt
     #   black
     #   virtualenv
-pre-commit==2.17.0
+pre-commit==2.18.1
     # via -r requirements/../../../requirements/devenv.txt
 pyyaml==5.4.1
     # via
@@ -60,7 +60,7 @@ tomli==2.0.1
     #   -c requirements/_test.txt
     #   black
     #   pep517
-typing-extensions==3.10.0.2
+typing-extensions==4.1.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

~~🔒️ Fixing vulnerabilities by upgrading ``rsa==4.7``~~  : Currently blocked until PR https://github.com/Pennsieve/pennsieve-python/pull/15 is merged and released
- [Access Restriction Bypass](https://github.com/ITISFoundation/osparc-simcore/security/dependabot/47): GHSA-xrx6-fmxq-rjj2
- [Timing attacks in python-rsa](https://github.com/ITISFoundation/osparc-simcore/security/dependabot/48): GHSA-537h-rv9q-vvph



⬆️ General upgrade of all service libraries (only updated libraries are included)
- #packages before: 45
- #packages after : 44

|#|name|before|after|upgrade| count|
|-|----|------|-----|-------|------|
|   1 | aiodebug                  | 1.1.2           | 2.3.0      | **MAJOR**  | 1 |
|   2 | anyio                     | 3.2.1           | 3.5.0      | *minor*    | 2 |
|   3 | asgiref                   | 3.4.1           | 3.5.0      | *minor*    | 1 |
|   4 | black                     | 22.1.0          | 22.3.0     | *minor*    | 1 |
|   5 | boto3                     | 1.17.104        | 1.21.33    | *minor*    | 1 |
|   6 | botocore                  | 1.20.104        | 1.24.33    | *minor*    | 1 |
|   7 | certifi                   | 2021.5.30       | 2021.10.8  | *minor*    | 2 |
|   8 | chardet                   | 4.0.0           | 🗑️ removed |  | 2 |
|   9 | charset-normalizer        | 2.0.10          | 2.0.12     |            | 2 |
|  10 | click                     | 8.0.3           | 8.1.2      | *minor*    | 2 |
|  11 | configparser              | 5.0.2           | 5.2.0      | *minor*    | 1 |
|  12 | deprecated                | 1.2.12          | 1.2.13     |            | 1 |
|  13 | dnspython                 | 2.1.0           | 2.2.1      | *minor*    | 1 |
|  14 | faker                     | 13.3.3          | 13.3.4     |            | 1 |
|  15 | fastapi                   | 0.71.0          | 0.75.1     | *minor*    | 1 |
|  16 | fastapi-pagination        | 0.8.0           | 0.9.1      | *minor*    | 1 |
|  17 | futures                   | 3.1.1           | 3.0.5      | 🔥 downgrade | 1 |
|  18 | h2                        | 3.2.0           | 4.1.0      | **MAJOR**  | 1 |
|  19 | hpack                     | 3.0.0           | 4.0.0      | **MAJOR**  | 1 |
|  20 | httpcore                  | 0.14.4          | 0.14.7     |            | 2 |
|  21 | httptools                 | 0.3.0           | 0.4.0      | *minor*    | 1 |
|  22 | httpx                     | 0.21.3          | 0.22.0     | *minor*    | 2 |
|  23 | hyperframe                | 5.2.0           | 6.0.1      | **MAJOR**  | 1 |
|  24 | idna                      | 2.10            | 3.3        | **MAJOR**  | 2 |
|  25 | jmespath                  | 0.10.0          | 1.0.0      | **MAJOR**  | 1 |
|  26 | pre-commit                | 2.17.0          | 2.18.1     | *minor*    | 1 |
|  27 | protobuf                  | 3.17.3          | 3.20.0     | *minor*    | 1 |
|  28 | psutil                    | 5.8.0           | 5.9.0      | *minor*    | 1 |
|  29 | pyinstrument              | 4.0.3           | 4.1.1      | *minor*    | 1 |
|  30 | pylint                    | 2.13.2          | 2.13.4     |            | 1 |
|  31 | python-dateutil           | 2.8.1           | 2.8.2      |            | 2 |
|  32 | python-dotenv             | 0.18.0          | 0.20.0     | *minor*    | 1 |
|  33 | pytz                      | 2021.1          | 2022.1     | **MAJOR**  | 1 |
|  34 | requests                  | 2.25.1          | 2.27.1     | *minor*    | 2 |
|  35 | s3transfer                | 0.4.2           | 0.5.2      | *minor*    | 1 |
|  36 | thrift                    | 0.13.0          | 0.16.0     | *minor*    | 1 |
|  37 | typer                     | 0.4.0           | 0.4.1      |            | 1 |
|  38 | typing-extensions         | 3.10.0.2        | 4.1.1      | **MAJOR**  | 3 |
|  39 | urllib3                   | 1.26.7          | 1.26.9     |            | 2 |
|  40 | uvicorn                   | 0.17.0          | 0.17.6     |            | 1 |
|  41 | uvloop                    | 0.15.2          | 0.16.0     | *minor*    | 1 |
|  42 | watchgod                  | 0.7             | 0.8.2      | *minor*    | 1 |
|  43 | websocket-client          | 1.1.0           | 1.3.2      | *minor*    | 1 |
|  44 | websockets                | 10.1            | 10.2       | *minor*    | 1 |
|  45 | wrapt                     | 1.12.1          | 1.14.0     | *minor*    | 2 |


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
