### PR TITLE
♻️dynamic-sidecar log-level review  (⚠️ devops)

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -155,7 +155,7 @@ class DynamicSidecarSettings(BaseCustomSettings):
     )
 
     DYNAMIC_SIDECAR_LOG_LEVEL: str = Field(
-        "WARNING",
+        "INFO",
         description="log level of the dynamic sidecar"
         "If defined, it captures global env vars LOG_LEVEL and LOGLEVEL from the director-v2 service",
         env=["DYNAMIC_SIDECAR_LOG_LEVEL", "LOG_LEVEL", "LOGLEVEL"],

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -155,7 +155,7 @@ class DynamicSidecarSettings(BaseCustomSettings):
     )
 
     DYNAMIC_SIDECAR_LOG_LEVEL: str = Field(
-        "INFO",
+        "WARNING",
         description="log level of the dynamic sidecar"
         "If defined, it captures global env vars LOG_LEVEL and LOGLEVEL from the director-v2 service",
         env=["DYNAMIC_SIDECAR_LOG_LEVEL", "LOG_LEVEL", "LOGLEVEL"],

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
@@ -38,7 +38,7 @@ class DetachContainerFromNetworkItem(_BaseNetworkItem):
 
 
 async def send_message(rabbitmq: RabbitMQ, message: str) -> None:
-    logger.info(message)
+    logger.debug(message)
     await rabbitmq.post_log_message(f"[sidecar] {message}")
 
 
@@ -114,7 +114,7 @@ async def attach_container_to_network(
         }
 
         if item.network_id in attached_network_ids:
-            logger.info(
+            logger.debug(
                 "Container %s already attached to network %s",
                 container_id,
                 item.network_id,
@@ -152,7 +152,7 @@ async def detach_container_from_network(
         }
 
         if item.network_id not in attached_network_ids:
-            logger.info(
+            logger.debug(
                 "Container %s already detached from network %s",
                 container_id,
                 item.network_id,

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
@@ -42,14 +42,14 @@ async def _write_file_and_spawn_process(
     async with write_to_tmp_file(yaml_content) as file_path:
         cmd = command.format(file_path=file_path)
 
-        logger.info("Runs %s ...\n%s", cmd, yaml_content)
+        logger.debug("Runs %s ...\n%s", cmd, yaml_content)
 
         result = await async_command(
             command=cmd,
             timeout=process_termination_timeout,
         )
 
-        logger.info("Done %s", pformat(deepcopy(result._asdict())))
+        logger.debug("Done %s", pformat(deepcopy(result._asdict())))
         return result
 
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_logs.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_logs.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 async def _logs_fetcher_worker(
     container_name: str, dispatch_log: Callable[..., Coroutine[Any, Any, None]]
 ) -> None:
-    logger.info("Started log fetching for container %s", container_name)
+    logger.debug("Started log fetching for container %s", container_name)
 
     async with docker_client() as docker:
         container = await docker.containers.get(container_name)
@@ -64,7 +64,7 @@ class BackgroundLogFetcher:
             name=f"rabbitmq_log_processor_tasks/{container_name}",
         )
 
-        logger.info("Subscribed to fetch logs from '%s'", container_name)
+        logger.debug("Subscribed to fetch logs from '%s'", container_name)
 
     async def stop_log_fetching(self, container_name: str) -> None:
         logger.debug("Stopping logs fetching from container '%s'", container_name)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 async def send_message(rabbitmq: RabbitMQ, message: str) -> None:
-    logger.info(message)
+    logger.debug(message)
     await rabbitmq.post_log_message(f"[sidecar] {message}")
 
 
@@ -60,8 +60,7 @@ async def task_create_service_containers(
     )
     shared_store.container_names = assemble_container_names(shared_store.compose_spec)
 
-    # This "info" message should be visible on production deployments
-    logger.warning("INFO: Validated compose-spec:\n%s", f"{shared_store.compose_spec}")
+    logger.info("Validated compose-spec:\n%s", f"{shared_store.compose_spec}")
 
     await send_message(rabbitmq, "starting service containers")
     assert shared_store.compose_spec  # nosec
@@ -84,7 +83,7 @@ async def task_create_service_containers(
 
     if r.success:
         await send_message(rabbitmq, "service containers started")
-        logger.info(message)
+        logger.debug(message)
         for container_name in shared_store.container_names:
             await start_log_fetching(app, container_name)
     else:


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## ⚠️ devops

Make sure `DYNAMIC_SIDECAR_LOG_LEVEL` is not set on the director-v2, if set put it to `INFO`.


## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Review log levels in dynamic-sidecar. Making its logs more helpful.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

- https://github.com/ITISFoundation/osparc-issues/issues/638

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
