### PR TITLE
🐛 Is91/fix alphanumeric sender  (⚠️ devops)

### DIFF
--- a/packages/settings-library/setup.cfg
+++ b/packages/settings-library/setup.cfg
@@ -14,5 +14,6 @@ universal = 1
 # Define setup.py command aliases here
 test = pytest
 
-[tool:pytest]
-asyncio_mode = auto
+# NOTE: uncomment when pytest-asyncio is added in requirements
+# [tool:pytest]
+# asyncio_mode = auto

--- a/packages/settings-library/src/settings_library/twilio.py
+++ b/packages/settings-library/src/settings_library/twilio.py
@@ -6,11 +6,32 @@ For twilio SMS services:
 """
 
 
-from pydantic import Field
+from pydantic import Field, constr
 
 from .base import BaseCustomSettings
+
+# Based on https://countrycode.org/
+CountryCodeStr = constr(strip_whitespace=True, regex=r"^\d{1,4}")
 
 
 class TwilioSettings(BaseCustomSettings):
     TWILIO_ACCOUNT_SID: str = Field(..., description="Twilio account String Identifier")
     TWILIO_AUTH_TOKEN: str = Field(..., description="API tokens")
+    TWILIO_COUNTRY_CODES_W_ALPHANUMERIC_SID_SUPPORT: list[CountryCodeStr] = Field(
+        [
+            "41",
+        ],
+        description="list of country-codes supporting alphanumeric sender ID",
+    )
+
+    def is_alphanumeric_supported(self, phone_number: str) -> bool:
+        # Some countries do not support alphanumeric serder ID
+        #
+        # SEE https://support.twilio.com/hc/en-us/articles/223181348-Alphanumeric-Sender-ID-for-Twilio-Programmable-SMS
+        phone_number_wo_international_code = (
+            phone_number.strip().removeprefix("00").lstrip("+")
+        )
+        return any(
+            phone_number_wo_international_code.startswith(code)
+            for code in self.TWILIO_COUNTRY_CODES_W_ALPHANUMERIC_SID_SUPPORT
+        )

--- a/packages/settings-library/src/settings_library/twilio.py
+++ b/packages/settings-library/src/settings_library/twilio.py
@@ -21,7 +21,8 @@ class TwilioSettings(BaseCustomSettings):
         [
             "41",
         ],
-        description="list of country-codes supporting alphanumeric sender ID",
+        description="list of country-codes supporting/registered for alphanumeric sender ID"
+        "See https://support.twilio.com/hc/en-us/articles/223133767-International-support-for-Alphanumeric-Sender-ID",
     )
 
     def is_alphanumeric_supported(self, phone_number: str) -> bool:

--- a/packages/settings-library/tests/test_twilio.py
+++ b/packages/settings-library/tests/test_twilio.py
@@ -24,10 +24,44 @@ def test_twilio_settings_within_envdevel(
                 "TWILIO_ACCOUNT_SID": "fake-account",
                 "TWILIO_AUTH_TOKEN": "fake-token",
                 "TWILIO_MESSAGING_SID": "x" * 34,
-                "TWILIO_COUNTRY_CODES_W_ALPHANUMERIC_SID_SUPPORT": "[41, 34, 55]",
+            },
+        )
+        settings = TwilioSettings.create_from_envs()
+        print(settings.json(indent=2))
+        assert settings
+
+
+def test_twilio_settings_with_country_codes(
+    mock_env_devel_environment: dict[str, str], monkeypatch: MonkeyPatch
+):
+
+    # defaults
+    with monkeypatch.context() as patch:
+        setenvs_from_dict(
+            patch,
+            {
+                "TWILIO_ACCOUNT_SID": "fake-account",
+                "TWILIO_AUTH_TOKEN": "fake-token",
+                "TWILIO_MESSAGING_SID": "x" * 34,
             },
         )
         settings = TwilioSettings.create_from_envs()
 
         assert settings.is_alphanumeric_supported("+41 456 789 156")
         assert not settings.is_alphanumeric_supported(" +1 123456 789 456 ")
+
+    # custom country codes
+    with monkeypatch.context() as patch:
+        setenvs_from_dict(
+            patch,
+            {
+                "TWILIO_ACCOUNT_SID": "fake-account",
+                "TWILIO_AUTH_TOKEN": "fake-token",
+                "TWILIO_MESSAGING_SID": "x" * 34,
+                "TWILIO_COUNTRY_CODES_W_ALPHANUMERIC_SID_SUPPORT": "[1, 34]",
+            },
+        )
+        settings = TwilioSettings.create_from_envs()
+
+        assert not settings.is_alphanumeric_supported("+41 456 789 156")
+        assert settings.is_alphanumeric_supported(" +1 123456 789 456 ")

--- a/packages/settings-library/tests/test_twilio.py
+++ b/packages/settings-library/tests/test_twilio.py
@@ -64,4 +64,5 @@ def test_twilio_settings_with_country_codes(
         settings = TwilioSettings.create_from_envs()
 
         assert not settings.is_alphanumeric_supported("+41 456 789 156")
-        assert settings.is_alphanumeric_supported(" +1 123456 789 456 ")
+        assert settings.is_alphanumeric_supported(" 001 123456 789 456 ")
+        assert settings.is_alphanumeric_supported("+1 123456 789 456 ")

--- a/packages/settings-library/tests/test_twilio.py
+++ b/packages/settings-library/tests/test_twilio.py
@@ -23,7 +23,6 @@ def test_twilio_settings_within_envdevel(
             {
                 "TWILIO_ACCOUNT_SID": "fake-account",
                 "TWILIO_AUTH_TOKEN": "fake-token",
-                "TWILIO_MESSAGING_SID": "x" * 34,
             },
         )
         settings = TwilioSettings.create_from_envs()
@@ -42,7 +41,6 @@ def test_twilio_settings_with_country_codes(
             {
                 "TWILIO_ACCOUNT_SID": "fake-account",
                 "TWILIO_AUTH_TOKEN": "fake-token",
-                "TWILIO_MESSAGING_SID": "x" * 34,
             },
         )
         settings = TwilioSettings.create_from_envs()
@@ -57,7 +55,6 @@ def test_twilio_settings_with_country_codes(
             {
                 "TWILIO_ACCOUNT_SID": "fake-account",
                 "TWILIO_AUTH_TOKEN": "fake-token",
-                "TWILIO_MESSAGING_SID": "x" * 34,
                 "TWILIO_COUNTRY_CODES_W_ALPHANUMERIC_SID_SUPPORT": "[1, 34]",
             },
         )

--- a/packages/settings-library/tests/test_twilio.py
+++ b/packages/settings-library/tests/test_twilio.py
@@ -24,6 +24,10 @@ def test_twilio_settings_within_envdevel(
                 "TWILIO_ACCOUNT_SID": "fake-account",
                 "TWILIO_AUTH_TOKEN": "fake-token",
                 "TWILIO_MESSAGING_SID": "x" * 34,
+                "TWILIO_COUNTRY_CODES_W_ALPHANUMERIC_SID_SUPPORT": "[41, 34, 55]",
             },
         )
-        TwilioSettings.create_from_envs()
+        settings = TwilioSettings.create_from_envs()
+
+        assert settings.is_alphanumeric_supported("+41 456 789 156")
+        assert not settings.is_alphanumeric_supported(" +1 123456 789 456 ")


### PR DESCRIPTION
## What do these changes do?

Some countries do not support [alphanumeric serder ID](https://support.twilio.com/hc/en-us/articles/223181348-Alphanumeric-Sender-ID-for-Twilio-Programmable-SMS). Since the [list is pretty long and even some require pre-registration](https://support.twilio.com/hc/en-us/articles/223133767-International-support-for-Alphanumeric-Sender-ID) the codes of the supported countries are passed in a list in ``TWILIO_COUNTRY_CODES_W_ALPHANUMERIC_SID_SUPPORT``

###  ⚠️ devops
  - New environ ``TWILIO_COUNTRY_CODES_W_ALPHANUMERIC_SID_SUPPORT``. Adjust with @odeimaiz
  - SEE examples in https://github.com/ITISFoundation/osparc-simcore/blob/bf7e93e4451ec8e5b13ea44d581737a62c6705be/packages/settings-library/tests/test_twilio.py#L58


## Related issue/s

- ITISFoundation/osparc-issues#91


## How to test

- @odeimaiz could you please do a little manual test when deployed to master?

```cmd
cd services/web/servier
make install-dev
pytest -vv tests/unit/**/test_*2fa*.py
```
```cmd
cd packages/settings-library
make install-dev
pytest -vv tests/test_twilio.py
```


## Checklist

- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes

