### PR TITLE
🐛 Fixes failing test in master

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/task.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/task.py
@@ -409,6 +409,10 @@ class DynamicSidecarsScheduler:
         settings: DynamicServicesSchedulerSettings = (
             self.app.state.settings.DYNAMIC_SERVICES.DYNAMIC_SCHEDULER
         )
+        logger.debug(
+             "dynamic-sidecars observation interval %s",
+             settings.DIRECTOR_V2_DYNAMIC_SCHEDULER_INTERVAL_SECONDS,
+         )
 
         while self._keep_running:
             logger.debug("Observing dynamic-sidecars %s", self._to_observe.keys())
@@ -500,14 +504,13 @@ async def setup_scheduler(app: FastAPI):
 
 async def shutdown_scheduler(app: FastAPI):
     scheduler: DynamicSidecarsScheduler = app.state.dynamic_sidecar_scheduler
-    ## FIXME: somehow this does not work
-    # assert isinstance(scheduler, DynamicSidecarsScheduler)  # nosec
+    assert isinstance(scheduler, DynamicSidecarsScheduler)  # nosec
 
     # FIXME: PC->ANE: if not started, should it be shutdown?
     await scheduler.shutdown()
 
 
-__all__: tuple[str] = (
+__all__: tuple[str, ...] = (
     "DynamicSidecarsScheduler",
     "setup_scheduler",
     "shutdown_scheduler",

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_scheduler.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_scheduler.py
@@ -7,7 +7,6 @@ import logging
 import re
 import urllib.parse
 from contextlib import asynccontextmanager, contextmanager
-from importlib import reload
 from typing import AsyncGenerator, AsyncIterator, Callable, Iterator, List, Type, Union
 from unittest.mock import AsyncMock
 
@@ -42,7 +41,6 @@ from simcore_service_director_v2.modules.dynamic_sidecar.scheduler import (
     DynamicSidecarsScheduler,
     setup_scheduler,
     shutdown_scheduler,
-    task,
 )
 from simcore_service_director_v2.modules.dynamic_sidecar.scheduler.events import (
     REGISTERED_EVENTS,
@@ -266,10 +264,9 @@ def mocked_client_api(scheduler_data: SchedulerData) -> Iterator[MockRouter]:
 @pytest.fixture
 def mock_service_running(mocker: MockerFixture) -> Iterator[AsyncMock]:
     mock = mocker.patch(
-        "simcore_service_director_v2.modules.dynamic_sidecar.docker_api.get_dynamic_sidecar_state",
+        "simcore_service_director_v2.modules.dynamic_sidecar.scheduler.task.get_dynamic_sidecar_state",
         return_value=(ServiceState.RUNNING, ""),
     )
-    reload(task)
 
     yield mock
 
@@ -277,10 +274,9 @@ def mock_service_running(mocker: MockerFixture) -> Iterator[AsyncMock]:
 @pytest.fixture
 def mock_update_label(mocker: MockerFixture) -> Iterator[None]:
     mocker.patch(
-        "simcore_service_director_v2.modules.dynamic_sidecar.docker_api.update_scheduler_data_label",
+        "simcore_service_director_v2.modules.dynamic_sidecar.scheduler.task.update_scheduler_data_label",
         return_value=None,
     )
-    reload(task)
 
     yield None
 

--- a/services/director-v2/tests/unit/test_routes_dynamic_services.py
+++ b/services/director-v2/tests/unit/test_routes_dynamic_services.py
@@ -7,7 +7,8 @@ import logging
 import os
 import urllib.parse
 from argparse import Namespace
-from typing import Any, AsyncIterator, Dict, NamedTuple, Optional
+from time import sleep
+from typing import Any, AsyncIterator, Dict, Final, NamedTuple, Optional
 from uuid import UUID
 
 import pytest
@@ -34,6 +35,8 @@ from simcore_service_director_v2.modules.dynamic_sidecar.errors import (
 )
 from starlette import status
 from starlette.testclient import TestClient
+
+WAIT_FOR_HEALTH_CALLS: Final[float] = 1.0
 
 
 class ServiceParams(NamedTuple):
@@ -280,6 +283,8 @@ def test_create_dynamic_services(
     if exp_status_code == status.HTTP_201_CREATED:
         # check the returned data
         pass
+
+    sleep(WAIT_FOR_HEALTH_CALLS)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

After an `httpx` upgrade a test started failing due to timing timing/concurrency. Making sure all the pending requests finish before closing the client.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist