### PR TITLE
🔨 Maintenance/pyupgrade code base targeting py3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,13 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
       - id: check-merge-conflict
-  # NOTE: Keep order as pycln (remove unused imports), then isort (sort them) and black (final formatting)
+  # NOTE: Keep order as pyupgrade (will update code) then pycln (remove unused imports), then isort (sort them) and black (final formatting)
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.34.0
+    hooks:
+      - id: pyupgrade
+        args:
+          - "--py39-plus"
   - repo: https://github.com/hadialqattan/pycln
     rev: v1.2.5
     hooks:

--- a/api/tests/test_full_openapis.py
+++ b/api/tests/test_full_openapis.py
@@ -1,20 +1,19 @@
-import pytest
 from pathlib import Path
+
+import pytest
 from openapi_spec_validator import validate_spec
 from openapi_spec_validator.exceptions import OpenAPIValidationError
-
-from utils import is_openapi_schema, load_specs, list_files_in_api_specs
-
-
+from utils import is_openapi_schema, list_files_in_api_specs, load_specs
 
 # TESTS ----------------------------------------------------------
 # NOTE: parametrizing tests per file makes more visible which file failed
 # NOTE: to debug use the wildcard and select problematic file, e.g. list_files_in_api_specs("*log_message.y*ml"))
 
 
-@pytest.mark.parametrize("spec_file_path",
-                        list_files_in_api_specs("*.json") +
-                        list_files_in_api_specs("*.y*ml") )
+@pytest.mark.parametrize(
+    "spec_file_path",
+    list_files_in_api_specs("*.json") + list_files_in_api_specs("*.y*ml"),
+)
 def test_valid_openapi_specs(spec_file_path):
     spec_file_path = Path(spec_file_path)
     specs = load_specs(spec_file_path)
@@ -22,4 +21,4 @@ def test_valid_openapi_specs(spec_file_path):
         try:
             validate_spec(specs, spec_url=spec_file_path.as_uri())
         except OpenAPIValidationError as err:
-            pytest.fail("Failed validating {}:\n{}".format(spec_file_path, err.message))
+            pytest.fail(f"Failed validating {spec_file_path}:\n{err.message}")

--- a/api/tests/test_individual_json_schemas.py
+++ b/api/tests/test_individual_json_schemas.py
@@ -1,17 +1,18 @@
-import pytest
 from pathlib import Path
-from jsonschema import SchemaError, ValidationError, validate
 
-from utils import load_specs, is_json_schema, list_files_in_api_specs
+import pytest
+from jsonschema import SchemaError, ValidationError, validate
+from utils import is_json_schema, list_files_in_api_specs, load_specs
 
 
 # TESTS ----------------------------------------------------------
 # NOTE: parametrizing tests per file makes more visible which file failed
 # NOTE: to debug use the wildcard and select problematic file, e.g. list_files_in_api_specs("*log_message.y*ml"))
 @pytest.mark.skip(reason="Implementing in PR 324")
-@pytest.mark.parametrize("spec_file_path",
-                        list_files_in_api_specs("*.json") +
-                        list_files_in_api_specs("*.y*ml") )                        
+@pytest.mark.parametrize(
+    "spec_file_path",
+    list_files_in_api_specs("*.json") + list_files_in_api_specs("*.y*ml"),
+)
 def test_valid_individual_json_schemas_specs(spec_file_path):
     spec_file_path = Path(spec_file_path)
     specs_dict = load_specs(spec_file_path)
@@ -23,10 +24,12 @@ def test_valid_individual_json_schemas_specs(spec_file_path):
             validate(dummy_instance, specs_dict)
         except SchemaError as err:
             # this is not good
-            pytest.fail("Failed validating %s: \n %s " % (spec_file_path, err.message))
+            pytest.fail(f"Failed validating {spec_file_path}: \n {err.message} ")
         except ValidationError:
             # this is good
             return
         else:
             # this is also not good and bad from the validator...
-            pytest.fail("Expecting an instance validation error if the schema in {file} was correct".format(file=spec_file_path))
+            pytest.fail(
+                f"Expecting an instance validation error if the schema in {spec_file_path} was correct"
+            )

--- a/api/tests/test_individual_openapi_schemas.py
+++ b/api/tests/test_individual_openapi_schemas.py
@@ -2,23 +2,14 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-import json
 import os
 import shutil
 from pathlib import Path
 
 import pytest
-import yaml
 from openapi_spec_validator import validate_spec
 from openapi_spec_validator.exceptions import OpenAPIValidationError
-from utils import (
-    dump_specs,
-    is_json_schema,
-    is_openapi_schema,
-    list_files_in_api_specs,
-    load_specs,
-    specs_folder,
-)
+from utils import dump_specs, is_json_schema, is_openapi_schema, load_specs
 
 # Conventions
 _REQUIRED_FIELDS = ["error", "data"]
@@ -45,7 +36,7 @@ def add_namespace_for_converted_schemas(schema_specs: dict):
 
 
 def change_references_to_schemas(filepath: Path, specs: dict):
-    from os.path import relpath, isabs, join, abspath, exists
+    from os.path import abspath, exists, isabs, relpath
 
     filedir = filepath.parent
 
@@ -97,12 +88,12 @@ def change_references_to_schemas(filepath: Path, specs: dict):
 @pytest.fixture(scope="session")
 def converted_specs_testdir(api_specs_dir, all_api_specs_tails, tmpdir_factory):
     """
-        - All api_specs files are copied into tmpdir
-        - All openapi files under schemas/ folders are processed into valid openapi specs
-        - All references to these files are replaced from
-            $ref: ... /schemas/some_file.yaml#Reference
-        to
-            $ref: ... /schemas/some_file.yaml#/components/reference/Reference
+    - All api_specs files are copied into tmpdir
+    - All openapi files under schemas/ folders are processed into valid openapi specs
+    - All references to these files are replaced from
+        $ref: ... /schemas/some_file.yaml#Reference
+    to
+        $ref: ... /schemas/some_file.yaml#/components/reference/Reference
 
     """
     basedir = api_specs_dir
@@ -155,4 +146,4 @@ def test_valid_individual_openapi_specs(api_specs_tail, converted_specs_testdir)
         specs = load_specs(api_specs_path)
         validate_spec(specs, spec_url=api_specs_path.as_uri())
     except OpenAPIValidationError as err:
-        pytest.fail("Failed validating {}:\n{}".format(api_specs_path, err.message))
+        pytest.fail(f"Failed validating {api_specs_path}:\n{err.message}")

--- a/api/tests/utils.py
+++ b/api/tests/utils.py
@@ -1,7 +1,6 @@
 import json
 import sys
 from pathlib import Path
-from typing import List
 
 import yaml
 
@@ -10,23 +9,25 @@ CONVERTED_SUFFIX = "-converted.yaml"
 
 current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
+
 def find_current_repo_folder():
     cpath = Path(current_dir)
     while not any(cpath.glob(".git")):
         cpath = cpath.parent
-        assert cpath!=cpath.parent
+        assert cpath != cpath.parent
     assert cpath.glob("services")
     return cpath
 
-current_repo_dir = find_current_repo_folder()
 
+current_repo_dir = find_current_repo_folder()
 
 
 def specs_folder():
     return current_dir.parent / "specs"
 
-def list_files_in_api_specs(wildcard: str) -> List[str]:
-    """ Helper function to parameterize tests with list of files
+
+def list_files_in_api_specs(wildcard: str) -> list[str]:
+    """Helper function to parameterize tests with list of files
 
     e.g.  pytest -v  test_individual_openapi_schemas.py
 
@@ -38,17 +39,17 @@ def list_files_in_api_specs(wildcard: str) -> List[str]:
     return list(str(p) for p in specs_dir.rglob(wildcard))
 
 
-def list_all_openapi() -> List[str]:
-    """ Lists paths to all 'services/**/api/v*/openapi.y*ml'
-        These are single documents that bundles all parts
+def list_all_openapi() -> list[str]:
+    """Lists paths to all 'services/**/api/v*/openapi.y*ml'
+    These are single documents that bundles all parts
     """
-    return [str(p) for p in current_repo_dir.rglob("api/v*/openapi.y*ml") ]
+    return [str(p) for p in current_repo_dir.rglob("api/v*/openapi.y*ml")]
 
 
 def load_specs(spec_file_path: Path) -> dict:
     assert spec_file_path.exists(), spec_file_path
     with spec_file_path.open() as file_ptr:
-        if ".json" in  spec_file_path.suffix:
+        if ".json" in spec_file_path.suffix:
             schema_specs = json.load(file_ptr)
         else:
             schema_specs = yaml.safe_load(file_ptr)

--- a/packages/pytest-simcore/src/pytest_simcore/db_entries_mocks.py
+++ b/packages/pytest-simcore/src/pytest_simcore/db_entries_mocks.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Iterator, List
+from typing import Any, Callable, Iterator
 from uuid import uuid4
 
 import pytest
@@ -12,10 +12,10 @@ from simcore_postgres_database.models.users import UserRole, UserStatus, users
 @pytest.fixture()
 def registered_user(
     postgres_db: sa.engine.Engine, faker: Faker
-) -> Iterator[Callable[..., Dict]]:
+) -> Iterator[Callable[..., dict]]:
     created_user_ids = []
 
-    def creator(**user_kwargs) -> Dict[str, Any]:
+    def creator(**user_kwargs) -> dict[str, Any]:
         with postgres_db.connect() as con:
             # removes all users before continuing
             user_config = {
@@ -52,9 +52,9 @@ def registered_user(
 def project(
     postgres_db: sa.engine.Engine, faker: Faker
 ) -> Iterator[Callable[..., ProjectAtDB]]:
-    created_project_ids: List[str] = []
+    created_project_ids: list[str] = []
 
-    def creator(user: Dict[str, Any], **overrides) -> ProjectAtDB:
+    def creator(user: dict[str, Any], **overrides) -> ProjectAtDB:
         project_uuid = uuid4()
         print(f"Created new project with uuid={project_uuid}")
         project_config = {

--- a/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
@@ -1,11 +1,12 @@
-# pylint:disable=unused-variable
-# pylint:disable=unused-argument
-# pylint:disable=redefined-outer-name
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
 
 """ Fixtures to create docker-compose.yaml configuration files (as in Makefile)
 
     - Basically runs `docker-compose config
     - Services in stack can be selected using 'core_services_selection', 'ops_services_selection' fixtures
+
 """
 
 import json
@@ -15,7 +16,7 @@ import subprocess
 import sys
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Iterator, List
+from typing import Any, Iterator
 
 import pytest
 import yaml
@@ -53,7 +54,7 @@ def testing_environ_vars(env_devel_file: Path) -> EnvVarsDict:
     env_devel["LOG_LEVEL"] = "DEBUG"
 
     env_devel["REGISTRY_SSL"] = "False"
-    env_devel["REGISTRY_URL"] = "{}:5000".format(get_localhost_ip())
+    env_devel["REGISTRY_URL"] = f"{get_localhost_ip()}:5000"
     env_devel["REGISTRY_PATH"] = "127.0.0.1:5000"
     env_devel["REGISTRY_USER"] = "simcore"
     env_devel["REGISTRY_PW"] = ""
@@ -83,7 +84,7 @@ def testing_environ_vars(env_devel_file: Path) -> EnvVarsDict:
 
 @pytest.fixture(scope="module")
 def env_file_for_testing(
-    testing_environ_vars: Dict[str, str],
+    testing_environ_vars: dict[str, str],
     temp_folder: Path,
     osparc_simcore_root_dir: Path,
 ) -> Iterator[Path]:
@@ -126,7 +127,7 @@ def simcore_docker_compose(
     osparc_simcore_root_dir: Path,
     env_file_for_testing: Path,
     temp_folder: Path,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Resolves docker-compose for simcore stack in local host
 
     Produces same as  `make .stack-simcore-version.yml` in a temporary folder
@@ -200,7 +201,7 @@ def ops_docker_compose(
     env_file_for_testing: Path,
     temp_folder: Path,
     inject_filestash_config_path: None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Filters only services in docker-compose-ops.yml and returns yaml data
 
     Produces same as  `make .stack-ops.yml` in a temporary folder
@@ -230,7 +231,7 @@ def ops_docker_compose(
 
 
 @pytest.fixture(scope="module")
-def core_services_selection(request) -> List[str]:
+def core_services_selection(request) -> list[str]:
     """Selection of services from the simcore stack"""
     core_services = getattr(request.module, FIXTURE_CONFIG_CORE_SERVICES_SELECTION, [])
 
@@ -242,7 +243,7 @@ def core_services_selection(request) -> List[str]:
 
 @pytest.fixture(scope="module")
 def core_docker_compose_file(
-    core_services_selection: List[str], temp_folder: Path, simcore_docker_compose: Dict
+    core_services_selection: list[str], temp_folder: Path, simcore_docker_compose: dict
 ) -> Path:
     """A compose with a selection of services from simcore_docker_compose
 
@@ -259,7 +260,7 @@ def core_docker_compose_file(
 
 
 @pytest.fixture(scope="module")
-def ops_services_selection(request) -> List[str]:
+def ops_services_selection(request) -> list[str]:
     """Selection of services from the ops stack"""
     ops_services = getattr(request.module, FIXTURE_CONFIG_OPS_SERVICES_SELECTION, [])
     return ops_services
@@ -267,7 +268,7 @@ def ops_services_selection(request) -> List[str]:
 
 @pytest.fixture(scope="module")
 def ops_docker_compose_file(
-    ops_services_selection: List[str], temp_folder: Path, ops_docker_compose: Dict
+    ops_services_selection: list[str], temp_folder: Path, ops_docker_compose: dict
 ) -> Path:
     """A compose with a selection of services from ops_docker_compose
 
@@ -314,7 +315,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: ExitCode) -> None:
 # HELPERS ---------------------------------------------
 
 
-def _minio_fix(service_environs: Dict) -> Dict:
+def _minio_fix(service_environs: dict) -> dict:
     """this hack ensures that S3 is accessed from the host at all time, thus pre-signed links work."""
     if "S3_ENDPOINT" in service_environs:
         service_environs["S3_ENDPOINT"] = f"{get_localhost_ip()}:9001"
@@ -322,7 +323,7 @@ def _minio_fix(service_environs: Dict) -> Dict:
 
 
 def _filter_services_and_dump(
-    include: List, services_compose: Dict, docker_compose_path: Path
+    include: list, services_compose: dict, docker_compose_path: Path
 ):
     content = deepcopy(services_compose)
 
@@ -344,7 +345,7 @@ def _filter_services_and_dump(
     with docker_compose_path.open("wt") as fh:
         if "TRAVIS" in os.environ:
             # in travis we do not have access to file
-            print("{:-^100}".format(str(docker_compose_path)))
+            print(f"{str(docker_compose_path):-^100}")
             yaml.dump(content, sys.stdout, default_flow_style=False)
             print("-" * 100)
         else:

--- a/packages/pytest-simcore/src/pytest_simcore/docker_registry.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_registry.py
@@ -7,7 +7,7 @@ import os
 import time
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, Optional
+from typing import Any, Callable, Iterator, Optional
 
 import docker
 import jsonschema
@@ -27,7 +27,7 @@ def docker_registry(keep_docker_up: bool) -> Iterator[str]:
     # try to login to private registry
     host = "127.0.0.1"
     port = 5000
-    url = "{host}:{port}".format(host=host, port=port)
+    url = f"{host}:{port}"
     container = None
     try:
         docker_client.login(registry=url, username="simcore")
@@ -112,9 +112,9 @@ def _pull_push_service(
     pull_key: str,
     tag: str,
     new_registry: str,
-    node_meta_schema: Dict,
+    node_meta_schema: dict,
     owner_email: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     client = docker.from_env()
     # pull image from original location
     print(f"Pulling {pull_key}:{tag} ...")
@@ -122,7 +122,7 @@ def _pull_push_service(
     assert image, f"image {pull_key}:{tag} could NOT be pulled!"
 
     # get io.simcore.* labels
-    image_labels: Dict = dict(image.labels)
+    image_labels: dict = dict(image.labels)
 
     if owner_email:
         print("Overriding labels to take ownership as %s ...", owner_email)
@@ -186,8 +186,8 @@ def _pull_push_service(
 
 @pytest.fixture(scope="session")
 def docker_registry_image_injector(
-    docker_registry: str, node_meta_schema: Dict
-) -> Callable[..., Dict[str, Any]]:
+    docker_registry: str, node_meta_schema: dict
+) -> Callable[..., dict[str, Any]]:
     def inject_image(
         source_image_repo: str, source_image_tag: str, owner_email: Optional[str] = None
     ):
@@ -204,8 +204,8 @@ def docker_registry_image_injector(
 
 @pytest.fixture(scope="function")
 def osparc_service(
-    docker_registry: str, node_meta_schema: Dict, service_repo: str, service_tag: str
-) -> Dict[str, Any]:
+    docker_registry: str, node_meta_schema: dict, service_repo: str, service_tag: str
+) -> dict[str, Any]:
     """pulls the service from service_repo:service_tag and pushes to docker_registry using the oSparc node meta schema
     NOTE: 'service_repo' and 'service_tag' defined as parametrization
     """
@@ -215,7 +215,7 @@ def osparc_service(
 
 
 @pytest.fixture(scope="session")
-def sleeper_service(docker_registry: str, node_meta_schema: Dict) -> Dict[str, Any]:
+def sleeper_service(docker_registry: str, node_meta_schema: dict) -> dict[str, Any]:
     """Adds a itisfoundation/sleeper in docker registry"""
     return _pull_push_service(
         "itisfoundation/sleeper", "1.0.0", docker_registry, node_meta_schema
@@ -223,7 +223,7 @@ def sleeper_service(docker_registry: str, node_meta_schema: Dict) -> Dict[str, A
 
 
 @pytest.fixture(scope="session")
-def jupyter_service(docker_registry: str, node_meta_schema: Dict) -> Dict[str, Any]:
+def jupyter_service(docker_registry: str, node_meta_schema: dict) -> dict[str, Any]:
     """Adds a itisfoundation/jupyter-base-notebook in docker registry"""
     return _pull_push_service(
         "itisfoundation/jupyter-base-notebook",
@@ -240,8 +240,8 @@ def dy_static_file_server_version(request):
 
 @pytest.fixture(scope="session")
 def dy_static_file_server_service(
-    docker_registry: str, node_meta_schema: Dict, dy_static_file_server_version: str
-) -> Dict[str, Any]:
+    docker_registry: str, node_meta_schema: dict, dy_static_file_server_version: str
+) -> dict[str, Any]:
     """
     Adds the below service in docker registry
     itisfoundation/dy-static-file-server
@@ -256,8 +256,8 @@ def dy_static_file_server_service(
 
 @pytest.fixture(scope="session")
 def dy_static_file_server_dynamic_sidecar_service(
-    docker_registry: str, node_meta_schema: Dict, dy_static_file_server_version: str
-) -> Dict[str, Any]:
+    docker_registry: str, node_meta_schema: dict, dy_static_file_server_version: str
+) -> dict[str, Any]:
     """
     Adds the below service in docker registry
     itisfoundation/dy-static-file-server-dynamic-sidecar
@@ -272,8 +272,8 @@ def dy_static_file_server_dynamic_sidecar_service(
 
 @pytest.fixture(scope="session")
 def dy_static_file_server_dynamic_sidecar_compose_spec_service(
-    docker_registry: str, node_meta_schema: Dict, dy_static_file_server_version: str
-) -> Dict[str, Any]:
+    docker_registry: str, node_meta_schema: dict, dy_static_file_server_version: str
+) -> dict[str, Any]:
     """
     Adds the below service in docker registry
     itisfoundation/dy-static-file-server-dynamic-sidecar-compose-spec

--- a/packages/pytest-simcore/src/pytest_simcore/docker_swarm.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_swarm.py
@@ -254,7 +254,7 @@ def docker_stack(
 
         async def _check_all_services_are_running():
             async for attempt in AsyncRetrying(
-                wait=wait_fixed(1),
+                wait=wait_fixed(5),
                 stop=stop_after_delay(8 * MINUTE),
                 before_sleep=before_sleep_log(log, logging.INFO),
                 reraise=True,

--- a/packages/pytest-simcore/src/pytest_simcore/docker_swarm.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_swarm.py
@@ -7,10 +7,9 @@ import asyncio
 import json
 import logging
 import subprocess
-import sys
 from contextlib import suppress
 from pathlib import Path
-from typing import Any, Dict, Iterator
+from typing import Any, Iterator
 
 import docker
 import pytest
@@ -28,10 +27,6 @@ from .helpers.utils_docker import get_localhost_ip
 
 log = logging.getLogger(__name__)
 
-
-#
-# NOTE: this file must be PYTHON >=3.6 COMPATIBLE because it is used by the director service
-#
 
 # HELPERS --------------------------------------------------------------------------------
 
@@ -61,7 +56,7 @@ def _in_docker_swarm(
 def assert_service_is_running(service):
     """Checks that a number of tasks of this service are in running state"""
 
-    def _get(obj: Dict[str, Any], dotted_key: str, default=None) -> Any:
+    def _get(obj: dict[str, Any], dotted_key: str, default=None) -> Any:
         keys = dotted_key.split(".")
         value = obj
         for key in keys[:-1]:
@@ -196,7 +191,7 @@ def docker_stack(
     ops_docker_compose_file: Path,
     keep_docker_up: bool,
     testing_environ_vars: EnvVarsDict,
-) -> Iterator[Dict]:
+) -> Iterator[dict]:
     """deploys core and ops stacks and returns as soon as all are running"""
 
     # WARNING: keep prefix "pytest-" in stack names
@@ -219,7 +214,7 @@ def docker_stack(
     ]
 
     # make up-version
-    stacks_deployed: Dict[str, Dict] = {}
+    stacks_deployed: dict[str, dict] = {}
     for key, stack_name, compose_file in stacks:
         try:
             subprocess.run(
@@ -255,38 +250,26 @@ def docker_stack(
     # - notice that the timeout is set for all services in both stacks
     # - TODO: the time to deploy will depend on the number of services selected
     try:
-        if sys.version_info >= (3, 7):
-            from tenacity._asyncio import AsyncRetrying
+        from tenacity._asyncio import AsyncRetrying
 
-            async def _check_all_services_are_running():
-                async for attempt in AsyncRetrying(
-                    wait=wait_fixed(1),
-                    stop=stop_after_delay(8 * MINUTE),
-                    before_sleep=before_sleep_log(log, logging.INFO),
-                    reraise=True,
-                ):
-                    with attempt:
-                        await asyncio.gather(
-                            *[
-                                asyncio.get_event_loop().run_in_executor(
-                                    None, assert_service_is_running, service
-                                )
-                                for service in docker_client.services.list()
-                            ]
-                        )
-
-            asyncio.run(_check_all_services_are_running())
-
-        else:
-            for attempt in Retrying(
-                wait=wait_fixed(5),
+        async def _check_all_services_are_running():
+            async for attempt in AsyncRetrying(
+                wait=wait_fixed(1),
                 stop=stop_after_delay(8 * MINUTE),
                 before_sleep=before_sleep_log(log, logging.INFO),
                 reraise=True,
             ):
                 with attempt:
-                    for service in docker_client.services.list():
-                        assert_service_is_running(service)
+                    await asyncio.gather(
+                        *[
+                            asyncio.get_event_loop().run_in_executor(
+                                None, assert_service_is_running, service
+                            )
+                            for service in docker_client.services.list()
+                        ]
+                    )
+
+        asyncio.run(_check_all_services_are_running())
 
     finally:
         _fetch_and_print_services(docker_client, "[BEFORE TEST]")

--- a/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
+++ b/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
@@ -5,7 +5,6 @@
 
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict
 
 import dotenv
 import pytest
@@ -13,7 +12,7 @@ from _pytest.monkeypatch import MonkeyPatch
 
 
 @pytest.fixture(scope="session")
-def env_devel_dict(env_devel_file: Path) -> Dict[str, str]:
+def env_devel_dict(env_devel_file: Path) -> dict[str, str]:
     assert env_devel_file.exists()
     assert env_devel_file.name == ".env-devel"
     environ = dotenv.dotenv_values(env_devel_file, verbose=True, interpolate=True)
@@ -23,8 +22,8 @@ def env_devel_dict(env_devel_file: Path) -> Dict[str, str]:
 
 @pytest.fixture(scope="function")
 def mock_env_devel_environment(
-    env_devel_dict: Dict[str, str], monkeypatch: MonkeyPatch
-) -> Dict[str, str]:
+    env_devel_dict: dict[str, str], monkeypatch: MonkeyPatch
+) -> dict[str, str]:
     for key, value in env_devel_dict.items():
         monkeypatch.setenv(key, str(value))
     return deepcopy(env_devel_dict)

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/rawdata_fakers.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/rawdata_fakers.py
@@ -15,7 +15,7 @@ import itertools
 import json
 import random
 from datetime import datetime, timedelta
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 from uuid import uuid4
 
 import faker
@@ -56,7 +56,7 @@ def _compute_hash(password: str) -> str:
 _DEFAULT_HASH = _compute_hash("secret")
 
 
-def random_user(**overrides) -> Dict[str, Any]:
+def random_user(**overrides) -> dict[str, Any]:
     data = dict(
         name=_faker.name(),
         email=_faker.email(),
@@ -64,7 +64,7 @@ def random_user(**overrides) -> Dict[str, Any]:
         status=UserStatus.ACTIVE,
         created_ip=_faker.ipv4(),
     )
-    assert set(data.keys()).issubset(set(c.name for c in users.columns))  # nosec
+    assert set(data.keys()).issubset({c.name for c in users.columns})  # nosec
 
     # transform password in hash
     password = overrides.pop("password", None)
@@ -75,7 +75,7 @@ def random_user(**overrides) -> Dict[str, Any]:
     return data
 
 
-def random_project(**overrides) -> Dict[str, Any]:
+def random_project(**overrides) -> dict[str, Any]:
     """Generates random fake data projects DATABASE table"""
     data = dict(
         uuid=_faker.uuid4(),
@@ -87,13 +87,13 @@ def random_project(**overrides) -> Dict[str, Any]:
         workbench={},
         published=False,
     )
-    assert set(data.keys()).issubset(set(c.name for c in projects.columns))  # nosec
+    assert set(data.keys()).issubset({c.name for c in projects.columns})  # nosec
 
     data.update(overrides)
     return data
 
 
-def random_group(**overrides) -> Dict[str, Any]:
+def random_group(**overrides) -> dict[str, Any]:
     data = dict(
         name=_faker.company(), description=_faker.text(), type=ProjectType.STANDARD.name
     )
@@ -101,7 +101,7 @@ def random_group(**overrides) -> Dict[str, Any]:
     return data
 
 
-def fake_pipeline(**overrides) -> Dict[str, Any]:
+def fake_pipeline(**overrides) -> dict[str, Any]:
     data = dict(
         dag_adjacency_list=json.dumps({}),
         state=random.choice(STATES),
@@ -114,7 +114,7 @@ def fake_task_factory(first_internal_id=1) -> Callable:
     # Each new instance of fake_task will get a copy
     _index_in_sequence = itertools.count(start=first_internal_id)
 
-    def fake_task(**overrides) -> Dict[str, Any]:
+    def fake_task(**overrides) -> dict[str, Any]:
 
         t0 = datetime.utcnow()
         data = dict(

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/typing_docker.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/typing_docker.py
@@ -2,7 +2,7 @@
 Adds type hints to data structures in responses from docker daemon (typically included in docker sdk and aiodocker libraries)
 """
 
-from typing import Dict, List, TypedDict
+from typing import TypedDict
 
 UrlStr = str
 DateTimeStr = str
@@ -19,13 +19,13 @@ class ServiceSpecDict(TypedDict):
     docker service inspect $(id) | jq ".[0].Spec | keys"
     """
 
-    EndpointSpec: Dict
-    Labels: Dict[str, str]
-    Mode: Dict
+    EndpointSpec: dict
+    Labels: dict[str, str]
+    Mode: dict
     Name: str
-    RollbackConfig: Dict
-    TaskTemplate: Dict
-    UpdateConfig: Dict
+    RollbackConfig: dict
+    TaskTemplate: dict
+    UpdateConfig: dict
 
 
 class ServiceDict(TypedDict):
@@ -34,16 +34,16 @@ class ServiceDict(TypedDict):
     """
 
     ID: str
-    Version: Dict
+    Version: dict
     CreatedAt: DateTimeStr
     UpdatedAt: DateTimeStr
     Spec: ServiceSpecDict
-    Endpoint: Dict
+    Endpoint: dict
 
 
 class ContainerSpec(TypedDict):
     Image: str
-    Labels: Dict[str, str]
+    Labels: dict[str, str]
     Hostname: str
 
 
@@ -62,7 +62,7 @@ class StatusDict(TypedDict):
     # e.g. in StatusDict1 we add
     # ContainerStatus:
 
-    PortStatus: Dict
+    PortStatus: dict
 
 
 class VersionDict(TypedDict):
@@ -83,9 +83,9 @@ class TaskDict(TypedDict):
     ServiceID: str
     NodeID: str
     Slot: int
-    Status: Dict
+    Status: dict
     DesiredState: str
-    NetworkAttachments: List[Dict]
+    NetworkAttachments: list[dict]
     # ...
 
 

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/typing_docker.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/typing_docker.py
@@ -1,12 +1,12 @@
 """
 Adds type hints to data structures in responses from docker daemon (typically included in docker sdk and aiodocker libraries)
+
 """
 
 from typing import TypedDict
 
 UrlStr = str
 DateTimeStr = str
-
 
 #
 # Docker API JSON bodies
@@ -87,6 +87,3 @@ class TaskDict(TypedDict):
     DesiredState: str
     NetworkAttachments: list[dict]
     # ...
-
-
-UrlStr = str

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/typing_env.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/typing_env.py
@@ -1,7 +1,6 @@
-# SKIP pyupgrade (used in director)
-from typing import Optional, Dict
+from typing import Optional
 
-EnvVarsDict = Dict[str, Optional[str]]
+EnvVarsDict = dict[str, Optional[str]]
 #
 # NOTE: that this means that env vars do not require a value. If that happens a None is assigned
 #   For instance, a valid env file is

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/typing_env.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/typing_env.py
@@ -1,6 +1,6 @@
-from typing import Dict, Optional
+from typing import Optional
 
-EnvVarsDict = Dict[str, Optional[str]]
+EnvVarsDict = dict[str, Optional[str]]
 #
 # NOTE: that this means that env vars do not require a value. If that happens a None is assigned
 #   For instance, a valid env file is

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/typing_env.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/typing_env.py
@@ -1,6 +1,7 @@
-from typing import Optional
+# SKIP pyupgrade (used in director)
+from typing import Optional, Dict
 
-EnvVarsDict = dict[str, Optional[str]]
+EnvVarsDict = Dict[str, Optional[str]]
 #
 # NOTE: that this means that env vars do not require a value. If that happens a None is assigned
 #   For instance, a valid env file is

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_assert.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_assert.py
@@ -2,7 +2,7 @@
 
 """
 from pprint import pformat
-from typing import Dict, Optional, Tuple, Type
+from typing import Optional
 
 from aiohttp import ClientResponse
 from aiohttp.web import HTTPError, HTTPException, HTTPInternalServerError, HTTPNoContent
@@ -11,12 +11,12 @@ from servicelib.aiohttp.rest_responses import unwrap_envelope
 
 async def assert_status(
     response: ClientResponse,
-    expected_cls: Type[HTTPException],
+    expected_cls: type[HTTPException],
     expected_msg: Optional[str] = None,
     expected_error_code: Optional[str] = None,
     include_meta: Optional[bool] = False,
     include_links: Optional[bool] = False,
-) -> Tuple[Dict, ...]:
+) -> tuple[dict, ...]:
     """
     Asserts for enveloped responses
     """
@@ -55,7 +55,7 @@ async def assert_status(
 
 async def assert_error(
     response: ClientResponse,
-    expected_cls: Type[HTTPException],
+    expected_cls: type[HTTPException],
     expected_msg: Optional[str] = None,
 ):
     data, error = unwrap_envelope(await response.json())
@@ -65,7 +65,7 @@ async def assert_error(
 def do_assert_error(
     data,
     error,
-    expected_cls: Type[HTTPException],
+    expected_cls: type[HTTPException],
     expected_msg: Optional[str] = None,
     expected_error_code: Optional[str] = None,
 ):

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_dict.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_dict.py
@@ -1,8 +1,8 @@
 """ Utils to operate with dicts """
 
-from typing import Any, Dict, Mapping, Optional, Set, Union
+from typing import Any, Mapping, Optional, Union
 
-ConfigDict = Dict[str, Any]
+ConfigDict = dict[str, Any]
 
 
 def get_from_dict(obj: Mapping[str, Any], dotted_key: str, default=None) -> Any:
@@ -13,7 +13,7 @@ def get_from_dict(obj: Mapping[str, Any], dotted_key: str, default=None) -> Any:
     return value.get(keys[-1], default)
 
 
-def copy_from_dict(data: Dict[str, Any], *, include: Optional[Union[Set, Dict]] = None):
+def copy_from_dict(data: dict[str, Any], *, include: Optional[Union[set, dict]] = None):
     #
     # Analogous to advanced includes from pydantic exports
     #   https://pydantic-docs.helpmanual.io/usage/exporting_models/#advanced-include-and-exclude
@@ -33,7 +33,7 @@ def copy_from_dict(data: Dict[str, Any], *, include: Optional[Union[Set, Dict]] 
     return {key: copy_from_dict(data[key], include=include[key]) for key in include}
 
 
-def update_dict(obj: Dict, **updates):
+def update_dict(obj: dict, **updates):
     for key, update_value in updates.items():
         if callable(update_value):
             update_value = update_value(obj[key])

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_docker.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_docker.py
@@ -5,7 +5,7 @@ import re
 import socket
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import docker
 import yaml
@@ -42,7 +42,7 @@ def get_localhost_ip(default="127.0.0.1") -> str:
     after=after_log(log, logging.WARNING),
 )
 def get_service_published_port(
-    service_name: str, target_ports: Optional[Union[List[int], int]] = None
+    service_name: str, target_ports: Optional[Union[list[int], int]] = None
 ) -> str:
     # WARNING: ENSURE that service name exposes a port in
     # Dockerfile file or docker-compose config file
@@ -79,7 +79,7 @@ def get_service_published_port(
         published_port = service_ports[0]["PublishedPort"]
 
     else:
-        ports_to_look_for: List = (
+        ports_to_look_for: list = (
             [target_ports] if isinstance(target_ports, (int, str)) else target_ports
         )
 
@@ -97,11 +97,11 @@ def get_service_published_port(
 
 
 def run_docker_compose_config(
-    docker_compose_paths: Union[List[Path], Path],
+    docker_compose_paths: Union[list[Path], Path],
     project_dir: Path,
     env_file_path: Path,
     destination_path: Optional[Path] = None,
-) -> Dict:
+) -> dict:
     """Runs docker-compose config to validate and resolve a compose file configuration
 
     - Composes all configurations passed in 'docker_compose_paths'
@@ -162,7 +162,7 @@ def run_docker_compose_config(
     )
 
     compose_file_str = process.stdout.decode("utf-8")
-    compose_file: Dict[str, Any] = yaml.safe_load(compose_file_str)
+    compose_file: dict[str, Any] = yaml.safe_load(compose_file_str)
 
     if destination_path:
         #

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_environs.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_environs.py
@@ -5,7 +5,6 @@ import re
 import warnings
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, List
 
 import yaml
 
@@ -19,7 +18,7 @@ warnings.warn(
 )
 
 
-def _load_env(file_handler) -> Dict:
+def _load_env(file_handler) -> dict:
     """Deserializes an environment file like .env-devel and
     returns a key-value map of the environment
 
@@ -38,9 +37,9 @@ def _load_env(file_handler) -> Dict:
 
 
 def eval_environs_in_docker_compose(
-    docker_compose: Dict,
+    docker_compose: dict,
     docker_compose_dir: Path,
-    host_environ: Dict = None,
+    host_environ: dict = None,
     *,
     use_env_devel=True,
 ):
@@ -58,9 +57,9 @@ def eval_environs_in_docker_compose(
 
 
 def replace_environs_in_docker_compose_service(
-    service_section: Dict,
+    service_section: dict,
     docker_compose_dir: Path,
-    host_environ: Dict = None,
+    host_environ: dict = None,
     *,
     use_env_devel=True,
 ):
@@ -75,7 +74,7 @@ def replace_environs_in_docker_compose_service(
     service_environ = {}
 
     # environment defined in env_file
-    env_files: List[str] = service_section.pop("env_file", [])
+    env_files: list[str] = service_section.pop("env_file", [])
     for env_file in env_files:
         if env_file.endswith(".env") and use_env_devel:
             env_file += "-devel"
@@ -110,8 +109,8 @@ def replace_environs_in_docker_compose_service(
 def eval_service_environ(
     docker_compose_path: Path,
     service_name: str,
-    host_environ: Dict = None,
-    image_environ: Dict = None,
+    host_environ: dict = None,
+    image_environ: dict = None,
     *,
     use_env_devel=True,
 ) -> EnvVarsDict:

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_login.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_login.py
@@ -55,7 +55,7 @@ async def create_user(db: AsyncpgStorage, data=None) -> UserInfoDict:
     password = get_random_string(10)
     params = {
         "name": get_random_string(10),
-        "email": "{}@gmail.com".format(get_random_string(10)),
+        "email": f"{get_random_string(10)}@gmail.com",
         "password_hash": encrypt_password(password),
     }
     params.update(data)

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_postgres.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_postgres.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from copy import deepcopy
-from typing import Any, Dict, Iterator
+from typing import Any, Iterator
 
 import simcore_postgres_database.cli
 import sqlalchemy as sa
@@ -9,8 +9,8 @@ from simcore_postgres_database.models.base import metadata
 
 @contextmanager
 def migrated_pg_tables_context(
-    postgres_config: Dict[str, Any]
-) -> Iterator[Dict[str, Any]]:
+    postgres_config: dict[str, Any]
+) -> Iterator[dict[str, Any]]:
     """
     Within the context, tables are created and dropped
     using migration upgrade/downgrade routines

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_projects.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_projects.py
@@ -6,7 +6,7 @@
 import json
 import uuid as uuidlib
 from pathlib import Path
-from typing import Any, Dict, Optional, Type
+from typing import Any, Optional
 
 from aiohttp import web
 from aiohttp.test_utils import TestClient
@@ -36,7 +36,7 @@ def empty_project_data():
 
 async def create_project(
     app: web.Application,
-    params_override: Optional[Dict[str, Any]] = None,
+    params_override: Optional[dict[str, Any]] = None,
     user_id: Optional[int] = None,
     *,
     default_project_json: Optional[Path] = None,
@@ -92,7 +92,7 @@ async def delete_all_projects(app: web.Application):
 class NewProject:
     def __init__(
         self,
-        params_override: Optional[Dict] = None,
+        params_override: Optional[dict] = None,
         app: Optional[web.Application] = None,
         clear_all: bool = True,
         user_id: Optional[int] = None,
@@ -140,9 +140,9 @@ class NewProject:
 async def assert_get_same_project(
     client: TestClient,
     project: ProjectDict,
-    expected: Type[web.HTTPException],
+    expected: type[web.HTTPException],
     api_vtag="/v0",
-) -> Dict:
+) -> dict:
     # GET /v0/projects/{project_id}
 
     # with a project owned by user

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_rate_limit.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_rate_limit.py
@@ -2,11 +2,10 @@ import asyncio
 import logging
 import math
 import time
-
-from typing import List, Awaitable
 from functools import wraps
+from typing import Awaitable
 
-from aiohttp import ClientSession, ClientTimeout, ClientResponse
+from aiohttp import ClientResponse, ClientSession, ClientTimeout
 
 log = logging.getLogger()
 
@@ -125,7 +124,7 @@ async def assert_steady_rate_in_5_seconds(
     return sleep_interval
 
 
-CHECKS_TO_RUN: List[Awaitable] = [
+CHECKS_TO_RUN: list[Awaitable] = [
     assert_steady_rate_in_5_seconds,
     assert_burst_rate_limit,
 ]

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_scrunch_citations.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_scrunch_citations.py
@@ -9,11 +9,10 @@
 """
 
 import re
-from typing import List, Tuple
 
 
-def split_citations(citations: List[str]) -> List[Tuple[str, str]]:
-    def _split(citation: str) -> Tuple[str, str]:
+def split_citations(citations: list[str]) -> list[tuple[str, str]]:
+    def _split(citation: str) -> tuple[str, str]:
         if "," not in citation:
             citation = citation.replace("(", "(,")
         name, rrid = re.match(r"^\((.*),\s*RRID:(.+)\)$", citation).groups()

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_services.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_services.py
@@ -1,7 +1,7 @@
 """
     NOTE: avoid creating dependencies
 """
-from typing import Any, Dict, List
+from typing import Any
 
 FAKE_FILE_CONSUMER_SERVICES = [
     # services support one filetype
@@ -51,7 +51,7 @@ FAKE_FILE_CONSUMER_SERVICES = [
 ]
 
 
-def list_fake_file_consumers() -> List[Dict[str, Any]]:
+def list_fake_file_consumers() -> list[dict[str, Any]]:
     consumers = []
     for service in FAKE_FILE_CONSUMER_SERVICES:
         for consumable in service["consumes"]:
@@ -68,7 +68,7 @@ def list_fake_file_consumers() -> List[Dict[str, Any]]:
     return consumers
 
 
-def list_supported_filetypes() -> List[str]:
+def list_supported_filetypes() -> list[str]:
     return sorted(
         {
             consumable.split(":")[0]

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_tokens.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_tokens.py
@@ -49,11 +49,7 @@ async def get_token_from_db(
             token_service=token_service,
             token_data=token_data,
         )
-        stmt = sa.select(
-            [
-                tokens,
-            ]
-        ).where(expr)
+        stmt = sa.select([tokens]).where(expr)
         result = await conn.execute(stmt)
         row = await result.first()
         return dict(row) if row else None

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_tokens.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_tokens.py
@@ -5,12 +5,11 @@ import random
 from functools import reduce
 
 import sqlalchemy as sa
-from sqlalchemy import JSON, String, cast
-from sqlalchemy.sql import and_  # , or_, not_
-
 from servicelib.common_aiopg_utils import DSN
 from simcore_service_webserver.db_models import metadata, tokens, users
 from simcore_service_webserver.login.utils import get_random_string
+from sqlalchemy import JSON, String, cast
+from sqlalchemy.sql import and_  # , or_, not_
 
 
 def create_db_tables(**kargs):
@@ -50,7 +49,11 @@ async def get_token_from_db(
             token_service=token_service,
             token_data=token_data,
         )
-        stmt = sa.select([tokens,]).where(expr)
+        stmt = sa.select(
+            [
+                tokens,
+            ]
+        ).where(expr)
         result = await conn.execute(stmt)
         row = await result.first()
         return dict(row) if row else None

--- a/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
+++ b/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, Dict, Type
+from typing import Any
 
 import pytest
 from pydantic import BaseModel
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 
 @pytest.fixture
-def model_cls_examples(model_cls: Type[BaseModel]) -> Dict[str, Dict[str, Any]]:
+def model_cls_examples(model_cls: type[BaseModel]) -> dict[str, dict[str, Any]]:
     """
     Extracts examples from pydantic model class Config
     """

--- a/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
@@ -7,7 +7,7 @@ import logging
 import os
 import socket
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Dict, Optional
+from typing import Any, AsyncIterator, Optional
 
 import aio_pika
 import pytest
@@ -40,7 +40,7 @@ async def wait_till_rabbit_responsive(url: str) -> None:
 
 @pytest.fixture(scope="function")
 async def rabbit_settings(
-    docker_stack: Dict, testing_environ_vars: Dict  # stack is up
+    docker_stack: dict, testing_environ_vars: dict  # stack is up
 ) -> RabbitSettings:
     """Returns the settings of a rabbit service that is up and responsive"""
 

--- a/packages/pytest-simcore/src/pytest_simcore/redis_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/redis_service.py
@@ -3,7 +3,7 @@
 # pylint:disable=redefined-outer-name
 
 import logging
-from typing import AsyncIterator, Dict, Union
+from typing import AsyncIterator, Union
 
 import pytest
 import tenacity
@@ -21,8 +21,8 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture
 async def redis_settings(
-    docker_stack: Dict,  # stack is up
-    testing_environ_vars: Dict,
+    docker_stack: dict,  # stack is up
+    testing_environ_vars: dict,
 ) -> RedisSettings:
     """Returns the settings of a redis service that is up and responsive"""
 

--- a/packages/pytest-simcore/src/pytest_simcore/schemas.py
+++ b/packages/pytest-simcore/src/pytest_simcore/schemas.py
@@ -4,7 +4,7 @@ import json
 import logging
 import subprocess
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable
+from typing import Any, Callable, Iterable
 
 import pytest
 
@@ -26,7 +26,7 @@ def node_meta_schema_file(common_schemas_specs_dir: Path) -> Path:
 
 
 @pytest.fixture(scope="session")
-def node_meta_schema(node_meta_schema_file: Path) -> Dict:
+def node_meta_schema(node_meta_schema_file: Path) -> dict:
     with node_meta_schema_file.open() as fp:
         node_schema = json.load(fp)
         return node_schema
@@ -34,7 +34,7 @@ def node_meta_schema(node_meta_schema_file: Path) -> Dict:
 
 @pytest.fixture(scope="session")
 def json_schema_dict(common_schemas_specs_dir: Path) -> Iterable[Callable]:
-    def schema_getter(schema_name: str) -> Dict:
+    def schema_getter(schema_name: str) -> dict:
         json_file = common_schemas_specs_dir / schema_name
         assert (
             json_file.exists()
@@ -55,10 +55,10 @@ def json_faker_script(osparc_simcore_scripts_dir: Path) -> Path:
 @pytest.fixture(scope="session")
 def random_json_from_schema(
     json_faker_script: Path, tmp_path_factory
-) -> Iterable[Callable[[str], Dict[str, Any]]]:
+) -> Iterable[Callable[[str], dict[str, Any]]]:
     # tmp_path_factory fixture: https://docs.pytest.org/en/stable/tmpdir.html
 
-    def _generator(json_schema: str) -> Dict[str, Any]:
+    def _generator(json_schema: str) -> dict[str, Any]:
         tmp_path = tmp_path_factory.mktemp(__name__)
         schema_path = tmp_path / "schema.json"
 
@@ -99,7 +99,7 @@ def json_diff_script(osparc_simcore_scripts_dir: Path) -> Path:
 
 @pytest.fixture(scope="session")
 def diff_json_schemas(json_diff_script: Path, tmp_path_factory) -> Callable:
-    def _run_diff(schema_lhs: Dict, schema_rhs: Dict) -> subprocess.CompletedProcess:
+    def _run_diff(schema_lhs: dict, schema_rhs: dict) -> subprocess.CompletedProcess:
         tmpdir = tmp_path_factory.mktemp(basename=__name__, numbered=True)
         schema_lhs_path = tmpdir / "schema_lhs.json"
         schema_lhs_path.write_text(json.dumps(schema_lhs, indent=1))

--- a/packages/pytest-simcore/src/pytest_simcore/service_environs.py
+++ b/packages/pytest-simcore/src/pytest_simcore/service_environs.py
@@ -16,6 +16,5 @@ def service_env_file(project_slug_dir: Path) -> Path:
 
 @pytest.fixture(scope="session", autouse=True)
 def service_test_environ(service_env_file: Path) -> None:
-    """this fixtures overload the environ with unit testing only variables
-    """
+    """this fixtures overload the environ with unit testing only variables"""
     load_dotenv(service_env_file, verbose=True)

--- a/packages/pytest-simcore/src/pytest_simcore/services_api_mocks_for_aiohttp_clients.py
+++ b/packages/pytest-simcore/src/pytest_simcore/services_api_mocks_for_aiohttp_clients.py
@@ -6,7 +6,7 @@ import json
 import random
 import re
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest
 from aiohttp import web
@@ -28,7 +28,7 @@ PASSTHROUGH_REQUESTS_PREFIXES = ["http://127.0.0.1", "ws://"]
 
 
 # The adjacency list is defined as a dictionary with the key to the node and its list of successors
-FULL_PROJECT_PIPELINE_ADJACENCY: Dict[str, List[str]] = {
+FULL_PROJECT_PIPELINE_ADJACENCY: dict[str, list[str]] = {
     "62bca361-8594-48c8-875e-b8577e868aec": [
         "e0d7a1a5-0700-42c7-b033-97f72ac4a5cd",
         "5284bb5b-b068-4d0e-9075-3d5d8eec5060",
@@ -40,7 +40,7 @@ FULL_PROJECT_PIPELINE_ADJACENCY: Dict[str, List[str]] = {
     "e83a359a-1efe-41d3-83aa-a285afbfaf12": [],
 }
 
-FULL_PROJECT_NODE_STATES: Dict[str, Dict[str, Any]] = {
+FULL_PROJECT_NODE_STATES: dict[str, dict[str, Any]] = {
     "62bca361-8594-48c8-875e-b8577e868aec": {"modified": True, "dependencies": []},
     "e0d7a1a5-0700-42c7-b033-97f72ac4a5cd": {
         "modified": True,
@@ -76,7 +76,7 @@ def create_computation_cb(url, **kwargs) -> CallbackResult:
         if "start_pipeline" in body and body["start_pipeline"]
         else RunningState.NOT_STARTED
     )
-    pipeline: Dict[str, List[str]] = FULL_PROJECT_PIPELINE_ADJACENCY
+    pipeline: dict[str, list[str]] = FULL_PROJECT_PIPELINE_ADJACENCY
     node_states = FULL_PROJECT_NODE_STATES
     if body.get("subgraph"):
         # create some fake adjacency list
@@ -116,7 +116,7 @@ def create_computation_cb(url, **kwargs) -> CallbackResult:
 
 def get_computation_cb(url, **kwargs) -> CallbackResult:
     state = RunningState.NOT_STARTED
-    pipeline: Dict[str, List[str]] = FULL_PROJECT_PIPELINE_ADJACENCY
+    pipeline: dict[str, list[str]] = FULL_PROJECT_PIPELINE_ADJACENCY
     node_states = FULL_PROJECT_NODE_STATES
 
     return CallbackResult(

--- a/packages/pytest-simcore/src/pytest_simcore/simcore_services.py
+++ b/packages/pytest-simcore/src/pytest_simcore/simcore_services.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass
-from typing import Dict, List
 
 import aiohttp
 import pytest
@@ -105,10 +104,10 @@ class ServiceHealthcheckEndpoint:
 
 @pytest.fixture(scope="module")
 def services_endpoint(
-    core_services_selection: List[str],
-    docker_stack: Dict,
+    core_services_selection: list[str],
+    docker_stack: dict,
     testing_environ_vars: EnvVarsDict,
-) -> Dict[str, URL]:
+) -> dict[str, URL]:
     services_endpoint = {}
 
     stack_name = testing_environ_vars["SWARM_STACK_NAME"]
@@ -136,7 +135,7 @@ def services_endpoint(
 
 @pytest.fixture(scope="module")
 def simcore_services_ready(
-    services_endpoint: Dict[str, URL], monkeypatch_module: MonkeyPatch
+    services_endpoint: dict[str, URL], monkeypatch_module: MonkeyPatch
 ) -> None:
     """
     - Waits for services in `core_services_selection` to be healthy

--- a/packages/pytest-simcore/src/pytest_simcore/simcore_storage_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/simcore_storage_service.py
@@ -3,7 +3,7 @@
 # pylint:disable=redefined-outer-name
 import os
 from copy import deepcopy
-from typing import Callable, Dict, Iterable
+from typing import Callable, Iterable
 
 import aiohttp
 import pytest
@@ -19,7 +19,7 @@ from .helpers.utils_docker import get_localhost_ip, get_service_published_port
 
 
 @pytest.fixture(scope="module")
-def storage_endpoint(docker_stack: Dict, testing_environ_vars: Dict) -> Iterable[URL]:
+def storage_endpoint(docker_stack: dict, testing_environ_vars: dict) -> Iterable[URL]:
     prefix = testing_environ_vars["SWARM_STACK_NAME"]
     assert f"{prefix}_storage" in docker_stack["services"]
 
@@ -40,7 +40,7 @@ def storage_endpoint(docker_stack: Dict, testing_environ_vars: Dict) -> Iterable
 
 @pytest.fixture(scope="function")
 async def storage_service(
-    minio_service: Minio, storage_endpoint: URL, docker_stack: Dict
+    minio_service: Minio, storage_endpoint: URL, docker_stack: dict
 ) -> URL:
     await wait_till_storage_responsive(storage_endpoint)
 

--- a/packages/pytest-simcore/src/pytest_simcore/simcore_webserver_projects_rest_api.py
+++ b/packages/pytest-simcore/src/pytest_simcore/simcore_webserver_projects_rest_api.py
@@ -6,7 +6,7 @@
 from copy import deepcopy
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import Any, Dict, Literal, Optional, Tuple
+from typing import Any, Literal, Optional
 
 import pytest
 
@@ -22,8 +22,8 @@ class HttpApiCallCapture:
     description: str
     method: Literal["GET", "PUT", "POST", "PATCH"]
     path: str
-    request_payload: Optional[Dict[str, Any]]
-    response_body: Optional[Dict[str, Any]]
+    request_payload: Optional[dict[str, Any]]
+    response_body: Optional[dict[str, Any]]
     status_code: HTTPStatus = HTTPStatus.OK
 
     def __str__(self) -> str:
@@ -711,5 +711,5 @@ SESSION_WORKFLOW = (
 
 
 @pytest.fixture
-def project_workflow_captures() -> Tuple[HttpApiCallCapture, ...]:
+def project_workflow_captures() -> tuple[HttpApiCallCapture, ...]:
     return tuple(deepcopy(c) for c in SESSION_WORKFLOW)

--- a/packages/pytest-simcore/src/pytest_simcore/simcore_webserver_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/simcore_webserver_service.py
@@ -2,7 +2,6 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-from typing import Dict
 
 import aiohttp
 import pytest
@@ -14,7 +13,7 @@ from .helpers.utils_docker import get_service_published_port
 
 
 @pytest.fixture(scope="module")
-def webserver_endpoint(docker_stack: Dict, testing_environ_vars: Dict) -> URL:
+def webserver_endpoint(docker_stack: dict, testing_environ_vars: dict) -> URL:
     prefix = testing_environ_vars["SWARM_STACK_NAME"]
     assert f"{prefix}_webserver" in docker_stack["services"]
 
@@ -23,7 +22,7 @@ def webserver_endpoint(docker_stack: Dict, testing_environ_vars: Dict) -> URL:
 
 
 @pytest.fixture(scope="function")
-async def webserver_service(webserver_endpoint: URL, docker_stack: Dict) -> URL:
+async def webserver_service(webserver_endpoint: URL, docker_stack: dict) -> URL:
     await wait_till_webserver_responsive(webserver_endpoint)
 
     yield webserver_endpoint

--- a/packages/pytest-simcore/src/pytest_simcore/traefik_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/traefik_service.py
@@ -2,7 +2,6 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-from typing import Dict, Tuple
 
 import aiohttp
 import pytest
@@ -15,8 +14,8 @@ from .helpers.utils_docker import get_service_published_port
 
 @pytest.fixture(scope="module")
 def traefik_endpoints(
-    docker_stack: Dict, testing_environ_vars: Dict
-) -> Tuple[URL, URL, URL]:
+    docker_stack: dict, testing_environ_vars: dict
+) -> tuple[URL, URL, URL]:
     """get the endpoint for the given simcore_service.
     NOTE: simcore_service defined as a parametrization
     """
@@ -35,8 +34,8 @@ def traefik_endpoints(
 
 @pytest.fixture(scope="function")
 async def traefik_service(
-    loop, traefik_endpoints: Tuple[URL, URL, URL], docker_stack: Dict
-) -> Tuple[URL, URL, URL]:
+    loop, traefik_endpoints: tuple[URL, URL, URL], docker_stack: dict
+) -> tuple[URL, URL, URL]:
     traefik_api_endpoint, webserver_endpoint, apiserver_endpoint = traefik_endpoints
     await wait_till_traefik_responsive(traefik_api_endpoint)
     yield traefik_endpoints

--- a/packages/pytest-simcore/src/pytest_simcore/websocket_client.py
+++ b/packages/pytest-simcore/src/pytest_simcore/websocket_client.py
@@ -3,7 +3,7 @@
 # pylint:disable=redefined-outer-name
 
 import logging
-from typing import AsyncIterable, Awaitable, Callable, List, Optional
+from typing import AsyncIterable, Awaitable, Callable, Optional
 from uuid import uuid4
 
 import pytest
@@ -62,7 +62,7 @@ async def socketio_client_factory(
 ) -> AsyncIterable[
     Callable[[Optional[str], Optional[TestClient]], Awaitable[socketio.AsyncClient]]
 ]:
-    clients: List[socketio.AsyncClient] = []
+    clients: list[socketio.AsyncClient] = []
 
     async def _connect(
         client_session_id: Optional[str] = None, client: Optional[TestClient] = None

--- a/packages/pytest-simcore/tests/test_fixture_environs.py
+++ b/packages/pytest-simcore/tests/test_fixture_environs.py
@@ -8,8 +8,8 @@ assert any(repo_base_dir.glob(".git"))
 
 
 def test_root_dir_with_installed_plugin(testdir):
-    """ Make sure osparc_simcore_root_dir is correct
-        even when pytest-simcore installed
+    """Make sure osparc_simcore_root_dir is correct
+    even when pytest-simcore installed
     """
 
     # create a temporary pytest test module
@@ -27,7 +27,9 @@ def test_root_dir_with_installed_plugin(testdir):
     # fnmatch_lines does an assertion internally
     # WARNING: this does not work with pytest-sugar!
     result.stdout.fnmatch_lines(
-        ["*::test_sth PASSED*",]
+        [
+            "*::test_sth PASSED*",
+        ]
     )
 
     # make sure that that we get a '0' exit code for the testsuite

--- a/packages/pytest-simcore/tests/test_simcore_plugin.py
+++ b/packages/pytest-simcore/tests/test_simcore_plugin.py
@@ -1,28 +1,26 @@
-# -*- coding: utf-8 -*-
-
-
 def test_using_pytest_simcore_fixture(testdir):
     """Make sure that pytest accepts our fixture."""
 
     # create a temporary pytest test module
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         pytest_plugins = ["pytest_simcore.repository_paths"]
 
         def test_sth(request):
             assert request.config.getoption("--keep-docker-up") == True
-    """)
+    """
+    )
 
     # run pytest with the following cmd args
-    result = testdir.runpytest(
-        '--keep-docker-up',
-        '-v'
-    )
+    result = testdir.runpytest("--keep-docker-up", "-v")
 
     # fnmatch_lines does an assertion internally
     # WARNING: this does not work with pytest-sugar!
-    result.stdout.fnmatch_lines([
-        '*::test_sth PASSED*',
-    ])
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_sth PASSED*",
+        ]
+    )
 
     # make sure that that we get a '0' exit code for the testsuite
     assert result.ret == 0
@@ -30,22 +28,27 @@ def test_using_pytest_simcore_fixture(testdir):
 
 def test_help_message(testdir):
     result = testdir.runpytest(
-        '--help',
+        "--help",
     )
     # fnmatch_lines does an assertion internally
-    result.stdout.fnmatch_lines([
-        'simcore:',
-        '*--keep-docker-up*Keep stack/registry up after fixtures closes',
-    ])
+    result.stdout.fnmatch_lines(
+        [
+            "simcore:",
+            "*--keep-docker-up*Keep stack/registry up after fixtures closes",
+        ]
+    )
 
 
 def test_hello_ini_setting(testdir):
-    testdir.makeini("""
+    testdir.makeini(
+        """
         [pytest]
         HELLO = world
-    """)
+    """
+    )
 
-    testdir.makepyfile("""
+    testdir.makepyfile(
+        """
         import pytest
 
         @pytest.fixture
@@ -54,14 +57,17 @@ def test_hello_ini_setting(testdir):
 
         def test_hello_world(hello):
             assert hello == 'world'
-    """)
+    """
+    )
 
-    result = testdir.runpytest('-v')
+    result = testdir.runpytest("-v")
 
     # fnmatch_lines does an assertion internally
-    result.stdout.fnmatch_lines([
-        '*::test_hello_world PASSED*',
-    ])
+    result.stdout.fnmatch_lines(
+        [
+            "*::test_hello_world PASSED*",
+        ]
+    )
 
     # make sure that that we get a '0' exit code for the testsuite
     assert result.ret == 0

--- a/packages/settings-library/setup.py
+++ b/packages/settings-library/setup.py
@@ -1,12 +1,11 @@
 import re
 import sys
 from pathlib import Path
-from typing import Set
 
 from setuptools import find_packages, setup
 
 
-def read_reqs(reqs_path: Path) -> Set[str]:
+def read_reqs(reqs_path: Path) -> set[str]:
     return {
         r
         for r in re.findall(

--- a/packages/settings-library/src/settings_library/utils_cli.py
+++ b/packages/settings-library/src/settings_library/utils_cli.py
@@ -2,7 +2,7 @@ import logging
 import os
 from functools import partial
 from pprint import pformat
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Callable, Optional
 
 import typer
 from pydantic import BaseModel, SecretStr, ValidationError
@@ -67,7 +67,7 @@ def print_as_json(settings_obj, *, compact=False, **pydantic_export_options):
     )
 
 
-def create_json_encoder_wo_secrets(model_cls: Type[BaseModel]):
+def create_json_encoder_wo_secrets(model_cls: type[BaseModel]):
     current_encoders = getattr(model_cls.Config, "json_encoders", {})
     encoder = partial(
         custom_pydantic_encoder,
@@ -80,7 +80,7 @@ def create_json_encoder_wo_secrets(model_cls: Type[BaseModel]):
 
 
 def create_settings_command(
-    settings_cls: Type[BaseCustomSettings], logger: Optional[logging.Logger] = None
+    settings_cls: type[BaseCustomSettings], logger: Optional[logging.Logger] = None
 ) -> Callable:
     """Creates typer command function for settings"""
 
@@ -139,7 +139,7 @@ def create_settings_command(
             )
             raise
 
-        pydantic_export_options: Dict[str, Any] = {"exclude_unset": exclude_unset}
+        pydantic_export_options: dict[str, Any] = {"exclude_unset": exclude_unset}
         if show_secrets:
             # NOTE: this option is for json-only
             pydantic_export_options["encoder"] = create_json_encoder_wo_secrets(

--- a/packages/settings-library/src/settings_library/utils_r_clone.py
+++ b/packages/settings-library/src/settings_library/utils_r_clone.py
@@ -1,11 +1,10 @@
 import configparser
 from copy import deepcopy
 from io import StringIO
-from typing import Dict
 
 from .r_clone import RCloneSettings, S3Provider
 
-_COMMON_ENTRIES: Dict[str, str] = {
+_COMMON_ENTRIES: dict[str, str] = {
     "type": "s3",
     "access_key_id": "{access_key}",
     "secret_access_key": "{secret_key}",
@@ -13,7 +12,7 @@ _COMMON_ENTRIES: Dict[str, str] = {
     "acl": "private",
 }
 
-_PROVIDER_ENTRIES: Dict[S3Provider, Dict[str, str]] = {
+_PROVIDER_ENTRIES: dict[S3Provider, dict[str, str]] = {
     # NOTE: # AWS_SESSION_TOKEN should be required for STS
     S3Provider.AWS: {"provider": "AWS"},
     S3Provider.CEPH: {"provider": "Ceph", "endpoint": "{endpoint}"},
@@ -21,7 +20,7 @@ _PROVIDER_ENTRIES: Dict[S3Provider, Dict[str, str]] = {
 }
 
 
-def _format_config(entries: Dict[str, str]) -> str:
+def _format_config(entries: dict[str, str]) -> str:
     config = configparser.ConfigParser()
     config["dst"] = entries
     with StringIO() as string_io:

--- a/packages/settings-library/tests/conftest.py
+++ b/packages/settings-library/tests/conftest.py
@@ -4,7 +4,7 @@
 
 import sys
 from pathlib import Path
-from typing import Optional, Type
+from typing import Optional
 
 import pytest
 import settings_library
@@ -70,7 +70,7 @@ def mock_environment(
 
 
 @pytest.fixture
-def fake_settings_class() -> Type[BaseCustomSettings]:
+def fake_settings_class() -> type[BaseCustomSettings]:
     """Creates a fake Settings class
 
     NOTE: How to use this fixture? BaseCustomSettings captures env vars, therefore

--- a/packages/settings-library/tests/test_docker_registry.py
+++ b/packages/settings-library/tests/test_docker_registry.py
@@ -2,13 +2,12 @@
 # pylint: disable=unused-argument
 
 from copy import deepcopy
-from typing import Dict
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from settings_library.docker_registry import RegistrySettings
 
-MOCKED_BASE_REGISTRY_ENV_VARS: Dict[str, str] = {
+MOCKED_BASE_REGISTRY_ENV_VARS: dict[str, str] = {
     "REGISTRY_AUTH": "False",
     "REGISTRY_USER": "usr",
     "REGISTRY_PW": "pwd",
@@ -16,13 +15,13 @@ MOCKED_BASE_REGISTRY_ENV_VARS: Dict[str, str] = {
 }
 
 
-def _add_parameter_to_env(env: Dict[str, str], key: str, value: str) -> Dict[str, str]:
+def _add_parameter_to_env(env: dict[str, str], key: str, value: str) -> dict[str, str]:
     registry_env = deepcopy(env)
     registry_env[key] = value
     return registry_env
 
 
-def _mock_env_vars(monkeypatch: MonkeyPatch, env_vars: Dict[str, str]) -> None:
+def _mock_env_vars(monkeypatch: MonkeyPatch, env_vars: dict[str, str]) -> None:
     for key, value in env_vars.items():
         monkeypatch.setenv(key, value)
 

--- a/packages/settings-library/tests/test_email.py
+++ b/packages/settings-library/tests/test_email.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -31,7 +31,7 @@ from settings_library.email import SMTPSettings
         },
     ],
 )
-def test_smtp_configuration_ok(cfg: Dict[str, Any]):
+def test_smtp_configuration_ok(cfg: dict[str, Any]):
     assert SMTPSettings.parse_obj(cfg)
 
 
@@ -62,6 +62,6 @@ def test_smtp_configuration_ok(cfg: Dict[str, Any]):
         },
     ],
 )
-def test_smtp_configuration_fails(cfg: Dict[str, Any]):
+def test_smtp_configuration_fails(cfg: dict[str, Any]):
     with pytest.raises(ValidationError):
         assert SMTPSettings.parse_obj(cfg)

--- a/packages/settings-library/tests/test_postgres.py
+++ b/packages/settings-library/tests/test_postgres.py
@@ -2,7 +2,6 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
-from typing import Dict
 
 import pytest
 from settings_library.postgres import PostgresSettings
@@ -13,7 +12,7 @@ def env_file():
     return ".env-sample"
 
 
-def test_cached_property_dsn(mock_environment: Dict):
+def test_cached_property_dsn(mock_environment: dict):
 
     settings = PostgresSettings()
 
@@ -29,7 +28,7 @@ def test_cached_property_dsn(mock_environment: Dict):
     assert "dsn" in settings.dict().keys()
 
 
-def test_dsn_with_query(mock_environment: Dict, monkeypatch):
+def test_dsn_with_query(mock_environment: dict, monkeypatch):
 
     settings = PostgresSettings()
 

--- a/packages/settings-library/tests/test_utils_cli.py
+++ b/packages/settings-library/tests/test_utils_cli.py
@@ -5,7 +5,7 @@
 import json
 import logging
 from io import StringIO
-from typing import Any, Callable, Dict, Type
+from typing import Any, Callable
 
 import pytest
 import typer
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 # HELPERS  --------------------------------------------------------------------------------
 
 
-def envs_to_kwargs(envs: EnvVarsDict) -> Dict[str, Any]:
+def envs_to_kwargs(envs: EnvVarsDict) -> dict[str, Any]:
     kwargs = {}
     for k, v in envs.items():
         if v is not None:
@@ -39,7 +39,7 @@ def envs_to_kwargs(envs: EnvVarsDict) -> Dict[str, Any]:
 
 
 @pytest.fixture
-def cli(fake_settings_class: Type[BaseCustomSettings]) -> typer.Typer:
+def cli(fake_settings_class: type[BaseCustomSettings]) -> typer.Typer:
     main = typer.Typer(name="app")
 
     @main.command()
@@ -140,7 +140,7 @@ Options:
 
 def test_settings_as_json(
     cli: typer.Typer,
-    fake_settings_class: Type[BaseCustomSettings],
+    fake_settings_class: type[BaseCustomSettings],
     mock_environment,
     cli_runner: CliRunner,
 ):
@@ -151,13 +151,13 @@ def test_settings_as_json(
     print(result.stdout)
 
     # reuse resulting json to build settings
-    settings: Dict = json.loads(result.stdout)
+    settings: dict = json.loads(result.stdout)
     assert fake_settings_class.parse_obj(settings)
 
 
 def test_settings_as_json_schema(
     cli: typer.Typer,
-    fake_settings_class: Type[BaseCustomSettings],
+    fake_settings_class: type[BaseCustomSettings],
     mock_environment,
     cli_runner: CliRunner,
 ):
@@ -168,12 +168,12 @@ def test_settings_as_json_schema(
     print(result.stdout)
 
     # reuse resulting json to build settings
-    settings_schema: Dict = json.loads(result.stdout)
+    settings_schema: dict = json.loads(result.stdout)
 
 
 def test_cli_default_settings_envs(
     cli: typer.Typer,
-    fake_settings_class: Type[BaseCustomSettings],
+    fake_settings_class: type[BaseCustomSettings],
     fake_granular_env_file_content: str,
     export_as_dict: Callable,
     cli_runner: CliRunner,
@@ -221,7 +221,7 @@ def test_cli_default_settings_envs(
 
 def test_cli_compact_settings_envs(
     cli: typer.Typer,
-    fake_settings_class: Type[BaseCustomSettings],
+    fake_settings_class: type[BaseCustomSettings],
     fake_granular_env_file_content: str,
     export_as_dict: Callable,
     cli_runner: CliRunner,
@@ -280,7 +280,7 @@ def test_cli_compact_settings_envs(
 
 def test_compact_format(
     monkeypatch: pytest.MonkeyPatch,
-    fake_settings_class: Type[BaseCustomSettings],
+    fake_settings_class: type[BaseCustomSettings],
 ):
     compact_envs: EnvVarsDict = setenvs_as_envfile(
         monkeypatch,
@@ -300,7 +300,7 @@ def test_compact_format(
 
 def test_granular_format(
     monkeypatch: pytest.MonkeyPatch,
-    fake_settings_class: Type[BaseCustomSettings],
+    fake_settings_class: type[BaseCustomSettings],
 ):
     setenvs_as_envfile(
         monkeypatch,

--- a/requirements/how-to-upgrade-python.md
+++ b/requirements/how-to-upgrade-python.md
@@ -1,0 +1,65 @@
+# Python version
+
+In principle every service can use a different python version (*) but in practice it is more
+suitable to keep the same python version througout the entire repository.
+
+
+(*) so far only ``director`` service uses a different python version because it was
+frozen and marked as deprecated.
+
+## Where is python version specified?
+
+Both python and pip version are specified:
+
+-  repository's *prefered* python version file in ``requirements/PYTHON_VERSION`` (could not version standard `.python-version` because then we cannot work with different versions on the same repo)
+-  in the services/scripts ``Dockerfile``:
+  ```Dockerfile
+    ARG PYTHON_VERSION="3.9.12"
+    FROM python:${PYTHON_VERSION}-slim-buster as base
+  ```
+- in the CI ``.github/workflows/ci-testing-deploy.yml``
+  ```yaml
+  jobs:
+  ... :
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python: ["3.9"]
+  ```
+  and in ``ci/helpers/ensure_python_pip.bash``
+
+
+
+## How are these versions synced?
+
+- Reusing ``PYTHON_VERSION`` variables when possible
+- ``tests/environment-setup/test_used_python.py`` checks that all these configurations are in sync
+
+
+
+## Tools to assist python upgrade?
+
+- CI ``.github/workflows/ci-testing-deploy.yml`` runs ``unit-test-python-linting`` job that monitor early incompatibilities fo the codebase with next python's version. See
+  ```yaml
+  unit-test-python-linting:
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
+    name: "[unit] python-linting"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python: ["3.9", "3.10"]
+  ```
+- [pyupgrade](https://github.com/asottile/pyupgrade) tool which has been containarized (``scripts/pyupgrade.bash``) and added as a Makefile recipe (``make pyupgrade``)
+
+
+
+## When to upgrade python's version?
+
+Some points to consider (draft)
+
+ - codebase ``pylint`` passes
+ - all third-party libraries are available for the new python distribution
+ - all tools are compatible with new python version
+ - ...
+
+ SEE https://pythonspeed.com/articles/switch-python-3.10/

--- a/scripts/common.Makefile
+++ b/scripts/common.Makefile
@@ -118,6 +118,11 @@ autoformat: ## runs black python formatter on this service's code. Use AFTER mak
 		$(CURDIR)
 
 
+.PHONY: pyupgrade
+pyupgrade: ## Upgrade python syntax for newer versions of the language (SEE https://github.com/asottile/pyupgrade)
+	@$(REPO_BASE_DIR)/scripts/pyupgrade.bash $(shell find . -type f -name '*.py')
+
+
 .PHONY: mypy
 mypy: $(REPO_BASE_DIR)/scripts/mypy.bash $(REPO_BASE_DIR)/mypy.ini ## runs mypy python static type checker on this services's code. Use AFTER make install-*
 	@$(REPO_BASE_DIR)/scripts/mypy.bash src

--- a/scripts/mypy.bash
+++ b/scripts/mypy.bash
@@ -31,7 +31,7 @@ echo using "$(docker run --rm "$image_name" --version)"
 docker run --rm \
   --volume /etc/passwd:/etc/passwd:ro \
   --volume /etc/group:/etc/group:ro \
-  --user $(id -u):$(id -g) \
+  --user "$(id -u):$(id -g)" \
   --volume "${mypy_config}":/config/mypy.ini \
   --volume "${target_path}":/src \
   --workdir=/src \

--- a/scripts/pyupgrade.bash
+++ b/scripts/pyupgrade.bash
@@ -1,11 +1,13 @@
 #!/bin/bash
-# http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -o errexit
 set -o nounset
 set -o pipefail
 IFS=$'\n\t'
-
-
+#
+# SEE https://github.com/asottile/pyupgrade
+#
+#
+# NOTE: check --py* flag in CLI when PYTHON_VERSION is modified
 PYTHON_VERSION=3.9.12
 IMAGE_NAME="local/pyupgrade-devkit:${PYTHON_VERSION}"
 WORKDIR="$(pwd)"
@@ -42,14 +44,6 @@ Run() {
     "$@"
 
 }
-
-# Examples:
-#  - SEE  https://pydeps.readthedocs.io/en/latest/#usage
-#
-# ./scripts/pydeps.bash services/web/server/src/simcore_service_webserver --cluster
-# ./scripts/pydeps.bash services/web/server/src/simcore_service_webserver --only "simcore_service_webserver.projects" --cluster
-#
-#
 
 Build
 Run "$@"

--- a/scripts/pyupgrade.bash
+++ b/scripts/pyupgrade.bash
@@ -1,0 +1,56 @@
+#!/bin/bash
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit
+set -o nounset
+set -o pipefail
+IFS=$'\n\t'
+
+
+PYTHON_VERSION=3.9.12
+IMAGE_NAME="local/pyupgrade-devkit:${PYTHON_VERSION}"
+WORKDIR="$(pwd)"
+
+Build() {
+  docker buildx build \
+    --build-arg HOME_DIR="/home/$USER" \
+    --tag "$IMAGE_NAME" \
+    - <<EOF
+FROM python:${PYTHON_VERSION}-slim-buster
+RUN pip --no-cache-dir install --upgrade \
+  pip \
+  wheel \
+  setuptools
+
+RUN pip install \
+  pyupgrade
+
+ENTRYPOINT ["pyupgrade", \
+  "--py39-plus" ]
+EOF
+}
+
+Run() {
+  docker run \
+    -it \
+    --workdir="/home/$USER/workdir" \
+    --volume="/etc/group:/etc/group:ro" \
+    --volume="/etc/passwd:/etc/passwd:ro" \
+    --volume="$WORKDIR:/home/$USER/workdir" \
+    --user="$(id --user "$USER")":"$(id --group "$USER")" \
+    "$IMAGE_NAME" \
+    \
+    "$@"
+
+}
+
+# Examples:
+#  - SEE  https://pydeps.readthedocs.io/en/latest/#usage
+#
+# ./scripts/pydeps.bash services/web/server/src/simcore_service_webserver --cluster
+# ./scripts/pydeps.bash services/web/server/src/simcore_service_webserver --only "simcore_service_webserver.projects" --cluster
+#
+#
+
+Build
+Run "$@"
+echo "DONE"

--- a/services/director/requirements/_test.in
+++ b/services/director/requirements/_test.in
@@ -11,9 +11,18 @@
 # IT WON'T HAVE ANY EFFECT
 #
 
+# FROZEN as well (DO NOT CHANGE anything in pytest-simcore, it will have no effect in the director package)
+pytest-simcore @  git+https://github.com/ITISFoundation/osparc-simcore.git@79f866219bf650c5eeb4fcdf8f017319087c92c7#egg=pytest-simcore&subdirectory=packages/pytest-simcore
+
 # testing
 aioresponses
+codecov
 coverage==4.5.1 # TODO: Downgraded because of a bug https://github.com/nedbat/coveragepy/issues/716
+coveralls
+docker
+openapi-spec-validator~=0.2  # TODO: this library is limiting jsonschema<3
+ptvsd
+pylint
 pytest
 pytest-aiohttp  # incompatible with pytest-asyncio. See https://github.com/pytest-dev/pytest-asyncio/issues/76
 pytest-cov
@@ -21,14 +30,4 @@ pytest-instafail
 pytest-mock
 pytest-runner
 pytest-sugar
-
-# fixtures
-openapi-spec-validator~=0.2  # TODO: this library is limiting jsonschema<3
 python-dotenv
-docker
-
-# tools
-pylint
-ptvsd
-coveralls
-codecov

--- a/services/director/requirements/_test.txt
+++ b/services/director/requirements/_test.txt
@@ -164,6 +164,7 @@ pytest==6.1.2
     #   pytest-cov
     #   pytest-instafail
     #   pytest-mock
+    #   pytest-simcore
     #   pytest-sugar
 pytest-aiohttp==0.3.0
     # via -r requirements/_test.in
@@ -174,6 +175,8 @@ pytest-instafail==0.4.2
 pytest-mock==3.3.1
     # via -r requirements/_test.in
 pytest-runner==5.2
+    # via -r requirements/_test.in
+pytest-simcore @ git+https://github.com/ITISFoundation/osparc-simcore.git@79f866219bf650c5eeb4fcdf8f017319087c92c7#subdirectory=packages/pytest-simcore
     # via -r requirements/_test.in
 pytest-sugar==0.9.4
     # via -r requirements/_test.in

--- a/services/director/requirements/ci.txt
+++ b/services/director/requirements/ci.txt
@@ -8,7 +8,6 @@
 
 # installs base + tests requirements
 --requirement _test.txt
-../../packages/pytest-simcore/
 
 # installs current package
 .

--- a/services/director/requirements/dev.txt
+++ b/services/director/requirements/dev.txt
@@ -12,8 +12,5 @@
 --requirement _test.txt
 --requirement _tools.txt
 
-# installs this repo's packages
---editable ../../packages/pytest-simcore/
-
 # installs current package
 --editable .

--- a/tests/e2e/utils/wait_for_services.py
+++ b/tests/e2e/utils/wait_for_services.py
@@ -4,7 +4,6 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
 
 import docker
 import yaml
@@ -47,7 +46,7 @@ FAILED_STATES = [
 def get_tasks_summary(service_tasks):
     msg = ""
     for task in service_tasks:
-        status: Dict = task["Status"]
+        status: dict = task["Status"]
         msg += f"- task ID:{task['ID']}, CREATED: {task['CreatedAt']}, UPDATED: {task['UpdatedAt']}, DESIRED_STATE: {task['DesiredState']}, STATE: {status['State']}"
         error = status.get("Err")
         if error:
@@ -78,7 +77,7 @@ def core_docker_compose_file() -> Path:
     return stack_files[0]
 
 
-def core_services() -> List[str]:
+def core_services() -> list[str]:
     with core_docker_compose_file().open() as fp:
         dc_specs = yaml.safe_load(fp)
         return list(dc_specs["services"].keys())
@@ -88,7 +87,7 @@ def ops_docker_compose_file() -> Path:
     return osparc_simcore_root_dir() / ".stack-ops.yml"
 
 
-def ops_services() -> List[str]:
+def ops_services() -> list[str]:
     with ops_docker_compose_file().open() as fp:
         dc_specs = yaml.safe_load(fp)
         return list(dc_specs["services"].keys())
@@ -122,11 +121,11 @@ def wait_for_services() -> int:
         ):
             with attempt:
                 started_services = sorted(
-                    [
+                    (
                         s
                         for s in client.services.list()
                         if s.name.split("_")[-1] in expected_services
-                    ],
+                    ),
                     key=by_service_creation,
                 )
 
@@ -157,7 +156,7 @@ def wait_for_services() -> int:
                 wait=wait_fixed(WAIT_BEFORE_RETRY),
             ):
                 with attempt:
-                    service_tasks: List[Dict] = service.tasks()  #  freeze
+                    service_tasks: list[dict] = service.tasks()  #  freeze
                     print(get_tasks_summary(service_tasks))
 
                     #

--- a/tests/environment-setup/test_used_docker_compose.py
+++ b/tests/environment-setup/test_used_docker_compose.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from itertools import chain
 from pathlib import Path
-from typing import Iterable, List, Set, Tuple
+from typing import Iterable
 
 import pytest
 import yaml
@@ -17,7 +17,7 @@ import yaml
 @pytest.fixture(scope="module")
 def docker_compose_in_requirement_files(
     osparc_simcore_root_dir: Path,
-) -> List[Tuple[Path, str]]:
+) -> list[tuple[Path, str]]:
 
     reqs_path_version_tuples = []
 
@@ -31,11 +31,11 @@ def docker_compose_in_requirement_files(
 
 
 @pytest.fixture(scope="module")
-def docker_compose_in_ci_scripts(osparc_simcore_root_dir: Path) -> Tuple[Path, str]:
+def docker_compose_in_ci_scripts(osparc_simcore_root_dir: Path) -> tuple[Path, str]:
     ci_workflows_path = osparc_simcore_root_dir / ".github/workflows"
-    versions_in_workflow_files: Set[str] = set()
+    versions_in_workflow_files: set[str] = set()
     for workflow_file in ci_workflows_path.rglob("ci-*.yml"):
-        versions_in_file: Set[str] = {
+        versions_in_file: set[str] = {
             found.group(1)
             for found in re.finditer(
                 r"docker_compose: \[([\d\.]+)\]", workflow_file.read_text()

--- a/tests/environment-setup/test_used_python.py
+++ b/tests/environment-setup/test_used_python.py
@@ -7,7 +7,6 @@ import configparser
 import re
 import sys
 from pathlib import Path
-from typing import List, Tuple
 
 import pytest
 import yaml
@@ -21,7 +20,7 @@ FROZEN_SERVICES = ["director"]
 
 
 # TODO: enhance version comparison with from packaging.version from setuptools
-def to_version(version: str) -> Tuple[int, ...]:
+def to_version(version: str) -> tuple[int, ...]:
     return tuple(int(v) for v in version.split("."))
 
 
@@ -29,7 +28,7 @@ def to_str(version) -> str:
     return ".".join(map(str, version))
 
 
-def make_versions_comparable(*versions) -> List[Tuple[int]]:
+def make_versions_comparable(*versions) -> list[tuple[int]]:
     vers = []
     n = 10000
     for v in versions:
@@ -42,7 +41,7 @@ def make_versions_comparable(*versions) -> List[Tuple[int]]:
 
 
 @pytest.fixture(scope="session")
-def expected_python_version(osparc_simcore_root_dir: Path) -> Tuple[int, ...]:
+def expected_python_version(osparc_simcore_root_dir: Path) -> tuple[int, ...]:
     py_version: str = (
         (osparc_simcore_root_dir / "requirements" / "PYTHON_VERSION")
         .read_text()
@@ -72,7 +71,7 @@ def expected_pip_version(osparc_simcore_root_dir: Path) -> str:
 
 
 @pytest.fixture(scope="session")
-def pip_in_dockerfiles(osparc_simcore_root_dir: Path) -> List[Tuple[Path, str]]:
+def pip_in_dockerfiles(osparc_simcore_root_dir: Path) -> list[tuple[Path, str]]:
     res = []
     for dockerfile_path in osparc_simcore_root_dir.rglob("Dockerfile"):
         found = PIP_INSTALL_UPGRADE_PATTERN.search(dockerfile_path.read_text())
@@ -91,7 +90,7 @@ def pip_in_dockerfiles(osparc_simcore_root_dir: Path) -> List[Tuple[Path, str]]:
 
 
 @pytest.fixture(scope="session")
-def python_in_dockerfiles(osparc_simcore_root_dir: Path) -> List[Tuple[Path, str]]:
+def python_in_dockerfiles(osparc_simcore_root_dir: Path) -> list[tuple[Path, str]]:
     res = []
     for dockerfile_path in osparc_simcore_root_dir.rglob("Dockerfile"):
         found = PYTHON_VERSION_DOCKER_PATTERN.search(dockerfile_path.read_text())

--- a/tests/performance/locust_files/platform_ping_test.py
+++ b/tests/performance/locust_files/platform_ping_test.py
@@ -6,13 +6,17 @@ import logging
 import os
 from typing import NamedTuple
 
-import locust_plugins # necessary to use --check-fail-ratio 
+import locust_plugins
 from dotenv import load_dotenv
 from locust import task
 from locust.contrib.fasthttp import FastHttpUser
 
 logging.basicConfig(level=logging.INFO)
 
+
+# 'import locust_plugins' is necessary to use --check-fail-ratio
+assert locust_plugins  # nosec
+# adds assert here to avoid pycln removing it
 
 load_dotenv()  # take environment variables from .env
 

--- a/tests/performance/locust_files/platform_ping_test.py
+++ b/tests/performance/locust_files/platform_ping_test.py
@@ -14,9 +14,11 @@ from locust.contrib.fasthttp import FastHttpUser
 logging.basicConfig(level=logging.INFO)
 
 
-# 'import locust_plugins' is necessary to use --check-fail-ratio
+# NOTE: 'import locust_plugins' is necessary to use --check-fail-ratio
+# this assert is added to avoid that pycln pre-commit hook does not
+# remove the import (the tool assumes the import is not necessary)
 assert locust_plugins  # nosec
-# adds assert here to avoid pycln removing it
+
 
 load_dotenv()  # take environment variables from .env
 

--- a/tests/public-api/conftest.py
+++ b/tests/public-api/conftest.py
@@ -8,7 +8,7 @@ import logging
 import os
 import time
 from pprint import pformat
-from typing import Any, Callable, Dict, Iterable, List
+from typing import Any, Callable, Iterable
 
 import httpx
 import osparc
@@ -40,7 +40,7 @@ pytest_plugins = [
 
 
 @pytest.fixture(scope="session")
-def testing_environ_vars(testing_environ_vars: Dict[str, str]) -> Dict[str, str]:
+def testing_environ_vars(testing_environ_vars: dict[str, str]) -> dict[str, str]:
     ## OVERRIDES packages/pytest-simcore/src/pytest_simcore/docker_compose.py::testing_environ_vars fixture
 
     # help faster update of service_metadata table by catalog
@@ -49,7 +49,7 @@ def testing_environ_vars(testing_environ_vars: Dict[str, str]) -> Dict[str, str]
 
 
 @pytest.fixture(scope="module")
-def core_services_selection(simcore_docker_compose: Dict) -> List[str]:
+def core_services_selection(simcore_docker_compose: dict) -> list[str]:
     """Selection of services from the simcore stack"""
     ## OVERRIDES packages/pytest-simcore/src/pytest_simcore/docker_compose.py::core_services_selection fixture
     all_core_services = list(simcore_docker_compose["services"].keys())
@@ -57,7 +57,7 @@ def core_services_selection(simcore_docker_compose: Dict) -> List[str]:
 
 
 @pytest.fixture(scope="module")
-def ops_services_selection(ops_docker_compose: Dict) -> List[str]:
+def ops_services_selection(ops_docker_compose: dict) -> list[str]:
     """Selection of services from the ops stack"""
     ## OVERRIDES packages/pytest-simcore/src/pytest_simcore/docker_compose.py::ops_services_selection fixture
     all_ops_services = list(ops_docker_compose["services"].keys())
@@ -76,9 +76,9 @@ def event_loop(request) -> Iterable[asyncio.AbstractEventLoop]:
 def simcore_docker_stack_and_registry_ready(
     event_loop: asyncio.AbstractEventLoop,
     docker_registry: UrlStr,
-    docker_stack: Dict,
+    docker_stack: dict,
     simcore_services_ready: None,
-) -> Dict:
+) -> dict:
     # At this point `simcore_services_ready` waited until all services
     # are running. Let's make one more check on the web-api
     for attempt in Retrying(
@@ -149,9 +149,9 @@ def registered_user(simcore_docker_stack_and_registry_ready):
 @pytest.fixture(scope="module")
 def services_registry(
     docker_registry_image_injector: Callable,
-    registered_user: Dict[str, str],
-    testing_environ_vars: Dict[str, str],
-) -> Dict[str, Any]:
+    registered_user: dict[str, str],
+    testing_environ_vars: dict[str, str],
+) -> dict[str, Any]:
     # NOTE: service image MUST be injected in registry AFTER user is registered
     #
     # See injected fixture in packages/pytest-simcore/src/pytest_simcore/docker_registry.py

--- a/tests/public-api/examples/osparc_isolve_api.py
+++ b/tests/public-api/examples/osparc_isolve_api.py
@@ -5,7 +5,7 @@ import tarfile
 import time
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import osparc
 from EmFdtdSimulator import EmFdtdMultiportSimulation
@@ -29,7 +29,7 @@ class ISolveType(Enum):
     mpi = "mpi"
 
 
-def get_isolves(solvers_api: osparc.SolversApi, latest: bool) -> List[osparc.Solver]:
+def get_isolves(solvers_api: osparc.SolversApi, latest: bool) -> list[osparc.Solver]:
     solvers: osparc.Solver = (
         solvers_api.list_solvers() if latest else solvers_api.list_solvers_releases()
     )
@@ -84,7 +84,7 @@ def submit_simulation(
     sim: Simulation,
     solver_version: str,
     wait: Optional[bool] = True,
-) -> Tuple[osparc.Job, osparc.JobStatus]:
+) -> tuple[osparc.Job, osparc.JobStatus]:
     solver_type = get_solver_type(sim)
     solver: osparc.Solver = get_isolve(solvers_api, solver_type, version=solver_version)
 

--- a/tests/public-api/test_solvers_api.py
+++ b/tests/public-api/test_solvers_api.py
@@ -5,7 +5,7 @@
 
 import random
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import pytest
 from osparc.api.solvers_api import SolversApi
@@ -15,7 +15,7 @@ from packaging.version import parse as parse_version
 
 
 @pytest.fixture(scope="module")
-def sleeper_key_and_version(services_registry: Dict[str, Any]) -> Tuple[str, str]:
+def sleeper_key_and_version(services_registry: dict[str, Any]) -> tuple[str, str]:
     # image in registry
     repository_name = services_registry["sleeper_service"]["name"]
     tag = services_registry["sleeper_service"]["version"]
@@ -31,7 +31,7 @@ def sleeper_key_and_version(services_registry: Dict[str, Any]) -> Tuple[str, str
 
 
 def test_get_latest_solver(solvers_api: SolversApi):
-    solvers: List[Solver] = solvers_api.list_solvers()  # latest versions of all solvers
+    solvers: list[Solver] = solvers_api.list_solvers()  # latest versions of all solvers
 
     solver_names = []
     for latest in solvers:
@@ -45,14 +45,14 @@ def test_get_latest_solver(solvers_api: SolversApi):
 
 def test_get_all_releases(solvers_api: SolversApi):
 
-    all_releases: List[
+    all_releases: list[
         Solver
     ] = solvers_api.list_solvers_releases()  # all release of all solvers
 
     assert all_releases
 
     one_solver = random.choice(all_releases)
-    all_releases_of_given_solver: List[Solver] = solvers_api.list_solver_releases(
+    all_releases_of_given_solver: list[Solver] = solvers_api.list_solver_releases(
         one_solver.id
     )
 

--- a/tests/public-api/test_solvers_jobs_api.py
+++ b/tests/public-api/test_solvers_jobs_api.py
@@ -11,7 +11,7 @@
 import time
 from operator import attrgetter
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from urllib.parse import quote_plus
 from zipfile import ZipFile
 
@@ -27,7 +27,7 @@ assert OSPARC_CLIENT_VERSION >= (0, 4, 3)
 @pytest.fixture(scope="module")
 def sleeper_solver(
     solvers_api: SolversApi,
-    services_registry: Dict[str, Any],
+    services_registry: dict[str, Any],
 ) -> Solver:
     # this part is tested in test_solvers_api so it becomes a fixture here
 

--- a/tests/swarm-deploy/conftest.py
+++ b/tests/swarm-deploy/conftest.py
@@ -4,7 +4,7 @@
 
 import logging
 import subprocess
-from typing import Any, Dict, List, Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 import pytest
 from docker import DockerClient
@@ -37,7 +37,7 @@ _MINUTE: int = 60  # secs
 
 
 ServiceNameStr = str
-ComposeSpec = Dict[str, Any]
+ComposeSpec = dict[str, Any]
 UrlStr = str
 
 
@@ -47,15 +47,15 @@ class StackInfo(TypedDict):
 
 
 class DockerStackInfo(TypedDict):
-    stacks: Dict[Literal["core", "ops"], StackInfo]
-    services: List[ServiceNameStr]
+    stacks: dict[Literal["core", "ops"], StackInfo]
+    services: list[ServiceNameStr]
 
 
 # CORE stack -----------------------------------
 
 
 @pytest.fixture(scope="module")
-def core_services_selection(simcore_docker_compose: Dict) -> List[ServiceNameStr]:
+def core_services_selection(simcore_docker_compose: dict) -> list[ServiceNameStr]:
     ## OVERRIDES packages/pytest-simcore/src/pytest_simcore/docker_compose.py::core_services_selection
     # select ALL services for these tests
     return list(simcore_docker_compose["services"].keys())
@@ -71,7 +71,7 @@ def core_stack_namespace(testing_environ_vars: EnvVarsDict) -> str:
 
 @pytest.fixture(scope="module")
 def core_stack_compose_specs(
-    docker_stack: DockerStackInfo, simcore_docker_compose: Dict
+    docker_stack: DockerStackInfo, simcore_docker_compose: dict
 ) -> ComposeSpec:
     # verifies core_services_selection
     assert set(docker_stack["stacks"]["core"]["compose"]["services"]) == set(
@@ -87,7 +87,7 @@ def simcore_stack_deployed_services(
     ops_stack_namespace: str,
     core_stack_compose_specs: ComposeSpec,
     docker_client: DockerClient,
-) -> List[Service]:
+) -> list[Service]:
 
     # NOTE: the goal here is NOT to test time-to-deploy but
     # rather guaranteing that the framework is fully deployed before starting
@@ -119,7 +119,7 @@ def simcore_stack_deployed_services(
         # ...
 
     # TODO: find a more reliable way to list services in a stack
-    core_stack_services: List[Service] = [
+    core_stack_services: list[Service] = [
         service
         for service in docker_client.services.list(
             filters={"label": f"com.docker.stack.namespace={core_stack_namespace}"}
@@ -139,7 +139,7 @@ def simcore_stack_deployed_services(
 
 
 @pytest.fixture(scope="module")
-def ops_services_selection(ops_docker_compose: ComposeSpec) -> List[ServiceNameStr]:
+def ops_services_selection(ops_docker_compose: ComposeSpec) -> list[ServiceNameStr]:
     ## OVERRIDES packages/pytest-simcore/src/pytest_simcore/docker_compose.py::ops_services_selection
     # select ALL services for these tests
     return list(ops_docker_compose["services"].keys())

--- a/tests/swarm-deploy/test_frontend_served.py
+++ b/tests/swarm-deploy/test_frontend_served.py
@@ -2,7 +2,6 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
-from typing import List
 
 import pytest
 import requests
@@ -23,7 +22,7 @@ from yarl import URL
     ],
 )
 def test_product_frontend_app_served(
-    simcore_stack_deployed_services: List[Service],
+    simcore_stack_deployed_services: list[Service],
     traefik_service: URL,
     test_url: str,
     expected_in_content: str,

--- a/tests/swarm-deploy/test_service_images.py
+++ b/tests/swarm-deploy/test_service_images.py
@@ -5,7 +5,6 @@
 import re
 import subprocess
 from pathlib import Path
-from typing import Dict, Set
 
 import pytest
 
@@ -19,8 +18,8 @@ import pytest
 )
 async def test_python_package_installation(
     package_name: str,
-    services: Set[str],
-    simcore_docker_compose: Dict,
+    services: set[str],
+    simcore_docker_compose: dict,
     osparc_simcore_root_dir: Path,
 ):
     def _extract_from_dockerfile(service_name: str) -> str:

--- a/tests/swarm-deploy/test_service_restart.py
+++ b/tests/swarm-deploy/test_service_restart.py
@@ -5,7 +5,6 @@
 import logging
 import time
 from pprint import pformat
-from typing import List
 
 import pytest
 from docker.models.services import Service
@@ -39,7 +38,7 @@ MAX_TIME_TO_RESTART_SERVICE = 10
     ids=[f"service={x[0]},exit_code={x[1]}" for x in SERVICES_AND_EXIT_CODES],
 )
 def test_graceful_restart_services(
-    simcore_stack_deployed_services: List[Service],
+    simcore_stack_deployed_services: list[Service],
     docker_compose_service_key: str,
     exit_code: int,
 ):

--- a/tests/swarm-deploy/test_stack_deploy.py
+++ b/tests/swarm-deploy/test_stack_deploy.py
@@ -8,7 +8,6 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Tuple
 
 import aiodocker
 import docker
@@ -30,7 +29,7 @@ log = logging.getLogger(__name__)
 
 async def assert_service_is_running(
     service_id: str, docker, *, max_running_delay=1 * MINUTE
-) -> Tuple[List[TaskDict], TenacityStatsDict]:
+) -> tuple[list[TaskDict], TenacityStatsDict]:
     MAX_WAIT = 5
     assert max_running_delay > 3 * MAX_WAIT
 
@@ -61,7 +60,7 @@ async def assert_service_is_running(
             )
 
             # tasks in a service
-            tasks: List[TaskDict] = await docker.tasks.list(
+            tasks: list[TaskDict] = await docker.tasks.list(
                 filters={"service": service_name}
             )
 
@@ -132,7 +131,7 @@ async def docker_async_client():
 @pytest.fixture(scope="module")
 def core_stack_services_names(
     core_docker_compose_file: Path, core_stack_namespace: str
-) -> List[str]:
+) -> list[str]:
     """Expected names of service in core stack at runtime"""
     spec_service_names = yaml.safe_load(core_docker_compose_file.read_text())[
         "services"
@@ -180,12 +179,12 @@ async def test_core_services_running(
     docker_stack_core_and_ops: None,
     core_stack_namespace: str,
     docker_async_client: aiodocker.Docker,
-    core_stack_services_names: List[str],
+    core_stack_services_names: list[str],
 ):
     docker = docker_async_client
 
     # check expected services deployed
-    core_services: List[ServiceDict] = await docker.services.list(
+    core_services: list[ServiceDict] = await docker.services.list(
         filters={"label": f"com.docker.stack.namespace={core_stack_namespace}"}
     )
     assert core_services


### PR DESCRIPTION

## What do these changes do?

The entire repo (*) use python 3.9. 
Upgrading to the new syntax (e.g. ``List`` -> ``list``-like ) is very time consuming, noisy and error-prone. 

This PR uses [pyupgrade](https://github.com/asottile/pyupgrade) to automatically upgrade targeted code syntax to py3.9
- 🔥 we start (this PR) with some non-critical code base in the repo (namely ``tests``, ``api`` and ``packages/settings-library``). Subsequent PRs  will address packages and then one service at a time.
- 🔨 Adds pre-commit hook that applies pyupgrade to modified code
- 🔨Adds ``scripts/pyupgrade.bash`` 
- 📝 adds some doc on python versioning (draft) since this tool can also assist in future python's upgrades

(*) Except for ``services/director`` and some files in ``packages/pytest-simcore`` used as well there

## How to test

- 100% test coverage should ideally cover this

## TODO
- [x] pre-commit hook
- [x] shell script in ``scripts/`` with containarized tool
- [x] make recipe
- [x] document py ugrade
