### PR TITLE
♻️ Is638/dy sidecar refactoring (round 6)

### DIFF
--- a/packages/service-library/src/servicelib/fastapi/openapi.py
+++ b/packages/service-library/src/servicelib/fastapi/openapi.py
@@ -10,10 +10,13 @@ from fastapi.routing import APIRoute, APIRouter
 
 from ..functools_utils import copy_func
 
-# Some common values for FastAPI(... server=[ ... ]) parameter
-# It will be added to the OpenAPI Specs (OAS).
+# SEE https://swagger.io/docs/specification/api-host-and-base-path/
+_OAS_DEFAULT_SERVER = {
+    "description": "Default server: requests directed to serving url",
+    "url": "/",
+}
 _OAS_DEVELOPMENT_SERVER = {
-    "description": "Development server",
+    "description": "Development server: can configure any base url",
     "url": "http://{host}:{port}",
     "variables": {
         "host": {"default": "127.0.0.1"},
@@ -24,14 +27,14 @@ _OAS_DEVELOPMENT_SERVER = {
 
 def get_common_oas_options(is_devel_mode: bool) -> dict[str, Any]:
     """common OAS options for FastAPI constructor"""
-    servers = None
+    servers = [
+        _OAS_DEFAULT_SERVER,
+    ]
     if is_devel_mode:
         # NOTE: for security, only exposed in devel mode
         # Make sure also that this is NOT used in edge services
         # SEE https://sonarcloud.io/project/security_hotspots?id=ITISFoundation_osparc-simcore&pullRequest=3165&hotspots=AYHPqDfX5LRQZ1Ko6y4-
-        servers = [
-            _OAS_DEVELOPMENT_SERVER,
-        ]
+        servers.append(_OAS_DEVELOPMENT_SERVER)
 
     return dict(
         servers=servers,

--- a/packages/service-library/tests/test_async_utils.py
+++ b/packages/service-library/tests/test_async_utils.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
+# pylint: disable=unused-variable
 
 import asyncio
 import copy
@@ -7,9 +8,10 @@ import random
 from collections import deque
 from dataclasses import dataclass
 from time import time
-from typing import Any, AsyncIterable, Dict, List, Optional
+from typing import Any, AsyncIterable, Optional
 
 import pytest
+from faker import Faker
 from servicelib.async_utils import (
     _sequential_jobs_contexts,
     run_sequentially_in_context,
@@ -30,8 +32,8 @@ async def ensure_run_in_sequence_context_is_empty() -> AsyncIterable[None]:
 
 
 @pytest.fixture
-def payload() -> str:
-    return "some string payload"
+def payload(faker: Faker) -> str:
+    return faker.text()
 
 
 @pytest.fixture
@@ -55,7 +57,7 @@ class LockedStore:
         async with self._lock:
             self._queue.append(item)
 
-    async def get_all(self) -> List[Any]:
+    async def get_all(self) -> list[Any]:
         async with self._lock:
             return list(self._queue)
 
@@ -78,7 +80,7 @@ async def test_context_aware_dispatch(
         context = dict(c1=c1, c2=c2, c3=c3)
         await locked_stores[make_key_from_context(context)].push(control)
 
-    def make_key_from_context(context: Dict) -> str:
+    def make_key_from_context(context: dict) -> str:
         return ".".join([f"{k}:{v}" for k, v in context.items()])
 
     def make_context():

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/task.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/task.py
@@ -365,8 +365,9 @@ class DynamicSidecarsScheduler:
 
                 error_code = create_error_code(e)
                 logger.exception(
-                    "Observation of %s unexpectedly failed",
-                    f"{service_name=}",
+                    "Observation of %s unexpectedly failed [%s]",
+                    f"{service_name=} ",
+                    f"{error_code}",
                     extra={"error_code": error_code},
                 )
                 scheduler_data.dynamic_sidecar.status.update_failing_status(

--- a/services/dynamic-sidecar/docker/boot.sh
+++ b/services/dynamic-sidecar/docker/boot.sh
@@ -6,11 +6,16 @@ IFS=$(printf '\n\t')
 
 INFO="INFO: [$(basename "$0")] "
 
-# BOOTING application ---------------------------------------------
 echo "$INFO" "Booting in ${SC_BOOT_MODE} mode ..."
 echo "$INFO" "User :$(id "$(whoami)")"
 echo "$INFO" "Workdir : $(pwd)"
 
+#
+# DEVELOPMENT MODE
+#
+# - prints environ info
+# - installs requirements in mounted volume
+#
 if [ "${SC_BUILD_TARGET}" = "development" ]; then
   echo "$INFO" "Environment :"
   printenv | sed 's/=/: /' | sed 's/^/    /' | sort
@@ -25,8 +30,10 @@ if [ "${SC_BUILD_TARGET}" = "development" ]; then
   pip list | sed 's/^/    /'
 fi
 
-# RUNNING application ----------------------------------------
-APP_LOG_LEVEL=${DIRECTOR_V2_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL:-INFO}}}
+#
+# RUNNING application
+#
+APP_LOG_LEVEL=${DYNAMIC_SIDECAR_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL:-INFO}}}
 SERVER_LOG_LEVEL=$(echo "${APP_LOG_LEVEL}" | tr '[:upper:]' '[:lower:]')
 echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
 
@@ -46,5 +53,4 @@ else
   exec uvicorn simcore_service_dynamic_sidecar.main:the_app \
     --host 0.0.0.0 \
     --log-level "${SERVER_LOG_LEVEL}"
-
 fi

--- a/services/dynamic-sidecar/openapi.json
+++ b/services/dynamic-sidecar/openapi.json
@@ -7,8 +7,12 @@
   },
   "servers": [
     {
+      "url": "/",
+      "description": "Default server: requests directed to serving url"
+    },
+    {
       "url": "http://{host}:{port}",
-      "description": "Development server",
+      "description": "Development server: can configure any base url",
       "variables": {
         "host": {
           "default": "127.0.0.1"
@@ -99,9 +103,9 @@
             "required": false,
             "schema": {
               "title": "Command Timeout",
-              "type": "integer",
+              "type": "number",
               "description": "docker-compose up command timeout run as a background",
-              "default": 3600
+              "default": 3600.0
             },
             "name": "command_timeout",
             "in": "query"
@@ -111,9 +115,9 @@
             "required": false,
             "schema": {
               "title": "Validation Timeout",
-              "type": "integer",
+              "type": "number",
               "description": "docker-compose config timeout (EXPERIMENTAL)",
-              "default": 60
+              "default": 60.0
             },
             "name": "validation_timeout",
             "in": "query"
@@ -164,9 +168,9 @@
             "required": false,
             "schema": {
               "title": "Command Timeout",
-              "type": "integer",
+              "type": "number",
               "description": "docker-compose down command timeout default  (EXPERIMENTAL)",
-              "default": 10
+              "default": 10.0
             },
             "name": "command_timeout",
             "in": "query"
@@ -596,9 +600,9 @@
             "required": false,
             "schema": {
               "title": "Command Timeout",
-              "type": "integer",
+              "type": "number",
               "description": "docker-compose stop command timeout default",
-              "default": 10
+              "default": 10.0
             },
             "name": "command_timeout",
             "in": "query"

--- a/services/dynamic-sidecar/openapi.json
+++ b/services/dynamic-sidecar/openapi.json
@@ -99,9 +99,9 @@
             "required": false,
             "schema": {
               "title": "Command Timeout",
-              "type": "number",
+              "type": "integer",
               "description": "docker-compose up command timeout run as a background",
-              "default": 3600.0
+              "default": 3600
             },
             "name": "command_timeout",
             "in": "query"
@@ -111,9 +111,9 @@
             "required": false,
             "schema": {
               "title": "Validation Timeout",
-              "type": "number",
+              "type": "integer",
               "description": "docker-compose config timeout (EXPERIMENTAL)",
-              "default": 60.0
+              "default": 60
             },
             "name": "validation_timeout",
             "in": "query"
@@ -164,9 +164,9 @@
             "required": false,
             "schema": {
               "title": "Command Timeout",
-              "type": "number",
+              "type": "integer",
               "description": "docker-compose down command timeout default  (EXPERIMENTAL)",
-              "default": 10.0
+              "default": 10
             },
             "name": "command_timeout",
             "in": "query"
@@ -596,9 +596,9 @@
             "required": false,
             "schema": {
               "title": "Command Timeout",
-              "type": "number",
+              "type": "integer",
               "description": "docker-compose stop command timeout default",
-              "default": 10.0
+              "default": 10
             },
             "name": "command_timeout",
             "in": "query"

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
@@ -158,9 +158,9 @@ def create_app():
                 command_timeout=app.state.settings.DYNAMIC_SIDECAR_DOCKER_COMPOSE_DOWN_TIMEOUT,
             )
 
-            logger.info(
-                "Removed spawned containers [%s]:\n%s",
-                "OK" if result.success else "FAILED",
+            logger.log(
+                logging.INFO if result.success else logging.ERROR,
+                "Removed spawned containers:\n%s",
                 result.decoded_stdout,
             )
         # FINISHED

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
@@ -47,10 +47,10 @@ TSCHUESS_MSG = "{:=^100}".format("🎉 App shutdown completed 🎉")
 
 
 class AppState:
-    """Guarantees states are initialized upon construction
+    """Exposes states of an initialized app
 
-    Defines access to app's states, i.e. which are read/write
-    after the app is initialized
+    Provides a stricter control on the read/write access
+    of the different app.state fields during the app's lifespan
     """
 
     _STATES = {
@@ -67,7 +67,9 @@ class AppState:
             if not isinstance(getattr(initialized_app.state, name, None), type_)
         ]
         if errors:
-            raise ValueError(f"App states are not properly initialized. Found {errors}")
+            raise ValueError(
+                f"These app states were not properly initialized: {errors}"
+            )
 
         self._app = initialized_app
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
@@ -84,13 +84,13 @@ class AppState:
         return self._app.state.mounted_volumes
 
     @property
-    def _shared_store(self) -> SharedStore:
+    def shared_store(self) -> SharedStore:
         assert isinstance(self._app.state.shared_store, SharedStore)  # nosec
         return self._app.state.shared_store
 
     @property
     def compose_spec(self) -> Optional[str]:
-        return self._shared_store.compose_spec
+        return self.shared_store.compose_spec
 
 
 def setup_logger(settings: DynamicSidecarSettings):
@@ -161,10 +161,10 @@ def create_app():
 
     async def _on_shutdown() -> None:
         if docker_compose_yaml := app_state.compose_spec:
-            logger.info("Removing spawned containers")
+            logger.info("Removing spawned containers%s", docker_compose_yaml)
 
             result = await docker_compose_down(
-                docker_compose_yaml,
+                app.state.shared_store,
                 app.state.settings,
                 command_timeout=app.state.settings.DYNAMIC_SIDECAR_DOCKER_COMPOSE_DOWN_TIMEOUT,
             )

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 # https://patorjk.com/software/taag/#p=display&f=AMC%20Tubes&t=DYSIDECAR
 #
 
-WELCOME_MSG = r"""
+APP_STARTED_BANNER_MSG = r"""
 d ss    Ss   sS   sss. d d ss    d sss     sSSs. d s.   d ss.
 S   ~o    S S   d      S S   ~o  S        S      S  ~O  S    b
 S     b    S    Y      S S     b S       S       S   `b S    P
@@ -43,7 +43,7 @@ P ss"      P    ` ss'  P P ss"   P sSSss   "sss' P    P P    P   {} 🚀
     f"v{__version__}"
 )
 
-TSCHUESS_MSG = "{:=^100}".format("🎉 App shutdown completed 🎉")
+APP_FINISHED_BANNER_MSG = "{:=^100}".format("🎉 App shutdown completed 🎉")
 
 
 class AppState:
@@ -157,7 +157,7 @@ def create_app():
         await login_registry(app_state.settings.REGISTRY_SETTINGS)
         await volumes_fix_permissions(app_state.mounted_volumes)
         # STARTED
-        print(WELCOME_MSG, flush=True)
+        print(APP_STARTED_BANNER_MSG, flush=True)
 
     async def _on_shutdown() -> None:
         if docker_compose_yaml := app_state.compose_spec:
@@ -175,7 +175,7 @@ def create_app():
                 result.decoded_stdout,
             )
         # FINISHED
-        print(TSCHUESS_MSG, flush=True)
+        print(APP_FINISHED_BANNER_MSG, flush=True)
 
     app.add_event_handler("startup", _on_startup)
     app.add_event_handler("shutdown", _on_shutdown)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
@@ -43,7 +43,7 @@ P ss"      P    ` ss'  P P ss"   P sSSss   "sss' P    P P    P   {} 🚀
     f"v{__version__}"
 )
 
-TSCHUESS_MSG = "{:=^100}".format("App shutdown completed 🎉")
+TSCHUESS_MSG = "{:=^100}".format("🎉 App shutdown completed 🎉")
 
 
 class AppState:

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
@@ -53,28 +53,37 @@ class AppState:
     after the app is initialized
     """
 
+    _STATES = {
+        "settings": DynamicSidecarSettings,
+        "mounted_volumes": MountedVolumes,
+        "shared_store": SharedStore,
+    }
+
     def __init__(self, initialized_app: FastAPI):
         # guarantees app states are in place
-        assert isinstance(
-            initialized_app.state.settings, DynamicSidecarSettings
-        )  # nosec
-        assert isinstance(
-            initialized_app.state.mounted_volumes, MountedVolumes
-        )  # nosec
-        assert isinstance(initialized_app.state.shared_store, SharedStore)  # nosec
+        errors = [
+            "app.state.{name}"
+            for name, type_ in AppState._STATES.items()
+            if not isinstance(getattr(initialized_app.state, name, None), type_)
+        ]
+        if errors:
+            raise ValueError(f"App states are not properly initialized. Found {errors}")
 
         self._app = initialized_app
 
     @property
     def settings(self) -> DynamicSidecarSettings:
+        assert isinstance(self._app.state.settings, DynamicSidecarSettings)  # nosec
         return self._app.state.settings
 
     @property
     def mounted_volumes(self) -> MountedVolumes:
+        assert isinstance(self._app.state.mounted_volumes, MountedVolumes)  # nosec
         return self._app.state.mounted_volumes
 
     @property
     def _shared_store(self) -> SharedStore:
+        assert isinstance(self._app.state.shared_store, SharedStore)  # nosec
         return self._app.state.shared_store
 
     @property

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/settings.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/settings.py
@@ -32,7 +32,9 @@ class DynamicSidecarSettings(BaseCustomSettings, MixinLoggingSettings):
     )
 
     # LOGGING
-    LOG_LEVEL: str = Field(default="WARNING")
+    LOG_LEVEL: str = Field(
+        default="WARNING", env=["DYNAMIC_SIDECAR_LOGLEVEL", "LOG_LEVEL", "LOGLEVEL"]
+    )
 
     # SERVICE SERVER (see : https://www.uvicorn.org/settings/)
     DYNAMIC_SIDECAR_HOST: str = Field(

--- a/services/dynamic-sidecar/tests/conftest.py
+++ b/services/dynamic-sidecar/tests/conftest.py
@@ -16,8 +16,12 @@ from models_library.projects import ProjectID
 from models_library.projects_nodes import NodeID
 from models_library.users import UserID
 from pytest import MonkeyPatch
-from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_envfile
 from servicelib.json_serialization import json_dumps
+from pytest_simcore.helpers.utils_envs import (
+    EnvVarsDict,
+    setenvs_from_dict,
+    setenvs_from_envfile,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -125,40 +129,45 @@ def mock_environment(
     project_id: ProjectID,
     node_id: NodeID,
     run_id: UUID,
-) -> None:
+) -> EnvVarsDict:
     """Main test environment used to build the application
 
     Override if new configuration for the app is needed.
     """
+    envs = {}
     # envs in Dockerfile
-    monkeypatch.setenv("SC_BOOT_MODE", "production")
-    monkeypatch.setenv("SC_BUILD_TARGET", "production")
-    monkeypatch.setenv("DYNAMIC_SIDECAR_DY_VOLUMES_MOUNT_DIR", f"{dy_volumes}")
+    envs["SC_BOOT_MODE"] = "production"
+    envs["SC_BUILD_TARGET"] = "production"
+    envs["DYNAMIC_SIDECAR_DY_VOLUMES_MOUNT_DIR"] = f"{dy_volumes}"
 
     # envs on container
-    monkeypatch.setenv("DYNAMIC_SIDECAR_COMPOSE_NAMESPACE", compose_namespace)
+    envs["DYNAMIC_SIDECAR_COMPOSE_NAMESPACE"] = compose_namespace
 
-    monkeypatch.setenv("REGISTRY_AUTH", "false")
-    monkeypatch.setenv("REGISTRY_USER", "test")
-    monkeypatch.setenv("REGISTRY_PW", "test")
-    monkeypatch.setenv("REGISTRY_SSL", "false")
+    envs["REGISTRY_AUTH"] = "false"
+    envs["REGISTRY_USER"] = "test"
+    envs["REGISTRY_PW"] = "test"
+    envs["REGISTRY_SSL"] = "false"
 
-    monkeypatch.setenv("DY_SIDECAR_USER_ID", f"{user_id}")
-    monkeypatch.setenv("DY_SIDECAR_PROJECT_ID", f"{project_id}")
-    monkeypatch.setenv("DY_SIDECAR_RUN_ID", f"{run_id}")
-    monkeypatch.setenv("DY_SIDECAR_NODE_ID", f"{node_id}")
-    monkeypatch.setenv("DY_SIDECAR_PATH_INPUTS", f"{inputs_dir}")
-    monkeypatch.setenv("DY_SIDECAR_PATH_OUTPUTS", f"{outputs_dir}")
-    monkeypatch.setenv("DY_SIDECAR_STATE_PATHS", json_dumps(state_paths_dirs))
-    monkeypatch.setenv("DY_SIDECAR_STATE_EXCLUDE", json_dumps(state_exclude_dirs))
+    envs["DY_SIDECAR_USER_ID"] = f"{user_id}"
+    envs["DY_SIDECAR_PROJECT_ID"] = f"{project_id}"
+    envs["DY_SIDECAR_RUN_ID"] = f"{run_id}"
+    envs["DY_SIDECAR_NODE_ID"] = f"{node_id}"
+    envs["DY_SIDECAR_PATH_INPUTS"] = f"{inputs_dir}"
+    envs["DY_SIDECAR_PATH_OUTPUTS"] = f"{outputs_dir}"
+    envs["DY_SIDECAR_STATE_PATHS"] = json_dumps(state_paths_dirs)
+    envs["DY_SIDECAR_STATE_EXCLUDE"] = json_dumps(state_exclude_dirs)
 
-    monkeypatch.setenv("S3_ENDPOINT", "endpoint")
-    monkeypatch.setenv("S3_ACCESS_KEY", "access_key")
-    monkeypatch.setenv("S3_SECRET_KEY", "secret_key")
-    monkeypatch.setenv("S3_BUCKET_NAME", "bucket_name")
-    monkeypatch.setenv("S3_SECURE", "false")
+    envs["S3_ENDPOINT"] = "endpoint"
+    envs["S3_ACCESS_KEY"] = "access_key"
+    envs["S3_SECRET_KEY"] = "secret_key"
+    envs["S3_BUCKET_NAME"] = "bucket_name"
+    envs["S3_SECURE"] = "false"
 
-    monkeypatch.setenv("R_CLONE_PROVIDER", "MINIO")
+    envs["R_CLONE_PROVIDER"] = "MINIO"
+
+    setenvs_from_dict(monkeypatch, envs)
+
+    return envs
 
 
 @pytest.fixture

--- a/services/dynamic-sidecar/tests/conftest.py
+++ b/services/dynamic-sidecar/tests/conftest.py
@@ -16,12 +16,12 @@ from models_library.projects import ProjectID
 from models_library.projects_nodes import NodeID
 from models_library.users import UserID
 from pytest import MonkeyPatch
-from servicelib.json_serialization import json_dumps
 from pytest_simcore.helpers.utils_envs import (
     EnvVarsDict,
     setenvs_from_dict,
     setenvs_from_envfile,
 )
+from servicelib.json_serialization import json_dumps
 
 logger = logging.getLogger(__name__)
 

--- a/services/dynamic-sidecar/tests/unit/conftest.py
+++ b/services/dynamic-sidecar/tests/unit/conftest.py
@@ -12,6 +12,7 @@ from aiodocker.volumes import DockerVolume
 from async_asgi_testclient import TestClient
 from fastapi import FastAPI
 from pytest_mock import MockerFixture
+from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_service_dynamic_sidecar.core.application import AppState, create_app
 from simcore_service_dynamic_sidecar.core.docker_compose_utils import (
     _write_file_and_run_command,
@@ -71,7 +72,7 @@ def mock_core_rabbitmq(mocker: MockerFixture) -> dict[str, AsyncMock]:
 
 @pytest.fixture
 def app(
-    mock_environment: None,
+    mock_environment: EnvVarsDict,
     mock_registry_service: AsyncMock,
     mock_core_rabbitmq: dict[str, AsyncMock],
 ) -> FastAPI:

--- a/services/dynamic-sidecar/tests/unit/conftest.py
+++ b/services/dynamic-sidecar/tests/unit/conftest.py
@@ -177,7 +177,7 @@ async def cleanup_containers(app: FastAPI) -> AsyncIterator[None]:
     yield
     # run docker compose down here
 
-    if app_state.shared_store.compose_spec is None:
+    if app_state.compose_spec is None:
         # if no compose-spec is stored skip this operation
         return
 
@@ -187,7 +187,7 @@ async def cleanup_containers(app: FastAPI) -> AsyncIterator[None]:
     )
     await _write_file_and_run_command(
         settings=app_state.settings,
-        file_content=app_state.shared_store.compose_spec,
+        file_content=app_state.compose_spec,
         command=command,
         command_timeout=5.0,
     )

--- a/services/dynamic-sidecar/tests/unit/test_api_containers.py
+++ b/services/dynamic-sidecar/tests/unit/test_api_containers.py
@@ -36,7 +36,7 @@ from simcore_service_dynamic_sidecar.models.shared_store import SharedStore
 
 ContainerTimes = namedtuple("ContainerTimes", "created, started_at, finished_at")
 
-DEFAULT_COMMAND_TIMEOUT = 5.0
+DEFAULT_COMMAND_TIMEOUT = 5
 WAIT_FOR_DIRECTORY_WATCHER = 0.1
 
 

--- a/services/dynamic-sidecar/tests/unit/test_core_application.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_application.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable

--- a/services/dynamic-sidecar/tests/unit/test_core_application.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_application.py
@@ -20,9 +20,9 @@ def test_class_appstate_decorator_class(mock_environment_with_envdevel: EnvVarsD
     app_state = AppState(app)
 
     # ensure exposed properties are init after creation
-    exclude = {"compose_spec", "_shared_store"}
     properties = inspect.getmembers(
-        AppState, lambda o: isinstance(o, property) and o.fget.__name__ not in exclude
+        AppState,
+        lambda o: isinstance(o, property) and o.fget.__name__ in AppState._STATES,
     )
     for prop_name, prop in properties:
         # checks GETTERS

--- a/services/dynamic-sidecar/tests/unit/test_core_application.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_application.py
@@ -1,7 +1,9 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
+
 import inspect
+from typing import Union, get_args, get_origin
 
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_service_dynamic_sidecar.core.application import AppState, create_app
@@ -13,16 +15,28 @@ def test_create_app(mock_environment_with_envdevel: EnvVarsDict):
     assert isinstance(app.state.settings, DynamicSidecarSettings)
 
 
-def test_AppState_decorator_class(mock_environment_with_envdevel: EnvVarsDict):
+def test_class_appstate_decorator_class(mock_environment_with_envdevel: EnvVarsDict):
     app = create_app()
     app_state = AppState(app)
 
     # ensure exposed properties are init after creation
-    properties = inspect.getmembers(AppState, lambda o: isinstance(o, property))
+    exclude = {"compose_spec", "_shared_store"}
+    properties = inspect.getmembers(
+        AppState, lambda o: isinstance(o, property) and o.fget.__name__ not in exclude
+    )
     for prop_name, prop in properties:
+        # checks GETTERS
+
         # app.state.prop_name -> ReturnType annotation?
         value = getattr(app_state, prop_name)
-        assert isinstance(value, inspect.signature(prop.fget).return_annotation)
+
+        return_annotation = inspect.signature(prop.fget).return_annotation
+        if get_origin(return_annotation) is Union:
+            return_annotation = tuple(
+                t for t in get_args(return_annotation) if inspect.isclass(t)
+            )
+
+        assert isinstance(value, return_annotation)
 
         # app.state.prop_name == app_state.prop_name
         assert getattr(app.state, prop_name) == value


### PR DESCRIPTION
## What do these changes do?

Some refactoring prior to PR #3157 so it does not clutter the review of changes there.

####  ``servicelib``
- OAS server definition adds a default server as well
- cleanup async_utils 

####  ``director-v2``
- small fix in logging format to display error codes (OEC). OECs will be displayed in graylog next to entire error stack
```cmd
ERROR Observation of service_name=dy-sidecar_012346 unexpectedly failed [OEC:123456789]
... # here long stack of error
```

####  ``dynamic-service``
- cleanup boot. NOTE: multiple forks in development mode are due to the directory watcher!!
- cleanup app startup and logs

## Related issue/s

- ITISFoundation/osparc-issues#638

