### PR TITLE
🐛 Return correct scheme in storage links when uploading file

### DIFF
--- a/services/web/server/src/simcore_service_webserver/storage_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/storage_handlers.py
@@ -86,7 +86,7 @@ def _unresolve_storage_url(request: web.Request, storage_url: AnyUrl) -> AnyUrl:
     prefix = f"/{_get_storage_vtag(request.app)}"
     converted_url = request.url.with_path(
         f"/v0/storage{storage_url.path.removeprefix(prefix)}"
-    )
+    ).with_scheme(request.headers.get("X-Forwarded-Proto", request.url.scheme))
     return parse_obj_as(AnyUrl, f"{converted_url}")
 
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
The links returned by PUT upload_file are returning the request.scheme and did not check for the ```X-Forwarded-Proto``` header. therefore the links were using ```http``` instead of ```https``` in the deployments.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
