### PR TITLE
  🐛    Pass resource limits to dynamic services

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_compose_specs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_compose_specs.py
@@ -12,6 +12,7 @@ from models_library.services_resources import (
 )
 from servicelib.docker_compose import replace_env_vars_in_compose_spec
 from servicelib.json_serialization import json_dumps
+from servicelib.resources import CPU_RESOURCE_LIMIT_KEY, MEM_RESOURCE_LIMIT_KEY
 from settings_library.docker_registry import RegistrySettings
 
 EnvKeyEqValueList = list[str]
@@ -107,13 +108,15 @@ def _update_resource_limits_and_reservations(
 ) -> None:
     # example: '2.3' -> 2 ; '3.7' -> 3
     docker_compose_major_version: int = int(service_spec["version"].split(".")[0])
-
     for spec_service_key, spec in service_spec["services"].items():
         resources: ResourcesDict = service_resources[spec_service_key].resources
         logger.debug("Resources for %s: %s", spec_service_key, f"{resources=}")
 
         cpu: ResourceValue = resources["CPU"]
         memory: ResourceValue = resources["RAM"]
+
+        nano_cpu_limits: float = 0.0
+        mem_limits: str = "0"
 
         if docker_compose_major_version >= 3:
             # compos spec version 3 and beyond
@@ -133,12 +136,29 @@ def _update_resource_limits_and_reservations(
             resources["limits"] = limits
             deploy["resources"] = resources
             spec["deploy"] = deploy
+
+            nano_cpu_limits = limits["cpus"] * 10**9
+            mem_limits = limits["memory"]
         else:
             # compos spec version 2
             spec["mem_limit"] = f"{memory.limit}"
             spec["mem_reservation"] = f"{memory.reservation}"
             # NOTE: there is no distinction between limit and reservation, taking the higher value
             spec["cpus"] = float(max(cpu.limit, cpu.reservation))
+
+            nano_cpu_limits = spec["cpus"] * 10**9
+            mem_limits = spec["mem_limit"]
+
+        # Update env vars for services that need to know the current resources specs
+        environment = spec.get("environment", [])
+
+        resource_limits = [
+            f"{CPU_RESOURCE_LIMIT_KEY}={int(nano_cpu_limits)}",
+            f"{MEM_RESOURCE_LIMIT_KEY}={mem_limits}",
+        ]
+
+        environment.extend(resource_limits)
+        spec["environment"] = environment
 
 
 def assemble_spec(

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_compose_specs.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_compose_specs.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access
 
 
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 import yaml
@@ -12,6 +12,7 @@ from models_library.services_resources import (
     ServiceResourcesDict,
 )
 from pydantic import parse_obj_as
+from servicelib.resources import CPU_RESOURCE_LIMIT_KEY, MEM_RESOURCE_LIMIT_KEY
 from simcore_service_director_v2.modules.dynamic_sidecar import docker_compose_specs
 
 # TESTS
@@ -98,7 +99,7 @@ environment:
     ],
 )
 async def test_inject_resource_limits_and_reservations(
-    service_spec: Dict[str, Any],
+    service_spec: dict[str, Any],
     service_resources: ServiceResourcesDict,
 ) -> None:
     docker_compose_specs._update_resource_limits_and_reservations(
@@ -122,9 +123,21 @@ async def test_inject_resource_limits_and_reservations(
             )
             assert spec["deploy"]["resources"]["limits"]["cpus"] == cpu.limit
             assert spec["deploy"]["resources"]["limits"]["memory"] == f"{memory.limit}"
+
+            assert (
+                f"{CPU_RESOURCE_LIMIT_KEY}={int(cpu.limit*10**9)}"
+                in spec["environment"]
+            )
+            assert f"{MEM_RESOURCE_LIMIT_KEY}={memory.limit}" in spec["environment"]
     else:
         for spec in service_spec["services"].values():
             assert spec["mem_limit"] == f"{memory.limit}"
             assert spec["mem_reservation"] == f"{memory.reservation}"
             assert int(spec["mem_reservation"]) <= int(spec["mem_limit"])
             assert spec["cpus"] == max(cpu.limit, cpu.reservation)
+
+            assert (
+                f"{CPU_RESOURCE_LIMIT_KEY}={int(max(cpu.limit, cpu.reservation)*10**9)}"
+                in spec["environment"]
+            )
+            assert f"{MEM_RESOURCE_LIMIT_KEY}={memory.limit}" in spec["environment"]


### PR DESCRIPTION
## What do these changes do?

Services powered by the dynamic sidecar would not get the resource limits assigned to the corresponding containers. This PR fixes that.

## How to test

All services spawned by the docker-compose spec should inject corresponding environment variables.
