### PR TITLE
🚑️ Is638/tmp disable cancellation 

### DIFF
--- a/packages/service-library/src/servicelib/fastapi/requests_decorators.py
+++ b/packages/service-library/src/servicelib/fastapi/requests_decorators.py
@@ -90,6 +90,8 @@ def cancellable_request(handler_fun: _FastAPIHandlerCallable):
         try:
             return await handler_task
         except CancelledError:
+            # TODO: check that 'auto_cancel_task' actually executed this cancellation
+            # E.g. app shutdown might cancel all pending tasks
             logger.warning(
                 "Request %s was cancelled since client %s disconnected !",
                 f"{request.url}",

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers.py
@@ -16,7 +16,6 @@ from fastapi import (
     status,
 )
 from fastapi.responses import PlainTextResponse
-from servicelib.fastapi.requests_decorators import cancellable_request
 
 from ..core.docker_compose_utils import docker_compose_down, docker_compose_up
 from ..core.docker_logs import start_log_fetching, stop_log_fetching
@@ -107,7 +106,6 @@ containers_router = APIRouter(tags=["containers"])
         }
     },
 )
-@cancellable_request
 async def runs_docker_compose_up(
     _request: Request,
     background_tasks: BackgroundTasks,
@@ -217,7 +215,6 @@ async def runs_docker_compose_down(
         status.HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Errors in container"}
     },
 )
-@cancellable_request
 async def containers_docker_inspect(
     _request: Request,
     only_status: bool = Query(
@@ -264,7 +261,6 @@ async def containers_docker_inspect(
         status.HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Errors in container"},
     },
 )
-@cancellable_request
 async def get_container_logs(
     _request: Request,
     id: str,
@@ -310,7 +306,6 @@ async def get_container_logs(
         },
     },
 )
-@cancellable_request
 async def get_containers_name(
     _request: Request,
     filters: str = Query(
@@ -370,7 +365,6 @@ async def get_containers_name(
         status.HTTP_500_INTERNAL_SERVER_ERROR: {"description": "Errors in container"},
     },
 )
-@cancellable_request
 async def inspect_container(
     _request: Request, id: str, shared_store: SharedStore = Depends(get_shared_store)
 ) -> dict[str, Any]:

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
@@ -18,7 +18,6 @@ from fastapi import (
 )
 from models_library.services import ServiceOutput
 from pydantic.main import BaseModel
-from servicelib.fastapi.requests_decorators import cancellable_request
 from servicelib.utils import logged_gather
 from simcore_sdk.node_ports_v2.port_utils import is_file_type
 
@@ -246,7 +245,6 @@ async def push_output_ports(
         },
     },
 )
-@cancellable_request
 async def restarts_containers(
     _request: Request,
     command_timeout: float = Query(
@@ -295,7 +293,6 @@ async def restarts_containers(
     response_class=Response,
     status_code=status.HTTP_204_NO_CONTENT,
 )
-@cancellable_request
 async def attach_container_to_network(
     _request: Request,
     id: str,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

Removes all ``@cancellable_requests`` decorators from dy-sidecar handlers. This feature malfunctions and currently prevents to start dynamic-services in master deploy. 

This PR reverts cancellable requests added in PR #3155 until we find a more reliable solution

## Related issue/s


- ITISFoundation/osparc-issues#638
