### PR TITLE
🐛 Various fixes

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_api/_volume.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_api/_volume.py
@@ -115,15 +115,8 @@ async def remove_volumes_from_node(
                         task_state == "complete"
                         and task_status["ContainerStatus"]["ExitCode"] == 0
                     ):
-                        # recover logs from command for a simpler debugging
-                        container_id = task_status["ContainerStatus"]["ContainerID"]
-                        container = await client.containers.get(container_id)
-                        container_logs = await container.log(stdout=True, stderr=True)
                         log.error(
-                            "Service %s, %s output: %s",
-                            service_id,
-                            f"{task_status=}",
-                            "\n".join(container_logs),
+                            "Service %s status: %s", service_id, f"{task_status=}"
                         )
                         # NOTE: above implies the volumes will remain in the system and
                         # have to be manually removed.

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
@@ -145,10 +145,10 @@ async def upload_outputs(
             await logged_gather(*archiving_tasks)
         await PORTS.set_multiple(ports_values)
 
-    elapsed_time = time.perf_counter() - start_time
-    total_bytes = sum(_get_size_of_value(x) for x in ports_values.values())
-    logger.info("Uploaded %s bytes in %s seconds", total_bytes, elapsed_time)
-    logger.debug(_CONTROL_TESTMARK_DY_SIDECAR_NODEPORT_UPLOADED_MESSAGE)
+        elapsed_time = time.perf_counter() - start_time
+        total_bytes = sum(_get_size_of_value(x) for x in ports_values.values())
+        logger.info("Uploaded %s bytes in %s seconds", total_bytes, elapsed_time)
+        logger.debug(_CONTROL_TESTMARK_DY_SIDECAR_NODEPORT_UPLOADED_MESSAGE)
 
 
 async def dispatch_update_for_directory(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

- This was failing since it is running in swarm mode. Removing the logs fetching since they bring no real benefit.
- computing folder size outside of directory cleanup context fails

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
