### PR TITLE
✨ Bring download/upload progress logs to the frontend

### DIFF
--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -11,6 +11,7 @@ from typing import Final, Iterator, Optional, Union
 from servicelib.pools import non_blocking_process_pool_executor
 from tqdm import tqdm
 from tqdm.asyncio import tqdm_asyncio
+from tqdm.contrib.logging import logging_redirect_tqdm, tqdm_logging_redirect
 
 MAX_UNARCHIVING_WORKER_COUNT: Final[int] = 2
 CHUNK_SIZE: Final[int] = 1024 * 8
@@ -101,7 +102,7 @@ def _zipfile_single_file_extract_worker(
         desc = f"decompressing {zip_file_path}:{file_in_archive.filename} -> {destination_path}\n"
         with zf.open(name=file_in_archive) as zip_fp, destination_path.open(
             "wb"
-        ) as dest_fp, tqdm(
+        ) as dest_fp, tqdm_logging_redirect(
             total=file_in_archive.file_size, desc=desc, **_TQDM_FILE_OPTIONS
         ) as pbar:
             while chunk := zip_fp.read(CHUNK_SIZE):
@@ -136,7 +137,9 @@ async def unarchive_dir(
     Returns a set with all the paths extracted from archive. It includes
     all tree leafs, which might include files or empty folders
     """
-    with zipfile.ZipFile(archive_to_extract, mode="r") as zip_file_handler:
+    with zipfile.ZipFile(
+        archive_to_extract, mode="r"
+    ) as zip_file_handler, logging_redirect_tqdm():
         with non_blocking_process_pool_executor(max_workers=max_workers) as pool:
             loop = asyncio.get_event_loop()
 
@@ -167,6 +170,7 @@ async def unarchive_dir(
                 f"/{_human_readable_size(archive_to_extract.stat().st_size)}]\n",
                 total=len(tasks),
                 unit="file",
+                miniters=1,
             )
 
             # NOTE: extracted_paths includes all tree leafs, which might include files and empty folders
@@ -216,8 +220,7 @@ def _add_to_archive(
             for file in _iter_files_to_compress(dir_to_compress, exclude_patterns)
         )
         desc = f"compressing {dir_to_compress} -> {destination}"
-
-        with tqdm(
+        with tqdm_logging_redirect(
             desc=f"{desc}\n", total=folder_size_bytes, **_TQDM_FILE_OPTIONS
         ) as progress_bar, _progress_enabled_zip_write_handler(
             zipfile.ZipFile(destination, "w", compression=compression), progress_bar

--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -79,6 +79,10 @@ _TQDM_FILE_OPTIONS = dict(
     colour="yellow",
     miniters=1,
 )
+_TQDM_MULTI_FILES_OPTIONS = _TQDM_FILE_OPTIONS | dict(
+    unit="file",
+    unit_divisor=1000,
+)
 
 
 def _zipfile_single_file_extract_worker(
@@ -169,9 +173,7 @@ async def unarchive_dir(
                 desc=f"decompressing {archive_to_extract} -> {destination_folder} [{len(tasks)} file{'s' if len(tasks) > 1 else ''}"
                 f"/{_human_readable_size(archive_to_extract.stat().st_size)}]\n",
                 total=len(tasks),
-                **_TQDM_FILE_OPTIONS,
-                unit="file",
-                unit_divisor=1000,
+                **_TQDM_MULTI_FILES_OPTIONS,
             )
 
             # NOTE: extracted_paths includes all tree leafs, which might include files and empty folders

--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -169,8 +169,9 @@ async def unarchive_dir(
                 desc=f"decompressing {archive_to_extract} -> {destination_folder} [{len(tasks)} file{'s' if len(tasks) > 1 else ''}"
                 f"/{_human_readable_size(archive_to_extract.stat().st_size)}]\n",
                 total=len(tasks),
+                **_TQDM_FILE_OPTIONS,
                 unit="file",
-                miniters=1,
+                unit_divisor=1000,
             )
 
             # NOTE: extracted_paths includes all tree leafs, which might include files and empty folders

--- a/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
@@ -76,6 +76,10 @@ async def push(
         archive_file_path = (
             Path(tmp_dir_name) / f"{rename_to or file_or_folder.stem}.zip"
         )
+        if log_redirect:
+            await log_redirect(
+                f"archiving {file_or_folder} into {archive_file_path}, please wait..."
+            )
         await archive_dir(
             dir_to_compress=file_or_folder,
             destination=archive_file_path,
@@ -83,6 +87,10 @@ async def push(
             store_relative_path=True,
             exclude_patterns=archive_exclude_patterns,
         )
+        if log_redirect:
+            await log_redirect(
+                f"archiving {file_or_folder} into {archive_file_path} completed."
+            )
         await _push_file(
             user_id,
             project_id,
@@ -117,7 +125,7 @@ async def _pull_file(
     if downloaded_file != destination_path:
         destination_path.unlink(missing_ok=True)
         move(f"{downloaded_file}", destination_path)
-    log.info("%s successfuly pulled", destination_path)
+    log.info("completed pull of %s.", destination_path)
 
 
 def _get_archive_name(path: Path) -> str:
@@ -147,13 +155,19 @@ async def pull(
         await _pull_file(
             user_id, project_id, node_uuid, archive_file, log_redirect=log_redirect
         )
-        log.info("extracting data from %s", archive_file)
 
         destination_folder = file_or_folder if save_to is None else save_to
+        if log_redirect:
+            await log_redirect(
+                f"unarchiving {archive_file} into {destination_folder}, please wait..."
+            )
         await unarchive_dir(
             archive_to_extract=archive_file, destination_folder=destination_folder
         )
-        log.info("extraction completed")
+        if log_redirect:
+            await log_redirect(
+                f"unarchiving {archive_file} into {destination_folder} completed."
+            )
 
 
 async def exists(

--- a/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
@@ -30,7 +30,7 @@ async def _push_file(
     file_path: Path,
     *,
     rename_to: Optional[str],
-    log_redirect: Optional[LogRedirectCB],
+    io_log_redirect_cb: Optional[LogRedirectCB],
     r_clone_settings: Optional[RCloneSettings] = None,
 ) -> None:
     store_id = SIMCORE_LOCATION
@@ -45,7 +45,7 @@ async def _push_file(
         s3_object=s3_object,
         file_to_upload=file_path,
         r_clone_settings=r_clone_settings,
-        log_redirect=log_redirect,
+        io_log_redirect_cb=io_log_redirect_cb,
     )
     log.info("%s successfuly uploaded", file_path)
 
@@ -55,7 +55,7 @@ async def push(
     project_id: str,
     node_uuid: str,
     file_or_folder: Path,
-    log_redirect: Optional[LogRedirectCB],
+    io_log_redirect_cb: Optional[LogRedirectCB],
     rename_to: Optional[str] = None,
     r_clone_settings: Optional[RCloneSettings] = None,
     archive_exclude_patterns: Optional[set[str]] = None,
@@ -67,7 +67,7 @@ async def push(
             node_uuid,
             file_or_folder,
             rename_to=rename_to,
-            log_redirect=log_redirect,
+            io_log_redirect_cb=io_log_redirect_cb,
         )
     # we have a folder, so we create a compressed file
     with TemporaryDirectory() as tmp_dir_name:
@@ -76,8 +76,8 @@ async def push(
         archive_file_path = (
             Path(tmp_dir_name) / f"{rename_to or file_or_folder.stem}.zip"
         )
-        if log_redirect:
-            await log_redirect(
+        if io_log_redirect_cb:
+            await io_log_redirect_cb(
                 f"archiving {file_or_folder} into {archive_file_path}, please wait..."
             )
         await archive_dir(
@@ -87,8 +87,8 @@ async def push(
             store_relative_path=True,
             exclude_patterns=archive_exclude_patterns,
         )
-        if log_redirect:
-            await log_redirect(
+        if io_log_redirect_cb:
+            await io_log_redirect_cb(
                 f"archiving {file_or_folder} into {archive_file_path} completed."
             )
         await _push_file(
@@ -98,7 +98,7 @@ async def push(
             archive_file_path,
             rename_to=None,
             r_clone_settings=r_clone_settings,
-            log_redirect=log_redirect,
+            io_log_redirect_cb=io_log_redirect_cb,
         )
 
 
@@ -108,7 +108,7 @@ async def _pull_file(
     node_uuid: str,
     file_path: Path,
     *,
-    log_redirect: Optional[LogRedirectCB],
+    io_log_redirect_cb: Optional[LogRedirectCB],
     save_to: Optional[Path] = None,
 ) -> None:
     destination_path = file_path if save_to is None else save_to
@@ -120,7 +120,7 @@ async def _pull_file(
         store_name=None,
         s3_object=s3_object,
         local_folder=destination_path.parent,
-        log_redirect=log_redirect,
+        io_log_redirect_cb=io_log_redirect_cb,
     )
     if downloaded_file != destination_path:
         destination_path.unlink(missing_ok=True)
@@ -137,7 +137,7 @@ async def pull(
     project_id: str,
     node_uuid: str,
     file_or_folder: Path,
-    log_redirect: Optional[LogRedirectCB],
+    io_log_redirect_cb: Optional[LogRedirectCB],
     save_to: Optional[Path] = None,
 ) -> None:
     if file_or_folder.is_file():
@@ -147,25 +147,29 @@ async def pull(
             node_uuid,
             file_or_folder,
             save_to=save_to,
-            log_redirect=log_redirect,
+            io_log_redirect_cb=io_log_redirect_cb,
         )
     # we have a folder, so we need somewhere to extract it to
     with TemporaryDirectory() as tmp_dir_name:
         archive_file = Path(tmp_dir_name) / _get_archive_name(file_or_folder)
         await _pull_file(
-            user_id, project_id, node_uuid, archive_file, log_redirect=log_redirect
+            user_id,
+            project_id,
+            node_uuid,
+            archive_file,
+            io_log_redirect_cb=io_log_redirect_cb,
         )
 
         destination_folder = file_or_folder if save_to is None else save_to
-        if log_redirect:
-            await log_redirect(
+        if io_log_redirect_cb:
+            await io_log_redirect_cb(
                 f"unarchiving {archive_file} into {destination_folder}, please wait..."
             )
         await unarchive_dir(
             archive_to_extract=archive_file, destination_folder=destination_folder
         )
-        if log_redirect:
-            await log_redirect(
+        if io_log_redirect_cb:
+            await io_log_redirect_cb(
                 f"unarchiving {archive_file} into {destination_folder} completed."
             )
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
@@ -3,7 +3,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import IO, AsyncGenerator, Optional, Protocol, Union
+from typing import IO, AsyncGenerator, Optional, Protocol, Union, runtime_checkable
 
 import aiofiles
 from aiohttp import (
@@ -62,6 +62,7 @@ async def _file_chunk_reader(
             yield chunk
 
 
+@runtime_checkable
 class LogRedirectCB(Protocol):
     async def __call__(self, msg: str) -> None:
         ...

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
@@ -23,6 +23,7 @@ from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_exponential
 from tqdm import tqdm
+from tqdm.contrib.logging import tqdm_logging_redirect
 from yarl import URL
 
 from . import exceptions
@@ -99,7 +100,7 @@ async def download_link_to_file(
                 # SEE https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length
                 file_size = int(response.headers.get("Content-Length", 0)) or None
                 try:
-                    with tqdm(
+                    with tqdm_logging_redirect(
                         desc=f"downloading {url.path} --> {file_path.name}\n",
                         total=file_size,
                         **_TQDM_FILE_OPTIONS,
@@ -195,7 +196,7 @@ async def upload_file_to_presigned_links(
     num_urls = len(file_upload_links.urls)
     last_chunk_size = file_size - file_chunk_size * (num_urls - 1)
     upload_tasks = []
-    with tqdm(
+    with tqdm_logging_redirect(
         desc=f"uploading {file_name}\n", total=file_size, **_TQDM_FILE_OPTIONS
     ) as pbar:
         for index, upload_url in enumerate(file_upload_links.urls):

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -246,6 +246,8 @@ async def download_file_from_link(
     if local_file_path.exists():
         local_file_path.unlink()
 
+    if log_redirect:
+        await log_redirect(f"downloading {local_file_path}, please wait...")
     async with ClientSessionContextManager(client_session) as session:
         await download_link_to_file(
             session,
@@ -254,7 +256,8 @@ async def download_file_from_link(
             num_retries=NodePortsSettings.create_from_envs().NODE_PORTS_IO_NUM_RETRY_ATTEMPTS,
             log_redirect=log_redirect,
         )
-
+    if log_redirect:
+        await log_redirect(f"download of {local_file_path} complete.")
     return local_file_path
 
 
@@ -303,7 +306,8 @@ async def upload_file(
         and store_id == SIMCORE_LOCATION
         and isinstance(file_to_upload, Path)
     )
-
+    if log_redirect:
+        await log_redirect(f"uploading {file_to_upload}, please wait...")
     async with ClientSessionContextManager(client_session) as session:
         upload_links = None
         try:
@@ -354,6 +358,8 @@ async def upload_file(
                 await _abort_upload(session, upload_links, reraise_exceptions=False)
                 log.warning("Upload aborted")
             raise exceptions.S3TransferError from exc
+        if log_redirect:
+            await log_redirect(f"upload of {file_to_upload} complete.")
         return store_id, e_tag
 
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -32,6 +32,7 @@ from ..node_ports_common.client_session_manager import ClientSessionContextManag
 from . import exceptions, r_clone, storage_client
 from .constants import SIMCORE_LOCATION
 from .file_io_utils import (
+    LogRedirectCB,
     UploadableFileObject,
     download_link_to_file,
     upload_file_to_presigned_links,
@@ -188,6 +189,7 @@ async def download_file_from_s3(
     store_id: Optional[LocationID],
     s3_object: StorageFileID,
     local_folder: Path,
+    log_redirect: Optional[LogRedirectCB],
     client_session: Optional[ClientSession] = None,
 ) -> Path:
     """Downloads a file from S3
@@ -225,12 +227,14 @@ async def download_file_from_s3(
             download_link,
             local_folder,
             client_session=session,
+            log_redirect=log_redirect,
         )
 
 
 async def download_file_from_link(
     download_link: URL,
     destination_folder: Path,
+    log_redirect: Optional[LogRedirectCB],
     file_name: Optional[str] = None,
     client_session: Optional[ClientSession] = None,
 ) -> Path:
@@ -248,6 +252,7 @@ async def download_file_from_link(
             download_link,
             local_file_path,
             num_retries=NodePortsSettings.create_from_envs().NODE_PORTS_IO_NUM_RETRY_ATTEMPTS,
+            log_redirect=log_redirect,
         )
 
     return local_file_path
@@ -272,6 +277,7 @@ async def upload_file(
     store_name: Optional[LocationName],
     s3_object: StorageFileID,
     file_to_upload: Union[Path, UploadableFileObject],
+    log_redirect: Optional[LogRedirectCB],
     client_session: Optional[ClientSession] = None,
     r_clone_settings: Optional[RCloneSettings] = None,
 ) -> tuple[LocationID, ETag]:
@@ -332,6 +338,7 @@ async def upload_file(
                     upload_links,
                     file_to_upload,
                     num_retries=NodePortsSettings.create_from_envs().NODE_PORTS_IO_NUM_RETRY_ATTEMPTS,
+                    log_redirect=log_redirect,
                 )
 
             # complete the upload

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -189,7 +189,7 @@ async def download_file_from_s3(
     store_id: Optional[LocationID],
     s3_object: StorageFileID,
     local_folder: Path,
-    log_redirect: Optional[LogRedirectCB],
+    io_log_redirect_cb: Optional[LogRedirectCB],
     client_session: Optional[ClientSession] = None,
 ) -> Path:
     """Downloads a file from S3
@@ -227,14 +227,14 @@ async def download_file_from_s3(
             download_link,
             local_folder,
             client_session=session,
-            log_redirect=log_redirect,
+            io_log_redirect_cb=io_log_redirect_cb,
         )
 
 
 async def download_file_from_link(
     download_link: URL,
     destination_folder: Path,
-    log_redirect: Optional[LogRedirectCB],
+    io_log_redirect_cb: Optional[LogRedirectCB],
     file_name: Optional[str] = None,
     client_session: Optional[ClientSession] = None,
 ) -> Path:
@@ -246,18 +246,18 @@ async def download_file_from_link(
     if local_file_path.exists():
         local_file_path.unlink()
 
-    if log_redirect:
-        await log_redirect(f"downloading {local_file_path}, please wait...")
+    if io_log_redirect_cb:
+        await io_log_redirect_cb(f"downloading {local_file_path}, please wait...")
     async with ClientSessionContextManager(client_session) as session:
         await download_link_to_file(
             session,
             download_link,
             local_file_path,
             num_retries=NodePortsSettings.create_from_envs().NODE_PORTS_IO_NUM_RETRY_ATTEMPTS,
-            log_redirect=log_redirect,
+            io_log_redirect_cb=io_log_redirect_cb,
         )
-    if log_redirect:
-        await log_redirect(f"download of {local_file_path} complete.")
+    if io_log_redirect_cb:
+        await io_log_redirect_cb(f"download of {local_file_path} complete.")
     return local_file_path
 
 
@@ -280,7 +280,7 @@ async def upload_file(
     store_name: Optional[LocationName],
     s3_object: StorageFileID,
     file_to_upload: Union[Path, UploadableFileObject],
-    log_redirect: Optional[LogRedirectCB],
+    io_log_redirect_cb: Optional[LogRedirectCB],
     client_session: Optional[ClientSession] = None,
     r_clone_settings: Optional[RCloneSettings] = None,
 ) -> tuple[LocationID, ETag]:
@@ -306,8 +306,8 @@ async def upload_file(
         and store_id == SIMCORE_LOCATION
         and isinstance(file_to_upload, Path)
     )
-    if log_redirect:
-        await log_redirect(f"uploading {file_to_upload}, please wait...")
+    if io_log_redirect_cb:
+        await io_log_redirect_cb(f"uploading {file_to_upload}, please wait...")
     async with ClientSessionContextManager(client_session) as session:
         upload_links = None
         try:
@@ -342,7 +342,7 @@ async def upload_file(
                     upload_links,
                     file_to_upload,
                     num_retries=NodePortsSettings.create_from_envs().NODE_PORTS_IO_NUM_RETRY_ATTEMPTS,
-                    log_redirect=log_redirect,
+                    io_log_redirect_cb=io_log_redirect_cb,
                 )
 
             # complete the upload
@@ -358,8 +358,8 @@ async def upload_file(
                 await _abort_upload(session, upload_links, reraise_exceptions=False)
                 log.warning("Upload aborted")
             raise exceptions.S3TransferError from exc
-        if log_redirect:
-            await log_redirect(f"upload of {file_to_upload} complete.")
+        if io_log_redirect_cb:
+            await io_log_redirect_cb(f"upload of {file_to_upload} complete.")
         return store_id, e_tag
 
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/__init__.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/__init__.py
@@ -24,7 +24,7 @@ async def ports(
     *,
     db_manager: Optional[DBManager] = None,
     r_clone_settings: Optional[RCloneSettings] = None,
-    io_log_redirect: Optional[LogRedirectCB] = None
+    io_log_redirect_cb: Optional[LogRedirectCB] = None
 ) -> Nodeports:
     log.debug("creating node_ports_v2 object using provided dbmanager: %s", db_manager)
     # FIXME: warning every dbmanager create a new db engine!
@@ -39,7 +39,7 @@ async def ports(
         node_uuid=node_uuid,
         auto_update=True,
         r_clone_settings=r_clone_settings,
-        io_log_redirect=io_log_redirect,
+        io_log_redirect_cb=io_log_redirect_cb,
     )
 
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/__init__.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/__init__.py
@@ -1,10 +1,14 @@
 import logging
 from typing import Optional
 
+from models_library.projects import ProjectIDStr
+from models_library.projects_nodes_io import NodeIDStr
+from models_library.users import UserID
 from settings_library.r_clone import RCloneSettings
 
 from ..node_ports_common import exceptions
 from ..node_ports_common.dbmanager import DBManager
+from ..node_ports_common.file_io_utils import LogRedirectCB
 from ..node_ports_common.storage_client import LinkType as FileLinkType
 from .nodeports_v2 import Nodeports
 from .port import Port
@@ -14,12 +18,13 @@ log = logging.getLogger(__name__)
 
 
 async def ports(
-    user_id: int,
-    project_id: str,
-    node_uuid: str,
+    user_id: UserID,
+    project_id: ProjectIDStr,
+    node_uuid: NodeIDStr,
     *,
     db_manager: Optional[DBManager] = None,
-    r_clone_settings: Optional[RCloneSettings] = None
+    r_clone_settings: Optional[RCloneSettings] = None,
+    io_log_redirect: Optional[LogRedirectCB] = None
 ) -> Nodeports:
     log.debug("creating node_ports_v2 object using provided dbmanager: %s", db_manager)
     # FIXME: warning every dbmanager create a new db engine!
@@ -34,6 +39,7 @@ async def ports(
         node_uuid=node_uuid,
         auto_update=True,
         r_clone_settings=r_clone_settings,
+        io_log_redirect=io_log_redirect,
     )
 
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
@@ -251,7 +251,7 @@ class Port(BaseServiceIOModel):
                     key=self.key,
                     fileToKeyMap=self.file_to_key_map,
                     value=self.value,
-                    log_redirect=None,
+                    log_redirect=self._node_ports.io_log_redirect_cb,
                 )
                 value = path_concrete_value
 
@@ -262,7 +262,7 @@ class Port(BaseServiceIOModel):
                         key=self.key,
                         fileToKeyMap=self.file_to_key_map,
                         value=self.value,
-                        log_redirect=None,
+                        log_redirect=self._node_ports.io_log_redirect_cb,
                     )
                 )
                 value = path_concrete_value
@@ -316,7 +316,7 @@ class Port(BaseServiceIOModel):
                     project_id=self._node_ports.project_id,
                     node_id=self._node_ports.node_uuid,
                     r_clone_settings=self._node_ports.r_clone_settings,
-                    log_redirect=None,
+                    log_redirect=self._node_ports.io_log_redirect_cb,
                 )
             else:
                 new_value = converted_value

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
@@ -251,7 +251,7 @@ class Port(BaseServiceIOModel):
                     key=self.key,
                     fileToKeyMap=self.file_to_key_map,
                     value=self.value,
-                    log_redirect=self._node_ports.io_log_redirect_cb,
+                    io_log_redirect_cb=self._node_ports.io_log_redirect_cb,
                 )
                 value = path_concrete_value
 
@@ -262,7 +262,7 @@ class Port(BaseServiceIOModel):
                         key=self.key,
                         fileToKeyMap=self.file_to_key_map,
                         value=self.value,
-                        log_redirect=self._node_ports.io_log_redirect_cb,
+                        io_log_redirect_cb=self._node_ports.io_log_redirect_cb,
                     )
                 )
                 value = path_concrete_value
@@ -316,7 +316,7 @@ class Port(BaseServiceIOModel):
                     project_id=self._node_ports.project_id,
                     node_id=self._node_ports.node_uuid,
                     r_clone_settings=self._node_ports.r_clone_settings,
-                    log_redirect=self._node_ports.io_log_redirect_cb,
+                    io_log_redirect_cb=self._node_ports.io_log_redirect_cb,
                 )
             else:
                 new_value = converted_value

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
@@ -2,7 +2,7 @@ import logging
 import os
 from pathlib import Path
 from pprint import pformat
-from typing import Any, Callable, Dict, Optional, Tuple, Type
+from typing import Any, Callable, Optional
 
 from models_library.services import PROPERTY_KEY_RE, BaseServiceIOModel
 from pydantic import AnyUrl, Field, PrivateAttr, ValidationError, validator
@@ -28,7 +28,7 @@ from .port_validation import validate_port_content
 log = logging.getLogger(__name__)
 
 
-TYPE_TO_PYTYPE: Dict[str, Type[ItemConcreteValue]] = {
+TYPE_TO_PYTYPE: dict[str, type[ItemConcreteValue]] = {
     "integer": int,
     "number": float,
     "boolean": bool,
@@ -59,7 +59,7 @@ def can_parse_as(v, *types) -> bool:
 
 class Port(BaseServiceIOModel):
     key: str = Field(..., regex=PROPERTY_KEY_RE)
-    widget: Optional[Dict[str, Any]] = None
+    widget: Optional[dict[str, Any]] = None
     default_value: Optional[DataItemValue] = Field(None, alias="defaultValue")
 
     value: Optional[DataItemValue] = None
@@ -73,7 +73,7 @@ class Port(BaseServiceIOModel):
     value_concrete: Optional[ItemConcreteValue] = Field(None, exclude=True)
 
     # Types expected in _value_concrete
-    _py_value_type: Tuple[Type[ItemConcreteValue], ...] = PrivateAttr()
+    _py_value_type: tuple[type[ItemConcreteValue], ...] = PrivateAttr()
     # Function to convert from ItemValue -> ItemConcreteValue
     _py_value_converter: Callable[[Any], ItemConcreteValue] = PrivateAttr()
     # Reference to the `NodePorts` instance that contains this port
@@ -87,7 +87,7 @@ class Port(BaseServiceIOModel):
 
     @validator("value", always=True)
     @classmethod
-    def check_value(cls, v: DataItemValue, values: Dict[str, Any]) -> DataItemValue:
+    def check_value(cls, v: DataItemValue, values: dict[str, Any]) -> DataItemValue:
 
         if (
             v is not None
@@ -251,6 +251,7 @@ class Port(BaseServiceIOModel):
                     key=self.key,
                     fileToKeyMap=self.file_to_key_map,
                     value=self.value,
+                    log_redirect=None,
                 )
                 value = path_concrete_value
 
@@ -261,6 +262,7 @@ class Port(BaseServiceIOModel):
                         key=self.key,
                         fileToKeyMap=self.file_to_key_map,
                         value=self.value,
+                        log_redirect=None,
                     )
                 )
                 value = path_concrete_value
@@ -314,6 +316,7 @@ class Port(BaseServiceIOModel):
                     project_id=self._node_ports.project_id,
                     node_id=self._node_ports.node_uuid,
                     r_clone_settings=self._node_ports.r_clone_settings,
+                    log_redirect=None,
                 )
             else:
                 new_value = converted_value
@@ -331,7 +334,6 @@ class Port(BaseServiceIOModel):
         """
         await self._set(new_concrete_value=new_value)
         await self._node_ports.save_to_db_cb(self._node_ports)
-        
 
     async def set_value(self, new_item_value: Optional[ItemValue]) -> None:
         """set the value on the port using an item-value

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
@@ -12,6 +12,7 @@ from yarl import URL
 
 from ..node_ports_common import data_items_utils, filemanager
 from ..node_ports_common.constants import SIMCORE_LOCATION
+from ..node_ports_common.filemanager import LogRedirectCB
 from ..node_ports_common.storage_client import LinkType
 from .links import DownloadLink, FileLink, ItemConcreteValue, ItemValue, PortLink
 
@@ -168,6 +169,7 @@ async def pull_file_from_store(
     key: str,
     fileToKeyMap: Optional[dict[str, str]],
     value: FileLink,
+    log_redirect: Optional[LogRedirectCB],
 ) -> Path:
     log.debug("pulling file from storage %s", value)
     # do not make any assumption about s3_path, it is a str containing stuff that can be anything depending on the store
@@ -178,6 +180,7 @@ async def pull_file_from_store(
         store_name=None,
         s3_object=value.path,
         local_folder=local_path,
+        log_redirect=log_redirect,
     )
     # if a file alias is present use it to rename the file accordingly
     if fileToKeyMap:
@@ -196,6 +199,7 @@ async def push_file_to_store(
     user_id: UserID,
     project_id: str,
     node_id: str,
+    log_redirect: Optional[LogRedirectCB],
     r_clone_settings: Optional[RCloneSettings] = None,
 ) -> FileLink:
     log.debug("file path %s will be uploaded to s3", file)
@@ -207,6 +211,7 @@ async def push_file_to_store(
         s3_object=s3_object,
         file_to_upload=file,
         r_clone_settings=r_clone_settings,
+        log_redirect=log_redirect,
     )
     log.debug("file path %s uploaded, received ETag %s", file, e_tag)
     return FileLink(store=store_id, path=s3_object, e_tag=e_tag)
@@ -216,6 +221,7 @@ async def pull_file_from_download_link(
     key: str,
     fileToKeyMap: Optional[dict[str, str]],
     value: DownloadLink,
+    log_redirect: Optional[LogRedirectCB],
 ) -> Path:
     log.debug(
         "Getting value from download link [%s] with label %s",
@@ -225,8 +231,7 @@ async def pull_file_from_download_link(
 
     local_path = data_items_utils.create_folder_path(key)
     downloaded_file = await filemanager.download_file_from_link(
-        URL(f"{value.download_link}"),
-        local_path,
+        URL(f"{value.download_link}"), local_path, log_redirect=log_redirect
     )
 
     # if a file alias is present use it to rename the file accordingly

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
@@ -169,7 +169,7 @@ async def pull_file_from_store(
     key: str,
     fileToKeyMap: Optional[dict[str, str]],
     value: FileLink,
-    log_redirect: Optional[LogRedirectCB],
+    io_log_redirect_cb: Optional[LogRedirectCB],
 ) -> Path:
     log.debug("pulling file from storage %s", value)
     # do not make any assumption about s3_path, it is a str containing stuff that can be anything depending on the store
@@ -180,7 +180,7 @@ async def pull_file_from_store(
         store_name=None,
         s3_object=value.path,
         local_folder=local_path,
-        log_redirect=log_redirect,
+        io_log_redirect_cb=io_log_redirect_cb,
     )
     # if a file alias is present use it to rename the file accordingly
     if fileToKeyMap:
@@ -199,7 +199,7 @@ async def push_file_to_store(
     user_id: UserID,
     project_id: str,
     node_id: str,
-    log_redirect: Optional[LogRedirectCB],
+    io_log_redirect_cb: Optional[LogRedirectCB],
     r_clone_settings: Optional[RCloneSettings] = None,
 ) -> FileLink:
     log.debug("file path %s will be uploaded to s3", file)
@@ -211,7 +211,7 @@ async def push_file_to_store(
         s3_object=s3_object,
         file_to_upload=file,
         r_clone_settings=r_clone_settings,
-        log_redirect=log_redirect,
+        io_log_redirect_cb=io_log_redirect_cb,
     )
     log.debug("file path %s uploaded, received ETag %s", file, e_tag)
     return FileLink(store=store_id, path=s3_object, e_tag=e_tag)
@@ -221,7 +221,7 @@ async def pull_file_from_download_link(
     key: str,
     fileToKeyMap: Optional[dict[str, str]],
     value: DownloadLink,
-    log_redirect: Optional[LogRedirectCB],
+    io_log_redirect_cb: Optional[LogRedirectCB],
 ) -> Path:
     log.debug(
         "Getting value from download link [%s] with label %s",
@@ -231,7 +231,7 @@ async def pull_file_from_download_link(
 
     local_path = data_items_utils.create_folder_path(key)
     downloaded_file = await filemanager.download_file_from_link(
-        URL(f"{value.download_link}"), local_path, log_redirect=log_redirect
+        URL(f"{value.download_link}"), local_path, io_log_redirect_cb=io_log_redirect_cb
     )
 
     # if a file alias is present use it to rename the file accordingly

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/serialization_v2.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/serialization_v2.py
@@ -34,7 +34,7 @@ async def load(
     user_id: int,
     project_id: str,
     node_uuid: str,
-    io_log_redirect: Optional[LogRedirectCB],
+    io_log_redirect_cb: Optional[LogRedirectCB],
     auto_update: bool = False,
     r_clone_settings: Optional[RCloneSettings] = None,
 ) -> Nodeports:
@@ -91,10 +91,12 @@ async def load(
         project_id=project_id,
         node_uuid=node_uuid,
         save_to_db_cb=dump,
-        node_port_creator_cb=functools.partial(load, io_log_redirect=io_log_redirect),
+        node_port_creator_cb=functools.partial(
+            load, io_log_redirect_cb=io_log_redirect_cb
+        ),
         auto_update=auto_update,
         r_clone_settings=r_clone_settings,
-        io_log_redirect=io_log_redirect,
+        io_log_redirect_cb=io_log_redirect_cb,
     )
     log.debug(
         "created node_ports_v2 object %s",
@@ -123,7 +125,7 @@ async def dump(nodeports: Nodeports) -> None:
                 user_id=nodeports.user_id,
                 project_id=nodeports.project_id,
                 node_uuid=f"{node_id}",
-                io_log_redirect=nodeports.io_log_redirect_cb,
+                io_log_redirect_cb=nodeports.io_log_redirect_cb,
             )
         )
 

--- a/packages/simcore-sdk/tests/integration/conftest.py
+++ b/packages/simcore-sdk/tests/integration/conftest.py
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 from aiohttp import ClientSession
 from models_library.api_schemas_storage import FileUploadSchema
 from models_library.generics import Envelope
-from models_library.projects_nodes_io import LocationID, SimcoreS3FileID
+from models_library.projects_nodes_io import LocationID, NodeIDStr, SimcoreS3FileID
 from models_library.users import UserID
 from pytest_simcore.helpers.rawdata_fakers import random_project, random_user
 from settings_library.r_clone import RCloneSettings, S3Provider
@@ -75,8 +75,8 @@ def project_id(user_id: int, postgres_db: sa.engine.Engine) -> Iterable[str]:
 
 
 @pytest.fixture(scope="module")
-def node_uuid() -> str:
-    return f"{uuid4()}"
+def node_uuid() -> NodeIDStr:
+    return NodeIDStr(f"{uuid4()}")
 
 
 @pytest.fixture(scope="session")

--- a/packages/simcore-sdk/tests/integration/test_node_data_data_manager_.py
+++ b/packages/simcore-sdk/tests/integration/test_node_data_data_manager_.py
@@ -141,6 +141,7 @@ async def test_valid_upload_download(
         project_id=project_id,
         node_uuid=node_uuid,
         file_or_folder=content_path,
+        log_redirect=None,
     )
 
     uploaded_hashes = _get_file_hashes_in_path(content_path)
@@ -152,6 +153,7 @@ async def test_valid_upload_download(
         project_id=project_id,
         node_uuid=node_uuid,
         file_or_folder=content_path,
+        log_redirect=None,
     )
 
     downloaded_hashes = _get_file_hashes_in_path(content_path)
@@ -181,6 +183,7 @@ async def test_valid_upload_download_saved_to(
         project_id=project_id,
         node_uuid=node_uuid,
         file_or_folder=content_path,
+        log_redirect=None,
     )
 
     uploaded_hashes = _get_file_hashes_in_path(content_path)
@@ -195,6 +198,7 @@ async def test_valid_upload_download_saved_to(
         node_uuid=node_uuid,
         file_or_folder=content_path,
         save_to=new_destination,
+        log_redirect=None,
     )
 
     downloaded_hashes = _get_file_hashes_in_path(new_destination)

--- a/packages/simcore-sdk/tests/integration/test_node_data_data_manager_.py
+++ b/packages/simcore-sdk/tests/integration/test_node_data_data_manager_.py
@@ -141,7 +141,7 @@ async def test_valid_upload_download(
         project_id=project_id,
         node_uuid=node_uuid,
         file_or_folder=content_path,
-        log_redirect=None,
+        io_log_redirect_cb=None,
     )
 
     uploaded_hashes = _get_file_hashes_in_path(content_path)
@@ -153,7 +153,7 @@ async def test_valid_upload_download(
         project_id=project_id,
         node_uuid=node_uuid,
         file_or_folder=content_path,
-        log_redirect=None,
+        io_log_redirect_cb=None,
     )
 
     downloaded_hashes = _get_file_hashes_in_path(content_path)
@@ -183,7 +183,7 @@ async def test_valid_upload_download_saved_to(
         project_id=project_id,
         node_uuid=node_uuid,
         file_or_folder=content_path,
-        log_redirect=None,
+        io_log_redirect_cb=None,
     )
 
     uploaded_hashes = _get_file_hashes_in_path(content_path)
@@ -198,7 +198,7 @@ async def test_valid_upload_download_saved_to(
         node_uuid=node_uuid,
         file_or_folder=content_path,
         save_to=new_destination,
-        log_redirect=None,
+        io_log_redirect_cb=None,
     )
 
     downloaded_hashes = _get_file_hashes_in_path(new_destination)

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
@@ -319,6 +319,7 @@ async def test_errors_upon_invalid_file_identifiers(
             store_name=None,
             s3_object="",  # type: ignore
             file_to_upload=file_path,
+            io_log_redirect_cb=None,
         )
 
     with pytest.raises(exceptions.StorageInvalidCall):
@@ -328,6 +329,7 @@ async def test_errors_upon_invalid_file_identifiers(
             store_name=None,
             s3_object="file_id",  # type: ignore
             file_to_upload=file_path,
+            io_log_redirect_cb=None,
         )
 
     download_folder = Path(tmpdir) / "downloads"
@@ -338,6 +340,7 @@ async def test_errors_upon_invalid_file_identifiers(
             store_name=None,
             s3_object="",  # type: ignore
             local_folder=download_folder,
+            io_log_redirect_cb=None,
         )
 
     with pytest.raises(exceptions.S3InvalidPathError):
@@ -372,6 +375,7 @@ async def test_invalid_store(
             store_name=store,  # type: ignore
             s3_object=file_id,
             file_to_upload=file_path,
+            io_log_redirect_cb=None,
         )
 
     download_folder = Path(tmpdir) / "downloads"
@@ -382,6 +386,7 @@ async def test_invalid_store(
             store_name=store,  # type: ignore
             s3_object=file_id,
             local_folder=download_folder,
+            io_log_redirect_cb=None,
         )
 
 

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
@@ -69,6 +69,7 @@ async def test_valid_upload_download(
         s3_object=file_id,
         file_to_upload=file_path,
         r_clone_settings=optional_r_clone,
+        io_log_redirect_cb=None,
     )
     assert store_id == s3_simcore_location
     assert e_tag
@@ -85,6 +86,7 @@ async def test_valid_upload_download(
         store_name=None,
         s3_object=file_id,
         local_folder=download_folder,
+        io_log_redirect_cb=None,
     )
     assert download_file_path.exists()
     assert download_file_path.name == "test.test"
@@ -122,6 +124,7 @@ async def test_valid_upload_download_using_file_object(
                 file_object, file_path.name, file_path.stat().st_size
             ),
             r_clone_settings=optional_r_clone,
+            io_log_redirect_cb=None,
         )
     assert store_id == s3_simcore_location
     assert e_tag
@@ -138,6 +141,7 @@ async def test_valid_upload_download_using_file_object(
         store_name=None,
         s3_object=file_id,
         local_folder=download_folder,
+        io_log_redirect_cb=None,
     )
     assert download_file_path.exists()
     assert download_file_path.name == "test.test"
@@ -186,6 +190,7 @@ async def test_failed_upload_is_properly_removed_from_storage(
             s3_object=file_id,
             file_to_upload=file_path,
             r_clone_settings=optional_r_clone,
+            io_log_redirect_cb=None,
         )
     with pytest.raises(exceptions.S3InvalidPathError):
         await filemanager.get_file_metadata(
@@ -221,6 +226,7 @@ async def test_failed_upload_after_valid_upload_keeps_last_valid_state(
         s3_object=file_id,
         file_to_upload=file_path,
         r_clone_settings=optional_r_clone,
+        io_log_redirect_cb=None,
     )
     assert store_id == s3_simcore_location
     assert e_tag
@@ -249,6 +255,7 @@ async def test_failed_upload_after_valid_upload_keeps_last_valid_state(
             s3_object=file_id,
             file_to_upload=file_path,
             r_clone_settings=optional_r_clone,
+            io_log_redirect_cb=None,
         )
     # the file shall be back to its original state
     old_store_id, old_e_tag = await filemanager.get_file_metadata(
@@ -278,6 +285,7 @@ async def test_invalid_file_path(
             store_name=None,
             s3_object=file_id,
             file_to_upload=Path(tmpdir) / "some other file.txt",
+            io_log_redirect_cb=None,
         )
 
     download_folder = Path(tmpdir) / "downloads"
@@ -288,6 +296,7 @@ async def test_invalid_file_path(
             store_name=None,
             s3_object=file_id,
             local_folder=download_folder,
+            io_log_redirect_cb=None,
         )
 
 
@@ -340,6 +349,7 @@ async def test_errors_upon_invalid_file_identifiers(
                 Path("invisible.txt"), project_id, f"{uuid4()}"
             ),
             local_folder=download_folder,
+            io_log_redirect_cb=None,
         )
 
 
@@ -403,6 +413,7 @@ async def test_valid_metadata(
         store_name=None,
         s3_object=file_id,
         file_to_upload=file_path,
+        io_log_redirect_cb=None,
     )
     assert store_id == s3_simcore_location
     assert e_tag
@@ -460,6 +471,7 @@ async def test_delete_File(
         store_name=None,
         s3_object=file_id,
         file_to_upload=file_path,
+        io_log_redirect_cb=None,
     )
     assert store_id == s3_simcore_location
     assert e_tag

--- a/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 import np_helpers
 import pytest
 import sqlalchemy as sa
-from models_library.projects_nodes_io import LocationID
+from models_library.projects_nodes_io import LocationID, NodeIDStr
 from settings_library.r_clone import RCloneSettings
 from simcore_sdk import node_ports_v2
 from simcore_sdk.node_ports_common.exceptions import UnboundPortError
@@ -145,7 +145,7 @@ async def option_r_clone_settings(
 async def test_default_configuration(
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     default_configuration: dict[str, Any],
     option_r_clone_settings: Optional[RCloneSettings],
 ):
@@ -164,7 +164,7 @@ async def test_default_configuration(
 async def test_invalid_ports(
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     create_special_configuration: Callable,
     option_r_clone_settings: Optional[RCloneSettings],
 ):
@@ -202,7 +202,7 @@ async def test_invalid_ports(
 async def test_port_value_accessors(
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     create_special_configuration: Callable,
     item_type: str,
     item_value: ItemConcreteValue,
@@ -259,7 +259,7 @@ async def test_port_file_accessors(
     config_value: dict[str, str],
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     e_tag: str,
     option_r_clone_settings: Optional[RCloneSettings],
 ):  # pylint: disable=W0613, W0621
@@ -321,7 +321,7 @@ async def test_port_file_accessors(
 async def test_adding_new_ports(
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     create_special_configuration: Callable,
     postgres_db: sa.engine.Engine,
     option_r_clone_settings: Optional[RCloneSettings],
@@ -372,7 +372,7 @@ async def test_adding_new_ports(
 async def test_removing_ports(
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     create_special_configuration: Callable,
     postgres_db: sa.engine.Engine,
     option_r_clone_settings: Optional[RCloneSettings],
@@ -423,7 +423,7 @@ async def test_removing_ports(
 async def test_get_value_from_previous_node(
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     create_2nodes_configuration: Callable,
     create_node_link: Callable,
     item_type: str,
@@ -466,7 +466,7 @@ async def test_get_file_from_previous_node(
     create_2nodes_configuration: Callable,
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     create_node_link: Callable,
     create_store_link: Callable,
     item_type: str,
@@ -520,7 +520,7 @@ async def test_get_file_from_previous_node_with_mapping_of_same_key_name(
     create_2nodes_configuration: Callable,
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     create_node_link: Callable,
     create_store_link: Callable,
     postgres_db: sa.engine.Engine,
@@ -580,7 +580,7 @@ async def test_file_mapping(
     create_special_configuration: Callable,
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     s3_simcore_location: LocationID,
     create_store_link: Callable,
     postgres_db: sa.engine.Engine,
@@ -668,7 +668,7 @@ def port_count() -> int:
 async def test_regression_concurrent_port_update_fails(
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     create_special_configuration: Callable,
     int_item_value: int,
     parallel_int_item_value: int,
@@ -721,7 +721,7 @@ async def test_regression_concurrent_port_update_fails(
 async def test_batch_update_inputs_outputs(
     user_id: int,
     project_id: str,
-    node_uuid: str,
+    node_uuid: NodeIDStr,
     create_special_configuration: Callable,
     port_count: int,
     option_r_clone_settings: Optional[RCloneSettings],

--- a/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
+++ b/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
@@ -71,13 +71,14 @@ async def test_push_folder(
         assert file_path.exists()
 
     await data_manager.push(
-        user_id, project_id, node_uuid, test_folder, log_redirect=None
+        user_id, project_id, node_uuid, test_folder, io_log_redirect_cb=None
     )
 
     mock_temporary_directory.assert_called_once()
     mock_filemanager.upload_file.assert_called_once_with(
         file_to_upload=(test_compression_folder / f"{test_folder.stem}.zip"),
         r_clone_settings=None,
+        io_log_redirect_cb=None,
         s3_object=f"{project_id}/{node_uuid}/{test_folder.stem}.zip",
         store_id=SIMCORE_LOCATION,
         store_name=None,
@@ -121,11 +122,12 @@ async def test_push_file(
 
     # test push file by file
     await data_manager.push(
-        user_id, project_id, node_uuid, file_path, log_redirect=None
+        user_id, project_id, node_uuid, file_path, io_log_redirect_cb=None
     )
     mock_temporary_directory.assert_not_called()
     mock_filemanager.upload_file.assert_called_once_with(
         r_clone_settings=None,
+        io_log_redirect_cb=None,
         file_to_upload=file_path,
         s3_object=f"{project_id}/{node_uuid}/{file_path.name}",
         store_id=SIMCORE_LOCATION,
@@ -183,7 +185,7 @@ async def test_pull_folder(
     )
 
     await data_manager.pull(
-        user_id, project_id, node_uuid, test_folder, log_redirect=None
+        user_id, project_id, node_uuid, test_folder, io_log_redirect_cb=None
     )
     mock_temporary_directory.assert_called_once()
     mock_filemanager.download_file_from_s3.assert_called_once_with(
@@ -192,6 +194,7 @@ async def test_pull_folder(
         store_id=SIMCORE_LOCATION,
         store_name=None,
         user_id=user_id,
+        io_log_redirect_cb=None,
     )
 
     matchs, mismatchs, errors = cmpfiles(
@@ -230,7 +233,7 @@ async def test_pull_file(
     )
 
     await data_manager.pull(
-        user_id, project_id, node_uuid, file_path, log_redirect=None
+        user_id, project_id, node_uuid, file_path, io_log_redirect_cb=None
     )
     mock_temporary_directory.assert_not_called()
     mock_filemanager.download_file_from_s3.assert_called_once_with(
@@ -239,4 +242,5 @@ async def test_pull_file(
         store_id=SIMCORE_LOCATION,
         store_name=None,
         user_id=user_id,
+        io_log_redirect_cb=None,
     )

--- a/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
+++ b/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
@@ -70,7 +70,9 @@ async def test_push_folder(
     for file_path in test_folder.glob("**/*"):
         assert file_path.exists()
 
-    await data_manager.push(user_id, project_id, node_uuid, test_folder)
+    await data_manager.push(
+        user_id, project_id, node_uuid, test_folder, log_redirect=None
+    )
 
     mock_temporary_directory.assert_called_once()
     mock_filemanager.upload_file.assert_called_once_with(
@@ -118,7 +120,9 @@ async def test_push_file(
     assert file_path.exists()
 
     # test push file by file
-    await data_manager.push(user_id, project_id, node_uuid, file_path)
+    await data_manager.push(
+        user_id, project_id, node_uuid, file_path, log_redirect=None
+    )
     mock_temporary_directory.assert_not_called()
     mock_filemanager.upload_file.assert_called_once_with(
         r_clone_settings=None,
@@ -178,7 +182,9 @@ async def test_pull_folder(
         test_compression_folder
     )
 
-    await data_manager.pull(user_id, project_id, node_uuid, test_folder)
+    await data_manager.pull(
+        user_id, project_id, node_uuid, test_folder, log_redirect=None
+    )
     mock_temporary_directory.assert_called_once()
     mock_filemanager.download_file_from_s3.assert_called_once_with(
         local_folder=test_compression_folder,
@@ -223,7 +229,9 @@ async def test_pull_file(
         "simcore_sdk.node_data.data_manager.TemporaryDirectory"
     )
 
-    await data_manager.pull(user_id, project_id, node_uuid, file_path)
+    await data_manager.pull(
+        user_id, project_id, node_uuid, file_path, log_redirect=None
+    )
     mock_temporary_directory.assert_not_called()
     mock_filemanager.download_file_from_s3.assert_called_once_with(
         local_folder=file_path.parent,

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
@@ -179,6 +179,7 @@ async def mock_download_file(
     async def mock_download_file_from_link(
         download_link: URL,
         local_folder: Path,
+        io_log_redirect_cb: Optional[LogRedirectCB],
         file_name: Optional[str] = None,
         client_session: Optional[ClientSession] = None,
     ) -> Path:
@@ -196,6 +197,7 @@ async def mock_download_file(
     mocker.patch(
         "simcore_sdk.node_ports_common.filemanager.download_file_from_link",
         side_effect=mock_download_file_from_link,
+        autospec=True,
     )
 
 

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
@@ -21,6 +21,7 @@ from attr import dataclass
 from models_library.projects_nodes_io import LocationID
 from pydantic.error_wrappers import ValidationError
 from pytest_mock.plugin import MockerFixture
+from simcore_sdk.node_ports_common.file_io_utils import LogRedirectCB
 from simcore_sdk.node_ports_v2 import exceptions
 from simcore_sdk.node_ports_v2.links import (
     DataItemValue,
@@ -597,6 +598,7 @@ async def test_valid_port(
         project_id: str
         node_uuid: str
         r_clone_settings: Optional[Any] = None
+        io_log_redirect_cb: Optional[LogRedirectCB] = None
 
         @staticmethod
         async def get(key):

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_serialization_v2.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_serialization_v2.py
@@ -2,7 +2,7 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 from simcore_sdk.node_ports_v2 import DBManager, exceptions
@@ -16,7 +16,7 @@ async def test_load(
     user_id: int,
     project_id: str,
     node_uuid: str,
-    default_configuration: Dict[str, Any],
+    default_configuration: dict[str, Any],
 ):
     db_manager: DBManager = mock_db_manager(default_configuration)
     node_ports = await load(
@@ -25,6 +25,7 @@ async def test_load(
         project_id=project_id,
         node_uuid=node_uuid,
         auto_update=auto_update,
+        io_log_redirect_cb=None,
     )
     assert node_ports.db_manager == db_manager
     assert node_ports.node_uuid == node_uuid
@@ -48,6 +49,7 @@ async def test_load_with_invalid_cfg(
             user_id=user_id,
             project_id=project_id,
             node_uuid=node_uuid,
+            io_log_redirect_cb=None,
         )
 
 
@@ -56,7 +58,7 @@ async def test_dump(
     user_id: int,
     project_id: str,
     node_uuid: str,
-    default_configuration: Dict[str, Any],
+    default_configuration: dict[str, Any],
 ):
     db_manager: DBManager = mock_db_manager(default_configuration)
     node_ports = await load(
@@ -64,6 +66,7 @@ async def test_dump(
         user_id=user_id,
         project_id=project_id,
         node_uuid=node_uuid,
+        io_log_redirect_cb=None,
     )
 
     await dump(node_ports)

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_serialization_v2.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_serialization_v2.py
@@ -2,6 +2,7 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
+import functools
 from typing import Any
 
 import pytest
@@ -31,7 +32,8 @@ async def test_load(
     assert node_ports.node_uuid == node_uuid
     # pylint: disable=comparison-with-callable
     assert node_ports.save_to_db_cb == dump
-    assert node_ports.node_port_creator_cb == load
+    assert isinstance(node_ports.node_port_creator_cb, functools.partial)
+    assert node_ports.node_port_creator_cb.keywords == {"io_log_redirect_cb": None}
     assert node_ports.auto_update == auto_update
 
 

--- a/services/api-server/src/simcore_service_api_server/api/routes/files.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/files.py
@@ -121,7 +121,7 @@ async def upload_file(
             StorageFileID, f"api/{file_meta.id}/{file_meta.filename}"
         ),
         file_to_upload=UploadableFileObject(file.file, file.filename, file_size),
-        log_redirect=None,
+        io_log_redirect_cb=None,
     )
 
     file_meta.checksum = entity_tag

--- a/services/api-server/src/simcore_service_api_server/api/routes/files.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/files.py
@@ -121,6 +121,7 @@ async def upload_file(
             StorageFileID, f"api/{file_meta.id}/{file_meta.filename}"
         ),
         file_to_upload=UploadableFileObject(file.file, file.filename, file_size),
+        log_redirect=None,
     )
 
     file_meta.checksum = entity_tag

--- a/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
+++ b/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
@@ -591,7 +591,7 @@ async def _fetch_data_via_data_manager(
         node_uuid=service_uuid,
         file_or_folder=DY_SERVICES_STATE_PATH,
         save_to=save_to,
-        log_redirect=None,
+        io_log_redirect_cb=None,
     )
 
     return save_to

--- a/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
+++ b/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
@@ -31,7 +31,7 @@ from models_library.projects_networks import (
     NetworksWithAliases,
     ProjectsNetworks,
 )
-from models_library.projects_nodes_io import NodeID
+from models_library.projects_nodes_io import NodeID, NodeIDStr
 from models_library.projects_pipeline import PipelineDetails
 from models_library.projects_state import RunningState
 from models_library.users import UserID
@@ -424,7 +424,7 @@ async def _get_mapped_nodeports_values(
         PORTS: Nodeports = await node_ports_v2.ports(
             user_id=user_id,
             project_id=project_id,
-            node_uuid=str(node_uuid),
+            node_uuid=NodeIDStr(node_uuid),
             db_manager=db_manager,
         )
         result[str(node_uuid)] = InputsOutputs(
@@ -591,6 +591,7 @@ async def _fetch_data_via_data_manager(
         node_uuid=service_uuid,
         file_or_folder=DY_SERVICES_STATE_PATH,
         save_to=save_to,
+        log_redirect=None,
     )
 
     return save_to

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
@@ -9,7 +9,6 @@ from pydantic.main import BaseModel
 from simcore_sdk.node_ports_v2.port_utils import is_file_type
 
 from ..core.docker_utils import docker_client
-from ..core.rabbitmq import RabbitMQ
 from ..modules import directory_watcher
 from ..modules.mounted_fs import MountedVolumes
 from ._dependencies import get_application, get_mounted_volumes
@@ -35,11 +34,6 @@ class AttachContainerToNetworkItem(_BaseNetworkItem):
 
 class DetachContainerFromNetworkItem(_BaseNetworkItem):
     pass
-
-
-async def send_message(rabbitmq: RabbitMQ, message: str) -> None:
-    logger.debug(message)
-    await rabbitmq.post_log_message(f"[sidecar] {message}")
 
 
 #

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
@@ -187,6 +187,11 @@ class RabbitMQ:  # pylint: disable = too-many-instance-attributes
                 await self._queues_worker
 
 
+async def send_message(rabbitmq: RabbitMQ, msg: str) -> None:
+    log.debug(msg)
+    await rabbitmq.post_log_message(f"[sidecar] {msg}")
+
+
 def setup_rabbitmq(app: FastAPI) -> None:
     async def on_startup() -> None:
         app.state.rabbitmq = RabbitMQ(app)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/directory_watcher.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/directory_watcher.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import logging
 import time
 from asyncio import AbstractEventLoop
@@ -11,10 +12,12 @@ from typing import Any, Awaitable, Callable, Deque, Generator, Optional
 
 from fastapi import FastAPI
 from servicelib.utils import logged_gather
+from simcore_sdk.node_ports_common.file_io_utils import LogRedirectCB
 from simcore_service_dynamic_sidecar.modules import nodeports
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
+from ..core.rabbitmq import send_message
 from .mounted_fs import MountedVolumes
 
 DETECTION_INTERVAL: float = 1.0
@@ -76,22 +79,29 @@ def async_run_once_after_event_chain(
     return internal
 
 
-async def _push_directory(directory_path: Path) -> None:
-    await nodeports.dispatch_update_for_directory(directory_path)
+async def _push_directory(
+    directory_path: Path, io_log_redirect_cb: Optional[LogRedirectCB]
+) -> None:
+    await nodeports.dispatch_update_for_directory(
+        directory_path, io_log_redirect_cb=io_log_redirect_cb
+    )
 
 
 @async_run_once_after_event_chain(detection_interval=DETECTION_INTERVAL)
-async def _push_directory_after_event_chain(directory_path: Path) -> None:
-    await _push_directory(directory_path)
+async def _push_directory_after_event_chain(
+    directory_path: Path, io_log_redirect_cb: Optional[LogRedirectCB]
+) -> None:
+    await _push_directory(directory_path, io_log_redirect_cb=io_log_redirect_cb)
 
 
 def async_push_directory(
     event_loop: AbstractEventLoop,
     directory_path: Path,
     tasks_collection: set[asyncio.Task[Any]],
+    io_log_redirect_cb: Optional[LogRedirectCB],
 ) -> None:
     task = event_loop.create_task(
-        _push_directory_after_event_chain(directory_path),
+        _push_directory_after_event_chain(directory_path, io_log_redirect_cb),
         name=TASK_NAME_FOR_CLEANUP,
     )
     tasks_collection.add(task)
@@ -99,13 +109,19 @@ def async_push_directory(
 
 
 class UnifyingEventHandler(FileSystemEventHandler):
-    def __init__(self, loop: AbstractEventLoop, directory_path: Path):
+    def __init__(
+        self,
+        loop: AbstractEventLoop,
+        directory_path: Path,
+        io_log_redirect_cb: Optional[LogRedirectCB],
+    ):
         super().__init__()
 
         self.loop: AbstractEventLoop = loop
         self.directory_path: Path = directory_path
         self._is_enabled: bool = True
         self._background_tasks: set[asyncio.Task[Any]] = set()
+        self.io_log_redirect_cb: Optional[LogRedirectCB] = io_log_redirect_cb
 
     def set_enabled(self, is_enabled: bool) -> None:
         self._is_enabled = is_enabled
@@ -113,7 +129,12 @@ class UnifyingEventHandler(FileSystemEventHandler):
     def _invoke_push_directory(self) -> None:
         # wrapping the function call in the object
         # helps with testing, it is simplet to mock
-        async_push_directory(self.loop, self.directory_path, self._background_tasks)
+        async_push_directory(
+            self.loop,
+            self.directory_path,
+            self._background_tasks,
+            self.io_log_redirect_cb,
+        )
 
     def on_any_event(self, event: FileSystemEvent) -> None:
         super().on_any_event(event)
@@ -124,19 +145,21 @@ class UnifyingEventHandler(FileSystemEventHandler):
 class DirectoryWatcherObservers:
     """Used to keep tack of observer threads"""
 
-    def __init__(
-        self,
-    ) -> None:
+    def __init__(self, *, io_log_redirect_cb: Optional[LogRedirectCB]) -> None:
         self._observers: Deque[Observer] = deque()
 
         self._keep_running: bool = True
         self._blocking_task: Optional[Awaitable[Any]] = None
         self.outputs_event_handle: Optional[UnifyingEventHandler] = None
+        self.io_log_redirect_cb: Optional[LogRedirectCB] = io_log_redirect_cb
 
     def observe_directory(self, directory_path: Path, recursive: bool = True) -> None:
+        logger.debug("observing %s, %s", f"{directory_path=}", f"{recursive=}")
         path = directory_path.absolute()
         self.outputs_event_handle = UnifyingEventHandler(
-            loop=asyncio.get_event_loop(), directory_path=path
+            loop=asyncio.get_event_loop(),
+            directory_path=path,
+            io_log_redirect_cb=self.io_log_redirect_cb,
         )
         observer = Observer()
         observer.schedule(self.outputs_event_handle, str(path), recursive=recursive)
@@ -201,8 +224,16 @@ def setup_directory_watcher(app: FastAPI) -> None:
     async def on_startup() -> None:
         mounted_volumes: MountedVolumes
         mounted_volumes = app.state.mounted_volumes  # nosec
-
-        app.state.dir_watcher = DirectoryWatcherObservers()
+        io_log_redirect_cb = None
+        if app.state.settings.RABBIT_SETTINGS:
+            io_log_redirect_cb = functools.partial(send_message, app.state.rabbitmq)
+        logger.debug(
+            "setting up directory watcher %s",
+            "with redirection of logs..." if io_log_redirect_cb else "...",
+        )
+        app.state.dir_watcher = DirectoryWatcherObservers(
+            io_log_redirect_cb=io_log_redirect_cb
+        )
         app.state.dir_watcher.observe_directory(mounted_volumes.disk_outputs_path)
         app.state.dir_watcher.disable_event_propagation()
         app.state.dir_watcher.start()

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 from collections import deque
 from typing import Any, Awaitable, Final, Optional
@@ -180,6 +181,7 @@ async def task_restore_state(
                 project_id=str(settings.DY_SIDECAR_PROJECT_ID),
                 node_uuid=str(settings.DY_SIDECAR_NODE_ID),
                 file_or_folder=path,
+                log_redirect=functools.partial(send_message, rabbitmq),
             )
             for path, exists in zip(mounted_volumes.disk_state_paths(), existing_files)
             if exists
@@ -212,6 +214,7 @@ async def task_save_state(
                 file_or_folder=state_path,
                 r_clone_settings=settings.rclone_settings_for_nodeports,
                 archive_exclude_patterns=mounted_volumes.state_exclude,
+                log_redirect=functools.partial(send_message, rabbitmq),
             )
         )
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -176,7 +176,7 @@ async def task_restore_state(
                 project_id=str(settings.DY_SIDECAR_PROJECT_ID),
                 node_uuid=str(settings.DY_SIDECAR_NODE_ID),
                 file_or_folder=path,
-                log_redirect=functools.partial(send_message, rabbitmq),
+                io_log_redirect_cb=functools.partial(send_message, rabbitmq),
             )
             for path, exists in zip(mounted_volumes.disk_state_paths(), existing_files)
             if exists
@@ -209,7 +209,7 @@ async def task_save_state(
                 file_or_folder=state_path,
                 r_clone_settings=settings.rclone_settings_for_nodeports,
                 archive_exclude_patterns=mounted_volumes.state_exclude,
-                log_redirect=functools.partial(send_message, rabbitmq),
+                io_log_redirect_cb=functools.partial(send_message, rabbitmq),
             )
         )
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -21,7 +21,7 @@ from ..core.docker_compose_utils import (
     docker_compose_start,
 )
 from ..core.docker_logs import start_log_fetching, stop_log_fetching
-from ..core.rabbitmq import RabbitMQ
+from ..core.rabbitmq import RabbitMQ, send_message
 from ..core.settings import ApplicationSettings
 from ..core.utils import CommandResult, assemble_container_names
 from ..core.validation import validate_compose_spec
@@ -33,11 +33,6 @@ from ..modules.directory_watcher import directory_watcher_disabled
 from ..modules.mounted_fs import MountedVolumes
 
 logger = logging.getLogger(__name__)
-
-
-async def send_message(rabbitmq: RabbitMQ, msg: str) -> None:
-    logger.debug(msg)
-    await rabbitmq.post_log_message(f"[sidecar] {msg}")
 
 
 # TASKS

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
@@ -59,7 +59,9 @@ def _get_size_of_value(value: ItemConcreteValue) -> int:
 
 @run_sequentially_in_context()
 async def upload_outputs(
-    outputs_path: Path, port_keys: list[str], io_log_redirect_cb: LogRedirectCB
+    outputs_path: Path,
+    port_keys: list[str],
+    io_log_redirect_cb: Optional[LogRedirectCB],
 ) -> None:
     """calls to this function will get queued and invoked in sequence"""
     # pylint: disable=too-many-branches
@@ -72,7 +74,7 @@ async def upload_outputs(
         project_id=ProjectIDStr(settings.DY_SIDECAR_PROJECT_ID),
         node_uuid=NodeIDStr(settings.DY_SIDECAR_NODE_ID),
         r_clone_settings=settings.rclone_settings_for_nodeports,
-        io_log_redirect=io_log_redirect_cb,
+        io_log_redirect_cb=io_log_redirect_cb,
     )
 
     # let's gather the tasks
@@ -150,7 +152,7 @@ async def upload_outputs(
 
 
 async def dispatch_update_for_directory(
-    directory_path: Path, io_log_redirect_cb: LogRedirectCB
+    directory_path: Path, io_log_redirect_cb: Optional[LogRedirectCB]
 ) -> None:
     logger.debug("Uploading data for directory %s", directory_path)
     # TODO: how to figure out from directory_path which is the correct target to upload
@@ -271,7 +273,7 @@ async def download_target_ports(
         project_id=ProjectIDStr(settings.DY_SIDECAR_PROJECT_ID),
         node_uuid=NodeIDStr(settings.DY_SIDECAR_NODE_ID),
         r_clone_settings=settings.rclone_settings_for_nodeports,
-        io_log_redirect=io_log_redirect_cb,
+        io_log_redirect_cb=io_log_redirect_cb,
     )
 
     # let's gather all the data

--- a/services/dynamic-sidecar/tests/unit/test_modules_directory_watcher.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_directory_watcher.py
@@ -66,7 +66,7 @@ async def test_run_observer(
     tmp_path: Path,
 ) -> None:
 
-    directory_watcher_observers = DirectoryWatcherObservers()
+    directory_watcher_observers = DirectoryWatcherObservers(io_log_redirect_cb=None)
     directory_watcher_observers.observe_directory(tmp_path)
 
     directory_watcher_observers.start()

--- a/services/web/server/src/simcore_service_webserver/exporter/formatters/formatter_v1.py
+++ b/services/web/server/src/simcore_service_webserver/exporter/formatters/formatter_v1.py
@@ -193,7 +193,7 @@ async def upload_file_to_storage(
             s3_object=link_and_path.relative_path_to_file,
             file_to_upload=link_and_path.storage_path_to_file,
             client_session=session,
-            log_redirect=None,
+            io_log_redirect_cb=None,
         )
         return (link_and_path, e_tag)
     except (

--- a/services/web/server/src/simcore_service_webserver/exporter/formatters/formatter_v1.py
+++ b/services/web/server/src/simcore_service_webserver/exporter/formatters/formatter_v1.py
@@ -193,6 +193,7 @@ async def upload_file_to_storage(
             s3_object=link_and_path.relative_path_to_file,
             file_to_upload=link_and_path.storage_path_to_file,
             client_session=session,
+            log_redirect=None,
         )
         return (link_and_path, e_tag)
     except (


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
Allow to redirect tqdm library progress logs to the frontend to show the user when:
- downloading workspace
- downloading/uploading ports

Bonus:
- use tqdm contrib functions to make logging behave better when a progress bar is displayed.
NOTE: no progress shown for archiving/unarchiving since async/sync code is proving difficult to circumvent.
<!-- Explain REVIEWERS what is this PR about -->

[Screencast from 25. 08. 22 17:04:15.webm](https://user-images.githubusercontent.com/35365065/186707581-bf3db869-69d3-4b17-a988-33c92634903e.webm)


## Related issue/s

improves user experience https://github.com/ITISFoundation/osparc-issues/issues/638
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
