### PR TITLE
✨adds cli to list the content of state directories in dy-sidecar

### DIFF
--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/cli.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/cli.py
@@ -65,7 +65,7 @@ def state_list_dirs():
             state_path_content = list(state_path.glob("*"))
             typer.echo(f"Entries in {state_path}: {state_path_content}")
 
-    asyncio.get_event_loop().run_until_complete(_async_state_list_dirs())
+    asyncio.run(_async_state_list_dirs())
 
 
 @main.command()
@@ -83,7 +83,7 @@ def state_save():
             TaskProgress.create(), settings, mounted_volumes, rabbitmq
         )
 
-    asyncio.get_event_loop().run_until_complete(_async_save_state())
+    asyncio.run(_async_save_state())
     _print_highlight("state save finished successfully")
 
 
@@ -101,7 +101,7 @@ def outputs_push():
             TaskProgress.create(), None, mounted_volumes, rabbitmq
         )
 
-    asyncio.get_event_loop().run_until_complete(_async_outputs_push())
+    asyncio.run(_async_outputs_push())
     _print_highlight("output ports push finished successfully")
 
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/cli.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/cli.py
@@ -53,6 +53,22 @@ def _print_highlight(message: str) -> None:
 
 
 @main.command()
+def state_list_dirs():
+    """Lists files inside state directories"""
+
+    async def _async_state_list_dirs() -> None:
+        app = await _setup_app_for_task_execution()
+
+        mounted_volumes: MountedVolumes = app.state.mounted_volumes
+
+        for state_path in mounted_volumes.state_paths:
+            state_path_content = list(state_path.glob("*"))
+            typer.echo(f"Entries in {state_path}: {state_path_content}")
+
+    asyncio.get_event_loop().run_until_complete(_async_state_list_dirs())
+
+
+@main.command()
 def state_save():
     """Saves the state, usually workspace directory"""
 
@@ -75,7 +91,7 @@ def state_save():
 def outputs_push():
     """Pushes the output ports"""
 
-    async def _async_save_state() -> None:
+    async def _async_outputs_push() -> None:
         app = await _setup_app_for_task_execution()
 
         mounted_volumes: MountedVolumes = app.state.mounted_volumes
@@ -85,7 +101,7 @@ def outputs_push():
             TaskProgress.create(), None, mounted_volumes, rabbitmq
         )
 
-    asyncio.get_event_loop().run_until_complete(_async_save_state())
+    asyncio.get_event_loop().run_until_complete(_async_outputs_push())
     _print_highlight("output ports push finished successfully")
 
 

--- a/services/dynamic-sidecar/tests/unit/test_cli.py
+++ b/services/dynamic-sidecar/tests/unit/test_cli.py
@@ -6,6 +6,7 @@ from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_service_dynamic_sidecar.cli import main
 from typer.testing import CliRunner
+import os
 
 # FIXTURES
 
@@ -43,7 +44,7 @@ def test_list_state_dirs(
     cli_runner: CliRunner, mock_rabbitmq: None, mock_data_manager: None
 ):
     result = cli_runner.invoke(main, ["state-list-dirs"])
-    assert result.exit_code == 0, result.stdout
+    assert result.exit_code == os.EX_OK, result.stdout
     assert result.stdout.strip() == "\n".join(
         [f"Entries in /data/state_dir{i}: []" for i in range(4)]
     )
@@ -53,7 +54,7 @@ def test_outputs_push_interface(
     cli_runner: CliRunner, mock_rabbitmq: None, mock_data_manager: None
 ):
     result = cli_runner.invoke(main, ["state-save"])
-    assert result.exit_code == 0, result.stdout
+    assert result.exit_code == os.EX_OK, result.stdout
     assert result.stdout == "state save finished successfully\n"
 
 
@@ -61,5 +62,5 @@ def test_state_save_interface(
     cli_runner: CliRunner, mock_rabbitmq: None, mock_nodeports: None
 ):
     result = cli_runner.invoke(main, ["outputs-push"])
-    assert result.exit_code == 0, result.stdout
+    assert result.exit_code == os.EX_OK, result.stdout
     assert result.stdout == "output ports push finished successfully\n"

--- a/services/dynamic-sidecar/tests/unit/test_cli.py
+++ b/services/dynamic-sidecar/tests/unit/test_cli.py
@@ -1,12 +1,13 @@
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
 
+import os
+
 import pytest
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_service_dynamic_sidecar.cli import main
 from typer.testing import CliRunner
-import os
 
 # FIXTURES
 

--- a/services/dynamic-sidecar/tests/unit/test_cli.py
+++ b/services/dynamic-sidecar/tests/unit/test_cli.py
@@ -39,11 +39,21 @@ def mock_nodeports(mocker: MockerFixture) -> None:
 # TESTS
 
 
+def test_list_state_dirs(
+    cli_runner: CliRunner, mock_rabbitmq: None, mock_data_manager: None
+):
+    result = cli_runner.invoke(main, ["state-list-dirs"])
+    assert result.exit_code == 0, result.stdout
+    assert result.stdout.strip() == "\n".join(
+        [f"Entries in /data/state_dir{i}: []" for i in range(4)]
+    )
+
+
 def test_outputs_push_interface(
     cli_runner: CliRunner, mock_rabbitmq: None, mock_data_manager: None
 ):
     result = cli_runner.invoke(main, ["state-save"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.stdout
     assert result.stdout == "state save finished successfully\n"
 
 
@@ -51,5 +61,5 @@ def test_state_save_interface(
     cli_runner: CliRunner, mock_rabbitmq: None, mock_nodeports: None
 ):
     result = cli_runner.invoke(main, ["outputs-push"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.stdout
     assert result.stdout == "output ports push finished successfully\n"


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Allows for people trying to save the state of the sidecar figure out where the data is present, without know where the underlying defined service has it's state directories.

### 🦸 How would batman/robin use it?


- Check if the service has any data to save
```command
simcore-service-dynamic-sidecar state-list-dirs
```

- Save the data in the service
```command
simcore-service-dynamic-sidecar state-save
```

**NOTE: you also have autocomplete in the terminal**

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

- https://github.com/ITISFoundation/osparc-issues/issues/638


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist