### PR TITLE
🐛 fixes 2fa typo in twilio function and guvicorn access-logger level

### DIFF
--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -71,6 +71,9 @@ DEFAULT_FORMATTING = "%(levelname)s: [%(asctime)s/%(processName)s] [%(name)s:%(f
 
 
 def config_all_loggers():
+    """
+    Applies common configuration to ALL registered loggers
+    """
     the_manager: logging.Manager = logging.Logger.manager
 
     loggers = [logging.getLogger()] + [
@@ -90,6 +93,26 @@ def set_logging_handler(
 
     for handler in logger.handlers:
         handler.setFormatter(formatter_base(fmt))
+
+
+def test_logger_propagation(logger: logging.Logger):
+    """log propagation and levels can sometimes be daunting to get it right.
+
+    This function uses the `logger`` passed as argument to log the same message at different levels
+
+    This should help to visually test a given configuration
+
+    USAGE:
+        from servicelib.logging_utils import test_logger_propagation
+        for n in ("aiohttp.access", "gunicorn.access"):
+            test_logger_propagation(logging.getLogger(n))
+    """
+    msg = f"TESTING %s log using {logger=}"
+    logger.critical(msg, "critical")
+    logger.error(msg, "error")
+    logger.info(msg, "info")
+    logger.warning(msg, "warning")
+    logger.debug(msg, "debug")
 
 
 def _log_arguments(

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -82,9 +82,10 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
         False,
         description="Enables development features. WARNING: make sure it is disabled in production .env file!",
     )
-    WEBSERVER_LOG_LEVEL: LogLevel = Field(
+    WEBSERVER_LOGLEVEL: LogLevel = Field(
         LogLevel.WARNING.value,
         env=["WEBSERVER_LOGLEVEL", "LOG_LEVEL", "LOGLEVEL"],
+        # NOTE: suffix '_LOGLEVEL' is used overall
     )
     # TODO: find a better name!?
     WEBSERVER_SERVER_HOST: str = Field(
@@ -228,9 +229,9 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
 
     @cached_property
     def log_level(self) -> int:
-        return getattr(logging, self.WEBSERVER_LOG_LEVEL.upper())
+        return getattr(logging, self.WEBSERVER_LOGLEVEL.upper())
 
-    @validator("WEBSERVER_LOG_LEVEL")
+    @validator("WEBSERVER_LOGLEVEL")
     @classmethod
     def valid_log_level(cls, value) -> str:
         return cls.validate_log_level(value)

--- a/services/web/server/src/simcore_service_webserver/application_settings_utils.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings_utils.py
@@ -23,7 +23,7 @@ def convert_to_app_config(app_settings: ApplicationSettings) -> dict[str, Any]:
         "main": {
             "host": app_settings.WEBSERVER_SERVER_HOST,
             "port": app_settings.WEBSERVER_PORT,
-            "log_level": f"{app_settings.WEBSERVER_LOG_LEVEL}",
+            "log_level": f"{app_settings.WEBSERVER_LOGLEVEL}",
             "testing": False,  # TODO: deprecate!
             "studies_access_enabled": int(
                 app_settings.WEBSERVER_STUDIES_DISPATCHER.STUDIES_ACCESS_ANONYMOUS_ALLOWED
@@ -200,7 +200,7 @@ def convert_to_environ_vars(cfg: dict[str, Any]) -> dict[str, Any]:
 
     if main := cfg.get("main"):
         envs["WEBSERVER_PORT"] = main.get("port")
-        envs["WEBSERVER_LOG_LEVEL"] = main.get("log_level")
+        envs["WEBSERVER_LOGLEVEL"] = main.get("log_level")
         envs["WEBSERVER_STUDIES_ACCESS_ENABLED"] = main.get("studies_access_enabled")
 
     if section := cfg.get("tracing"):

--- a/services/web/server/src/simcore_service_webserver/login/_2fa.py
+++ b/services/web/server/src/simcore_service_webserver/login/_2fa.py
@@ -87,7 +87,7 @@ async def send_sms_code(
         "to": phone_number,
         "body": f"Dear {user_name[:20].capitalize().strip()}, your verification code is {code}",
     }
-    if twilo_auth.is_alpha_numeric_supported(phone_number):
+    if twilo_auth.is_alphanumeric_supported(phone_number):
         create_kwargs["from_"] = twilio_alpha_numeric_sender
 
     def _sender():


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

Fixes typo that breaks ``send_sms``, which makes 2fa unusable

This should not happen anymore when we setup static-analysis in the CI (expected in PR #3321 )

**EXTRA**: guvicorn access-logger set to WEBSERVER_LOGLEVEL  
![image](https://user-images.githubusercontent.com/32402063/188942165-b25255cc-148d-46fc-9830-abde236612ea.png)

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
