### PR TITLE
🐛BugFix: Does not allow re-registering the same phone number

### DIFF
--- a/services/web/server/tests/unit/with_dbs/03/test_login_2fa.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_login_2fa.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 from aiohttp import web
 from aiohttp.test_utils import TestClient
 from pytest import MonkeyPatch
+from pytest_simcore.helpers import utils_login
 from pytest_simcore.helpers.utils_assert import assert_status
 from pytest_simcore.helpers.utils_dict import ConfigDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict
@@ -238,3 +239,28 @@ async def test_workflow_register_and_login_with_2fa(
     assert user["email"] == EMAIL
     assert user["phone"] == PHONE
     assert user["status"] == UserStatus.ACTIVE.value
+
+
+async def test_register_phone_fails_with_used_number(
+    client: TestClient,
+    db: AsyncpgStorage,
+):
+    """
+    Tests https://github.com/ITISFoundation/osparc-simcore/issues/3304
+    """
+
+    # some user ALREADY registered with the same phone
+    await utils_login.create_user(db, data={"phone": PHONE})
+
+    # new registration with same phone
+    # 1. submit
+    url = client.app.router["auth_verify_2fa_phone"].url_for()
+    rsp = await client.post(
+        url,
+        json={
+            "email": EMAIL,
+            "phone": PHONE,
+        },
+    )
+    _, error = await assert_status(rsp, web.HTTPUnauthorized)
+    assert "phone" in error["message"]


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

De-authorizes (``HTTPUnauthorized``) registering the same phone more than once on the system. If user tries, it returns a more concrete message: ``"Cannot register this phone number because it is already assigned to an active user"``

## Related issue/s

- Closes #3304

## How to test

- Reproduce #3304, should get an error as ``"Cannot register this phone number because it is already assigned to an active user"``
- Automatically
```python
cd services/web/server
make install-dev
pytest -vv tests/unit/**/test_login_2fa.py
```

## Checklist

- [x] Unit tests for the changes exist
- [ ] Runs in the swarm
