### PR TITLE
WIP: Enhancement/stream_upload

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/__init__.py
+++ b/packages/pytest-simcore/src/pytest_simcore/__init__.py
@@ -15,3 +15,9 @@ def pytest_addoption(parser):
 
     # DUMMY
     parser.addini("HELLO", "Dummy pytest.ini setting")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "heavy_load: mark test that uses huge amount of data"
+    )

--- a/services/api-server/src/simcore_service_api_server/api/routes/files.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/files.py
@@ -103,8 +103,15 @@ async def stream_upload_file(
         created_at=datetime.utcnow().isoformat(),
     )
 
+    logger.debug("here we are receiving the call")
+    length_chunk = 0
     async for chunk in request.stream():
-        logger.warning("received %s", f"{chunk=}")
+        logger.warning("received %s bytes", f"{len(chunk)}")
+        logger.debug("%s", chunk)
+        length_chunk += len(chunk)
+    logger.debug(f"{length_chunk=}")
+
+    # logger.debug(await request.body())
 
     return file_meta
 

--- a/services/api-server/src/simcore_service_api_server/models/schemas/files.py
+++ b/services/api-server/src/simcore_service_api_server/models/schemas/files.py
@@ -97,5 +97,22 @@ class File(BaseModel):
         )
 
     @classmethod
+    async def create_from_stream(
+        cls,
+        file_name: str,
+        *,
+        file_size: int,
+        check_sum: str,
+        content_type: str,
+        created_at
+    ) -> "File":
+        return cls(
+            id=cls.create_id(file_size, file_name, created_at),
+            filename=file_name,
+            content_type=content_type,
+            checksum=check_sum,
+        )
+
+    @classmethod
     def create_id(cls, *keys) -> UUID:
         return uuid3(NAMESPACE_FILEID_KEY, ":".join(map(str, keys)))

--- a/services/api-server/tests/conftest.py
+++ b/services/api-server/tests/conftest.py
@@ -13,6 +13,7 @@ from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_dict
 CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
 pytest_plugins = [
+    "pytest_simcore.file_extra",
     "pytest_simcore.pydantic_models",
     "pytest_simcore.pytest_global_environs",
     "pytest_simcore.repository_paths",

--- a/services/api-server/tests/unit/test_api_files.py
+++ b/services/api-server/tests/unit/test_api_files.py
@@ -11,9 +11,11 @@ import respx
 from faker import Faker
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from pydantic import ByteSize
+from pydantic import ByteSize, parse_obj_as
 from pytest_mock import MockerFixture
+from pytest_simcore.helpers.utils_parametrizations import byte_size_ids
 from requests.auth import HTTPBasicAuth
+from simcore_sdk.node_ports_common.filemanager import UploadableFileObject
 from simcore_service_api_server._meta import API_VTAG
 from simcore_service_api_server.core.settings import ApplicationSettings
 from simcore_service_api_server.models.schemas.files import File
@@ -60,21 +62,31 @@ async def test_list_files(
     assert resp.status_code == status.HTTP_200_OK, resp.text
 
 
+@pytest.mark.parametrize(
+    "file_size",
+    [
+        (parse_obj_as(ByteSize, "1Mib")),
+        (parse_obj_as(ByteSize, "500Mib")),
+        pytest.param(parse_obj_as(ByteSize, "7Gib"), marks=pytest.mark.heavy_load),
+    ],
+    ids=byte_size_ids,
+)
 async def test_upload_file(
     mocker: MockerFixture,
     app: FastAPI,
     auth: HTTPBasicAuth,
     create_file_of_size: Callable[[ByteSize], Path],
+    file_size: ByteSize,
     faker: Faker,
 ):
     fake_checksum = faker.md5()
-    mocker.patch(
+    mocked_upload_file = mocker.patch(
         "simcore_service_api_server.api.routes.files.storage_upload_file",
         autospec=True,
         return_value=(faker.pyint(min_value=0), fake_checksum),
     )
 
-    path = create_file_of_size(ByteSize(500))
+    path = create_file_of_size(file_size)
 
     # NOTE: I was unable to make this work with the async client,
     # if someones knows better feel free to fix it
@@ -89,3 +101,10 @@ async def test_upload_file(
     received_file = File.parse_obj(resp.json())
     assert received_file.checksum == fake_checksum
     assert received_file.filename == path.name
+    mocked_upload_file.assert_called_once()
+    assert mocked_upload_file.call_args.kwargs
+    assert "file_to_upload" in mocked_upload_file.call_args.kwargs
+    uploadable_file_object = mocked_upload_file.call_args.kwargs["file_to_upload"]
+    assert isinstance(uploadable_file_object, UploadableFileObject)
+    assert uploadable_file_object.file_name == path.name
+    assert uploadable_file_object.file_size == path.stat().st_size

--- a/services/api-server/tests/unit/test_api_files.py
+++ b/services/api-server/tests/unit/test_api_files.py
@@ -108,3 +108,68 @@ async def test_upload_file(
     assert isinstance(uploadable_file_object, UploadableFileObject)
     assert uploadable_file_object.file_name == path.name
     assert uploadable_file_object.file_size == path.stat().st_size
+
+
+@pytest.mark.parametrize(
+    "file_size",
+    [
+        (parse_obj_as(ByteSize, "1Kib")),
+        # (parse_obj_as(ByteSize, "500Mib")),
+        # pytest.param(parse_obj_as(ByteSize, "7Gib"), marks=pytest.mark.heavy_load),
+    ],
+    ids=byte_size_ids,
+)
+async def test_upload_file_as_stream(
+    mocker: MockerFixture,
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    auth: HTTPBasicAuth,
+    create_file_of_size: Callable[[ByteSize], Path],
+    file_size: ByteSize,
+    faker: Faker,
+):
+    fake_checksum = faker.md5()
+    mocked_upload_file = mocker.patch(
+        "simcore_service_api_server.api.routes.files.storage_upload_file",
+        autospec=True,
+        return_value=(faker.pyint(min_value=0), fake_checksum),
+    )
+
+    path = create_file_of_size(file_size)
+
+    # NOTE: I was unable to make this work with the async client,
+    # if someones knows better feel free to fix it
+    # test_client = TestClient(app)
+
+    # resp = test_client.put(
+    #     f"{API_VTAG}/files/stream",
+    #     data=path.open("rb"),
+    #     auth=auth,
+    #     params={
+    #         "file_size": file_size,
+    #         "file_name": path.name,
+    #         "file_checksum": fake_checksum,
+    #     },
+    #     stream=True,
+    # )
+    resp = await client.put(
+        f"{API_VTAG}/files/stream",
+        files={"file": path.open("rb")},
+        auth=auth,
+        params={
+            "file_size": file_size,
+            "file_name": path.name,
+            "file_checksum": fake_checksum,
+        },
+    )
+    assert resp.status_code == status.HTTP_200_OK, resp.text
+    received_file = File.parse_obj(resp.json())
+    assert received_file.checksum == fake_checksum
+    assert received_file.filename == path.name
+    # mocked_upload_file.assert_called_once()
+    # assert mocked_upload_file.call_args.kwargs
+    # assert "file_to_upload" in mocked_upload_file.call_args.kwargs
+    # uploadable_file_object = mocked_upload_file.call_args.kwargs["file_to_upload"]
+    # assert isinstance(uploadable_file_object, UploadableFileObject)
+    # assert uploadable_file_object.file_name == path.name
+    # assert uploadable_file_object.file_size == path.stat().st_size

--- a/services/api-server/tests/unit/test_api_files.py
+++ b/services/api-server/tests/unit/test_api_files.py
@@ -1,0 +1,91 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from pathlib import Path
+from typing import Callable, Iterator
+
+import httpx
+import pytest
+import respx
+from faker import Faker
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ByteSize
+from pytest_mock import MockerFixture
+from requests.auth import HTTPBasicAuth
+from simcore_service_api_server._meta import API_VTAG
+from simcore_service_api_server.core.settings import ApplicationSettings
+from simcore_service_api_server.models.schemas.files import File
+from starlette import status
+from yarl import URL
+
+
+@pytest.fixture
+def mocked_storage_service_api(app: FastAPI) -> Iterator[respx.MockRouter]:
+    """Mocks some responses of web-server service"""
+
+    settings: ApplicationSettings = app.state.settings
+    assert settings.API_SERVER_WEBSERVER
+
+    assert settings.API_SERVER_STORAGE
+    with respx.mock(  # pylint: disable=not-context-manager
+        base_url=settings.API_SERVER_STORAGE.base_url,
+        assert_all_called=False,
+        assert_all_mocked=True,
+    ) as respx_mock:
+
+        def _list_files(request: httpx.Request):
+            # check expected query parameters are here
+            request_url = URL(f"{request.url}")
+            assert "user_id" in request_url.query
+            assert "startswith" in request_url.query
+            assert request_url.query["startswith"] == "api/"
+
+            return httpx.Response(status.HTTP_200_OK, json={"data": []})
+
+        respx_mock.post("/simcore-s3/files/metadata:search", name="list_files").mock(
+            side_effect=_list_files
+        )
+
+        yield respx_mock
+
+
+async def test_list_files(
+    mocked_storage_service_api: respx.MockRouter,
+    client: httpx.AsyncClient,
+    auth: httpx.BasicAuth,
+):
+    resp = await client.get(f"{API_VTAG}/files", auth=auth)
+    assert resp.status_code == status.HTTP_200_OK, resp.text
+
+
+async def test_upload_file(
+    mocker: MockerFixture,
+    app: FastAPI,
+    auth: HTTPBasicAuth,
+    create_file_of_size: Callable[[ByteSize], Path],
+    faker: Faker,
+):
+    fake_checksum = faker.md5()
+    mocker.patch(
+        "simcore_service_api_server.api.routes.files.storage_upload_file",
+        autospec=True,
+        return_value=(faker.pyint(min_value=0), fake_checksum),
+    )
+
+    path = create_file_of_size(ByteSize(500))
+
+    # NOTE: I was unable to make this work with the async client,
+    # if someones knows better feel free to fix it
+    test_client = TestClient(app)
+    resp = test_client.put(
+        f"{API_VTAG}/files/content",
+        files={"file": path.open("rb")},
+        auth=auth,
+    )
+
+    assert resp.status_code == status.HTTP_200_OK, resp.text
+    received_file = File.parse_obj(resp.json())
+    assert received_file.checksum == fake_checksum
+    assert received_file.filename == path.name


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
try to stream data directly to underlying S3 storage system instead of keeping the file in the api-server
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
