### PR TITLE
✨ Aiohttp long running tasks client

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
@@ -1,17 +1,26 @@
+import asyncio
 import logging
 from functools import wraps
-from typing import AsyncGenerator, Callable
+from typing import Any, AsyncGenerator, Callable
 
 from aiohttp import web
 from pydantic import PositiveFloat
+from servicelib.json_serialization import json_dumps
 
-from ...long_running_tasks._task import TasksManager
+from ...long_running_tasks._models import TaskGet
+from ...long_running_tasks._task import (
+    TaskContext,
+    TaskProtocol,
+    TasksManager,
+    start_task,
+)
 from ..typing_extension import Handler
 from ._constants import (
     APP_LONG_RUNNING_TASKS_MANAGER_KEY,
     MINUTE,
     RQT_LONG_RUNNING_TASKS_CONTEXT_KEY,
 )
+from ._dependencies import create_task_name_from_request, get_tasks_manager
 from ._error_handlers import base_long_running_error_handler
 from ._routes import routes
 
@@ -29,6 +38,49 @@ def no_task_context_decorator(handler: Handler):
         return await handler(request)
 
     return _wrap
+
+
+async def start_long_running_task(
+    request: web.Request,
+    task: TaskProtocol,
+    *,
+    task_context: TaskContext,
+    **task_kwargs: Any,
+) -> web.Response:
+    task_manager = get_tasks_manager(request.app)
+    task_name = create_task_name_from_request(request)
+    task_id = None
+    try:
+        task_id = start_task(
+            task_manager,
+            task,
+            task_context=task_context,
+            task_name=task_name,
+            **task_kwargs,
+        )
+        status_url = request.app.router["get_task_status"].url_for(task_id=task_id)
+        result_url = request.app.router["get_task_result"].url_for(task_id=task_id)
+        abort_url = request.app.router["cancel_and_delete_task"].url_for(
+            task_id=task_id
+        )
+        task_get = TaskGet(
+            task_id=task_id,
+            task_name=task_name,
+            status_href=f"{status_url}",
+            result_href=f"{result_url}",
+            abort_href=f"{abort_url}",
+        )
+        return web.json_response(
+            data={"data": task_get},
+            status=web.HTTPAccepted.status_code,
+            dumps=json_dumps,
+        )
+    except asyncio.CancelledError:
+        # cancel the task, the client has disconnected
+        if task_id:
+            task_manager = get_tasks_manager(request.app)
+            await task_manager.cancel_task(task_id, with_task_context=None)
+        raise
 
 
 def setup(

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
@@ -1,0 +1,105 @@
+import asyncio
+from typing import Any, AsyncGenerator, Final, Optional
+
+from aiohttp import ClientConnectionError, ClientSession
+from tenacity import TryAgain, retry
+from tenacity._asyncio import AsyncRetrying
+from tenacity.retry import retry_if_exception_type
+from tenacity.stop import stop_after_delay
+from tenacity.wait import wait_exponential, wait_fixed
+from yarl import URL
+
+from ..rest_responses import unwrap_envelope
+from .server import TaskGet, TaskId, TaskProgress, TaskStatus
+
+RequestBody = dict[str, Any]
+
+
+@retry(
+    retry=retry_if_exception_type(ClientConnectionError),
+    wait=wait_exponential(min=1, max=10),
+    reraise=True,
+)
+async def _start(
+    session: ClientSession, request: URL, data: Optional[RequestBody]
+) -> TaskGet:
+    async with session.post(request, data=data) as response:
+        response.raise_for_status()
+        data, error = unwrap_envelope(await response.json())
+    assert not error  # nosec
+    assert data is not None  # nosec
+    task = TaskGet.parse_obj(data)
+    return task
+
+
+async def _wait_for_completion(
+    session: ClientSession, task_id: TaskId, status_url: str, wait_timeout_s: int
+) -> AsyncGenerator[TaskProgress, None]:
+    async for attempt in AsyncRetrying(
+        wait=wait_fixed(1), stop=stop_after_delay(wait_timeout_s)
+    ):
+        with attempt:
+            async with session.get(status_url) as response:
+                response.raise_for_status()
+                data, error = unwrap_envelope(await response.json())
+                assert not error  # nosec
+                assert data is not None  # nosec
+            task_status = TaskStatus.parse_obj(data)
+            yield task_status.task_progress
+            if not task_status.done:
+                raise TryAgain(
+                    f"{task_id=}, {task_status.started=} has "
+                    f"status: '{task_status.task_progress.message}'"
+                    f" {task_status.task_progress.percent}%"
+                )
+
+
+@retry(
+    retry=retry_if_exception_type(ClientConnectionError),
+    wait=wait_exponential(min=1, max=10),
+    reraise=True,
+)
+async def _get_task_result(session: ClientSession, result_href: str) -> Any:
+    async with session.get(result_href) as response:
+        response.raise_for_status()
+        data, error = unwrap_envelope(await response.json())
+        assert not error  # nosec
+    return data
+
+
+@retry(
+    retry=retry_if_exception_type(ClientConnectionError),
+    wait=wait_exponential(min=1, max=10),
+    reraise=True,
+)
+async def _abort_task(session: ClientSession, abort_href: str) -> None:
+    async with session.delete(abort_href) as response:
+        response.raise_for_status()
+        data, error = unwrap_envelope(await response.json())
+        assert not error  # nosec
+        assert not data  # nosec
+
+
+_MINUTE: Final[int] = 60
+_HOUR: Final[int] = 60 * _MINUTE
+
+
+async def long_running_task_request(
+    session: ClientSession,
+    request: URL,
+    data: Optional[RequestBody] = None,
+    wait_timeout_s: int = 1 * _HOUR,
+) -> AsyncGenerator[TaskProgress, None]:
+    task = None
+    try:
+        task = await _start(session, request, data)
+        async for task_progress in _wait_for_completion(
+            session, task.task_id, task.status_href, wait_timeout_s
+        ):
+            yield task_progress
+
+        yield await _get_task_result(session, task.result_href)
+    except asyncio.CancelledError:
+        if task:
+            await _abort_task(session, task.abort_href)
+        raise

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
@@ -103,7 +103,12 @@ _HOUR: Final[int] = 60 * _MINUTE
 @dataclass(frozen=True)
 class LRTask:
     progress: TaskProgress
-    result: Optional[Coroutine[Any, Any, Any]] = None
+    _result: Optional[Coroutine[Any, Any, Any]] = None
+
+    async def result(self):
+        if not self._result:
+            raise ValueError("No result ready!")
+        return await self._result
 
 
 async def long_running_task_request(
@@ -124,7 +129,7 @@ async def long_running_task_request(
             yield LRTask(progress=task_progress)
         assert last_progress  # nosec
         yield LRTask(
-            progress=last_progress, result=_task_result(session, task.result_href)
+            progress=last_progress, _result=_task_result(session, task.result_href)
         )
 
     except (asyncio.CancelledError, asyncio.TimeoutError):

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
@@ -108,13 +108,13 @@ class LRTask:
 async def long_running_task_request(
     session: ClientSession,
     url: URL,
-    data: Optional[RequestBody] = None,
+    json: Optional[RequestBody] = None,
     wait_timeout_s: int = 1 * _HOUR,
     wait_interval_s: float = 1,
 ) -> AsyncGenerator[LRTask, None]:
     task = None
     try:
-        task = await _start(session, url, data)
+        task = await _start(session, url, json)
         last_progress = None
         async for task_progress in _wait_for_completion(
             session, task.task_id, task.status_href, wait_timeout_s, wait_interval_s

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
@@ -118,6 +118,25 @@ async def long_running_task_request(
     wait_timeout_s: int = 1 * _HOUR,
     wait_interval_s: float = 1,
 ) -> AsyncGenerator[LRTask, None]:
+    """Will use the passed `ClientSession` to call an oSparc long
+    running task `url` passing `json` as request body.
+    NOTE: this follows the usual aiohttp client syntax, and will raise the same errors
+
+    :param session: The client to use
+    :type session: ClientSession
+    :param url: The url to call. NOTE: the endpoint must follow oSparc long running task server syntax (202, then status, result urls)
+    :type url: URL
+    :param json: optional body as dictionary, defaults to None
+    :type json: Optional[RequestBody], optional
+    :param wait_timeout_s: after this timeout is reached and no result is ready will raise asyncio.TimeoutError, defaults to 1*_HOUR
+    :type wait_timeout_s: int, optional
+    :param wait_interval_s: will check for result every `wait_interval` seconds, defaults to 1
+    :type wait_interval_s: float, optional
+    :return: a task containing the final result
+    :rtype: AsyncGenerator[LRTask, None]
+    :yield: a task containing the current TaskProgress
+    :rtype: Iterator[AsyncGenerator[LRTask, None]]
+    """
     task = None
     try:
         task = await _start(session, url, json)

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
@@ -105,7 +105,10 @@ class LRTask:
     progress: TaskProgress
     _result: Optional[Coroutine[Any, Any, Any]] = None
 
-    async def result(self):
+    def done(self) -> bool:
+        return self._result is not None
+
+    async def result(self) -> Any:
         if not self._result:
             raise ValueError("No result ready!")
         return await self._result

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Coroutine, Final, Optional
 
 from aiohttp import ClientConnectionError, ClientSession, web
+from pydantic import Json
 from tenacity import TryAgain, retry
 from tenacity._asyncio import AsyncRetrying
 from tenacity.retry import retry_if_exception_type
@@ -13,7 +14,7 @@ from yarl import URL
 from ..rest_responses import unwrap_envelope
 from .server import TaskGet, TaskId, TaskProgress, TaskStatus
 
-RequestBody = dict[str, Any]
+RequestBody = Json
 
 
 @retry(
@@ -22,9 +23,9 @@ RequestBody = dict[str, Any]
     reraise=True,
 )
 async def _start(
-    session: ClientSession, request: URL, data: Optional[RequestBody]
+    session: ClientSession, request: URL, json: Optional[RequestBody]
 ) -> TaskGet:
-    async with session.post(request, data=data) as response:
+    async with session.post(request, json=json) as response:
         response.raise_for_status()
         data, error = unwrap_envelope(await response.json())
     assert not error  # nosec

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
@@ -144,7 +144,7 @@ async def long_running_task_request(
         async for task_progress in _wait_for_completion(
             session,
             task.task_id,
-            url.with_path(task.status_href),
+            url.with_path(task.status_href, encoded=True),
             wait_timeout_s,
             wait_interval_s,
         ):
@@ -153,10 +153,12 @@ async def long_running_task_request(
         assert last_progress  # nosec
         yield LRTask(
             progress=last_progress,
-            _result=_task_result(session, url.with_path(task.result_href)),
+            _result=_task_result(
+                session, url.with_path(task.result_href, encoded=True)
+            ),
         )
 
     except (asyncio.CancelledError, asyncio.TimeoutError):
         if task:
-            await _abort_task(session, url.with_path(task.abort_href))
+            await _abort_task(session, url.with_path(task.abort_href, encoded=True))
         raise

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/client.py
@@ -1,7 +1,8 @@
 import asyncio
-from typing import Any, AsyncGenerator, Final, Optional
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator, Coroutine, Final, Optional
 
-from aiohttp import ClientConnectionError, ClientSession
+from aiohttp import ClientConnectionError, ClientSession, web
 from tenacity import TryAgain, retry
 from tenacity._asyncio import AsyncRetrying
 from tenacity.retry import retry_if_exception_type
@@ -33,25 +34,37 @@ async def _start(
 
 
 async def _wait_for_completion(
-    session: ClientSession, task_id: TaskId, status_url: str, wait_timeout_s: int
+    session: ClientSession,
+    task_id: TaskId,
+    status_url: str,
+    wait_timeout_s: int,
+    wait_interval_s: float,
 ) -> AsyncGenerator[TaskProgress, None]:
-    async for attempt in AsyncRetrying(
-        wait=wait_fixed(1), stop=stop_after_delay(wait_timeout_s)
-    ):
-        with attempt:
-            async with session.get(status_url) as response:
-                response.raise_for_status()
-                data, error = unwrap_envelope(await response.json())
-                assert not error  # nosec
-                assert data is not None  # nosec
-            task_status = TaskStatus.parse_obj(data)
-            yield task_status.task_progress
-            if not task_status.done:
-                raise TryAgain(
-                    f"{task_id=}, {task_status.started=} has "
-                    f"status: '{task_status.task_progress.message}'"
-                    f" {task_status.task_progress.percent}%"
-                )
+    try:
+        async for attempt in AsyncRetrying(
+            wait=wait_fixed(wait_interval_s),
+            stop=stop_after_delay(wait_timeout_s),
+            reraise=True,
+        ):
+            with attempt:
+                async with session.get(status_url) as response:
+                    response.raise_for_status()
+                    data, error = unwrap_envelope(await response.json())
+                    assert not error  # nosec
+                    assert data is not None  # nosec
+                task_status = TaskStatus.parse_obj(data)
+                yield task_status.task_progress
+                if not task_status.done:
+                    raise TryAgain(
+                        f"{task_id=}, {task_status.started=} has "
+                        f"status: '{task_status.task_progress.message}'"
+                        f" {task_status.task_progress.percent}%"
+                    )
+    except TryAgain as exc:
+        # this is a timeout
+        raise asyncio.TimeoutError(
+            f"Long running task {task_id}, calling to {status_url} timed-out after {wait_timeout_s} seconds"
+        ) from exc
 
 
 @retry(
@@ -59,12 +72,14 @@ async def _wait_for_completion(
     wait=wait_exponential(min=1, max=10),
     reraise=True,
 )
-async def _get_task_result(session: ClientSession, result_href: str) -> Any:
+async def _task_result(session: ClientSession, result_href: str) -> Any:
     async with session.get(result_href) as response:
         response.raise_for_status()
-        data, error = unwrap_envelope(await response.json())
-        assert not error  # nosec
-    return data
+        if response.status != web.HTTPNoContent.status_code:
+            data, error = unwrap_envelope(await response.json())
+            assert not error  # nosec
+            assert data  # nosec
+            return data
 
 
 @retry(
@@ -84,22 +99,34 @@ _MINUTE: Final[int] = 60
 _HOUR: Final[int] = 60 * _MINUTE
 
 
+@dataclass(frozen=True)
+class LRTask:
+    progress: TaskProgress
+    result: Optional[Coroutine[Any, Any, Any]] = None
+
+
 async def long_running_task_request(
     session: ClientSession,
-    request: URL,
+    url: URL,
     data: Optional[RequestBody] = None,
     wait_timeout_s: int = 1 * _HOUR,
-) -> AsyncGenerator[TaskProgress, None]:
+    wait_interval_s: float = 1,
+) -> AsyncGenerator[LRTask, None]:
     task = None
     try:
-        task = await _start(session, request, data)
+        task = await _start(session, url, data)
+        last_progress = None
         async for task_progress in _wait_for_completion(
-            session, task.task_id, task.status_href, wait_timeout_s
+            session, task.task_id, task.status_href, wait_timeout_s, wait_interval_s
         ):
-            yield task_progress
+            last_progress = task_progress
+            yield LRTask(progress=task_progress)
+        assert last_progress  # nosec
+        yield LRTask(
+            progress=last_progress, result=_task_result(session, task.result_href)
+        )
 
-        yield await _get_task_result(session, task.result_href)
-    except asyncio.CancelledError:
+    except (asyncio.CancelledError, asyncio.TimeoutError):
         if task:
             await _abort_task(session, task.abort_href)
         raise

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/server.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/server.py
@@ -13,17 +13,16 @@ from ...long_running_tasks._task import (
     TaskProtocol,
     TasksManager,
     TaskStatus,
-    start_task,
 )
 from ._dependencies import create_task_name_from_request, get_tasks_manager
 from ._routes import TaskGet
-from ._server import setup
+from ._server import setup, start_long_running_task
 
 __all__: tuple[str, ...] = (
     "create_task_name_from_request",
     "get_tasks_manager",
     "setup",
-    "start_task",
+    "start_long_running_task",
     "TaskAlreadyRunningError",
     "TaskCancelledError",
     "TaskId",

--- a/packages/service-library/src/servicelib/long_running_tasks/_task.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/_task.py
@@ -422,4 +422,5 @@ def start_task(
         task_progress=task_progress,
         task_context=task_context or {},
     )
+
     return tracked_task.task_id

--- a/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks.py
+++ b/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks.py
@@ -18,8 +18,6 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient
 from pydantic import parse_obj_as
-
-# TESTS
 from pytest_simcore.helpers.utils_assert import assert_status
 from servicelib.aiohttp import long_running_tasks
 from servicelib.aiohttp.long_running_tasks.server import TaskGet, TaskId

--- a/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_client.py
+++ b/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_client.py
@@ -61,7 +61,7 @@ async def test_long_running_task_request(
     async for task in long_running_task_request(
         client,
         url.with_query(num_strings=10, sleep_time=0.1),
-        data=None,
+        json=None,
         wait_interval_s=0.01,
     ):
         print(f"<-- received {task.progress=}, {task.result=}")
@@ -81,7 +81,7 @@ async def test_long_running_task_request_timeout(
         async for task in long_running_task_request(
             client,
             url.with_query(num_strings=10, sleep_time=1),
-            data=None,
+            json=None,
             wait_interval_s=0.5,
             wait_timeout_s=2,
         ):
@@ -105,7 +105,7 @@ async def test_long_running_task_request_error(
     async for task in long_running_task_request(
         client,
         url.with_query(num_strings=10, sleep_time=0.1, fail=f"{True}"),
-        data=None,
+        json=None,
         wait_interval_s=0.01,
     ):
         print(f"<-- received {task.progress=}, {task.result=}")

--- a/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_client.py
+++ b/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_client.py
@@ -65,8 +65,10 @@ async def test_long_running_task_request(
         wait_interval_s=0.01,
     ):
         print(f"<-- received {task=}")
+        if task.done():
+            assert await task.result() == [f"{x}" for x in range(10)]
+
     assert task is not None
-    assert await task.result() == [f"{x}" for x in range(10)]
 
 
 async def test_long_running_task_request_timeout(

--- a/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_client.py
+++ b/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_client.py
@@ -1,13 +1,17 @@
 # pylint: disable=redefined-outer-name
 
 import asyncio
-from typing import Callable
+from typing import Callable, Optional
 
 import pytest
 from aiohttp import ClientResponseError, web
 from aiohttp.test_utils import TestClient
+from pytest_simcore.helpers.utils_assert import assert_status
 from servicelib.aiohttp import long_running_tasks
-from servicelib.aiohttp.long_running_tasks.client import long_running_task_request
+from servicelib.aiohttp.long_running_tasks.client import (
+    LRTask,
+    long_running_task_request,
+)
 from servicelib.aiohttp.rest_middlewares import append_rest_middlewares
 
 
@@ -35,17 +39,77 @@ def client(
     )
 
 
+async def test_long_running_task_request_raises_400(
+    client: TestClient, long_running_task_entrypoint: str
+):
+    assert client.app
+    url = client.app.router[long_running_task_entrypoint].url_for()
+
+    # missing parameters raises
+    with pytest.raises(ClientResponseError):
+        async for _ in long_running_task_request(client, url, None):
+            ...
+
+
 async def test_long_running_task_request(
     client: TestClient, long_running_task_entrypoint: str
 ):
     assert client.app
-    request = client.app.router[long_running_task_entrypoint].url_for()
+    url = client.app.router[long_running_task_entrypoint].url_for()
 
-    # missing parameters raises
-    with pytest.raises(ClientResponseError):
-        async for _ in long_running_task_request(client, request, None):
-            ...
-    async for _ in long_running_task_request(
-        client, request.with_query(num_strings=10, sleep_time=1), data=None
+    task: Optional[LRTask] = None
+    async for task in long_running_task_request(
+        client,
+        url.with_query(num_strings=10, sleep_time=0.1),
+        data=None,
+        wait_interval_s=0.01,
     ):
-        ...
+        print(f"<-- received {task.progress=}, {task.result=}")
+    assert task is not None
+    assert task.result
+    assert await task.result == [f"{x}" for x in range(10)]
+
+
+async def test_long_running_task_request_timeout(
+    client: TestClient, long_running_task_entrypoint: str
+):
+    assert client.app
+    url = client.app.router[long_running_task_entrypoint].url_for()
+
+    task: Optional[LRTask] = None
+    with pytest.raises(asyncio.TimeoutError):
+        async for task in long_running_task_request(
+            client,
+            url.with_query(num_strings=10, sleep_time=1),
+            data=None,
+            wait_interval_s=0.5,
+            wait_timeout_s=2,
+        ):
+            print(f"<-- received {task.progress=}, {task.result=}")
+
+    # check the task was properly aborted by the client
+    list_url = client.app.router["list_tasks"].url_for()
+    result = await client.get(f"{list_url}")
+    data, error = await assert_status(result, web.HTTPOk)
+    assert not error
+    assert data == []
+
+
+async def test_long_running_task_request_error(
+    client: TestClient, long_running_task_entrypoint: str
+):
+    assert client.app
+    url = client.app.router[long_running_task_entrypoint].url_for()
+
+    task: Optional[LRTask] = None
+    async for task in long_running_task_request(
+        client,
+        url.with_query(num_strings=10, sleep_time=0.1, fail=f"{True}"),
+        data=None,
+        wait_interval_s=0.01,
+    ):
+        print(f"<-- received {task.progress=}, {task.result=}")
+    assert task is not None
+    assert task.result
+    with pytest.raises(ClientResponseError):
+        await task.result

--- a/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_client.py
+++ b/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_client.py
@@ -1,0 +1,51 @@
+# pylint: disable=redefined-outer-name
+
+import asyncio
+from typing import Callable
+
+import pytest
+from aiohttp import ClientResponseError, web
+from aiohttp.test_utils import TestClient
+from servicelib.aiohttp import long_running_tasks
+from servicelib.aiohttp.long_running_tasks.client import long_running_task_request
+from servicelib.aiohttp.rest_middlewares import append_rest_middlewares
+
+
+@pytest.fixture
+def app(server_routes: web.RouteTableDef) -> web.Application:
+    app = web.Application()
+    app.add_routes(server_routes)
+    # this adds enveloping and error middlewares
+    append_rest_middlewares(app, api_version="")
+    long_running_tasks.server.setup(app, router_prefix="/futures")
+
+    return app
+
+
+@pytest.fixture
+def client(
+    event_loop: asyncio.AbstractEventLoop,
+    aiohttp_client: Callable,
+    unused_tcp_port_factory: Callable,
+    app: web.Application,
+) -> TestClient:
+
+    return event_loop.run_until_complete(
+        aiohttp_client(app, server_kwargs={"port": unused_tcp_port_factory()})
+    )
+
+
+async def test_long_running_task_request(
+    client: TestClient, long_running_task_entrypoint: str
+):
+    assert client.app
+    request = client.app.router[long_running_task_entrypoint].url_for()
+
+    # missing parameters raises
+    with pytest.raises(ClientResponseError):
+        async for _ in long_running_task_request(client, request, None):
+            ...
+    async for _ in long_running_task_request(
+        client, request.with_query(num_strings=10, sleep_time=1), data=None
+    ):
+        ...

--- a/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_client.py
+++ b/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_client.py
@@ -64,10 +64,9 @@ async def test_long_running_task_request(
         json=None,
         wait_interval_s=0.01,
     ):
-        print(f"<-- received {task.progress=}, {task.result=}")
+        print(f"<-- received {task=}")
     assert task is not None
-    assert task.result
-    assert await task.result == [f"{x}" for x in range(10)]
+    assert await task.result() == [f"{x}" for x in range(10)]
 
 
 async def test_long_running_task_request_timeout(
@@ -85,7 +84,7 @@ async def test_long_running_task_request_timeout(
             wait_interval_s=0.5,
             wait_timeout_s=2,
         ):
-            print(f"<-- received {task.progress=}, {task.result=}")
+            print(f"<-- received {task=}")
 
     # check the task was properly aborted by the client
     list_url = client.app.router["list_tasks"].url_for()
@@ -108,8 +107,7 @@ async def test_long_running_task_request_error(
         json=None,
         wait_interval_s=0.01,
     ):
-        print(f"<-- received {task.progress=}, {task.result=}")
+        print(f"<-- received {task=}")
     assert task is not None
-    assert task.result
     with pytest.raises(ClientResponseError):
-        await task.result
+        await task.result()

--- a/services/web/server/src/simcore_service_webserver/long_running_tasks.py
+++ b/services/web/server/src/simcore_service_webserver/long_running_tasks.py
@@ -1,5 +1,4 @@
 from functools import wraps
-from typing import Any
 
 from aiohttp import web
 from models_library.users import UserID
@@ -8,14 +7,7 @@ from pydantic import BaseModel, Field
 from servicelib.aiohttp.long_running_tasks._server import (
     RQT_LONG_RUNNING_TASKS_CONTEXT_KEY,
 )
-from servicelib.aiohttp.long_running_tasks.server import (
-    TaskGet,
-    TaskProtocol,
-    create_task_name_from_request,
-    get_tasks_manager,
-    setup,
-    start_task,
-)
+from servicelib.aiohttp.long_running_tasks.server import setup
 from servicelib.aiohttp.typing_extension import Handler
 
 from ._constants import RQ_PRODUCT_KEY
@@ -26,31 +18,6 @@ from .login.decorators import RQT_USERID_KEY, login_required
 class _RequestContext(BaseModel):
     user_id: UserID = Field(..., alias=RQT_USERID_KEY)
     product_name: str = Field(..., alias=RQ_PRODUCT_KEY)
-
-
-def start_task_with_context(
-    request: web.Request, task: TaskProtocol, **task_kwargs: Any
-) -> TaskGet:
-    req_ctx = _RequestContext.parse_obj(request)
-    task_manager = get_tasks_manager(request.app)
-    task_name = create_task_name_from_request(request)
-    task_id = start_task(
-        task_manager,
-        task,
-        task_context=jsonable_encoder(req_ctx),
-        task_name=task_name,
-        **task_kwargs,
-    )
-    status_url = request.app.router["get_task_status"].url_for(task_id=task_id)
-    result_url = request.app.router["get_task_result"].url_for(task_id=task_id)
-    abort_url = request.app.router["cancel_and_delete_task"].url_for(task_id=task_id)
-    return TaskGet(
-        task_id=task_id,
-        task_name=task_name,
-        status_href=f"{status_url}",
-        result_href=f"{result_url}",
-        abort_href=f"{abort_url}",
-    )
 
 
 def _webserver_request_context_decorator(handler: Handler):

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers_crud.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers_crud.py
@@ -130,7 +130,7 @@ async def create_projects(request: web.Request):
     if query_params.as_template:  # create template from
         await check_permission(request, "project.template.create")
 
-    return start_long_running_task(
+    return await start_long_running_task(
         request,
         _create_projects,
         task_context=jsonable_encoder(req_ctx),


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
- brings a common client for aiohttp-based clients to query osparc long running task REST APIs
pre-requisite to simplify usage in #3287 
## Related issue/s
related to https://github.com/ITISFoundation/osparc-issues/issues/558
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```bash
cd packages/service-library
make "install-dev[all]"
make "test-dev[all]"
```
## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
