### PR TITLE
🐛 Regression fix: computational services always restarting

### DIFF
--- a/ci/github/unit-testing/service-library.bash
+++ b/ci/github/unit-testing/service-library.bash
@@ -27,7 +27,6 @@ test_all() {
     --durations=10 \
     --log-date-format="%Y-%m-%d %H:%M:%S" \
     --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --numprocesses=auto \
     --verbose \
     -m "not heavy_load" \
     packages/service-library/tests

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_dict.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_dict.py
@@ -1,5 +1,6 @@
 """ Utils to operate with dicts """
 
+from copy import deepcopy
 from typing import Any, Mapping, Optional, Union
 
 ConfigDict = dict[str, Any]
@@ -13,24 +14,37 @@ def get_from_dict(obj: Mapping[str, Any], dotted_key: str, default=None) -> Any:
     return value.get(keys[-1], default)
 
 
-def copy_from_dict(data: dict[str, Any], *, include: Optional[Union[set, dict]] = None):
+def copy_from_dict_ex(data: dict[str, Any], exclude: set[str]) -> dict[str, Any]:
+    # NOTE: to be refactored by someone and merged with the next method
+    return {k: v for k, v in data.items() if k not in exclude}
+
+
+def copy_from_dict(
+    data: dict[str, Any],
+    *,
+    include: Optional[Union[set, dict]] = None,
+    deep: bool = False
+):
     #
     # Analogous to advanced includes from pydantic exports
     #   https://pydantic-docs.helpmanual.io/usage/exporting_models/#advanced-include-and-exclude
     #
 
     if include is None:
-        return data.copy()
+        return deepcopy(data) if deep else data.copy()
 
     if include == ...:
-        return data
+        return deepcopy(data) if deep else data.copy()
 
     if isinstance(include, set):
         return {key: data[key] for key in include}
 
     assert isinstance(include, dict)  # nosec
 
-    return {key: copy_from_dict(data[key], include=include[key]) for key in include}
+    return {
+        key: copy_from_dict(data[key], include=include[key], deep=deep)
+        for key in include
+    }
 
 
 def update_dict(obj: dict, **updates):

--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -225,7 +225,7 @@ def _add_to_archive(
             for file_to_add in _iter_files_to_compress(
                 dir_to_compress, exclude_patterns
             ):
-                progress_bar.set_description(f"{desc}/{file_to_add.name}")
+                progress_bar.set_description(f"{desc}/{file_to_add.name}\n")
                 file_name_in_archive = (
                     _strip_directory_from_path(file_to_add, dir_to_compress)
                     if store_relative_path

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
@@ -9,7 +9,6 @@ from uuid import UUID
 import pytest
 import respx
 from fastapi import FastAPI
-from fastapi.encoders import jsonable_encoder
 from models_library.aiodocker_api import AioDockerServiceSpec
 from models_library.service_settings_labels import (
     SimcoreServiceLabels,
@@ -348,12 +347,15 @@ def test_get_dynamic_proxy_spec(
             app_settings=minimal_app.state.settings,
         )
         assert dynamic_sidecar_spec
-        assert jsonable_encoder(dynamic_sidecar_spec) == jsonable_encoder(
-            AioDockerServiceSpec.parse_obj(expected_dynamic_sidecar_spec)
+        assert (
+            dynamic_sidecar_spec.dict()
+            == AioDockerServiceSpec.parse_obj(expected_dynamic_sidecar_spec).dict()
         )
         dynamic_sidecar_spec_accumulated = dynamic_sidecar_spec
-    assert jsonable_encoder(dynamic_sidecar_spec_accumulated) == jsonable_encoder(
-        AioDockerServiceSpec.parse_obj(expected_dynamic_sidecar_spec)
+    assert dynamic_sidecar_spec_accumulated is not None
+    assert (
+        dynamic_sidecar_spec_accumulated.dict()
+        == AioDockerServiceSpec.parse_obj(expected_dynamic_sidecar_spec).dict()
     )
     # TODO: finish test when working on https://github.com/ITISFoundation/osparc-simcore/issues/2454
 
@@ -380,8 +382,8 @@ async def test_merge_dynamic_sidecar_specs_with_user_specific_specs(
     )
     assert dynamic_sidecar_spec
     assert (
-        jsonable_encoder(dynamic_sidecar_spec, by_alias=True, exclude_unset=True)
-        == expected_dynamic_sidecar_spec
+        dynamic_sidecar_spec.dict()
+        == AioDockerServiceSpec.parse_obj(expected_dynamic_sidecar_spec).dict()
     )
 
     catalog_client = CatalogClient.instance(minimal_app)

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
@@ -316,9 +316,8 @@ def expected_dynamic_sidecar_spec(run_id: UUID) -> dict[str, Any]:
     }
 
 
-# TESTS
-
-
+# NOTE: this test is flaky because of a set is serialized unsorted
+@pytest.mark.flaky(max_runs=3)
 def test_get_dynamic_proxy_spec(
     mocked_catalog_service_api: respx.MockRouter,
     minimal_app: FastAPI,
@@ -335,10 +334,15 @@ def test_get_dynamic_proxy_spec(
         dynamic_sidecar_settings.dict()
         == minimal_app.state.settings.DYNAMIC_SERVICES.DYNAMIC_SIDECAR.dict()
     )
-
+    expected_dynamic_sidecar_spec_model = AioDockerServiceSpec.parse_obj(
+        expected_dynamic_sidecar_spec
+    )
+    assert expected_dynamic_sidecar_spec_model.TaskTemplate
+    assert expected_dynamic_sidecar_spec_model.TaskTemplate.ContainerSpec
+    assert expected_dynamic_sidecar_spec_model.TaskTemplate.ContainerSpec.Env
     for count in range(1, 11):  # loop to check it does not repeat copies
         print(f"{count:*^50}")
-        dynamic_sidecar_spec = get_dynamic_sidecar_spec(
+        dynamic_sidecar_spec: AioDockerServiceSpec = get_dynamic_sidecar_spec(
             scheduler_data=scheduler_data,
             dynamic_sidecar_settings=dynamic_sidecar_settings,
             dynamic_sidecar_network_id=dynamic_sidecar_network_id,
@@ -346,20 +350,16 @@ def test_get_dynamic_proxy_spec(
             settings=cast(SimcoreServiceSettingsLabel, simcore_service_labels.settings),
             app_settings=minimal_app.state.settings,
         )
-        assert dynamic_sidecar_spec
-        assert (
-            dynamic_sidecar_spec.dict()
-            == AioDockerServiceSpec.parse_obj(expected_dynamic_sidecar_spec).dict()
-        )
+
+        assert dynamic_sidecar_spec == expected_dynamic_sidecar_spec_model
         dynamic_sidecar_spec_accumulated = dynamic_sidecar_spec
     assert dynamic_sidecar_spec_accumulated is not None
-    assert (
-        dynamic_sidecar_spec_accumulated.dict()
-        == AioDockerServiceSpec.parse_obj(expected_dynamic_sidecar_spec).dict()
-    )
+    assert dynamic_sidecar_spec_accumulated == expected_dynamic_sidecar_spec_model
     # TODO: finish test when working on https://github.com/ITISFoundation/osparc-simcore/issues/2454
 
 
+# NOTE: this test is flaky because of a set is serialized unsorted
+@pytest.mark.flaky(max_runs=3)
 async def test_merge_dynamic_sidecar_specs_with_user_specific_specs(
     mocked_catalog_service_api: respx.MockRouter,
     minimal_app: FastAPI,
@@ -381,9 +381,8 @@ async def test_merge_dynamic_sidecar_specs_with_user_specific_specs(
         app_settings=minimal_app.state.settings,
     )
     assert dynamic_sidecar_spec
-    assert (
-        dynamic_sidecar_spec.dict()
-        == AioDockerServiceSpec.parse_obj(expected_dynamic_sidecar_spec).dict()
+    assert dynamic_sidecar_spec == AioDockerServiceSpec.parse_obj(
+        expected_dynamic_sidecar_spec
     )
 
     catalog_client = CatalogClient.instance(minimal_app)

--- a/services/storage/tests/unit/test_handlers_simcore_s3.py
+++ b/services/storage/tests/unit/test_handlers_simcore_s3.py
@@ -362,6 +362,7 @@ def mock_check_project_exists(mocker: MockerFixture):
     )
 
 
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize(
     "project",
     [pytest.param(prj, id=prj.name) for prj in _get_project_with_data()],

--- a/services/web/server/src/simcore_service_webserver/projects/projects_db.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_db.py
@@ -663,7 +663,7 @@ class ProjectDBAPI:
                 # update the workbench
                 def _update_workbench(
                     old_project: ProjectDict, new_project: ProjectDict
-                ) -> ProjectDict:
+                ) -> None:
                     # any non set entry in the new workbench is taken from the old one if available
                     old_workbench = old_project["workbench"]
                     new_workbench = new_project["workbench"]
@@ -676,7 +676,6 @@ class ProjectDBAPI:
                             if prop not in node:
                                 # use the old value
                                 node[prop] = old_node[prop]
-                    return new_project
 
                 _update_workbench(current_project, new_project_data)
                 # update timestamps

--- a/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_utils.py
@@ -324,7 +324,7 @@ def find_changed_node_keys(
     *,
     look_for_removed_keys: bool,
 ) -> dict[str, Any]:
-    # The `store` key inside outputs can be either `0` (integer) or `"0"` (string)
+    # The `store` key inside outputs could be either `0` (integer) or `"0"` (string)
     # this generates false positives.
     # Casting to `int` to fix the issue.
     # NOTE: this could make services relying on side effects to stop form propagating

--- a/services/web/server/tests/unit/with_dbs/02/test_project_db.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_project_db.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 from itertools import combinations
 from random import randint
 from secrets import choice
-from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Set, Tuple
+from typing import Any, AsyncIterator, Iterator, Optional
 from uuid import UUID, uuid5
 
 import pytest
@@ -21,26 +21,28 @@ from aiohttp.test_utils import TestClient
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from psycopg2.errors import UniqueViolation
+from pytest_simcore.helpers.utils_login import UserInfoDict
 from simcore_postgres_database.models.groups import GroupType
 from simcore_service_webserver.db_models import UserRole
+from simcore_service_webserver.projects.project_models import ProjectDict
 from simcore_service_webserver.projects.projects_db import (
+    APP_PROJECT_DBAPI,
+    DB_EXCLUSIVE_COLUMNS,
+    SCHEMA_NON_NULL_KEYS,
+    ProjectAccessRights,
+    ProjectDBAPI,
+    ProjectInvalidRightsError,
     _check_project_permissions,
     _convert_to_db_names,
     _convert_to_schema_names,
     _create_project_access_rights,
-    APP_PROJECT_DBAPI,
-    DB_EXCLUSIVE_COLUMNS,
-    ProjectAccessRights,
-    ProjectDBAPI,
-    ProjectInvalidRightsError,
-    SCHEMA_NON_NULL_KEYS,
 )
 from simcore_service_webserver.users_exceptions import UserNotFoundError
 from simcore_service_webserver.utils import to_datetime
 from sqlalchemy.engine.result import Row
 
 
-def test_convert_to_db_names(fake_project: Dict[str, Any]):
+def test_convert_to_db_names(fake_project: dict[str, Any]):
     db_entries = _convert_to_db_names(fake_project)
     assert "tags" not in db_entries
     assert "prjOwner" not in db_entries
@@ -49,7 +51,7 @@ def test_convert_to_db_names(fake_project: Dict[str, Any]):
     assert re.match(r"[A-Z]", json.dumps(list(db_entries.keys()))) is None
 
 
-def test_convert_to_schema_names(fake_project: Dict[str, Any]):
+def test_convert_to_schema_names(fake_project: dict[str, Any]):
     db_entries = _convert_to_db_names(fake_project)
 
     schema_entries = _convert_to_schema_names(db_entries, fake_project["prjOwner"])
@@ -109,7 +111,7 @@ def test_project_access_rights_creation(
     assert git_to_access_rights[str(group_id)] == project_access_rights.value
 
 
-def all_permission_combinations() -> List[str]:
+def all_permission_combinations() -> list[str]:
     entries_list = ["read", "write", "delete"]
     temp = []
     for i in range(1, len(entries_list) + 1):
@@ -139,7 +141,7 @@ def test_check_project_permissions(
 
     def _project_access_rights_from_permissions(
         permissions: str, invert: bool = False
-    ) -> Dict[str, bool]:
+    ) -> dict[str, bool]:
         access_rights = {}
         for p in ["read", "write", "delete"]:
             access_rights[p] = (
@@ -256,9 +258,9 @@ def db_api(client: TestClient, postgres_db: sa.engine.Engine) -> Iterator[Projec
 
 
 def _assert_added_project(
-    exp_project: Dict[str, Any],
-    added_project: Dict[str, Any],
-    exp_overrides: Dict[str, Any],
+    exp_project: dict[str, Any],
+    added_project: dict[str, Any],
+    exp_overrides: dict[str, Any],
 ):
     original_prj = deepcopy(exp_project)
     added_prj = deepcopy(added_project)
@@ -281,7 +283,7 @@ def _assert_added_project(
 
 
 def _assert_project_db_row(
-    postgres_db: sa.engine.Engine, project: Dict[str, Any], **kwargs
+    postgres_db: sa.engine.Engine, project: dict[str, Any], **kwargs
 ):
     row: Optional[Row] = postgres_db.execute(
         f"SELECT * FROM projects WHERE \"uuid\"='{project['uuid']}'"
@@ -319,10 +321,10 @@ def _assert_project_db_row(
     ],
 )
 async def test_add_project_to_db(
-    fake_project: Dict[str, Any],
+    fake_project: dict[str, Any],
     postgres_db: sa.engine.Engine,
-    logged_user: Dict[str, Any],
-    primary_group: Dict[str, str],
+    logged_user: dict[str, Any],
+    primary_group: dict[str, str],
     db_api: ProjectDBAPI,
 ):
     original_project = deepcopy(fake_project)
@@ -440,10 +442,10 @@ async def test_add_project_to_db(
 )
 @pytest.mark.parametrize("number_of_nodes", [1, randint(250, 300)])
 async def test_patch_user_project_workbench_concurrently(
-    fake_project: Dict[str, Any],
+    fake_project: dict[str, Any],
     postgres_db: sa.engine.Engine,
-    logged_user: Dict[str, Any],
-    primary_group: Dict[str, str],
+    logged_user: dict[str, Any],
+    primary_group: dict[str, str],
     db_api: ProjectDBAPI,
     number_of_nodes: int,
 ):
@@ -492,8 +494,8 @@ async def test_patch_user_project_workbench_concurrently(
     for n in range(_NUMBER_OF_NODES):
         expected_project["workbench"][node_uuids[n]].update(randomly_created_outputs[n])
 
-    patched_projects: Tuple[
-        Tuple[Dict[str, Any], Dict[str, Any]]
+    patched_projects: tuple[
+        tuple[dict[str, Any], dict[str, Any]]
     ] = await asyncio.gather(
         *[
             db_api.patch_user_project_workbench(
@@ -598,10 +600,10 @@ async def test_patch_user_project_workbench_concurrently(
 
 @pytest.fixture()
 async def lots_of_projects_and_nodes(
-    logged_user: Dict[str, Any],
-    fake_project: Dict[str, Any],
+    logged_user: dict[str, Any],
+    fake_project: dict[str, Any],
     db_api: ProjectDBAPI,
-) -> AsyncIterator[Dict[ProjectID, List[NodeID]]]:
+) -> AsyncIterator[dict[ProjectID, list[NodeID]]]:
     """Will create >1000 projects with each between 200-1434 nodes"""
     NUMBER_OF_PROJECTS = 1245
 
@@ -645,7 +647,7 @@ async def lots_of_projects_and_nodes(
     [UserRole.USER],
 )
 async def test_node_id_exists(
-    db_api: ProjectDBAPI, lots_of_projects_and_nodes: Dict[ProjectID, List[NodeID]]
+    db_api: ProjectDBAPI, lots_of_projects_and_nodes: dict[ProjectID, list[NodeID]]
 ):
 
     # create a node uuid that does not exist from an existing project
@@ -668,12 +670,81 @@ async def test_node_id_exists(
     [UserRole.USER],
 )
 async def test_get_node_ids_from_project(
-    db_api: ProjectDBAPI, lots_of_projects_and_nodes: Dict[ProjectID, List[NodeID]]
+    db_api: ProjectDBAPI, lots_of_projects_and_nodes: dict[ProjectID, list[NodeID]]
 ):
     for project_id in lots_of_projects_and_nodes:
-        node_ids_inside_project: Set[str] = await db_api.get_node_ids_from_project(
+        node_ids_inside_project: set[str] = await db_api.get_node_ids_from_project(
             f"{project_id}"
         )
         assert node_ids_inside_project == {
             f"{n}" for n in lots_of_projects_and_nodes[project_id]
         }
+
+
+def _ignore_dict_keys(input_dict: dict[str, Any], exclude: set[str]) -> dict[str, Any]:
+    return {k: v for k, v in input_dict.items() if k not in exclude}
+
+
+@pytest.mark.parametrize(
+    "user_role",
+    [UserRole.USER],
+)
+async def test_replace_user_project(
+    db_api: ProjectDBAPI,
+    user_project: ProjectDict,
+    logged_user: UserInfoDict,
+):
+    PROJECT_DICT_IGNORE_FIELDS = {"lastChangeDate"}
+    original_project = user_project
+    # replace the project with the same should do nothing
+    working_project = await db_api.replace_user_project(
+        original_project,
+        user_id=logged_user["id"],
+        project_uuid=original_project["uuid"],
+    )
+    assert _ignore_dict_keys(
+        original_project, PROJECT_DICT_IGNORE_FIELDS
+    ) == _ignore_dict_keys(working_project, PROJECT_DICT_IGNORE_FIELDS)
+
+    # now let's create some outputs (similar to what happens when running services)
+    NODE_INDEX = 1  # this is not the file-picker
+    node_id = tuple(working_project["workbench"].keys())[NODE_INDEX]
+    node_data = working_project["workbench"][node_id]
+    node_data["progress"] = 100
+    node_data["outputs"] = {
+        "output_1": {
+            "store": 0,
+            "path": "687b8dc2-fea2-11ec-b7fd-02420a6e3a4d/d61a2ec8-19b4-4375-adcb-fdd22f850333/single_number.txt",
+            "eTag": "c4ca4238a0b923820dcc509a6f75849b",
+        },
+        "output_2": 5,
+    }
+    node_data[
+        "runHash"
+    ] = "5b0583fa546ac82f0e41cef9705175b7187ce3928ba42892e842add912c16676"
+    # replacing with the new entries shall return the very same data
+    replaced_project = await db_api.replace_user_project(
+        working_project,
+        user_id=logged_user["id"],
+        project_uuid=working_project["uuid"],
+    )
+    assert _ignore_dict_keys(
+        working_project, PROJECT_DICT_IGNORE_FIELDS
+    ) == _ignore_dict_keys(replaced_project, PROJECT_DICT_IGNORE_FIELDS)
+
+    # the frontend sends project without some fields, but for FRONTEND type of nodes
+    # replacing should keep the values
+    FRONTEND_EXCLUDED_FIELDS = ["outputs", "progress", "runHash"]
+    incoming_frontend_project = deepcopy(original_project)
+    for node_data in incoming_frontend_project["workbench"].values():
+        if "frontend" not in node_data["key"]:
+            for field in FRONTEND_EXCLUDED_FIELDS:
+                node_data.pop(field, None)
+    replaced_project = await db_api.replace_user_project(
+        incoming_frontend_project,
+        user_id=logged_user["id"],
+        project_uuid=incoming_frontend_project["uuid"],
+    )
+    assert _ignore_dict_keys(
+        working_project, PROJECT_DICT_IGNORE_FIELDS
+    ) == _ignore_dict_keys(replaced_project, PROJECT_DICT_IGNORE_FIELDS)

--- a/services/web/server/tests/unit/with_dbs/02/test_project_db.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_project_db.py
@@ -21,6 +21,7 @@ from aiohttp.test_utils import TestClient
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from psycopg2.errors import UniqueViolation
+from pytest_simcore.helpers.utils_dict import copy_from_dict_ex
 from pytest_simcore.helpers.utils_login import UserInfoDict
 from simcore_postgres_database.models.groups import GroupType
 from simcore_service_webserver.db_models import UserRole
@@ -681,10 +682,6 @@ async def test_get_node_ids_from_project(
         }
 
 
-def _ignore_dict_keys(input_dict: dict[str, Any], exclude: set[str]) -> dict[str, Any]:
-    return {k: v for k, v in input_dict.items() if k not in exclude}
-
-
 @pytest.mark.parametrize(
     "user_role",
     [UserRole.USER],
@@ -702,9 +699,9 @@ async def test_replace_user_project(
         user_id=logged_user["id"],
         project_uuid=original_project["uuid"],
     )
-    assert _ignore_dict_keys(
+    assert copy_from_dict_ex(
         original_project, PROJECT_DICT_IGNORE_FIELDS
-    ) == _ignore_dict_keys(working_project, PROJECT_DICT_IGNORE_FIELDS)
+    ) == copy_from_dict_ex(working_project, PROJECT_DICT_IGNORE_FIELDS)
 
     # now let's create some outputs (similar to what happens when running services)
     NODE_INDEX = 1  # this is not the file-picker
@@ -728,9 +725,9 @@ async def test_replace_user_project(
         user_id=logged_user["id"],
         project_uuid=working_project["uuid"],
     )
-    assert _ignore_dict_keys(
+    assert copy_from_dict_ex(
         working_project, PROJECT_DICT_IGNORE_FIELDS
-    ) == _ignore_dict_keys(replaced_project, PROJECT_DICT_IGNORE_FIELDS)
+    ) == copy_from_dict_ex(replaced_project, PROJECT_DICT_IGNORE_FIELDS)
 
     # the frontend sends project without some fields, but for FRONTEND type of nodes
     # replacing should keep the values
@@ -745,6 +742,6 @@ async def test_replace_user_project(
         user_id=logged_user["id"],
         project_uuid=incoming_frontend_project["uuid"],
     )
-    assert _ignore_dict_keys(
+    assert copy_from_dict_ex(
         working_project, PROJECT_DICT_IGNORE_FIELDS
-    ) == _ignore_dict_keys(replaced_project, PROJECT_DICT_IGNORE_FIELDS)
+    ) == copy_from_dict_ex(replaced_project, PROJECT_DICT_IGNORE_FIELDS)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Fixes regression.
added test to prevent this to happen again.

currently no test for the origin of the problem: https://github.com/ITISFoundation/osparc-simcore/pull/3058

## Related issue/s
closes #3137 
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
