### PR TITLE
Context to the Wheel

### DIFF
--- a/services/web/client/source/class/osparc/component/widget/NodeTreeItem.js
+++ b/services/web/client/source/class/osparc/component/widget/NodeTreeItem.js
@@ -202,6 +202,7 @@ qx.Class.define("osparc.component.widget.NodeTreeItem", {
             label: this.tr("Rename"),
             icon: "@FontAwesome5Solid/i-cursor/10"
           });
+          control.getChildControl("shortcut").setValue("F2");
           control.addListener("execute", () => this.fireDataEvent("renameNode", this.getId()));
           const optionsMenu = this.getChildControl("options-menu-button");
           optionsMenu.getMenu().add(control);
@@ -228,6 +229,7 @@ qx.Class.define("osparc.component.widget.NodeTreeItem", {
             label: this.tr("Information..."),
             icon: "@FontAwesome5Solid/info/10"
           });
+          control.getChildControl("shortcut").setValue("I");
           control.addListener("execute", () => this.fireDataEvent("infoNode", this.getId()));
           const optionsMenu = this.getChildControl("options-menu-button");
           optionsMenu.getMenu().add(control);
@@ -238,6 +240,7 @@ qx.Class.define("osparc.component.widget.NodeTreeItem", {
             label: this.tr("Delete"),
             icon: "@FontAwesome5Solid/trash/10"
           });
+          control.getChildControl("shortcut").setValue("Del");
           control.addListener("execute", () => this.fireDataEvent("deleteNode", this.getId()));
           const optionsMenu = this.getChildControl("options-menu-button");
           optionsMenu.getMenu().add(control);

--- a/services/web/client/source/class/osparc/component/widget/NodeTreeItem.js
+++ b/services/web/client/source/class/osparc/component/widget/NodeTreeItem.js
@@ -213,13 +213,7 @@ qx.Class.define("osparc.component.widget.NodeTreeItem", {
             icon: "@FontAwesome5Solid/bookmark/10",
             visibility: "excluded"
           });
-          control.addListener("execute", () => {
-            if (this.getNode().getMarker()) {
-              this.getNode().removeMarker();
-            } else {
-              this.getNode().addMarker();
-            }
-          });
+          control.addListener("execute", () => this.getNode().toggleMarker());
           const optionsMenu = this.getChildControl("options-menu-button");
           optionsMenu.getMenu().add(control);
           break;

--- a/services/web/client/source/class/osparc/component/workbench/BaseNodeUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/BaseNodeUI.js
@@ -145,6 +145,7 @@ qx.Class.define("osparc.component.workbench.BaseNodeUI", {
         label: this.tr("Rename"),
         icon: "@FontAwesome5Solid/i-cursor/10"
       });
+      renameBtn.getChildControl("shortcut").setValue("F2");
       renameBtn.addListener("execute", () => this.fireDataEvent("renameNode", this.getNodeId()));
       optionsMenu.add(renameBtn);
 
@@ -158,6 +159,7 @@ qx.Class.define("osparc.component.workbench.BaseNodeUI", {
         label: this.tr("Information..."),
         icon: "@FontAwesome5Solid/info/10"
       });
+      infoBtn.getChildControl("shortcut").setValue("I");
       infoBtn.addListener("execute", () => this.fireDataEvent("infoNode", this.getNodeId()));
       optionsMenu.add(infoBtn);
 
@@ -165,6 +167,7 @@ qx.Class.define("osparc.component.workbench.BaseNodeUI", {
         label: this.tr("Delete"),
         icon: "@FontAwesome5Solid/trash/10"
       });
+      deleteBtn.getChildControl("shortcut").setValue("Del");
       deleteBtn.addListener("execute", () => this.fireDataEvent("removeNode", this.getNodeId()));
       optionsMenu.add(deleteBtn);
 

--- a/services/web/client/source/class/osparc/component/workbench/NodeUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/NodeUI.js
@@ -231,13 +231,7 @@ qx.Class.define("osparc.component.workbench.NodeUI", {
       this.getNode().bind("marker", this._markerBtn, "label", {
         converter: val => val ? this.tr("Remove Marker") : this.tr("Add Marker")
       });
-      this._markerBtn.addListener("execute", () => {
-        if (this.getNode().getMarker()) {
-          this.getNode().removeMarker();
-        } else {
-          this.getNode().addMarker();
-        }
-      });
+      this._markerBtn.addListener("execute", () => this.getNode().toggleMarker());
 
       const marker = this.getChildControl("marker");
       const updateMarker = () => {

--- a/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -1338,13 +1338,7 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
         },
         addRemoveMarker: {
           "text": "\uf097", // marker
-          "action": () => {
-            if (nodeUI.getNode().getMarker()) {
-              nodeUI.getNode().removeMarker();
-            } else {
-              nodeUI.getNode().addMarker();
-            }
-          }
+          "action": () => nodeUI.getNode().toggleMarker()
         },
         addServiceInput: {
           "text": "\uf067", // plus

--- a/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -374,7 +374,6 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
       if (this.__nodesUI.length === 0) {
         return null;
       }
-      console.log("pos", pos);
       let onNodeUI = null;
       this.__nodesUI.forEach(nodeUI => {
         const nBounds = nodeUI.getBounds();
@@ -1349,18 +1348,46 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
         },
         addServiceInput: {
           "text": "\uf067", // plus
-          "action": () => console.log("input")
+          "action": () => {
+            const freePos = this.getStudy().getWorkbench().getFreePosition(nodeUI.getNode(), true);
+            const srvCat = this.openServiceCatalog({
+              x: 50,
+              y: 50
+            }, freePos);
+            srvCat.setContext(null, nodeUI.getNodeId());
+          }
         },
         addServiceOutput: {
           "text": "\uf067", // plus
-          "action": () => console.log("output")
+          "action": () => {
+            const freePos = this.getStudy().getWorkbench().getFreePosition(nodeUI.getNode(), false);
+            const srvCat = this.openServiceCatalog({
+              x: 50,
+              y: 50
+            }, freePos);
+            srvCat.setContext(nodeUI.getNodeId(), null);
+          }
+        },
+        noAction: {
+          "text": "\uf05e", // verboten
+          "action": () => {}
         }
       };
       let buttons = null;
       if (nodeUI) {
-        buttons = [actions.addRemoveMarker, actions.addServiceOutput, actions.removeNode, actions.addServiceInput];
+        const node = nodeUI.getNode();
+        buttons = [
+          actions.addRemoveMarker,
+          node.hasOutputs() ? actions.addServiceOutput : actions.noAction,
+          actions.removeNode,
+          node.hasInputs() ? actions.addServiceInput : actions.noAction
+        ];
       } else {
-        buttons = [actions.addService, actions.drawText, actions.drawRect];
+        buttons = [
+          actions.addService,
+          actions.drawText,
+          actions.drawRect
+        ];
       }
       this.__buttonsToContextMenu(e, buttons);
     },

--- a/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -370,6 +370,26 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
       return bounds;
     },
 
+    __cursorOnNodeUI: function(pos) {
+      if (this.__nodesUI.length === 0) {
+        return null;
+      }
+      console.log("pos", pos);
+      let onNodeUI = null;
+      this.__nodesUI.forEach(nodeUI => {
+        const nBounds = nodeUI.getBounds();
+        console.log();
+        if (onNodeUI === null &&
+          pos.x > nBounds.left &&
+          pos.x < nBounds.left + nBounds.width &&
+          pos.y > nBounds.top &&
+          pos.y < nBounds.top + nBounds.height) {
+          onNodeUI = nodeUI;
+        }
+      });
+      return onNodeUI;
+    },
+
     _addNodeUIToWorkbench: function(nodeUI, position) {
       if (position === undefined || !("x" in position) || isNaN(position["x"]) || position["x"] < 0) {
         position = {
@@ -1280,6 +1300,8 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
     },
 
     __doOpenContextMenu: function(e) {
+      const wbPos = this.__pointerEventToWorkbenchPos(e);
+      const nodeUI = this.__cursorOnNodeUI(wbPos);
       const actions = {
         addService: {
           "text": "\uf067", // plus
@@ -1310,9 +1332,36 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
         drawRect: {
           "text": "\uf044", // brush with rect
           "action": () => this.startAnnotationsRect()
+        },
+        removeNode: {
+          "text": "\uf014", // trash
+          "action": () => nodeUI.fireDataEvent("removeNode", nodeUI.getNodeId())
+        },
+        addRemoveMarker: {
+          "text": "\uf097", // marker
+          "action": () => {
+            if (nodeUI.getNode().getMarker()) {
+              nodeUI.getNode().removeMarker();
+            } else {
+              nodeUI.getNode().addMarker();
+            }
+          }
+        },
+        addServiceInput: {
+          "text": "\uf067", // plus
+          "action": () => console.log("input")
+        },
+        addServiceOutput: {
+          "text": "\uf067", // plus
+          "action": () => console.log("output")
         }
       };
-      const buttons = [actions.addService, actions.drawText, actions.drawRect];
+      let buttons = null;
+      if (nodeUI) {
+        buttons = [actions.addRemoveMarker, actions.addServiceOutput, actions.removeNode, actions.addServiceInput];
+      } else {
+        buttons = [actions.addService, actions.drawText, actions.drawRect];
+      }
       this.__buttonsToContextMenu(e, buttons);
     },
 

--- a/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -1384,12 +1384,13 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
         this.__annotationInitPos = null;
       }
       if (this.__annotatingRect || this.__annotatingText) {
-        this.__consolidateAnnotation(this.__rectAnnotationRepr, this.__annotatingRect ? "rect" : "text");
-        osparc.wrapper.Svg.removeItem(this.__rectAnnotationRepr);
-        this.__rectAnnotationRepr = null;
-        this.__annotatingRect = false;
-        this.__annotatingText = false;
-        this.__toolHint.setValue(null);
+        if (this.__consolidateAnnotation(this.__rectAnnotationRepr, this.__annotatingRect ? "rect" : "text")) {
+          osparc.wrapper.Svg.removeItem(this.__rectAnnotationRepr);
+          this.__rectAnnotationRepr = null;
+          this.__annotatingRect = false;
+          this.__annotatingText = false;
+          this.__toolHint.setValue(null);
+        }
       }
 
       if (this.__panning) {
@@ -1823,9 +1824,9 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
     },
 
     __consolidateAnnotation: function(annotation, type) {
-      if (annotation === undefined) {
+      if ([null, undefined].includes(annotation)) {
         osparc.component.message.FlashMessenger.getInstance().logAs(this.tr("Draw a rectanlge first"), "WARNING");
-        return;
+        return false;
       }
       const serializeData = {
         type,
@@ -1845,6 +1846,7 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
         titleEditor.center();
         titleEditor.open();
       }
+      return true;
     },
 
     __addAnnotation: function(data, id) {

--- a/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -1341,7 +1341,7 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
           "action": () => nodeUI.getNode().toggleMarker()
         },
         addServiceInput: {
-          "text": "\uf067", // plus
+          "text": "\uf090", // in
           "action": () => {
             const freePos = this.getStudy().getWorkbench().getFreePosition(nodeUI.getNode(), true);
             const srvCat = this.openServiceCatalog({
@@ -1352,7 +1352,7 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
           }
         },
         addServiceOutput: {
-          "text": "\uf067", // plus
+          "text": "\uf08b", // out
           "action": () => {
             const freePos = this.getStudy().getWorkbench().getFreePosition(nodeUI.getNode(), false);
             const srvCat = this.openServiceCatalog({

--- a/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -1280,32 +1280,46 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
     },
 
     __doOpenContextMenu: function(e) {
+      const actions = {
+        addService: {
+          "text": "\uf067", // plus
+          "action": () => this.__openServiceCatalog(e)
+        },
+        zoomIn: {
+          "text": "\uf00e", // search-plus
+          "action": () => {
+            this.__pointerPos = this.__pointerEventToWorkbenchPos(e);
+            this.zoom(true);
+          }
+        },
+        zoomReset: {
+          "text": "\uf002", // search
+          "action": () => this.setScale(1)
+        },
+        zoomOut: {
+          "text": "\uf010", // search-minus
+          "action": () => {
+            this.__pointerPos = this.__pointerEventToWorkbenchPos(e);
+            this.zoom(false);
+          }
+        },
+        drawText: {
+          "text": "\uf040", // pencil
+          "action": () => this.startAnnotationsText()
+        },
+        drawRect: {
+          "text": "\uf044", // brush with rect
+          "action": () => this.startAnnotationsRect()
+        }
+      };
+      const buttons = [actions.addService, actions.drawText, actions.drawRect];
+      this.__buttonsToContextMenu(e, buttons);
+    },
+
+    __buttonsToContextMenu: function(e, buttons) {
       if (this.__contextMenu) {
         this.__contextMenu.hide();
       }
-      const buttons = [{
-        "text": "\uf067", // plus
-        "action": () => {
-          this.__openServiceCatalog(e);
-        }
-      }, {
-        "text": "\uf00e", // search-plus
-        "action": () => {
-          this.__pointerPos = this.__pointerEventToWorkbenchPos(e);
-          this.zoom(true);
-        }
-      }, {
-        "text": "\uf002", // search
-        "action": () => {
-          this.setScale(1);
-        }
-      }, {
-        "text": "\uf010", // search-minus
-        "action": () => {
-          this.__pointerPos = this.__pointerEventToWorkbenchPos(e);
-          this.zoom(false);
-        }
-      }];
       let rotation = 3 * Math.PI / 2;
       rotation -= (2/buttons.length) * (Math.PI / 2);
       const radialMenuWrapper = osparc.wrapper.RadialMenu.getInstance();

--- a/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/web/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -1823,6 +1823,10 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
     },
 
     __consolidateAnnotation: function(annotation, type) {
+      if (annotation === undefined) {
+        osparc.component.message.FlashMessenger.getInstance().logAs(this.tr("Draw a rectanlge first"), "WARNING");
+        return;
+      }
       const serializeData = {
         type,
         attributes: osparc.wrapper.Svg.getRectAttributes(annotation)

--- a/services/web/client/source/class/osparc/dashboard/ResourceBrowserBase.js
+++ b/services/web/client/source/class/osparc/dashboard/ResourceBrowserBase.js
@@ -36,9 +36,7 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
 
     this._showLoadingPage(this.tr("Starting..."));
 
-    this.addListener("appear", () => {
-      this._moreResourcesRequired();
-    });
+    this.addListener("appear", () => this._moreResourcesRequired());
   },
 
   events: {
@@ -85,17 +83,14 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
     _createChildControlImpl: function(id) {
       let control;
       switch (id) {
-        case "scroll-container":
-          control = new qx.ui.container.Scroll();
-          this._add(control, {
-            flex: 1
-          });
-          control.getChildControl("pane").addListener("scrollY", () => this._moreResourcesRequired(), this);
-          break;
         case "resources-layout": {
-          const scroll = this.getChildControl("scroll-container");
+          const scroll = new qx.ui.container.Scroll();
+          scroll.getChildControl("pane").addListener("scrollY", () => this._moreResourcesRequired(), this);
           control = this._createLayout();
           scroll.add(control);
+          this._add(scroll, {
+            flex: 1
+          });
           break;
         }
       }
@@ -115,23 +110,15 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
     },
 
     _createResourcesLayout: function(resourceType) {
-      const resourcesLayout = new qx.ui.container.Composite(new qx.ui.layout.VBox(10));
-
       const topBar = this.__createTopBar(resourceType);
-      resourcesLayout.add(topBar);
+      this._add(topBar);
 
       const secondaryBar = this._secondaryBar = new qx.ui.container.Composite(new qx.ui.layout.HBox(10));
-      resourcesLayout.add(secondaryBar);
+      this._add(secondaryBar);
 
-      const resourcesContainer = this._resourcesContainer = this.__createResourcesContainer();
-      resourcesLayout.add(resourcesContainer);
-
-      return resourcesLayout;
-    },
-
-    __createResourcesContainer: function() {
       const spacing = osparc.dashboard.GridButtonBase.SPACING;
-      return new osparc.component.form.ToggleButtonContainer(new qx.ui.layout.Flow(spacing, spacing));
+      const resourcesContainer = this._resourcesContainer = new osparc.component.form.ToggleButtonContainer(new qx.ui.layout.Flow(spacing, spacing));
+      this._add(resourcesContainer);
     },
 
     __createTopBar: function(resourceType) {

--- a/services/web/client/source/class/osparc/dashboard/ServiceBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/ServiceBrowser.js
@@ -84,7 +84,7 @@ qx.Class.define("osparc.dashboard.ServiceBrowser", {
     },
 
     _createLayout: function() {
-      const servicesLayout = this._createResourcesLayout("service");
+      this._createResourcesLayout("service");
 
       this.__addNewServiceButtons();
 
@@ -92,7 +92,7 @@ qx.Class.define("osparc.dashboard.ServiceBrowser", {
 
       this._resourcesContainer.addListener("changeMode", () => this._resetResourcesList());
 
-      return servicesLayout;
+      return this._resourcesContainer;
     },
 
     _createStudyFromService: function(key, version) {

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -137,7 +137,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     },
 
     _createLayout: function() {
-      const studiesLayout = this._createResourcesLayout("study");
+      this._createResourcesLayout("study");
 
       const importStudyButton = this.__createImportButton();
       this._secondaryBar.add(importStudyButton);
@@ -211,7 +211,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         });
       }, this);
 
-      return studiesLayout;
+      return this._resourcesContainer;
     },
 
     __createImportButton: function() {

--- a/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -424,6 +424,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
           return;
         }
         const studyItem = this.__createStudyItem(study);
+        studyItem.setMultiSelectionMode(this.getMultiSelection());
         this._resourcesContainer.add(studyItem);
       });
       osparc.dashboard.ResourceBrowserBase.sortStudyList(studyList.filter(card => osparc.dashboard.ResourceBrowserBase.isCardButtonItem(card)));

--- a/services/web/client/source/class/osparc/dashboard/TemplateBrowser.js
+++ b/services/web/client/source/class/osparc/dashboard/TemplateBrowser.js
@@ -49,8 +49,7 @@ qx.Class.define("osparc.dashboard.TemplateBrowser", {
     },
 
     _createLayout: function() {
-      const templatesLayout = this._createResourcesLayout("template");
-
+      this._createResourcesLayout("template");
       osparc.utils.Utils.setIdToWidget(this._resourcesContainer, "templatesList");
 
       const loadingTemplatesBtn = this._createLoadMoreButton("templatesLoading");
@@ -59,7 +58,7 @@ qx.Class.define("osparc.dashboard.TemplateBrowser", {
       this._resourcesContainer.addListener("changeVisibility", () => this._moreResourcesRequired());
       this._resourcesContainer.addListener("changeMode", () => this._resetResourcesList());
 
-      return templatesLayout;
+      return this._resourcesContainer;
     },
 
     __startStudy: function(studyId, templateData) {

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -451,7 +451,7 @@ qx.Class.define("osparc.data.model.Node", {
         this.setPosition(nodeUIData.position);
       }
       if ("marker" in nodeUIData) {
-        this.addMarker(nodeUIData.marker);
+        this.__addMarker(nodeUIData.marker);
       }
     },
 
@@ -623,7 +623,15 @@ qx.Class.define("osparc.data.model.Node", {
       }
     },
 
-    addMarker: function(marker) {
+    toggleMarker: function() {
+      if (this.getMarker()) {
+        this.__removeMarker();
+      } else {
+        this.__addMarker();
+      }
+    },
+
+    __addMarker: function(marker) {
       if (marker === undefined) {
         marker = {
           color: osparc.utils.Utils.getRandomColor()
@@ -633,7 +641,7 @@ qx.Class.define("osparc.data.model.Node", {
       this.setMarker(markerModel);
     },
 
-    removeMarker: function() {
+    __removeMarker: function() {
       this.setMarker(null);
     },
 

--- a/services/web/client/source/class/osparc/data/model/Workbench.js
+++ b/services/web/client/source/class/osparc/data/model/Workbench.js
@@ -360,7 +360,7 @@ qx.Class.define("osparc.data.model.Workbench", {
       }
     },
 
-    __getFreePosition: function(node, toTheLeft = true) {
+    getFreePosition: function(node, toTheLeft = true) {
       // do not overlap the new node2 with other nodes
       const pos = node.getPosition();
       const nodeWidth = osparc.component.workbench.NodeUI.NODE_WIDTH;
@@ -391,7 +391,7 @@ qx.Class.define("osparc.data.model.Workbench", {
     __connectFilePicker: function(nodeId, portId) {
       return new Promise((resolve, reject) => {
         const requesterNode = this.getNode(nodeId);
-        const freePos = this.__getFreePosition(requesterNode);
+        const freePos = this.getFreePosition(requesterNode);
 
         // create a new FP
         const filePickerMetadata = osparc.utils.Services.getFilePicker();
@@ -447,7 +447,7 @@ qx.Class.define("osparc.data.model.Workbench", {
         const pm = this.createNode(pmMD["key"], pmMD["version"], null, parent);
 
         // do not overlap the new Parameter Node with other nodes
-        const freePos = this.__getFreePosition(requesterNode);
+        const freePos = this.getFreePosition(requesterNode);
         pm.setPosition(freePos);
 
         // create connection
@@ -481,7 +481,7 @@ qx.Class.define("osparc.data.model.Workbench", {
         probeNode.setLabel(requesterPortMD.label);
 
         // do not overlap the new Parameter Node with other nodes
-        const freePos = this.__getFreePosition(requesterNode, false);
+        const freePos = this.getFreePosition(requesterNode, false);
         probeNode.setPosition(freePos);
 
         // create connection
@@ -566,10 +566,10 @@ qx.Class.define("osparc.data.model.Workbench", {
       }
       if (leftNodeId) {
         const leftNode = this.getNode(leftNodeId);
-        node.setPosition(this.__getFreePosition(leftNode, false));
+        node.setPosition(this.getFreePosition(leftNode, false));
       } else if (rightNodeId) {
         const rightNode = this.getNode(rightNodeId);
-        node.setPosition(this.__getFreePosition(rightNode, true));
+        node.setPosition(this.getFreePosition(rightNode, true));
       } else {
         node.setPosition({
           x: 20,

--- a/services/web/client/source/class/osparc/wrapper/RadialMenu.js
+++ b/services/web/client/source/class/osparc/wrapper/RadialMenu.js
@@ -27,6 +27,7 @@
 /**
  * A qooxdoo wrapper for
  * <a href='https://github.com/victorqribeiro/radialMenu' target='_blank'>RadialMenu</a>
+ * icons: https://victorribeiro.com/radialMenu/font-visualizer.html
  */
 
 qx.Class.define("osparc.wrapper.RadialMenu", {


### PR DESCRIPTION
## What do these changes do?
- When right-clicking on the Workbench, the following actions show up:
  - Add new service
  - Draw rectangle
  - Draw text
- When right-clicking on a Node, the following actions show up:
  - Add/Remove Marker
  - Delete node
  - Connect to the input
  - Connect to the output

## Bonus:
- Study Browser: Only studies are part of the scroll area, search filter and selection will get anchored at the top
- Command shortcuts are shown on NodesTree's and NodeUI's menus

The smart wheel:
![TheWheel](https://user-images.githubusercontent.com/33152403/164490511-f10c5320-1043-4e9a-b2ea-aca981b8a094.gif)

Scroll studies:
![scrollStudies](https://user-images.githubusercontent.com/33152403/164450910-c18fcbc4-1c48-497e-82e5-339543120eda.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
