### PR TITLE
♻️ Refactor long running tasks, result shall be directly returned

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_error_handlers.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_error_handlers.py
@@ -1,7 +1,11 @@
 from aiohttp import web
 
 from ...json_serialization import json_dumps
-from ...long_running_tasks._errors import TaskNotCompletedError, TaskNotFoundError
+from ...long_running_tasks._errors import (
+    TaskCancelledError,
+    TaskNotCompletedError,
+    TaskNotFoundError,
+)
 
 
 @web.middleware
@@ -13,3 +17,8 @@ async def base_long_running_error_handler(request, handler):
         raise web.HTTPNotFound(
             reason=f"{json_dumps(error_fields)}",
         ) from exc
+    except TaskCancelledError as exc:
+        # NOTE: only use-case would be accessing an already cancelled task
+        # which should not happen, so we return a conflict
+        error_fields = dict(code=exc.code, message=f"{exc}")
+        raise web.HTTPConflict(reason=f"{json_dumps(error_fields)}") from exc

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_routes.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_routes.py
@@ -31,9 +31,9 @@ async def get_task_result(request: web.Request) -> web.Response:
     path_params = parse_request_path_parameters_as(_PathParam, request)
     tasks_manager = get_tasks_manager(request.app)
 
+    # NOTE: this might raise an exception that will be catached by the _error_handlers
+    # in case it did not raise, then we remove the task from the manager
     task_result = tasks_manager.get_task_result(task_id=path_params.task_id)
-    # NOTE: we do not reraise here, in case the result returned an error,
-    # but we still want to remove the task
     await tasks_manager.remove_task(path_params.task_id, reraise_errors=False)
     return task_result
 

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_routes.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_routes.py
@@ -34,6 +34,7 @@ async def get_task_result(request: web.Request) -> web.Response:
     # NOTE: this might raise an exception that will be catached by the _error_handlers
     # in case it did not raise, then we remove the task from the manager
     task_result = tasks_manager.get_task_result(task_id=path_params.task_id)
+    # NOTE: this will fail if the task failed for some reason....
     await tasks_manager.remove_task(path_params.task_id, reraise_errors=False)
     return task_result
 

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_routes.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_routes.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from servicelib.aiohttp.requests_validation import parse_request_path_parameters_as
 
 from ...json_serialization import json_dumps
-from ...long_running_tasks._models import TaskId, TaskResult, TaskStatus
+from ...long_running_tasks._models import TaskId, TaskStatus
 from ...mimetype_constants import MIMETYPE_APPLICATION_JSON
 from ._dependencies import get_tasks_manager
 
@@ -31,11 +31,11 @@ async def get_task_result(request: web.Request) -> web.Response:
     path_params = parse_request_path_parameters_as(_PathParam, request)
     tasks_manager = get_tasks_manager(request.app)
 
-    task_result: TaskResult = tasks_manager.get_task_result(task_id=path_params.task_id)
+    task_result = tasks_manager.get_task_result(task_id=path_params.task_id)
     # NOTE: we do not reraise here, in case the result returned an error,
     # but we still want to remove the task
     await tasks_manager.remove_task(path_params.task_id, reraise_errors=False)
-    return web.json_response({"data": task_result}, dumps=json_dumps)
+    return task_result
 
 
 @routes.delete("/{task_id}", name="cancel_and_delete_task")

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/server.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/server.py
@@ -10,7 +10,6 @@ from ...long_running_tasks._task import (
     TaskCancelledError,
     TaskId,
     TaskProgress,
-    TaskResult,
     TasksManager,
     TaskStatus,
     start_task,
@@ -27,7 +26,6 @@ __all__: tuple[str, ...] = (
     "TaskId",
     "TasksManager",
     "TaskProgress",
-    "TaskResult",
     "TaskStatus",
 )
 

--- a/packages/service-library/src/servicelib/fastapi/long_running_tasks/_routes.py
+++ b/packages/service-library/src/servicelib/fastapi/long_running_tasks/_routes.py
@@ -40,7 +40,7 @@ async def get_task_result(
     task_manager: TasksManager = Depends(get_tasks_manager),
 ) -> TaskResult:
     assert request  # nosec
-
+    # TODO: refactor this to use same as in https://github.com/ITISFoundation/osparc-simcore/issues/3265
     task_result = task_manager.get_task_result_old(task_id=task_id)
     await task_manager.remove_task(task_id, reraise_errors=False)
 

--- a/packages/service-library/src/servicelib/fastapi/long_running_tasks/_routes.py
+++ b/packages/service-library/src/servicelib/fastapi/long_running_tasks/_routes.py
@@ -41,7 +41,7 @@ async def get_task_result(
 ) -> TaskResult:
     assert request  # nosec
 
-    task_result = task_manager.get_task_result(task_id=task_id)
+    task_result = task_manager.get_task_result_old(task_id=task_id)
     await task_manager.remove_task(task_id, reraise_errors=False)
 
     return task_result

--- a/packages/service-library/src/servicelib/long_running_tasks/_task.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/_task.py
@@ -240,7 +240,12 @@ class TasksManager:
         self, task_id: TaskId, *, reraise_errors: bool = True
     ) -> None:
         """cancels and removes task"""
-        tracked_task = self._get_tracked_task(task_id)
+        try:
+            tracked_task = self._get_tracked_task(task_id)
+        except TaskNotFoundError:
+            if reraise_errors:
+                raise
+            return
         try:
             await self._cancel_tracked_task(
                 tracked_task.task, task_id, reraise_errors=reraise_errors

--- a/packages/service-library/src/servicelib/long_running_tasks/_task.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/_task.py
@@ -184,6 +184,7 @@ class TasksManager:
 
         raises TaskNotFoundError if the task cannot be found
         raises TaskCancelledError if the task was cancelled
+        raises TaskNotCompletedError if the task is not completed
         """
         tracked_task = self._get_tracked_task(task_id)
 

--- a/packages/service-library/tests/long_running_tasks/test_long_running_tasks_task.py
+++ b/packages/service-library/tests/long_running_tasks/test_long_running_tasks_task.py
@@ -5,11 +5,8 @@
 
 
 import asyncio
-from asyncio import Task
-from contextlib import asynccontextmanager
 from datetime import datetime
-from enum import Enum
-from typing import AsyncIterable, AsyncIterator, Final, Optional
+from typing import AsyncIterator, Final
 
 import pytest
 from fastapi import status
@@ -19,12 +16,7 @@ from servicelib.long_running_tasks._errors import (
     TaskNotCompletedError,
     TaskNotFoundError,
 )
-from servicelib.long_running_tasks._models import (
-    TaskId,
-    TaskProgress,
-    TaskResult,
-    TaskStatus,
-)
+from servicelib.long_running_tasks._models import TaskProgress, TaskResult, TaskStatus
 from servicelib.long_running_tasks._task import TasksManager, start_task
 from tenacity._asyncio import AsyncRetrying
 from tenacity.retry import retry_if_exception_type
@@ -54,7 +46,7 @@ async def fast_background_task(task_progress: TaskProgress) -> int:
     return 42
 
 
-async def failing_background_task(task_progress: TaskProgress) -> None:
+async def failing_background_task(task_progress: TaskProgress):
     """this task does nothing and returns a constant"""
     raise RuntimeError("failing asap")
 
@@ -82,6 +74,28 @@ async def test_unchecked_task_is_auto_removed(tasks_manager: TasksManager):
     await asyncio.sleep(2 * TEST_CHECK_STALE_INTERVAL_S + 1)
     with pytest.raises(TaskNotFoundError):
         tasks_manager.get_task_status(task_id)
+    with pytest.raises(TaskNotFoundError):
+        tasks_manager.get_task_result(task_id)
+    with pytest.raises(TaskNotFoundError):
+        tasks_manager.get_task_result_old(task_id)
+
+
+async def test_checked_once_task_is_auto_removed(tasks_manager: TasksManager):
+    task_id = start_task(
+        tasks_manager,
+        a_background_task,
+        raise_when_finished=False,
+        total_sleep=10 * TEST_CHECK_STALE_INTERVAL_S,
+    )
+    # check once (different branch in code)
+    tasks_manager.get_task_status(task_id)
+    await asyncio.sleep(2 * TEST_CHECK_STALE_INTERVAL_S + 1)
+    with pytest.raises(TaskNotFoundError):
+        tasks_manager.get_task_status(task_id)
+    with pytest.raises(TaskNotFoundError):
+        tasks_manager.get_task_result(task_id)
+    with pytest.raises(TaskNotFoundError):
+        tasks_manager.get_task_result_old(task_id)
 
 
 async def test_checked_task_is_not_auto_removed(tasks_manager: TasksManager):
@@ -100,11 +114,26 @@ async def test_checked_task_is_not_auto_removed(tasks_manager: TasksManager):
         with attempt:
             status = tasks_manager.get_task_status(task_id)
             assert status.done, f"task {task_id} not complete"
-    tasks_manager.get_task_result(task_id)
+    result = tasks_manager.get_task_result(task_id)
+    assert result
 
 
-async def test_unique_task_already_running(tasks_manager: TasksManager) -> None:
-    async def unique_task(task_progress: TaskProgress) -> None:
+async def test_get_result_of_unfinished_task_raises(tasks_manager: TasksManager):
+    task_id = start_task(
+        tasks_manager,
+        a_background_task,
+        raise_when_finished=False,
+        total_sleep=5 * TEST_CHECK_STALE_INTERVAL_S,
+    )
+    with pytest.raises(TaskNotCompletedError):
+        tasks_manager.get_task_result(task_id)
+
+    with pytest.raises(TaskNotCompletedError):
+        tasks_manager.get_task_result_old(task_id)
+
+
+async def test_unique_task_already_running(tasks_manager: TasksManager):
+    async def unique_task(task_progress: TaskProgress):
         await asyncio.sleep(1)
 
     start_task(tasks_manager=tasks_manager, handler=unique_task, unique=True)
@@ -115,19 +144,19 @@ async def test_unique_task_already_running(tasks_manager: TasksManager) -> None:
             start_task(tasks_manager=tasks_manager, handler=unique_task, unique=True)
 
 
-async def test_start_multiple_not_unique_tasks(tasks_manager: TasksManager) -> None:
-    async def not_unique_task(task_progress: TaskProgress) -> None:
+async def test_start_multiple_not_unique_tasks(tasks_manager: TasksManager):
+    async def not_unique_task(task_progress: TaskProgress):
         await asyncio.sleep(1)
 
     for _ in range(5):
         start_task(tasks_manager=tasks_manager, handler=not_unique_task)
 
 
-def test_get_task_id() -> None:
+def test_get_task_id():
     assert TasksManager._create_task_id("") != TasksManager._create_task_id("")
 
 
-async def test_get_status(tasks_manager: TasksManager) -> None:
+async def test_get_status(tasks_manager: TasksManager):
     task_id = start_task(
         tasks_manager=tasks_manager,
         handler=a_background_task,
@@ -142,59 +171,59 @@ async def test_get_status(tasks_manager: TasksManager) -> None:
     assert isinstance(task_status.started, datetime)
 
 
-async def test_get_status_missing(tasks_manager: TasksManager) -> None:
+async def test_get_status_missing(tasks_manager: TasksManager):
     with pytest.raises(TaskNotFoundError) as exec_info:
         tasks_manager.get_task_status("missing_task_id")
     assert f"{exec_info.value}" == "No task with missing_task_id found"
 
 
-async def test_get_result(tasks_manager: TasksManager) -> None:
+async def test_get_result(tasks_manager: TasksManager):
     task_id = start_task(tasks_manager=tasks_manager, handler=fast_background_task)
     await asyncio.sleep(0.1)
     result = tasks_manager.get_task_result(task_id)
     assert result == 42
 
 
-async def test_get_result_old(tasks_manager: TasksManager) -> None:
+async def test_get_result_old(tasks_manager: TasksManager):
     task_id = start_task(tasks_manager=tasks_manager, handler=fast_background_task)
     await asyncio.sleep(0.1)
     result = tasks_manager.get_task_result_old(task_id)
     assert result == TaskResult(result=42, error=None)
 
 
-async def test_get_result_missing(tasks_manager: TasksManager) -> None:
+async def test_get_result_missing(tasks_manager: TasksManager):
     with pytest.raises(TaskNotFoundError) as exec_info:
         tasks_manager.get_task_result("missing_task_id")
     assert f"{exec_info.value}" == "No task with missing_task_id found"
 
 
-async def test_get_result_finished_with_error(tasks_manager: TasksManager) -> None:
+async def test_get_result_finished_with_error(tasks_manager: TasksManager):
     task_id = start_task(tasks_manager=tasks_manager, handler=failing_background_task)
-
-    can_continue = True
-    while can_continue:
-        try:
-            tasks_manager.get_task_result(task_id)
-        except TaskNotCompletedError:
-            can_continue = False
-
-        await asyncio.sleep(0.1)
+    # wait for result
+    async for attempt in AsyncRetrying(
+        reraise=True,
+        wait=wait_fixed(0.1),
+        stop=stop_after_delay(60),
+        retry=retry_if_exception_type(AssertionError),
+    ):
+        with attempt:
+            assert tasks_manager.get_task_status(task_id).done
 
     with pytest.raises(RuntimeError, match="failing asap"):
         tasks_manager.get_task_result(task_id)
 
 
-async def test_get_result_old_finished_with_error(tasks_manager: TasksManager) -> None:
+async def test_get_result_old_finished_with_error(tasks_manager: TasksManager):
     task_id = start_task(tasks_manager=tasks_manager, handler=failing_background_task)
-
-    can_continue = True
-    while can_continue:
-        try:
-            tasks_manager.get_task_result(task_id)
-        except TaskNotCompletedError:
-            can_continue = False
-
-        await asyncio.sleep(0.1)
+    # wait for result
+    async for attempt in AsyncRetrying(
+        reraise=True,
+        wait=wait_fixed(0.1),
+        stop=stop_after_delay(60),
+        retry=retry_if_exception_type(AssertionError),
+    ):
+        with attempt:
+            assert tasks_manager.get_task_status(task_id).done
 
     task_result = tasks_manager.get_task_result_old(task_id)
     assert task_result.result is None
@@ -205,7 +234,7 @@ async def test_get_result_old_finished_with_error(tasks_manager: TasksManager) -
 
 async def test_get_result_task_was_cancelled_multiple_times(
     tasks_manager: TasksManager,
-) -> None:
+):
     task_id = start_task(
         tasks_manager=tasks_manager,
         handler=a_background_task,
@@ -223,7 +252,7 @@ async def test_get_result_task_was_cancelled_multiple_times(
 
 async def test_get_result_old_task_was_cancelled_multiple_times(
     tasks_manager: TasksManager,
-) -> None:
+):
     task_id = start_task(
         tasks_manager=tasks_manager,
         handler=a_background_task,
@@ -238,135 +267,25 @@ async def test_get_result_old_task_was_cancelled_multiple_times(
     assert task_result.error == f"Task {task_id} was cancelled before completing"
 
 
-async def test_remove_ok(tasks_manager: TasksManager) -> None:
+async def test_remove_ok(tasks_manager: TasksManager):
     task_id = start_task(
         tasks_manager=tasks_manager,
         handler=a_background_task,
         raise_when_finished=False,
         total_sleep=10,
     )
-    # pylint: disable=protected-access
-    assert tasks_manager._get_tracked_task(task_id)
+    tasks_manager.get_task_status(task_id)
     await tasks_manager.remove_task(task_id)
     with pytest.raises(TaskNotFoundError):
-        assert tasks_manager._get_tracked_task(task_id)
-
-
-# TESTS - stale task detection
-
-
-class ExpectedTaskResult(str, Enum):
-    RUNNING = "RUNNING"
-    RAISE_ERROR = "RAISE_ERROR"
-    HAS_RESULT = "HAS_RESULT"
-
-
-BASE_SLEEP = 1.0
-STATUS_POLL_INTERVAL = BASE_SLEEP * 0.2
-TASK_CHECK_INTERVAL = BASE_SLEEP * 0.6
-TASK_DETECT_TIMEOUT = BASE_SLEEP * 0.3
-
-
-async def task_to_track(expected_task_result: ExpectedTaskResult) -> Optional[int]:
-    if expected_task_result == ExpectedTaskResult.RUNNING:
-        # sleeps for a very long amount of time
-        await asyncio.sleep(BASE_SLEEP * 10)
-    if expected_task_result == ExpectedTaskResult.RAISE_ERROR:
-        raise RuntimeError("Task raised error as expected")
-    if expected_task_result == ExpectedTaskResult.HAS_RESULT:
-        return 42
-
-    raise RuntimeError("OPS task finished running, this is unexpected!")
-
-
-TASK_NAME = task_to_track.__name__
-
-
-@pytest.fixture
-async def stall_task_manager() -> AsyncIterable[TasksManager]:
-    tasks_manager = TasksManager(
-        stale_task_check_interval_s=TASK_CHECK_INTERVAL,
-        stale_task_detect_timeout_s=TASK_DETECT_TIMEOUT,
-    )
-
-    yield tasks_manager
-
-    await tasks_manager.close()
-
-
-@asynccontextmanager
-async def poll_status(
-    tasks_manager: TasksManager, task_id: TaskId
-) -> AsyncIterator[None]:
-    continue_progress_check = True
-
-    async def progress_checker() -> None:
-        while continue_progress_check:
-            task_status = tasks_manager.get_task_status(task_id)
-            print(f"POLLING STATUS------> {task_status=}")
-            await asyncio.sleep(STATUS_POLL_INTERVAL)
-
-    progress_checker_task: Task = asyncio.create_task(progress_checker())
-    try:
-        yield
-    finally:
-        # close progress checker task when done with it
-        assert progress_checker_task
-        continue_progress_check = False
-        await progress_checker_task
-
-
-@pytest.mark.parametrize(
-    "expected_task_result, is_done",
-    [
-        (ExpectedTaskResult.RUNNING, False),
-        (ExpectedTaskResult.HAS_RESULT, True),
-        (ExpectedTaskResult.RAISE_ERROR, True),
-    ],
-)
-async def test_stall_task_is_tracked(
-    stall_task_manager: TasksManager,
-    expected_task_result: ExpectedTaskResult,
-    is_done: bool,
-) -> None:
-    task = asyncio.create_task(task_to_track(expected_task_result))
-    tracked_task = stall_task_manager.add_task(TASK_NAME, task, TaskProgress.create())
-    assert len(stall_task_manager.get_task_group(TASK_NAME)) == 1
-
-    async with poll_status(stall_task_manager, tracked_task.task_id):
-        # let some time pass
-        await asyncio.sleep(STATUS_POLL_INTERVAL)
-
-        task_status: TaskStatus = stall_task_manager.get_task_status(
-            tracked_task.task_id
-        )
-        assert task_status.done is is_done
-    assert len(stall_task_manager.get_task_group(TASK_NAME)) == 1
-
-
-@pytest.mark.parametrize(
-    "expected_task_result",
-    [
-        ExpectedTaskResult.RUNNING,
-        ExpectedTaskResult.HAS_RESULT,
-        ExpectedTaskResult.RAISE_ERROR,
-    ],
-)
-async def test_stall_task_not_tracked(
-    stall_task_manager: TasksManager, expected_task_result: ExpectedTaskResult
-) -> None:
-    task = asyncio.create_task(task_to_track(expected_task_result))
-    tracked_task = stall_task_manager.add_task(TASK_NAME, task, TaskProgress.create())
-    assert len(stall_task_manager.get_task_group(TASK_NAME)) == 1
-    # expected task still running
-    await asyncio.sleep(TASK_CHECK_INTERVAL)
-    assert len(stall_task_manager.get_task_group(TASK_NAME)) == 1
-
-    # let task remove itself
-    await asyncio.sleep(TASK_CHECK_INTERVAL * 2)
-
-    # task will no longer be found
+        tasks_manager.get_task_status(task_id)
     with pytest.raises(TaskNotFoundError):
-        stall_task_manager.get_task_status(tracked_task.task_id)
-    # expect this to have been removed
-    assert len(stall_task_manager.get_task_group(TASK_NAME)) == 0
+        tasks_manager.get_task_result(task_id)
+    with pytest.raises(TaskNotFoundError):
+        tasks_manager.get_task_result_old(task_id)
+
+
+async def test_remove_unknown_task(tasks_manager: TasksManager):
+    with pytest.raises(TaskNotFoundError):
+        await tasks_manager.remove_task("invalid_id")
+
+    await tasks_manager.remove_task("invalid_id", reraise_errors=False)

--- a/packages/service-library/tests/long_running_tasks/test_long_running_tasks_task.py
+++ b/packages/service-library/tests/long_running_tasks/test_long_running_tasks_task.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from typing import AsyncIterator, Final
 
 import pytest
-from fastapi import status
 from servicelib.long_running_tasks._errors import (
     TaskAlreadyRunningError,
     TaskCancelledError,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
NOTE: currently only concerns REST long running tasks for AIOHTTP-based services (such as the webserver), PR is a pre-requisite for making copies of a project. FastAPI-based services are not concerned yet, since this would mean many more changes. But this should be changed ASAP.

A long running task in REST is handled like so in oSparc:
- client POST a request
- server returns a 202 (Accepted) with a ```{"task_id": TaskID, "status_href": LINK_TO_STATUS, "result_href": LINK_TO_RESULT}```
- client shall poll on ```GET status_href``` until status is *done*
- client shall then get the result by ```GET result_href```

This PR changes what the result is like from using a wrapper of result to **directly** returning the result. In essence this means for example when copying project:

## Before change
```python
# POST /projects -> 202 - Accepted (TaskId)
# GET /tasks/TaskId -> until it's done
# GET /tasks/TaskId/result
# returns 200 - Ok with {"data": resultObject} or 200 - Ok  with {"errors": stringified error that happened server side}
```
## After change
```python
# POST /projects -> 202 - Accepted (TaskId)
# GET /tasks/TaskId -> until it's done
# GET /tasks/TaskId/result
# returns 2XX code with resultObject or standard HTTP error code with reason why it happened
```

This way it is not necessary to change all the logic client side.


## Related issue/s
pre-requisite for #3235 
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
