### PR TITLE
Add the apparently missing delay and some more screenshots.

### DIFF
--- a/tests/e2e/tutorials/jupyterlabs.js
+++ b/tests/e2e/tutorials/jupyterlabs.js
@@ -48,24 +48,32 @@ async function runTutorial() {
       }
       const jLabIframe = iframes2.find(iframe => iframe._url.includes(workbenchData["nodeIds"][j]));
 
+      await tutorial.takeScreenshot("before_nb_selection");
       const input2outputFileSelector = '[title~="jl_notebook.ipynb"]';
       await jLabIframe.waitForSelector(input2outputFileSelector);
       await jLabIframe.click(input2outputFileSelector, {
         clickCount: 2
       });
+      await tutorial.takeScreenshot("after_nb_selection");
+
       await tutorial.waitFor(5000);
       // click Run Menu
       const mainRunMenuBtnSelector = '#jp-MainMenu > ul > li:nth-child(4)'; // select the Run Menu
       await utils.waitAndClick(jLabIframe, mainRunMenuBtnSelector)
 
+      await tutorial.takeScreenshot("after_run_menu");
+
       // click Run All Cells
       const mainRunAllBtnSelector = '#jp-mainmenu-run > ul > li:nth-child(12)'; // select the Run
       await utils.waitAndClick(jLabIframe, mainRunAllBtnSelector)
 
+      await tutorial.takeScreenshot("after_run_all_menu");
+
       if (j === 2) {
         await tutorial.waitFor(40000); // we are solving an em problem
+      } else {
+        await tutorial.waitFor(5000); // we are not solving an em problem
       }
-
 
       const outFiles = [
         "TheNumber.txt",


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

# 🐛 Fix error in jupyterlabs test

## What do these changes do?

Hopefully fixes the jupyterlabs e2e test. 
- Seemed like a delay was needed before checking the outputs. 
-  Add some possibly useful extra screenshots


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
