### PR TITLE
⬆️ Maintenance/week 35: tools and tests dependencies upgrade

### DIFF
--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -19,9 +19,9 @@ attrs==22.1.0
     #   jsonschema
     #   openapi-core
     #   pytest
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via aiohttp
-coverage[toml]==6.4.3
+coverage[toml]==6.4.4
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -37,7 +37,7 @@ iniconfig==1.1.1
     # via pytest
 isodate==0.6.1
     # via openapi-core
-jsonschema==4.9.1
+jsonschema==4.15.0
     # via
     #   openapi-schema-validator
     #   openapi-spec-validator

--- a/ci/helpers/requirements.txt
+++ b/ci/helpers/requirements.txt
@@ -8,23 +8,23 @@ aiohttp==3.8.1
     # via -r requirements.in
 aiosignal==1.2.0
     # via aiohttp
-anyio==3.5.0
+anyio==3.6.1
     # via starlette
 async-timeout==4.0.2
     # via aiohttp
-attrs==21.4.0
+attrs==22.1.0
     # via aiohttp
-certifi==2021.10.8
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via
     #   aiohttp
     #   requests
-docker==5.0.3
+docker==6.0.0
     # via -r requirements.in
-fastapi==0.76.0
+fastapi==0.81.0
     # via -r requirements.in
-frozenlist==1.3.0
+frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
@@ -37,23 +37,29 @@ multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
-pydantic==1.9.0
-    # via fastapi
-pyjwt==2.3.0
-    # via -r requirements.in
-requests==2.27.1
+packaging==21.3
     # via docker
-sniffio==1.2.0
-    # via anyio
-starlette==0.18.0
+pydantic==1.10.1
     # via fastapi
-typing-extensions==4.2.0
+pyjwt==2.4.0
+    # via -r requirements.in
+pyparsing==3.0.9
+    # via packaging
+requests==2.28.1
+    # via docker
+sniffio==1.3.0
+    # via anyio
+starlette==0.19.1
+    # via fastapi
+typing-extensions==4.3.0
     # via
     #   pydantic
     #   starlette
-urllib3==1.26.9
-    # via requests
-websocket-client==1.3.2
+urllib3==1.26.12
+    # via
+    #   docker
+    #   requests
+websocket-client==1.4.0
     # via docker
-yarl==1.7.2
+yarl==1.8.1
     # via aiohttp

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -12,17 +12,17 @@ cloudpickle==2.1.0
     # via
     #   dask
     #   distributed
-dask==2022.8.0
+dask==2022.8.1
     # via
     #   -r requirements/_base.in
     #   distributed
-distributed==2022.8.0
+distributed==2022.8.1
     # via dask
 dnspython==2.2.1
     # via email-validator
 email-validator==1.2.1
     # via pydantic
-fsspec==2022.7.1
+fsspec==2022.8.2
     # via dask
 heapdict==1.0.1
     # via zict
@@ -33,7 +33,7 @@ jinja2==3.1.2
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   distributed
-jsonschema==4.9.1
+jsonschema==4.15.0
     # via -r requirements/../../../packages/models-library/requirements/_base.in
 locket==1.0.0
     # via
@@ -47,11 +47,11 @@ packaging==21.3
     # via
     #   dask
     #   distributed
-partd==1.2.0
+partd==1.3.0
     # via dask
 psutil==5.9.1
     # via distributed
-pydantic==1.9.1
+pydantic==1.10.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -80,7 +80,7 @@ tornado==6.1
     # via distributed
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -10,7 +10,7 @@ aiohttp==3.8.1
     #   pytest-aiohttp
 aiosignal==1.2.0
     # via aiohttp
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 async-timeout==4.0.2
     # via aiohttp
@@ -21,11 +21,11 @@ attrs==22.1.0
     #   pytest
 certifi==2022.6.15
     # via requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   aiohttp
     #   requests
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -36,7 +36,7 @@ dill==0.3.5.1
     # via pylint
 docopt==0.6.2
     # via coveralls
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 frozenlist==1.3.1
     # via
@@ -76,7 +76,7 @@ pprintpp==0.4.0
     # via pytest-icdiff
 py==1.11.0
     # via pytest
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
     # via
@@ -126,14 +126,14 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   pylint
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -142,6 +142,3 @@ wrapt==1.14.1
     # via astroid
 yarl==1.8.1
     # via aiohttp
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -17,7 +17,7 @@ click==8.1.3
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -36,7 +36,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -73,7 +73,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/packages/dask-task-models-library/setup.cfg
+++ b/packages/dask-task-models-library/setup.cfg
@@ -12,3 +12,6 @@ universal = 1
 
 [aliases]
 test = pytest
+
+[tool:pytest]
+asyncio_mode = auto

--- a/packages/models-library/requirements/_base.txt
+++ b/packages/models-library/requirements/_base.txt
@@ -12,9 +12,9 @@ email-validator==1.2.1
     # via pydantic
 idna==3.3
     # via email-validator
-jsonschema==4.9.1
+jsonschema==4.15.0
     # via -r requirements/_base.in
-pydantic==1.9.1
+pydantic==1.10.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -13,7 +13,7 @@ aiosignal==1.2.0
     # via aiohttp
 alembic==1.8.1
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 async-timeout==4.0.2
     # via aiohttp
@@ -24,11 +24,11 @@ attrs==22.1.0
     #   pytest
 certifi==2022.6.15
     # via requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   aiohttp
     #   requests
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -39,13 +39,13 @@ dill==0.3.5.1
     # via pylint
 docopt==0.6.2
     # via coveralls
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
-greenlet==1.1.2
+greenlet==1.1.3
     # via sqlalchemy
 icdiff==2.0.5
     # via pytest-icdiff
@@ -60,7 +60,7 @@ isort==5.10.1
     # via pylint
 lazy-object-proxy==1.7.1
     # via astroid
-mako==1.2.1
+mako==1.2.2
     # via alembic
 markupsafe==2.1.1
     # via mako
@@ -86,7 +86,7 @@ psycopg2-binary==2.9.3
     # via sqlalchemy
 py==1.11.0
     # via pytest
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
     # via packaging
@@ -140,14 +140,14 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   pylint
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -158,6 +158,3 @@ yarl==1.8.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   aiohttp
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/packages/models-library/requirements/_tools.txt
+++ b/packages/models-library/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -17,7 +17,7 @@ click==8.1.3
     #   black
     #   pip-tools
     #   typer
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -35,7 +35,7 @@ packaging==21.3
     # via
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -72,7 +72,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/packages/models-library/setup.cfg
+++ b/packages/models-library/setup.cfg
@@ -13,3 +13,6 @@ universal = 1
 [aliases]
 # Define setup.py command aliases here
 test = pytest
+
+[tool:pytest]
+asyncio_mode = auto

--- a/packages/postgres-database/requirements/_base.txt
+++ b/packages/postgres-database/requirements/_base.txt
@@ -6,11 +6,11 @@
 #
 alembic==1.8.1
     # via -r requirements/_base.in
-greenlet==1.1.2
+greenlet==1.1.3
     # via sqlalchemy
 idna==3.3
     # via yarl
-mako==1.2.1
+mako==1.2.2
     # via alembic
 markupsafe==2.1.1
     # via mako

--- a/packages/postgres-database/requirements/_migration.txt
+++ b/packages/postgres-database/requirements/_migration.txt
@@ -10,13 +10,13 @@ alembic==1.8.1
     #   -r requirements/_migration.in
 certifi==2022.6.15
     # via requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via -r requirements/_migration.in
-docker==5.0.3
+docker==6.0.0
     # via -r requirements/_migration.in
-greenlet==1.1.2
+greenlet==1.1.3
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
@@ -24,7 +24,7 @@ idna==3.3
     # via
     #   -c requirements/_base.txt
     #   requests
-mako==1.2.1
+mako==1.2.2
     # via
     #   -c requirements/_base.txt
     #   alembic
@@ -32,10 +32,14 @@ markupsafe==2.1.1
     # via
     #   -c requirements/_base.txt
     #   mako
+packaging==21.3
+    # via docker
 psycopg2-binary==2.9.3
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
+pyparsing==3.0.9
+    # via packaging
 requests==2.28.1
     # via docker
 six==1.16.0
@@ -47,10 +51,11 @@ sqlalchemy==1.4.40
     #   alembic
 tenacity==8.0.1
     # via -r requirements/_migration.in
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_migration.in
+    #   docker
     #   requests
 websocket-client==0.59.0
     # via

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -12,7 +12,7 @@ aiopg==1.3.4
     # via -r requirements/_test.in
 aiosignal==1.2.0
     # via aiohttp
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 async-timeout==4.0.2
     # via
@@ -27,12 +27,12 @@ certifi==2022.6.15
     # via
     #   -c requirements/_migration.txt
     #   requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   -c requirements/_migration.txt
     #   aiohttp
     #   requests
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -43,13 +43,13 @@ dill==0.3.5.1
     # via pylint
 docopt==0.6.2
     # via coveralls
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
-greenlet==1.1.2
+greenlet==1.1.3
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_migration.txt
@@ -74,7 +74,9 @@ multidict==6.0.2
     #   aiohttp
     #   yarl
 packaging==21.3
-    # via pytest
+    # via
+    #   -c requirements/_migration.txt
+    #   pytest
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
@@ -87,10 +89,12 @@ psycopg2-binary==2.9.3
     #   sqlalchemy
 py==1.11.0
     # via pytest
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
-    # via packaging
+    # via
+    #   -c requirements/_migration.txt
+    #   packaging
 pytest==7.1.2
     # via
     #   -r requirements/_test.in
@@ -136,13 +140,13 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
     #   astroid
     #   pylint
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_migration.txt
@@ -153,6 +157,3 @@ yarl==1.8.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/packages/postgres-database/requirements/_tools.txt
+++ b/packages/postgres-database/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -16,7 +16,7 @@ click==8.1.3
     # via
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -34,7 +34,7 @@ packaging==21.3
     # via
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -68,7 +68,7 @@ typing-extensions==4.3.0
     # via
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/packages/service-integration/requirements/_base.txt
+++ b/packages/service-integration/requirements/_base.txt
@@ -10,13 +10,13 @@ attrs==22.1.0
     #   pytest
 certifi==2022.6.15
     # via requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via -r requirements/_base.in
 dnspython==2.2.1
     # via email-validator
-docker==5.0.3
+docker==6.0.0
     # via -r requirements/_base.in
 email-validator==1.2.1
     # via pydantic
@@ -26,17 +26,19 @@ idna==3.3
     #   requests
 iniconfig==1.1.1
     # via pytest
-jsonschema==4.9.1
+jsonschema==4.15.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/_base.in
 packaging==21.3
-    # via pytest
+    # via
+    #   docker
+    #   pytest
 pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pydantic==1.9.1
+pydantic==1.10.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
@@ -58,10 +60,11 @@ tomli==2.0.1
     # via pytest
 typing-extensions==4.3.0
     # via pydantic
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
+    #   docker
     #   requests
-websocket-client==1.3.3
+websocket-client==1.4.0
     # via docker

--- a/packages/service-integration/requirements/_test.txt
+++ b/packages/service-integration/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 attrs==22.1.0
     # via
@@ -14,11 +14,11 @@ certifi==2022.6.15
     # via
     #   -c requirements/_base.txt
     #   requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   -c requirements/_base.txt
     #   requests
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -58,7 +58,7 @@ py==1.11.0
     # via
     #   -c requirements/_base.txt
     #   pytest
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
     # via
@@ -91,20 +91,17 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   pylint
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   requests
 wrapt==1.14.1
     # via astroid
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/packages/service-integration/requirements/_tools.txt
+++ b/packages/service-integration/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -17,7 +17,7 @@ click==8.1.3
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -36,7 +36,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -73,7 +73,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/packages/service-integration/setup.cfg
+++ b/packages/service-integration/setup.cfg
@@ -12,3 +12,6 @@ universal = 1
 
 [aliases]
 test = pytest
+
+[tool:pytest]
+asyncio_mode = auto

--- a/packages/service-library/requirements/_aiohttp.txt
+++ b/packages/service-library/requirements/_aiohttp.txt
@@ -26,13 +26,13 @@ attrs==20.3.0
     #   aiohttp
     #   jsonschema
     #   openapi-core
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via aiohttp
 frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
-greenlet==1.1.2
+greenlet==1.1.3
     # via sqlalchemy
 idna==3.3
     # via yarl

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -8,11 +8,11 @@ aiodebug==2.3.0
     # via -r requirements/_base.in
 aiofiles==0.8.0
     # via -r requirements/_base.in
-pydantic==1.9.2
+pydantic==1.10.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
-pyinstrument==4.2.0
+pyinstrument==4.3.0
     # via -r requirements/_base.in
 pyyaml==5.4.1
     # via

--- a/packages/service-library/requirements/_fastapi.txt
+++ b/packages/service-library/requirements/_fastapi.txt
@@ -14,7 +14,7 @@ certifi==2022.6.15
     #   httpx
 click==8.1.3
     # via uvicorn
-fastapi==0.79.0
+fastapi==0.81.0
     # via
     #   -r requirements/_fastapi.in
     #   fastapi-contrib
@@ -40,7 +40,7 @@ opentracing==2.4.0
     # via
     #   fastapi-contrib
     #   jaeger-client
-pydantic==1.9.2
+pydantic==1.10.1
     # via
     #   -c requirements/./../../../requirements/constraints.txt
     #   -c requirements/./_base.in
@@ -49,7 +49,7 @@ rfc3986==1.5.0
     # via httpx
 six==1.16.0
     # via thrift
-sniffio==1.2.0
+sniffio==1.3.0
     # via
     #   anyio
     #   httpcore
@@ -68,5 +68,5 @@ typing-extensions==4.3.0
     # via
     #   pydantic
     #   starlette
-uvicorn==0.18.2
+uvicorn==0.18.3
     # via -r requirements/_fastapi.in

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -15,7 +15,7 @@ aiosignal==1.2.0
     #   aiohttp
 asgi-lifespan==1.0.1
     # via -r requirements/_test.in
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 async-timeout==4.0.2
     # via
@@ -37,7 +37,7 @@ charset-normalizer==2.1.0
     #   -c requirements/_aiohttp.txt
     #   aiohttp
     #   requests
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -50,7 +50,7 @@ docopt==0.6.2
     # via coveralls
 execnet==1.9.0
     # via pytest-xdist
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 flaky==3.7.0
     # via -r requirements/_test.in
@@ -105,7 +105,7 @@ py==1.11.0
     # via
     #   pytest
     #   pytest-forked
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
     # via packaging
@@ -172,7 +172,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
@@ -180,7 +180,7 @@ typing-extensions==4.3.0
     #   -c requirements/_fastapi.txt
     #   astroid
     #   pylint
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   requests

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -32,7 +32,7 @@ certifi==2022.6.15
     # via
     #   -c requirements/_fastapi.txt
     #   requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   -c requirements/_aiohttp.txt
     #   aiohttp
@@ -161,7 +161,7 @@ six==1.16.0
     #   -c requirements/_fastapi.txt
     #   jsonschema
     #   python-dateutil
-sniffio==1.2.0
+sniffio==1.3.0
     # via
     #   -c requirements/_fastapi.txt
     #   asgi-lifespan

--- a/packages/service-library/requirements/_tools.txt
+++ b/packages/service-library/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -16,7 +16,7 @@ click==8.1.3
     # via
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -34,7 +34,7 @@ packaging==21.3
     # via
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -70,7 +70,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/packages/settings-library/requirements/_base.txt
+++ b/packages/settings-library/requirements/_base.txt
@@ -6,7 +6,7 @@
 #
 click==8.1.3
     # via typer
-pydantic==1.9.1
+pydantic==1.10.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in

--- a/packages/settings-library/requirements/_test.txt
+++ b/packages/settings-library/requirements/_test.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 attrs==22.1.0
     # via pytest
 certifi==2022.6.15
     # via requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via requests
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -43,7 +43,7 @@ pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
     # via packaging
@@ -75,19 +75,16 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   pylint
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
 wrapt==1.14.1
     # via astroid
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/packages/settings-library/requirements/_tools.txt
+++ b/packages/settings-library/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -17,7 +17,7 @@ click==8.1.3
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -35,7 +35,7 @@ packaging==21.3
     # via
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -69,7 +69,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/packages/settings-library/setup.cfg
+++ b/packages/settings-library/setup.cfg
@@ -13,3 +13,6 @@ universal = 1
 [aliases]
 # Define setup.py command aliases here
 test = pytest
+
+[tool:pytest]
+asyncio_mode = auto

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -35,7 +35,7 @@ attrs==20.3.0
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   aiohttp
     #   jsonschema
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via aiohttp
 click==8.1.3
     # via typer
@@ -47,7 +47,7 @@ frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
-greenlet==1.1.2
+greenlet==1.1.3
     # via sqlalchemy
 idna==3.3
     # via
@@ -57,7 +57,7 @@ jsonschema==3.2.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
-mako==1.2.1
+mako==1.2.2
     # via alembic
 markupsafe==2.1.1
     # via mako
@@ -73,7 +73,7 @@ psycopg2-binary==2.9.3
     # via
     #   aiopg
     #   sqlalchemy
-pydantic==1.9.1
+pydantic==1.10.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -84,7 +84,7 @@ pydantic==1.9.1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
-pyinstrument==4.2.0
+pyinstrument==4.3.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 pyparsing==3.0.9
     # via packaging

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -27,7 +27,7 @@ alembic==1.8.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 async-timeout==4.0.2
     # via
@@ -49,7 +49,7 @@ certifi==2022.6.15
     # via
     #   minio
     #   requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -58,7 +58,7 @@ click==8.1.3
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -67,13 +67,13 @@ coveralls==3.3.1
     # via -r requirements/_test.in
 dill==0.3.5.1
     # via pylint
-docker==5.0.3
+docker==6.0.0
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
 execnet==1.9.0
     # via pytest-xdist
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 flaky==3.7.0
     # via -r requirements/_test.in
@@ -82,7 +82,7 @@ frozenlist==1.3.1
     #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
-greenlet==1.1.2
+greenlet==1.1.3
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
@@ -103,7 +103,7 @@ jmespath==1.0.1
     #   botocore
 lazy-object-proxy==1.7.1
     # via astroid
-mako==1.2.1
+mako==1.2.2
     # via
     #   -c requirements/_base.txt
     #   alembic
@@ -125,6 +125,7 @@ multidict==6.0.2
 packaging==21.3
     # via
     #   -c requirements/_base.txt
+    #   docker
     #   pytest
     #   pytest-sugar
 platformdirs==2.5.2
@@ -141,7 +142,7 @@ py==1.11.0
     # via
     #   pytest
     #   pytest-forked
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
     # via
@@ -211,7 +212,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
@@ -219,13 +220,14 @@ typing-extensions==4.3.0
     #   aioitertools
     #   astroid
     #   pylint
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   botocore
+    #   docker
     #   minio
     #   requests
-websocket-client==1.3.3
+websocket-client==1.4.0
     # via docker
 wrapt==1.14.1
     # via
@@ -235,6 +237,3 @@ yarl==1.8.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -18,7 +18,7 @@ click==8.1.3
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -37,7 +37,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -73,7 +73,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/packages/simcore-sdk/setup.cfg
+++ b/packages/simcore-sdk/setup.cfg
@@ -12,3 +12,6 @@ universal = 1
 
 [aliases]
 test = pytest
+
+[tool:pytest]
+asyncio_mode = auto

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import filecmp
+import re
 import urllib.parse
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -88,7 +89,7 @@ def _fake_upload_file_link(
         urls=[
             parse_obj_as(
                 AnyUrl,
-                f"s3://{r_clone_settings.R_CLONE_S3.S3_BUCKET_NAME}/{urllib.parse.quote( s3_object, safe='')}",
+                f"s3://{r_clone_settings.R_CLONE_S3.S3_BUCKET_NAME}/{urllib.parse.quote(s3_object)}",
             )
         ],
         links=FileUploadLinks(
@@ -96,6 +97,21 @@ def _fake_upload_file_link(
             complete_upload=parse_obj_as(AnyUrl, "https://www.fakecomplete.com"),
         ),
     )
+
+
+def test_s3_url_quote_and_unquote():
+    """This test was added to validate quotation operations in _fake_upload_file_link
+    against unquotation operation in
+
+    """
+    src = "53a35372-d44d-4d2e-8319-b40db5f31ce0/2f67d5cb-ea9c-4f8c-96ef-eae8445a0fe7/6fa73b0f-4006-46c6-9847-967b45ff3ae7.bin"
+    # as in _fake_upload_file_link
+    url = f"s3://simcore/{urllib.parse.quote(src)}"
+
+    # as in sync_local_to_s3
+    unquoted_url = urllib.parse.unquote(url)
+    truncated_url = re.sub(r"^s3://", "", unquoted_url)
+    assert truncated_url == f"simcore/{src}"
 
 
 # TESTS

--- a/requirements/tools/check_changes.py
+++ b/requirements/tools/check_changes.py
@@ -6,7 +6,7 @@ import sys
 from collections import Counter, defaultdict
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, List, Literal, NamedTuple, Optional, Set
+from typing import Literal, NamedTuple, Optional
 
 from packaging.version import Version
 
@@ -15,7 +15,7 @@ REPODIR = (HERE / ".." / "..").resolve()
 
 
 @contextmanager
-def printing_table(columns: List[str]):
+def printing_table(columns: list[str]):
     print("|" + "|".join(columns) + "|")
     print("|" + "|".join(["-" * len(c) for c in columns]) + "|")
 
@@ -146,8 +146,8 @@ def main_changes_stats() -> None:
             # TODO: where are these libraries?
             # TODO: are they first dependencies?
             # TODO: if major, get link to release notes
-            from_versions = set(str(v) for v in before[name])
-            to_versions = set(str(v) for v in after[name])
+            from_versions = {str(v) for v in before[name]}
+            to_versions = {str(v) for v in after[name]}
 
             used_packages = []
             if req_paths := lib2reqs.get(name):
@@ -183,10 +183,10 @@ def main_changes_stats() -> None:
 
 
 ## Stats on installed packages (i.e. defined in txt files)
-DEPENDENCY = re.compile(r"([\w_-]+)==([0-9\.-]+)")
+DEPENDENCY = re.compile(r"([\w_-]+)==([0-9\.-post]+)")
 
 
-def parse_dependencies_in_reqfile(reqfile: Path) -> Dict[str, Version]:
+def parse_dependencies_in_reqfile(reqfile: Path) -> dict[str, Version]:
     name2version = {}
     for name, version in DEPENDENCY.findall(reqfile.read_text()):
         # TODO: typing-extensions==4.0.1 ; python_version < "3.9" might intro multiple versions
@@ -198,12 +198,12 @@ def parse_dependencies_in_reqfile(reqfile: Path) -> Dict[str, Version]:
 class ReqFile(NamedTuple):
     path: Path
     target: Literal["base", "test", "tool", "other"]
-    dependencies: Dict[str, Version]
+    dependencies: dict[str, Version]
 
 
 def parse_dependencies(
-    repodir: Path, *, exclude: Optional[Set] = None
-) -> List[ReqFile]:
+    repodir: Path, *, exclude: Optional[set] = None
+) -> list[ReqFile]:
     reqs = []
     exclude = exclude or set()
     for reqfile in repodir.rglob("**/requirements/_*.txt"):
@@ -229,7 +229,7 @@ def parse_dependencies(
     return reqs
 
 
-def repo_wide_changes(exclude: Optional[Set] = None) -> None:
+def repo_wide_changes(exclude: Optional[set] = None) -> None:
     reqs = parse_dependencies(REPODIR, exclude=exclude)
 
     # format

--- a/scripts/maintenance/image_triage.py
+++ b/scripts/maintenance/image_triage.py
@@ -1,10 +1,8 @@
-import typer
 import asyncio
-import httpx
-from httpx import Response
-from typing import Dict, List
-from collections import deque
 
+import httpx
+import typer
+from httpx import Response
 
 PREFIX_SERVICES_COMPUTATIONAL = "simcore/services/comp"
 PREFIX_SERVICES_DYNAMIC = "simcore/services/dynamic"
@@ -26,13 +24,13 @@ async def _httpx_request(
 
 async def _compile_registry_report(
     registry: str, user: str, password: str
-) -> Dict[str, List[str]]:
+) -> dict[str, list[str]]:
     response = await _httpx_request(registry, user, password, "_catalog")
     repositories = response.json()["repositories"]
 
     progressbar = typer.progressbar(length=len(repositories), label="fetching tags")
 
-    async def _get_tag(repository: str) -> Dict:
+    async def _get_tag(repository: str) -> dict:
         response = await _httpx_request(
             registry, user, password, f"{repository}/tags/list"
         )
@@ -48,7 +46,7 @@ async def _compile_registry_report(
 
 
 def _format(
-    repo_tags: Dict[str, List[str]], header_name: str, header_color: str
+    repo_tags: dict[str, list[str]], header_name: str, header_color: str
 ) -> str:
     service_header = typer.style(header_name, fg=typer.colors.WHITE, bg=header_color)
     service_list = "\n".join(f"- {k} {v}" for k, v in repo_tags.items())
@@ -56,9 +54,9 @@ def _format(
 
 
 def _format_print(
-    computational: Dict[str, List[str]],
-    dynamic: Dict[str, List[str]],
-    other: Dict[str, List[str]],
+    computational: dict[str, list[str]],
+    dynamic: dict[str, list[str]],
+    other: dict[str, list[str]],
 ) -> None:
     message = "\nListing services\n"
 
@@ -72,10 +70,10 @@ def _format_print(
     typer.echo(message)
 
 
-def _format_repositories(repository_tags: Dict[str, List[str]]) -> None:
-    computational: Dict[str, List[str]] = {}
-    dynamic: Dict[str, List[str]] = {}
-    other: Dict[str, List[str]] = {}
+def _format_repositories(repository_tags: dict[str, list[str]]) -> None:
+    computational: dict[str, list[str]] = {}
+    dynamic: dict[str, list[str]] = {}
+    other: dict[str, list[str]] = {}
 
     for repo, tags in repository_tags.items():
         if repo.startswith(PREFIX_SERVICES_COMPUTATIONAL):

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -14,7 +14,7 @@ anyio==3.6.1
     #   httpcore
 asgi-lifespan==1.0.1
     # via -r requirements/_test.in
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 attrs==20.3.0
     # via
@@ -24,27 +24,25 @@ attrs==20.3.0
     #   pytest
     #   pytest-docker
     #   sarif-om
-aws-sam-translator==1.45.0
+aws-sam-translator==1.50.0
     # via cfn-lint
-aws-xray-sdk==2.9.0
+aws-xray-sdk==2.10.0
     # via moto
-bcrypt==3.2.2
-    # via
-    #   paramiko
-    #   passlib
-boto3==1.23.4
+bcrypt==4.0.0
+    # via passlib
+boto3==1.24.65
     # via
     #   aws-sam-translator
     #   moto
-boto3-stubs==1.23.9
+boto3-stubs==1.24.65
     # via types-boto3
-botocore==1.26.4
+botocore==1.27.65
     # via
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
-botocore-stubs==1.26.9
+botocore-stubs==1.27.65
     # via boto3-stubs
 certifi==2022.5.18.1
     # via
@@ -55,10 +53,8 @@ certifi==2022.5.18.1
 cffi==1.15.0
     # via
     #   -c requirements/_base.txt
-    #   bcrypt
     #   cryptography
-    #   pynacl
-cfn-lint==0.60.1
+cfn-lint==0.63.2
     # via moto
 charset-normalizer==2.0.12
     # via
@@ -71,7 +67,7 @@ click==8.1.3
     #   flask
 codecov==2.1.12
     # via -r requirements/_test.in
-coverage==6.4
+coverage==6.4.4
     # via
     #   codecov
     #   coveralls
@@ -83,43 +79,29 @@ cryptography==36.0.2
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   moto
-    #   paramiko
     #   python-jose
     #   sshpubkeys
-dill==0.3.5
+dill==0.3.5.1
     # via pylint
-distro==1.7.0
-    # via docker-compose
-docker==5.0.3
+docker==6.0.0
     # via
     #   -r requirements/_test.in
-    #   docker-compose
     #   moto
-docker-compose==1.29.1
-    # via
-    #   -c requirements/../../../requirements/constraints.txt
-    #   pytest-docker
-dockerpty==0.4.1
-    # via docker-compose
 docopt==0.6.2
-    # via
-    #   coveralls
-    #   docker-compose
-ecdsa==0.17.0
+    # via coveralls
+ecdsa==0.18.0
     # via
     #   moto
     #   python-jose
     #   sshpubkeys
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
-flask==2.1.2
+flask==2.1.3
     # via
     #   flask-cors
     #   moto
 flask-cors==3.0.10
     # via moto
-future==0.18.2
-    # via aws-xray-sdk
 graphql-core==3.2.1
     # via moto
 greenlet==1.1.2
@@ -146,7 +128,7 @@ idna==3.3
     #   moto
     #   requests
     #   rfc3986
-importlib-metadata==4.11.3
+importlib-metadata==4.12.0
     # via flask
 iniconfig==1.1.1
     # via pytest
@@ -162,7 +144,7 @@ jinja2==3.1.2
     #   -c requirements/_base.txt
     #   flask
     #   moto
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
@@ -181,7 +163,8 @@ jsonschema==3.2.0
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   cfn-lint
-    #   docker-compose
+    #   openapi-schema-validator
+    #   openapi-spec-validator
 junit-xml==1.9
     # via cfn-lint
 lazy-object-proxy==1.7.1
@@ -198,21 +181,22 @@ markupsafe==2.1.1
     #   moto
 mccabe==0.7.0
     # via pylint
-moto==3.1.9
+moto==4.0.1
     # via -r requirements/_test.in
-networkx==2.8.1
+networkx==2.8.6
     # via cfn-lint
+openapi-schema-validator==0.2.3
+    # via openapi-spec-validator
+openapi-spec-validator==0.4.0
+    # via moto
 packaging==21.3
     # via
     #   -c requirements/_base.txt
-    #   pytest
-paramiko==2.11.0
-    # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   docker
+    #   pytest
 passlib==1.7.4
     # via -r requirements/_test.in
-pbr==5.9.0
+pbr==5.10.0
     # via
     #   jschema-to-python
     #   sarif-om
@@ -234,10 +218,8 @@ pycparser==2.21
     # via
     #   -c requirements/_base.txt
     #   cffi
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
-pynacl==1.5.0
-    # via paramiko
 pyparsing==3.0.9
     # via
     #   -c requirements/_base.txt
@@ -254,13 +236,13 @@ pytest==7.1.2
     #   pytest-cov
     #   pytest-docker
     #   pytest-mock
-pytest-asyncio==0.18.3
+pytest-asyncio==0.19.0
     # via -r requirements/_test.in
 pytest-cov==3.0.0
     # via -r requirements/_test.in
-pytest-docker==0.12.0
+pytest-docker==1.0.0
     # via -r requirements/_test.in
-pytest-mock==3.7.0
+pytest-mock==3.8.2
     # via -r requirements/_test.in
 pytest-runner==6.0.0
     # via -r requirements/_test.in
@@ -269,31 +251,26 @@ python-dateutil==2.8.2
     #   botocore
     #   faker
     #   moto
-python-dotenv==0.20.0
-    # via
-    #   -c requirements/_base.txt
-    #   docker-compose
 python-jose==3.3.0
     # via moto
-pytz==2022.1
+pytz==2022.2.1
     # via moto
 pyyaml==5.4.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   cfn-lint
-    #   docker-compose
     #   moto
+    #   openapi-spec-validator
 requests==2.27.1
     # via
     #   -c requirements/_base.txt
     #   codecov
     #   coveralls
     #   docker
-    #   docker-compose
     #   moto
     #   responses
-responses==0.20.0
+responses==0.21.0
     # via moto
 respx==0.19.2
     # via -r requirements/_test.in
@@ -301,25 +278,22 @@ rfc3986==1.5.0
     # via
     #   -c requirements/_base.txt
     #   httpx
-rsa==4.8
+rsa==4.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   python-jose
-s3transfer==0.5.2
+s3transfer==0.6.0
     # via boto3
 sarif-om==1.0.4
     # via cfn-lint
 six==1.16.0
     # via
     #   -c requirements/_base.txt
-    #   dockerpty
     #   ecdsa
     #   flask-cors
     #   jsonschema
     #   junit-xml
-    #   paramiko
     #   python-dateutil
-    #   websocket-client
 sniffio==1.2.0
     # via
     #   -c requirements/_base.txt
@@ -334,35 +308,35 @@ sqlalchemy==1.4.37
     #   alembic
 sshpubkeys==3.3.1
     # via moto
-texttable==1.6.4
-    # via docker-compose
 tomli==2.0.1
     # via
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
+types-awscrt==0.14.3
+    # via botocore-stubs
 types-boto3==1.0.2
     # via -r requirements/_test.in
+types-s3transfer==0.6.0.post4
+    # via boto3-stubs
 typing-extensions==4.3.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   boto3-stubs
-    #   botocore-stubs
     #   pylint
 urllib3==1.26.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   botocore
+    #   docker
     #   requests
     #   responses
-websocket-client==0.59.0
-    # via
-    #   docker
-    #   docker-compose
+websocket-client==1.4.0
+    # via docker
 werkzeug==2.1.2
     # via
     #   flask
@@ -373,7 +347,7 @@ wrapt==1.14.1
     #   aws-xray-sdk
 xmltodict==0.13.0
     # via moto
-zipp==3.8.0
+zipp==3.8.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/api-server/requirements/_tools.txt
+++ b/services/api-server/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -20,7 +20,7 @@ click==8.1.3
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -50,7 +50,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -88,7 +88,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 watchdog==2.1.9
     # via -r requirements/_tools.in

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -18,7 +18,7 @@ anyio==3.6.1
     # via
     #   -c requirements/_base.txt
     #   httpcore
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 async-timeout==4.0.2
     # via
@@ -48,7 +48,7 @@ click==8.1.3
     #   -r requirements/_test.in
 codecov==2.1.12
     # via -r requirements/_test.in
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   codecov
     #   coveralls
@@ -57,11 +57,11 @@ coveralls==3.3.1
     # via -r requirements/_test.in
 dill==0.3.5.1
     # via pylint
-docker==5.0.3
+docker==6.0.0
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 frozenlist==1.3.1
     # via
@@ -119,6 +119,7 @@ multidict==6.0.2
 packaging==21.3
     # via
     #   -c requirements/_base.txt
+    #   docker
     #   pytest
 platformdirs==2.5.2
     # via pylint
@@ -134,7 +135,7 @@ py==1.11.0
     # via pytest
 py-cpuinfo==8.0.0
     # via pytest-benchmark
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
     # via
@@ -202,7 +203,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
@@ -213,8 +214,9 @@ urllib3==1.26.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
+    #   docker
     #   requests
-websocket-client==1.3.3
+websocket-client==1.4.0
     # via docker
 wrapt==1.14.1
     # via astroid

--- a/services/catalog/requirements/_tools.txt
+++ b/services/catalog/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -18,7 +18,7 @@ click==8.1.3
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -37,7 +37,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -73,7 +73,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 watchdog==2.1.9
     # via -r requirements/_tools.in

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -13,7 +13,7 @@ aiosignal==1.2.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 async-timeout==4.0.2
     # via
@@ -39,7 +39,7 @@ charset-normalizer==2.0.12
     #   -c requirements/_base.txt
     #   aiohttp
     #   requests
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   coveralls
@@ -52,11 +52,11 @@ cryptography==37.0.4
     #   pyopenssl
 dill==0.3.5.1
     # via pylint
-docker==5.0.3
+docker==6.0.0
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 frozenlist==1.3.0
     # via
@@ -92,6 +92,7 @@ packaging==21.3
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_packages.txt
+    #   docker
     #   pytest
     #   pytest-sugar
 platformdirs==2.5.2
@@ -110,7 +111,7 @@ pycparser==2.20
     #   cffi
 pyftpdlib==1.5.6
     # via pytest-localftpserver
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyopenssl==22.0.0
     # via pytest-localftpserver
@@ -172,7 +173,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
@@ -185,6 +186,7 @@ urllib3==1.26.9
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -c requirements/_packages.txt
+    #   docker
     #   minio
     #   requests
 websocket-client==0.59.0
@@ -199,6 +201,3 @@ yarl==1.7.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -18,7 +18,7 @@ click==8.1.3
     #   -c requirements/_packages.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -38,7 +38,7 @@ packaging==21.3
     #   -c requirements/_packages.txt
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -78,7 +78,7 @@ typing-extensions==4.3.0
     #   -c requirements/_packages.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 watchdog==2.1.9
     # via -r requirements/_tools.in

--- a/services/dask-sidecar/setup.cfg
+++ b/services/dask-sidecar/setup.cfg
@@ -6,3 +6,6 @@ tag = False
 commit_args = --no-verify
 
 [bumpversion:file:VERSION]
+
+[tool:pytest]
+asyncio_mode = auto

--- a/services/datcore-adapter/requirements/_test.txt
+++ b/services/datcore-adapter/requirements/_test.txt
@@ -10,7 +10,7 @@ anyio==3.5.0
     #   httpcore
 asgi-lifespan==1.0.1
     # via -r requirements/_test.in
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 attrs==20.3.0
     # via
@@ -28,7 +28,7 @@ charset-normalizer==2.0.12
     #   requests
 codecov==2.1.12
     # via -r requirements/_test.in
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   codecov
@@ -44,7 +44,7 @@ docopt==0.6.2
     #   coveralls
 execnet==1.9.0
     # via pytest-xdist
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 h11==0.12.0
     # via
@@ -89,7 +89,7 @@ py==1.11.0
     # via
     #   pytest
     #   pytest-forked
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
     # via packaging
@@ -155,7 +155,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
@@ -171,6 +171,3 @@ wrapt==1.14.0
     # via
     #   -c requirements/_base.txt
     #   astroid
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/services/datcore-adapter/requirements/_tools.txt
+++ b/services/datcore-adapter/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -17,7 +17,7 @@ click==8.1.3
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -35,7 +35,7 @@ packaging==21.3
     # via
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -71,7 +71,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 watchdog==2.1.9
     # via -r requirements/_tools.in

--- a/services/datcore-adapter/setup.cfg
+++ b/services/datcore-adapter/setup.cfg
@@ -6,3 +6,6 @@ tag = False
 commit_args = --no-verify
 
 [bumpversion:file:VERSION]
+
+[tool:pytest]
+asyncio_mode = auto

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -39,7 +39,7 @@ anyio==3.6.1
     #   httpcore
 asgi-lifespan==1.0.1
     # via -r requirements/_test.in
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 async-asgi-testclient==1.4.11
     # via -r requirements/_test.in
@@ -78,9 +78,9 @@ charset-normalizer==2.0.12
     #   requests
 codecov==2.1.12
     # via -r requirements/_test.in
-colorlog==6.6.0
+colorlog==6.7.0
     # via dask-gateway-server
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   codecov
     #   coveralls
@@ -95,13 +95,13 @@ dask-gateway-server==2022.6.1
     # via -r requirements/_test.in
 dill==0.3.5.1
     # via pylint
-docker==5.0.3
+docker==6.0.0
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
 execnet==1.9.0
     # via pytest-xdist
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 flaky==3.7.0
     # via -r requirements/_test.in
@@ -172,12 +172,13 @@ multidict==6.0.2
     #   aiohttp
     #   async-asgi-testclient
     #   yarl
-numpy==1.23.1
+numpy==1.23.2
     # via bokeh
 packaging==21.3
     # via
     #   -c requirements/_base.txt
     #   bokeh
+    #   docker
     #   pytest
 pamqp==2.3.0
     # via
@@ -201,7 +202,7 @@ py==1.11.0
     #   pytest-forked
 pycparser==2.21
     # via cffi
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
     # via
@@ -282,7 +283,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 tornado==6.1
     # via
@@ -302,9 +303,10 @@ urllib3==1.26.9
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   botocore
+    #   docker
     #   minio
     #   requests
-websocket-client==1.3.3
+websocket-client==1.4.0
     # via docker
 wrapt==1.14.1
     # via
@@ -317,6 +319,3 @@ yarl==1.7.2
     #   aio-pika
     #   aiohttp
     #   aiormq
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -17,7 +17,7 @@ click==8.1.3
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -36,7 +36,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -74,7 +74,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 watchdog==2.1.9
     # via -r requirements/_tools.in

--- a/services/director-v2/src/simcore_service_director_v2/modules/rabbitmq.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/rabbitmq.py
@@ -1,6 +1,5 @@
 import logging
 from dataclasses import dataclass
-from typing import Dict
 
 import aio_pika
 from fastapi import FastAPI
@@ -41,11 +40,11 @@ def setup(app: FastAPI) -> None:
     app.add_event_handler("shutdown", on_shutdown)
 
 
-_MESSAGE_TO_EXCHANGE_MAP = {
-    LoggerRabbitMessage: "log",
-    ProgressRabbitMessage: "progress",
-    InstrumentationRabbitMessage: "instrumentation",
-}
+_MESSAGE_TO_EXCHANGE_MAP = [
+    (LoggerRabbitMessage, "log"),
+    (ProgressRabbitMessage, "progress"),
+    (InstrumentationRabbitMessage, "instrumentation"),
+]
 
 
 @dataclass
@@ -53,7 +52,7 @@ class RabbitMQClient:
     app: FastAPI
     connection: aio_pika.RobustConnection
     channel: aio_pika.RobustChannel
-    exchanges: Dict[str, aio_pika.RobustExchange]
+    exchanges: dict[str, aio_pika.RobustExchange]
 
     @classmethod
     async def create(cls, app: FastAPI) -> "RabbitMQClient":
@@ -87,7 +86,7 @@ class RabbitMQClient:
         message: RabbitMessageTypes,
     ) -> None:
         def get_exchange(message) -> aio_pika.Exchange:
-            for message_type, exchange_name in _MESSAGE_TO_EXCHANGE_MAP.items():
+            for message_type, exchange_name in _MESSAGE_TO_EXCHANGE_MAP:
                 if isinstance(message, message_type):
                     assert exchange_name in self.exchanges  # nosec
                     return self.exchanges[exchange_name]

--- a/services/dynamic-sidecar/requirements/_test.txt
+++ b/services/dynamic-sidecar/requirements/_test.txt
@@ -20,9 +20,9 @@ charset-normalizer==2.0.12
     # via
     #   -c requirements/_base.txt
     #   requests
-coverage==6.4.3
+coverage==6.4.4
     # via pytest-cov
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 idna==2.10
     # via
@@ -76,7 +76,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-types-aiofiles==0.8.10
+types-aiofiles==0.8.11
     # via -r requirements/_test.in
 types-pkg-resources==0.1.3
     # via -r requirements/_test.in

--- a/services/dynamic-sidecar/requirements/_tools.txt
+++ b/services/dynamic-sidecar/requirements/_tools.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -21,7 +21,7 @@ click==8.1.3
     #   pip-tools
 dill==0.3.5.1
     # via pylint
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -44,7 +44,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -57,7 +57,7 @@ platformdirs==2.5.2
     #   virtualenv
 pre-commit==2.20.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_tools.in
 pyparsing==3.0.9
     # via
@@ -78,7 +78,7 @@ tomli==2.0.1
     #   build
     #   pep517
     #   pylint
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
@@ -86,7 +86,7 @@ typing-extensions==4.3.0
     #   astroid
     #   black
     #   pylint
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -17,7 +17,7 @@ aiosignal==1.2.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 async-timeout==4.0.2
     # via
@@ -31,9 +31,9 @@ attrs==20.3.0
     #   jsonschema
     #   pytest
     #   sarif-om
-aws-sam-translator==1.46.0
+aws-sam-translator==1.50.0
     # via cfn-lint
-aws-xray-sdk==2.9.0
+aws-xray-sdk==2.10.0
     # via moto
 boto3==1.21.21
     # via
@@ -47,13 +47,13 @@ botocore==1.24.21
     #   boto3
     #   moto
     #   s3transfer
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via
     #   requests
     #   simcore-service-storage-sdk
-cffi==1.15.0
+cffi==1.15.1
     # via cryptography
-cfn-lint==0.61.1
+cfn-lint==0.63.2
     # via moto
 charset-normalizer==2.0.12
     # via
@@ -66,7 +66,7 @@ click==8.1.3
     #   flask
 codecov==2.1.12
     # via -r requirements/_test.in
-coverage==6.3.2
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   codecov
@@ -74,28 +74,28 @@ coverage==6.3.2
     #   pytest-cov
 coveralls==3.3.1
     # via -r requirements/_test.in
-cryptography==37.0.2
+cryptography==37.0.4
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   moto
     #   python-jose
     #   sshpubkeys
-dill==0.3.4
+dill==0.3.5.1
     # via pylint
-docker==5.0.3
+docker==6.0.0
     # via
     #   -r requirements/_test.in
     #   moto
 docopt==0.6.2
     # via coveralls
-ecdsa==0.17.0
+ecdsa==0.18.0
     # via
     #   moto
     #   python-jose
     #   sshpubkeys
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
-flask==2.1.2
+flask==2.1.3
     # via
     #   flask-cors
     #   moto
@@ -106,8 +106,6 @@ frozenlist==1.3.0
     #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
-future==0.18.2
-    # via aws-xray-sdk
 graphql-core==3.2.1
     # via moto
 icdiff==2.0.5
@@ -167,16 +165,16 @@ markupsafe==2.1.1
     #   moto
 mccabe==0.7.0
     # via pylint
-moto==3.1.15
+moto==4.0.1
     # via -r requirements/_test.in
 multidict==6.0.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-networkx==2.8.4
+networkx==2.8.6
     # via cfn-lint
-numpy==1.22.3
+numpy==1.23.2
     # via pandas
 openapi-schema-validator==0.2.3
     # via
@@ -188,11 +186,12 @@ openapi-spec-validator==0.4.0
     #   moto
 packaging==21.3
     # via
+    #   docker
     #   pytest
     #   pytest-sugar
-pandas==1.4.2
+pandas==1.4.4
     # via -r requirements/_test.in
-pbr==5.9.0
+pbr==5.10.0
     # via
     #   jschema-to-python
     #   sarif-om
@@ -210,7 +209,7 @@ pyasn1==0.4.8
     #   rsa
 pycparser==2.21
     # via cffi
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
     # via
@@ -232,19 +231,19 @@ pytest==7.1.2
     #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
-pytest-asyncio==0.18.3
+pytest-asyncio==0.19.0
     # via pytest-aiohttp
 pytest-cov==3.0.0
     # via -r requirements/_test.in
-pytest-icdiff==0.5
+pytest-icdiff==0.6
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
-pytest-mock==3.7.0
+pytest-mock==3.8.2
     # via -r requirements/_test.in
 pytest-runner==6.0.0
     # via -r requirements/_test.in
-pytest-sugar==0.9.4
+pytest-sugar==0.9.5
     # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via
@@ -258,7 +257,7 @@ python-dotenv==0.20.0
     # via -r requirements/_test.in
 python-jose==3.3.0
     # via moto
-pytz==2022.1
+pytz==2022.2.1
     # via
     #   moto
     #   pandas
@@ -269,7 +268,7 @@ pyyaml==5.4.1
     #   cfn-lint
     #   moto
     #   openapi-spec-validator
-requests==2.27.1
+requests==2.28.1
     # via
     #   codecov
     #   coveralls
@@ -278,7 +277,7 @@ requests==2.27.1
     #   responses
 responses==0.21.0
     # via moto
-rsa==4.8
+rsa==4.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   python-jose
@@ -308,7 +307,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
@@ -320,10 +319,11 @@ urllib3==1.26.9
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   botocore
+    #   docker
     #   requests
     #   responses
     #   simcore-service-storage-sdk
-websocket-client==1.3.2
+websocket-client==1.4.0
     # via docker
 werkzeug==2.0.3
     # via
@@ -341,7 +341,7 @@ yarl==1.7.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-zipp==3.8.0
+zipp==3.8.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/storage/requirements/_tools.txt
+++ b/services/storage/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -18,7 +18,7 @@ click==8.1.3
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -36,7 +36,7 @@ packaging==21.3
     # via
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -73,7 +73,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 watchdog==2.1.9
     # via -r requirements/_tools.in

--- a/services/storage/setup.cfg
+++ b/services/storage/setup.cfg
@@ -10,3 +10,6 @@ commit_args = --no-verify
 [bumpversion:file:../../api/specs/storage/openapi.yaml]
 
 [bumpversion:file:./src/simcore_service_storage/api/v0/openapi.yaml]
+
+[tool:pytest]
+asyncio_mode = auto

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -20,7 +20,7 @@ alembic==1.8.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-astroid==2.11.7
+astroid==2.12.5
     # via pylint
 async-timeout==4.0.2
     # via
@@ -50,7 +50,7 @@ click==8.1.3
     #   -r requirements/_test.in
 codecov==2.1.12
     # via -r requirements/_test.in
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   codecov
@@ -64,13 +64,13 @@ deprecated==1.2.13
     #   redis
 dill==0.3.5.1
     # via pylint
-docker==5.0.3
+docker==6.0.0
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
-exceptiongroup==1.0.0rc8
+exceptiongroup==1.0.0rc9
     # via hypothesis
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 flaky==3.7.0
     # via -r requirements/_test.in
@@ -83,7 +83,7 @@ greenlet==1.1.2
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
-hypothesis==6.54.2
+hypothesis==6.54.4
     # via -r requirements/_test.in
 icdiff==2.0.5
     # via pytest-icdiff
@@ -132,6 +132,7 @@ openapi-spec-validator==0.4.0
 packaging==21.3
     # via
     #   -c requirements/_base.txt
+    #   docker
     #   pytest
     #   pytest-sugar
     #   redis
@@ -149,7 +150,7 @@ ptvsd==4.3.2
     # via -r requirements/_test.in
 py==1.11.0
     # via pytest
-pylint==2.14.5
+pylint==2.15.0
     # via -r requirements/_test.in
 pyparsing==3.0.9
     # via
@@ -230,7 +231,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.3
+tomlkit==0.11.4
     # via pylint
 typing-extensions==4.3.0
     # via
@@ -241,8 +242,9 @@ urllib3==1.26.11
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
+    #   docker
     #   requests
-websocket-client==1.3.3
+websocket-client==1.4.0
     # via docker
 websockets==10.3
     # via -r requirements/_test.in

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -18,7 +18,7 @@ click==8.1.3
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -41,7 +41,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -78,7 +78,7 @@ typing-extensions==4.3.0
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/tests/e2e/requirements/requirements.txt
+++ b/tests/e2e/requirements/requirements.txt
@@ -6,12 +6,16 @@
 #
 certifi==2022.6.15
     # via requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via requests
-docker==5.0.3
+docker==6.0.0
     # via -r requirements/requirements.in
 idna==3.3
     # via requests
+packaging==21.3
+    # via docker
+pyparsing==3.0.9
+    # via packaging
 pyyaml==6.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -20,9 +24,10 @@ requests==2.28.1
     # via docker
 tenacity==8.0.1
     # via -r requirements/requirements.in
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../requirements/constraints.txt
+    #   docker
     #   requests
-websocket-client==1.3.3
+websocket-client==1.4.0
     # via docker

--- a/tests/environment-setup/requirements/requirements.txt
+++ b/tests/environment-setup/requirements/requirements.txt
@@ -19,7 +19,7 @@ attrs==20.3.0
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   aiohttp
     #   pytest
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via aiohttp
 frozenlist==1.3.1
     # via
@@ -41,7 +41,7 @@ pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pydantic==1.9.1
+pydantic==1.10.1
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/_base.in

--- a/tests/public-api/requirements/_test.txt
+++ b/tests/public-api/requirements/_test.txt
@@ -24,15 +24,15 @@ certifi==2022.6.15
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   aiohttp
     #   requests
-coverage==6.4.3
+coverage==6.4.4
     # via pytest-cov
-docker==5.0.3
+docker==6.0.0
     # via -r requirements/_test.in
-faker==13.15.1
+faker==14.2.0
     # via -r requirements/_test.in
 frozenlist==1.3.1
     # via
@@ -54,14 +54,16 @@ idna==3.3
     #   yarl
 iniconfig==1.1.1
     # via pytest
-jsonschema==4.9.1
+jsonschema==4.15.0
     # via -r requirements/_test.in
 multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
 packaging==21.3
-    # via pytest
+    # via
+    #   docker
+    #   pytest
 pluggy==1.0.0
     # via pytest
 py==1.11.0
@@ -93,7 +95,7 @@ rfc3986==1.5.0
     # via httpx
 six==1.16.0
     # via python-dateutil
-sniffio==1.2.0
+sniffio==1.3.0
     # via
     #   anyio
     #   httpcore
@@ -104,11 +106,12 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../requirements/constraints.txt
+    #   docker
     #   requests
-websocket-client==1.3.3
+websocket-client==1.4.0
     # via docker
 yarl==1.8.1
     # via aiohttp

--- a/tests/public-api/requirements/_tools.txt
+++ b/tests/public-api/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -16,7 +16,7 @@ click==8.1.3
     # via
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -32,7 +32,7 @@ packaging==21.3
     # via
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -63,7 +63,7 @@ tomli==2.0.1
     #   pep517
 typing-extensions==4.3.0
     # via black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-aio-pika==8.1.1
+aio-pika==8.2.0
     # via -r requirements/_test.in
 aiocache==0.11.1
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
@@ -35,7 +35,7 @@ aiohttp==3.8.1
     #   pytest-aiohttp
 aiopg==1.3.4
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-aiormq==6.4.0
+aiormq==6.4.1
     # via aio-pika
 aiosignal==1.2.0
     # via aiohttp
@@ -60,7 +60,7 @@ certifi==2022.6.15
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   minio
     #   requests
-charset-normalizer==2.1.0
+charset-normalizer==2.1.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   aiohttp
@@ -70,13 +70,13 @@ click==8.1.3
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/_test.in
     #   typer
-coverage==6.4.3
+coverage==6.4.4
     # via
     #   -r requirements/_test.in
     #   pytest-cov
 dnspython==2.2.1
     # via email-validator
-docker==5.0.3
+docker==6.0.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/_test.in
@@ -86,7 +86,7 @@ frozenlist==1.3.1
     # via
     #   aiohttp
     #   aiosignal
-greenlet==1.1.2
+greenlet==1.1.3
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   sqlalchemy
@@ -105,7 +105,7 @@ jsonschema==3.2.0
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/_test.in
-mako==1.2.1
+mako==1.2.2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   alembic
@@ -131,7 +131,9 @@ multidict==6.0.2
     #   yarl
 packaging==21.3
     # via
+    #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
+    #   docker
     #   pytest
     #   pytest-sugar
 pamqp==3.2.0
@@ -147,7 +149,7 @@ psycopg2-binary==2.9.3
     #   sqlalchemy
 py==1.11.0
     # via pytest
-pydantic==1.9.1
+pydantic==1.10.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
@@ -165,12 +167,14 @@ pydantic==1.9.1
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-pyinstrument==4.2.0
+pyinstrument==4.3.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 pyparsing==3.0.9
-    # via packaging
+    # via
+    #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
+    #   packaging
 pyrsistent==0.18.1
     # via jsonschema
 pytest==7.1.2
@@ -265,7 +269,7 @@ typing-extensions==4.3.0
     #   aiodebug
     #   aiodocker
     #   pydantic
-urllib3==1.26.11
+urllib3==1.26.12
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
@@ -277,6 +281,7 @@ urllib3==1.26.11
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
+    #   docker
     #   minio
     #   requests
 websocket-client==0.59.0

--- a/tests/swarm-deploy/requirements/_tools.txt
+++ b/tests/swarm-deploy/requirements/_tools.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-black==22.6.0
+black==22.8.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.8.0
     # via pip-tools
@@ -17,7 +17,7 @@ click==8.1.3
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
@@ -33,7 +33,7 @@ packaging==21.3
     # via
     #   -c requirements/_test.txt
     #   build
-pathspec==0.9.0
+pathspec==0.10.0
     # via black
 pep517==0.13.0
     # via build
@@ -67,7 +67,7 @@ typing-extensions==4.3.0
     # via
     #   -c requirements/_test.txt
     #   black
-virtualenv==20.16.3
+virtualenv==20.16.4
     # via pre-commit
 watchdog==2.1.9
     # via -r requirements/_tools.in


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

- ⬆️ Upgrade of test and tooling libraries (details below)
- 🔨 Minor fix in reporter script
- 🐛 fixes issues detected by new version of ``pylint`` (see commits for details)

###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 69
- #packages after : 67

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 8.1.1           | 8.2.0      | *minor*    | 1 | swarm-deploy🧪 |
|   2 | aiormq                    | 6.4.0           | 6.4.1      |            | 1 | swarm-deploy🧪 |
|   3 | astroid                   | 2.11.7          | 2.12.5     | *minor*    | 15 | api-server🧪</br>catalog🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>datcore-adapter🧪</br>director-v2🧪</br>dynamic-sidecar🔧</br>models-library🧪</br>postgres-database🧪</br>service-integration🧪</br>service-library🧪</br>settings-library🧪</br>simcore-sdk🧪</br>storage🧪</br>web🧪 |
|   4 | aws-sam-translator        | 1.45.0, 1.46.0  | 1.50.0     | *minor*    | 2 | api-server🧪</br>storage🧪 |
|   5 | aws-xray-sdk              | 2.9.0           | 2.10.0     | *minor*    | 2 | api-server🧪</br>storage🧪 |
|   6 | bcrypt                    | 3.2.2           | 4.0.0      | **MAJOR**  | 1 | api-server🧪 |
|   7 | black                     | 22.6.0          | 22.8.0     | *minor*    | 17 | api-server🔧</br>catalog🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-sidecar🔧</br>models-library🔧</br>postgres-database🔧</br>public-api🧪</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|   8 | boto3                     | 1.23.4          | 1.24.65    | *minor*    | 1 | api-server🧪 |
|   9 | boto3-stubs               | 1.23.9          | 1.24.65    | *minor*    | 1 | api-server🧪 |
|  10 | botocore                  | 1.26.4          | 1.27.65    | *minor*    | 1 | api-server🧪 |
|  11 | botocore-stubs            | 1.26.9          | 1.27.65    | *minor*    | 1 | api-server🧪 |
|  12 | certifi                   | 2022.5.18.1     | 2022.6.15  | *minor*    | 1 | storage🧪 |
|  13 | cffi                      | 1.15.0          | 1.15.1     |            | 1 | storage🧪 |
|  14 | cfn-lint                  | 0.61.1, 0.60.1  | 0.63.2     | *minor*    | 2 | api-server🧪</br>storage🧪 |
|  15 | charset-normalizer        | 2.1.0           | 2.1.1      |            | 14 | dask-task-models-library🧪</br>e2e🧪</br>environment-setup🧪</br>models-library🧪</br>postgres-database🧪🧪</br>public-api🧪</br>service-integration🧪🧪</br>settings-library🧪</br>simcore-sdk🧪🧪</br>swarm-deploy🧪</br>tests🧪 |
|  16 | colorlog                  | 6.6.0           | 6.7.0      | *minor*    | 1 | director-v2🧪 |
|  17 | coverage                  | 6.4, 6.3.2, 6.4.3 | 6.4.4      |            | 17 | api-server🧪</br>catalog🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>datcore-adapter🧪</br>director-v2🧪</br>dynamic-sidecar🧪</br>models-library🧪</br>postgres-database🧪</br>public-api🧪</br>service-integration🧪</br>service-library🧪</br>settings-library🧪</br>simcore-sdk🧪</br>storage🧪</br>swarm-deploy🧪</br>web🧪 |
|  18 | cryptography              | 37.0.2          | 37.0.4     |            | 1 | storage🧪 |
|  19 | dask                      | 2022.8.0        | 2022.8.1   |            | 1 | dask-task-models-library🧪 |
|  20 | dill                      | 0.3.5, 0.3.4    | 0.3.5.1    |            | 2 | api-server🧪</br>storage🧪 |
|  21 | distlib                   | 0.3.5           | 0.3.6      |            | 17 | api-server🔧</br>catalog🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-sidecar🔧</br>models-library🔧</br>postgres-database🔧</br>public-api🧪</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  22 | distributed               | 2022.8.0        | 2022.8.1   |            | 1 | dask-task-models-library🧪 |
|  23 | distro                    | 1.7.0           | 🗑️ removed |  | 1 | api-server🧪 |
|  24 | docker                    | 5.0.3           | 6.0.0      | **MAJOR**  | 12 | api-server🧪</br>catalog🧪</br>dask-sidecar🧪</br>director-v2🧪</br>e2e🧪</br>postgres-database🧪</br>public-api🧪</br>service-integration🧪</br>simcore-sdk🧪</br>storage🧪</br>swarm-deploy🧪</br>web🧪 |
|  25 | docker-compose            | 1.29.1          | 🗑️ removed |  | 1 | api-server🧪 |
|  26 | dockerpty                 | 0.4.1           | 🗑️ removed |  | 1 | api-server🧪 |
|  27 | ecdsa                     | 0.17.0          | 0.18.0     | *minor*    | 2 | api-server🧪</br>storage🧪 |
|  28 | exceptiongroup            | 1.0.0           | 1.0.0      |            | 1 | web🧪 |
|  29 | faker                     | 13.15.1         | 14.2.0     | **MAJOR**  | 14 | api-server🧪</br>catalog🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>datcore-adapter🧪</br>director-v2🧪</br>dynamic-sidecar🧪</br>models-library🧪</br>postgres-database🧪</br>public-api🧪</br>service-library🧪</br>simcore-sdk🧪</br>storage🧪</br>web🧪 |
|  30 | flask                     | 2.1.2           | 2.1.3      |            | 2 | api-server🧪</br>storage🧪 |
|  31 | fsspec                    | 2022.7.1        | 2022.8.2   | *minor*    | 1 | dask-task-models-library🧪 |
|  32 | future                    | 0.18.2          | 🗑️ removed |  | 2 | api-server🧪</br>storage🧪 |
|  33 | greenlet                  | 1.1.2           | 1.1.3      |            | 7 | models-library🧪</br>postgres-database🧪🧪🧪</br>simcore-sdk🧪🧪</br>swarm-deploy🧪 |
|  34 | hypothesis                | 6.54.2          | 6.54.4     |            | 1 | web🧪 |
|  35 | importlib-metadata        | 4.11.3          | 4.12.0     | *minor*    | 1 | api-server🧪 |
|  36 | jmespath                  | 1.0.0           | 1.0.1      |            | 1 | api-server🧪 |
|  37 | jsonschema                | 4.9.1           | 4.15.0     | *minor*    | 5 | dask-task-models-library🧪</br>models-library🧪</br>public-api🧪</br>service-integration🧪</br>tests🧪 |
|  38 | mako                      | 1.2.1           | 1.2.2      |            | 6 | models-library🧪</br>postgres-database🧪🧪</br>simcore-sdk🧪🧪</br>swarm-deploy🧪 |
|  39 | moto                      | 3.1.15, 3.1.9   | 4.0.1      | **MAJOR**  | 2 | api-server🧪</br>storage🧪 |
|  40 | networkx                  | 2.8.1, 2.8.4    | 2.8.6      |            | 2 | api-server🧪</br>storage🧪 |
|  41 | numpy                     | 1.23.1, 1.22.3  | 1.23.2     |            | 2 | director-v2🧪</br>storage🧪 |
|  42 | pandas                    | 1.4.2           | 1.4.4      |            | 1 | storage🧪 |
|  43 | paramiko                  | 2.11.0          | 🗑️ removed |  | 1 | api-server🧪 |
|  44 | partd                     | 1.2.0           | 1.3.0      | *minor*    | 1 | dask-task-models-library🧪 |
|  45 | pathspec                  | 0.9.0           | 0.10.0     | *minor*    | 17 | api-server🔧</br>catalog🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-sidecar🔧</br>models-library🔧</br>postgres-database🔧</br>public-api🧪</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  46 | pbr                       | 5.9.0           | 5.10.0     | *minor*    | 2 | api-server🧪</br>storage🧪 |
|  47 | pydantic                  | 1.9.1, 1.9.2    | 1.10.1     | *minor*    | 8 | dask-task-models-library🧪</br>environment-setup🧪</br>models-library🧪</br>service-integration🧪</br>service-library🧪</br>settings-library🧪</br>simcore-sdk🧪</br>swarm-deploy🧪 |
|  48 | pyinstrument              | 4.2.0           | 4.3.0      | *minor*    | 3 | service-library🧪</br>simcore-sdk🧪</br>swarm-deploy🧪 |
|  49 | pylint                    | 2.14.5          | 2.15.0     | *minor*    | 15 | api-server🧪</br>catalog🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>datcore-adapter🧪</br>director-v2🧪</br>dynamic-sidecar🔧</br>models-library🧪</br>postgres-database🧪</br>service-integration🧪</br>service-library🧪</br>settings-library🧪</br>simcore-sdk🧪</br>storage🧪</br>web🧪 |
|  50 | pynacl                    | 1.5.0           | 🗑️ removed |  | 1 | api-server🧪 |
|  51 | pytest-asyncio            | 0.18.3          | 0.19.0     | *minor*    | 2 | api-server🧪</br>storage🧪 |
|  52 | pytest-docker             | 0.12.0          | 1.0.0      | **MAJOR**  | 1 | api-server🧪 |
|  53 | pytest-icdiff             | 0.5             | 0.6        | *minor*    | 1 | storage🧪 |
|  54 | pytest-mock               | 3.7.0           | 3.8.2      | *minor*    | 2 | api-server🧪</br>storage🧪 |
|  55 | pytest-sugar              | 0.9.4           | 0.9.5      |            | 1 | storage🧪 |
|  56 | python-dotenv             | 0.20.0          | 🗑️ removed |  | 1 | api-server🧪 |
|  57 | pytz                      | 2022.1          | 2022.2.1   | *minor*    | 2 | api-server🧪</br>storage🧪 |
|  58 | requests                  | 2.27.1          | 2.28.1     | *minor*    | 1 | storage🧪 |
|  59 | responses                 | 0.20.0          | 0.21.0     | *minor*    | 1 | api-server🧪 |
|  60 | rsa                       | 4.8             | 4.9        | *minor*    | 2 | api-server🧪</br>storage🧪 |
|  61 | s3transfer                | 0.5.2           | 0.6.0      | *minor*    | 1 | api-server🧪 |
|  62 | sniffio                   | 1.2.0           | 1.3.0      | *minor*    | 1 | public-api🧪 |
|  63 | texttable                 | 1.6.4           | 🗑️ removed |  | 1 | api-server🧪 |
|  64 | tomlkit                   | 0.11.3          | 0.11.4     |            | 15 | api-server🧪</br>catalog🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>datcore-adapter🧪</br>director-v2🧪</br>dynamic-sidecar🔧</br>models-library🧪</br>postgres-database🧪</br>service-integration🧪</br>service-library🧪</br>settings-library🧪</br>simcore-sdk🧪</br>storage🧪</br>web🧪 |
|  65 | types-aiofiles            | 0.8.10          | 0.8.11     |            | 1 | dynamic-sidecar🧪 |
|  66 | urllib3                   | 1.26.11         | 1.26.12    |            | 13 | dask-task-models-library🧪🧪</br>e2e🧪</br>models-library🧪</br>postgres-database🧪🧪</br>public-api🧪</br>service-integration🧪🧪</br>service-library🧪</br>settings-library🧪</br>simcore-sdk🧪</br>swarm-deploy🧪 |
|  67 | virtualenv                | 20.16.3         | 20.16.4    |            | 17 | api-server🔧</br>catalog🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-sidecar🔧</br>models-library🔧</br>postgres-database🔧</br>public-api🧪</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  68 | websocket-client          | 0.59.0, 1.3.3, 1.3.2 | 1.4.0      | *minor*    | 9 | api-server🧪</br>catalog🧪</br>director-v2🧪</br>e2e🧪</br>public-api🧪</br>service-integration🧪</br>simcore-sdk🧪</br>storage🧪</br>web🧪 |
|  69 | zipp                      | 3.8.0           | 3.8.1      |            | 2 | api-server🧪</br>storage🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 57

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 6.8.0, 7.2.0              | 6.8.0, 8.2.0              |                           |
|   2 | aioboto3                  | 9.6.0                     | 10.0.0                    |                           |
|   3 | aiobotocore               | 2.3.0, 2.3.3              | 2.3.4                     |                           |
|   4 | aiocache                  | 0.11.1                    | 0.11.1                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.19.1, 0.21.0            | 0.21.0                    |                           |
|   7 | aiofiles                  | 0.8.0                     | 0.8.0                     |                           |
|   8 | aiohttp                   | 3.8.1                     | 3.8.1                     |                           |
|   9 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  10 | aiohttp-security          | 0.4.0                     |                           |                           |
|  11 | aiohttp-session           | 2.11.0                    |                           |                           |
|  12 | aiohttp-swagger           | 1.0.16                    |                           |                           |
|  13 | aioitertools              | 0.10.0                    | 0.10.0                    |                           |
|  14 | aiopg                     | 1.3.3, 1.3.4              | 1.3.4                     |                           |
|  15 | aioredis                  | 2.0.1                     |                           |                           |
|  16 | aioresponses              |                           | 0.7.3                     |                           |
|  17 | aiormq                    | 3.3.1, 6.2.3              | 3.3.1, 6.4.1              |                           |
|  18 | aiosignal                 | 1.2.0                     | 1.2.0                     |                           |
|  19 | aiosmtplib                | 1.1.6                     |                           |                           |
|  20 | aiozipkin                 | 1.1.1                     |                           |                           |
|  21 | alembic                   | 1.8.0, 1.8.1              | 1.8.0, 1.8.1              |                           |
|  22 | anyio                     | 3.5.0, 3.6.1              | 3.5.0, 3.6.1              |                           |
|  23 | argon2-cffi               | 20.1.0                    |                           |                           |
|  24 | asgi-lifespan             |                           | 1.0.1                     |                           |
|  25 | asgiref                   | 3.5.0, 3.5.2              |                           |                           |
|  26 | astroid                   |                           | 2.12.5                    | 2.12.5                    |
|  27 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  28 | async-generator           | 1.10                      |                           |                           |
|  29 | async-timeout             | 4.0.2                     | 4.0.2                     |                           |
|  30 | asyncpg                   | 0.25.0                    |                           |                           |
|  31 | attrs                     | 20.3.0, 22.1.0            | 20.3.0, 21.4.0, 22.1.0    |                           |
|  32 | aws-sam-translator        |                           | 1.50.0                    |                           |
|  33 | aws-xray-sdk              |                           | 2.10.0                    |                           |
|  34 | bcrypt                    | 3.2.0                     | 4.0.0                     |                           |
|  35 | beautifulsoup4            | 4.10.0                    |                           |                           |
|  36 | black                     |                           |                           | 22.8.0                    |
|  37 | bleach                    | 3.3.0                     |                           |                           |
|  38 | blosc                     | 1.10.6                    |                           |                           |
|  39 | bokeh                     | 2.4.3                     | 2.4.3                     |                           |
|  40 | boto3                     | 1.21.21, 1.21.33          | 1.21.21, 1.24.65          |                           |
|  41 | boto3-stubs               |                           | 1.24.65                   |                           |
|  42 | botocore                  | 1.24.21, 1.24.33          | 1.24.21, 1.27.65          |                           |
|  43 | botocore-stubs            | 1.27.17                   | 1.27.65                   |                           |
|  44 | build                     |                           |                           | 0.8.0                     |
|  45 | bump2version              |                           |                           | 1.0.1                     |
|  46 | certifi                   | 2021.10.8, 2022.5.18.1, 2022.6.15 | 2021.10.8, 2022.5.18.1, 2022.6.15 |                           |
|  47 | cffi                      | 1.15.0                    | 1.15.0, 1.15.1            |                           |
|  48 | cfgv                      |                           |                           | 3.3.1                     |
|  49 | cfn-lint                  |                           | 0.63.2                    |                           |
|  50 | change-case               |                           |                           | 0.5.2                     |
|  51 | charset-normalizer        | 2.0.12, 2.1.1             | 2.0.12, 2.1.0, 2.1.1      |                           |
|  52 | click                     | 8.1.3                     | 8.1.3                     | 8.1.3                     |
|  53 | cloudpickle               | 2.0.0, 2.1.0              |                           |                           |
|  54 | codecov                   |                           | 2.1.12                    |                           |
|  55 | colorlog                  |                           | 6.7.0                     |                           |
|  56 | configparser              | 5.2.0                     |                           |                           |
|  57 | coverage                  |                           | 6.4.4                     |                           |
|  58 | coveralls                 |                           | 3.3.1                     |                           |
|  59 | cryptography              | 3.4.7, 36.0.2, 37.0.2     | 36.0.2, 37.0.4            |                           |
|  60 | cytoolz                   | 0.11.0                    |                           |                           |
|  61 | dask                      | 2022.6.0, 2022.8.1        |                           |                           |
|  62 | dask-gateway              | 2022.6.1                  |                           |                           |
|  63 | dask-gateway-server       |                           | 2022.6.1                  |                           |
|  64 | decorator                 | 4.4.2                     |                           |                           |
|  65 | defusedxml                | 0.7.1                     |                           |                           |
|  66 | deprecated                | 1.2.13                    | 1.2.13                    |                           |
|  67 | dill                      |                           | 0.3.5.1                   | 0.3.5.1                   |
|  68 | distlib                   |                           |                           | 0.3.6                     |
|  69 | distributed               | 2022.6.0, 2022.8.1        |                           |                           |
|  70 | distro                    | 1.5.0                     |                           |                           |
|  71 | dnspython                 | 2.0.0, 2.1.0, 2.2.1       | 2.2.1                     |                           |
|  72 | docker                    | 5.0.3, 6.0.0              | 6.0.0                     |                           |
|  73 | docker-compose            | 1.29.1                    |                           |                           |
|  74 | dockerpty                 | 0.4.1                     |                           |                           |
|  75 | docopt                    | 0.6.2                     | 0.6.2                     |                           |
|  76 | ecdsa                     | 0.14.1                    | 0.18.0                    |                           |
|  77 | email-validator           | 1.2.1                     | 1.2.1                     |                           |
|  78 | entrypoints               | 0.3                       |                           |                           |
|  79 | et-xmlfile                | 1.1.0                     |                           |                           |
|  80 | exceptiongroup            |                           | 1.0.0rc9                  |                           |
|  81 | execnet                   |                           | 1.9.0                     |                           |
|  82 | expiringdict              | 1.2.1                     |                           |                           |
|  83 | faker                     |                           | 14.2.0                    |                           |
|  84 | fastapi                   | 0.71.0, 0.75.0, 0.75.1    |                           |                           |
|  85 | fastapi-contrib           | 0.2.11                    |                           |                           |
|  86 | fastapi-pagination        | 0.9.1                     |                           |                           |
|  87 | fastjsonschema            | 2.15.3                    |                           |                           |
|  88 | filelock                  |                           |                           | 3.8.0                     |
|  89 | flaky                     |                           | 3.7.0                     |                           |
|  90 | flask                     |                           | 2.1.3                     |                           |
|  91 | flask-cors                |                           | 3.0.10                    |                           |
|  92 | frozenlist                | 1.3.0, 1.3.1              | 1.3.0, 1.3.1              |                           |
|  93 | fsspec                    | 2022.5.0, 2022.8.2        |                           |                           |
|  94 | future                    | 0.18.2                    |                           |                           |
|  95 | futures                   | 3.0.5                     |                           |                           |
|  96 | graphql-core              |                           | 3.2.1                     |                           |
|  97 | greenlet                  | 1.1.2, 1.1.3              | 1.1.2, 1.1.3              |                           |
|  98 | gunicorn                  | 20.1.0                    |                           |                           |
|  99 | h11                       | 0.12.0                    | 0.12.0                    |                           |
| 100 | h2                        | 4.1.0                     |                           |                           |
| 101 | heapdict                  | 1.0.1                     |                           |                           |
| 102 | hpack                     | 4.0.0                     |                           |                           |
| 103 | httpcore                  | 0.15.0                    | 0.15.0                    |                           |
| 104 | httptools                 | 0.2.0, 0.4.0              |                           |                           |
| 105 | httpx                     | 0.23.0                    | 0.23.0                    |                           |
| 106 | hyperframe                | 6.0.1                     |                           |                           |
| 107 | hypothesis                |                           | 6.54.4                    |                           |
| 108 | icdiff                    |                           | 2.0.5                     |                           |
| 109 | identify                  |                           |                           | 2.5.3                     |
| 110 | idna                      | 2.10, 3.3                 | 2.10, 3.3                 |                           |
| 111 | importlib-metadata        |                           | 4.12.0                    |                           |
| 112 | iniconfig                 | 1.1.1                     | 1.1.1                     |                           |
| 113 | inotify                   |                           |                           | 0.2.10                    |
| 114 | isodate                   | 0.6.1                     |                           |                           |
| 115 | isort                     |                           | 5.10.1                    | 5.10.1                    |
| 116 | itsdangerous              | 1.1.0, 2.1.2              | 2.1.2                     |                           |
| 117 | jaeger-client             | 4.8.0                     |                           |                           |
| 118 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 119 | jinja2                    | 3.1.2                     | 3.1.2                     | 3.1.2                     |
| 120 | jmespath                  | 1.0.0                     | 1.0.0, 1.0.1              |                           |
| 121 | jschema-to-python         |                           | 1.2.3                     |                           |
| 122 | json2html                 | 1.3.0                     |                           |                           |
| 123 | jsondiff                  | 2.0.0                     | 2.0.0                     |                           |
| 124 | jsonpatch                 |                           | 1.32                      |                           |
| 125 | jsonpickle                |                           | 2.2.0                     |                           |
| 126 | jsonpointer               |                           | 2.3                       |                           |
| 127 | jsonschema                | 3.2.0, 4.15.0             | 3.2.0, 4.15.0             |                           |
| 128 | junit-xml                 |                           | 1.9                       |                           |
| 129 | jupyter-client            | 6.1.12                    |                           |                           |
| 130 | jupyter-core              | 4.7.1                     |                           |                           |
| 131 | jupyter-server            | 1.18.1                    |                           |                           |
| 132 | jupyter-server-proxy      | 3.2.1                     |                           |                           |
| 133 | jupyterlab-pygments       | 0.1.2                     |                           |                           |
| 134 | lazy-object-proxy         | 1.4.3                     | 1.4.3, 1.7.1              | 1.7.1                     |
| 135 | locket                    | 1.0.0                     |                           |                           |
| 136 | lz4                       | 4.0.0                     |                           |                           |
| 137 | mako                      | 1.1.5, 1.2.0, 1.2.2       | 1.1.5, 1.2.0, 1.2.2       |                           |
| 138 | markupsafe                | 2.1.1                     | 2.1.1                     | 2.1.1                     |
| 139 | mccabe                    |                           | 0.7.0                     | 0.7.0                     |
| 140 | minio                     |                           | 7.0.4                     |                           |
| 141 | mistune                   | 0.8.4                     |                           |                           |
| 142 | moto                      |                           | 4.0.1                     |                           |
| 143 | msgpack                   | 1.0.3, 1.0.4              |                           |                           |
| 144 | multidict                 | 6.0.2                     | 6.0.2                     |                           |
| 145 | mypy-extensions           |                           |                           | 0.4.3                     |
| 146 | nbclient                  | 0.5.3                     |                           |                           |
| 147 | nbconvert                 | 6.4.5                     |                           |                           |
| 148 | nbformat                  | 5.3.0                     |                           |                           |
| 149 | nest-asyncio              | 1.5.1                     |                           |                           |
| 150 | networkx                  | 2.5.1                     | 2.8.6                     |                           |
| 151 | nodeenv                   |                           |                           | 1.7.0                     |
| 152 | nose                      |                           |                           | 1.3.7                     |
| 153 | numpy                     | 1.22.3                    | 1.23.2                    |                           |
| 154 | openapi-core              | 0.12.0                    |                           |                           |
| 155 | openapi-schema-validator  | 0.2.3                     | 0.2.3                     |                           |
| 156 | openapi-spec-validator    | 0.4.0                     | 0.4.0                     |                           |
| 157 | openpyxl                  | 3.0.9                     |                           |                           |
| 158 | opentracing               | 2.4.0                     |                           |                           |
| 159 | orjson                    | 3.7.2                     |                           |                           |
| 160 | packaging                 | 21.3                      | 21.3                      | 21.3                      |
| 161 | pamqp                     | 2.3.0, 3.1.0              | 2.3.0, 3.2.0              |                           |
| 162 | pandas                    | 1.2.4                     | 1.4.4                     |                           |
| 163 | pandocfilters             | 1.4.3                     |                           |                           |
| 164 | paramiko                  | 2.11.0                    |                           |                           |
| 165 | parfive                   | 1.5.1                     |                           |                           |
| 166 | partd                     | 1.2.0, 1.3.0              |                           |                           |
| 167 | passlib                   | 1.7.4                     | 1.7.4                     |                           |
| 168 | pathspec                  |                           |                           | 0.10.0                    |
| 169 | pbr                       |                           | 5.10.0                    |                           |
| 170 | pennsieve                 | 6.2.0                     |                           |                           |
| 171 | pep517                    |                           |                           | 0.13.0                    |
| 172 | pillow                    | 9.0.1                     | 9.2.0                     |                           |
| 173 | pint                      | 0.19.2                    | 0.19.2                    |                           |
| 174 | pip-tools                 |                           |                           | 6.8.0                     |
| 175 | platformdirs              |                           | 2.5.2                     | 2.5.2                     |
| 176 | pluggy                    | 1.0.0                     | 1.0.0                     |                           |
| 177 | pprintpp                  |                           | 0.4.0                     |                           |
| 178 | pre-commit                |                           |                           | 2.20.0                    |
| 179 | prometheus-client         | 0.14.1                    |                           |                           |
| 180 | protobuf                  | 3.20.0                    |                           |                           |
| 181 | psutil                    | 5.9.0, 5.9.1              |                           |                           |
| 182 | psycopg2-binary           | 2.9.3                     | 2.9.3                     |                           |
| 183 | ptvsd                     |                           | 4.3.2                     |                           |
| 184 | ptyprocess                | 0.7.0                     |                           |                           |
| 185 | py                        | 1.11.0                    | 1.11.0                    |                           |
| 186 | py-cpuinfo                |                           | 8.0.0                     |                           |
| 187 | pyasn1                    | 0.4.8                     | 0.4.8                     |                           |
| 188 | pycparser                 | 2.20, 2.21                | 2.20, 2.21                |                           |
| 189 | pydantic                  | 1.9.0, 1.10.1             | 1.10.1                    |                           |
| 190 | pyftpdlib                 |                           | 1.5.6                     |                           |
| 191 | pygments                  | 2.9.0                     |                           |                           |
| 192 | pyinstrument              | 3.4.2, 4.1.1, 4.3.0       | 4.3.0                     |                           |
| 193 | pyinstrument-cext         | 0.2.4                     |                           |                           |
| 194 | pyjwt                     | 2.4.0                     |                           |                           |
| 195 | pylint                    |                           | 2.15.0                    | 2.15.0                    |
| 196 | pynacl                    | 1.4.0                     |                           |                           |
| 197 | pyopenssl                 |                           | 22.0.0                    |                           |
| 198 | pyparsing                 | 3.0.9                     | 3.0.9                     | 3.0.9                     |
| 199 | pyrsistent                | 0.18.1                    | 0.18.1                    |                           |
| 200 | pytest                    | 7.1.2                     | 7.1.2                     |                           |
| 201 | pytest-aiohttp            |                           | 1.0.4                     |                           |
| 202 | pytest-asyncio            |                           | 0.19.0                    |                           |
| 203 | pytest-benchmark          |                           | 3.4.1                     |                           |
| 204 | pytest-cov                |                           | 3.0.0                     |                           |
| 205 | pytest-docker             |                           | 1.0.0                     |                           |
| 206 | pytest-forked             |                           | 1.4.0                     |                           |
| 207 | pytest-icdiff             |                           | 0.6                       |                           |
| 208 | pytest-instafail          |                           | 0.4.2                     |                           |
| 209 | pytest-lazy-fixture       |                           | 0.6.3                     |                           |
| 210 | pytest-localftpserver     |                           | 1.1.3                     |                           |
| 211 | pytest-mock               |                           | 3.8.2                     |                           |
| 212 | pytest-runner             |                           | 6.0.0                     |                           |
| 213 | pytest-sugar              |                           | 0.9.5                     |                           |
| 214 | pytest-xdist              |                           | 2.5.0                     |                           |
| 215 | python-dateutil           | 2.8.1, 2.8.2              | 2.8.1, 2.8.2              |                           |
| 216 | python-dotenv             | 0.20.0                    | 0.20.0                    |                           |
| 217 | python-engineio           | 3.14.2                    |                           |                           |
| 218 | python-jose               | 3.2.0                     | 3.3.0                     |                           |
| 219 | python-magic              | 0.4.25                    |                           |                           |
| 220 | python-multipart          | 0.0.5                     |                           |                           |
| 221 | python-socketio           | 4.6.1                     |                           |                           |
| 222 | pytz                      | 2020.1, 2022.1            | 2022.2.1                  |                           |
| 223 | pyyaml                    | 5.4.1, 6.0                | 5.4.1, 6.0                | 5.4.1, 6.0                |
| 224 | pyzmq                     | 22.1.0                    |                           |                           |
| 225 | redis                     | 4.3.1, 4.3.4              | 4.3.1                     |                           |
| 226 | requests                  | 2.27.1, 2.28.1            | 2.27.1, 2.28.1            |                           |
| 227 | responses                 |                           | 0.21.0                    |                           |
| 228 | respx                     |                           | 0.19.2                    |                           |
| 229 | rfc3986                   | 1.4.0, 1.5.0              | 1.4.0, 1.5.0              |                           |
| 230 | rsa                       | 4.9                       | 4.9                       |                           |
| 231 | s3fs                      | 2022.5.0                  |                           |                           |
| 232 | s3transfer                | 0.5.2                     | 0.5.2, 0.6.0              |                           |
| 233 | sarif-om                  |                           | 1.0.4                     |                           |
| 234 | semantic-version          | 2.9.0                     |                           |                           |
| 235 | semver                    | 2.13.0                    |                           |                           |
| 236 | send2trash                | 1.7.1                     |                           |                           |
| 237 | setproctitle              | 1.2.3                     |                           |                           |
| 238 | simpervisor               | 0.4                       |                           |                           |
| 239 | six                       | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            |                           |
| 240 | sniffio                   | 1.2.0                     | 1.2.0, 1.3.0              |                           |
| 241 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 242 | soupsieve                 | 2.3.2                     |                           |                           |
| 243 | sqlalchemy                | 1.4.37, 1.4.40            | 1.4.37, 1.4.40            |                           |
| 244 | sshpubkeys                |                           | 3.3.1                     |                           |
| 245 | starlette                 | 0.17.1                    |                           |                           |
| 246 | strict-rfc3339            | 0.7                       |                           |                           |
| 247 | tblib                     | 1.7.0                     |                           |                           |
| 248 | tenacity                  | 8.0.1                     | 8.0.1                     |                           |
| 249 | termcolor                 |                           | 1.1.0                     |                           |
| 250 | terminado                 | 0.10.1                    |                           |                           |
| 251 | testpath                  | 0.5.0                     |                           |                           |
| 252 | texttable                 | 1.6.3                     |                           |                           |
| 253 | threadloop                | 1.0.2                     |                           |                           |
| 254 | thrift                    | 0.16.0                    |                           |                           |
| 255 | toml                      |                           |                           | 0.10.2                    |
| 256 | tomli                     | 2.0.1                     | 2.0.1                     | 2.0.1                     |
| 257 | tomlkit                   |                           | 0.11.4                    | 0.11.4                    |
| 258 | toolz                     | 0.11.1, 0.12.0            |                           |                           |
| 259 | tornado                   | 6.1                       | 6.1                       |                           |
| 260 | tqdm                      | 4.64.0                    | 4.64.0                    |                           |
| 261 | traitlets                 | 5.1.1                     | 5.3.0                     |                           |
| 262 | twilio                    | 7.12.0                    |                           |                           |
| 263 | typer                     | 0.4.1, 0.6.1              | 0.6.1                     | 0.6.1                     |
| 264 | types-aiobotocore         | 2.3.3                     |                           |                           |
| 265 | types-aiobotocore-s3      | 2.3.3                     |                           |                           |
| 266 | types-aiofiles            |                           | 0.8.11                    |                           |
| 267 | types-awscrt              |                           | 0.14.3                    |                           |
| 268 | types-boto3               |                           | 1.0.2                     |                           |
| 269 | types-pkg-resources       |                           | 0.1.3                     |                           |
| 270 | types-pyyaml              |                           | 6.0.11                    |                           |
| 271 | types-s3transfer          |                           | 0.6.0.post4               |                           |
| 272 | typing-extensions         | 4.3.0                     | 4.3.0                     | 4.3.0                     |
| 273 | ujson                     | 4.3.0, 5.3.0              |                           |                           |
| 274 | urllib3                   | 1.26.9, 1.26.11, 1.26.12  | 1.26.9, 1.26.11, 1.26.12  |                           |
| 275 | uvicorn                   | 0.15.0, 0.17.0, 0.17.6    |                           |                           |
| 276 | uvloop                    | 0.16.0                    |                           |                           |
| 277 | virtualenv                |                           |                           | 20.16.4                   |
| 278 | watchdog                  | 2.1.5                     |                           | 2.1.9                     |
| 279 | watchgod                  | 0.8.2                     |                           |                           |
| 280 | webencodings              | 0.5.1                     |                           |                           |
| 281 | websocket-client          | 0.59.0, 1.3.2, 1.4.0      | 0.59.0, 1.4.0             |                           |
| 282 | websockets                | 10.1, 10.2                | 10.3                      |                           |
| 283 | werkzeug                  | 2.0.3, 2.1.2              | 2.0.3, 2.1.2              |                           |
| 284 | wheel                     |                           |                           | 0.37.1                    |
| 285 | wrapt                     | 1.14.0, 1.14.1            | 1.14.0, 1.14.1            | 1.14.1                    |
| 286 | xmltodict                 |                           | 0.13.0                    |                           |
| 287 | yarl                      | 1.5.1, 1.7.2, 1.8.1       | 1.5.1, 1.7.2, 1.8.1       |                           |
| 288 | zict                      | 2.2.0                     |                           |                           |
| 289 | zipp                      |                           | 3.8.1                     |                           |

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
