### PR TITLE
♻️ make call to docker-compose verbose to ease debugging

### DIFF
--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
@@ -11,11 +11,19 @@ from pprint import pformat
 from typing import Optional
 
 from servicelib.async_utils import run_sequentially_in_context
+from settings_library.basic_types import LogLevel
 
 from .settings import ApplicationSettings
 from .utils import CommandResult, async_command, write_to_tmp_file
 
 logger = logging.getLogger(__name__)
+
+
+def _docker_compose_options_from_settings(settings: ApplicationSettings) -> str:
+    options = []
+    if settings.LOG_LEVEL == LogLevel.DEBUG:
+        options.append("--verbose")
+    return " ".join(options)
 
 
 def _pad_docker_command_timeout(
@@ -67,7 +75,7 @@ async def docker_compose_config(
     """
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
-        command='docker-compose --verbose --file "{file_path}" config',
+        command='docker-compose --file "{file_path}" config',
         process_termination_timeout=timeout,
     )
     return result  # type: ignore
@@ -85,7 +93,7 @@ async def docker_compose_pull(
     # can easily get progress out of it and report it back to the UI
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
-        command=f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" pull',
+        command=f'docker-compose {_docker_compose_options_from_settings(settings)} --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" pull',
         process_termination_timeout=None,
     )
     return result  # type: ignore
@@ -105,7 +113,7 @@ async def docker_compose_up(
     # building is a security risk hence is disabled via "--no-build" parameter
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
-        command=f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" up'
+        command=f'docker-compose {_docker_compose_options_from_settings(settings)} --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" up'
         " --no-build --detach",
         process_termination_timeout=None,
     )
@@ -122,7 +130,7 @@ async def docker_compose_start(
     """
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
-        command=f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" start',
+        command=f'docker-compose {_docker_compose_options_from_settings(settings)} --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" start',
         process_termination_timeout=None,
     )
     return result  # type: ignore
@@ -141,7 +149,7 @@ async def docker_compose_restart(
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
         command=(
-            f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" restart'
+            f'docker-compose {_docker_compose_options_from_settings(settings)} --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" restart'
             f" --timeout {default_compose_restart_timeout}"
         ),
         process_termination_timeout=_pad_docker_command_timeout(
@@ -168,7 +176,7 @@ async def docker_compose_down(
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
         command=(
-            f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" down'
+            f'docker-compose {_docker_compose_options_from_settings(settings)} --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" down'
             f" --volumes --remove-orphans --timeout {default_compose_down_timeout}"
         ),
         process_termination_timeout=_pad_docker_command_timeout(
@@ -192,7 +200,7 @@ async def docker_compose_rm(
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
         command=(
-            f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" rm'
+            f'docker-compose {_docker_compose_options_from_settings(settings)} --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" rm'
             " --force -v"
         ),
         process_termination_timeout=None,

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
@@ -67,7 +67,7 @@ async def docker_compose_config(
     """
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
-        command='docker-compose --file "{file_path}" config',
+        command='docker-compose --verbose --file "{file_path}" config',
         process_termination_timeout=timeout,
     )
     return result  # type: ignore
@@ -85,7 +85,7 @@ async def docker_compose_pull(
     # can easily get progress out of it and report it back to the UI
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
-        command=f'docker-compose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" pull',
+        command=f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" pull',
         process_termination_timeout=None,
     )
     return result  # type: ignore
@@ -105,7 +105,7 @@ async def docker_compose_up(
     # building is a security risk hence is disabled via "--no-build" parameter
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
-        command=f'docker-compose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" up'
+        command=f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" up'
         " --no-build --detach",
         process_termination_timeout=None,
     )
@@ -122,7 +122,7 @@ async def docker_compose_start(
     """
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
-        command=f'docker-compose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" start',
+        command=f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" start',
         process_termination_timeout=None,
     )
     return result  # type: ignore
@@ -141,7 +141,7 @@ async def docker_compose_restart(
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
         command=(
-            f'docker-compose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" restart'
+            f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" restart'
             f" --timeout {default_compose_restart_timeout}"
         ),
         process_termination_timeout=_pad_docker_command_timeout(
@@ -168,7 +168,7 @@ async def docker_compose_down(
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
         command=(
-            f'docker-compose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" down'
+            f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" down'
             f" --volumes --remove-orphans --timeout {default_compose_down_timeout}"
         ),
         process_termination_timeout=_pad_docker_command_timeout(
@@ -192,7 +192,7 @@ async def docker_compose_rm(
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
         command=(
-            f'docker-compose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" rm'
+            f'docker-compose --verbose --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" rm'
             " --force -v"
         ),
         process_termination_timeout=None,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
Since we do see strange behavior sometimes starting containers, this will help (in conjunction with setting the dy-sidecar log level to DEBUG)
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
