### PR TITLE
♻️ Dy-sidecar client unexpected error to be logged as an error

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_base.py
@@ -40,7 +40,7 @@ def _log_retry(log: Logger, max_retries: int) -> Callable[[RetryCallState], None
         assert isinstance(e, HTTPError)  # nosec
         assert e._request  # nosec
 
-        log.info(
+        log.warning(
             "[%s/%s]Retry. Unexpected %s while requesting '%s %s': %s",
             retry_state.attempt_number,
             max_retries,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_base.py
@@ -38,16 +38,12 @@ def _log_retry(log: Logger, max_retries: int) -> Callable[[RetryCallState], None
         assert retry_state.outcome  # nosec
         e = retry_state.outcome.exception()
         assert isinstance(e, HTTPError)  # nosec
-        assert e._request  # nosec
-
-        log.warning(
-            "[%s/%s]Retry. Unexpected %s while requesting '%s %s': %s",
+        log.error(
+            "Unexpected error with '%s': %s, (attempt [%s/%s])",
+            f"{e.request=}",
+            f"{e=}",
             retry_state.attempt_number,
             max_retries,
-            e.__class__.__name__,
-            e._request.method,
-            e._request.url,
-            f"{e=}",
         )
 
     return log_it

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_base.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_base.py
@@ -81,9 +81,8 @@ async def test_retry_on_errors(
     # check if the right amount of messages was captured by the logs
     assert len(caplog_info_level.messages) == retry_count
     for i, log_message in enumerate(caplog_info_level.messages):
-        assert log_message.startswith(
-            f"[{i+1}/{retry_count}]Retry. Unexpected ConnectError"
-        )
+        assert log_message.startswith("Unexpected error")
+        assert log_message.endswith(f"(attempt [{i+1}/{retry_count}])")
 
 
 @pytest.mark.parametrize("error_class", [ConnectError, PoolTimeout])
@@ -112,17 +111,15 @@ async def test_retry_on_errors_by_error_type(
     assert len(caplog_info_level.messages) == log_count
 
     if error_class == PoolTimeout:
-        for i, retry_message in enumerate(caplog_info_level.messages[:-1]):
-            assert retry_message.startswith(
-                f"[{i+1}/{retry_count}]Retry. Unexpected PoolTimeout"
-            )
+        for i, log_message in enumerate(caplog_info_level.messages[:-1]):
+            assert log_message.startswith("Unexpected error")
+            assert log_message.endswith(f"(attempt [{i+1}/{retry_count}])")
         connections_message = caplog_info_level.messages[-1]
         assert connections_message == "Requests while event 'POOL TIMEOUT': []"
     else:
         for i, log_message in enumerate(caplog_info_level.messages):
-            assert log_message.startswith(
-                f"[{i+1}/{retry_count}]Retry. Unexpected ConnectError"
-            )
+            assert log_message.startswith("Unexpected error")
+            assert log_message.endswith(f"(attempt [{i+1}/{retry_count}])")
 
 
 async def test_retry_on_errors_raises_client_http_error() -> None:

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_public.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_public.py
@@ -129,9 +129,8 @@ async def test_is_healthy_times_out(
 ) -> None:
     assert await dynamic_sidecar_client.is_healthy(dynamic_sidecar_endpoint) is False
     for i, log_message in enumerate(caplog_info_level.messages):
-        assert log_message.startswith(
-            f"[{i+1}/{retry_count}]Retry. Unexpected ConnectError"
-        )
+        assert log_message.startswith("Unexpected error")
+        assert log_message.endswith(f"(attempt [{i+1}/{retry_count}])")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

- when the director-v2 client unexpectedly fails it should log an error not an info message
## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
