### PR TITLE
🐛 Nodeports filemanager incorrectly closes request

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
@@ -18,6 +18,7 @@ from models_library.api_schemas_storage import ETag, FileUploadSchema, UploadedP
 from pydantic import AnyUrl
 from servicelib.utils import logged_gather
 from tenacity._asyncio import AsyncRetrying
+from tenacity.after import after_log
 from tenacity.before_sleep import before_sleep_log
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_attempt
@@ -105,7 +106,8 @@ async def download_link_to_file(
         wait=wait_exponential(min=1, max=10),
         stop=stop_after_attempt(num_retries),
         retry=retry_if_exception_type(ClientConnectionError),
-        before_sleep=before_sleep_log(log, logging.WARNING),
+        before_sleep=before_sleep_log(log, logging.WARNING, exc_info=True),
+        after=after_log(log, log_level=logging.ERROR),
     ):
         with attempt:
             async with session.get(url) as response:
@@ -165,7 +167,8 @@ async def _upload_file_part(
         wait=wait_exponential(min=1, max=10),
         stop=stop_after_attempt(num_retries),
         retry=retry_if_exception_type(ClientConnectionError),
-        before_sleep=before_sleep_log(log, logging.WARNING),
+        before_sleep=before_sleep_log(log, logging.WARNING, exc_info=True),
+        after=after_log(log, log_level=logging.ERROR),
     ):
         with attempt:
             async with session.put(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
This PR properly uses aiohttp request call inside a context manager to ensure the request resources are properly closed.
This might be one of the reasons why uploading fails sometimes with large projects.

bonus: improves logging of errors.
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s
related to https://github.com/ITISFoundation/osparc-issues/issues/663
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
