### PR TITLE
🐛 Fix dy-sidecar gets multiple same placement constraints

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/sidecar.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/sidecar.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 from typing import Dict
 
 from models_library.aiodocker_api import AioDockerServiceSpec
@@ -230,7 +231,9 @@ def get_dynamic_sidecar_spec(
                 "Mounts": mounts,
             },
             "Placement": {
-                "Constraints": app_settings.DIRECTOR_V2_SERVICES_CUSTOM_CONSTRAINTS
+                "Constraints": deepcopy(
+                    app_settings.DIRECTOR_V2_SERVICES_CUSTOM_CONSTRAINTS
+                )
             },
             "RestartPolicy": {
                 "Condition": "on-failure",

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
@@ -318,7 +318,7 @@ def test_get_dynamic_proxy_spec(
     expected_dynamic_sidecar_spec: dict[str, Any],
 ) -> None:
     dynamic_sidecar_spec_accumulated = None
-    for n in range(10):
+    for _ in range(10):
         dynamic_sidecar_spec = get_dynamic_sidecar_spec(
             scheduler_data=scheduler_data,
             dynamic_sidecar_settings=dynamic_sidecar_settings,

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
@@ -1,7 +1,6 @@
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
 
-from pprint import pprint
 from typing import Any, Dict, Iterator, cast
 from uuid import UUID
 
@@ -318,20 +317,28 @@ def test_get_dynamic_proxy_spec(
     simcore_service_labels: SimcoreServiceLabels,
     expected_dynamic_sidecar_spec: dict[str, Any],
 ) -> None:
-    dynamic_sidecar_spec = get_dynamic_sidecar_spec(
-        scheduler_data=scheduler_data,
-        dynamic_sidecar_settings=dynamic_sidecar_settings,
-        dynamic_sidecar_network_id=dynamic_sidecar_network_id,
-        swarm_network_id=swarm_network_id,
-        settings=cast(SimcoreServiceSettingsLabel, simcore_service_labels.settings),
-        app_settings=minimal_app.state.settings,
-    )
-    assert dynamic_sidecar_spec
+    dynamic_sidecar_spec_accumulated = None
+    for n in range(10):
+        dynamic_sidecar_spec = get_dynamic_sidecar_spec(
+            scheduler_data=scheduler_data,
+            dynamic_sidecar_settings=dynamic_sidecar_settings,
+            dynamic_sidecar_network_id=dynamic_sidecar_network_id,
+            swarm_network_id=swarm_network_id,
+            settings=cast(SimcoreServiceSettingsLabel, simcore_service_labels.settings),
+            app_settings=minimal_app.state.settings,
+        )
+        assert dynamic_sidecar_spec
+        assert (
+            jsonable_encoder(dynamic_sidecar_spec, by_alias=True, exclude_unset=True)
+            == expected_dynamic_sidecar_spec
+        )
+        dynamic_sidecar_spec_accumulated = dynamic_sidecar_spec
     assert (
-        jsonable_encoder(dynamic_sidecar_spec, by_alias=True, exclude_unset=True)
+        jsonable_encoder(
+            dynamic_sidecar_spec_accumulated, by_alias=True, exclude_unset=True
+        )
         == expected_dynamic_sidecar_spec
     )
-    pprint(dynamic_sidecar_spec)
     # TODO: finish test when working on https://github.com/ITISFoundation/osparc-simcore/issues/2454
 
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
This PR fixes the problem where the dy-sidecar services gets multiple ```Placement Constraints``` in the thousands.



## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
