### PR TITLE
🐛🔨 Maintenance: fixes log-level of server in boot and bumpversion commit failure

### DIFF
--- a/packages/dask-task-models-library/setup.cfg
+++ b/packages/dask-task-models-library/setup.cfg
@@ -3,6 +3,7 @@ current_version = 0.1.0
 commit = True
 message = packages/dask-task-models-library version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]
 

--- a/packages/models-library/setup.cfg
+++ b/packages/models-library/setup.cfg
@@ -3,6 +3,7 @@ current_version = 0.1.0
 commit = True
 message = packages/models-library version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]
 

--- a/packages/postgres-database/setup.cfg
+++ b/packages/postgres-database/setup.cfg
@@ -3,5 +3,6 @@ current_version = 0.3.0
 commit = True
 message = packages/postgres-database version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]

--- a/packages/pytest-simcore/setup.cfg
+++ b/packages/pytest-simcore/setup.cfg
@@ -3,5 +3,6 @@ current_version = 0.1.0
 commit = True
 message = packages/pytest-simcore version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]

--- a/packages/service-integration/setup.cfg
+++ b/packages/service-integration/setup.cfg
@@ -3,6 +3,7 @@ current_version = 1.0.1
 commit = True
 message = service-integration version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]
 

--- a/packages/service-library/setup.cfg
+++ b/packages/service-library/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 1.2.0
 commit = False
-message = servicelib version: {current_version} → {new_version}
+message = service-library version: {current_version} → {new_version}
 tag = False
 
 [bumpversion:file:VERSION]

--- a/packages/service-library/setup.cfg
+++ b/packages/service-library/setup.cfg
@@ -3,6 +3,7 @@ current_version = 1.2.0
 commit = False
 message = service-library version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]
 

--- a/packages/settings-library/setup.cfg
+++ b/packages/settings-library/setup.cfg
@@ -3,6 +3,7 @@ current_version = 0.1.0
 commit = True
 message = packages/settings-library version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]
 

--- a/packages/simcore-sdk/setup.cfg
+++ b/packages/simcore-sdk/setup.cfg
@@ -3,6 +3,7 @@ current_version = 1.3.0
 commit = True
 message = packages/simcore-sdk version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]
 

--- a/services/api-server/docker/boot.sh
+++ b/services/api-server/docker/boot.sh
@@ -26,7 +26,7 @@ if [ "${SC_BUILD_TARGET}" = "development" ]; then
 fi
 
 # RUNNING application ----------------------------------------
-APP_LOG_LEVEL=${API_SERVER_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+APP_LOG_LEVEL=${API_SERVER_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL:-INFO}}}
 SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
 echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
 

--- a/services/api-server/docker/boot.sh
+++ b/services/api-server/docker/boot.sh
@@ -26,6 +26,10 @@ if [ "${SC_BUILD_TARGET}" = "development" ]; then
 fi
 
 # RUNNING application ----------------------------------------
+APP_LOG_LEVEL=${API_SERVER_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
+echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
+
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   reload_dir_packages=$(find /devel/packages -maxdepth 3 -type d -path "*/src/*" ! -path "*.*" -exec echo '--reload-dir {} \' \;)
 
@@ -35,9 +39,11 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages
-      --reload-dir .
+      --reload-dir . \
+      --log-level \"${SERVER_LOG_LEVEL}\"
   "
 else
   exec uvicorn simcore_service_api_server.main:the_app \
-    --host 0.0.0.0
+    --host 0.0.0.0 \
+    --log-level "${SERVER_LOG_LEVEL}"
 fi

--- a/services/api-server/setup.cfg
+++ b/services/api-server/setup.cfg
@@ -3,5 +3,6 @@ current_version = 0.3.0
 commit = True
 message = services/api-server version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]

--- a/services/catalog/docker/boot.sh
+++ b/services/catalog/docker/boot.sh
@@ -27,7 +27,7 @@ fi
 
 
 # RUNNING application ----------------------------------------
-APP_LOG_LEVEL=${CATALOG_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+APP_LOG_LEVEL=${CATALOG_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL:-INFO}}}
 SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
 echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
 

--- a/services/catalog/docker/boot.sh
+++ b/services/catalog/docker/boot.sh
@@ -25,7 +25,12 @@ if [ "${SC_BUILD_TARGET}" = "development" ]; then
   pip list | sed 's/^/    /'
 fi
 
+
 # RUNNING application ----------------------------------------
+APP_LOG_LEVEL=${CATALOG_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
+echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
+
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   reload_dir_packages=$(find /devel/packages -maxdepth 3 -type d -path "*/src/*" ! -path "*.*" -exec echo '--reload-dir {} \' \;)
 
@@ -35,9 +40,11 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages
-      --reload-dir .
+      --reload-dir . \
+      --log-level \"${SERVER_LOG_LEVEL}\"
   "
 else
   exec uvicorn simcore_service_catalog.main:the_app \
-    --host 0.0.0.0
+    --host 0.0.0.0 \
+    --log-level "${SERVER_LOG_LEVEL}"
 fi

--- a/services/catalog/setup.cfg
+++ b/services/catalog/setup.cfg
@@ -3,6 +3,7 @@ current_version = 0.3.2
 commit = True
 message = services/catalog version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]
 

--- a/services/dask-sidecar/setup.cfg
+++ b/services/dask-sidecar/setup.cfg
@@ -3,5 +3,6 @@ current_version = 0.1.0-alpha
 commit = True
 message = services/dask-sidecar version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]

--- a/services/datcore-adapter/docker/boot.sh
+++ b/services/datcore-adapter/docker/boot.sh
@@ -30,9 +30,11 @@ if [ "${SC_BUILD_TARGET}" = "development" ]; then
   pip list | sed 's/^/    /'
 fi
 
-#
-# RUNNING application
-#
+# RUNNING application ----------------------------------------
+APP_LOG_LEVEL=${DATCORE_ADAPTER_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
+echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
+
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   reload_dir_packages=$(find /devel/packages -maxdepth 3 -type d -path "*/src/*" ! -path "*.*" -exec echo '--reload-dir {} \' \;)
 
@@ -42,9 +44,11 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages
-      --reload-dir .
+      --reload-dir . \
+      --log-level \"${SERVER_LOG_LEVEL}\"
   "
 else
   exec uvicorn simcore_service_datcore_adapter.main:the_app \
-    --host 0.0.0.0
+    --host 0.0.0.0 \
+    --log-level "${SERVER_LOG_LEVEL}"
 fi

--- a/services/datcore-adapter/docker/boot.sh
+++ b/services/datcore-adapter/docker/boot.sh
@@ -31,7 +31,7 @@ if [ "${SC_BUILD_TARGET}" = "development" ]; then
 fi
 
 # RUNNING application ----------------------------------------
-APP_LOG_LEVEL=${DATCORE_ADAPTER_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+APP_LOG_LEVEL=${DATCORE_ADAPTER_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL:-INFO}}}
 SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
 echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
 

--- a/services/datcore-adapter/setup.cfg
+++ b/services/datcore-adapter/setup.cfg
@@ -3,5 +3,6 @@ current_version = 0.1.0-alpha
 commit = True
 message = services/datcore-adapter version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]

--- a/services/datcore-adapter/src/simcore_service_datcore_adapter/core/application.py
+++ b/services/datcore-adapter/src/simcore_service_datcore_adapter/core/application.py
@@ -39,7 +39,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
         redoc_url=None,  # default disabled
     )
 
-    logger.debug(settings)
+    logger.debug(settings.json(indent=1))
     app.state.settings = settings
 
     # events

--- a/services/datcore-adapter/src/simcore_service_datcore_adapter/core/settings.py
+++ b/services/datcore-adapter/src/simcore_service_datcore_adapter/core/settings.py
@@ -23,7 +23,7 @@ class Settings(BaseCustomSettings, MixinLoggingSettings):
 
     LOG_LEVEL: LogLevel = Field(
         LogLevel.INFO.value,
-        env=["DATCORE-ADAPTER_LOGLEVEL", "LOG_LEVEL", "LOGLEVEL"],
+        env=["DATCORE_ADAPTER_LOGLEVEL", "LOG_LEVEL", "LOGLEVEL"],
     )
 
     PENNSIEVE: PennsieveSettings = Field(auto_default_from_env=True)

--- a/services/director-v2/docker/boot.sh
+++ b/services/director-v2/docker/boot.sh
@@ -33,7 +33,7 @@ fi
 #
 # RUNNING application
 #
-APP_LOG_LEVEL=${DIRECTOR_V2_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+APP_LOG_LEVEL=${DIRECTOR_V2_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL:-INFO}}}
 SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
 echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
 

--- a/services/director-v2/docker/boot.sh
+++ b/services/director-v2/docker/boot.sh
@@ -33,6 +33,11 @@ fi
 #
 # RUNNING application
 #
+APP_LOG_LEVEL=${DIRECTOR_V2_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
+echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
+
+
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   reload_dir_packages=$(find /devel/packages -maxdepth 3 -type d -path "*/src/*" ! -path "*.*" -exec echo '--reload-dir {} \' \;)
 
@@ -42,9 +47,11 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages
-      --reload-dir .
+      --reload-dir . \
+      --log-level \"${SERVER_LOG_LEVEL}\"
   "
 else
   exec uvicorn simcore_service_director_v2.main:the_app \
-    --host 0.0.0.0
+    --host 0.0.0.0 \
+    --log-level "${SERVER_LOG_LEVEL}"
 fi

--- a/services/director-v2/setup.cfg
+++ b/services/director-v2/setup.cfg
@@ -3,5 +3,6 @@ current_version = 2.1.0
 commit = True
 message = services/director-v2 version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]

--- a/services/director/setup.cfg
+++ b/services/director/setup.cfg
@@ -3,6 +3,7 @@ current_version = 0.1.0
 commit = True
 message = director api version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:setup.py]
 search = "{current_version}"

--- a/services/dynamic-sidecar/docker/boot.sh
+++ b/services/dynamic-sidecar/docker/boot.sh
@@ -26,7 +26,7 @@ if [ "${SC_BUILD_TARGET}" = "development" ]; then
 fi
 
 # RUNNING application ----------------------------------------
-APP_LOG_LEVEL=${DIRECTOR_V2_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+APP_LOG_LEVEL=${DIRECTOR_V2_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL:-INFO}}}
 SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
 echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
 

--- a/services/dynamic-sidecar/docker/boot.sh
+++ b/services/dynamic-sidecar/docker/boot.sh
@@ -26,6 +26,10 @@ if [ "${SC_BUILD_TARGET}" = "development" ]; then
 fi
 
 # RUNNING application ----------------------------------------
+APP_LOG_LEVEL=${DIRECTOR_V2_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
+echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
+
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   reload_dir_packages=$(find /devel/packages -maxdepth 3 -type d -path "*/src/*" ! -path "*.*" -exec echo '--reload-dir {} \' \;)
 
@@ -35,9 +39,12 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages
-      --reload-dir .
+      --reload-dir . \
+      --log-level \"${SERVER_LOG_LEVEL}\"
   "
 else
   exec uvicorn simcore_service_dynamic_sidecar.main:app \
-    --host 0.0.0.0
+    --host 0.0.0.0 \
+    --log-level "${SERVER_LOG_LEVEL}"
+
 fi

--- a/services/dynamic-sidecar/setup.cfg
+++ b/services/dynamic-sidecar/setup.cfg
@@ -3,5 +3,6 @@ current_version = 1.0.0
 commit = True
 message = services/dynamic-sidecar version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]

--- a/services/storage/docker/boot.sh
+++ b/services/storage/docker/boot.sh
@@ -31,7 +31,7 @@ elif [ "${SC_BUILD_TARGET}" = "production" ]; then
   entrypoint=""
 fi
 
-APP_LOG_LEVEL=${STORAGE_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+APP_LOG_LEVEL=${STORAGE_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL:-INFO}}}
 SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
 
 # RUNNING application ----------------------------------------

--- a/services/storage/docker/boot.sh
+++ b/services/storage/docker/boot.sh
@@ -31,8 +31,13 @@ elif [ "${SC_BUILD_TARGET}" = "production" ]; then
   entrypoint=""
 fi
 
+APP_LOG_LEVEL=${STORAGE_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
+
 # RUNNING application ----------------------------------------
 echo "$INFO" "Selected config ${SC_BUILD_TARGET}"
+echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
+
 if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   # NOTE: needs ptvsd installed
   echo "$INFO" "PTVSD Debugger initializing in port 3000 with ${SC_BUILD_TARGET}"

--- a/services/storage/setup.cfg
+++ b/services/storage/setup.cfg
@@ -3,6 +3,7 @@ current_version = 0.2.1
 commit = True
 message = services/storage api version: {current_version} → {new_version}
 tag = False
+commit_args = --no-verify
 
 [bumpversion:file:VERSION]
 

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -29,7 +29,7 @@ elif [ "${SC_BUILD_TARGET}" = "production" ]; then
   APP_CONFIG=server-docker-prod.yaml
 fi
 
-APP_LOG_LEVEL=${WEBSERVER_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+APP_LOG_LEVEL=${WEBSERVER_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL:-INFO}}}
 SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
 
 # RUNNING application ----------------------------------------

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -33,7 +33,8 @@ APP_LOG_LEVEL=${WEBSERVER_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
 SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
 
 # RUNNING application ----------------------------------------
-echo "$INFO" "Selected config $APP_CONFIG w/ log-level $APP_LOG_LEVEL"
+echo "$INFO" "Selected config ${APP_CONFIG}"
+echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
 
 # NOTE: the number of workers ```(2 x $num_cores) + 1``` is
 # the official recommendation [https://docs.gunicorn.org/en/latest/design.html#how-many-workers]

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -30,6 +30,7 @@ elif [ "${SC_BUILD_TARGET}" = "production" ]; then
 fi
 
 APP_LOG_LEVEL=${WEBSERVER_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL}}}
+SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
 
 # RUNNING application ----------------------------------------
 echo "$INFO" "Selected config $APP_CONFIG w/ log-level $APP_LOG_LEVEL"
@@ -46,7 +47,7 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
     --worker-class aiohttp.GunicornWebWorker \
     --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
     --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$" \
-    --log-level="${APP_LOG_LEVEL:-info}" \
+    --log-level="${SERVER_LOG_LEVEL}"\
     --access-logfile='-' \
     --access-logformat='%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"' \
     --reload
@@ -57,7 +58,7 @@ else
     --worker-class aiohttp.GunicornWebWorker \
     --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
     --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$" \
-    --log-level="${APP_LOG_LEVEL:-warning}" \
+    --log-level="${SERVER_LOG_LEVEL}" \
     --access-logfile='-' \
     --access-logformat='%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"'
 fi

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -44,22 +44,23 @@ if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
   # NOTE: ptvsd is programmatically enabled inside of the service
   # this way we can have reload in place as well
   exec gunicorn simcore_service_webserver.cli:app_factory \
+    --log-level="${SERVER_LOG_LEVEL}"\
     --bind 0.0.0.0:8080 \
     --worker-class aiohttp.GunicornWebWorker \
     --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
     --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$" \
-    --log-level="${SERVER_LOG_LEVEL}"\
     --access-logfile='-' \
     --access-logformat='%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"' \
     --reload
 
 else
+
   exec gunicorn simcore_service_webserver.cli:app_factory \
+    --log-level="${SERVER_LOG_LEVEL}" \
     --bind 0.0.0.0:8080 \
     --worker-class aiohttp.GunicornWebWorker \
     --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
     --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$" \
-    --log-level="${SERVER_LOG_LEVEL}" \
     --access-logfile='-' \
     --access-logformat='%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"'
 fi

--- a/services/web/server/setup.cfg
+++ b/services/web/server/setup.cfg
@@ -3,6 +3,7 @@ current_version = 0.7.0
 commit = True
 message = services/webserver api version: {current_version} → {new_version}
 tag = False
+commit-args = --no-verify
 
 [bumpversion:file:VERSION]
 
@@ -12,8 +13,7 @@ tag = False
 
 [tool:pytest]
 addopts = --strict-markers
-# switching to 'auto' for the sake of pytest-aiohttp backward compatibility
-asyncio_mode=auto
+asyncio_mode = auto
 markers =
 	slow: marks tests as slow (deselect with '-m "not slow"')
 	acceptance_test: "marks tests as 'acceptance tests' i.e. does the system do what the user expects? Typically those are workflows."


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

Two very verbose but simple fixes:

- 🐛 ``boot.sh`` sets the same log-level to the app as to the server (i.e. ``uvicorn`` or ``gunicorn``). Up to now, they were not connected and portainer would always show INFO logs of the server regardless the log-level we set via env vars
- 🔨 ``bumpversion`` was failing to commit due to pre-commit-hook failing in modified README -> disabled pre-commit check on bumpversion changes.

## Related issue/s
 Maintenance

