### PR TITLE
🐛: ensure negative values are set to 0

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
@@ -44,6 +44,17 @@ class Worker(BaseModel):
     memory_limit: ByteSize
     metrics: WorkerMetrics
 
+    @validator("used_resources", pre=True)
+    @classmethod
+    def ensure_negative_value_is_zero(cls, v):
+        # dasks adds/remove resource values and sometimes
+        # they end up being negative instead of 0
+        if v is not None:
+            for res_key, res_value in v.items():
+                if res_value < 0:
+                    v[res_key] = 0
+        return v
+
 
 class WorkersDict(DictModel[AnyUrl, Worker]):
     ...

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/clusters.py
@@ -23,37 +23,42 @@ from pydantic import (
     validator,
 )
 from pydantic.networks import AnyUrl
-from pydantic.types import ByteSize, PositiveFloat
+from pydantic.types import ByteSize, NonNegativeInt, PositiveFloat
 
 
 class WorkerMetrics(BaseModel):
-    cpu: float = Field(..., description="consumed # of cpus")
+    cpu: float = Field(..., description="consumed % of cpus")
     memory: ByteSize = Field(..., description="consumed memory")
     num_fds: int = Field(..., description="consumed file descriptors")
-    ready: int = Field(..., description="# tasks ready to run")
-    executing: int = Field(..., description="# tasks currently executing")
-    in_flight: int = Field(..., description="# tasks currenntly waiting for data")
-    in_memory: ByteSize = Field(..., description="result data still in memory")
+    ready: NonNegativeInt = Field(..., description="# tasks ready to run")
+    executing: NonNegativeInt = Field(..., description="# tasks currently executing")
+    in_flight: NonNegativeInt = Field(..., description="# tasks waiting for data")
+    in_memory: NonNegativeInt = Field(..., description="# tasks in worker memory")
+
+
+AvailableResources = DictModel[str, PositiveFloat]
+
+
+class UsedResources(DictModel[str, NonNegativeFloat]):
+    @root_validator(pre=True)
+    @classmethod
+    def ensure_negative_value_is_zero(cls, values):
+        # dasks adds/remove resource values and sometimes
+        # they end up being negative instead of 0
+        if v := values.get("__root__", {}):
+            for res_key, res_value in v.items():
+                if res_value < 0:
+                    v[res_key] = 0
+        return values
 
 
 class Worker(BaseModel):
     id: str
     name: str
-    resources: DictModel[str, PositiveFloat]
-    used_resources: DictModel[str, NonNegativeFloat]
+    resources: AvailableResources
+    used_resources: UsedResources
     memory_limit: ByteSize
     metrics: WorkerMetrics
-
-    @validator("used_resources", pre=True)
-    @classmethod
-    def ensure_negative_value_is_zero(cls, v):
-        # dasks adds/remove resource values and sometimes
-        # they end up being negative instead of 0
-        if v is not None:
-            for res_key, res_value in v.items():
-                if res_value < 0:
-                    v[res_key] = 0
-        return v
 
 
 class WorkersDict(DictModel[AnyUrl, Worker]):

--- a/services/director-v2/tests/unit/test_models_clusters.py
+++ b/services/director-v2/tests/unit/test_models_clusters.py
@@ -3,12 +3,15 @@ from typing import Any, Dict, Type
 
 import pytest
 from faker import Faker
-from pydantic import BaseModel
+from pydantic import BaseModel, parse_obj_as
 from simcore_service_director_v2.models.schemas.clusters import (
+    AvailableResources,
     ClusterCreate,
     ClusterPatch,
     Scheduler,
+    UsedResources,
     Worker,
+    WorkerMetrics,
     WorkersDict,
 )
 
@@ -59,18 +62,21 @@ def test_worker_constructor_corrects_negative_used_resources(faker: Faker):
     worker = Worker(
         id=faker.pyint(min_value=1),
         name=faker.name(),
-        resources={},
-        used_resources={"CPU": -0.0000234},
+        resources=parse_obj_as(AvailableResources, {}),
+        used_resources=parse_obj_as(UsedResources, {"CPU": -0.0000234}),
         memory_limit=faker.pyint(min_value=1),
-        metrics={
-            "cpu": faker.pyfloat(min_value=0),
-            "memory": faker.pyint(min_value=0),
-            "num_fds": faker.pyint(),
-            "ready": faker.pyint(),
-            "executing": faker.pyint(),
-            "in_flight": faker.pyint(),
-            "in_memory": faker.pyint(),
-        },
+        metrics=parse_obj_as(
+            WorkerMetrics,
+            {
+                "cpu": faker.pyfloat(min_value=0),
+                "memory": faker.pyint(min_value=0),
+                "num_fds": faker.pyint(),
+                "ready": faker.pyint(min_value=0),
+                "executing": faker.pyint(min_value=0),
+                "in_flight": faker.pyint(min_value=0),
+                "in_memory": faker.pyint(min_value=0),
+            },
+        ),
     )
     assert worker
     assert worker.used_resources["CPU"] == 0

--- a/services/director-v2/tests/unit/test_models_clusters.py
+++ b/services/director-v2/tests/unit/test_models_clusters.py
@@ -8,6 +8,7 @@ from simcore_service_director_v2.models.schemas.clusters import (
     ClusterCreate,
     ClusterPatch,
     Scheduler,
+    Worker,
     WorkersDict,
 )
 
@@ -52,3 +53,24 @@ def test_scheduler_constructor_with_no_workers_has_correct_dict(faker: Faker):
     scheduler = Scheduler(status=faker.text(), workers=None)
     assert isinstance(scheduler.workers, WorkersDict)
     assert len(scheduler.workers) == 0
+
+
+def test_worker_constructor_corrects_negative_used_resources(faker: Faker):
+    worker = Worker(
+        id=faker.pyint(min_value=1),
+        name=faker.name(),
+        resources={},
+        used_resources={"CPU": -0.0000234},
+        memory_limit=faker.pyint(min_value=1),
+        metrics={
+            "cpu": faker.pyfloat(min_value=0),
+            "memory": faker.pyint(min_value=0),
+            "num_fds": faker.pyint(),
+            "ready": faker.pyint(),
+            "executing": faker.pyint(),
+            "in_flight": faker.pyint(),
+            "in_memory": faker.pyint(),
+        },
+    )
+    assert worker
+    assert worker.used_resources["CPU"] == 0


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
The dask scheduler counts the available resources. these are added and subtracted. We expect no negative values, therefore this is now corrected using a validator.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
