### PR TITLE
✨ Api-server can upload >5Gb files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ The SIM-CORE, named **o<sup>2</sup>S<sup>2</sup>PARC** – **O**pen **O**nline *
 The aim of o<sup>2</sup>S<sup>2</sup>PARC is to establish a comprehensive, freely accessible, intuitive, and interactive online platform for simulating peripheral nerve system neuromodulation/ stimulation and its impact on organ physiology in a precise and predictive manner.
 To achieve this, the platform will comprise both state-of-the art and highly detailed animal and human anatomical models with realistic tissue property distributions that make it possible to perform simulations ranging from the molecular scale up to the complexity of the human body.
 
-
 ## Getting Started
-
 
 This is the common workflow to build and deploy locally:
 
@@ -67,11 +65,10 @@ for operations during development. This is a representation of ``simcore-stack``
 
 ![](docs/img/.stack-simcore-version.yml.png)
 
-
 ### Requirements
 
 To verify current base OS, Docker and Python build versions have a look at:
-- Travis CI [config](.travis.yml)
+
 - GitHub Actions [config](.github/workflows/ci-testing-deploy.yml)
 
 To build and run:
@@ -82,23 +79,20 @@ To build and run:
 
 To develop, in addition:
 
-- python 3.6 (this dependency will be deprecated soon)
+- python 3.9
 - nodejs for client part (this dependency will be deprecated soon)
 - swagger-cli (make sure to have a recent version of nodejs)
 - [vscode] (highly recommended)
 
 This project works and is developed under **linux (Ubuntu recommended)**.
 
-##### Setting up Other Operating Systems
+#### Setting up Other Operating Systems
 
 When developing on these platforms you are on your own.
 
-In **windows**, it works under [WSL] (windows subsystem for linux). Some details on the setup:
+In **windows**, it works under [WSL2] (windows subsystem for linux **version2**). Some details on the setup:
 
-- [Install](https://chocolatey.org/docs/installation) [chocolatey] package manager
-  - ``choco install docker-for-windows``
-  - ``choco install wsl`` or using [instructions](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
--  Follow **all details** on [how to setup flawlessly](https://nickjanetakis.com/blog/setting-up-docker-for-windows-and-wsl-to-work-flawlessly) docker for windows and [WSL]
+- Follow **all details** on [how to setup WSL2 with docker and ZSH](https://nickymeuleman.netlify.app/blog/linux-on-windows-wsl2-zsh-docker) docker for windows and [WSL2]
 
 In **MacOS**, [replacing the MacOS utilities with GNU utils](https://apple.stackexchange.com/a/69332) might be required.
 
@@ -107,20 +101,25 @@ In **MacOS**, [replacing the MacOS utilities with GNU utils](https://apple.stack
 Updates are upgraded using a docker container and pip-sync.
 Build and start the container:
 
+```bash
     cd requirements/tools
     make build
     make shell
+```
 
 Once inside the container navigate to the service's requirements directory.
 
 To upgrade all requirements run:
 
+```bash
     make reqs
+```
 
 To upgrade a single requirement named `fastapi`run:
 
+```bash
     make reqs upgrade=fastapi
-
+```
 
 ## Releases
 
@@ -136,11 +135,9 @@ To upgrade a single requirement named `fastapi`run:
 
 Would you like to make a change or add something new? Please read the [contributing guidelines](CONTRIBUTING.md).
 
-
 ## License
 
 This project is licensed under the terms of the [MIT license](LICENSE).
-
 
 ---
 
@@ -151,4 +148,4 @@ This project is licensed under the terms of the [MIT license](LICENSE).
 <!-- ADD REFERENCES BELOW AND KEEP THEM IN ALPHABETICAL ORDER -->
 [chocolatey]:https://chocolatey.org/
 [vscode]:https://code.visualstudio.com/
-[WSL]:https://docs.microsoft.com/en-us/windows/wsl/faq
+[WSL2]:https://docs.microsoft.com/en-us/windows/wsl

--- a/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
@@ -40,7 +40,7 @@ async def _push_file(
         store_id=store_id,
         store_name=None,
         s3_object=s3_object,
-        local_file_path=file_path,
+        file_to_upload=file_path,
         r_clone_settings=r_clone_settings,
     )
     log.info("%s successfuly uploaded", file_path)

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -62,9 +62,6 @@ class UploadableFileObject:
     file_size: int
 
 
-UploadFile = Union[Path, UploadableFileObject]
-
-
 async def _get_location_id_from_location_name(
     user_id: UserID,
     store: LocationName,
@@ -492,7 +489,7 @@ async def upload_file(
     store_id: Optional[LocationID],
     store_name: Optional[LocationName],
     s3_object: StorageFileID,
-    file_to_upload: UploadFile,
+    file_to_upload: Union[Path, UploadableFileObject],
     client_session: Optional[ClientSession] = None,
     r_clone_settings: Optional[RCloneSettings] = None,
 ) -> tuple[LocationID, ETag]:

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -272,6 +272,8 @@ async def _upload_file_to_presigned_links(
             results = await logged_gather(
                 *upload_tasks,
                 log=log,
+                # NOTE: when the file object is already created it cannot be duplicated so
+                # no concurrency is allowed in that case
                 max_concurrency=4 if isinstance(file_to_upload, Path) else 1,
             )
             part_to_etag = [

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -1,9 +1,10 @@
+import asyncio
 import json
 
 # pylint: disable=too-many-arguments
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import IO, AsyncGenerator, Optional
 
 import aiofiles
 from aiohttp import ClientError, ClientPayloadError, ClientSession, web
@@ -141,7 +142,22 @@ async def _download_link_to_file(session: ClientSession, url: URL, file_path: Pa
             raise exceptions.TransferError(url) from exc
 
 
-async def _file_part_sender(file: Path, *, offset: int, bytes_to_send: int):
+async def _file_object_chunk_reader(
+    file_object: IO, *, offset: int, bytes_to_send: int
+) -> AsyncGenerator[bytes, None]:
+    chunk_size = CHUNK_SIZE
+    await asyncio.get_event_loop().run_in_executor(None, file_object.seek, offset)
+    num_read_bytes = 0
+    while chunk := await asyncio.get_event_loop().run_in_executor(
+        None, file_object.read, min(chunk_size, bytes_to_send - num_read_bytes)
+    ):
+        num_read_bytes += len(chunk)
+        yield chunk
+
+
+async def _file_chunk_reader(
+    file: Path, *, offset: int, bytes_to_send: int
+) -> AsyncGenerator[bytes, None]:
     chunk_size = CHUNK_SIZE
     async with aiofiles.open(file, "rb") as f:
         await f.seek(offset)
@@ -149,6 +165,51 @@ async def _file_part_sender(file: Path, *, offset: int, bytes_to_send: int):
         while chunk := await f.read(min(chunk_size, bytes_to_send - num_read_bytes)):
             num_read_bytes += len(chunk)
             yield chunk
+
+
+async def _upload_file_object(
+    session: ClientSession,
+    file_object: IO,
+    file_name: str,
+    part_index: int,
+    file_offset: int,
+    this_file_chunk_size: int,
+    num_parts: int,
+    upload_url: AnyUrl,
+    pbar,
+) -> tuple[int, ETag]:
+    log.debug(
+        "--> uploading %s of %s, [%s]...",
+        f"{this_file_chunk_size=}",
+        f"{file_name=}",
+        f"{part_index+1}/{num_parts}",
+    )
+    response = await session.put(
+        upload_url,
+        data=_file_object_chunk_reader(
+            file_object,
+            offset=file_offset,
+            bytes_to_send=this_file_chunk_size,
+        ),
+        headers={
+            "Content-Length": f"{this_file_chunk_size}",
+        },
+    )
+    response.raise_for_status()
+    pbar.update(this_file_chunk_size)
+    # NOTE: the response from minio does not contain a json body
+    assert response.status == web.HTTPOk.status_code
+    assert response.headers
+    assert "Etag" in response.headers
+    received_e_tag = json.loads(response.headers["Etag"])
+    log.info(
+        "--> completed upload %s of %s, [%s], %s",
+        f"{this_file_chunk_size=}",
+        f"{file_name=}",
+        f"{part_index+1}/{num_parts}",
+        f"{received_e_tag=}",
+    )
+    return (part_index, received_e_tag)
 
 
 async def _upload_file_part(
@@ -169,7 +230,7 @@ async def _upload_file_part(
     )
     response = await session.put(
         upload_url,
-        data=_file_part_sender(
+        data=_file_chunk_reader(
             file,
             offset=file_offset,
             bytes_to_send=this_file_chunk_size,
@@ -193,6 +254,50 @@ async def _upload_file_part(
         f"{received_e_tag=}",
     )
     return (part_index, received_e_tag)
+
+
+async def _upload_file_object_to_presigned_links(
+    session: ClientSession,
+    file_upload_links: FileUploadSchema,
+    file_object: IO,
+    file_name: str,
+    file_size: int,
+) -> list[UploadedPart]:
+    file_chunk_size = int(file_upload_links.chunk_size)
+    num_urls = len(file_upload_links.urls)
+    last_chunk_size = file_size - file_chunk_size * (num_urls - 1)
+    part_to_etag: list[UploadedPart] = []
+    with tqdm(
+        desc=f"uploading {file_name}\n", total=file_size, **_TQDM_FILE_OPTIONS
+    ) as pbar:
+        for index, upload_url in enumerate(file_upload_links.urls):
+            this_file_chunk_size = (
+                file_chunk_size if (index + 1) < num_urls else last_chunk_size
+            )
+            try:
+                index, e_tag = await _upload_file_object(
+                    session,
+                    file_object,
+                    file_name,
+                    index,
+                    index * file_chunk_size,
+                    this_file_chunk_size,
+                    num_urls,
+                    upload_url,
+                    pbar,
+                )
+                part_to_etag.append(UploadedPart(number=index + 1, e_tag=e_tag))
+
+            except ClientError as exc:
+                raise exceptions.S3TransferError(
+                    f"Could not upload file {file_name}:{exc}"
+                ) from exc
+    log.info(
+        "Uploaded %s, received %s",
+        f"{file_name=}",
+        f"{part_to_etag=}",
+    )
+    return part_to_etag
 
 
 async def _upload_file_to_presigned_links(
@@ -434,6 +539,56 @@ async def _abort_upload(
         log.warning("Error while aborting upload", exc_info=True)
         if reraise_exceptions:
             raise
+
+
+async def upload_file_io(
+    *,
+    user_id: UserID,
+    store_id: Optional[LocationID],
+    store_name: Optional[LocationName],
+    s3_object: StorageFileID,
+    file_object: IO,
+    file_name: str,
+    file_size: int,
+    client_session: Optional[ClientSession] = None,
+) -> tuple[LocationID, ETag]:
+    log.debug(
+        "Uploading file object of %s to %s:%s@%s [%s]bytes",
+        f"{file_name=}",
+        f"{store_id=}",
+        f"{store_name=}",
+        f"{s3_object=}",
+        f"{file_size}",
+    )
+    async with ClientSessionContextManager(client_session) as session:
+        upload_links = None
+        try:
+            store_id, upload_links = await get_upload_links_from_s3(
+                user_id=user_id,
+                store_name=store_name,
+                store_id=store_id,
+                s3_object=s3_object,
+                client_session=session,
+                link_type=storage_client.LinkType.PRESIGNED,
+                file_size=ByteSize(file_size),
+            )
+            uploaded_parts = await _upload_file_object_to_presigned_links(
+                session, upload_links, file_object, file_name, file_size
+            )
+            # complete the upload
+            e_tag = await _complete_upload(
+                session,
+                upload_links,
+                uploaded_parts,
+            )
+        except (r_clone.RCloneFailedError, exceptions.S3TransferError) as exc:
+            log.error("The upload failed with an unexpected error:", exc_info=True)
+            if upload_links:
+                # abort the upload correctly, so it can revert back to last version
+                await _abort_upload(session, upload_links, reraise_exceptions=False)
+                log.warning("Upload aborted")
+            raise exceptions.S3TransferError from exc
+        return store_id, e_tag
 
 
 async def upload_file(

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
@@ -205,7 +205,7 @@ async def push_file_to_store(
         store_id=SIMCORE_LOCATION,
         store_name=None,
         s3_object=s3_object,
-        local_file_path=file,
+        file_to_upload=file,
         r_clone_settings=r_clone_settings,
     )
     log.debug("file path %s uploaded, received ETag %s", file, e_tag)

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
@@ -67,7 +67,7 @@ async def test_valid_upload_download(
         store_id=s3_simcore_location,
         store_name=None,
         s3_object=file_id,
-        local_file_path=file_path,
+        file_to_upload=file_path,
         r_clone_settings=optional_r_clone,
     )
     assert store_id == s3_simcore_location
@@ -131,7 +131,7 @@ async def test_failed_upload_is_properly_removed_from_storage(
             store_id=s3_simcore_location,
             store_name=None,
             s3_object=file_id,
-            local_file_path=file_path,
+            file_to_upload=file_path,
             r_clone_settings=optional_r_clone,
         )
     with pytest.raises(exceptions.S3InvalidPathError):
@@ -166,7 +166,7 @@ async def test_failed_upload_after_valid_upload_keeps_last_valid_state(
         store_id=s3_simcore_location,
         store_name=None,
         s3_object=file_id,
-        local_file_path=file_path,
+        file_to_upload=file_path,
         r_clone_settings=optional_r_clone,
     )
     assert store_id == s3_simcore_location
@@ -194,7 +194,7 @@ async def test_failed_upload_after_valid_upload_keeps_last_valid_state(
             store_id=s3_simcore_location,
             store_name=None,
             s3_object=file_id,
-            local_file_path=file_path,
+            file_to_upload=file_path,
             r_clone_settings=optional_r_clone,
         )
     # the file shall be back to its original state
@@ -224,7 +224,7 @@ async def test_invalid_file_path(
             store_id=store,
             store_name=None,
             s3_object=file_id,
-            local_file_path=Path(tmpdir) / "some other file.txt",
+            file_to_upload=Path(tmpdir) / "some other file.txt",
         )
 
     download_folder = Path(tmpdir) / "downloads"
@@ -256,7 +256,7 @@ async def test_errors_upon_invalid_file_identifiers(
             store_id=store,
             store_name=None,
             s3_object="",  # type: ignore
-            local_file_path=file_path,
+            file_to_upload=file_path,
         )
 
     with pytest.raises(exceptions.StorageInvalidCall):
@@ -265,7 +265,7 @@ async def test_errors_upon_invalid_file_identifiers(
             store_id=store,
             store_name=None,
             s3_object="file_id",  # type: ignore
-            local_file_path=file_path,
+            file_to_upload=file_path,
         )
 
     download_folder = Path(tmpdir) / "downloads"
@@ -308,7 +308,7 @@ async def test_invalid_store(
             store_id=None,
             store_name=store,  # type: ignore
             s3_object=file_id,
-            local_file_path=file_path,
+            file_to_upload=file_path,
         )
 
     download_folder = Path(tmpdir) / "downloads"
@@ -349,7 +349,7 @@ async def test_valid_metadata(
         store_id=s3_simcore_location,
         store_name=None,
         s3_object=file_id,
-        local_file_path=file_path,
+        file_to_upload=file_path,
     )
     assert store_id == s3_simcore_location
     assert e_tag
@@ -406,7 +406,7 @@ async def test_delete_File(
         store_id=s3_simcore_location,
         store_name=None,
         s3_object=file_id,
-        local_file_path=file_path,
+        file_to_upload=file_path,
     )
     assert store_id == s3_simcore_location
     assert e_tag

--- a/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
+++ b/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
@@ -74,7 +74,7 @@ async def test_push_folder(
 
     mock_temporary_directory.assert_called_once()
     mock_filemanager.upload_file.assert_called_once_with(
-        local_file_path=(test_compression_folder / f"{test_folder.stem}.zip"),
+        file_to_upload=(test_compression_folder / f"{test_folder.stem}.zip"),
         r_clone_settings=None,
         s3_object=f"{project_id}/{node_uuid}/{test_folder.stem}.zip",
         store_id=SIMCORE_LOCATION,
@@ -122,7 +122,7 @@ async def test_push_file(
     mock_temporary_directory.assert_not_called()
     mock_filemanager.upload_file.assert_called_once_with(
         r_clone_settings=None,
-        local_file_path=file_path,
+        file_to_upload=file_path,
         s3_object=f"{project_id}/{node_uuid}/{file_path.name}",
         store_id=SIMCORE_LOCATION,
         store_name=None,

--- a/services/api-server/README.md
+++ b/services/api-server/README.md
@@ -41,6 +41,10 @@ will start the api-server in development-mode together with a postgres db initia
 - [Design patterns for modern web APIs](https://blog.feathersjs.com/design-patterns-for-modern-web-apis-1f046635215) by D. Luecke
 - [API Design Guide](https://cloud.google.com/apis/design/) by Google Cloud
 
+## Clients
+
+- [Python client for osparc-simcore API](https://github.com/ITISFoundation/osparc-simcore-python-client)
+
 ## Acknowledgments
 
   Many of the ideas in this design were taken from the **excellent** work at https://github.com/nsidnev/fastapi-realworld-example-app by *Nik Sidnev* using the **extraordinary** [fastapi](https://fastapi.tiangolo.com/) package by *Sebastian Ramirez*.

--- a/services/api-server/README.md
+++ b/services/api-server/README.md
@@ -14,17 +14,19 @@ Platform's public API server
 [image-commit]:https://images.microbadger.com/badges/commit/itisfoundation/api-server.svg
 <!------------------------->
 
-
 ## Development
 
 Setup environment
+
 ```cmd
 make devenv
 source .venv/bin/activate
 cd services/api-server
 make install-dev
 ```
+
 Then
+
 ```cmd
 make run-devel
 ```
@@ -34,15 +36,11 @@ will start the api-server in development-mode together with a postgres db initia
 - http://127.0.0.1:8000/docs: redoc documentation
 - http://127.0.0.1:8000/dev/docs: swagger type of documentation
 
-
-
-
 ## References
 
 - [Design patterns for modern web APIs](https://blog.feathersjs.com/design-patterns-for-modern-web-apis-1f046635215) by D. Luecke
 - [API Design Guide](https://cloud.google.com/apis/design/) by Google Cloud
 
-
-## Acknoledgments
+## Acknowledgments
 
   Many of the ideas in this design were taken from the **excellent** work at https://github.com/nsidnev/fastapi-realworld-example-app by *Nik Sidnev* using the **extraordinary** [fastapi](https://fastapi.tiangolo.com/) package by *Sebastian Ramirez*.

--- a/services/api-server/src/simcore_service_api_server/models/schemas/files.py
+++ b/services/api-server/src/simcore_service_api_server/models/schemas/files.py
@@ -22,7 +22,7 @@ class File(BaseModel):
 
     filename: str = Field(..., description="Name of the file with extension")
     content_type: Optional[str] = Field(
-        None, description="Guess of type content [EXPERIMENTAL]"
+        default=None, description="Guess of type content [EXPERIMENTAL]"
     )
     checksum: Optional[str] = Field(
         None, description="MD5 hash of the file's content [EXPERIMENTAL]"

--- a/services/storage/tests/unit/test_handlers_simcore_s3.py
+++ b/services/storage/tests/unit/test_handlers_simcore_s3.py
@@ -175,51 +175,121 @@ async def random_project_with_files(
         [ByteSize, str, str], Awaitable[tuple[Path, SimcoreS3FileID]]
     ],
     faker: Faker,
-) -> tuple[dict[str, Any], dict[NodeID, dict[SimcoreS3FileID, Path]]]:
-    project = await create_project()
-    NUM_NODES = 12
-    FILE_SIZES = [
-        parse_obj_as(ByteSize, "7Mib"),
-        parse_obj_as(ByteSize, "110Mib"),
-        parse_obj_as(ByteSize, "1Mib"),
-    ]
-    src_projects_list: dict[NodeID, dict[SimcoreS3FileID, Path]] = {}
-    upload_tasks: deque[Awaitable] = deque()
-    for _node_index in range(NUM_NODES):
-        src_node_id = await create_project_node(ProjectID(project["uuid"]))
-        src_projects_list[src_node_id] = {}
+) -> Callable[
+    [int, tuple[ByteSize, ...]],
+    Awaitable[tuple[dict[str, Any], dict[NodeID, dict[SimcoreS3FileID, Path]]]],
+]:
+    async def _creator(
+        num_nodes: int = 12,
+        file_sizes: tuple[ByteSize, ...] = (
+            parse_obj_as(ByteSize, "7Mib"),
+            parse_obj_as(ByteSize, "110Mib"),
+            parse_obj_as(ByteSize, "1Mib"),
+        ),
+    ) -> tuple[dict[str, Any], dict[NodeID, dict[SimcoreS3FileID, Path]]]:
+        project = await create_project()
+        src_projects_list: dict[NodeID, dict[SimcoreS3FileID, Path]] = {}
+        upload_tasks: deque[Awaitable] = deque()
+        for _node_index in range(num_nodes):
+            src_node_id = await create_project_node(ProjectID(project["uuid"]))
+            src_projects_list[src_node_id] = {}
 
-        async def _upload_file_and_update_project(project, src_node_id):
-            src_file_name = faker.file_name()
-            src_file_uuid = create_simcore_file_id(
-                ProjectID(project["uuid"]), src_node_id, src_file_name
+            async def _upload_file_and_update_project(project, src_node_id):
+                src_file_name = faker.file_name()
+                src_file_uuid = create_simcore_file_id(
+                    ProjectID(project["uuid"]), src_node_id, src_file_name
+                )
+                src_file, _ = await upload_file(
+                    choice(file_sizes), src_file_name, src_file_uuid
+                )
+                src_projects_list[src_node_id][src_file_uuid] = src_file
+
+            upload_tasks.extend(
+                [
+                    _upload_file_and_update_project(project, src_node_id)
+                    for _ in range(randint(0, 3))
+                ]
             )
-            src_file, _ = await upload_file(
-                choice(FILE_SIZES), src_file_name, src_file_uuid
-            )
-            src_projects_list[src_node_id][src_file_uuid] = src_file
+        await logged_gather(*upload_tasks, max_concurrency=2)
 
-        upload_tasks.extend(
-            [
-                _upload_file_and_update_project(project, src_node_id)
-                for _ in range(randint(0, 3))
-            ]
-        )
-    await logged_gather(*upload_tasks, max_concurrency=2)
+        project = await _get_updated_project(aiopg_engine, project["uuid"])
+        return project, src_projects_list
 
-    project = await _get_updated_project(aiopg_engine, project["uuid"])
-    return project, src_projects_list
+    return _creator
 
 
-@pytest.mark.flaky(max_runs=3)
-async def test_copy_folders_from_valid_project(
+@pytest.fixture
+def short_dsm_cleaner_interval(monkeypatch: pytest.MonkeyPatch) -> int:
+    monkeypatch.setenv("STORAGE_CLEANER_INTERVAL_S", "1")
+    return 1
+
+
+async def test_copy_folders_from_valid_project_with_one_large_file(
+    short_dsm_cleaner_interval: int,
     client: TestClient,
     user_id: UserID,
     create_project: Callable[[], Awaitable[dict[str, Any]]],
     create_simcore_file_id: Callable[[ProjectID, NodeID, str], SimcoreS3FileID],
     aiopg_engine: Engine,
-    random_project_with_files: tuple[
-        dict[str, Any], dict[NodeID, dict[SimcoreS3FileID, Path]]
+    random_project_with_files: Callable[
+        ..., Awaitable[tuple[dict[str, Any], dict[NodeID, dict[SimcoreS3FileID, Path]]]]
+    ],
+):
+    assert client.app
+    url = (
+        client.app.router["copy_folders_from_project"]
+        .url_for()
+        .with_query(user_id=user_id)
+    )
+    # 1. create a src project with 1 large file
+    src_project, src_projects_list = await random_project_with_files(
+        num_nodes=1, file_sizes=(parse_obj_as(ByteSize, "210Mib"),)
+    )
+    # 2. create a dst project without files
+    dst_project, nodes_map = clone_project_data(src_project)
+    dst_project = await create_project(**dst_project)
+    # copy the project files
+    response = await client.post(
+        f"{url}",
+        json=jsonable_encoder(
+            FoldersBody(
+                source=src_project,
+                destination=dst_project,
+                nodes_map={NodeID(i): NodeID(j) for i, j in nodes_map.items()},
+            )
+        ),
+    )
+    data, error = await assert_status(response, web.HTTPCreated)
+    assert not error
+    assert data == jsonable_encoder(
+        await _get_updated_project(aiopg_engine, dst_project["uuid"])
+    )
+    # check that file meta data was effectively copied
+    for src_node_id in src_projects_list:
+        dst_node_id = nodes_map.get(NodeIDStr(f"{src_node_id}"))
+        assert dst_node_id
+        for src_file in src_projects_list[src_node_id].values():
+            await assert_file_meta_data_in_db(
+                aiopg_engine,
+                file_id=create_simcore_file_id(
+                    ProjectID(dst_project["uuid"]), NodeID(dst_node_id), src_file.name
+                ),
+                expected_entry_exists=True,
+                expected_file_size=src_file.stat().st_size,
+                expected_upload_id=None,
+                expected_upload_expiration_date=None,
+            )
+
+
+async def test_copy_folders_from_valid_project(
+    short_dsm_cleaner_interval: int,
+    client: TestClient,
+    user_id: UserID,
+    create_project: Callable[[], Awaitable[dict[str, Any]]],
+    create_simcore_file_id: Callable[[ProjectID, NodeID, str], SimcoreS3FileID],
+    aiopg_engine: Engine,
+    random_project_with_files: Callable[
+        ..., Awaitable[tuple[dict[str, Any], dict[NodeID, dict[SimcoreS3FileID, Path]]]]
     ],
 ):
     assert client.app
@@ -230,7 +300,7 @@ async def test_copy_folders_from_valid_project(
     )
 
     # 1. create a src project with some files
-    src_project, src_projects_list = random_project_with_files
+    src_project, src_projects_list = await random_project_with_files()
     # 2. create a dst project without files
     dst_project, nodes_map = clone_project_data(src_project)
     dst_project = await create_project(**dst_project)
@@ -363,7 +433,6 @@ def mock_check_project_exists(mocker: MockerFixture):
     )
 
 
-@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize(
     "project",
     [pytest.param(prj, id=prj.name) for prj in _get_project_with_data()],

--- a/services/web/server/src/simcore_service_webserver/exporter/formatters/formatter_v1.py
+++ b/services/web/server/src/simcore_service_webserver/exporter/formatters/formatter_v1.py
@@ -191,7 +191,7 @@ async def upload_file_to_storage(
             store_id=link_and_path.storage_type,
             store_name=None,
             s3_object=link_and_path.relative_path_to_file,
-            local_file_path=link_and_path.storage_path_to_file,
+            file_to_upload=link_and_path.storage_path_to_file,
             client_session=session,
         )
         return (link_and_path, e_tag)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
These change shall allow the upload of large files to osparc storage (>2Gb which seemed to be the current limit hit by @newton1985).

Nevertheless the API-server inner parts will still create some limitations as during an upload the following happens:
- an API client connects with the API-server
- the client starts uploading a file to osparc using ```PUT /v0/files/content``` entrypoint
- the ```api-server``` then receives the file as a [SpooledTemporaryFile](https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile) which is nicely provided by the FastAPI library. e.g. This is a file that is partially in memory and on the disk to prevent exploding the RAM.
- the ```api-server``` then calls ```storage``` to generate multipart upload links
- the ```api-server``` then uploads the file in chunks to the S3 backend
- once completed, the ```api-server``` returns a ```200 - OK``` to the API client

The changes in this PR will now "break" the 5Gb limit inherent to using a single presigned link by now using multiple links as ```storage``` service now allows.

**IMPORTANT NOTE**:
- even like that the API-server will still have some limitations due to how this is currently constructed:
  - if a very large file is uploaded the host where the api-server is located could be overloaded especially if the file is larger than the available disk space ([issue](https://github.com/ITISFoundation/osparc-simcore/issues/3223))
- if the client is unable to handle large files then it will fail as well

bonus:
- made uploading a file a cancellable request
- fixed storage test flakyness by actually fixing a case where the dsm cleaner would remove an upload that was just created.

## Related issue/s
fixes #3166 
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
