### PR TITLE
🐛 Fix storage not starting with regular https addresses

### DIFF
--- a/services/storage/src/simcore_service_storage/s3.py
+++ b/services/storage/src/simcore_service_storage/s3.py
@@ -5,8 +5,8 @@ import logging
 from typing import Dict
 
 from aiohttp import web
-from tenacity import before_sleep_log, retry, stop_after_attempt, wait_fixed
 from pydantic import AnyUrl, parse_obj_as
+from tenacity import before_sleep_log, retry, stop_after_attempt, wait_fixed
 
 from .constants import APP_CONFIG_KEY, APP_S3_KEY
 from .s3wrapper.s3_client import MinioClientWrapper
@@ -58,9 +58,10 @@ async def _setup_s3_bucket(app):
 def _minio_client_endpint(s3_endpoint: str) -> str:
     # Minio client adds http and https based on the secure paramenter
     # provided at construction time, already including the schema
-    # will cause issues, encoding url to HOST:PORT
+    # will cause issues, encoding url to HOST:PORT or just HOST
+    # if port is missing
     url = parse_obj_as(AnyUrl, s3_endpoint)
-    return f"{url.host}:{url.port}"
+    return f"{url.host}" if url.port is None else f"{url.host}:{url.port}"
 
 
 def setup_s3(app: web.Application):

--- a/services/storage/tests/unit/test_route_s3_access.py
+++ b/services/storage/tests/unit/test_route_s3_access.py
@@ -1,5 +1,4 @@
 # pylint: disable=redefined-outer-name
-# pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 

--- a/services/storage/tests/unit/test_s3.py
+++ b/services/storage/tests/unit/test_s3.py
@@ -1,0 +1,17 @@
+# pylint: disable=protected-access
+
+import pytest
+from simcore_service_storage import s3
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://ceph.com", "ceph.com"),
+        ("http://ciao.com", "ciao.com"),
+        ("http://local.address:8012", "local.address:8012"),
+        ("https://remote.stragen.com:4432", "remote.stragen.com:4432"),
+    ],
+)
+def test_minio_client_endpint(url: str, expected: str) -> None:
+    assert s3._minio_client_endpint(url) == expected


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Fixes issues with storage not being able to start when configured with an S3 url not containing a port

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist
