### PR TITLE
🐛 fixed flaky director-v2 test

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/sidecar.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/sidecar.py
@@ -46,9 +46,9 @@ def _get_environment_variables(
         "DY_SIDECAR_PATH_OUTPUTS": f"{scheduler_data.paths_mapping.outputs_path}",
         "DY_SIDECAR_PROJECT_ID": f"{scheduler_data.project_id}",
         "DY_SIDECAR_RUN_ID": f"{scheduler_data.dynamic_sidecar.run_id}",
-        "DY_SIDECAR_STATE_EXCLUDE": json_dumps([f"{x}" for x in state_exclude]),
+        "DY_SIDECAR_STATE_EXCLUDE": json_dumps(f"{x}" for x in state_exclude),
         "DY_SIDECAR_STATE_PATHS": json_dumps(
-            [f"{x}" for x in scheduler_data.paths_mapping.state_paths]
+            f"{x}" for x in scheduler_data.paths_mapping.state_paths
         ),
         "DY_SIDECAR_USER_ID": f"{scheduler_data.user_id}",
         "DYNAMIC_SIDECAR_COMPOSE_NAMESPACE": compose_namespace,

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
@@ -360,7 +360,7 @@ def test_get_dynamic_proxy_spec(
             "TaskTemplate": {"ContainerSpec": {"Env": True}},
         }
 
-        # NOTE: some falkyness here
+        # NOTE: some flakiness here
         # state_exclude is a set and does not preserve order
         # when dumping to json it gets converted to a list
         dynamic_sidecar_spec.TaskTemplate.ContainerSpec.Env[

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs.py
@@ -190,7 +190,7 @@ def expected_dynamic_sidecar_spec(run_id: UUID) -> dict[str, Any]:
                     "DY_SIDECAR_PATH_INPUTS": "/tmp/inputs",
                     "DY_SIDECAR_PATH_OUTPUTS": "/tmp/outputs",
                     "DY_SIDECAR_PROJECT_ID": "dd1d04d9-d704-4f7e-8f0f-1ca60cc771fe",
-                    "DY_SIDECAR_STATE_EXCLUDE": json_dumps(["/tmp/strip_me/*", "*.py"]),
+                    "DY_SIDECAR_STATE_EXCLUDE": json_dumps({"*.py", "/tmp/strip_me/*"}),
                     "DY_SIDECAR_STATE_PATHS": json_dumps(
                         ["/tmp/save_1", "/tmp_save_2"]
                     ),
@@ -359,6 +359,24 @@ def test_get_dynamic_proxy_spec(
             "Labels": True,
             "TaskTemplate": {"ContainerSpec": {"Env": True}},
         }
+
+        # NOTE: some falkyness here
+        # state_exclude is a set and does not preserve order
+        # when dumping to json it gets converted to a list
+        dynamic_sidecar_spec.TaskTemplate.ContainerSpec.Env[
+            "DY_SIDECAR_STATE_EXCLUDE"
+        ] = sorted(
+            dynamic_sidecar_spec.TaskTemplate.ContainerSpec.Env[
+                "DY_SIDECAR_STATE_EXCLUDE"
+            ]
+        )
+        expected_dynamic_sidecar_spec_model.TaskTemplate.ContainerSpec.Env[
+            "DY_SIDECAR_STATE_EXCLUDE"
+        ] = sorted(
+            expected_dynamic_sidecar_spec_model.TaskTemplate.ContainerSpec.Env[
+                "DY_SIDECAR_STATE_EXCLUDE"
+            ]
+        )
 
         assert dynamic_sidecar_spec.dict(
             exclude=exclude_keys


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Inside the pydantic model `state_exclude` is a `set`, since it will not preserve the order. We sort result after it's being parsed.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist