### PR TITLE
✨ added retries for upload and download in the node ports package

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/constants.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/constants.py
@@ -2,5 +2,6 @@ from typing import Final
 
 from models_library.api_schemas_storage import LocationID
 
-SIMCORE_LOCATION: Final[LocationID] = 0
+CHUNK_SIZE: Final[int] = 16 * 1024 * 1024
 MINUTE: Final[int] = 60
+SIMCORE_LOCATION: Final[LocationID] = 0

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
@@ -1,0 +1,30 @@
+import asyncio
+from pathlib import Path
+from typing import IO, AsyncGenerator
+
+import aiofiles
+
+
+async def file_object_chunk_reader(
+    file_object: IO, *, offset: int, total_bytes_to_read: int, chunk_size: int
+) -> AsyncGenerator[bytes, None]:
+    await asyncio.get_event_loop().run_in_executor(None, file_object.seek, offset)
+    num_read_bytes = 0
+    while chunk := await asyncio.get_event_loop().run_in_executor(
+        None, file_object.read, min(chunk_size, total_bytes_to_read - num_read_bytes)
+    ):
+        num_read_bytes += len(chunk)
+        yield chunk
+
+
+async def file_chunk_reader(
+    file: Path, *, offset: int, total_bytes_to_read: int, chunk_size: int
+) -> AsyncGenerator[bytes, None]:
+    async with aiofiles.open(file, "rb") as f:
+        await f.seek(offset)
+        num_read_bytes = 0
+        while chunk := await f.read(
+            min(chunk_size, total_bytes_to_read - num_read_bytes)
+        ):
+            num_read_bytes += len(chunk)
+            yield chunk

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
@@ -1,30 +1,238 @@
 import asyncio
+import json
+import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import IO, AsyncGenerator
+from typing import IO, AsyncGenerator, Union
 
 import aiofiles
+from aiohttp import (
+    ClientConnectionError,
+    ClientError,
+    ClientPayloadError,
+    ClientResponse,
+    ClientSession,
+    web,
+)
+from models_library.api_schemas_storage import ETag, FileUploadSchema, UploadedPart
+from pydantic import AnyUrl
+from servicelib.utils import logged_gather
+from tenacity._asyncio import AsyncRetrying
+from tenacity.before_sleep import before_sleep_log
+from tenacity.retry import retry_if_exception_type
+from tenacity.stop import stop_after_attempt
+from tenacity.wait import wait_exponential
+from tqdm import tqdm
+from yarl import URL
+
+from . import exceptions
+from .constants import CHUNK_SIZE
 
 
-async def file_object_chunk_reader(
-    file_object: IO, *, offset: int, total_bytes_to_read: int, chunk_size: int
+@dataclass(frozen=True)
+class UploadableFileObject:
+    file_object: IO
+    file_name: str
+    file_size: int
+
+
+async def _file_object_chunk_reader(
+    file_object: IO, *, offset: int, total_bytes_to_read: int
 ) -> AsyncGenerator[bytes, None]:
     await asyncio.get_event_loop().run_in_executor(None, file_object.seek, offset)
     num_read_bytes = 0
     while chunk := await asyncio.get_event_loop().run_in_executor(
-        None, file_object.read, min(chunk_size, total_bytes_to_read - num_read_bytes)
+        None, file_object.read, min(CHUNK_SIZE, total_bytes_to_read - num_read_bytes)
     ):
         num_read_bytes += len(chunk)
         yield chunk
 
 
-async def file_chunk_reader(
-    file: Path, *, offset: int, total_bytes_to_read: int, chunk_size: int
+async def _file_chunk_reader(
+    file: Path, *, offset: int, total_bytes_to_read: int
 ) -> AsyncGenerator[bytes, None]:
     async with aiofiles.open(file, "rb") as f:
         await f.seek(offset)
         num_read_bytes = 0
         while chunk := await f.read(
-            min(chunk_size, total_bytes_to_read - num_read_bytes)
+            min(CHUNK_SIZE, total_bytes_to_read - num_read_bytes)
         ):
             num_read_bytes += len(chunk)
             yield chunk
+
+
+async def _file_chunk_writer(file: Path, response: ClientResponse, pbar: tqdm):
+    async with aiofiles.open(file, "wb") as file_pointer:
+        while chunk := await response.content.read(CHUNK_SIZE):
+            await file_pointer.write(chunk)
+            pbar.update(len(chunk))
+
+
+log = logging.getLogger(__name__)
+_TQDM_FILE_OPTIONS = dict(
+    unit="byte",
+    unit_scale=True,
+    unit_divisor=1024,
+    colour="yellow",
+    miniters=1,
+)
+
+
+async def download_link_to_file(
+    session: ClientSession, url: URL, file_path: Path, *, num_retries: int
+):
+    log.debug("Downloading from %s to %s", url, file_path)
+    async for attempt in AsyncRetrying(
+        reraise=True,
+        wait=wait_exponential(min=1, max=10),
+        stop=stop_after_attempt(num_retries),
+        retry=retry_if_exception_type(ClientConnectionError),
+        before_sleep=before_sleep_log(log, logging.WARNING),
+    ):
+        with attempt:
+            async with session.get(url) as response:
+                if response.status == 404:
+                    raise exceptions.InvalidDownloadLinkError(url)
+                if response.status > 299:
+                    raise exceptions.TransferError(url)
+                file_path.parent.mkdir(parents=True, exist_ok=True)
+                # SEE https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length
+                file_size = int(response.headers.get("Content-Length", 0)) or None
+                try:
+                    with tqdm(
+                        desc=f"downloading {url.path} --> {file_path.name}\n",
+                        total=file_size,
+                        **_TQDM_FILE_OPTIONS,
+                    ) as pbar:
+                        await _file_chunk_writer(file_path, response, pbar)
+                        log.debug("Download complete")
+                except ClientPayloadError as exc:
+                    raise exceptions.TransferError(url) from exc
+
+
+async def _upload_file_part(
+    session: ClientSession,
+    file_to_upload: Union[Path, UploadableFileObject],
+    part_index: int,
+    file_offset: int,
+    file_part_size: int,
+    num_parts: int,
+    upload_url: AnyUrl,
+    pbar: tqdm,
+    num_retries: int,
+) -> tuple[int, ETag]:
+    log.debug(
+        "--> uploading %s of %s, [%s]...",
+        f"{file_part_size=} bytes",
+        f"{file_to_upload=}",
+        f"{part_index+1}/{num_parts}",
+    )
+    file_uploader = _file_chunk_reader(
+        file_to_upload,  # type: ignore
+        offset=file_offset,
+        total_bytes_to_read=file_part_size,
+    )
+    if isinstance(file_to_upload, UploadableFileObject):
+        file_uploader = _file_object_chunk_reader(
+            file_to_upload.file_object,
+            offset=file_offset,
+            total_bytes_to_read=file_part_size,
+        )
+    async for attempt in AsyncRetrying(
+        reraise=True,
+        wait=wait_exponential(min=1, max=10),
+        stop=stop_after_attempt(num_retries),
+        retry=retry_if_exception_type(ClientConnectionError),
+        before_sleep=before_sleep_log(log, logging.WARNING),
+    ):
+        with attempt:
+            response = await session.put(
+                upload_url,
+                data=file_uploader,
+                headers={
+                    "Content-Length": f"{file_part_size}",
+                },
+            )
+            response.raise_for_status()
+            pbar.update(file_part_size)
+            # NOTE: the response from minio does not contain a json body
+            assert response.status == web.HTTPOk.status_code  # nosec
+            assert response.headers  # nosec
+            assert "Etag" in response.headers  # nosec
+            received_e_tag = json.loads(response.headers["Etag"])
+            log.info(
+                "--> completed upload %s of %s, [%s], %s",
+                f"{file_part_size=}",
+                f"{file_to_upload=}",
+                f"{part_index+1}/{num_parts}",
+                f"{received_e_tag=}",
+            )
+            return (part_index, received_e_tag)
+    raise exceptions.S3TransferError(
+        f"Unexpected error while transferring {file_to_upload} to {upload_url}"
+    )
+
+
+async def upload_file_to_presigned_links(
+    session: ClientSession,
+    file_upload_links: FileUploadSchema,
+    file_to_upload: Union[Path, UploadableFileObject],
+    *,
+    num_retries: int,
+) -> list[UploadedPart]:
+    file_size = 0
+    file_name = ""
+    if isinstance(file_to_upload, Path):
+        file_size = file_to_upload.stat().st_size
+        file_name = file_to_upload.as_posix()
+    else:
+        file_size = file_to_upload.file_size
+        file_name = file_to_upload.file_name
+
+    log.debug("Uploading from %s to %s", f"{file_name=}", f"{file_upload_links=}")
+
+    file_chunk_size = int(file_upload_links.chunk_size)
+    num_urls = len(file_upload_links.urls)
+    last_chunk_size = file_size - file_chunk_size * (num_urls - 1)
+    upload_tasks = []
+    with tqdm(
+        desc=f"uploading {file_name}\n", total=file_size, **_TQDM_FILE_OPTIONS
+    ) as pbar:
+        for index, upload_url in enumerate(file_upload_links.urls):
+            this_file_chunk_size = (
+                file_chunk_size if (index + 1) < num_urls else last_chunk_size
+            )
+            upload_tasks.append(
+                _upload_file_part(
+                    session,
+                    file_to_upload,
+                    index,
+                    index * file_chunk_size,
+                    this_file_chunk_size,
+                    num_urls,
+                    upload_url,
+                    pbar,
+                    num_retries,
+                )
+            )
+        try:
+            results = await logged_gather(
+                *upload_tasks,
+                log=log,
+                # NOTE: when the file object is already created it cannot be duplicated so
+                # no concurrency is allowed in that case
+                max_concurrency=4 if isinstance(file_to_upload, Path) else 1,
+            )
+            part_to_etag = [
+                UploadedPart(number=index + 1, e_tag=e_tag) for index, e_tag in results
+            ]
+            log.info(
+                "Uploaded %s, received %s",
+                f"{file_name=}",
+                f"{part_to_etag=}",
+            )
+            return part_to_etag
+        except ClientError as exc:
+            raise exceptions.S3TransferError(
+                f"Could not upload file {file_name}:{exc}"
+            ) from exc

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -250,6 +250,9 @@ async def _upload_file_part(
                 f"{received_e_tag=}",
             )
             return (part_index, received_e_tag)
+    raise exceptions.S3TransferError(
+        f"Unexpected error while transferring {file_to_upload} to {upload_url}"
+    )
 
 
 async def _upload_file_to_presigned_links(

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -35,12 +35,11 @@ from pydantic import ByteSize, parse_obj_as
 from pydantic.networks import AnyUrl
 from servicelib.utils import logged_gather
 from settings_library.r_clone import RCloneSettings
-from tenacity import wait_random
 from tenacity._asyncio import AsyncRetrying
 from tenacity.before_sleep import before_sleep_log
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
-from tenacity.wait import wait_fixed
+from tenacity.wait import wait_exponential, wait_fixed
 from tqdm import tqdm
 from yarl import URL
 
@@ -136,7 +135,7 @@ async def _download_link_to_file(session: ClientSession, url: URL, file_path: Pa
     log.debug("Downloading from %s to %s", url, file_path)
     async for attempt in AsyncRetrying(
         reraise=True,
-        wait=wait_random(min=0.1, max=2),
+        wait=wait_exponential(min=1, max=10),
         stop=stop_after_delay(
             NodePortsSettings.create_from_envs().NODE_PORTS_IO_RETRY_DELAY_S
         ),

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -79,31 +79,6 @@ async def _get_location_id_from_location_name(
     raise exceptions.S3InvalidStore(store)
 
 
-async def _get_download_link(
-    user_id: UserID,
-    store_id: LocationID,
-    file_id: StorageFileID,
-    session: ClientSession,
-    link_type: storage_client.LinkType,
-) -> URL:
-    """
-    :raises exceptions.S3InvalidPathError
-    :raises exceptions.StorageInvalidCall
-    :raises exceptions.StorageServerIssue
-    """
-    link: AnyUrl = await storage_client.get_download_file_link(
-        session=session,
-        file_id=file_id,
-        location_id=store_id,
-        user_id=user_id,
-        link_type=link_type,
-    )
-    if not link:
-        raise exceptions.S3InvalidPathError(file_id)
-
-    return URL(link)
-
-
 async def _get_upload_links(
     user_id: UserID,
     store_id: LocationID,
@@ -376,8 +351,14 @@ async def get_download_link_from_s3(
                 user_id, store_name, session
             )
         assert store_id is not None  # nosec
-        return await _get_download_link(
-            user_id, store_id, s3_object, session, link_type
+        return URL(
+            await storage_client.get_download_file_link(
+                session=session,
+                file_id=s3_object,
+                location_id=store_id,
+                user_id=user_id,
+                link_type=link_type,
+            )
         )
 
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/settings.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/settings.py
@@ -1,4 +1,4 @@
-from pydantic import Field, NonNegativeInt
+from pydantic import Field, NonNegativeInt, PositiveInt
 from settings_library.base import BaseCustomSettings
 from settings_library.postgres import PostgresSettings
 from settings_library.storage import StorageSettings
@@ -11,4 +11,4 @@ class NodePortsSettings(BaseCustomSettings):
     POSTGRES_SETTINGS: PostgresSettings = Field(auto_default_from_env=True)
 
     NODE_PORTS_MULTIPART_UPLOAD_COMPLETION_TIMEOUT_S: NonNegativeInt = 5 * MINUTE
-    NODE_PORTS_IO_RETRY_DELAY_S: NonNegativeInt = 5 * MINUTE
+    NODE_PORTS_IO_NUM_RETRY_ATTEMPTS: PositiveInt = 5

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/settings.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/settings.py
@@ -11,3 +11,4 @@ class NodePortsSettings(BaseCustomSettings):
     POSTGRES_SETTINGS: PostgresSettings = Field(auto_default_from_env=True)
 
     NODE_PORTS_MULTIPART_UPLOAD_COMPLETION_TIMEOUT_S: NonNegativeInt = 5 * MINUTE
+    NODE_PORTS_IO_RETRY_DELAY_S: NonNegativeInt = 5 * MINUTE

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/storage_client.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/storage_client.py
@@ -94,7 +94,10 @@ async def get_download_file_link(
         presigned_link_enveloped = Envelope[PresignedLink].parse_obj(
             await response.json()
         )
-        if presigned_link_enveloped.data is None:
+        if (
+            presigned_link_enveloped.data is None
+            or not presigned_link_enveloped.data.link
+        ):
             raise exceptions.S3InvalidPathError(
                 f"file {location_id}@{file_id} not found"
             )

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
@@ -152,7 +152,7 @@ def mocked_upload_file_raising_exceptions(mocker: MockerFixture):
         side_effect=RCloneFailedError,
     )
     mocker.patch(
-        "simcore_sdk.node_ports_common.filemanager._upload_file_part",
+        "simcore_sdk.node_ports_common.file_io_utils.upload_file_part",
         autospec=True,
         side_effect=ClientError,
     )
@@ -237,7 +237,7 @@ async def test_failed_upload_after_valid_upload_keeps_last_valid_state(
         side_effect=RCloneFailedError,
     )
     mocker.patch(
-        "simcore_sdk.node_ports_common.filemanager._upload_file_part",
+        "simcore_sdk.node_ports_common.file_io_utils.upload_file_part",
         autospec=True,
         side_effect=ClientError,
     )

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
@@ -152,7 +152,7 @@ def mocked_upload_file_raising_exceptions(mocker: MockerFixture):
         side_effect=RCloneFailedError,
     )
     mocker.patch(
-        "simcore_sdk.node_ports_common.file_io_utils.upload_file_part",
+        "simcore_sdk.node_ports_common.file_io_utils._upload_file_part",
         autospec=True,
         side_effect=ClientError,
     )
@@ -237,7 +237,7 @@ async def test_failed_upload_after_valid_upload_keeps_last_valid_state(
         side_effect=RCloneFailedError,
     )
     mocker.patch(
-        "simcore_sdk.node_ports_common.file_io_utils.upload_file_part",
+        "simcore_sdk.node_ports_common.file_io_utils._upload_file_part",
         autospec=True,
         side_effect=ClientError,
     )

--- a/swagger-cli
+++ b/swagger-cli
@@ -1,0 +1,1 @@
+node_modules/swagger-cli/swagger-cli.js

--- a/swagger-cli
+++ b/swagger-cli
@@ -1,1 +1,0 @@
-node_modules/swagger-cli/swagger-cli.js


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
This PR adds retries in case of ConnectionError (see [aiohttp docs](https://docs.aiohttp.org/en/stable/client_reference.html#connection-errors))

It will retry using a default of 5 minutes, changeable via ENV variable

## Related issue/s
fixes https://github.com/ITISFoundation/osparc-simcore/issues/3242
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
