### PR TITLE
♻️ Maintenance: renamed travis tests to heavy load

### DIFF
--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -75,7 +75,7 @@ jobs:
         run: ./ci/deploy/dockerhub-test-images.bash
 
   unit-test-webserver-01:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] webserver 01"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -126,7 +126,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-webserver-02:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] webserver 02"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -175,7 +175,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-webserver-03:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] webserver 03"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -224,7 +224,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-api:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] api"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -260,7 +260,7 @@ jobs:
         run: ./ci/github/unit-testing/api.bash test
 
   unit-test-api-server:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] api-server"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -309,7 +309,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-catalog:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] catalog"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -364,7 +364,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-datcore-adapter:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] datcore-adapter"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -419,7 +419,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-director:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] director"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -469,7 +469,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-director-v2:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] director-v2"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -524,7 +524,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-dask-task-models-library:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] dask-task-models-library"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -575,7 +575,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-dask-sidecar:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] dask-sidecar"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -624,7 +624,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-dynamic-sidecar:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] dynamic-sidecar"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -675,7 +675,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-frontend:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] frontend"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -713,7 +713,7 @@ jobs:
     #     flags: unittests #optional
 
   unit-test-python-linting:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] python-linting"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -749,7 +749,7 @@ jobs:
         run: ./ci/github/unit-testing/python-linting.bash test
 
   unit-test-postgres-database:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] postgres-database"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -799,7 +799,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-service-integration:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] service-integration"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -848,7 +848,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-service-library:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] service-library"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -897,7 +897,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-settings-library:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] settings-library"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -946,7 +946,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-models-library:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] models-library"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -995,7 +995,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-simcore-sdk:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] simcore-sdk"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -1046,7 +1046,7 @@ jobs:
           path: codeclimate.${{ github.job }}_coverage.json
 
   unit-test-storage:
-    timeout-minutes: 15 # if this timeout gets too small, then split the tests
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] storage"
     runs-on: ${{ matrix.os }}
     strategy:

--- a/ci/github/integration-testing/director-v2.bash
+++ b/ci/github/integration-testing/director-v2.bash
@@ -21,12 +21,21 @@ install() {
 
 test() {
   echo "testing in services/director-v2/tests/integration/$1"
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_service_director_v2 --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" "services/director-v2/tests/integration/$1" --log-level=DEBUG
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_director_v2 \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --log-level=DEBUG \
+    --verbose \
+    -m "not heavy_load" \
+    "services/director-v2/tests/integration/$1"
 }
 
 clean_up() {

--- a/ci/github/integration-testing/simcore-sdk.bash
+++ b/ci/github/integration-testing/simcore-sdk.bash
@@ -20,12 +20,21 @@ install() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_sdk --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" packages/simcore-sdk/tests/integration --log-level=DEBUG
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_sdk \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --log-level=DEBUG \
+    --verbose \
+    -m "not heavy_load" \
+    packages/simcore-sdk/tests/integration
 }
 
 clean_up() {

--- a/ci/github/integration-testing/webserver.bash
+++ b/ci/github/integration-testing/webserver.bash
@@ -20,12 +20,20 @@ install() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_service_webserver --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" "services/web/server/tests/integration/$1"
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_webserver \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    "services/web/server/tests/integration/$1"
 }
 
 clean_up() {

--- a/ci/github/unit-testing/api-server.bash
+++ b/ci/github/unit-testing/api-server.bash
@@ -14,12 +14,20 @@ install() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_service_api_server --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" services/api-server/tests/unit
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_api_server \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    services/api-server/tests/unit
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/api.bash
+++ b/ci/github/unit-testing/api.bash
@@ -12,8 +12,11 @@ install() {
 }
 
 test() {
-  pytest --durations=10 \
-          -v -m "not travis" api/tests
+  pytest \
+    --durations=10 \
+    --verbose \
+    -m "not heavy_load" \
+    api/tests
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/api.bash
+++ b/ci/github/unit-testing/api.bash
@@ -13,7 +13,10 @@ install() {
 
 test() {
   pytest \
+    --color=yes \
     --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
     --verbose \
     -m "not heavy_load" \
     api/tests

--- a/ci/github/unit-testing/catalog.bash
+++ b/ci/github/unit-testing/catalog.bash
@@ -14,12 +14,20 @@ install() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_service_catalog --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" services/catalog/tests/unit
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_catalog \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    services/catalog/tests/unit
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/dask-sidecar.bash
+++ b/ci/github/unit-testing/dask-sidecar.bash
@@ -14,12 +14,20 @@ install() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_service_dask_sidecar --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v services/dask-sidecar/tests/unit
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_dask_sidecar \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    services/dask-sidecar/tests/unit
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/dask-task-models-library.bash
+++ b/ci/github/unit-testing/dask-task-models-library.bash
@@ -31,7 +31,10 @@ test() {
     --cov-report=xml \
     --cov=dask_task_models_library \
     --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
     --verbose \
+    -m "not heavy_load" \
     packages/dask-task-models-library/tests
 }
 

--- a/ci/github/unit-testing/datcore-adapter.bash
+++ b/ci/github/unit-testing/datcore-adapter.bash
@@ -14,10 +14,21 @@ install() {
 }
 
 test() {
-  pytest --numprocesses=auto --cov=simcore_service_datcore_adapter --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" services/datcore-adapter/tests/unit
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_datcore_adapter \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --numprocesses=auto \
+    --verbose \
+    -m "not heavy_load" \
+    services/datcore-adapter/tests/unit
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/director-v2.bash
+++ b/ci/github/unit-testing/director-v2.bash
@@ -14,17 +14,39 @@ install() {
 }
 
 test() {
-  pytest --numprocesses=auto --cov=simcore_service_director_v2 --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
-    -v -m "not travis" services/director-v2/tests/unit --ignore=services/director-v2/tests/unit/with_dbs \
+  # tests without DB can be safely run in parallel
+  pytest \
     --asyncio-mode=auto \
-  # these tests cannot be run in parallel
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_director_v2 \
+    --durations=10 \
+    --ignore=services/director-v2/tests/unit/with_dbs \
     --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_service_director_v2 --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --numprocesses=auto \
+    --verbose \
+    -m "not heavy_load" \
+    services/director-v2/tests/unit
+
+  # these tests cannot be run in parallel
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" services/director-v2/tests/unit/with_dbs
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_director_v2 \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    services/director-v2/tests/unit/with_dbs
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/director.bash
+++ b/ci/github/unit-testing/director.bash
@@ -27,11 +27,19 @@ install() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
+  pytest \
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_director \
+    --durations=10 \
     --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_service_director --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
-    -v -m "not travis" services/director/tests
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    services/director/tests
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/dynamic-sidecar.bash
+++ b/ci/github/unit-testing/dynamic-sidecar.bash
@@ -20,12 +20,20 @@ codestyle() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_service_dynamic_sidecar --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" services/dynamic-sidecar/tests/unit
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_dynamic_sidecar \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    services/dynamic-sidecar/tests/unit
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/models-library.bash
+++ b/ci/github/unit-testing/models-library.bash
@@ -14,12 +14,20 @@ install() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=models_library --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" packages/models-library/tests
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=models_library \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    packages/models-library/tests
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/postgres-database.bash
+++ b/ci/github/unit-testing/postgres-database.bash
@@ -15,13 +15,16 @@ test() {
     pytest \
       --asyncio-mode=auto \
       --color=yes \
-      --durations=10 \
-      --cov=simcore_postgres_database \
       --cov-append \
+      --cov-config=.coveragerc \
       --cov-report=term-missing \
       --cov-report=xml \
-      --cov-config=.coveragerc \
+      --cov=simcore_postgres_database \
+      --log-date-format="%Y-%m-%d %H:%M:%S" \
+      --log-format="%(asctime)s %(levelname)s %(message)s" \
+      --durations=10 \
       --verbose \
+      -m "not heavy_load" \
       packages/postgres-database/tests
 }
 

--- a/ci/github/unit-testing/service-integration.bash
+++ b/ci/github/unit-testing/service-integration.bash
@@ -14,11 +14,19 @@ install() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
+  pytest \
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=service_integration \
+    --durations=10 \
     --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=service_integration --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
-    -v -m "not travis" packages/service-integration/tests
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    packages/service-integration/tests
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/service-library.bash
+++ b/ci/github/unit-testing/service-library.bash
@@ -16,12 +16,20 @@ install_all() {
 }
 
 test_all() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=servicelib --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" packages/service-library/tests
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=servicelib \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    packages/service-library/tests
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/settings-library.bash
+++ b/ci/github/unit-testing/settings-library.bash
@@ -14,11 +14,19 @@ install() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
+  pytest \
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=settings_library \
+    --durations=10 \
     --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=settings_library --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
-    -v packages/settings-library/tests
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    packages/settings-library/tests
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/simcore-sdk.bash
+++ b/ci/github/unit-testing/simcore-sdk.bash
@@ -17,12 +17,20 @@ install() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_sdk --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" packages/simcore-sdk/tests/unit
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_sdk \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    packages/simcore-sdk/tests/unit
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/storage.bash
+++ b/ci/github/unit-testing/storage.bash
@@ -14,12 +14,20 @@ install() {
 }
 
 test() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_service_storage --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" services/storage/tests
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_storage \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    services/storage/tests
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/webserver.bash
+++ b/ci/github/unit-testing/webserver.bash
@@ -21,22 +21,38 @@ install() {
 # As the plan is to strip the webserver into small micro-services I did not create now a super fancy classification but merely split the tests in ~equivalent test times.
 
 test_isolated() {
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_service_webserver --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" services/web/server/tests/unit/isolated
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_webserver \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    services/web/server/tests/unit/isolated
 }
 
 test_with_db() {
   echo "testing in services/web/server/tests/unit/with_dbs/$1"
-  pytest --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --cov=simcore_service_webserver --durations=10 --cov-append \
-    --color=yes --cov-report=term-missing --cov-report=xml --cov-config=.coveragerc \
+  pytest \
     --asyncio-mode=auto \
-    -v -m "not travis" "services/web/server/tests/unit/with_dbs/$1"
+    --color=yes \
+    --cov-append \
+    --cov-config=.coveragerc \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --cov=simcore_service_webserver \
+    --durations=10 \
+    --log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+    "services/web/server/tests/unit/with_dbs/$1"
 }
 
 # Check if the function exists (bash specific)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- sorted calls in bash scripts alphabetically
- renamed the marker "travis" (outdated) to "heavy_load"
  - one can now create a test **that should not run in the CI because it is too heavy** (for example a test that moves around 10 GB of data which the CI does not like too much) one can do for example:
```python
@pytest.mark.parametrize(
    "file_size",
    [
        _file_size("10Mib"),
        _file_size("1003Mib"),
        pytest.mark.heavy_load(_file_size("7Gib")),
    ],
)
```

It will skip the test if the marker "not heavy_load" is set
## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


Additional Note:
- Since there is currently an issue in Github Actions with the setup-node/setup-python actions (caching is broken), the timeout for unit tests was expended by 3 minutes.

Note: pre-requisiste to #3021 

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
