### PR TITLE
✨Do not auto-cancel study copy if the user disconnects

### DIFF
--- a/ci/github/unit-testing/models-library.bash
+++ b/ci/github/unit-testing/models-library.bash
@@ -7,27 +7,21 @@ IFS=$'\n\t'
 
 install() {
   bash ci/helpers/ensure_python_pip.bash
+  make devenv
+  # shellcheck source=/dev/null
+  source .venv/bin/activate
   pushd packages/models-library
-  pip3 install -r requirements/ci.txt
+  make install-ci
   popd
-  pip list -v
+  .venv/bin/pip list --verbose
 }
 
 test() {
-  pytest \
-    --asyncio-mode=auto \
-    --color=yes \
-    --cov-append \
-    --cov-config=.coveragerc \
-    --cov-report=term-missing \
-    --cov-report=xml \
-    --cov=models_library \
-    --durations=10 \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --verbose \
-    -m "not heavy_load" \
-    packages/models-library/tests
+  # shellcheck source=/dev/null
+  source .venv/bin/activate
+  pushd packages/models-library
+  make tests-ci
+  popd
 }
 
 # Check if the function exists (bash specific)

--- a/ci/github/unit-testing/postgres-database.bash
+++ b/ci/github/unit-testing/postgres-database.bash
@@ -6,27 +6,24 @@ set -o pipefail  # don't hide errors within pipes
 IFS=$'\n\t'
 
 install() {
-    bash ci/helpers/ensure_python_pip.bash
-    pushd packages/postgres-database; pip3 install -r requirements/ci.txt; popd;
-    pip list -v
+  bash ci/helpers/ensure_python_pip.bash
+  make devenv
+  # shellcheck source=/dev/null
+  source .venv/bin/activate
+  pushd packages/postgres-database
+  make install-ci
+  popd
+  .venv/bin/pip list --verbose
 }
 
 test() {
-    pytest \
-      --asyncio-mode=auto \
-      --color=yes \
-      --cov-append \
-      --cov-config=.coveragerc \
-      --cov-report=term-missing \
-      --cov-report=xml \
-      --cov=simcore_postgres_database \
-      --log-date-format="%Y-%m-%d %H:%M:%S" \
-      --log-format="%(asctime)s %(levelname)s %(message)s" \
-      --durations=10 \
-      --verbose \
-      -m "not heavy_load" \
-      packages/postgres-database/tests
+  # shellcheck source=/dev/null
+  source .venv/bin/activate
+  pushd packages/postgres-database
+  make tests-ci
+  popd
 }
+
 
 # Check if the function exists (bash specific)
 if declare -f "$1" > /dev/null

--- a/ci/github/unit-testing/service-integration.bash
+++ b/ci/github/unit-testing/service-integration.bash
@@ -7,26 +7,21 @@ IFS=$'\n\t'
 
 install() {
   bash ci/helpers/ensure_python_pip.bash
+  make devenv
+  # shellcheck source=/dev/null
+  source .venv/bin/activate
   pushd packages/service-integration
-  pip3 install -r requirements/ci.txt
+  make install-ci
   popd
-  pip list -v
+  .venv/bin/pip list --verbose
 }
 
 test() {
-  pytest \
-    --color=yes \
-    --cov-append \
-    --cov-config=.coveragerc \
-    --cov-report=term-missing \
-    --cov-report=xml \
-    --cov=service_integration \
-    --durations=10 \
-    --log-date-format="%Y-%m-%d %H:%M:%S" \
-    --log-format="%(asctime)s %(levelname)s %(message)s" \
-    --verbose \
-    -m "not heavy_load" \
-    packages/service-integration/tests
+  # shellcheck source=/dev/null
+  source .venv/bin/activate
+  pushd packages/service-integration
+  make tests-ci
+  popd
 }
 
 # Check if the function exists (bash specific)

--- a/packages/models-library/Makefile
+++ b/packages/models-library/Makefile
@@ -15,14 +15,38 @@ install-dev install-prod install-ci: _check_venv_active ## install app in develo
 	pip-sync requirements/$(subst install-,,$@).txt
 
 
-.PHONY: tests
+.PHONY: tests tests-ci
 tests: ## runs unit tests
 	# running unit tests
-	@pytest -vv --color=yes --exitfirst --failed-first --durations=10 \
-	--cov-config=../../.coveragerc --cov=models_library --cov-report=term-missing \
-	--asyncio-mode=auto \
-	--pdb $(CURDIR)/tests
+	@pytest \
+		--asyncio-mode=auto \
+		--color=yes \
+		--cov-config=../../.coveragerc \
+		--cov-report=term-missing \
+		--cov=models_library \
+		--durations=10 \
+		--exitfirst \
+		--failed-first \
+		--pdb \
+		-vv \
+		$(CURDIR)/tests
 
+tests-ci: ## runs unit tests [ci-mode]
+	# running unit tests
+	@pytest \
+		--asyncio-mode=auto \
+		--color=yes \
+		--cov-append \
+		--cov-config=../../.coveragerc \
+		--cov-report=term-missing \
+		--cov-report=xml \
+		--cov=models_library \
+		--durations=10 \
+		--log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+		$(CURDIR)/tests
 
 .PHONY: project-jsonschema.ignore.json
 project-jsonschema.ignore.json: ## creates project-v0.0.1.json for DEV purposes

--- a/packages/postgres-database/Makefile
+++ b/packages/postgres-database/Makefile
@@ -16,10 +16,38 @@ install-dev install-prod install-ci: _check_venv_active ## install app in develo
 	pip-sync requirements/$(subst install-,,$@).txt
 
 
-.PHONY: tests
+.PHONY: tests tests-ci
 tests: ## runs unit tests
 	# running unit tests
-	@pytest -vv --asyncio-mode=auto --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests
+	@pytest \
+		--asyncio-mode=auto \
+		--color=yes \
+		--cov-config=../../.coveragerc \
+		--cov-report=term-missing \
+		--cov=simcore_postgres_database \
+		--durations=10 \
+		--exitfirst \
+		--failed-first \
+		--pdb \
+		-vv \
+		$(CURDIR)/tests
+
+tests-ci: ## runs unit tests [ci-mode]
+	# running unit tests
+	@pytest \
+		--asyncio-mode=auto \
+		--color=yes \
+		--cov-append \
+		--cov-config=../../.coveragerc \
+		--cov-report=term-missing \
+		--cov-report=xml \
+		--cov=simcore_postgres_database \
+		--durations=10 \
+		--log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+		$(CURDIR)/tests
 
 
 .PHONY: import-db

--- a/packages/service-integration/Makefile
+++ b/packages/service-integration/Makefile
@@ -15,11 +15,36 @@ install-dev install-prod install-ci: _check_venv_active ## install app in develo
 	pip-sync requirements/$(subst install-,,$@).txt
 
 
-.PHONY: tests
+.PHONY: tests tests-ci
 tests: ## runs unit tests
 	# running unit tests
-	@pytest -vv --exitfirst --failed-first --durations=10 --pdb $(CURDIR)/tests
+	@pytest \
+		--color=yes \
+		--cov-config=../../.coveragerc \
+		--cov-report=term-missing \
+		--cov=service_integration \
+		--durations=10 \
+		--exitfirst \
+		--failed-first \
+		--pdb \
+		-vv \
+		$(CURDIR)/tests
 
+tests-ci: ## runs unit tests [ci-mode]
+	# running unit tests
+	@pytest \
+		--color=yes \
+		--cov-append \
+		--cov-config=../../.coveragerc \
+		--cov-report=term-missing \
+		--cov-report=xml \
+		--cov=service_integration \
+		--durations=10 \
+		--log-date-format="%Y-%m-%d %H:%M:%S" \
+    --log-format="%(asctime)s %(levelname)s %(message)s" \
+    --verbose \
+    -m "not heavy_load" \
+		$(CURDIR)/tests
 
 
 # Auto-generation of compose-spec model

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
@@ -44,6 +44,7 @@ async def start_long_running_task(
     request: web.Request,
     task: TaskProtocol,
     *,
+    fire_and_forget: bool = False,
     task_context: TaskContext,
     **task_kwargs: Any,
 ) -> web.Response:
@@ -54,6 +55,7 @@ async def start_long_running_task(
         task_id = start_task(
             task_manager,
             task,
+            fire_and_forget=fire_and_forget,
             task_context=task_context,
             task_name=task_name,
             **task_kwargs,

--- a/packages/service-library/src/servicelib/long_running_tasks/_models.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/_models.py
@@ -71,6 +71,10 @@ class TrackedTask(BaseModel):
     task_progress: TaskProgress
     # NOTE: this context lifetime is with the tracked task (similar to aiohttp storage concept)
     task_context: dict[str, Any]
+    fire_and_forget: bool = Field(
+        ...,
+        description="if True then the task will not be auto-cancelled if no one enquires of its status",
+    )
 
     started: datetime = Field(default_factory=datetime.utcnow)
     last_status_check: Optional[datetime] = Field(

--- a/packages/service-library/tests/long_running_tasks/test_long_running_tasks_task.py
+++ b/packages/service-library/tests/long_running_tasks/test_long_running_tasks_task.py
@@ -119,6 +119,20 @@ async def test_checked_task_is_not_auto_removed(tasks_manager: TasksManager):
     assert result
 
 
+async def test_fire_and_forget_task_is_not_auto_removed(tasks_manager: TasksManager):
+    task_id = start_task(
+        tasks_manager,
+        a_background_task,
+        raise_when_finished=False,
+        total_sleep=5 * TEST_CHECK_STALE_INTERVAL_S,
+        fire_and_forget=True,
+    )
+    await asyncio.sleep(2 * TEST_CHECK_STALE_INTERVAL_S + 1)
+    # the task shall still be present
+    status = tasks_manager.get_task_status(task_id, with_task_context=None)
+    assert not status.done, "task was removed although it is fire and forget"
+
+
 async def test_get_result_of_unfinished_task_raises(tasks_manager: TasksManager):
     task_id = start_task(
         tasks_manager,

--- a/packages/service-library/tests/long_running_tasks/test_long_running_tasks_task.py
+++ b/packages/service-library/tests/long_running_tasks/test_long_running_tasks_task.py
@@ -127,10 +127,15 @@ async def test_fire_and_forget_task_is_not_auto_removed(tasks_manager: TasksMana
         total_sleep=5 * TEST_CHECK_STALE_INTERVAL_S,
         fire_and_forget=True,
     )
-    await asyncio.sleep(2 * TEST_CHECK_STALE_INTERVAL_S + 1)
-    # the task shall still be present
+    await asyncio.sleep(3 * TEST_CHECK_STALE_INTERVAL_S)
+    # the task shall still be present even if we did not check the status before
     status = tasks_manager.get_task_status(task_id, with_task_context=None)
     assert not status.done, "task was removed although it is fire and forget"
+    # the task shall finish
+    await asyncio.sleep(3 * TEST_CHECK_STALE_INTERVAL_S)
+    # get the result
+    task_result = tasks_manager.get_task_result(task_id, with_task_context=None)
+    assert task_result == 42
 
 
 async def test_get_result_of_unfinished_task_raises(tasks_manager: TasksManager):

--- a/packages/settings-library/Makefile
+++ b/packages/settings-library/Makefile
@@ -30,7 +30,7 @@ tests: ## runs unit tests
 		-vv \
 		$(CURDIR)/tests
 
-tests-ci: ## runs unit tests
+tests-ci: ## runs unit tests [ci-mode]
 	# running unit tests
 	@pytest \
 		--color=yes \

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers_crud.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers_crud.py
@@ -137,6 +137,7 @@ async def create_projects(request: web.Request):
         query_params=query_params,
         user_id=req_ctx.user_id,
         predefined_project=predefined_project,
+        fire_and_forget=True,
     )
 
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
This PR allows to disable the auto-cancellation mechanism when a client stops asking for the status of a long running task
The auto-cancel process is disabled for study copying.

Bonus:
- service integration lib, models lib and postgres-database lib CI now use Makefile recipes

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```
make build up-prod
```
Create a large study, initiate a duplication, refresh the browser page (F5) --> the copy completes

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
