### PR TITLE
⬆️ maintenance/updates pennsieve library

### DIFF
--- a/requirements/tools/Makefile
+++ b/requirements/tools/Makefile
@@ -128,7 +128,9 @@ guard-%:
 	@if [ "${${*}}" = "" ]; then echo "Environment variable $* not set"; exit 1; fi
 
 
-.PHONY: update-report
-update-report: ## generates an update-report to be pasteed in the PR
-	@python check_changes.py --changed-reqs > upgrade-report.ignore.md
-	@python check_changes.py >> upgrade-report.ignore.md
+.PHONY: report
+report: ## generates a report of updated requirements that shall be pasted in the PR
+	@python check_changes.py --changed-reqs > report.ignore.md
+	@python check_changes.py >> report.ignore.md
+	@cat report.ignore.md
+	@echo SEE $(shell realpath report.ignore.md)

--- a/services/datcore-adapter/requirements/_base.in
+++ b/services/datcore-adapter/requirements/_base.in
@@ -16,7 +16,7 @@ aiofiles
 fastapi
 fastapi-pagination
 httpx[http2]
-pennsieve # NOTE: prevents from upgrading repo requirements/constraint on 'rsa'. Waiting for https://github.com/Pennsieve/pennsieve-python/pull/15
+pennsieve
 pydantic[email]
 python-multipart # for fastapi multipart uploads
 uvicorn[standard]

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -20,6 +20,8 @@ anyio==3.5.0
     #   watchgod
 asgiref==3.5.0
     # via uvicorn
+async-asgi-testclient==1.4.11
+    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 attrs==20.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
@@ -87,6 +89,7 @@ httpx==0.23.0
     #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
 hyperframe==6.0.1
     # via h2
@@ -107,11 +110,13 @@ jsonschema==3.2.0
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
+multidict==6.0.2
+    # via async-asgi-testclient
 opentracing==2.4.0
     # via
     #   fastapi-contrib
     #   jaeger-client
-pennsieve==6.1.2
+pennsieve==6.2.0
     # via -r requirements/_base.in
 protobuf==3.20.0
     # via pennsieve
@@ -166,11 +171,18 @@ pyyaml==5.4.1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   uvicorn
 requests==2.27.1
-    # via pennsieve
+    # via
+    #   async-asgi-testclient
+    #   pennsieve
 rfc3986==1.5.0
     # via httpx
-rsa==4.0
+rsa==4.9
     # via
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   pennsieve
     #   python-jose
 s3transfer==0.5.2
@@ -204,6 +216,10 @@ tornado==6.1
     # via
     #   jaeger-client
     #   threadloop
+tqdm==4.64.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 typer==0.4.1
     # via -r requirements/../../../packages/settings-library/requirements/_base.in
 typing-extensions==4.1.1
@@ -220,7 +236,9 @@ urllib3==1.26.9
     #   botocore
     #   requests
 uvicorn==0.17.6
-    # via -r requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   -r requirements/_base.in
 uvloop==0.16.0
     # via uvicorn
 watchgod==0.8.2


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

- Updates to latest pennsieve. This update unblocks the upgrade of rsa
- Remaining changes in requirement files suggest that changes in servicelib requirements were not propagated downstream. It will be corrected in a separate PR


###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 2
- #packages after : 5

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | pennsieve                 | 6.1.2           | 6.2.0      | *minor*    | 1 | datcore-adapter⬆️ |
|   2 | rsa                       | 4.0             | 4.9        | *minor*    | 1 | datcore-adapter⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency


## Related issue/s


