### PR TITLE
🐛Separate caching director call from user dependent service listing

### DIFF
--- a/packages/models-library/src/models_library/services_access.py
+++ b/packages/models-library/src/models_library/services_access.py
@@ -11,11 +11,11 @@ GroupId = PositiveInt
 
 class ServiceGroupAccessRights(BaseModel):
     execute_access: bool = Field(
-        False,
+        default=False,
         description="defines whether the group can execute the service",
     )
     write_access: bool = Field(
-        False, description="defines whether the group can modify the service"
+        default=False, description="defines whether the group can modify the service"
     )
 
 

--- a/services/catalog/src/simcore_service_catalog/api/routes/services.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services.py
@@ -3,8 +3,7 @@
 import asyncio
 import logging
 import urllib.parse
-from collections import deque
-from typing import Any, Deque, Dict, Final, List, Optional, Set, Tuple, cast
+from typing import Any, Dict, Final, List, Optional, Set, Tuple, cast
 
 from aiocache import cached
 from fastapi import APIRouter, Depends, Header, HTTPException, status
@@ -143,19 +142,11 @@ async def list_services(
 
     # caching this steps brings down the time to generate it at the expense of being sometimes a bit out of date
     @cached(ttl=DIRECTOR_CACHING_TTL)
-    async def cached_registry_services() -> Deque[Tuple[str, str, Dict[str, Any]]]:
-        services_in_registry = await director_client.get("/services")
-        filtered_services = deque(
-            (s["key"], s["version"], s)
-            for s in (
-                request.app.state.frontend_services_catalog + services_in_registry
-            )
-            if (s.get("key"), s.get("version")) in services_in_db
-        )
-        return filtered_services
+    async def cached_registry_services() -> dict[str, Any]:
+        return cast(dict[str, Any], await director_client.get("/services"))
 
     (
-        registry_filtered_services,
+        services_in_registry,
         services_access_rights,
         services_owner_emails,
     ) = await asyncio.gather(
@@ -181,11 +172,16 @@ async def list_services(
                 None,
                 _prepare_service_details,
                 details,
-                services_in_db[key, version],
-                services_access_rights[key, version],
-                services_owner_emails.get(services_in_db[key, version].owner),
+                services_in_db[s["key"], s["version"]],
+                services_access_rights[s["key"], s["version"]],
+                services_owner_emails.get(
+                    services_in_db[s["key"], s["version"]].owner or 0
+                ),
             )
-            for key, version, details in registry_filtered_services
+            for s in (
+                request.app.state.frontend_services_catalog + services_in_registry
+            )
+            if (s.get("key"), s.get("version")) in services_in_db
         ]
     )
     return [s for s in services_details if s is not None]
@@ -315,8 +311,11 @@ async def get_service(
         )
         _service_data = frontend_service
     else:
-        services_in_registry = await director_client.get(
-            f"/services/{urllib.parse.quote_plus(service_key)}/{service_version}"
+        services_in_registry = cast(
+            list[Any],
+            await director_client.get(
+                f"/services/{urllib.parse.quote_plus(service_key)}/{service_version}"
+            ),
         )
         _service_data = services_in_registry[0]
 

--- a/services/catalog/src/simcore_service_catalog/api/routes/services.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services.py
@@ -171,7 +171,7 @@ async def list_services(
             asyncio.get_event_loop().run_in_executor(
                 None,
                 _prepare_service_details,
-                details,
+                s,
                 services_in_db[s["key"], s["version"]],
                 services_access_rights[s["key"], s["version"]],
                 services_owner_emails.get(

--- a/services/catalog/src/simcore_service_catalog/utils/requests_decorators.py
+++ b/services/catalog/src/simcore_service_catalog/utils/requests_decorators.py
@@ -24,7 +24,7 @@ async def _cancel_task_if_client_disconnected(
             await asyncio.sleep(interval)
 
 
-def cancellable_request(handler: Callable[..., Coroutine[Any, Any, Response]]):
+def cancellable_request(handler: Callable[..., Coroutine[Any, Any, Any]]):
     """this decorator periodically checks if the client disconnected and then will cancel the request and return a 499 code (a la nginx)."""
 
     @wraps(handler)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->


The caching of the list of services from the director was filtered with a user-dependent list of services available in the database. This explains the various errors in the catalog.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->
fixes #3005 

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
