### PR TITLE
🐛 Bug Fix: de/serialize bootOptions when opening/closing the study

### DIFF
--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -158,6 +158,12 @@ qx.Class.define("osparc.data.model.Node", {
       apply: "__applyErrors"
     },
 
+    bootOptions: {
+      check: "Object",
+      init: null,
+      nullable: true
+    },
+
     // GUI elements //
     propsForm: {
       check: "osparc.component.form.renderer.PropForm",
@@ -424,6 +430,9 @@ qx.Class.define("osparc.data.model.Node", {
         this.populateStates(nodeData);
         if (nodeData.thumbnail) {
           this.setThumbnail(nodeData.thumbnail);
+        }
+        if (nodeData.bootOptions) {
+          this.setBootOptions(nodeData.bootOptions);
         }
       }
 
@@ -1327,7 +1336,8 @@ qx.Class.define("osparc.data.model.Node", {
         inputAccess: this.getInputAccess(),
         inputNodes: this.getInputNodes(),
         parent: this.getParentNodeId(),
-        thumbnail: this.getThumbnail()
+        thumbnail: this.getThumbnail(),
+        bootOptions: this.getBootOptions()
       };
       if (!clean) {
         nodeEntry.progress = this.getStatus().getProgress();


### PR DESCRIPTION
## What do these changes do?

When opening the study bootOptions information was not deserialized and therefore, from that moment on, that user preference was lost.

![RememberBootOptions](https://user-images.githubusercontent.com/33152403/175337549-69c8dc3f-90e4-4f96-b16b-06440d73c1b7.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
