### PR TITLE
✨ Is638/client cancellation

### DIFF
--- a/packages/service-library/requirements/_fastapi.in
+++ b/packages/service-library/requirements/_fastapi.in
@@ -14,9 +14,9 @@ fastapi_contrib[jaegertracing]
 # NOTE: What test client to use for fastapi-based apps?
 #
 # fastapi comes with a default test client: fatapi.testclient.TestClient (SEE https://fastapi.tiangolo.com/tutorial/testing/)
-# which basically is basically an indirection to starlette.testclient (SEE https://www.starlette.io/testclient/)
+# which is essentially an indirection to starlette.testclient (SEE https://www.starlette.io/testclient/)
 #
-# the limitation of that client is that it is syncronous.
+# the limitation of that client is that it is fd synchronous.
 #
 # There are two options in place:
 # a) fastapi recommends to use httpx and create your own AsyncTestClient: https://fastapi.tiangolo.com/advanced/async-tests/

--- a/packages/service-library/requirements/_fastapi.in
+++ b/packages/service-library/requirements/_fastapi.in
@@ -5,5 +5,24 @@
 
 --constraint ./_base.in
 
+
+async-asgi-testclient # replacement for fastapi.testclient.TestClient [see b) below]
 fastapi
 fastapi_contrib[jaegertracing]
+
+
+# NOTE: What test client to use for fastapi-based apps?
+#
+# fastapi comes with a default test client: fatapi.testclient.TestClient (SEE https://fastapi.tiangolo.com/tutorial/testing/)
+# which basically is basically an indirection to starlette.testclient (SEE https://www.starlette.io/testclient/)
+#
+# the limitation of that client is that it is syncronous.
+#
+# There are two options in place:
+# a) fastapi recommends to use httpx and create your own AsyncTestClient: https://fastapi.tiangolo.com/advanced/async-tests/
+#   PROS: can use respx to mock responses, used to httpx API
+#   CONS: do it yourself, does not include app member out-of-the-box
+# b) use generic Async ASGI TestClient library:  https://github.com/vinissimus/async-asgi-testclient
+#   PROS: generic closed solution, has 'app' member , requests-like API (i.e. equivalent to starletter TESTClient)
+#   CONS: basically does not have the PROS from a), adds extra deps to 'requests' lib.
+#

--- a/packages/service-library/requirements/_fastapi.txt
+++ b/packages/service-library/requirements/_fastapi.txt
@@ -6,6 +6,12 @@
 #
 anyio==3.6.1
     # via starlette
+async-asgi-testclient==1.4.11
+    # via -r requirements/_fastapi.in
+certifi==2022.6.15
+    # via requests
+charset-normalizer==2.0.12
+    # via requests
 fastapi==0.76.0
     # via
     #   -r requirements/_fastapi.in
@@ -13,9 +19,13 @@ fastapi==0.76.0
 fastapi-contrib==0.2.11
     # via -r requirements/_fastapi.in
 idna==3.3
-    # via anyio
+    # via
+    #   anyio
+    #   requests
 jaeger-client==4.8.0
     # via fastapi-contrib
+multidict==6.0.2
+    # via async-asgi-testclient
 opentracing==2.4.0
     # via
     #   fastapi-contrib
@@ -25,6 +35,8 @@ pydantic==1.9.0
     #   -c requirements/./../../../requirements/constraints.txt
     #   -c requirements/./_base.in
     #   fastapi
+requests==2.28.0
+    # via async-asgi-testclient
 six==1.16.0
     # via thrift
 sniffio==1.2.0
@@ -43,3 +55,7 @@ typing-extensions==4.2.0
     # via
     #   pydantic
     #   starlette
+urllib3==1.26.9
+    # via
+    #   -c requirements/./../../../requirements/constraints.txt
+    #   requests

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -28,8 +28,10 @@ attrs==20.3.0
     #   pytest-docker
 bcrypt==3.2.2
     # via paramiko
-certifi==2022.5.18.1
-    # via requests
+certifi==2022.6.15
+    # via
+    #   -c requirements/_fastapi.txt
+    #   requests
 cffi==1.15.0
     # via
     #   bcrypt
@@ -38,6 +40,7 @@ cffi==1.15.0
 charset-normalizer==2.0.12
     # via
     #   -c requirements/_aiohttp.txt
+    #   -c requirements/_fastapi.txt
     #   aiohttp
     #   requests
 coverage==6.3.2
@@ -101,6 +104,7 @@ mccabe==0.7.0
 multidict==6.0.2
     # via
     #   -c requirements/_aiohttp.txt
+    #   -c requirements/_fastapi.txt
     #   aiohttp
     #   yarl
 openapi-schema-validator==0.2.3
@@ -174,8 +178,9 @@ pyyaml==5.4.1
     #   -c requirements/_base.txt
     #   docker-compose
     #   openapi-spec-validator
-requests==2.27.1
+requests==2.28.0
     # via
+    #   -c requirements/_fastapi.txt
     #   coveralls
     #   docker
     #   docker-compose
@@ -206,6 +211,7 @@ typing-extensions==4.2.0
 urllib3==1.26.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_fastapi.txt
     #   requests
 websocket-client==0.59.0
     # via

--- a/packages/service-library/src/servicelib/fastapi/requests_decorators.py
+++ b/packages/service-library/src/servicelib/fastapi/requests_decorators.py
@@ -11,6 +11,13 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_CHECK_INTERVAL_S: float = 0.5
 
+HTTP_499_CLIENT_CLOSED_REQUEST = 499
+# A non-standard status code introduced by nginx for the case when a client
+# closes the connection while nginx is processing the request.
+# SEE https://www.webfx.com/web-development/glossary/http-status-codes/what-is-a-499-status-code/
+
+_FastAPIHandlerCallable = Callable[..., Coroutine[Any, Any, Optional[Any]]]
+
 
 async def _cancel_task_if_client_disconnected(
     request: Request, task: asyncio.Task, interval: float = _DEFAULT_CHECK_INTERVAL_S
@@ -32,38 +39,49 @@ async def _cancel_task_if_client_disconnected(
         logger.debug("task completed")
 
 
-def cancellable_request(handler: Callable[..., Coroutine[Any, Any, Optional[Any]]]):
-    """this decorator periodically checks if the client disconnected and then will cancel the request and return a 499 code (a la nginx).
-    Usage:
+def cancellable_request(handler_fun: _FastAPIHandlerCallable):
+    """This decorator periodically checks if the client disconnected and
+    then will cancel the request and return a HTTP_499_CLIENT_CLOSED_REQUEST code (a la nginx).
 
-    decorate the cancellable route and add request: Request as an argument
+    Usage: decorate the cancellable route and add request: Request as an argument
 
-    @cancellable_request
-    async def route(
-        _request: Request,
-        ...
-    )
+        @cancellable_request
+        async def route(
+            _request: Request,
+            ...
+        )
     """
 
-    @wraps(handler)
+    @wraps(handler_fun)
     async def wrapper(*args, **kwargs) -> Optional[Any]:
         request: Request = kwargs["_request"]
+
+        # Intercepts handler call and creates a task out of it
         handler_task = asyncio.create_task(
-            handler(*args, **kwargs),
-            name=f"cancellable_request/handler/{handler.__name__}",
+            handler_fun(*args, **kwargs),
+            name=f"cancellable_request/handler/{handler_fun.__name__}",
         )
+        # An extra task to monitor when the client disconnects so it can
+        # cancel 'handler_task'
         auto_cancel_task = asyncio.create_task(
             _cancel_task_if_client_disconnected(request, handler_task),
-            name=f"cancellable_request/auto_cancel/{handler.__name__}",
+            name=f"cancellable_request/auto_cancel/{handler_fun.__name__}",
         )
+
         try:
             return await handler_task
         except CancelledError:
             logger.warning(
-                "request %s was cancelled by client %s!", request.url, request.client
+                "Request %s was cancelled since client %s disconnected !",
+                f"{request.url}",
+                request.client,
             )
-            return Response("Oh No!", status_code=499)
+            return Response(
+                "Request cancelled because client disconnected",
+                status_code=HTTP_499_CLIENT_CLOSED_REQUEST,
+            )
         finally:
+            # TODO: is this called when return ??? Should it stop when responded?
             auto_cancel_task.cancel()
             with suppress(CancelledError):
                 await auto_cancel_task

--- a/packages/service-library/src/servicelib/fastapi/requests_decorators.py
+++ b/packages/service-library/src/servicelib/fastapi/requests_decorators.py
@@ -32,15 +32,19 @@ async def _cancel_task_if_client_disconnected(
                 logger.debug("task %s is done", task)
                 break
             if await request.is_disconnected():
-                logger.warning("client %s disconnected!", request.client)
+                logger.warning(
+                    "client %s disconnected! Cancelling handler for %s",
+                    request.client,
+                    f"{request.url=}",
+                )
                 task.cancel()
                 break
             await asyncio.sleep(interval)
     except CancelledError:
-        logger.debug("task was cancelled")
+        logger.debug("task monitoring %s handler was cancelled", f"{request.url=}")
         raise
     finally:
-        logger.debug("task completed")
+        logger.debug("task monitoring %s handler completed", f"{request.url}")
 
 
 def cancellable_request(handler_fun: _FastAPIHandlerCallable):

--- a/packages/service-library/src/servicelib/fastapi/requests_decorators.py
+++ b/packages/service-library/src/servicelib/fastapi/requests_decorators.py
@@ -1,0 +1,71 @@
+import asyncio
+import logging
+from asyncio import CancelledError
+from contextlib import suppress
+from functools import wraps
+from typing import Any, Callable, Coroutine, Optional
+
+from fastapi import Request, Response
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CHECK_INTERVAL_S: float = 0.5
+
+
+async def _cancel_task_if_client_disconnected(
+    request: Request, task: asyncio.Task, interval: float = _DEFAULT_CHECK_INTERVAL_S
+) -> None:
+    try:
+        while True:
+            if task.done():
+                logger.debug("task %s is done", task)
+                break
+            if await request.is_disconnected():
+                logger.warning("client %s disconnected!", request.client)
+                task.cancel()
+                break
+            await asyncio.sleep(interval)
+    except CancelledError:
+        logger.debug("task was cancelled")
+        raise
+    finally:
+        logger.debug("task completed")
+
+
+def cancellable_request(handler: Callable[..., Coroutine[Any, Any, Optional[Any]]]):
+    """this decorator periodically checks if the client disconnected and then will cancel the request and return a 499 code (a la nginx).
+    Usage:
+
+    decorate the cancellable route and add request: Request as an argument
+
+    @cancellable_request
+    async def route(
+        _request: Request,
+        ...
+    )
+    """
+
+    @wraps(handler)
+    async def wrapper(*args, **kwargs) -> Optional[Any]:
+        request: Request = kwargs["_request"]
+        handler_task = asyncio.create_task(
+            handler(*args, **kwargs),
+            name=f"cancellable_request/handler/{handler.__name__}",
+        )
+        auto_cancel_task = asyncio.create_task(
+            _cancel_task_if_client_disconnected(request, handler_task),
+            name=f"cancellable_request/auto_cancel/{handler.__name__}",
+        )
+        try:
+            return await handler_task
+        except CancelledError:
+            logger.warning(
+                "request %s was cancelled by client %s!", request.url, request.client
+            )
+            return Response("Oh No!", status_code=499)
+        finally:
+            auto_cancel_task.cancel()
+            with suppress(CancelledError):
+                await auto_cancel_task
+
+    return wrapper

--- a/packages/service-library/tests/fastapi/test_request_decorators.py
+++ b/packages/service-library/tests/fastapi/test_request_decorators.py
@@ -1,0 +1,192 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+import asyncio
+from asyncio import AbstractEventLoop, Task
+from datetime import datetime
+from typing import AsyncIterable, Callable
+
+import pytest
+from async_asgi_testclient import TestClient
+from fastapi import APIRouter, FastAPI, Request, Response, status
+from fastapi.testclient import TestClient as SyncTestClient
+from pydantic import NonNegativeInt
+from servicelib.fastapi.requests_decorators import TASK_NAME_PREFIX, cancellable_request
+
+
+@pytest.fixture
+def app() -> FastAPI:
+
+    api_router = APIRouter()
+
+    @api_router.get("/")
+    def _get_root():
+        return {"name": __name__, "timestamp": datetime.utcnow().isoformat()}
+
+    @api_router.get("/sleep/{delay}")
+    @cancellable_request
+    async def _cancellable_with_await(_request: Request, delay: NonNegativeInt):
+        await asyncio.sleep(delay)
+
+    # @api_router.get("/sleep/{delay}/aio-tasks")
+    # @cancellable_request
+    # async def _cancellable_with_aio_tasks(_request: Request, delay: NonNegativeInt):
+    #    await asyncio.sleep(delay)
+
+    # TODO: handler spawns subprocesses
+    # TODO: handler spawns threads
+    # TODO: handler spawns aio-tasks
+
+    _app = FastAPI()
+    _app.include_router(api_router)
+
+    return _app
+
+
+@pytest.fixture
+async def test_client(app: FastAPI) -> AsyncIterable[TestClient]:
+    async with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture()
+def inspect_app_tasks(
+    event_loop: AbstractEventLoop,
+) -> Callable[[], list[Task]]:
+    """Function to return cancellable tasks"""
+
+    def go():
+        return [
+            task
+            for task in asyncio.all_tasks(event_loop)
+            if task.get_name().startswith(f"{TASK_NAME_PREFIX}/")
+        ]
+
+    return go
+
+
+def test_raises_if_wrong_signature_upon_import(app: FastAPI):
+    # let's define some routes
+    @app.get("/correct")
+    @cancellable_request
+    async def _correct_signature(_request: Request, x: int):
+        ...
+
+    with pytest.raises(ValueError) as exc_info:
+
+        @app.get("/wrong")
+        @cancellable_request
+        async def _wrong_signature():
+            ...
+
+    assert "_wrong_signature" in str(exc_info.value)
+
+
+async def test_with_non_cancellable_entrypoint(
+    test_client: TestClient, inspect_app_tasks: Callable[[], list[Task]]
+):
+    assert not inspect_app_tasks()
+
+    # NOT cancellable entrypoint
+    r = await test_client.get("/")
+    assert r.status_code == status.HTTP_200_OK
+
+    assert not inspect_app_tasks()
+
+
+async def test_cancellable_handler_with_successful_request(
+    test_client: TestClient, inspect_app_tasks: Callable[[], list[Task]]
+):
+    # cancellable entrypoint
+
+    r = await test_client.get("/sleep/0")
+    assert r.status_code == status.HTTP_200_OK
+
+    assert all(
+        t.done() for t in inspect_app_tasks()
+    ), "All tasks (if any) should be done"
+
+
+@pytest.mark.skip(reason="DEV")
+async def test_it(app: FastAPI, inspect_app_tasks: Callable[[], list[Task]]):
+
+    # interrupt request
+    with SyncTestClient(app) as test_client:
+        with pytest.raises(asyncio.TimeoutError):
+            r = test_client.get(
+                "/sleep/100", headers={"Connection": "close"}, timeout=0.001
+            )
+            r.reason
+
+    app_tasks = inspect_app_tasks()
+    assert app_tasks
+    assert all(not t.done() for t in app_tasks)
+
+    while not all(t.done() for t in app_tasks):
+        await asyncio.sleep(0.5)
+
+
+@pytest.mark.skip(reason="DEV")
+async def test_it2(
+    test_client: TestClient, inspect_app_tasks: Callable[[], list[Task]]
+):
+    client_task = asyncio.create_task(test_client.get("/sleep/100"))
+
+    await asyncio.sleep(0.1)
+
+    app_tasks = inspect_app_tasks()
+    assert app_tasks
+    assert all(not t.done() for t in app_tasks)
+
+    assert client_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await client_task
+
+    while not all(t.done() for t in app_tasks):
+        await asyncio.sleep(0.5)
+
+
+@pytest.mark.skip(reason="DEV")
+async def test_it3(
+    test_client: TestClient, inspect_app_tasks: Callable[[], list[Task]]
+):
+
+    # Client cancels
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(test_client.get("/sleep/100"), timeout=0.5)
+
+    cancellable_tasks = inspect_app_tasks()
+    # assert cancellable_tasks
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(test_client.get("/sleep-uncancelled/100"), timeout=0.5)
+    cancellable_tasks = inspect_app_tasks()
+    # assert cancellable_tasks
+
+    # TODO: check that _create_slow_call was cancelled!
+    # probably client
+
+    # are tasks cancelled?
+    # create process and cancel
+    # create a thread and cancel
+    # create a aio task and cancel
+
+
+@pytest.mark.skip(reason="DEV")
+async def test_it4(test_client: TestClient):
+
+    # will cancel
+    reqs = [test_client.get("/sleep/5", timeout=1) for _ in range(100)]
+
+    # will
+    reqs += [test_client.get("/sleep/1") for _ in range(100)]
+
+    results = await asyncio.gather(*reqs, return_exceptions=True)
+
+    assert all(isinstance(r, Exception) for r in results[:100])
+    assert all(
+        isinstance(r, Response) and r.status_code == status.HTTP_200_OK
+        for r in results[100:]
+    )

--- a/packages/service-library/tests/fastapi/test_request_decorators.py
+++ b/packages/service-library/tests/fastapi/test_request_decorators.py
@@ -37,6 +37,7 @@ def app() -> FastAPI:
     # TODO: handler spawns subprocesses
     # TODO: handler spawns threads
     # TODO: handler spawns aio-tasks
+    # TODO: handler with backgroundtask
 
     _app = FastAPI()
     _app.include_router(api_router)
@@ -117,7 +118,6 @@ async def test_it(app: FastAPI, inspect_app_tasks: Callable[[], list[Task]]):
             r = test_client.get(
                 "/sleep/100", headers={"Connection": "close"}, timeout=0.001
             )
-            r.reason
 
     app_tasks = inspect_app_tasks()
     assert app_tasks

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers.py
@@ -175,9 +175,7 @@ async def runs_docker_compose_up(
         },
     },
 )
-@cancellable_request
 async def runs_docker_compose_down(
-    _request: Request,
     command_timeout: float = Query(
         10.0, description="docker-compose down command timeout default"
     ),
@@ -187,6 +185,7 @@ async def runs_docker_compose_down(
 ) -> Union[str, dict[str, Any]]:
     """Removes the previously started service
     and returns the docker-compose output"""
+    # TODO: convert into long running operation
 
     stored_compose_content = shared_store.compose_spec
     if stored_compose_content is None:

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/health.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/health.py
@@ -24,4 +24,4 @@ async def health_endpoint(
     return application_health
 
 
-__all__ = ["health_router"]
+__all__: tuple[str, ...] = ("health_router",)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

Implements from ITISFoundation/osparc-issues#638
> we need to have the fix that cancels tasks in the dy-sidecar when the REST client timesout (currently all these task are accumulating)

Specifically:
- ✨ adds ``servicelib.fastapi.request_decorators.cancellable_request`` helper (taken from datcore-adapter utils and modified)
   - ``tests/fastapi/test_request_decorators.py``: Tried to test, but unable to emulate a client disconnect using ``TestClient``. ANY IDEAS WELCOME! :-)
- applies decorator to most of the ``/container``-base paths in dynamic-sidecar


NOTE: if ``servicelib.fastapi.request_decorators.cancellable_request`` is accepted, it will be reused in the other services (right now very similar copies in catalog and datcore-adapter).

## Related issue/s

- ITISFoundation/osparc-issues#638



## How to test

```cmd
make devenv
source .venv/bin/activate
cd packages/service-library
make install-dev
pytest -v tests/fastapi/test_request_decorators.py
```
