### PR TITLE
🐛 Fix/backwards compatibility on service annotation labels

### DIFF
--- a/packages/models-library/src/models_library/service_settings_labels.py
+++ b/packages/models-library/src/models_library/service_settings_labels.py
@@ -47,7 +47,13 @@ class SimcoreServiceSettingLabelEntry(BaseModel):
     _destination_container: str = PrivateAttr()
     name: str = Field(..., description="The name of the service setting")
     setting_type: Literal[
-        "string", "int", "integer", "number", "object", "ContainerSpec", "Resources"
+        "string",
+        "int",
+        "integer",
+        "number",
+        "object",
+        "ContainerSpec",
+        "Resources",
     ] = Field(
         ...,
         description="The type of the service setting (follows Docker REST API naming scheme)",
@@ -57,6 +63,14 @@ class SimcoreServiceSettingLabelEntry(BaseModel):
         ...,
         description="The value of the service setting (shall follow Docker REST API scheme for services",
     )
+
+    @validator("setting_type", pre=True)
+    @classmethod
+    def ensure_backwards_compatible_setting_type(cls, v):
+        if v == "resources":
+            # renamed in the latest version as
+            return "Resources"
+        return v
 
     class Config(_BaseConfig):
         schema_extra = {
@@ -103,6 +117,20 @@ class SimcoreServiceSettingLabelEntry(BaseModel):
                 },
                 # environments
                 {"name": "env", "type": "string", "value": ["DISPLAY=:0"]},
+                # SEE 'simcore.service.settings' label annotations for simcore/services/dynamic/jupyter-octave-python-math:1.6.5
+                {"name": "ports", "type": "int", "value": 8888},
+                {
+                    "name": "constraints",
+                    "type": "string",
+                    "value": ["node.platform.os == linux"],
+                },
+                {
+                    "name": "resources",
+                    "type": "resources",
+                    "value": {
+                        "Limits": {"NanoCPUs": 4000000000, "MemoryBytes": 8589934592}
+                    },
+                },
             ]
         }
 

--- a/packages/models-library/src/models_library/service_settings_labels.py
+++ b/packages/models-library/src/models_library/service_settings_labels.py
@@ -87,7 +87,7 @@ class SimcoreServiceSettingLabelEntry(BaseModel):
                     "type": "ContainerSpec",
                     "value": {"Command": ["run"]},
                 },
-                # SEE service_resources.py::ResourceValue
+                # SEE services_resources.py::ResourceValue
                 {
                     "name": "Resources",
                     "type": "Resources",

--- a/packages/service-integration/tests/test_osparc_config.py
+++ b/packages/service-integration/tests/test_osparc_config.py
@@ -5,12 +5,11 @@
 import json
 from pathlib import Path
 from pprint import pformat
-from typing import Any, Type
+from typing import Any
 
 import pytest
 import yaml
 from models_library.service_settings_labels import SimcoreServiceSettingLabelEntry
-from pydantic import BaseModel
 from service_integration.osparc_config import MetaConfig, RuntimeConfig, SettingsItem
 
 
@@ -66,12 +65,24 @@ def test_load_from_labels(
 
 
 @pytest.mark.parametrize(
-    "model_cls",
-    (SimcoreServiceSettingLabelEntry,),
+    "example_data", SimcoreServiceSettingLabelEntry.Config.schema_extra["examples"]
 )
 def test_settings_item_in_sync_with_service_settings_label(
-    model_cls: Type[BaseModel], model_cls_examples: dict[str, dict[str, Any]]
+    example_data: dict[str, Any]
 ):
-    for name, example in model_cls_examples.items():
-        print(name, ":", pformat(example))
-        SettingsItem.parse_obj(example)
+
+    print(pformat(example_data))
+
+    # First we parse with SimcoreServiceSettingLabelEntry since it also supports backwards compatibility
+    # and will upgrade old version
+    example_model = SimcoreServiceSettingLabelEntry.parse_obj(example_data)
+
+    # SettingsItem is exclusively for NEW labels, so it should not support backwards compatibility
+    new_model = SettingsItem(
+        name=example_model.name,
+        type=example_model.setting_type,
+        value=example_model.value,
+    )
+
+    # check back
+    SimcoreServiceSettingLabelEntry.parse_obj(new_model.dict(by_alias=True))

--- a/requirements/tools/Dockerfile
+++ b/requirements/tools/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
 
 # SEE bug with pip==22.1 https://github.com/jazzband/pip-tools/issues/1617
 RUN pip --no-cache-dir install --upgrade \
-  pip~=22.0.1  \
+  pip~=22.0  \
   wheel \
   setuptools
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

e2e detected that the ``jupyters`` template project fail to open due to a validation error of some of its service labels


```log
ERROR: File "/home/scu/.venv/lib/python3.9/site-packages/simcore_service_director_v2/modules/director_v0.py", line 142, in get_service_labels return SimcoreServiceLabels.parse_obj(unenvelope_or_raise_error(resp)) File "pydantic/main.py", line 511, in pydantic.main.BaseModel.parse_obj File "pydantic/main.py", line 331, in pydantic.main.BaseModel.__init__ pydantic.error_wrappers.ValidationError: 1 validation error for SimcoreServiceLabels simcore.service.settings -> __root__ -> 2 -> type unexpected value; permitted: 'string', 'int', 'integer', 'number', 'object', 'ContainerSpec', 'Resources' (type=value_error.const; given=resources; permitted=('string', 'int', 'integer', 'number', 'object', 'ContainerSpec', 'Resources')) ERROR:uvicorn.error:Exception in ASGI application Traceback (most recent call last): File "/home/scu/.venv/lib/python3.9/site-packages/anyio/streams/memory.py", line 79, in receive return self.receive_nowait() File "/home/scu/.venv/lib/python3.9/site-packages/anyio/streams/memory.py", line 74, in receive_nowait raise WouldBlock anyio.WouldBlock
```

The problem was that ``jupyter-base-notebook:2.13.1 `` and ``simcore/services/dynamic/jupyter-octave-python-math:1.6.5
`` have old type names. 

Added a validator that upgrades the name to keep backwards compatibilty



## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
