### PR TITLE
🐛 Fixes FileLink validation legacy format

### DIFF
--- a/packages/models-library/src/models_library/projects_nodes_io.py
+++ b/packages/models-library/src/models_library/projects_nodes_io.py
@@ -118,7 +118,7 @@ class BaseFileLink(BaseModel):
     @validator("store", pre=True)
     @classmethod
     def legacy_enforce_str_to_int(cls, v):
-        """SEE"""
+        # SEE example 'legacy: store as string'
         if isinstance(v, str):
             return int(v)
         return v
@@ -159,7 +159,7 @@ class SimCoreFileLink(BaseFileLink):
                 "label": "input.txt",
             },
             "examples": [
-                # legacy (SEE incident https://git.speag.com/oSparc/e2e-portal-testing/-/issues/2)
+                # legacy: store as string (SEE incident https://git.speag.com/oSparc/e2e-portal-testing/-/issues/2)
                 {
                     "store": "0",
                     "path": "50339632-ee1d-11ec-a0c2-02420a0194e4/23b1522f-225f-5a4c-9158-c4c19a70d4a8/output.h5",

--- a/packages/models-library/src/models_library/projects_nodes_io.py
+++ b/packages/models-library/src/models_library/projects_nodes_io.py
@@ -159,7 +159,7 @@ class SimCoreFileLink(BaseFileLink):
                 "label": "input.txt",
             },
             "examples": [
-                # legacy: store as string (SEE incident https://git.speag.com/oSparc/e2e-portal-testing/-/issues/2)
+                # legacy: store as string (SEE incident https://git.speag.com/oSparc/e2e-testing/-/issues/1)
                 {
                     "store": "0",
                     "path": "50339632-ee1d-11ec-a0c2-02420a0194e4/23b1522f-225f-5a4c-9158-c4c19a70d4a8/output.h5",

--- a/packages/models-library/src/models_library/projects_nodes_io.py
+++ b/packages/models-library/src/models_library/projects_nodes_io.py
@@ -115,6 +115,14 @@ class BaseFileLink(BaseModel):
         alias="eTag",
     )
 
+    @validator("store", pre=True)
+    @classmethod
+    def legacy_enforce_str_to_int(cls, v):
+        """SEE"""
+        if isinstance(v, str):
+            return int(v)
+        return v
+
 
 class SimCoreFileLink(BaseFileLink):
     """I/O port type to hold a link to a file in simcore S3 storage"""
@@ -151,6 +159,12 @@ class SimCoreFileLink(BaseFileLink):
                 "label": "input.txt",
             },
             "examples": [
+                # legacy (SEE incident https://git.speag.com/oSparc/e2e-portal-testing/-/issues/2)
+                {
+                    "store": "0",
+                    "path": "50339632-ee1d-11ec-a0c2-02420a0194e4/23b1522f-225f-5a4c-9158-c4c19a70d4a8/output.h5",
+                    "eTag": "f7e4c7076761a42a871e978c8691c676",
+                },
                 # minimal
                 {
                     "store": 0,

--- a/packages/models-library/tests/test__pydantic_models.py
+++ b/packages/models-library/tests/test__pydantic_models.py
@@ -138,9 +138,10 @@ def test_union_types_coercion():
     assert model.output == "some/path/or/string"
 
     # (undefined) json string vs SimCoreFileLink.dict() ------------
+    MINIMAL = 1
     assert SimCoreFileLink in get_args(OutputTypes)
     example = SimCoreFileLink.parse_obj(
-        SimCoreFileLink.Config.schema_extra["examples"][0]
+        SimCoreFileLink.Config.schema_extra["examples"][MINIMAL]
     )
     model = Func.parse_obj(
         {

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
@@ -97,8 +97,7 @@ class Port(BaseServiceIOModel):
             if port_utils.is_file_type(property_type):
                 if not isinstance(v, (FileLink, DownloadLink)):
                     raise ValueError(
-                        f"{property_type!r} must follow "
-                        f"{FileLink.schema()}, {DownloadLink.schema()} or {PortLink.schema()}"
+                        f"{property_type!r} does not validat against any of FileLink, DownloadLink or PortLink schemas"
                     )
             elif property_type == "ref_contentSchema":
                 v, _ = validate_port_content(

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
@@ -97,7 +97,7 @@ class Port(BaseServiceIOModel):
             if port_utils.is_file_type(property_type):
                 if not isinstance(v, (FileLink, DownloadLink)):
                     raise ValueError(
-                        f"{property_type!r} does not validat against any of FileLink, DownloadLink or PortLink schemas"
+                        f"{property_type!r} value does not validate against any of FileLink, DownloadLink or PortLink schemas"
                     )
             elif property_type == "ref_contentSchema":
                 v, _ = validate_port_content(

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_port_validation.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_port_validation.py
@@ -265,7 +265,7 @@ async def test_port_with_units_and_constraints(mocker):
 
 
 def test_incident__port_validator_check_value():
-    # SEE incident https://git.speag.com/oSparc/e2e-portal-testing/-/issues/2)
+    # SEE incident https://git.speag.com/oSparc/e2e-testing/-/issues/1)
 
     # schema in comp_tasks table
     comp_tasks_schema = {

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -13,10 +13,9 @@ LABEL maintainer="Andrei Neagu <neagu@itis.swiss>"
 RUN set -eux && \
   apt-get update && \
   apt-get install -y \
+  curl \
   gosu \
-  curl \
   libmagic1 \
-  curl \
   && \
   rm -rf /var/lib/apt/lists/* && \
   # verify that the binary works


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

*isolve-gpu* e2e test failed (see [incident](https://git.speag.com/oSparc/e2e-testing/-/issues/1)) because ``comp_task`` tables included some outputs with an old FileLink format. 

This PR adds a validator in FileLink that handles that legacy format.

A question remains, though: which service is still adding ``store="0"`` to the ``comp_task``?? 


## How to test

- model_library tests adds example of data with legacy-format 
- simcore_sdk tests adds test with data taken from e2e test mentioned above

