### PR TITLE
♻️ dy-sidecar: remove unnecessary traefik labels

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/sidecar.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/sidecar.py
@@ -196,14 +196,6 @@ def get_dynamic_sidecar_spec(
     create_service_params = {
         "endpoint_spec": endpoint_spec,
         "labels": {
-            # TODO: let's use a pydantic model with descriptions
-            "io.simcore.zone": scheduler_data.simcore_traefik_zone,
-            "traefik.docker.network": scheduler_data.dynamic_sidecar_network_name,  # also used for scheduling
-            "traefik.enable": "true",
-            f"traefik.http.routers.{scheduler_data.service_name}.entrypoints": "http",
-            f"traefik.http.routers.{scheduler_data.service_name}.priority": "10",
-            f"traefik.http.routers.{scheduler_data.service_name}.rule": "PathPrefix(`/`)",
-            f"traefik.http.services.{scheduler_data.service_name}.loadbalancer.server.port": f"{dynamic_sidecar_settings.DYNAMIC_SIDECAR_PORT}",
             "type": ServiceType.MAIN.value,  # required to be listed as an interactive service and be properly cleaned up
             "user_id": f"{scheduler_data.user_id}",
             "port": f"{dynamic_sidecar_settings.DYNAMIC_SIDECAR_PORT}",


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Traefik labels on the dy-sidecar service are unnecessary, they create unwanted work for the traefik service, unnecessary routes, etc. thus they are removed.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
