### PR TITLE
🐛 Started dynamic services do not take the correct Reservation

### DIFF
--- a/packages/models-library/src/models_library/aiodocker_api.py
+++ b/packages/models-library/src/models_library/aiodocker_api.py
@@ -2,7 +2,13 @@ from typing import Optional
 
 from pydantic import Field, validator
 
-from .generated_models.docker_rest_api import ContainerSpec, ServiceSpec, TaskSpec
+from .generated_models.docker_rest_api import (
+    ContainerSpec,
+    ResourceObject,
+    Resources1,
+    ServiceSpec,
+    TaskSpec,
+)
 from .utils.converters import to_snake_case
 
 
@@ -26,9 +32,25 @@ class AioDockerContainerSpec(ContainerSpec):
         return v
 
 
+class AioDockerResources1(Resources1):
+    # NOTE: The Docker REST API documentation is wrong!!!
+    # Do not set that back to singular Reservation.
+    Reservation: Optional[ResourceObject] = Field(
+        None, description="Define resources reservation.", alias="Reservations"
+    )
+
+    class Config(Resources1.Config):
+        allow_population_by_field_name = True
+
+
 class AioDockerTaskSpec(TaskSpec):
     ContainerSpec: Optional[AioDockerContainerSpec] = Field(
         None,
+    )
+
+    Resources: Optional[AioDockerResources1] = Field(
+        None,
+        description="Resource requirements which apply to each individual container created\nas part of the service.\n",
     )
 
 

--- a/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
@@ -26,9 +26,6 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-# TODO: Reservation and not Reservations https://github.com/ITISFoundation/osparc-simcore/issues/3044
-
-
 def _parse_generic_resource(
     generic_resources: list[Any], service_resources: ServiceResources
 ) -> None:

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/settings.py
@@ -100,12 +100,8 @@ def inject_settings_to_create_service_params(
                     "NanoCPUs"
                 ] = param.value["cpu_reservation"]
             # REST-API compatible
-            if (
-                "Limits" in param.value
-                or "Reservation" in param.value
-                or "Reservations" in param.value
-            ):
-                # NOTE: Reservations is incorrect. It's Reservation but we keep it for backwards compatibility
+            if "Limits" in param.value or "Reservations" in param.value:
+                # NOTE: The Docker REST API reads Reservation when actually it's Reservations
                 create_service_params["task_template"]["Resources"].update(param.value)
 
         # publishing port on the ingress network.
@@ -156,27 +152,6 @@ def inject_settings_to_create_service_params(
     container_spec["Labels"]["mem_limit"] = str(
         create_service_params["task_template"]["Resources"]["Limits"]["MemoryBytes"]
     )
-
-    _clean_reservation_field(create_service_params)
-
-
-def _clean_reservation_field(service_spec: dict[str, Any]) -> None:
-    WRONG_FIELD = "Reservations"
-    RIGHT_FIELD = "Reservation"
-    if WRONG_FIELD not in service_spec["task_template"].get("Resources", {}):
-        return
-    # NOTE: in old services, there is a typo in the field. There is no s in Reservation in
-    # the Docker API (see https://docs.docker.com/engine/api/v1.41/#operation/ServiceCreate)
-    new_reservation = service_spec["task_template"]["Resources"][WRONG_FIELD]
-    if (
-        current_reservation := service_spec["task_template"]
-        .get("Resources", {})
-        .get(RIGHT_FIELD)
-    ):
-        new_reservation = current_reservation | new_reservation
-
-    service_spec["task_template"]["Resources"][RIGHT_FIELD] = new_reservation
-    service_spec["task_template"]["Resources"].pop(WRONG_FIELD)
 
 
 def _assemble_key(service_key: str, service_tag: str) -> str:

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
@@ -271,7 +271,7 @@ def expected_dynamic_sidecar_spec() -> dict[str, Any]:
             "Placement": {"Constraints": ["node.platform.os == linux"]},
             "Resources": {
                 "Limits": {"MemoryBytes": 8589934592, "NanoCPUs": 4000000000},
-                "Reservation": {
+                "Reservations": {
                     "GenericResources": [
                         {"DiscreteResourceSpec": {"Kind": "VRAM", "Value": 1}}
                     ],


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

The Docker REST API requires a Singular form of Reservation, where it is actually the plural form...
🐛🐛🐛🐛
[https://github.com/docker/cli/issues/3611](https://github.com/docker/cli/issues/3611)

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
