### PR TITLE
🐛 is659/decompressing-hangs

### DIFF
--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -166,8 +166,8 @@ async def unarchive_dir(
                 destination_folder=destination_folder,
             )
 
-            tasks = [
-                asyncio.create_task(
+            tasks: list[asyncio.Task] = [
+                asyncio.ensure_future(
                     event_loop.run_in_executor(
                         process_pool,
                         # ---------

--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -193,14 +193,13 @@ async def unarchive_dir(
                 )
 
             except Exception as err:
-
                 for f in futures:
                     f.cancel()
 
-                # give a chance to event-loop context switch since some futures
-                # might be operating in 'destination_folder'
-                await asyncio.sleep(0.1)
+                # wait until all tasks are cancelled.
+                await asyncio.gather(*futures, return_exceptions=True)
 
+                # now we can cleanup
                 if destination_folder.exists() and destination_folder.is_dir():
                     shutil.rmtree(destination_folder, ignore_errors=True)
 

--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -116,7 +116,9 @@ def _zipfile_single_file_extract_worker(
 
 
 class ArchiveError(Exception):
-    pass
+    """
+    Error raised while archiving or unarchiving
+    """
 
 
 def ensure_destination_subdirectories_exist(

--- a/packages/service-library/src/servicelib/file_utils.py
+++ b/packages/service-library/src/servicelib/file_utils.py
@@ -25,4 +25,4 @@ async def remove_directory(
     if only_children:
         await asyncio.gather(*[_rm(child, ignore_errors) for child in path.glob("*")])
     else:
-        shutil.rmtree(path, ignore_errors=ignore_errors)
+        await _shutil_rmtree(path, ignore_errors=ignore_errors)

--- a/packages/service-library/tests/test_archiving_utils.py
+++ b/packages/service-library/tests/test_archiving_utils.py
@@ -240,6 +240,31 @@ def assert_unarchived_paths(
 # TESTS
 
 
+@pytest.mark.skip(reason="DEV:only for manual tessting")
+async def test_archiving_utils_against_sample(
+    osparc_simcore_root_dir: Path, tmp_path: Path
+):
+    """
+    ONLY for manual testing
+    User MUST provide a sample of a zip file in ``sample_path``
+    """
+    sample_path = osparc_simcore_root_dir / "keep.ignore" / "workspace.zip"
+    destination = tmp_path / "unzipped"
+
+    extracted_paths = await unarchive_dir(sample_path, destination)
+    assert extracted_paths
+
+    for p in extracted_paths:
+        assert isinstance(p, Path), p
+
+    await archive_dir(
+        dir_to_compress=destination,
+        destination=tmp_path / "test_it.zip",
+        compress=True,
+        store_relative_path=True,
+    )
+
+
 @pytest.mark.parametrize(
     "compress,store_relative_path",
     itertools.product([True, False], repeat=2),


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

Bug reproduced by running ``test_archiving_utils::test_archiving_utils_against_sample`` against a sample ``workspace.zip`` provided by @GitHK. It revealed:
 1. ``gather`` results ``extracted_paths`` included Exception instances (therefore it would fail ``p.is_file`` etc)
 1. ``event_loop`` would get suddenly closed

This PR enhances error handling for archiving utils:
 - cancels children tasks when ``asyncio.gather``-like raises
 - Defines ``ArchiveError`` as a custom error for archive utils 
 - Adds some guarantees to state upon failure (e.g. zip file/unzipped dst is deleted )


 



## Related issue/s

- ITISFoundation/osparc-issues#659


## How to test

```cmd
cd packages/service-library
make install-dev
make tests
```
