### PR TITLE
✨ retrieve dask available/used resources

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/redis_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/redis_service.py
@@ -65,7 +65,7 @@ async def redis_client(
     yield client
 
     await client.flushall()
-    await client.close()
+    await client.close(close_connection_pool=True)
 
 
 @pytest.fixture(scope="function")
@@ -78,7 +78,7 @@ async def redis_locks_client(
     yield client
 
     await client.flushall()
-    await client.close()
+    await client.close(close_connection_pool=True)
 
 
 # HELPERS --

--- a/services/director-v2/requirements/_base.in
+++ b/services/director-v2/requirements/_base.in
@@ -19,6 +19,7 @@
 
 
 aio-pika
+aiocache[redis,msgpack]
 aiodocker
 aiopg[sa]
 dask-gateway

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -6,6 +6,8 @@
 #
 aio-pika==6.8.0
     # via -r requirements/_base.in
+aiocache==0.11.1
+    # via -r requirements/_base.in
 aiodebug==1.1.2
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
@@ -40,6 +42,8 @@ aiopg==1.3.3
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
+aioredis==2.0.1
+    # via aiocache
 aiormq==3.3.1
     # via aio-pika
 aiosignal==1.2.0
@@ -58,6 +62,7 @@ async-timeout==4.0.2
     # via
     #   aiohttp
     #   aiopg
+    #   aioredis
 attrs==20.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
@@ -208,6 +213,7 @@ markupsafe==2.0.1
 msgpack==1.0.3
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   aiocache
     #   distributed
 multidict==5.2.0
     # via
@@ -386,6 +392,7 @@ typing-extensions==4.1.1 ; python_version < "3.9"
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
     #   aiodocker
+    #   aioredis
     #   pydantic
 ujson==4.0.2
     # via fastapi

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
@@ -1,7 +1,8 @@
 import logging
 from asyncio.log import logger
-from typing import List
+from typing import Final, List
 
+from aiocache import cached
 from fastapi import APIRouter, Depends, HTTPException
 from models_library.clusters import DEFAULT_CLUSTER_ID, Cluster, ClusterID
 from models_library.users import UserID
@@ -30,6 +31,14 @@ router = APIRouter()
 log = logging.getLogger(__name__)
 
 
+GET_CLUSTER_DETAILS_CACHING_TTL: Final[int] = 3
+
+
+def _build_cache_key(fct, *_, **kwargs):
+    return f"{fct.__name__}_{kwargs['cluster_id']}"
+
+
+@cached(ttl=GET_CLUSTER_DETAILS_CACHING_TTL, key_builder=_build_cache_key)
 async def _get_cluster_details_with_id(
     settings: ComputationalBackendSettings,
     user_id: UserID,

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/clusters.py
@@ -5,7 +5,6 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException
 from models_library.clusters import DEFAULT_CLUSTER_ID, Cluster, ClusterID
 from models_library.users import UserID
-from pydantic import AnyUrl, parse_obj_as
 from simcore_service_director_v2.api.dependencies.scheduler import (
     get_scheduler_settings,
 )
@@ -16,11 +15,11 @@ from ...core.errors import ClusterInvalidOperationError, ConfigurationError
 from ...core.settings import ComputationalBackendSettings
 from ...models.schemas.clusters import (
     ClusterCreate,
+    ClusterDetails,
     ClusterDetailsGet,
     ClusterGet,
     ClusterPatch,
     ClusterPing,
-    Scheduler,
 )
 from ...modules.dask_clients_pool import DaskClientsPool
 from ...modules.db.repositories.clusters import ClustersRepository
@@ -37,21 +36,15 @@ async def _get_cluster_details_with_id(
     cluster_id: ClusterID,
     clusters_repo: ClustersRepository,
     dask_clients_pool: DaskClientsPool,
-) -> ClusterDetailsGet:
+) -> ClusterDetails:
     log.debug("Getting details for cluster '%s'", cluster_id)
     cluster: Cluster = settings.default_cluster
     if cluster_id != DEFAULT_CLUSTER_ID:
         cluster = await clusters_repo.get_cluster(user_id, cluster_id)
     async with dask_clients_pool.acquire(cluster) as client:
-        scheduler_info = client.dask_subsystem.client.scheduler_info()
-        scheduler_status = client.dask_subsystem.client.status
-        dashboard_link = client.dask_subsystem.client.dashboard_link
-    assert dashboard_link  # nosec
+        cluster_details = await client.get_cluster_details()
 
-    return ClusterDetailsGet(
-        scheduler=Scheduler(status=scheduler_status, **scheduler_info),
-        dashboard_link=parse_obj_as(AnyUrl, dashboard_link),
-    )
+    return cluster_details
 
 
 @router.post(

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
@@ -13,7 +13,15 @@ from models_library.clusters import (
 )
 from models_library.generics import DictModel
 from models_library.users import GroupID
-from pydantic import AnyHttpUrl, BaseModel, Field, HttpUrl, root_validator, validator
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    Field,
+    HttpUrl,
+    NonNegativeFloat,
+    root_validator,
+    validator,
+)
 from pydantic.networks import AnyUrl
 from pydantic.types import ByteSize, PositiveFloat
 
@@ -32,6 +40,7 @@ class Worker(BaseModel):
     id: str
     name: str
     resources: DictModel[str, PositiveFloat]
+    used_resources: DictModel[str, NonNegativeFloat]
     memory_limit: ByteSize
     metrics: WorkerMetrics
 
@@ -52,6 +61,16 @@ class Scheduler(BaseModel):
         return v
 
 
+class ClusterDetails(BaseModel):
+    scheduler: Scheduler = Field(
+        ...,
+        description="This contains dask scheduler information given by the underlying dask library",
+    )
+    dashboard_link: AnyUrl = Field(
+        ..., description="Link to this scheduler's dashboard"
+    )
+
+
 class ClusterGet(Cluster):
     access_rights: Dict[GroupID, ClusterAccessRights] = Field(
         alias="accessRights", default_factory=dict
@@ -69,14 +88,8 @@ class ClusterGet(Cluster):
         return values
 
 
-class ClusterDetailsGet(BaseModel):
-    scheduler: Scheduler = Field(
-        ...,
-        description="This contains dask scheduler information given by the underlying dask library",
-    )
-    dashboard_link: AnyUrl = Field(
-        ..., description="Link to this scheduler's dashboard"
-    )
+class ClusterDetailsGet(ClusterDetails):
+    ...
 
 
 class ClusterCreate(BaseCluster):

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -321,7 +321,7 @@ class DaskClient:
         # process, and report when it is finished and properly cancelled.
         logger.debug("cancelling task with %s", f"{job_id=}")
         try:
-            task_future = await self.dask_subsystem.client.get_dataset(name=job_id)  # type: ignore
+            task_future: distributed.Future = await self.dask_subsystem.client.get_dataset(name=job_id)  # type: ignore
             # NOTE: It seems there is a bug in the pubsub system in dask
             # Event are more robust to connections/disconnections
             cancel_event = await distributed.Event(

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -145,10 +145,10 @@ async def create_dask_client_from_scheduler(
         )
         assert not client._subscribed_tasks
 
-        assert client.dask_subsystem.client
-        assert not client.dask_subsystem.gateway
-        assert not client.dask_subsystem.gateway_cluster
-        scheduler_infos = client.dask_subsystem.client.scheduler_info()  # type: ignore
+        assert client.backend.client
+        assert not client.backend.gateway
+        assert not client.backend.gateway_cluster
+        scheduler_infos = client.backend.client.scheduler_info()  # type: ignore
         print(
             f"--> Connected to scheduler via client {client=} to scheduler {scheduler_infos=}"
         )
@@ -186,16 +186,16 @@ async def create_dask_client_from_gateway(
         )
         assert not client._subscribed_tasks
 
-        assert client.dask_subsystem.client
-        assert client.dask_subsystem.gateway
-        assert client.dask_subsystem.gateway_cluster
+        assert client.backend.client
+        assert client.backend.gateway
+        assert client.backend.gateway_cluster
 
-        scheduler_infos = client.dask_subsystem.client.scheduler_info()  # type: ignore
-        print(f"--> Connected to gateway {client.dask_subsystem.gateway=}")
-        print(f"--> Cluster {client.dask_subsystem.gateway_cluster=}")
+        scheduler_infos = client.backend.client.scheduler_info()  # type: ignore
+        print(f"--> Connected to gateway {client.backend.gateway=}")
+        print(f"--> Cluster {client.backend.gateway_cluster=}")
         print(f"--> Client {client=}")
         print(
-            f"--> Cluster dashboard link {client.dask_subsystem.gateway_cluster.dashboard_link}"
+            f"--> Cluster dashboard link {client.backend.gateway_cluster.dashboard_link}"
         )
         created_clients.append(client)
         return client
@@ -350,7 +350,7 @@ async def test_dask_cluster_executes_simple_functions(dask_client: DaskClient):
     def test_fct_add(x: int, y: int) -> int:
         return x + y
 
-    future = dask_client.dask_subsystem.client.submit(test_fct_add, 2, 5)
+    future = dask_client.backend.client.submit(test_fct_add, 2, 5)
     assert future
 
     result = await future.result(timeout=_ALLOW_TIME_FOR_GATEWAY_TO_CREATE_WORKERS)  # type: ignore
@@ -371,7 +371,7 @@ async def test_dask_does_not_report_asyncio_cancelled_error_in_task(
 
         raise asyncio.CancelledError("task was cancelled, but dask does not care...")
 
-    future = dask_client.dask_subsystem.client.submit(fct_that_raise_cancellation_error)
+    future = dask_client.backend.client.submit(fct_that_raise_cancellation_error)
     # NOTE: Since asyncio.CancelledError is derived from BaseException and the worker code checks Exception only
     # this goes through...
     # The day this is fixed, this test should detect it... SAN would be happy to know about it.
@@ -392,7 +392,7 @@ async def test_dask_does_not_report_base_exception_in_task(dask_client: DaskClie
 
         raise BaseException("task triggers a base exception, but dask does not care...")
 
-    future = dask_client.dask_subsystem.client.submit(fct_that_raise_base_exception)
+    future = dask_client.backend.client.submit(fct_that_raise_base_exception)
     # NOTE: Since asyncio.CancelledError is derived from BaseException and the worker code checks Exception only
     # this goes through...
     # The day this is fixed, this test should detect it... SAN would be happy to know about it.
@@ -412,7 +412,7 @@ async def test_dask_does_report_any_non_base_exception_derived_error(
     def fct_that_raise_exception():
         raise exc
 
-    future = dask_client.dask_subsystem.client.submit(fct_that_raise_exception)
+    future = dask_client.backend.client.submit(fct_that_raise_exception)
     # NOTE: Since asyncio.CancelledError does not work we define our own Exception derived cancellation
     task_exception = await future.exception(
         timeout=_ALLOW_TIME_FOR_GATEWAY_TO_CREATE_WORKERS
@@ -570,14 +570,14 @@ async def test_computation_task_is_persisted_on_dask_scheduler(
     assert not distributed.Future(job_id).done()
 
     # as the task is published on the dask-scheduler when sending, it shall still be published on the dask scheduler
-    list_of_persisted_datasets = await dask_client.dask_subsystem.client.list_datasets()  # type: ignore
+    list_of_persisted_datasets = await dask_client.backend.client.list_datasets()  # type: ignore
     assert list_of_persisted_datasets
     assert isinstance(list_of_persisted_datasets, tuple)
     assert len(list_of_persisted_datasets) == 1
     assert job_id in list_of_persisted_datasets
     assert list_of_persisted_datasets[0] == job_id
     # get the persisted future from the scheduler back
-    task_future = await dask_client.dask_subsystem.client.get_dataset(name=job_id)  # type: ignore
+    task_future = await dask_client.backend.client.get_dataset(name=job_id)  # type: ignore
     assert task_future
     assert isinstance(task_future, distributed.Future)
     assert task_future.key == job_id
@@ -745,7 +745,7 @@ async def test_missing_resource_send_computation_task(
 ):
 
     # remove the workers that can handle mpi
-    scheduler_info = dask_client.dask_subsystem.client.scheduler_info()
+    scheduler_info = dask_client.backend.client.scheduler_info()
     assert scheduler_info
     # find mpi workers
     workers_to_remove = [
@@ -753,7 +753,7 @@ async def test_missing_resource_send_computation_task(
         for worker_key, worker_info in scheduler_info["workers"].items()
         if "MPI" in worker_info["resources"]
     ]
-    await dask_client.dask_subsystem.client.retire_workers(workers=workers_to_remove)  # type: ignore
+    await dask_client.backend.client.retire_workers(workers=workers_to_remove)  # type: ignore
     await asyncio.sleep(5)  # a bit of time is needed so the cluster adapts
 
     # now let's adapt the task so it needs mpi
@@ -929,7 +929,7 @@ async def test_get_tasks_status(
     await _assert_wait_for_task_status(job_id, dask_client, RunningState.STARTED)
 
     # let the remote fct run through now
-    start_event = Event(_DASK_EVENT_NAME, dask_client.dask_subsystem.client)
+    start_event = Event(_DASK_EVENT_NAME, dask_client.backend.client)
     await start_event.set()  # type: ignore
     # it will become successful hopefuly
     await _assert_wait_for_task_status(

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -1102,10 +1102,8 @@ async def test_get_cluster_details(
             ), f"there are no workers in {cluster_details.scheduler=!r}"
             for worker_url, worker_data in cluster_details.scheduler.workers.items():
                 if all(
-                    [
-                        worker_data.used_resources.get(res_name) == res_value
-                        for res_name, res_value in image_params.expected_used_resources.items()
-                    ]
+                    worker_data.used_resources.get(res_name) == res_value
+                    for res_name, res_value in image_params.expected_used_resources.items()
                 ):
                     worker_with_the_task = worker_url
             assert (

--- a/services/director-v2/tests/unit/test_modules_dask_clients_pool.py
+++ b/services/director-v2/tests/unit/test_modules_dask_clients_pool.py
@@ -268,7 +268,7 @@ async def test_acquire_default_cluster(
         def just_a_quick_fct(x, y):
             return x + y
 
-        future = dask_client.dask_subsystem.client.submit(just_a_quick_fct, 12, 23)
+        future = dask_client.backend.client.submit(just_a_quick_fct, 12, 23)
         assert future
         result = await future.result(timeout=10)  # type: ignore
     assert result == 35

--- a/services/web/server/src/simcore_service_webserver/redis.py
+++ b/services/web/server/src/simcore_service_webserver/redis.py
@@ -50,7 +50,7 @@ async def setup_redis_client(app: web.Application):
                     address, encoding="utf-8", decode_responses=True
                 )
                 if not await client.ping():
-                    await client.close()
+                    await client.close(close_connection_pool=True)
                     raise ConnectionError(f"Connection to {address!r} failed")
                 log.info(
                     "Connection to %s succeeded with %s [%s]",
@@ -76,10 +76,10 @@ async def setup_redis_client(app: web.Application):
 
     if client is not app[APP_CLIENT_REDIS_CLIENT_KEY]:
         log.critical("Invalid redis client in app")
-        await client.close()
+        await client.close(close_connection_pool=True)
     if client_lock_db is not app[APP_CLIENT_REDIS_LOCK_MANAGER_CLIENT_KEY]:
         log.critical("Invalid redis client for lock db in app")
-        await client_lock_db.close()
+        await client_lock_db.close(close_connection_pool=True)
 
 
 def get_redis_client(app: web.Application) -> aioredis.Redis:

--- a/services/web/server/tests/integration/01/test_exporter.py
+++ b/services/web/server/tests/integration/01/test_exporter.py
@@ -129,7 +129,7 @@ async def __delete_all_redis_keys__(redis_settings: RedisSettings):
         redis_settings.dsn_resources, encoding="utf-8", decode_responses=True
     )
     await client.flushall()
-    await client.close()
+    await client.close(close_connection_pool=True)
     yield
     # do nothing on teadown
 

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -75,7 +75,7 @@ async def __delete_all_redis_keys__(redis_settings: RedisSettings):
         redis_settings.dsn_resources, encoding="utf-8", decode_responses=True
     )
     await client.flushall()
-    await client.close()
+    await client.close(close_connection_pool=True)
     yield
     # do nothing on teadown
 

--- a/services/web/server/tests/unit/with_dbs/01/clusters/test_clusters_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/01/clusters/test_clusters_handlers.py
@@ -232,7 +232,10 @@ async def test_delete_cluster(
 @hypothesis.settings(
     # hypothesis does not play well with fixtures, hence the warning
     # it will create several tests but not replay the fixtures
-    suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture],
+    suppress_health_check=[
+        hypothesis.HealthCheck.function_scoped_fixture,
+        hypothesis.HealthCheck.too_slow,
+    ],
     deadline=None,
 )
 async def test_ping_cluster(

--- a/services/web/server/tests/unit/with_dbs/01/clusters/test_clusters_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/01/clusters/test_clusters_handlers.py
@@ -187,7 +187,8 @@ async def test_get_cluster_details(
 @hypothesis.settings(
     # hypothesis does not play well with fixtures, hence the warning
     # it will create several tests but not replay the fixtures
-    suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture]
+    suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture],
+    deadline=None,
 )
 async def test_update_cluster(
     enable_dev_features: None,
@@ -231,7 +232,8 @@ async def test_delete_cluster(
 @hypothesis.settings(
     # hypothesis does not play well with fixtures, hence the warning
     # it will create several tests but not replay the fixtures
-    suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture]
+    suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture],
+    deadline=None,
 )
 async def test_ping_cluster(
     enable_dev_features: None,

--- a/services/web/server/tests/unit/with_dbs/01/clusters/test_clusters_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/01/clusters/test_clusters_handlers.py
@@ -187,7 +187,10 @@ async def test_get_cluster_details(
 @hypothesis.settings(
     # hypothesis does not play well with fixtures, hence the warning
     # it will create several tests but not replay the fixtures
-    suppress_health_check=[hypothesis.HealthCheck.function_scoped_fixture],
+    suppress_health_check=[
+        hypothesis.HealthCheck.function_scoped_fixture,
+        hypothesis.HealthCheck.too_slow,
+    ],
     deadline=None,
 )
 async def test_update_cluster(

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -361,7 +361,7 @@ async def redis_client(redis_service: RedisSettings):
     yield client
 
     await client.flushall()
-    await client.close()
+    await client.close(close_connection_pool=True)
 
 
 @pytest.fixture
@@ -376,7 +376,7 @@ async def redis_locks_client(
     yield client
 
     await client.flushall()
-    await client.close()
+    await client.close(close_connection_pool=True)
 
 
 def _is_redis_responsive(host: str, port: int) -> bool:


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
For the user it is desirable that the available vs used resources in the cluster are shown.

```GET /clusters/{project_id}/details``` now additionally returns:
- used_resources: contains a dictionary with the currently used defined generic resources on each dask-worker e.g. ```{"CPU": 1.4, "RAM": 123442, "GPU": 1}```
- resources: contain the total amount of the generic resources that this worker provides

NOTE: resources are currently one of ```CPU, GPU, RAM, MPI``` and MPI might soon be deprecated.

Also this PR introduce a cache on the cluster details in the director-v2 of 3 seconds to reduce the calls towards the corresponding dask-scheduler coming from potentially any number of users.


@odeimaiz : for the frontend that means that the resources and used_resources are **absolute** numbers. The metrics show only what the dask-worker is using for itself not what the containers are using.


![image](https://user-images.githubusercontent.com/35365065/162458878-1472e1a5-ecc4-4670-84c9-cd0dd8bc9c05.png)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
