### PR TITLE
🐛 Starts docker-compose services in 2 steps

### DIFF
--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
@@ -99,7 +99,7 @@ async def docker_compose_pull(
     return result  # type: ignore
 
 
-async def docker_compose_up(
+async def docker_compose_create(
     compose_spec_yaml: str, settings: ApplicationSettings
 ) -> CommandResult:
     """

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
@@ -114,7 +114,7 @@ async def docker_compose_up(
     result = await _write_file_and_spawn_process(
         compose_spec_yaml,
         command=f'docker-compose {_docker_compose_options_from_settings(settings)} --project-name {settings.DYNAMIC_SIDECAR_COMPOSE_NAMESPACE} --file "{{file_path}}" up'
-        " --no-build --detach",
+        " --no-build --no-start",
         process_termination_timeout=None,
     )
     return result  # type: ignore

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -8,12 +8,12 @@ from servicelib.utils import logged_gather
 from simcore_sdk.node_data import data_manager
 
 from ..core.docker_compose_utils import (
+    docker_compose_create,
     docker_compose_down,
     docker_compose_pull,
     docker_compose_restart,
     docker_compose_rm,
     docker_compose_start,
-    docker_compose_up,
 )
 from ..core.docker_logs import start_log_fetching, stop_log_fetching
 from ..core.rabbitmq import RabbitMQ
@@ -74,7 +74,7 @@ async def task_create_service_containers(
         await docker_compose_pull(shared_store.compose_spec, settings)
 
         progress.publish(message="creating and starting containers", percent=0.90)
-        await docker_compose_up(shared_store.compose_spec, settings)
+        await docker_compose_create(shared_store.compose_spec, settings)
 
         progress.publish(message="ensure containers are started", percent=0.95)
         r = await docker_compose_start(shared_store.compose_spec, settings)

--- a/services/dynamic-sidecar/tests/unit/test_api_containers.py
+++ b/services/dynamic-sidecar/tests/unit/test_api_containers.py
@@ -23,7 +23,9 @@ from pytest_mock.plugin import MockerFixture
 from servicelib.fastapi.long_running_tasks.client import TaskId
 from simcore_service_dynamic_sidecar._meta import API_VTAG
 from simcore_service_dynamic_sidecar.core.application import AppState
-from simcore_service_dynamic_sidecar.core.docker_compose_utils import docker_compose_up
+from simcore_service_dynamic_sidecar.core.docker_compose_utils import (
+    docker_compose_create,
+)
 from simcore_service_dynamic_sidecar.core.settings import ApplicationSettings
 from simcore_service_dynamic_sidecar.core.utils import HIDDEN_FILE_NAME, async_command
 from simcore_service_dynamic_sidecar.core.validation import parse_compose_spec
@@ -103,7 +105,7 @@ async def _docker_ps_a_container_names() -> list[str]:
 async def _assert_compose_spec_pulled(compose_spec: str, settings: ApplicationSettings):
     """ensures all containers inside compose_spec are pulled"""
 
-    result = await docker_compose_up(compose_spec, settings)
+    result = await docker_compose_create(compose_spec, settings)
 
     assert result.success is True, result.message
 

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_compose_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_compose_utils.py
@@ -11,12 +11,12 @@ from faker import Faker
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_service_dynamic_sidecar.core.docker_compose_utils import (
     docker_compose_config,
+    docker_compose_create,
     docker_compose_down,
     docker_compose_pull,
     docker_compose_restart,
     docker_compose_rm,
     docker_compose_start,
-    docker_compose_up,
 )
 from simcore_service_dynamic_sidecar.core.settings import ApplicationSettings
 from simcore_service_dynamic_sidecar.core.utils import CommandResult
@@ -75,8 +75,8 @@ async def test_docker_compose_workflow(
     _print_result(r)
     assert r.success, r.message
 
-    # creates and starts in detached mode
-    r = await docker_compose_up(compose_spec_yaml, settings)
+    # creates containers
+    r = await docker_compose_create(compose_spec_yaml, settings)
     _print_result(r)
     assert r.success, r.message
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
instead of calling ```docker-compose up --detach``` and directly ```docker-compose start``` which seems to not work in some cases.
Replaces the calls with:
```docker-compose up --no-start``` which only creates the containers and then ```docker-compose start``` which will start them.
<!-- Explain REVIEWERS what is this PR about -->

Actually calling ```docker-compose --verbose up --detach``` shows that it returns right after creating the containers.

## Related issue/s
might fix #3247 
requires #3245 
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
