### PR TITLE
♻️ boot options injected to all involved containers for the service

### DIFF
--- a/packages/models-library/src/models_library/service_settings_labels.py
+++ b/packages/models-library/src/models_library/service_settings_labels.py
@@ -4,7 +4,7 @@ import json
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Extra, Field, Json, PrivateAttr, validator
 
@@ -44,7 +44,7 @@ class SimcoreServiceSettingLabelEntry(BaseModel):
     Specifically the section under ``TaskTemplate``
     """
 
-    _destination_container: str = PrivateAttr()
+    _destination_containers: list[str] = PrivateAttr()
     name: str = Field(..., description="The name of the service setting")
     setting_type: Literal[
         "string",
@@ -162,7 +162,7 @@ class PathMappingsLabel(BaseModel):
         }
 
 
-ComposeSpecLabel = Dict[str, Any]
+ComposeSpecLabel = dict[str, Any]
 
 
 class RestartPolicy(str, Enum):

--- a/packages/models-library/tests/test_service_settings_labels.py
+++ b/packages/models-library/tests/test_service_settings_labels.py
@@ -6,7 +6,7 @@ import json
 from collections import namedtuple
 from copy import deepcopy
 from pprint import pformat
-from typing import Any, Dict, Type
+from typing import Any, Type
 
 import pytest
 from models_library.service_settings_labels import (
@@ -50,7 +50,7 @@ SIMCORE_SERVICE_EXAMPLES = [
     ids=[x.id for x in SIMCORE_SERVICE_EXAMPLES],
 )
 def test_simcore_service_labels(
-    example: Dict, items: int, uses_dynamic_sidecar: bool
+    example: dict, items: int, uses_dynamic_sidecar: bool
 ) -> None:
     simcore_service_labels = SimcoreServiceLabels.parse_obj(example)
 
@@ -72,7 +72,7 @@ def test_service_settings() -> None:
     # ensure private attribute assignment
     for service_setting in simcore_settings_settings_label:
         # pylint: disable=protected-access
-        service_setting._destination_container = "random_value"
+        service_setting._destination_containers = ["random_value1", "random_value2"]
 
 
 @pytest.mark.parametrize(
@@ -84,7 +84,7 @@ def test_service_settings() -> None:
     ),
 )
 def test_service_settings_model_examples(
-    model_cls: Type[BaseModel], model_cls_examples: Dict[str, Dict[str, Any]]
+    model_cls: Type[BaseModel], model_cls_examples: dict[str, dict[str, Any]]
 ) -> None:
     for name, example in model_cls_examples.items():
         print(name, ":", pformat(example))
@@ -97,7 +97,7 @@ def test_service_settings_model_examples(
     (SimcoreServiceLabels,),
 )
 def test_correctly_detect_dynamic_sidecar_boot(
-    model_cls: Type[BaseModel], model_cls_examples: Dict[str, Dict[str, Any]]
+    model_cls: Type[BaseModel], model_cls_examples: dict[str, dict[str, Any]]
 ) -> None:
     for name, example in model_cls_examples.items():
         print(name, ":", pformat(example))
@@ -108,7 +108,7 @@ def test_correctly_detect_dynamic_sidecar_boot(
 
 
 def test_raises_error_if_http_entrypoint_is_missing() -> None:
-    simcore_service_labels: Dict[str, Any] = deepcopy(
+    simcore_service_labels: dict[str, Any] = deepcopy(
         SimcoreServiceLabels.Config.schema_extra["examples"][2]
     )
     del simcore_service_labels["simcore.service.container-http-entrypoint"]
@@ -141,7 +141,7 @@ def test_simcore_services_labels_compose_spec_null_container_http_entry_provided
 
 
 def test_raises_error_wrong_restart_policy() -> None:
-    simcore_service_labels: Dict[str, Any] = deepcopy(
+    simcore_service_labels: dict[str, Any] = deepcopy(
         SimcoreServiceLabels.Config.schema_extra["examples"][2]
     )
     simcore_service_labels["simcore.service.restart-policy"] = "__not_a_valid_policy__"

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/validation.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/validation.py
@@ -49,9 +49,9 @@ def _get_forwarded_env_vars(container_key: str) -> List[str]:
         if key.startswith("FORWARD_ENV_"):
             new_entry_key = key.replace("FORWARD_ENV_", "")
 
-            # parsing `VAR={"destination_container": "destination_container", "env_var": "PAYLOAD"}`
+            # parsing `VAR={"destination_containers": ["destination_container"], "env_var": "PAYLOAD"}`
             new_entry_payload = json.loads(os.environ[key])
-            if new_entry_payload["destination_container"] != container_key:
+            if container_key not in new_entry_payload["destination_containers"]:
                 continue
 
             new_entry_value = new_entry_payload["env_var"]


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Some services like iSeg, which are composed of multiple containers, require the `boot options` to be present inside a different container than the one the option was defined on.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
