### PR TITLE
✨ 📝 TI manual link  (⚠️ devops)

### DIFF
--- a/.env-devel
+++ b/.env-devel
@@ -94,9 +94,9 @@ WEBSERVER_LOGIN_REGISTRATION_INVITATION_REQUIRED=0
 WEBSERVER_FEEDBACK_FORM_URL=https://docs.google.com/forms/d/e/1FAIpQLSe232bTigsM2zV97Kjp2OhCenl6o9gNGcDFt2kO_dfkIjtQAQ/viewform?usp=sf_link
 WEBSERVER_FOGBUGZ_LOGIN_URL=https://z43.manuscript.com/login
 WEBSERVER_FOGBUGZ_NEWCASE_URL=https://z43.manuscript.com/f/cases/new?command=new&pg=pgEditBug&ixProject=45&ixArea=449
+WEBSERVER_MANUAL_EXTRA_URL=https://itisfoundation.github.io/osparc-manual-z43/
 WEBSERVER_MANUAL_MAIN_URL=http://docs.osparc.io/
 WEBSERVER_MANUAL_TI_URL=https://itisfoundation.github.io/ti-planning-tool-manual/
-WEBSERVER_MANUAL_Z43_URL=https://itisfoundation.github.io/osparc-manual-z43/
 WEBSERVER_PROMETHEUS_API_VERSION=v1
 WEBSERVER_PROMETHEUS_HOST=http://prometheus
 WEBSERVER_PROMETHEUS_PORT=9090

--- a/.env-devel
+++ b/.env-devel
@@ -94,8 +94,9 @@ WEBSERVER_LOGIN_REGISTRATION_INVITATION_REQUIRED=0
 WEBSERVER_FEEDBACK_FORM_URL=https://docs.google.com/forms/d/e/1FAIpQLSe232bTigsM2zV97Kjp2OhCenl6o9gNGcDFt2kO_dfkIjtQAQ/viewform?usp=sf_link
 WEBSERVER_FOGBUGZ_LOGIN_URL=https://z43.manuscript.com/login
 WEBSERVER_FOGBUGZ_NEWCASE_URL=https://z43.manuscript.com/f/cases/new?command=new&pg=pgEditBug&ixProject=45&ixArea=449
-WEBSERVER_MANUAL_EXTRA_URL=https://itisfoundation.github.io/osparc-manual-z43/
 WEBSERVER_MANUAL_MAIN_URL=http://docs.osparc.io/
+WEBSERVER_MANUAL_TI_URL=https://itisfoundation.github.io/ti-planning-tool-manual/
+WEBSERVER_MANUAL_Z43_URL=https://itisfoundation.github.io/osparc-manual-z43/
 WEBSERVER_PROMETHEUS_API_VERSION=v1
 WEBSERVER_PROMETHEUS_HOST=http://prometheus
 WEBSERVER_PROMETHEUS_PORT=9090

--- a/services/web/client/source/class/osparc/navigation/Manuals.js
+++ b/services/web/client/source/class/osparc/navigation/Manuals.js
@@ -31,6 +31,26 @@ qx.Class.define("osparc.navigation.Manuals", {
       }
 
       return manuals;
+    },
+
+    addFeedbackButtonsToMenu: function(menu, statics) {
+      const newGHIssueBtn = new qx.ui.menu.Button(qx.locale.Manager.tr("Issue in GitHub"));
+      newGHIssueBtn.addListener("execute", () => osparc.navigation.UserMenuButton.openGithubIssueInfoDialog(), this);
+      menu.add(newGHIssueBtn);
+
+      if (osparc.utils.Utils.isInZ43()) {
+        const newFogbugzIssueBtn = new qx.ui.menu.Button(qx.locale.Manager.tr("Issue in Fogbugz"));
+        newFogbugzIssueBtn.addListener("execute", () => osparc.navigation.UserMenuButton.openFogbugzIssueInfoDialog(), this);
+        menu.add(newFogbugzIssueBtn);
+      }
+
+      const feedbackAnonBtn = new qx.ui.menu.Button(qx.locale.Manager.tr("Anonymous feedback"));
+      feedbackAnonBtn.addListener("execute", () => {
+        if (statics.feedbackFormUrl) {
+          window.open(statics.feedbackFormUrl);
+        }
+      });
+      menu.add(feedbackAnonBtn);
     }
   }
 });

--- a/services/web/client/source/class/osparc/navigation/Manuals.js
+++ b/services/web/client/source/class/osparc/navigation/Manuals.js
@@ -1,0 +1,36 @@
+
+qx.Class.define("osparc.navigation.Manuals", {
+  type: "static",
+
+  statics: {
+    getManuals: function(statics) {
+      let manuals = [];
+      if (statics && statics.manualMainUrl) {
+        manuals.push({
+          label: qx.locale.Manager.tr("User Manual"),
+          icon: "@FontAwesome5Solid/book/22",
+          url: statics.manualMainUrl
+        });
+      }
+
+      if (osparc.utils.Utils.isInZ43() && statics && statics.manualExtraUrl) {
+        manuals.push({
+          label: qx.locale.Manager.tr("Z43 Manual"),
+          icon: "@FontAwesome5Solid/book-medical/22",
+          url: statics.manualExtraUrl
+        });
+      }
+
+      if (osparc.utils.Utils.isProduct("tis") && statics && statics.manualTiUrl) {
+        // "TI Planning Tool Manual" only
+        manuals = [{
+          label: qx.locale.Manager.tr("TI Planning Tool Manual"),
+          icon: "@FontAwesome5Solid/book/22",
+          url: statics.manualTiUrl
+        }];
+      }
+
+      return manuals;
+    }
+  }
+});

--- a/services/web/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/web/client/source/class/osparc/navigation/NavigationBar.js
@@ -278,23 +278,7 @@ qx.Class.define("osparc.navigation.NavigationBar", {
         font: "text-14"
       });
 
-      const newGHIssueBtn = new qx.ui.menu.Button(this.tr("Issue in GitHub"));
-      newGHIssueBtn.addListener("execute", () => osparc.navigation.UserMenuButton.openGithubIssueInfoDialog(), this);
-      menu.add(newGHIssueBtn);
-
-      if (osparc.utils.Utils.isInZ43()) {
-        const newFogbugzIssueBtn = new qx.ui.menu.Button(this.tr("Issue in Fogbugz"));
-        newFogbugzIssueBtn.addListener("execute", () => osparc.navigation.UserMenuButton.openFogbugzIssueInfoDialog(), this);
-        menu.add(newFogbugzIssueBtn);
-      }
-
-      const feedbackAnonBtn = new qx.ui.menu.Button(this.tr("Anonymous feedback"));
-      feedbackAnonBtn.addListener("execute", () => {
-        if (this.__serverStatics.feedbackFormUrl) {
-          window.open(this.__serverStatics.feedbackFormUrl);
-        }
-      });
-      menu.add(feedbackAnonBtn);
+      osparc.navigation.Manuals.addFeedbackButtonsToMenu(menu, this.__serverStatics);
 
       const feedbackBtn = new qx.ui.form.MenuButton(null, "@FontAwesome5Solid/comments/22", menu).set({
         toolTipText: this.tr("Give us feedback")

--- a/services/web/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/web/client/source/class/osparc/navigation/NavigationBar.js
@@ -245,22 +245,7 @@ qx.Class.define("osparc.navigation.NavigationBar", {
     },
 
     __createManualMenuBtn: function() {
-      const manuals = [];
-      if (this.__serverStatics && this.__serverStatics.manualMainUrl) {
-        manuals.push({
-          label: this.tr("User Manual"),
-          icon: "@FontAwesome5Solid/book/22",
-          url: this.__serverStatics.manualMainUrl
-        });
-      }
-
-      if (osparc.utils.Utils.isInZ43() && this.__serverStatics && this.__serverStatics.manualExtraUrl) {
-        manuals.push({
-          label: this.tr("Z43 Manual"),
-          icon: "@FontAwesome5Solid/book-medical/22",
-          url: this.__serverStatics.manualExtraUrl
-        });
-      }
+      const manuals = osparc.navigation.Manuals.getManuals(this.__serverStatics);
 
       let control = new qx.ui.core.Widget();
       if (manuals.length === 1) {

--- a/services/web/client/source/class/osparc/navigation/UserMenuButton.js
+++ b/services/web/client/source/class/osparc/navigation/UserMenuButton.js
@@ -184,23 +184,7 @@ qx.Class.define("osparc.navigation.UserMenuButton", {
 
     __addFeedbacksToMenu: function() {
       const menu = this.getMenu();
-      const newGHIssueBtn = new qx.ui.menu.Button(this.tr("Issue in GitHub"));
-      newGHIssueBtn.addListener("execute", () => osparc.navigation.UserMenuButton.openGithubIssueInfoDialog(), this);
-      menu.add(newGHIssueBtn);
-
-      if (osparc.utils.Utils.isInZ43()) {
-        const newFogbugzIssueBtn = new qx.ui.menu.Button(this.tr("Issue in Fogbugz"));
-        newFogbugzIssueBtn.addListener("execute", () => osparc.navigation.UserMenuButton.openFogbugzIssueInfoDialog(), this);
-        menu.add(newFogbugzIssueBtn);
-      }
-
-      const feedbackAnonBtn = new qx.ui.menu.Button(this.tr("Anonymous feedback"));
-      feedbackAnonBtn.addListener("execute", () => {
-        if (this.__serverStatics.feedbackFormUrl) {
-          window.open(this.__serverStatics.feedbackFormUrl);
-        }
-      });
-      menu.add(feedbackAnonBtn);
+      osparc.navigation.Manuals.addFeedbackButtonsToMenu(menu, this.__serverStatics);
     }
   }
 });

--- a/services/web/client/source/class/osparc/navigation/UserMenuButton.js
+++ b/services/web/client/source/class/osparc/navigation/UserMenuButton.js
@@ -173,22 +173,7 @@ qx.Class.define("osparc.navigation.UserMenuButton", {
 
     __addManualsToMenu: function() {
       const menu = this.getMenu();
-      const manuals = [];
-      if (this.__serverStatics && this.__serverStatics.manualMainUrl) {
-        manuals.push({
-          label: this.tr("User Manual"),
-          icon: "@FontAwesome5Solid/book/22",
-          url: this.__serverStatics.manualMainUrl
-        });
-      }
-
-      if (osparc.utils.Utils.isInZ43() && this.__serverStatics && this.__serverStatics.manualExtraUrl) {
-        manuals.push({
-          label: this.tr("Z43 Manual"),
-          icon: "@FontAwesome5Solid/book-medical/22",
-          url: this.__serverStatics.manualExtraUrl
-        });
-      }
+      const manuals = osparc.navigation.Manuals.getManuals(this.__serverStatics);
 
       manuals.forEach(manual => {
         const manualBtn = new qx.ui.menu.Button(manual.label);

--- a/services/web/server/src/simcore_service_webserver/statics_constants.py
+++ b/services/web/server/src/simcore_service_webserver/statics_constants.py
@@ -1,7 +1,7 @@
 # these are the apps built right now by web/client
 
 FRONTEND_APPS_AVAILABLE = frozenset({"osparc", "tis", "s4l"})
-FRONTEND_APP_DEFAULT = "tis"
+FRONTEND_APP_DEFAULT = "osparc"
 
 assert FRONTEND_APP_DEFAULT in FRONTEND_APPS_AVAILABLE  # nosec
 

--- a/services/web/server/src/simcore_service_webserver/statics_constants.py
+++ b/services/web/server/src/simcore_service_webserver/statics_constants.py
@@ -1,7 +1,7 @@
 # these are the apps built right now by web/client
 
 FRONTEND_APPS_AVAILABLE = frozenset({"osparc", "tis", "s4l"})
-FRONTEND_APP_DEFAULT = "osparc"
+FRONTEND_APP_DEFAULT = "tis"
 
 assert FRONTEND_APP_DEFAULT in FRONTEND_APPS_AVAILABLE  # nosec
 

--- a/services/web/server/src/simcore_service_webserver/statics_settings.py
+++ b/services/web/server/src/simcore_service_webserver/statics_settings.py
@@ -77,7 +77,8 @@ class FrontEndAppSettings(BaseCustomSettings):
 
     # urls to manuals
     WEBSERVER_MANUAL_MAIN_URL: Optional[HttpUrl] = None
-    WEBSERVER_MANUAL_EXTRA_URL: Optional[HttpUrl] = None
+    WEBSERVER_MANUAL_Z43_URL: Optional[HttpUrl] = None
+    WEBSERVER_MANUAL_TI_URL: Optional[HttpUrl] = None
 
     # extra feedback url
     WEBSERVER_FEEDBACK_FORM_URL: Optional[HttpUrl] = None

--- a/services/web/server/src/simcore_service_webserver/statics_settings.py
+++ b/services/web/server/src/simcore_service_webserver/statics_settings.py
@@ -77,7 +77,7 @@ class FrontEndAppSettings(BaseCustomSettings):
 
     # urls to manuals
     WEBSERVER_MANUAL_MAIN_URL: Optional[HttpUrl] = None
-    WEBSERVER_MANUAL_Z43_URL: Optional[HttpUrl] = None
+    WEBSERVER_MANUAL_EXTRA_URL: Optional[HttpUrl] = None
     WEBSERVER_MANUAL_TI_URL: Optional[HttpUrl] = None
 
     # extra feedback url


### PR DESCRIPTION
## What do these changes do?

Now that we have a published TI manual (for now it's only the skeleton), we can link it to the manual button(s)

![TIManual](https://user-images.githubusercontent.com/33152403/183694189-37ab9ecc-6d11-4ba7-b593-9092ee722786.gif)


 ⚠️ devops: Set the correct link to the manual as an env-var, test if it works after deploying



## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
