### PR TITLE
⬆️ Maintenance: upgrade dask libraries

### DIFF
--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -14,6 +14,8 @@ on:
       - "!.vscode/**"
       - "**.py"
       - "**.js"
+      - "**/requirements/*.txt"
+      - "**.json"
       - ".github/workflows/ci-testing-deploy.yml"
   pull_request:
     branches:
@@ -27,6 +29,8 @@ on:
       - "!.vscode-template/**"
       - "**.py"
       - "**.js"
+      - "**/requirements/*.txt"
+      - "**.json"
       - ".github/workflows/ci-testing-deploy.yml"
 
 env:

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -12,17 +12,17 @@ cloudpickle==2.0.0
     # via
     #   dask
     #   distributed
-dask==2022.05.0
+dask==2022.6.0
     # via
     #   -r requirements/_base.in
     #   distributed
-distributed==2022.05.0
+distributed==2022.6.0
     # via dask
 dnspython==2.2.1
     # via email-validator
 email-validator==1.2.1
     # via pydantic
-fsspec==2022.3.0
+fsspec==2022.5.0
     # via dask
 heapdict==1.0.1
     # via zict

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -111,7 +111,6 @@ else
       dask-worker "${DASK_SCHEDULER_URL}" \
       --local-directory /tmp/dask-sidecar \
       --preload simcore_service_dask_sidecar.tasks \
-      --no-nanny \
       --nworkers ${DASK_NPROCS} \
       --nthreads "${DASK_NTHREADS}" \
       --dashboard-address 8787 \
@@ -122,7 +121,6 @@ else
     exec dask-worker "${DASK_SCHEDULER_URL}" \
       --local-directory /tmp/dask-sidecar \
       --preload simcore_service_dask_sidecar.tasks \
-      --no-nanny \
       --nworkers ${DASK_NPROCS} \
       --nthreads "${DASK_NTHREADS}" \
       --dashboard-address 8787 \

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -111,7 +111,6 @@ else
       dask-worker "${DASK_SCHEDULER_URL}" \
       --local-directory /tmp/dask-sidecar \
       --preload simcore_service_dask_sidecar.tasks \
-      --reconnect \
       --no-nanny \
       --nprocs ${DASK_NPROCS} \
       --nthreads "${DASK_NTHREADS}" \
@@ -123,7 +122,6 @@ else
     exec dask-worker "${DASK_SCHEDULER_URL}" \
       --local-directory /tmp/dask-sidecar \
       --preload simcore_service_dask_sidecar.tasks \
-      --reconnect \
       --no-nanny \
       --nprocs ${DASK_NPROCS} \
       --nthreads "${DASK_NTHREADS}" \

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -112,7 +112,7 @@ else
       --local-directory /tmp/dask-sidecar \
       --preload simcore_service_dask_sidecar.tasks \
       --no-nanny \
-      --nprocs ${DASK_NPROCS} \
+      --nworkers ${DASK_NPROCS} \
       --nthreads "${DASK_NTHREADS}" \
       --dashboard-address 8787 \
       --memory-limit "${DASK_MEMORY_LIMIT}" \
@@ -123,7 +123,7 @@ else
       --local-directory /tmp/dask-sidecar \
       --preload simcore_service_dask_sidecar.tasks \
       --no-nanny \
-      --nprocs ${DASK_NPROCS} \
+      --nworkers ${DASK_NPROCS} \
       --nthreads "${DASK_NTHREADS}" \
       --dashboard-address 8787 \
       --memory-limit "${DASK_MEMORY_LIMIT}" \

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-aiobotocore==2.2.0
+aiobotocore==2.3.3
     # via s3fs
 aiodocker==0.21.0
     # via -r requirements/_base.in
@@ -49,7 +49,7 @@ bleach==3.3.0
     # via nbconvert
 blosc==1.10.6
     # via -r requirements/_base.in
-bokeh==2.4.2
+bokeh==2.4.3
     # via dask
 botocore==1.24.21
     # via aiobotocore
@@ -62,24 +62,26 @@ charset-normalizer==2.0.12
     #   aiohttp
     #   requests
 click==8.1.3
-    # via distributed
+    # via
+    #   dask-gateway
+    #   distributed
 cloudpickle==2.0.0
     # via
     #   dask
     #   distributed
 cytoolz==0.11.0
     # via -r requirements/_base.in
-dask==2022.4.0
+dask==2022.6.0
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/_base.in
     #   -r requirements/_base.in
     #   dask-gateway
     #   distributed
-dask-gateway==0.9.0
+dask-gateway==2022.6.1
     # via -r requirements/_base.in
 defusedxml==0.7.1
     # via nbconvert
-distributed==2022.4.0
+distributed==2022.6.0
     # via
     #   dask
     #   dask-gateway
@@ -95,7 +97,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2022.3.0
+fsspec==2022.5.0
     # via
     #   -c requirements/constraints.txt
     #   dask
@@ -146,8 +148,10 @@ jupyter-server-proxy==3.2.1
     # via -r requirements/_base.in
 jupyterlab-pygments==0.1.2
     # via nbconvert
-locket==0.2.1
-    # via partd
+locket==1.0.0
+    # via
+    #   distributed
+    #   partd
 lz4==4.0.0
     # via -r requirements/_base.in
 markupsafe==2.1.1
@@ -247,6 +251,7 @@ pyyaml==5.4.1
     #   -c requirements/../../../requirements/constraints.txt
     #   bokeh
     #   dask
+    #   dask-gateway
     #   distributed
 pyzmq==22.1.0
     # via
@@ -254,7 +259,7 @@ pyzmq==22.1.0
     #   jupyter-server
 requests==2.27.1
     # via -r requirements/_base.in
-s3fs==2022.3.0
+s3fs==2022.5.0
     # via -r requirements/_base.in
 send2trash==1.7.1
     # via jupyter-server
@@ -288,6 +293,7 @@ toolz==0.11.1
 tornado==6.1
     # via
     #   bokeh
+    #   dask-gateway
     #   distributed
     #   jupyter-client
     #   jupyter-server

--- a/services/dask-sidecar/requirements/_dask-complete.txt
+++ b/services/dask-sidecar/requirements/_dask-complete.txt
@@ -8,7 +8,7 @@ blosc==1.10.6
     # via
     #   -c requirements/./_base.txt
     #   -r requirements/_dask-complete.in
-bokeh==2.4.2
+bokeh==2.4.3
     # via
     #   -c requirements/./_base.txt
     #   dask
@@ -21,16 +21,16 @@ cloudpickle==2.0.0
     #   -c requirements/./_base.txt
     #   dask
     #   distributed
-dask==2022.4.0
+dask==2022.6.0
     # via
     #   -c requirements/./_base.txt
     #   -r requirements/_dask-complete.in
     #   distributed
-distributed==2022.4.0
+distributed==2022.6.0
     # via
     #   -c requirements/./_base.txt
     #   dask
-fsspec==2022.3.0
+fsspec==2022.5.0
     # via
     #   -c requirements/./_base.txt
     #   dask
@@ -44,9 +44,10 @@ jinja2==2.11.3
     #   bokeh
     #   dask
     #   distributed
-locket==0.2.1
+locket==1.0.0
     # via
     #   -c requirements/./_base.txt
+    #   distributed
     #   partd
 lz4==4.0.0
     # via

--- a/services/dask-sidecar/requirements/_dask-distributed.txt
+++ b/services/dask-sidecar/requirements/_dask-distributed.txt
@@ -17,16 +17,16 @@ cloudpickle==2.0.0
     #   -c requirements/./_base.txt
     #   dask
     #   distributed
-dask==2022.4.0
+dask==2022.6.0
     # via
     #   -c requirements/./_base.txt
     #   -r requirements/_dask-distributed.in
     #   distributed
-distributed==2022.4.0
+distributed==2022.6.0
     # via
     #   -c requirements/./_base.txt
     #   dask
-fsspec==2022.3.0
+fsspec==2022.5.0
     # via
     #   -c requirements/./_base.txt
     #   dask
@@ -38,9 +38,10 @@ jinja2==2.11.3
     # via
     #   -c requirements/./_base.txt
     #   distributed
-locket==0.2.1
+locket==1.0.0
     # via
     #   -c requirements/./_base.txt
+    #   distributed
     #   partd
 lz4==4.0.0
     # via

--- a/services/dask-sidecar/requirements/_packages.txt
+++ b/services/dask-sidecar/requirements/_packages.txt
@@ -24,12 +24,12 @@ cloudpickle==2.0.0
     #   -c requirements/_base.txt
     #   dask
     #   distributed
-dask==2022.4.0
+dask==2022.6.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
     #   distributed
-distributed==2022.4.0
+distributed==2022.6.0
     # via
     #   -c requirements/_base.txt
     #   dask
@@ -41,7 +41,7 @@ email-validator==1.2.1
     # via
     #   -c requirements/_base.txt
     #   pydantic
-fsspec==2022.3.0
+fsspec==2022.5.0
     # via
     #   -c requirements/_base.txt
     #   dask
@@ -68,9 +68,10 @@ jsonschema==3.2.0
     #   -c requirements/_base.txt
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
-locket==0.2.1
+locket==1.0.0
     # via
     #   -c requirements/_base.txt
+    #   distributed
     #   partd
 markupsafe==2.1.1
     # via

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -88,6 +88,7 @@ charset-normalizer==2.0.12
 click==8.1.3
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask-gateway
     #   distributed
     #   typer
     #   uvicorn
@@ -96,17 +97,17 @@ cloudpickle==2.0.0
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-dask==2022.4.0
+dask==2022.6.0
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask-gateway
     #   distributed
-dask-gateway==0.9.0
+dask-gateway==2022.6.1
     # via -r requirements/_base.in
 decorator==4.4.2
     # via networkx
-distributed==2022.4.0
+distributed==2022.6.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -128,7 +129,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2022.3.0
+fsspec==2022.5.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -199,9 +200,10 @@ jsonschema==3.2.0
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
-locket==0.2.1
+locket==1.0.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
     #   partd
 lz4==4.0.0
     # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
@@ -320,6 +322,7 @@ pyyaml==5.4.1
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
+    #   dask-gateway
     #   distributed
     #   fastapi
     #   uvicorn
@@ -386,6 +389,7 @@ toolz==0.11.1
 tornado==6.1
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask-gateway
     #   distributed
     #   jaeger-client
     #   threadloop

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -98,7 +98,7 @@ cryptography==37.0.2
     #   -c requirements/../../../requirements/constraints.txt
     #   dask-gateway-server
     #   paramiko
-dask-gateway-server==2022.4.0
+dask-gateway-server==2022.6.1
     # via -r requirements/_test.in
 dill==0.3.4
     # via pylint
@@ -331,7 +331,7 @@ tornado==6.1
     # via
     #   -c requirements/_base.txt
     #   bokeh
-traitlets==5.1.1
+traitlets==5.3.0
     # via dask-gateway-server
 typing-extensions==4.2.0
     # via

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-aiobotocore==2.2.0
+aiobotocore==2.3.3
     # via -r requirements/_base.in
 aiodebug==2.3.0
     # via


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 10
- #packages after : 10

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aiobotocore               | 2.2.0           | 2.3.3      | *minor*    | 2 | dask-sidecar⬆️</br>storage⬆️ |
|   2 | bokeh                     | 2.4.2           | 2.4.3      |            | 2 | dask-sidecar⬆️⬆️ |
|   3 | dask                      | 2022.4.0, 2022.5.0 | 2022.6.0   | *minor*    | 6 | dask-sidecar⬆️⬆️⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️ |
|   4 | dask-gateway              | 0.9.0           | 2022.6.1   | **MAJOR**  | 2 | dask-sidecar⬆️</br>director-v2⬆️ |
|   5 | dask-gateway-server       | 2022.4.0        | 2022.6.1   | *minor*    | 1 | director-v2🧪 |
|   6 | distributed               | 2022.4.0, 2022.5.0 | 2022.6.0   | *minor*    | 6 | dask-sidecar⬆️⬆️⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️ |
|   7 | fsspec                    | 2022.3.0        | 2022.5.0   | *minor*    | 6 | dask-sidecar⬆️⬆️⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️ |
|   8 | locket                    | 0.2.1           | 1.0.0      | **MAJOR**  | 5 | dask-sidecar⬆️⬆️⬆️⬆️</br>director-v2⬆️ |
|   9 | s3fs                      | 2022.3.0        | 2022.5.0   | *minor*    | 1 | dask-sidecar⬆️ |
|  10 | traitlets                 | 5.1.1           | 5.3.0      | *minor*    | 1 | director-v2🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 57

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 6.8.0, 7.2.0              | 6.8.0, 7.2.0              |                           |
|   2 | aioboto3                  |                           | 9.6.0                     |                           |
|   3 | aiobotocore               | 2.3.3                     | 2.3.0                     |                           |
|   4 | aiocache                  | 0.11.1                    | 0.11.1                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.19.1, 0.21.0            | 0.21.0                    |                           |
|   7 | aiofiles                  | 0.8.0                     | 0.8.0                     |                           |
|   8 | aiohttp                   | 3.8.1                     | 3.8.1                     |                           |
|   9 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  10 | aiohttp-security          | 0.4.0                     |                           |                           |
|  11 | aiohttp-session           | 2.11.0                    |                           |                           |
|  12 | aiohttp-swagger           | 1.0.16                    |                           |                           |
|  13 | aioitertools              | 0.10.0                    | 0.10.0                    |                           |
|  14 | aiopg                     | 1.3.3                     | 1.3.3                     |                           |
|  15 | aioredis                  | 2.0.1                     |                           |                           |
|  16 | aioresponses              |                           | 0.7.3                     |                           |
|  17 | aiormq                    | 3.3.1, 6.2.3              | 3.3.1, 6.2.3              |                           |
|  18 | aiosignal                 | 1.2.0                     | 1.2.0                     |                           |
|  19 | aiosmtplib                | 1.1.6                     |                           |                           |
|  20 | aiozipkin                 | 1.1.1                     |                           |                           |
|  21 | alembic                   | 1.8.0                     | 1.8.0                     |                           |
|  22 | anyio                     | 3.5.0, 3.6.1              | 3.5.0, 3.6.1              |                           |
|  23 | argon2-cffi               | 20.1.0                    |                           |                           |
|  24 | asgi-lifespan             |                           | 1.0.1                     |                           |
|  25 | asgiref                   | 3.5.0, 3.5.2              |                           |                           |
|  26 | astroid                   |                           | 2.11.5                    | 2.11.5                    |
|  27 | async-asgi-testclient     |                           | 1.4.10                    |                           |
|  28 | async-generator           | 1.10                      |                           |                           |
|  29 | async-timeout             | 4.0.2                     | 4.0.2                     |                           |
|  30 | asyncpg                   | 0.25.0                    |                           |                           |
|  31 | attrs                     | 20.3.0, 21.4.0            | 20.3.0, 21.4.0            |                           |
|  32 | aws-sam-translator        |                           | 1.45.0                    |                           |
|  33 | aws-xray-sdk              |                           | 2.9.0                     |                           |
|  34 | bcrypt                    | 3.2.0                     | 3.2.2                     |                           |
|  35 | beautifulsoup4            | 4.10.0                    |                           |                           |
|  36 | black                     |                           |                           | 22.3.0                    |
|  37 | bleach                    | 3.3.0                     |                           |                           |
|  38 | blosc                     | 1.10.6                    |                           |                           |
|  39 | bokeh                     | 2.4.3                     | 2.4.2                     |                           |
|  40 | boto3                     | 1.21.33                   | 1.21.21, 1.23.4           |                           |
|  41 | boto3-stubs               |                           | 1.23.9                    |                           |
|  42 | botocore                  | 1.24.21, 1.24.33          | 1.24.21, 1.26.4           |                           |
|  43 | botocore-stubs            |                           | 1.26.9                    |                           |
|  44 | bump2version              |                           |                           | 1.0.1                     |
|  45 | certifi                   | 2021.10.8, 2022.5.18.1    | 2021.10.8, 2022.5.18.1    |                           |
|  46 | cffi                      | 1.15.0                    | 1.15.0                    |                           |
|  47 | cfgv                      |                           |                           | 3.3.1                     |
|  48 | cfn-lint                  |                           | 0.60.1                    |                           |
|  49 | change-case               |                           |                           | 0.5.2                     |
|  50 | charset-normalizer        | 2.0.12                    | 2.0.12                    |                           |
|  51 | click                     | 8.0.3, 8.1.2, 8.1.3       | 8.0.3, 8.1.3              | 8.0.3, 8.1.2, 8.1.3       |
|  52 | cloudpickle               | 2.0.0                     |                           |                           |
|  53 | codecov                   |                           | 2.1.12                    |                           |
|  54 | colorlog                  |                           | 6.6.0                     |                           |
|  55 | configparser              | 5.2.0                     |                           |                           |
|  56 | coverage                  |                           | 6.3.2, 6.4                |                           |
|  57 | coveralls                 |                           | 3.3.1                     |                           |
|  58 | cryptography              | 3.4.7, 36.0.2, 37.0.2     | 36.0.2, 37.0.2            |                           |
|  59 | cytoolz                   | 0.11.0                    |                           |                           |
|  60 | dask                      | 2022.6.0                  |                           |                           |
|  61 | dask-gateway              | 2022.6.1                  |                           |                           |
|  62 | dask-gateway-server       |                           | 2022.6.1                  |                           |
|  63 | decorator                 | 4.4.2                     |                           |                           |
|  64 | defusedxml                | 0.7.1                     |                           |                           |
|  65 | deprecated                | 1.2.13                    | 1.2.13                    |                           |
|  66 | dill                      |                           | 0.3.4, 0.3.5              | 0.3.5.1                   |
|  67 | distlib                   |                           |                           | 0.3.4                     |
|  68 | distributed               | 2022.6.0                  |                           |                           |
|  69 | distro                    | 1.5.0                     | 1.7.0                     |                           |
|  70 | dnspython                 | 2.0.0, 2.1.0, 2.2.1       | 2.2.1                     |                           |
|  71 | docker                    | 5.0.3                     | 5.0.3                     |                           |
|  72 | docker-compose            | 1.29.1                    | 1.29.1                    |                           |
|  73 | dockerpty                 | 0.4.1                     | 0.4.1                     |                           |
|  74 | docopt                    | 0.6.2                     | 0.6.2                     |                           |
|  75 | ecdsa                     | 0.14.1                    | 0.17.0                    |                           |
|  76 | email-validator           | 1.2.1                     | 1.2.1                     |                           |
|  77 | entrypoints               | 0.3                       |                           |                           |
|  78 | et-xmlfile                | 1.1.0                     |                           |                           |
|  79 | execnet                   |                           | 1.9.0                     |                           |
|  80 | expiringdict              | 1.2.1                     |                           |                           |
|  81 | faker                     |                           | 13.7.0, 13.11.0, 13.11.1  |                           |
|  82 | fastapi                   | 0.71.0, 0.75.0, 0.75.1    |                           |                           |
|  83 | fastapi-contrib           | 0.2.11                    |                           |                           |
|  84 | fastapi-pagination        | 0.9.1                     |                           |                           |
|  85 | fastjsonschema            | 2.15.3                    |                           |                           |
|  86 | filelock                  |                           |                           | 3.7.0                     |
|  87 | flaky                     |                           | 3.7.0                     |                           |
|  88 | flask                     |                           | 2.1.2                     |                           |
|  89 | flask-cors                |                           | 3.0.10                    |                           |
|  90 | frozenlist                | 1.3.0                     | 1.3.0                     |                           |
|  91 | fsspec                    | 2022.5.0                  |                           |                           |
|  92 | future                    | 0.18.2                    | 0.18.2                    |                           |
|  93 | futures                   | 3.0.5                     |                           |                           |
|  94 | graphql-core              |                           | 3.2.1                     |                           |
|  95 | greenlet                  | 1.1.2                     | 1.1.2                     |                           |
|  96 | gunicorn                  | 20.1.0                    |                           |                           |
|  97 | h11                       | 0.12.0                    | 0.12.0                    |                           |
|  98 | h2                        | 4.1.0                     |                           |                           |
|  99 | heapdict                  | 1.0.1                     |                           |                           |
| 100 | hpack                     | 4.0.0                     |                           |                           |
| 101 | httpcore                  | 0.15.0                    | 0.15.0                    |                           |
| 102 | httptools                 | 0.2.0, 0.4.0              |                           |                           |
| 103 | httpx                     | 0.23.0                    | 0.23.0                    |                           |
| 104 | hyperframe                | 6.0.1                     |                           |                           |
| 105 | hypothesis                |                           | 6.46.3                    |                           |
| 106 | icdiff                    |                           | 2.0.5                     |                           |
| 107 | identify                  |                           |                           | 2.5.1                     |
| 108 | idna                      | 2.10, 3.3                 | 2.10, 3.3                 |                           |
| 109 | importlib-metadata        |                           | 4.11.3                    |                           |
| 110 | iniconfig                 | 1.1.1                     | 1.1.1                     |                           |
| 111 | inotify                   |                           |                           | 0.2.10                    |
| 112 | isodate                   | 0.6.1                     |                           |                           |
| 113 | isort                     |                           | 5.10.1                    | 5.10.1                    |
| 114 | itsdangerous              | 1.1.0, 2.1.2              | 2.1.2                     |                           |
| 115 | jaeger-client             | 4.8.0                     |                           |                           |
| 116 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 117 | jinja2                    | 2.11.3, 3.1.2             | 2.11.3, 3.1.2             | 3.1.2                     |
| 118 | jmespath                  | 1.0.0                     | 1.0.0                     |                           |
| 119 | jschema-to-python         |                           | 1.2.3                     |                           |
| 120 | json2html                 | 1.3.0                     |                           |                           |
| 121 | jsondiff                  | 2.0.0                     | 2.0.0                     |                           |
| 122 | jsonpatch                 |                           | 1.32                      |                           |
| 123 | jsonpickle                |                           | 2.2.0                     |                           |
| 124 | jsonpointer               |                           | 2.3                       |                           |
| 125 | jsonschema                | 3.2.0, 4.6.0              | 3.2.0, 4.6.0              |                           |
| 126 | junit-xml                 |                           | 1.9                       |                           |
| 127 | jupyter-client            | 6.1.12                    |                           |                           |
| 128 | jupyter-core              | 4.7.1                     |                           |                           |
| 129 | jupyter-server            | 1.16.0                    |                           |                           |
| 130 | jupyter-server-proxy      | 3.2.1                     |                           |                           |
| 131 | jupyterlab-pygments       | 0.1.2                     |                           |                           |
| 132 | lazy-object-proxy         | 1.4.3                     | 1.4.3, 1.7.1              | 1.7.1                     |
| 133 | locket                    | 1.0.0                     |                           |                           |
| 134 | lz4                       | 4.0.0                     |                           |                           |
| 135 | mako                      | 1.1.5, 1.2.0              | 1.1.5, 1.2.0              |                           |
| 136 | markupsafe                | 2.1.1                     | 2.1.1                     | 2.1.1                     |
| 137 | mccabe                    |                           | 0.7.0                     | 0.7.0                     |
| 138 | minio                     | 7.0.4                     | 7.0.4                     |                           |
| 139 | mistune                   | 0.8.4                     |                           |                           |
| 140 | moto                      |                           | 3.1.9                     |                           |
| 141 | msgpack                   | 1.0.3                     |                           |                           |
| 142 | multidict                 | 6.0.2                     | 6.0.2                     |                           |
| 143 | mypy                      |                           |                           | 0.960                     |
| 144 | mypy-extensions           |                           |                           | 0.4.3                     |
| 145 | nbclient                  | 0.5.3                     |                           |                           |
| 146 | nbconvert                 | 6.4.5                     |                           |                           |
| 147 | nbformat                  | 5.3.0                     |                           |                           |
| 148 | nest-asyncio              | 1.5.1                     |                           |                           |
| 149 | networkx                  | 2.5.1                     | 2.8.1                     |                           |
| 150 | nodeenv                   |                           |                           | 1.6.0                     |
| 151 | nose                      |                           |                           | 1.3.7                     |
| 152 | numpy                     | 1.22.3                    | 1.22.3                    |                           |
| 153 | openapi-core              | 0.12.0                    |                           |                           |
| 154 | openapi-schema-validator  | 0.2.3                     | 0.2.3                     |                           |
| 155 | openapi-spec-validator    | 0.4.0                     | 0.4.0                     |                           |
| 156 | openpyxl                  | 3.0.9                     |                           |                           |
| 157 | opentracing               | 2.4.0                     |                           |                           |
| 158 | orjson                    | 3.7.2                     |                           |                           |
| 159 | packaging                 | 21.3                      | 21.3                      |                           |
| 160 | pamqp                     | 2.3.0, 3.1.0              | 2.3.0, 3.1.0              |                           |
| 161 | pandas                    | 1.2.4                     | 1.4.2                     |                           |
| 162 | pandocfilters             | 1.4.3                     |                           |                           |
| 163 | paramiko                  | 2.11.0                    | 2.11.0                    |                           |
| 164 | parfive                   | 1.5.1                     |                           |                           |
| 165 | partd                     | 1.2.0                     |                           |                           |
| 166 | passlib                   | 1.7.4                     | 1.7.4                     |                           |
| 167 | pathspec                  |                           |                           | 0.9.0                     |
| 168 | pbr                       |                           | 5.9.0                     |                           |
| 169 | pennsieve                 | 6.1.2                     |                           |                           |
| 170 | pep517                    |                           |                           | 0.12.0                    |
| 171 | pillow                    | 9.0.1                     | 9.1.0                     |                           |
| 172 | pint                      | 0.19.2                    | 0.19.2                    |                           |
| 173 | pip-tools                 |                           |                           | 6.6.2                     |
| 174 | platformdirs              |                           | 2.5.2                     | 2.5.2                     |
| 175 | pluggy                    | 1.0.0                     | 1.0.0                     |                           |
| 176 | pprintpp                  |                           | 0.4.0                     |                           |
| 177 | pre-commit                |                           |                           | 2.19.0                    |
| 178 | prometheus-client         | 0.14.1                    |                           |                           |
| 179 | protobuf                  | 3.20.0                    |                           |                           |
| 180 | psutil                    | 5.9.0, 5.9.1              |                           |                           |
| 181 | psycopg2-binary           | 2.9.3                     | 2.9.3                     |                           |
| 182 | ptvsd                     |                           | 4.3.2                     |                           |
| 183 | ptyprocess                | 0.7.0                     |                           |                           |
| 184 | py                        | 1.11.0                    | 1.11.0                    |                           |
| 185 | py-cpuinfo                |                           | 8.0.0                     |                           |
| 186 | pyasn1                    | 0.4.8                     | 0.4.8                     |                           |
| 187 | pycparser                 | 2.20, 2.21                | 2.20, 2.21                |                           |
| 188 | pydantic                  | 1.9.0                     | 1.9.0                     |                           |
| 189 | pyftpdlib                 |                           | 1.5.6                     |                           |
| 190 | pygments                  | 2.9.0                     |                           |                           |
| 191 | pyinstrument              | 3.4.2, 4.1.1              | 4.1.1                     |                           |
| 192 | pyinstrument-cext         | 0.2.4                     |                           |                           |
| 193 | pylint                    |                           | 2.13.8, 2.13.9            | 2.13.9                    |
| 194 | pynacl                    | 1.4.0                     | 1.5.0                     |                           |
| 195 | pyopenssl                 |                           | 22.0.0                    |                           |
| 196 | pyparsing                 | 3.0.9                     | 3.0.9                     |                           |
| 197 | pyrsistent                | 0.18.1                    | 0.18.1                    |                           |
| 198 | pytest                    | 7.1.2                     | 7.1.2                     |                           |
| 199 | pytest-aiohttp            |                           | 1.0.4                     |                           |
| 200 | pytest-asyncio            |                           | 0.18.3                    |                           |
| 201 | pytest-benchmark          |                           | 3.4.1                     |                           |
| 202 | pytest-cov                |                           | 3.0.0                     |                           |
| 203 | pytest-docker             |                           | 0.12.0                    |                           |
| 204 | pytest-forked             |                           | 1.4.0                     |                           |
| 205 | pytest-icdiff             |                           | 0.5                       |                           |
| 206 | pytest-instafail          |                           | 0.4.2                     |                           |
| 207 | pytest-lazy-fixture       |                           | 0.6.3                     |                           |
| 208 | pytest-localftpserver     |                           | 1.1.3                     |                           |
| 209 | pytest-mock               |                           | 3.7.0                     |                           |
| 210 | pytest-runner             |                           | 6.0.0                     |                           |
| 211 | pytest-sugar              |                           | 0.9.4                     |                           |
| 212 | pytest-xdist              |                           | 2.5.0                     |                           |
| 213 | python-dateutil           | 2.8.1, 2.8.2              | 2.8.1, 2.8.2              |                           |
| 214 | python-dotenv             | 0.20.0                    | 0.20.0                    |                           |
| 215 | python-engineio           | 3.14.2                    |                           |                           |
| 216 | python-jose               | 3.2.0                     | 3.3.0                     |                           |
| 217 | python-magic              | 0.4.25                    |                           |                           |
| 218 | python-multipart          | 0.0.5                     |                           |                           |
| 219 | python-socketio           | 4.6.1                     |                           |                           |
| 220 | pytz                      | 2020.1, 2022.1            | 2022.1                    |                           |
| 221 | pyyaml                    | 5.4.1, 6.0                | 5.4.1, 6.0                | 5.4.1, 6.0                |
| 222 | pyzmq                     | 22.1.0                    |                           |                           |
| 223 | redis                     | 4.3.1                     | 4.3.1                     |                           |
| 224 | requests                  | 2.27.1                    | 2.27.1                    |                           |
| 225 | responses                 |                           | 0.20.0                    |                           |
| 226 | respx                     |                           | 0.19.2                    |                           |
| 227 | rfc3986                   | 1.4.0, 1.5.0              | 1.4.0, 1.5.0              |                           |
| 228 | rsa                       | 4.0                       | 4.8                       |                           |
| 229 | s3fs                      | 2022.5.0                  |                           |                           |
| 230 | s3transfer                | 0.5.2                     | 0.5.2                     |                           |
| 231 | sarif-om                  |                           | 1.0.4                     |                           |
| 232 | semantic-version          | 2.9.0                     |                           |                           |
| 233 | semver                    | 2.13.0                    |                           |                           |
| 234 | send2trash                | 1.7.1                     |                           |                           |
| 235 | setproctitle              | 1.2.3                     |                           |                           |
| 236 | simpervisor               | 0.4                       |                           |                           |
| 237 | six                       | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            |
| 238 | sniffio                   | 1.2.0                     | 1.2.0                     |                           |
| 239 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 240 | soupsieve                 | 2.3.2                     |                           |                           |
| 241 | sqlalchemy                | 1.4.37                    | 1.4.37                    |                           |
| 242 | sshpubkeys                |                           | 3.3.1                     |                           |
| 243 | starlette                 | 0.17.1                    |                           |                           |
| 244 | strict-rfc3339            | 0.7                       |                           |                           |
| 245 | tblib                     | 1.7.0                     |                           |                           |
| 246 | tenacity                  | 8.0.1                     | 8.0.1                     |                           |
| 247 | termcolor                 |                           | 1.1.0                     |                           |
| 248 | terminado                 | 0.10.1                    |                           |                           |
| 249 | testpath                  | 0.5.0                     |                           |                           |
| 250 | texttable                 | 1.6.3                     | 1.6.4                     |                           |
| 251 | threadloop                | 1.0.2                     |                           |                           |
| 252 | thrift                    | 0.16.0                    |                           |                           |
| 253 | toml                      |                           |                           | 0.10.2                    |
| 254 | tomli                     | 2.0.1                     | 2.0.1                     | 2.0.1                     |
| 255 | toolz                     | 0.11.1, 0.11.2            |                           |                           |
| 256 | tornado                   | 6.1                       | 6.1                       |                           |
| 257 | tqdm                      | 4.62.3, 4.63.1, 4.64.0    | 4.64.0                    |                           |
| 258 | traitlets                 | 5.1.1                     | 5.3.0                     |                           |
| 259 | typer                     | 0.4.1                     | 0.4.1                     | 0.4.1                     |
| 260 | types-aiofiles            |                           | 0.8.8                     |                           |
| 261 | types-boto3               |                           | 1.0.2                     |                           |
| 262 | types-pkg-resources       |                           | 0.1.3                     |                           |
| 263 | types-pyyaml              |                           | 6.0.7                     |                           |
| 264 | typing-extensions         | 4.1.1, 4.2.0              | 4.1.1, 4.2.0              | 4.1.1, 4.2.0              |
| 265 | ujson                     | 4.3.0, 5.3.0              |                           |                           |
| 266 | urllib3                   | 1.26.9                    | 1.26.9                    |                           |
| 267 | uvicorn                   | 0.15.0, 0.17.0, 0.17.6    |                           |                           |
| 268 | uvloop                    | 0.16.0                    |                           |                           |
| 269 | virtualenv                |                           |                           | 20.14.1                   |
| 270 | watchdog                  | 2.1.5                     |                           | 2.1.8                     |
| 271 | watchgod                  | 0.8.2                     |                           |                           |
| 272 | webencodings              | 0.5.1                     |                           |                           |
| 273 | websocket-client          | 0.59.0, 1.3.2             | 0.59.0, 1.3.2             |                           |
| 274 | websockets                | 10.1, 10.2                | 10.3                      |                           |
| 275 | werkzeug                  | 2.0.3, 2.1.2              | 2.1.2                     |                           |
| 276 | wheel                     |                           |                           | 0.37.1                    |
| 277 | wrapt                     | 1.14.0, 1.14.1            | 1.14.0, 1.14.1            | 1.14.1                    |
| 278 | xmltodict                 |                           | 0.13.0                    |                           |
| 279 | yarl                      | 1.5.1, 1.7.2              | 1.5.1, 1.7.2              |                           |
| 280 | zict                      | 2.2.0                     |                           |                           |
| 281 | zipp                      |                           | 3.8.0                     |                           |


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
