### PR TITLE
⬇️ pins pip==22.0.1 until pip-tools is fixed [skip CI]

### DIFF
--- a/requirements/tools/Dockerfile
+++ b/requirements/tools/Dockerfile
@@ -20,8 +20,9 @@ RUN apt-get update \
   && apt-get clean
 
 
+# SEE bug with pip==22.1 https://github.com/jazzband/pip-tools/issues/1617
 RUN pip --no-cache-dir install --upgrade \
-  pip~=22.0  \
+  pip~=22.0.1  \
   wheel \
   setuptools
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

pip-tools fails to compile with latest ``pip==22.1`` upgrade

- pins pip until https://github.com/jazzband/pip-tools/issues/1617 fixed
- this only affects ``pip-tools`` (i.e. to upgrade requirements)
