### PR TITLE
🐛 iSeg sometimes stuck with invalid networks (maybe)

### DIFF
--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/validation.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/validation.py
@@ -125,7 +125,7 @@ def _merge_env_vars(
     return [f"{k}={v}" for k, v in dict_spec_env_vars.items()]
 
 
-DEFAULT_BACKEND_NETWORK_NAME = "__backend__"
+_DEFAULT_BACKEND_NETWORK_NAME = "__backend__"
 
 
 def _inject_backend_networking(parsed_compose_spec: dict[str, Any]) -> None:
@@ -137,20 +137,20 @@ def _inject_backend_networking(parsed_compose_spec: dict[str, Any]) -> None:
 
     networks = parsed_compose_spec.setdefault("networks", {})
     if not networks:
-        parsed_compose_spec["networks"] = {DEFAULT_BACKEND_NETWORK_NAME: None}
+        parsed_compose_spec["networks"] = {_DEFAULT_BACKEND_NETWORK_NAME: None}
     else:
-        networks[DEFAULT_BACKEND_NETWORK_NAME] = None
+        networks[_DEFAULT_BACKEND_NETWORK_NAME] = None
 
     for service_content in parsed_compose_spec["services"].values():
         service_networks = service_content.setdefault("networks", [])
         if isinstance(service_networks, list):
-            service_networks.append(DEFAULT_BACKEND_NETWORK_NAME)
+            service_networks.append(_DEFAULT_BACKEND_NETWORK_NAME)
         elif not service_networks:
             # if network is set without entries
-            service_content["networks"] = [DEFAULT_BACKEND_NETWORK_NAME]
+            service_content["networks"] = [_DEFAULT_BACKEND_NETWORK_NAME]
         else:
             # if the network is set as a dictionary (rather non official but works)
-            service_networks[DEFAULT_BACKEND_NETWORK_NAME] = None
+            service_networks[_DEFAULT_BACKEND_NETWORK_NAME] = None
 
 
 def parse_compose_spec(compose_file_content: str) -> Any:

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/validation.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/validation.py
@@ -134,20 +134,19 @@ def _inject_backend_networking(parsed_compose_spec: dict[str, Any]) -> None:
     The `network_name` must only be unique inside the user defined spec;
     docker-compose will add some prefix to it.
     """
-
     networks = parsed_compose_spec.setdefault("networks", {})
-    if not networks:
+    if networks is None:
         parsed_compose_spec["networks"] = {_DEFAULT_BACKEND_NETWORK_NAME: None}
     else:
         networks[_DEFAULT_BACKEND_NETWORK_NAME] = None
 
     for service_content in parsed_compose_spec["services"].values():
         service_networks = service_content.setdefault("networks", [])
-        if isinstance(service_networks, list):
-            service_networks.append(_DEFAULT_BACKEND_NETWORK_NAME)
-        elif not service_networks:
+        if service_networks is None:
             # if network is set without entries
             service_content["networks"] = [_DEFAULT_BACKEND_NETWORK_NAME]
+        elif isinstance(service_networks, list):
+            service_networks.append(_DEFAULT_BACKEND_NETWORK_NAME)
         else:
             # if the network is set as a dictionary (rather non official but works)
             service_networks[_DEFAULT_BACKEND_NETWORK_NAME] = None

--- a/services/dynamic-sidecar/tests/unit/test_core_validation.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_validation.py
@@ -1,0 +1,115 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+
+from inspect import signature
+
+import pytest
+from simcore_service_dynamic_sidecar.core.validation import (
+    DEFAULT_BACKEND_NETWORK_NAME,
+    _inject_backend_networking,
+    parse_compose_spec,
+)
+
+
+@pytest.fixture
+def incoming_iseg_compose_file_content() -> str:
+    return """
+networks:
+  dy-sidecar_6f54ecb4-cac2-424a-8b72-ee9366026ff8:
+    driver: overlay
+    external:
+      name: dy-sidecar_6f54ecb4-cac2-424a-8b72-ee9366026ff8
+services:
+  iseg-app:
+    image: registry.osparc.org/simcore/services/dynamic/iseg-app:1.0.7
+  iseg-web:
+    image: registry.osparc.org/simcore/services/dynamic/iseg-web:1.0.7
+    networks:
+      dy-sidecar_6f54ecb4-cac2-424a-8b72-ee9366026ff8:
+version: \'3.7\'
+    """
+
+
+@pytest.fixture
+def incoming_iseg_compose_file_content_missing_network() -> str:
+    return """
+networks:
+services:
+  iseg-app:
+    image: registry.osparc.org/simcore/services/dynamic/iseg-app:1.0.7
+  iseg-web:
+    image: registry.osparc.org/simcore/services/dynamic/iseg-web:1.0.7
+    networks:
+      dy-sidecar_6f54ecb4-cac2-424a-8b72-ee9366026ff8:
+version: \'3.7\'
+    """
+
+
+@pytest.fixture
+def incoming_iseg_compose_file_content_missing_network_list() -> str:
+    return """
+networks:
+services:
+  iseg-app:
+    image: registry.osparc.org/simcore/services/dynamic/iseg-app:1.0.7
+  iseg-web:
+    image: registry.osparc.org/simcore/services/dynamic/iseg-web:1.0.7
+    networks:
+      - dy-sidecar_6f54ecb4-cac2-424a-8b72-ee9366026ff8
+version: \'3.7\'
+    """
+
+
+@pytest.fixture
+def incoming_iseg_compose_file_content_no_networks() -> str:
+    return """
+services:
+  iseg-app:
+    image: registry.osparc.org/simcore/services/dynamic/iseg-app:1.0.7
+  iseg-web:
+    image: registry.osparc.org/simcore/services/dynamic/iseg-web:1.0.7
+version: \'3.7\'
+    """
+
+
+@pytest.fixture(
+    params=[
+        "incoming_iseg_compose_file_content",
+        "incoming_iseg_compose_file_content_missing_network",
+        "incoming_iseg_compose_file_content_missing_network_list",
+        "incoming_iseg_compose_file_content_no_networks",
+    ]
+)
+def incoming_compose_file(
+    request,
+    incoming_iseg_compose_file_content: str,
+    incoming_iseg_compose_file_content_missing_network: str,
+    incoming_iseg_compose_file_content_missing_network_list: str,
+    incoming_iseg_compose_file_content_no_networks: str,
+) -> str:
+    # check that fixture_name is present in this function's parameters
+    fixture_name = request.param
+    sig = signature(incoming_compose_file)
+    assert fixture_name in sig.parameters, (
+        f"Provided fixture name {fixture_name} was not found "
+        f"as a parameter in the signature {sig}"
+    )
+
+    # returns the parameter by name from the ones declared in the signature
+    result: str = locals()[fixture_name]
+    return result
+
+
+# NOTE: this goes with issue [https://github.com/ITISFoundation/osparc-simcore/issues/3261]
+def test_inject_backend_networking(incoming_compose_file: str):
+    parsed_compose_spec = parse_compose_spec(incoming_compose_file)
+    _inject_backend_networking(parsed_compose_spec)
+    assert DEFAULT_BACKEND_NETWORK_NAME in parsed_compose_spec["networks"]
+    assert (
+        DEFAULT_BACKEND_NETWORK_NAME
+        in parsed_compose_spec["services"]["iseg-app"]["networks"]
+    )
+    assert (
+        DEFAULT_BACKEND_NETWORK_NAME
+        in parsed_compose_spec["services"]["iseg-web"]["networks"]
+    )

--- a/services/dynamic-sidecar/tests/unit/test_core_validation.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_validation.py
@@ -5,7 +5,7 @@ from inspect import signature
 
 import pytest
 from simcore_service_dynamic_sidecar.core.validation import (
-    DEFAULT_BACKEND_NETWORK_NAME,
+    _DEFAULT_BACKEND_NETWORK_NAME,
     _inject_backend_networking,
     parse_compose_spec,
 )
@@ -104,12 +104,12 @@ def incoming_compose_file(
 def test_inject_backend_networking(incoming_compose_file: str):
     parsed_compose_spec = parse_compose_spec(incoming_compose_file)
     _inject_backend_networking(parsed_compose_spec)
-    assert DEFAULT_BACKEND_NETWORK_NAME in parsed_compose_spec["networks"]
+    assert _DEFAULT_BACKEND_NETWORK_NAME in parsed_compose_spec["networks"]
     assert (
-        DEFAULT_BACKEND_NETWORK_NAME
+        _DEFAULT_BACKEND_NETWORK_NAME
         in parsed_compose_spec["services"]["iseg-app"]["networks"]
     )
     assert (
-        DEFAULT_BACKEND_NETWORK_NAME
+        _DEFAULT_BACKEND_NETWORK_NAME
         in parsed_compose_spec["services"]["iseg-web"]["networks"]
     )

--- a/services/dynamic-sidecar/tests/unit/test_core_validation.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_validation.py
@@ -100,8 +100,10 @@ def incoming_compose_file(
     return result
 
 
-# NOTE: this goes with issue [https://github.com/ITISFoundation/osparc-simcore/issues/3261]
 def test_inject_backend_networking(incoming_compose_file: str):
+    """
+    NOTE: this goes with issue [https://github.com/ITISFoundation/osparc-simcore/issues/3261]
+    """
     parsed_compose_spec = parse_compose_spec(incoming_compose_file)
     _inject_backend_networking(parsed_compose_spec)
     assert _DEFAULT_BACKEND_NETWORK_NAME in parsed_compose_spec["networks"]


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
covers more use cases where a partially complete docker-compose would fail adding the ```__backend__``` network.
still not sure why this would fail though

## Related issue/s
might help with ITISFoundation/osparc-simcore#3261
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
