### PR TITLE
🐛 Fix node not found on start of dy-sidecar

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -205,7 +205,7 @@ async def add_project_node(
         project_uuid=project["uuid"],
     )
     # also ensure the project is updated by director-v2 since services
-    # are due to access comp_tasks at some point
+    # are due to access comp_tasks at some point see [https://github.com/ITISFoundation/osparc-simcore/issues/3216]
     await director_v2_api.create_or_update_pipeline(
         request.app, user_id, project["uuid"]
     )

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -183,6 +183,8 @@ async def add_project_node(
         user_id,
     )
     node_uuid = service_id if service_id else str(uuid4())
+
+    # ensure the project is up-to-date in the database prior to start any potential service
     project_workbench = project.get("workbench", {})
     assert node_uuid not in project_workbench  # nosec
     project_workbench[node_uuid] = jsonable_encoder(
@@ -202,6 +204,8 @@ async def add_project_node(
         user_id=user_id,
         project_uuid=project["uuid"],
     )
+    # also ensure the project is updated by director-v2 since services
+    # are due to access comp_tasks at some point
     await director_v2_api.create_or_update_pipeline(
         request.app, user_id, project["uuid"]
     )

--- a/services/web/server/src/simcore_service_webserver/projects/projects_nodes_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_nodes_handlers.py
@@ -53,7 +53,7 @@ async def create_node(request: web.Request) -> web.Response:
     try:
         # ensure the project exists
 
-        await projects_api.get_project_for_user(
+        project_data = await projects_api.get_project_for_user(
             request.app,
             project_uuid=f"{path_params.project_id}",
             user_id=req_ctx.user_id,
@@ -62,7 +62,7 @@ async def create_node(request: web.Request) -> web.Response:
         data = {
             "node_id": await projects_api.add_project_node(
                 request,
-                f"{path_params.project_id}",
+                project_data,
                 req_ctx.user_id,
                 body["service_key"],
                 body["service_version"],

--- a/services/web/server/src/simcore_service_webserver/projects/projects_nodes_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_nodes_handlers.py
@@ -39,8 +39,16 @@ async def create_node(request: web.Request) -> web.Response:
 
     try:
         body = await request.json()
+        for required_key in ["service_key", "service_version"]:
+            if required_key not in body:
+                raise web.HTTPUnprocessableEntity(
+                    reason=f"{required_key} is missing from request body"
+                )
+
     except json.JSONDecodeError as exc:
-        raise web.HTTPBadRequest(reason=f"Invalid request body: {exc}") from exc
+        raise web.HTTPUnprocessableEntity(
+            reason=f"Invalid request body: {exc}"
+        ) from exc
 
     try:
         # ensure the project exists

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
@@ -1,6 +1,7 @@
 # pylint:disable=unused-variable
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
+# pylint:disable=too-many-statements
 
 import asyncio
 import json
@@ -614,7 +615,7 @@ async def test_project_node_lifetime(
 
     # create a new dynamic node...
     url = client.app.router["create_node"].url_for(project_id=user_project["uuid"])
-    body = {"service_key": "some/dynamic/key", "service_version": "1.3.4"}
+    body = {"service_key": "simcore/services/dynamic/key", "service_version": "1.3.4"}
     resp = await client.post(url, json=body)
     data, errors = await assert_status(resp, expected_response_on_Create)
     node_id = (
@@ -634,7 +635,10 @@ async def test_project_node_lifetime(
     # create a new NOT dynamic node...
     mocked_director_v2_api["director_v2_api.run_dynamic_service"].reset_mock()
     url = client.app.router["create_node"].url_for(project_id=user_project["uuid"])
-    body = {"service_key": "some/notdynamic/key", "service_version": "1.3.4"}
+    body = {
+        "service_key": "simcore/services/comp/key",
+        "service_version": "1.3.4",
+    }
     resp = await client.post(url, json=body)
     data, errors = await assert_status(resp, expected_response_on_Create)
     node_id_2 = node_id

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
@@ -4,14 +4,18 @@
 # pylint: disable=unused-variable
 
 import re
+from collections import UserDict
+from copy import deepcopy
 from typing import Any
-from uuid import uuid4
+from unittest import mock
+from uuid import UUID, uuid4
 
 import pytest
 from _helpers import ExpectedResponse, standard_role_response
 from aiohttp import web
 from aiohttp.test_utils import TestClient
 from faker import Faker
+from pytest_mock import MockerFixture
 from pytest_simcore.helpers.utils_assert import assert_status
 from pytest_simcore.helpers.utils_login import UserInfoDict
 from settings_library.catalog import CatalogSettings
@@ -146,21 +150,63 @@ async def test_replace_node_resources(
 
 
 @pytest.mark.parametrize(*standard_role_response(), ids=str)
-async def test_create_node(
+async def test_create_node_properly_upgrade_database(
     client: TestClient,
+    logged_user: UserDict,
     user_project: ProjectDict,
     expected: ExpectedResponse,
     faker: Faker,
+    mocked_director_v2_api: dict[str, mock.MagicMock],
+    catalog_subsystem_mock,
+    mocker: MockerFixture,
 ):
+    create_or_update_mock = mocker.patch(
+        "simcore_service_webserver.director_v2_api.create_or_update_pipeline",
+        autospec=True,
+        return_value=None,
+    )
+
     assert client.app
     url = client.app.router["create_node"].url_for(project_id=user_project["uuid"])
+
+    # Use-case 1.: not passing a service UUID will generate a new one on the fly
     body = {
-        "service_key": faker.pystr(),
+        "service_key": f"simcore/services/frontend/{faker.pystr()}",
         "service_version": f"{faker.random_int()}.{faker.random_int()}.{faker.random_int()}",
-        "service_id": None,
     }
     response = await client.post(url.path, json=body)
     data, error = await assert_status(response, expected.created)
+    if not error:
+        assert data
+        assert "node_id" in data
+        assert UUID(data["node_id"])
+        new_node_uuid = UUID(data["node_id"])
+        expected_project_data = deepcopy(user_project)
+        expected_project_data["workbench"][f"{new_node_uuid}"] = {
+            "key": body["service_key"],
+            "version": body["service_version"],
+        }
+        # give access to services inside the project
+        catalog_subsystem_mock([expected_project_data])
+        # check the project was updated
+        get_url = client.app.router["get_project"].url_for(
+            project_id=user_project["uuid"]
+        )
+        response = await client.get(get_url.path)
+        prj_data, error = await assert_status(response, expected.ok)
+        assert prj_data
+        assert not error
+        assert "workbench" in prj_data
+        assert (
+            f"{new_node_uuid}" in prj_data["workbench"]
+        ), f"node {new_node_uuid} is missing from project workbench! workbench nodes {list(prj_data['workbench'].keys())}"
+
+        create_or_update_mock.assert_called_once_with(
+            mock.ANY, logged_user["id"], user_project["uuid"]
+        )
+
+    # this does not start anything in the backend since this is not a dynamic service
+    mocked_director_v2_api["director_v2_api.run_dynamic_service"].assert_not_called()
 
 
 @pytest.mark.parametrize(*standard_role_response(), ids=str)
@@ -169,6 +215,7 @@ async def test_create_node_returns_422_if_body_is_missing(
     user_project: ProjectDict,
     expected: ExpectedResponse,
     faker: Faker,
+    mocked_director_v2_api: dict[str, mock.MagicMock],
 ):
     assert client.app
     url = client.app.router["create_node"].url_for(project_id=user_project["uuid"])
@@ -181,3 +228,5 @@ async def test_create_node_returns_422_if_body_is_missing(
     ]:
         response = await client.post(url.path, json=partial_body)
         await assert_status(response, expected.unprocessable)
+    # this does not start anything in the backend
+    mocked_director_v2_api["director_v2_api.run_dynamic_service"].assert_not_called()

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
@@ -4,17 +4,20 @@
 # pylint: disable=unused-variable
 
 import re
-from typing import Any, Type
+from typing import Any
 from uuid import uuid4
 
 import pytest
+from _helpers import ExpectedResponse, standard_role_response
 from aiohttp import web
 from aiohttp.test_utils import TestClient
+from faker import Faker
 from pytest_simcore.helpers.utils_assert import assert_status
 from pytest_simcore.helpers.utils_login import UserInfoDict
 from settings_library.catalog import CatalogSettings
 from simcore_service_webserver.catalog_settings import get_plugin_settings
 from simcore_service_webserver.db_models import UserRole
+from simcore_service_webserver.projects.project_models import ProjectDict
 
 
 @pytest.fixture
@@ -62,7 +65,7 @@ async def test_get_node_resources(
     logged_user: UserInfoDict,
     user_project: dict[str, Any],
     mock_catalog_service_api_responses: None,
-    expected: Type[web.HTTPException],
+    expected: type[web.HTTPException],
 ):
     assert client.app
     project_workbench = user_project["workbench"]
@@ -84,7 +87,7 @@ async def test_get_wrong_project_raises_not_found_error(
     client: TestClient,
     logged_user: UserInfoDict,
     user_project: dict[str, Any],
-    expected: Type[web.HTTPException],
+    expected: type[web.HTTPException],
 ):
     assert client.app
     project_workbench = user_project["workbench"]
@@ -106,7 +109,7 @@ async def test_get_wrong_node_raises_not_found_error(
     client: TestClient,
     logged_user: UserInfoDict,
     user_project: dict[str, Any],
-    expected: Type[web.HTTPException],
+    expected: type[web.HTTPException],
 ):
     assert client.app
     url = client.app.router["get_node_resources"].url_for(
@@ -130,7 +133,7 @@ async def test_replace_node_resources(
     logged_user: UserInfoDict,
     user_project: dict[str, Any],
     mock_catalog_service_api_responses: None,
-    expected: Type[web.HTTPException],
+    expected: type[web.HTTPException],
 ):
     assert client.app
     project_workbench = user_project["workbench"]
@@ -140,3 +143,41 @@ async def test_replace_node_resources(
         )
         response = await client.put(f"{url}", json={})
         await assert_status(response, expected)
+
+
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
+async def test_create_node(
+    client: TestClient,
+    user_project: ProjectDict,
+    expected: ExpectedResponse,
+    faker: Faker,
+):
+    assert client.app
+    url = client.app.router["create_node"].url_for(project_id=user_project["uuid"])
+    body = {
+        "service_key": faker.pystr(),
+        "service_version": f"{faker.random_int()}.{faker.random_int()}.{faker.random_int()}",
+        "service_id": None,
+    }
+    response = await client.post(url.path, json=body)
+    data, error = await assert_status(response, expected.created)
+
+
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
+async def test_create_node_returns_422_if_body_is_missing(
+    client: TestClient,
+    user_project: ProjectDict,
+    expected: ExpectedResponse,
+    faker: Faker,
+):
+    assert client.app
+    url = client.app.router["create_node"].url_for(project_id=user_project["uuid"])
+    for partial_body in [
+        {},
+        {"service_key": faker.pystr()},
+        {
+            "service_version": f"{faker.random_int()}.{faker.random_int()}.{faker.random_int()}"
+        },
+    ]:
+        response = await client.post(url.path, json=partial_body)
+        await assert_status(response, expected.unprocessable)

--- a/services/web/server/tests/unit/with_dbs/_helpers.py
+++ b/services/web/server/tests/unit/with_dbs/_helpers.py
@@ -1,4 +1,4 @@
-from typing import List, NamedTuple, Tuple, Type, Union
+from typing import NamedTuple, Union
 from unittest import mock
 
 from aiohttp import web
@@ -14,23 +14,28 @@ class ExpectedResponse(NamedTuple):
     will have no access, therefore ExpectedResponse.ok = HTTPUnauthorized
     """
 
-    ok: Union[Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[web.HTTPOk]]
+    ok: Union[type[web.HTTPUnauthorized], type[web.HTTPForbidden], type[web.HTTPOk]]
     created: Union[
-        Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[web.HTTPCreated]
+        type[web.HTTPUnauthorized], type[web.HTTPForbidden], type[web.HTTPCreated]
     ]
     no_content: Union[
-        Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[web.HTTPNoContent]
+        type[web.HTTPUnauthorized], type[web.HTTPForbidden], type[web.HTTPNoContent]
     ]
     not_found: Union[
-        Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[web.HTTPNotFound]
+        type[web.HTTPUnauthorized], type[web.HTTPForbidden], type[web.HTTPNotFound]
     ]
     forbidden: Union[
-        Type[web.HTTPUnauthorized],
-        Type[web.HTTPForbidden],
+        type[web.HTTPUnauthorized],
+        type[web.HTTPForbidden],
     ]
-    locked: Union[Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[HTTPLocked]]
+    locked: Union[type[web.HTTPUnauthorized], type[web.HTTPForbidden], type[HTTPLocked]]
     accepted: Union[
-        Type[web.HTTPUnauthorized], Type[web.HTTPForbidden], Type[web.HTTPAccepted]
+        type[web.HTTPUnauthorized], type[web.HTTPForbidden], type[web.HTTPAccepted]
+    ]
+    unprocessable: Union[
+        type[web.HTTPUnauthorized],
+        type[web.HTTPForbidden],
+        type[web.HTTPUnprocessableEntity],
     ]
 
     def __str__(self) -> str:
@@ -38,7 +43,7 @@ class ExpectedResponse(NamedTuple):
         return f"{self.__class__.__name__}({items})"
 
 
-def standard_role_response() -> Tuple[str, List[Tuple[UserRole, ExpectedResponse]]]:
+def standard_role_response() -> tuple[str, list[tuple[UserRole, ExpectedResponse]]]:
     return (
         "user_role,expected",
         [
@@ -52,6 +57,7 @@ def standard_role_response() -> Tuple[str, List[Tuple[UserRole, ExpectedResponse
                     forbidden=web.HTTPUnauthorized,
                     locked=web.HTTPUnauthorized,
                     accepted=web.HTTPUnauthorized,
+                    unprocessable=web.HTTPUnauthorized,
                 ),
             ),
             (
@@ -64,6 +70,7 @@ def standard_role_response() -> Tuple[str, List[Tuple[UserRole, ExpectedResponse
                     forbidden=web.HTTPForbidden,
                     locked=web.HTTPForbidden,
                     accepted=web.HTTPForbidden,
+                    unprocessable=web.HTTPForbidden,
                 ),
             ),
             (
@@ -76,6 +83,7 @@ def standard_role_response() -> Tuple[str, List[Tuple[UserRole, ExpectedResponse
                     forbidden=web.HTTPForbidden,
                     locked=HTTPLocked,
                     accepted=web.HTTPAccepted,
+                    unprocessable=web.HTTPUnprocessableEntity,
                 ),
             ),
             (
@@ -88,6 +96,7 @@ def standard_role_response() -> Tuple[str, List[Tuple[UserRole, ExpectedResponse
                     forbidden=web.HTTPForbidden,
                     locked=HTTPLocked,
                     accepted=web.HTTPAccepted,
+                    unprocessable=web.HTTPUnprocessableEntity,
                 ),
             ),
         ],


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Due to historic reasons adding nodes were created/added by the frontend. Later the backend took care of starting/stopping services but the saving of the updated project still relied on the frontend.

Since the dy-sidecar was made in such a way that it starts very fast, it would sometimes try to access the *comp_tasks* table before it was actually filled by the frontend saving the project.

This PR aims to improve that by ensuring the project is updated **by the backend** when adding a new node. This update is done before the service is started, so this will fix this problem once and for all.

## Related issue/s
fixes #3216 
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
