### PR TITLE
🐛 workspace.zip disappears while uploading

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
@@ -7,6 +7,7 @@ from typing import Optional, Union
 from models_library.projects_nodes_io import StorageFileID
 from pydantic import parse_obj_as
 from servicelib.archiving_utils import archive_dir, unarchive_dir
+from servicelib.logging_utils import log_catch, log_context
 from settings_library.r_clone import RCloneSettings
 from simcore_sdk.node_ports_common.constants import SIMCORE_LOCATION
 
@@ -70,8 +71,9 @@ async def push(
             io_log_redirect_cb=io_log_redirect_cb,
         )
     # we have a folder, so we create a compressed file
-    with TemporaryDirectory() as tmp_dir_name:
-        log.info("compressing %s into %s...", file_or_folder.name, tmp_dir_name)
+    with log_catch(log), log_context(
+        log, logging.INFO, "pushing %s", file_or_folder
+    ), TemporaryDirectory() as tmp_dir_name:
         # compress the files
         archive_file_path = (
             Path(tmp_dir_name) / f"{rename_to or file_or_folder.stem}.zip"

--- a/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
+++ b/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
@@ -9,7 +9,6 @@ import os
 from collections import namedtuple
 from itertools import tee
 from pathlib import Path
-from pprint import pformat
 from typing import Any, AsyncIterable, Callable, Iterable, Iterator, cast
 from uuid import uuid4
 
@@ -60,8 +59,11 @@ from simcore_service_director_v2.models.schemas.constants import (
 )
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from starlette import status
+from tenacity._asyncio import AsyncRetrying
+from tenacity.retry import retry_if_exception_type
+from tenacity.stop import stop_after_delay
+from tenacity.wait import wait_fixed
 from utils import (
-    SEPARATOR,
     assert_all_services_running,
     assert_retrieve_service,
     assert_services_reply_200,
@@ -680,7 +682,7 @@ async def _wait_for_dy_services_to_fully_stop(
     to_observe = (
         director_v2_client._transport.app.state.dynamic_sidecar_scheduler._to_observe
     )
-
+    # TODO: ANE please use tenacity
     for i in range(TIMEOUT_DETECT_DYNAMIC_SERVICES_STOPPED):
         print(
             f"Sleeping for {i+1}/{TIMEOUT_DETECT_DYNAMIC_SERVICES_STOPPED} "
@@ -727,27 +729,6 @@ def _get_file_hashes_in_path(path_to_hash: Path) -> set[tuple[Path, str]]:
     }
 
 
-LINE_PARTS_TO_MATCH = [
-    (0, "INFO:simcore_service_dynamic_sidecar.modules.nodeports:Uploaded"),
-    (2, "bytes"),
-    (3, "in"),
-    (5, "seconds"),
-]
-
-
-def _is_matching_line_in_logs(logs: list[str]) -> bool:
-    for line in logs:
-        if LINE_PARTS_TO_MATCH[0][1] in line:
-            print("".join(logs))
-
-            line_parts = line.strip().split(" ")
-            for position, value in LINE_PARTS_TO_MATCH:
-                assert line_parts[position] == value
-
-            return True
-    return False
-
-
 async def _print_dynamic_sidecars_containers_logs_and_get_containers(
     dynamic_services_urls: dict[str, str]
 ) -> list[str]:
@@ -778,17 +759,9 @@ async def _print_dynamic_sidecars_containers_logs_and_get_containers(
     return containers_names
 
 
-async def _print_container_inspect(container_id: str) -> None:
-    async with aiodocker.Docker() as docker_client:
-        container = await docker_client.containers.get(container_id)
-        container_inspect = await container.show()
-        print(f"Container {container_id} inspect:\n{pformat(container_inspect)}")
-
-
-async def _print_all_docker_volumes() -> None:
-    async with aiodocker.Docker() as docker_client:
-        docker_volumes = await docker_client.volumes.list()
-        print(f"Detected volumes:\n{pformat(docker_volumes)}")
+_CONTROL_TESTMARK_DY_SIDECAR_NODEPORT_UPLOADED_MESSAGE = (
+    "TEST: test_nodeports_integration DO NOT REMOVE"
+)
 
 
 async def _assert_retrieve_completed(
@@ -806,50 +779,24 @@ async def _assert_retrieve_completed(
     # look at dynamic-sidecar's logs to be sure when nodeports
     # have been uploaded
     async with aiodocker.Docker() as docker_client:
-        container: DockerContainer = await docker_client.containers.get(container_id)
-
-        for i in range(TIMEOUT_OUTPUTS_UPLOAD_FINISH_DETECTED):
-            logs = await container.log(stdout=True, stderr=True)
-
-            if _is_matching_line_in_logs(logs):
-                break
-
-            if i == TIMEOUT_OUTPUTS_UPLOAD_FINISH_DETECTED - 1:
-                print(SEPARATOR)
-                print(f"Dumping information for service_uuid={service_uuid}")
-                print(SEPARATOR)
-
-                print("".join(logs))
-                print(SEPARATOR)
-
-                containers_names = (
-                    await _print_dynamic_sidecars_containers_logs_and_get_containers(
-                        dynamic_services_urls
-                    )
+        async for attempt in AsyncRetrying(
+            reraise=True,
+            retry=retry_if_exception_type(AssertionError),
+            stop=stop_after_delay(TIMEOUT_OUTPUTS_UPLOAD_FINISH_DETECTED),
+            wait=wait_fixed(0.5),
+        ):
+            with attempt:
+                print(
+                    f"--> checking container logs of {service_uuid=}, [attempt {attempt.retry_state.attempt_number}]..."
                 )
-                print(SEPARATOR)
+                container: DockerContainer = await docker_client.containers.get(
+                    container_id
+                )
 
-                # inspect dynamic-sidecar container
-                await _print_container_inspect(container_id=container_id)
-                print(SEPARATOR)
-
-                # inspect spawned container
-                for container_name in containers_names:
-                    await _print_container_inspect(container_id=container_name)
-                    print(SEPARATOR)
-
-                await _print_all_docker_volumes()
-                print(SEPARATOR)
-
-                assert False, "Timeout reached"
-
-            print(
-                f"Sleeping {i+1}/{TIMEOUT_OUTPUTS_UPLOAD_FINISH_DETECTED} "
-                f"before searching logs from {service_uuid} again"
-            )
-            await asyncio.sleep(1)
-
-        print(f"Nodeports outputs upload finish detected for {service_uuid}")
+                logs = " ".join(await container.log(stdout=True, stderr=True))
+                assert (
+                    _CONTROL_TESTMARK_DY_SIDECAR_NODEPORT_UPLOADED_MESSAGE in logs
+                ), "TIP: Message missing suggests that the data was never uploaded: look in services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py"
 
 
 # TESTS
@@ -966,21 +913,12 @@ async def test_nodeports_integration(
         dynamic_services_urls
     )
 
-    await _assert_retrieve_completed(
-        director_v2_client=async_client,
-        service_uuid=services_node_uuids.dy,
-        dynamic_services_urls=dynamic_services_urls,
-    )
-
-    # NOTE: Waits a bit for the DB to write the changes in
-    # comp_task for the upstream service.
-    await asyncio.sleep(2)
-
-    await _assert_retrieve_completed(
-        director_v2_client=async_client,
-        service_uuid=services_node_uuids.dy_compose_spec,
-        dynamic_services_urls=dynamic_services_urls,
-    )
+    for service_uuid in (services_node_uuids.dy, services_node_uuids.dy_compose_spec):
+        await _assert_retrieve_completed(
+            director_v2_client=async_client,
+            service_uuid=service_uuid,
+            dynamic_services_urls=dynamic_services_urls,
+        )
 
     # STEP 3
     # pull data via nodeports

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
@@ -9,6 +9,7 @@ from servicelib.fastapi.openapi import (
     get_common_oas_options,
     override_fastapi_openapi_method,
 )
+from servicelib.logging_utils import config_all_loggers
 from simcore_sdk.node_ports_common.exceptions import NodeNotFound
 
 from .._meta import API_VERSION, API_VTAG, PROJECT_NAME, SUMMARY, __version__
@@ -99,6 +100,7 @@ def setup_logger(settings: ApplicationSettings):
     # SEE https://github.com/ITISFoundation/osparc-simcore/issues/3148
     logging.basicConfig(level=settings.log_level)
     logging.root.setLevel(settings.log_level)
+    config_all_loggers()
 
 
 def create_base_app() -> FastAPI:
@@ -122,6 +124,7 @@ def create_base_app() -> FastAPI:
     long_running_tasks.server.setup(app)
 
     app.include_router(main_router)
+
     return app
 
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
@@ -58,6 +58,11 @@ def _get_size_of_value(value: ItemConcreteValue) -> int:
     return sys.getsizeof(value)
 
 
+_CONTROL_TESTMARK_DY_SIDECAR_NODEPORT_UPLOADED_MESSAGE = (
+    "TEST: test_nodeports_integration DO NOT REMOVE"
+)
+
+
 @run_sequentially_in_context()
 async def upload_outputs(
     outputs_path: Path,
@@ -141,6 +146,7 @@ async def upload_outputs(
     elapsed_time = time.perf_counter() - start_time
     total_bytes = sum(_get_size_of_value(x) for x in ports_values.values())
     logger.info("Uploaded %s bytes in %s seconds", total_bytes, elapsed_time)
+    logger.debug(_CONTROL_TESTMARK_DY_SIDECAR_NODEPORT_UPLOADED_MESSAGE)
 
 
 async def dispatch_update_for_directory(

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
@@ -144,11 +144,9 @@ async def upload_outputs(
         logger.info("Uploaded %s bytes in %s seconds", total_bytes, elapsed_time)
     finally:
         # clean up possible compressed files
-        for file_path in temp_paths:
-            await async_on_threadpool(
-                # pylint: disable=cell-var-from-loop
-                lambda: shutil.rmtree(file_path.parent, ignore_errors=True)
-            )
+        for dirpath in temp_paths:
+            assert dirpath.is_dir()  # nosec
+            await remove_directory(dirpath, ignore_errors=True)
 
 
 async def dispatch_update_for_directory(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
The dynamic sidecar concurrently uploads the output port files and the workspace file.
An issue was identified inside the dynamic sidecar:
- the output port archiver was deleting the entire ```/tmp``` folder after the upload of the output ports
- since the upload of workspace is happening concurrently, and the ```workspace.zip``` file was located in this very ```/tmp``` folder it would be deleted, and the logs were correctly reporting that the file was not there!

This PR fixes the archiver of output ports by using the temporary directory context manager.

--> Always use context managers



## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->
fixes https://github.com/ITISFoundation/osparc-issues/issues/664

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
