### PR TITLE
✨ Prevent deprecated services to start

### DIFF
--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -566,7 +566,10 @@ class ServiceMetaData(_BaseServiceCommonDataModel):
     name: Optional[str]
     thumbnail: Optional[HttpUrl]
     description: Optional[str]
-    deprecated: Optional[datetime]
+    deprecated: Optional[datetime] = Field(
+        default=None,
+        description="If filled with a date, then the service is to be deprecated at that date (e.g. cannot start anymore)",
+    )
 
     # user-defined metatada
     classifiers: Optional[list[str]]

--- a/packages/service-library/src/servicelib/aiohttp/requests_validation.py
+++ b/packages/service-library/src/servicelib/aiohttp/requests_validation.py
@@ -4,7 +4,7 @@ These functions are analogous to `pydantic.tools.parse_obj_as(model_class, obj)`
 """
 
 from contextlib import contextmanager
-from typing import Iterator, Type, TypeVar
+from typing import Iterator, TypeVar
 
 from aiohttp import web
 from pydantic import BaseModel, ValidationError
@@ -52,7 +52,12 @@ def handle_validation_as_http_error(
                 for e in details
             ]
             error_str = json_dumps(
-                {"error": {"status": web.HTTPBadRequest.status_code, "errors": errors}}
+                {
+                    "error": {
+                        "status": web.HTTPUnprocessableEntity.status_code,
+                        "errors": errors,
+                    }
+                }
             )
         else:
             # NEW proposed error for https://github.com/ITISFoundation/osparc-simcore/issues/443
@@ -66,7 +71,7 @@ def handle_validation_as_http_error(
                 }
             )
 
-        raise web.HTTPBadRequest(
+        raise web.HTTPUnprocessableEntity(
             reason=reason_msg,
             text=error_str,
             content_type=MIMETYPE_APPLICATION_JSON,
@@ -82,7 +87,7 @@ def handle_validation_as_http_error(
 
 
 def parse_request_path_parameters_as(
-    parameters_schema: Type[ModelType],
+    parameters_schema: type[ModelType],
     request: web.Request,
     *,
     use_enveloped_error_v1: bool = True,
@@ -101,7 +106,7 @@ def parse_request_path_parameters_as(
 
 
 def parse_request_query_parameters_as(
-    parameters_schema: Type[ModelType],
+    parameters_schema: type[ModelType],
     request: web.Request,
     *,
     use_enveloped_error_v1: bool = True,
@@ -121,7 +126,7 @@ def parse_request_query_parameters_as(
 
 
 async def parse_request_body_as(
-    model_schema: Type[ModelType],
+    model_schema: type[ModelType],
     request: web.Request,
     *,
     use_enveloped_error_v1: bool = True,

--- a/packages/service-library/tests/aiohttp/test_requests_validation.py
+++ b/packages/service-library/tests/aiohttp/test_requests_validation.py
@@ -192,7 +192,7 @@ async def test_parse_request_with_invalid_path_params(
         params=query_params.as_params(),
         json=body.dict(),
     )
-    assert r.status == web.HTTPBadRequest.status_code, f"{await r.text()}"
+    assert r.status == web.HTTPUnprocessableEntity.status_code, f"{await r.text()}"
 
     errors = await r.json()
     assert errors["error"].pop("resource")
@@ -221,7 +221,7 @@ async def test_parse_request_with_invalid_query_params(
         params={},
         json=body.dict(),
     )
-    assert r.status == web.HTTPBadRequest.status_code, f"{await r.text()}"
+    assert r.status == web.HTTPUnprocessableEntity.status_code, f"{await r.text()}"
 
     errors = await r.json()
     assert errors["error"].pop("resource")
@@ -250,7 +250,7 @@ async def test_parse_request_with_invalid_body(
         params=query_params.as_params(),
         json={"invalid": "body"},
     )
-    assert r.status == web.HTTPBadRequest.status_code, f"{await r.text()}"
+    assert r.status == web.HTTPUnprocessableEntity.status_code, f"{await r.text()}"
 
     errors = await r.json()
 

--- a/services/api-server/src/simcore_service_api_server/api/dependencies/application.py
+++ b/services/api-server/src/simcore_service_api_server/api/dependencies/application.py
@@ -2,9 +2,15 @@ from typing import Any, Callable
 
 from fastapi import Request
 
+from ...core.settings import ApplicationSettings
+
 
 def get_reverse_url_mapper(request: Request) -> Callable:
     def reverse_url_mapper(name: str, **path_params: Any) -> str:
         return request.url_for(name, **path_params)
 
     return reverse_url_mapper
+
+
+def get_settings(request: Request) -> ApplicationSettings:
+    return request.app.state.settings

--- a/services/api-server/src/simcore_service_api_server/core/settings.py
+++ b/services/api-server/src/simcore_service_api_server/core/settings.py
@@ -95,6 +95,9 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
     API_SERVER_DIRECTOR_V2: Optional[DirectorV2Settings] = Field(
         auto_default_from_env=True
     )
+    API_SERVER_DEFAULT_PRODUCT_NAME: str = Field(
+        default="osparc", description="The API-server default product name"
+    )
 
     # DIAGNOSTICS
     API_SERVER_TRACING: Optional[TracingSettings] = Field(auto_default_from_env=True)

--- a/services/api-server/src/simcore_service_api_server/modules/director_v2.py
+++ b/services/api-server/src/simcore_service_api_server/modules/director_v2.py
@@ -118,7 +118,7 @@ class DirectorV2Api(BaseServiceClientApi):
         return computation_task
 
     async def start_computation(
-        self, project_id: UUID, user_id: PositiveInt
+        self, project_id: UUID, user_id: PositiveInt, product_name: str
     ) -> ComputationTaskGet:
 
         with handle_errors_context(project_id):
@@ -128,6 +128,7 @@ class DirectorV2Api(BaseServiceClientApi):
                     "user_id": user_id,
                     "project_id": str(project_id),
                     "start_pipeline": True,
+                    "product_name": product_name,
                 },
             )
             resp.raise_for_status()

--- a/services/catalog/src/simcore_service_catalog/api/routes/services.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import urllib.parse
-from typing import Any, Dict, List, Optional, Set, Tuple, cast
+from typing import Any, Optional, cast
 
 from aiocache import cached
 from fastapi import APIRouter, Depends, Header, HTTPException, status
@@ -29,13 +29,13 @@ from ..dependencies.director import DirectorApi, get_director_api
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
-ServicesSelection = Set[Tuple[str, str]]
+ServicesSelection = set[tuple[str, str]]
 
 
 def _prepare_service_details(
-    service_in_registry: Dict[str, Any],
+    service_in_registry: dict[str, Any],
     service_in_db: ServiceMetaDataAtDB,
-    service_access_rights_in_db: List[ServiceAccessRightsAtDB],
+    service_access_rights_in_db: list[ServiceAccessRightsAtDB],
     service_owner: Optional[str],
 ) -> Optional[ServiceGet]:
     # compose service from registry and DB
@@ -67,7 +67,7 @@ def _build_cache_key(fct, *_, **kwargs):
 # NOTE: this call is pretty expensive and can be called several times
 # (when e2e runs or by the webserver when listing projects) therefore
 # a cache is setup here
-@router.get("", response_model=List[ServiceGet], **RESPONSE_MODEL_POLICY)
+@router.get("", response_model=list[ServiceGet], **RESPONSE_MODEL_POLICY)
 @cancellable_request
 @cached(
     ttl=LIST_SERVICES_CACHING_TTL,
@@ -119,6 +119,7 @@ async def list_services(
                 contact="nodetails@nodetails.com",
                 inputs={},
                 outputs={},
+                deprecated=services_in_db[(key, version)].deprecated,
             )
             for key, version in services_in_db
         ]
@@ -187,7 +188,7 @@ async def get_service(
 ):
     # check the service exists (raise HTTP_404_NOT_FOUND)
     if is_function_service(service_key):
-        frontend_service: Dict[str, Any] = get_function_service(
+        frontend_service: dict[str, Any] = get_function_service(
             key=service_key, version=service_version
         )
         _service_data = frontend_service
@@ -220,7 +221,7 @@ async def get_service(
     )
     if service_in_db:
         # we have full access, let's add the access to the output
-        service_access_rights: List[
+        service_access_rights: list[
             ServiceAccessRightsAtDB
         ] = await services_repo.get_service_access_rights(
             service.key, service.version, product_name=x_simcore_products_name

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -206,16 +206,12 @@ class ServicesRepository(BaseRepository):
                 raise ValueError(
                     f"{access_rights} does not correspond to service {new_service.key}:{new_service.version}"
                 )
-        # Set the deprecation datetime to None (will be converted top sql's null) if not given
-        new_service_dict = new_service.dict(by_alias=True)
-        if "deprecated" not in new_service_dict:
-            new_service_dict["deprecated"] = None
         async with self.db_engine.begin() as conn:
             # NOTE: this ensure proper rollback in case of issue
             result = await conn.execute(
                 # pylint: disable=no-value-for-parameter
                 services_meta_data.insert()
-                .values(**new_service_dict)
+                .values(**new_service.dict(by_alias=True))
                 .returning(literal_column("*"))
             )
             row = result.first()

--- a/services/catalog/src/simcore_service_catalog/models/schemas/services.py
+++ b/services/catalog/src/simcore_service_catalog/models/schemas/services.py
@@ -85,12 +85,12 @@ class ServiceGet(
                 "badges": None,
                 "authors": [
                     {
-                        "name": "Odei Maiz",
-                        "email": "maiz@itis.swiss",
+                        "name": "Red Pandas",
+                        "email": "redpandas@wonderland.com",
                         "affiliation": None,
                     }
                 ],
-                "contact": "maiz@itis.swiss",
+                "contact": "redpandas@wonderland.com",
                 "inputs": {},
                 "outputs": {
                     "outFile": {
@@ -102,7 +102,7 @@ class ServiceGet(
                         "widget": None,
                     }
                 },
-                "owner": "maiz@itis.swiss",
+                "owner": "redpandas@wonderland.com",
             }
         }
 

--- a/services/catalog/tests/unit/with_dbs/conftest.py
+++ b/services/catalog/tests/unit/with_dbs/conftest.py
@@ -5,6 +5,7 @@
 
 import itertools
 import random
+from datetime import datetime
 from random import randint
 from typing import Any, AsyncIterator, Awaitable, Callable, Iterable, Iterator
 
@@ -293,10 +294,15 @@ async def service_catalog_faker(
         return data
 
     def _fake_factory(
-        key, version, team_access=None, everyone_access=None, product=products_names[0]
+        key,
+        version,
+        team_access=None,
+        everyone_access=None,
+        product=products_names[0],
+        deprecated: Optional[datetime] = None,
     ) -> tuple[dict[str, Any], ...]:
 
-        service = _random_service(key=key, version=version)
+        service = _random_service(key=key, version=version, deprecated=deprecated)
 
         # owner always has full-access
         owner_access = _random_access(

--- a/services/catalog/tests/unit/with_dbs/conftest.py
+++ b/services/catalog/tests/unit/with_dbs/conftest.py
@@ -7,7 +7,7 @@ import itertools
 import random
 from datetime import datetime
 from random import randint
-from typing import Any, AsyncIterator, Awaitable, Callable, Iterable, Iterator
+from typing import Any, AsyncIterator, Awaitable, Callable, Iterable, Iterator, Optional
 
 import pytest
 import respx

--- a/services/catalog/tests/unit/with_dbs/test_entrypoint_services.py
+++ b/services/catalog/tests/unit/with_dbs/test_entrypoint_services.py
@@ -6,10 +6,14 @@
 # pylint: disable=unused-variable
 
 import re
-from typing import Callable, List
+from datetime import datetime, timedelta
+from typing import Callable
 
 from models_library.services import ServiceDockerData
+from pydantic import parse_obj_as
 from respx.router import MockRouter
+from simcore_service_catalog.models.schemas.services import ServiceGet
+from starlette import status
 from starlette.testclient import TestClient
 from yarl import URL
 
@@ -26,7 +30,7 @@ async def test_list_services_with_details(
     director_mockup: MockRouter,
     client: TestClient,
     user_id: int,
-    products_names: List[str],
+    products_names: list[str],
     service_catalog_faker: Callable,
     services_db_tables_injector: Callable,
     benchmark,
@@ -79,7 +83,7 @@ async def test_list_services_without_details(
     director_mockup: MockRouter,
     client: TestClient,
     user_id: int,
-    products_names: List[str],
+    products_names: list[str],
     service_catalog_faker: Callable,
     services_db_tables_injector: Callable,
     benchmark,
@@ -121,7 +125,7 @@ async def test_list_services_without_details_with_wrong_user_id_returns_403(
     director_mockup: MockRouter,
     client: TestClient,
     user_id: int,
-    products_names: List[str],
+    products_names: list[str],
     service_catalog_faker: Callable,
     services_db_tables_injector: Callable,
 ):
@@ -151,7 +155,7 @@ async def test_list_services_without_details_with_another_product_returns_other_
     director_mockup: MockRouter,
     client: TestClient,
     user_id: int,
-    products_names: List[str],
+    products_names: list[str],
     service_catalog_faker: Callable,
     services_db_tables_injector: Callable,
 ):
@@ -188,7 +192,7 @@ async def test_list_services_without_details_with_wrong_product_returns_0_servic
     director_mockup: MockRouter,
     client: TestClient,
     user_id: int,
-    products_names: List[str],
+    products_names: list[str],
     service_catalog_faker: Callable,
     services_db_tables_injector: Callable,
 ):
@@ -218,3 +222,65 @@ async def test_list_services_without_details_with_wrong_product_returns_0_servic
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 0
+
+
+async def test_list_services_that_are_deprecated(
+    mock_catalog_background_task,
+    director_mockup: MockRouter,
+    client: TestClient,
+    user_id: int,
+    products_names: list[str],
+    service_catalog_faker: Callable,
+    services_db_tables_injector: Callable,
+):
+    target_product = products_names[-1]
+    assert (
+        len(products_names) > 1
+    ), "please adjust the fixture to have the right number of products"
+    # injects fake data in db
+    deprecation_date = datetime.utcnow() + timedelta(days=1)
+    deprecated_service = service_catalog_faker(
+        "simcore/services/dynamic/jupyterlab",
+        "1.0.1",
+        team_access=None,
+        everyone_access=None,
+        product=target_product,
+        deprecated=deprecation_date,
+    )
+    await services_db_tables_injector([deprecated_service])
+
+    # check without details
+    url = URL("/v0/services").with_query({"user_id": user_id, "details": "false"})
+    resp = client.get(f"{url}", headers={"x-simcore-products-name": target_product})
+    assert resp.status_code == status.HTTP_200_OK
+    list_of_services = parse_obj_as(list[ServiceGet], resp.json())
+    assert list_of_services
+    assert len(list_of_services) == 1
+    received_service = list_of_services[0]
+    assert received_service.deprecated == deprecation_date
+
+    # for details, the director must return the same service
+    fake_registry_service_data = ServiceDockerData.Config.schema_extra["examples"][0]
+    director_mockup.get("/services", name="list_services").respond(
+        200,
+        json={
+            "data": [
+                {
+                    **fake_registry_service_data,
+                    **{
+                        "key": deprecated_service[0]["key"],
+                        "version": deprecated_service[0]["version"],
+                    },
+                }
+            ]
+        },
+    )
+
+    url = URL("/v0/services").with_query({"user_id": user_id, "details": "true"})
+    resp = client.get(f"{url}", headers={"x-simcore-products-name": target_product})
+    assert resp.status_code == status.HTTP_200_OK
+    list_of_services = parse_obj_as(list[ServiceGet], resp.json())
+    assert list_of_services
+    assert len(list_of_services) == 1
+    received_service = list_of_services[0]
+    assert received_service.deprecated == deprecation_date

--- a/services/catalog/tests/unit/with_dbs/test_entrypoint_services.py
+++ b/services/catalog/tests/unit/with_dbs/test_entrypoint_services.py
@@ -9,6 +9,7 @@ import re
 from datetime import datetime, timedelta
 from typing import Callable
 
+import pytest
 from models_library.services import ServiceDockerData
 from pydantic import parse_obj_as
 from respx.router import MockRouter
@@ -23,6 +24,11 @@ pytest_simcore_core_services_selection = [
 pytest_simcore_ops_services_selection = [
     "adminer",
 ]
+
+
+@pytest.fixture
+def disable_service_caching(monkeypatch):
+    monkeypatch.setenv("AIOCACHE_DISABLE", 1)
 
 
 async def test_list_services_with_details(
@@ -121,6 +127,7 @@ async def test_list_services_without_details(
 
 
 async def test_list_services_without_details_with_wrong_user_id_returns_403(
+    disable_service_caching,
     mock_catalog_background_task,
     director_mockup: MockRouter,
     client: TestClient,
@@ -151,6 +158,7 @@ async def test_list_services_without_details_with_wrong_user_id_returns_403(
 
 
 async def test_list_services_without_details_with_another_product_returns_other_services(
+    disable_service_caching,
     mock_catalog_background_task,
     director_mockup: MockRouter,
     client: TestClient,
@@ -188,6 +196,7 @@ async def test_list_services_without_details_with_another_product_returns_other_
 
 
 async def test_list_services_without_details_with_wrong_product_returns_0_service(
+    disable_service_caching,
     mock_catalog_background_task,
     director_mockup: MockRouter,
     client: TestClient,
@@ -225,6 +234,7 @@ async def test_list_services_without_details_with_wrong_product_returns_0_servic
 
 
 async def test_list_services_that_are_deprecated(
+    disable_service_caching,
     mock_catalog_background_task,
     director_mockup: MockRouter,
     client: TestClient,

--- a/services/director-v2/src/simcore_service_director_v2/api/dependencies/catalog.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/dependencies/catalog.py
@@ -1,0 +1,8 @@
+from fastapi import Request
+
+from ...modules.catalog import CatalogClient
+
+
+def get_catalog_client(request: Request) -> CatalogClient:
+    client = CatalogClient.instance(request.app)
+    return client

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -164,7 +164,10 @@ async def create_computation(
                 )
 
             if deprecated_tasks := await find_deprecated_tasks(
-                comp_tasks, catalog_client
+                computation.user_id,
+                computation.product_name,
+                inserted_comp_tasks,
+                catalog_client,
             ):
                 raise HTTPException(
                     status_code=status.HTTP_406_NOT_ACCEPTABLE,

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -47,7 +47,6 @@ from ...models.schemas.comp_tasks import (
     ComputationGet,
     ComputationStop,
 )
-from ...modules.catalog import CatalogClient
 from ...modules.comp_scheduler.base_scheduler import BaseCompScheduler
 from ...modules.db.repositories.comp_pipelines import CompPipelinesRepository
 from ...modules.db.repositories.comp_runs import CompRunsRepository
@@ -66,7 +65,6 @@ from ...utils.dags import (
     create_minimal_computational_graph_based_on_selection,
     find_computational_node_cycles,
 )
-from ..dependencies.catalog import get_catalog_client
 from ..dependencies.database import get_repository
 from ..dependencies.director_v0 import get_director_v0_client
 from ..dependencies.scheduler import get_scheduler
@@ -98,7 +96,6 @@ async def create_computation(
     comp_runs_repo: CompRunsRepository = Depends(get_repository(CompRunsRepository)),
     director_client: DirectorV0Client = Depends(get_director_v0_client),
     scheduler: BaseCompScheduler = Depends(get_scheduler),
-    catalog_client: CatalogClient = Depends(get_catalog_client),
 ) -> ComputationGet:
     log.debug(
         "User %s is creating a new computation from project %s",

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -55,7 +55,6 @@ from ...modules.db.repositories.comp_tasks import CompTasksRepository
 from ...modules.db.repositories.projects import ProjectsRepository
 from ...modules.director_v0 import DirectorV0Client
 from ...utils.computations import (
-    find_deprecated_tasks,
     get_pipeline_state_from_task_states,
     is_pipeline_running,
     is_pipeline_stopped,
@@ -161,14 +160,6 @@ async def create_computation(
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                     detail=f"Project {computation.project_id} has no computational services",
-                )
-
-            if deprecated_tasks := await find_deprecated_tasks(
-                comp_tasks, catalog_client
-            ):
-                raise HTTPException(
-                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                    detail=f"Project {computation.project_id} cannot run since it contains deprecated tasks {deprecated_tasks}",
                 )
 
             await scheduler.run_new_pipeline(

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -24,6 +24,7 @@ from models_library.clusters import DEFAULT_CLUSTER_ID
 from models_library.projects import ProjectAtDB, ProjectID
 from models_library.services import ServiceKeyVersion
 from models_library.users import UserID
+from models_library.utils.fastapi_encoders import jsonable_encoder
 from pydantic import AnyHttpUrl, parse_obj_as
 from servicelib.async_utils import run_sequentially_in_context
 from starlette import status
@@ -148,7 +149,7 @@ async def create_computation(
             ):
                 raise HTTPException(
                     status_code=status.HTTP_406_NOT_ACCEPTABLE,
-                    detail=f"Project {computation.project_id} cannot run since it contains deprecated tasks {deprecated_tasks}",
+                    detail=f"Project {computation.project_id} cannot run since it contains deprecated tasks {jsonable_encoder( deprecated_tasks)}",
                 )
         # ok so put the tasks in the db
         await comp_pipelines_repo.upsert_pipeline(

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -162,7 +162,7 @@ async def create_computation(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                     detail=f"Project {computation.project_id} has no computational services",
                 )
-
+            assert computation.product_name  # nosec
             if deprecated_tasks := await find_deprecated_tasks(
                 computation.user_id,
                 computation.product_name,

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -119,6 +119,9 @@ async def create_computation(
                 detail=f"Project {computation.project_id} already started, current state is {pipeline_state}",
             )
 
+        if is_any_task_deprecated(comp_tasks):
+            raise HTTPException(status_code=status.HTTP_406)
+
         # create the complete DAG graph
         complete_dag = create_complete_dag(project.workbench)
         # find the minimal viable graph to be run

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -47,6 +47,7 @@ from ...models.schemas.comp_tasks import (
     ComputationGet,
     ComputationStop,
 )
+from ...modules.catalog import CatalogClient
 from ...modules.comp_scheduler.base_scheduler import BaseCompScheduler
 from ...modules.db.repositories.comp_pipelines import CompPipelinesRepository
 from ...modules.db.repositories.comp_runs import CompRunsRepository
@@ -66,6 +67,7 @@ from ...utils.dags import (
     create_minimal_computational_graph_based_on_selection,
     find_computational_node_cycles,
 )
+from ..dependencies.catalog import get_catalog_client
 from ..dependencies.database import get_repository
 from ..dependencies.director_v0 import get_director_v0_client
 from ..dependencies.scheduler import get_scheduler
@@ -97,6 +99,7 @@ async def create_computation(
     comp_runs_repo: CompRunsRepository = Depends(get_repository(CompRunsRepository)),
     director_client: DirectorV0Client = Depends(get_director_v0_client),
     scheduler: BaseCompScheduler = Depends(get_scheduler),
+    catalog_client: CatalogClient = Depends(get_catalog_client),
 ) -> ComputationGet:
     log.debug(
         "User %s is creating a new computation from project %s",

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -54,6 +54,7 @@ from ...modules.db.repositories.comp_tasks import CompTasksRepository
 from ...modules.db.repositories.projects import ProjectsRepository
 from ...modules.director_v0 import DirectorV0Client
 from ...utils.computations import (
+    find_deprecated_tasks,
     get_pipeline_state_from_task_states,
     is_pipeline_running,
     is_pipeline_stopped,
@@ -157,6 +158,14 @@ async def create_computation(
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                     detail=f"Project {computation.project_id} has no computational services",
+                )
+
+            if deprecated_tasks := await find_deprecated_tasks(
+                comp_tasks, catalog_client
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_406_NOT_ACCEPTABLE,
+                    detail=f"Project {computation.project_id} cannot run since it contains deprecated tasks {deprecated_tasks}",
                 )
 
             await scheduler.run_new_pipeline(

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/comp_tasks.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from models_library.clusters import ClusterID
 from models_library.projects import ProjectID
@@ -21,17 +21,18 @@ class ComputationCreate(BaseModel):
     user_id: UserID
     project_id: ProjectID
     start_pipeline: Optional[bool] = Field(
-        False, description="if True the computation pipeline will start right away"
+        default=False,
+        description="if True the computation pipeline will start right away",
     )
-    subgraph: Optional[List[NodeID]] = Field(
-        None,
+    subgraph: Optional[list[NodeID]] = Field(
+        default=None,
         description="An optional set of nodes that must be executed, if empty the whole pipeline is executed",
     )
     force_restart: Optional[bool] = Field(
-        False, description="if True will force re-running all dependent nodes"
+        default=False, description="if True will force re-running all dependent nodes"
     )
     cluster_id: Optional[ClusterID] = Field(
-        None,
+        default=None,
         description="the computation shall use the cluster described by its id, 0 is the default cluster",
     )
 

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/comp_tasks.py
@@ -20,6 +20,7 @@ class ComputationGet(ComputationTask):
 class ComputationCreate(BaseModel):
     user_id: UserID
     project_id: ProjectID
+    product_name: str
     start_pipeline: Optional[bool] = Field(
         default=False,
         description="if True the computation pipeline will start right away",

--- a/services/director-v2/src/simcore_service_director_v2/modules/catalog.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/catalog.py
@@ -66,7 +66,7 @@ class CatalogClient:
 
         resp = await self.request(
             "GET",
-            f"/services/{urllib.parse.quote(service_key, safe='')}/{service_version}/specifications",
+            f"/services/{urllib.parse.quote( service_key, safe='')}/{service_version}/specifications",
             params={"user_id": user_id},
         )
         resp.raise_for_status()

--- a/services/director-v2/src/simcore_service_director_v2/modules/catalog.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/catalog.py
@@ -66,7 +66,7 @@ class CatalogClient:
 
         resp = await self.request(
             "GET",
-            f"/services/{urllib.parse.quote( service_key, safe='')}/{service_version}/specifications",
+            f"/services/{urllib.parse.quote(service_key, safe='')}/{service_version}/specifications",
             params={"user_id": user_id},
         )
         resp.raise_for_status()

--- a/services/director-v2/src/simcore_service_director_v2/modules/catalog.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/catalog.py
@@ -60,6 +60,26 @@ class CatalogClient:
         return await self.client.request(method, tail_path, **kwargs)
 
     @log_decorator(logger=logger)
+    async def get_service(
+        self,
+        user_id: UserID,
+        service_key: ServiceKey,
+        service_version: ServiceVersion,
+        product_name: str,
+    ) -> dict[str, Any]:
+
+        resp = await self.request(
+            "GET",
+            f"/services/{urllib.parse.quote( service_key, safe='')}/{service_version}",
+            params={"user_id": user_id},
+            headers={"X-Simcore-Products-Name": product_name},
+        )
+        resp.raise_for_status()
+        if resp.status_code == status.HTTP_200_OK:
+            return resp.json()
+        raise HTTPException(status_code=resp.status_code, detail=resp.content)
+
+    @log_decorator(logger=logger)
     async def get_service_specifications(
         self, user_id: UserID, service_key: ServiceKey, service_version: ServiceVersion
     ) -> dict[str, Any]:

--- a/services/director-v2/src/simcore_service_director_v2/utils/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/computations.py
@@ -5,6 +5,7 @@ from models_library.projects_state import RunningState
 from models_library.services import SERVICE_KEY_RE
 
 from ..models.domains.comp_tasks import CompTaskAtDB
+from ..modules.catalog import CatalogClient
 from ..modules.db.tables import NodeClass
 
 log = logging.getLogger(__name__)
@@ -92,3 +93,10 @@ def is_pipeline_running(pipeline_state: RunningState) -> bool:
 
 def is_pipeline_stopped(pipeline_state: RunningState) -> bool:
     return not pipeline_state.is_running()
+
+
+async def find_deprecated_tasks(
+    comp_tasks: list[CompTaskAtDB], catalog_client: CatalogClient
+) -> list[CompTaskAtDB]:
+    deprecated_tasks = []
+    return deprecated_tasks

--- a/services/director-v2/src/simcore_service_director_v2/utils/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/computations.py
@@ -1,11 +1,11 @@
 import logging
 import re
-from typing import List, Set
 
 from models_library.projects_state import RunningState
 from models_library.services import SERVICE_KEY_RE
 
 from ..models.domains.comp_tasks import CompTaskAtDB
+from ..modules.catalog import CatalogClient
 from ..modules.db.tables import NodeClass
 
 log = logging.getLogger(__name__)
@@ -51,13 +51,13 @@ _TASK_TO_PIPELINE_CONVERSIONS = {
 }
 
 
-def get_pipeline_state_from_task_states(tasks: List[CompTaskAtDB]) -> RunningState:
+def get_pipeline_state_from_task_states(tasks: list[CompTaskAtDB]) -> RunningState:
 
     # compute pipeline state from task states
     if not tasks:
         return RunningState.UNKNOWN
     # put in a set of unique values
-    set_states: Set[RunningState] = {task.state for task in tasks}
+    set_states: set[RunningState] = {task.state for task in tasks}
     if len(set_states) == 1:
         # there is only one state, so it's the one
         the_state = next(iter(set_states))
@@ -93,3 +93,10 @@ def is_pipeline_running(pipeline_state: RunningState) -> bool:
 
 def is_pipeline_stopped(pipeline_state: RunningState) -> bool:
     return not pipeline_state.is_running()
+
+
+async def find_deprecated_tasks(
+    comp_tasks: list[CompTaskAtDB], catalog_client: CatalogClient
+) -> list[CompTaskAtDB]:
+    deprecated_tasks = []
+    return deprecated_tasks

--- a/services/director-v2/src/simcore_service_director_v2/utils/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/computations.py
@@ -5,7 +5,6 @@ from models_library.projects_state import RunningState
 from models_library.services import SERVICE_KEY_RE
 
 from ..models.domains.comp_tasks import CompTaskAtDB
-from ..modules.catalog import CatalogClient
 from ..modules.db.tables import NodeClass
 
 log = logging.getLogger(__name__)
@@ -93,10 +92,3 @@ def is_pipeline_running(pipeline_state: RunningState) -> bool:
 
 def is_pipeline_stopped(pipeline_state: RunningState) -> bool:
     return not pipeline_state.is_running()
-
-
-async def find_deprecated_tasks(
-    comp_tasks: list[CompTaskAtDB], catalog_client: CatalogClient
-) -> list[CompTaskAtDB]:
-    deprecated_tasks = []
-    return deprecated_tasks

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -876,6 +876,7 @@ def test_pipeline_with_control_loop_made_of_dynamic_services_is_allowed(
     registered_user: Callable,
     project: Callable,
     jupyter_service: dict[str, Any],
+    product_name: str,
 ):
     user = registered_user()
     # create a workbench with just 2 dynamic service in a cycle
@@ -916,6 +917,7 @@ def test_pipeline_with_control_loop_made_of_dynamic_services_is_allowed(
             "user_id": user["id"],
             "project_id": str(project_with_dynamic_node.uuid),
             "start_pipeline": True,
+            "product_name": product_name,
         },
     )
     assert (
@@ -929,6 +931,7 @@ def test_pipeline_with_control_loop_made_of_dynamic_services_is_allowed(
             "user_id": user["id"],
             "project_id": str(project_with_dynamic_node.uuid),
             "start_pipeline": False,
+            "product_name": product_name,
         },
     )
     assert (
@@ -943,6 +946,7 @@ def test_pipeline_with_cycle_containing_a_computational_service_is_forbidden(
     project: Callable,
     sleeper_service: dict[str, Any],
     jupyter_service: dict[str, Any],
+    product_name: str,
 ):
     user = registered_user()
     # create a workbench with just 2 dynamic service in a cycle
@@ -995,6 +999,7 @@ def test_pipeline_with_cycle_containing_a_computational_service_is_forbidden(
             "user_id": user["id"],
             "project_id": str(project_with_cycly_and_comp_service.uuid),
             "start_pipeline": True,
+            "product_name": product_name,
         },
     )
     assert (
@@ -1008,6 +1013,7 @@ def test_pipeline_with_cycle_containing_a_computational_service_is_forbidden(
             "user_id": user["id"],
             "project_id": str(project_with_cycly_and_comp_service.uuid),
             "start_pipeline": False,
+            "product_name": product_name,
         },
     )
     assert (
@@ -1024,6 +1030,7 @@ async def test_burst_create_computations(
     update_project_workbench_with_comp_tasks: Callable,
     fake_workbench_computational_pipeline_details: PipelineDetails,
     fake_workbench_computational_pipeline_details_completed: PipelineDetails,
+    product_name: str,
 ):
     user = registered_user()
     sleepers_project = project(user, workbench=fake_workbench_without_outputs)
@@ -1036,6 +1043,7 @@ async def test_burst_create_computations(
                 "user_id": user["id"],
                 "project_id": str(project.uuid),
                 "start_pipeline": start_pipeline,
+                "product_name": product_name,
             },
             timeout=60,
         )

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -128,12 +128,6 @@ def fake_workbench_computational_pipeline_details_not_started(
     return completed_pipeline_details
 
 
-@pytest.fixture(scope="session")
-def product_name() -> str:
-    # NOTE: this is the default the catalog currently uses
-    return "osparc"
-
-
 @pytest.mark.parametrize(
     "body,exp_response",
     [

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -16,7 +16,6 @@ import httpx
 import pytest
 import sqlalchemy as sa
 from _pytest.monkeypatch import MonkeyPatch
-from faker import Faker
 from httpx import AsyncClient
 from models_library.clusters import DEFAULT_CLUSTER_ID
 from models_library.projects import ProjectAtDB
@@ -129,9 +128,10 @@ def fake_workbench_computational_pipeline_details_not_started(
     return completed_pipeline_details
 
 
-@pytest.fixture
-def product_name(faker: Faker) -> str:
-    return faker.name()
+@pytest.fixture(scope="session")
+def product_name() -> str:
+    # NOTE: this is the default the catalog currently uses
+    return "osparc"
 
 
 @pytest.mark.parametrize(

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -911,7 +911,7 @@ def test_pipeline_with_control_loop_made_of_dynamic_services_is_allowed(
             "user_id": user["id"],
             "project_id": str(project_with_dynamic_node.uuid),
             "start_pipeline": True,
-            "product_name": product_name,
+            "product_name": osparc_product_name,
         },
     )
     assert (
@@ -925,7 +925,7 @@ def test_pipeline_with_control_loop_made_of_dynamic_services_is_allowed(
             "user_id": user["id"],
             "project_id": str(project_with_dynamic_node.uuid),
             "start_pipeline": False,
-            "product_name": product_name,
+            "product_name": osparc_product_name,
         },
     )
     assert (
@@ -993,7 +993,7 @@ def test_pipeline_with_cycle_containing_a_computational_service_is_forbidden(
             "user_id": user["id"],
             "project_id": str(project_with_cycly_and_comp_service.uuid),
             "start_pipeline": True,
-            "product_name": product_name,
+            "product_name": osparc_product_name,
         },
     )
     assert (
@@ -1007,7 +1007,7 @@ def test_pipeline_with_cycle_containing_a_computational_service_is_forbidden(
             "user_id": user["id"],
             "project_id": str(project_with_cycly_and_comp_service.uuid),
             "start_pipeline": False,
-            "product_name": product_name,
+            "product_name": osparc_product_name,
         },
     )
     assert (
@@ -1037,7 +1037,7 @@ async def test_burst_create_computations(
                 "user_id": user["id"],
                 "project_id": str(project.uuid),
                 "start_pipeline": start_pipeline,
-                "product_name": product_name,
+                "product_name": osparc_product_name,
             },
             timeout=60,
         )

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -178,7 +178,7 @@ async def test_start_empty_computation_is_refused(
     async_client: httpx.AsyncClient,
     registered_user: Callable,
     project: Callable,
-    product_name: str,
+    osparc_product_name: str,
 ):
     user = registered_user()
     empty_project = project(user)
@@ -187,7 +187,7 @@ async def test_start_empty_computation_is_refused(
         project=empty_project,
         user_id=user["id"],
         start_pipeline=True,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
     )
 
@@ -357,7 +357,7 @@ async def test_run_partial_computation(
     update_project_workbench_with_comp_tasks: Callable,
     fake_workbench_without_outputs: dict[str, Any],
     params: PartialComputationParams,
-    product_name: str,
+    osparc_product_name: str,
 ):
     user = registered_user()
     sleepers_project: ProjectAtDB = project(
@@ -400,7 +400,7 @@ async def test_run_partial_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=True,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_201_CREATED,
         subgraph=[
             str(node_id)
@@ -444,7 +444,7 @@ async def test_run_partial_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=True,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         subgraph=[
             str(node_id)
@@ -465,7 +465,7 @@ async def test_run_partial_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=True,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_201_CREATED,
         subgraph=[
             str(node_id)
@@ -500,7 +500,7 @@ async def test_run_computation(
     update_project_workbench_with_comp_tasks: Callable,
     fake_workbench_computational_pipeline_details: PipelineDetails,
     fake_workbench_computational_pipeline_details_completed: PipelineDetails,
-    product_name: str,
+    osparc_product_name: str,
 ):
     user = registered_user()
     sleepers_project = project(user, workbench=fake_workbench_without_outputs)
@@ -510,7 +510,7 @@ async def test_run_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=True,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_201_CREATED,
     )
     task_out = ComputationGet.parse_obj(response.json())
@@ -556,7 +556,7 @@ async def test_run_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=True,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
     )
 
@@ -576,7 +576,7 @@ async def test_run_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=True,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_201_CREATED,
         force_restart=True,
     )
@@ -612,7 +612,7 @@ async def test_abort_computation(
     project: Callable,
     fake_workbench_without_outputs: dict[str, Any],
     fake_workbench_computational_pipeline_details: PipelineDetails,
-    product_name: str,
+    osparc_product_name: str,
 ):
     user = registered_user()
     # we need long running tasks to ensure cancellation is done properly
@@ -628,7 +628,7 @@ async def test_abort_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=True,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_201_CREATED,
     )
     task_out = ComputationGet.parse_obj(response.json())
@@ -693,7 +693,7 @@ async def test_update_and_delete_computation(
     fake_workbench_without_outputs: dict[str, Any],
     fake_workbench_computational_pipeline_details_not_started: PipelineDetails,
     fake_workbench_computational_pipeline_details: PipelineDetails,
-    product_name: str,
+    osparc_product_name: str,
 ):
     user = registered_user()
     sleepers_project = project(user, workbench=fake_workbench_without_outputs)
@@ -703,7 +703,7 @@ async def test_update_and_delete_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=False,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_201_CREATED,
     )
     task_out = ComputationGet.parse_obj(response.json())
@@ -724,7 +724,7 @@ async def test_update_and_delete_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=False,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_201_CREATED,
     )
     task_out = ComputationGet.parse_obj(response.json())
@@ -745,7 +745,7 @@ async def test_update_and_delete_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=False,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_201_CREATED,
     )
     task_out = ComputationGet.parse_obj(response.json())
@@ -766,7 +766,7 @@ async def test_update_and_delete_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=True,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_201_CREATED,
     )
     task_out = ComputationGet.parse_obj(response.json())
@@ -798,7 +798,7 @@ async def test_update_and_delete_computation(
         project=sleepers_project,
         user_id=user["id"],
         start_pipeline=False,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_403_FORBIDDEN,
     )
 
@@ -825,7 +825,7 @@ async def test_pipeline_with_no_computational_services_still_create_correct_comp
     registered_user: Callable,
     project: Callable,
     jupyter_service: dict[str, Any],
-    product_name: str,
+    osparc_product_name: str,
 ):
     user = registered_user()
     # create a workbench with just a dynamic service
@@ -846,7 +846,7 @@ async def test_pipeline_with_no_computational_services_still_create_correct_comp
         project=project_with_dynamic_node,
         user_id=user["id"],
         start_pipeline=True,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
     )
 
@@ -856,7 +856,7 @@ async def test_pipeline_with_no_computational_services_still_create_correct_comp
         project=project_with_dynamic_node,
         user_id=user["id"],
         start_pipeline=False,
-        product_name=product_name,
+        product_name=osparc_product_name,
         expected_response_status_code=status.HTTP_201_CREATED,
     )
     assert (
@@ -870,7 +870,7 @@ def test_pipeline_with_control_loop_made_of_dynamic_services_is_allowed(
     registered_user: Callable,
     project: Callable,
     jupyter_service: dict[str, Any],
-    product_name: str,
+    osparc_product_name: str,
 ):
     user = registered_user()
     # create a workbench with just 2 dynamic service in a cycle
@@ -940,7 +940,7 @@ def test_pipeline_with_cycle_containing_a_computational_service_is_forbidden(
     project: Callable,
     sleeper_service: dict[str, Any],
     jupyter_service: dict[str, Any],
-    product_name: str,
+    osparc_product_name: str,
 ):
     user = registered_user()
     # create a workbench with just 2 dynamic service in a cycle
@@ -1024,7 +1024,7 @@ async def test_burst_create_computations(
     update_project_workbench_with_comp_tasks: Callable,
     fake_workbench_computational_pipeline_details: PipelineDetails,
     fake_workbench_computational_pipeline_details_completed: PipelineDetails,
-    product_name: str,
+    osparc_product_name: str,
 ):
     user = registered_user()
     sleepers_project = project(user, workbench=fake_workbench_without_outputs)

--- a/services/director-v2/tests/integration/conftest.py
+++ b/services/director-v2/tests/integration/conftest.py
@@ -37,6 +37,6 @@ def update_project_workbench_with_comp_tasks(
 
 
 @pytest.fixture(scope="session")
-def product_name() -> str:
+def osparc_product_name() -> str:
     # NOTE: this is the default the catalog currently uses
     return "osparc"

--- a/services/director-v2/tests/integration/conftest.py
+++ b/services/director-v2/tests/integration/conftest.py
@@ -34,3 +34,9 @@ def update_project_workbench_with_comp_tasks(
             )
 
     yield updator
+
+
+@pytest.fixture(scope="session")
+def product_name() -> str:
+    # NOTE: this is the default the catalog currently uses
+    return "osparc"

--- a/services/director-v2/tests/integration/shared_comp_utils.py
+++ b/services/director-v2/tests/integration/shared_comp_utils.py
@@ -1,6 +1,6 @@
 import json
 import time
-from typing import List, Optional
+from typing import Optional
 from uuid import UUID
 
 import httpx
@@ -27,6 +27,7 @@ async def create_pipeline(
     *,
     project: ProjectAtDB,
     user_id: UserID,
+    product_name: str,
     start_pipeline: bool,
     expected_response_status_code: int,
     **kwargs,
@@ -37,6 +38,7 @@ async def create_pipeline(
             "user_id": user_id,
             "project_id": str(project.uuid),
             "start_pipeline": start_pipeline,
+            "product_name": product_name,
             **kwargs,
         },
     )
@@ -78,7 +80,7 @@ async def assert_and_wait_for_pipeline_status(
     url: AnyHttpUrl,
     user_id: UserID,
     project_uuid: UUID,
-    wait_for_states: Optional[List[RunningState]] = None,
+    wait_for_states: Optional[list[RunningState]] = None,
 ) -> ComputationGet:
     if not wait_for_states:
         wait_for_states = [

--- a/services/director-v2/tests/unit/with_dbs/test_route_computations.py
+++ b/services/director-v2/tests/unit/with_dbs/test_route_computations.py
@@ -80,9 +80,9 @@ def fake_service_details(mocks_dir: Path) -> ServiceDockerData:
     return ServiceDockerData(**fake_service_data)
 
 
-@pytest.fixture(params=range(len(ServiceExtras.Config.schema_extra["examples"])))
-def fake_service_extras(request) -> ServiceExtras:
-    extra_example = ServiceExtras.Config.schema_extra["examples"][request.param]
+@pytest.fixture
+def fake_service_extras() -> ServiceExtras:
+    extra_example = ServiceExtras.Config.schema_extra["examples"][2]
     random_extras = ServiceExtras(**extra_example)
     assert random_extras is not None
     return random_extras
@@ -117,7 +117,7 @@ def mocked_director_service_fcts(
         yield respx_mock
 
 
-async def test_start_computation_with_deprecated_services_raises(
+async def test_start_computation(
     minimal_configuration: None,
     mocked_director_service_fcts,
     fake_workbench_without_outputs: dict[str, Any],
@@ -136,7 +136,7 @@ async def test_start_computation_with_deprecated_services_raises(
             )
         ),
     )
-    assert response.status_code == status.HTTP_406_NOT_ACCEPTABLE, response.text
+    assert response.status_code == status.HTTP_201_CREATED, response.text
 
 
 async def test_get_computation_from_empty_project(

--- a/services/director-v2/tests/unit/with_dbs/test_route_computations.py
+++ b/services/director-v2/tests/unit/with_dbs/test_route_computations.py
@@ -121,12 +121,8 @@ async def test_start_computation_with_deprecated_services_raises(
     minimal_configuration: None,
     mocked_director_service_fcts,
     fake_workbench_without_outputs: dict[str, Any],
-    fake_workbench_adjacency: dict[str, Any],
     registered_user: Callable[..., dict[str, Any]],
     project: Callable[..., ProjectAtDB],
-    pipeline: Callable[..., CompPipelineAtDB],
-    tasks: Callable[..., list[CompTaskAtDB]],
-    faker: Faker,
     async_client: httpx.AsyncClient,
 ):
     user = registered_user()

--- a/services/director-v2/tests/unit/with_dbs/test_route_computations.py
+++ b/services/director-v2/tests/unit/with_dbs/test_route_computations.py
@@ -139,6 +139,28 @@ async def test_start_computation(
     assert response.status_code == status.HTTP_201_CREATED, response.text
 
 
+async def test_start_computation_with_deprecated_services_raises_406(
+    minimal_configuration: None,
+    mocked_director_service_fcts,
+    fake_workbench_without_outputs: dict[str, Any],
+    registered_user: Callable[..., dict[str, Any]],
+    project: Callable[..., ProjectAtDB],
+    async_client: httpx.AsyncClient,
+):
+    user = registered_user()
+    proj = project(user, workbench=fake_workbench_without_outputs)
+    create_computation_url = httpx.URL("/v2/computations")
+    response = await async_client.post(
+        create_computation_url,
+        json=jsonable_encoder(
+            ComputationCreate(
+                user_id=user["id"], project_id=proj.uuid, start_pipeline=True
+            )
+        ),
+    )
+    assert response.status_code == status.HTTP_406_NOT_ACCEPTABLE, response.text
+
+
 async def test_get_computation_from_empty_project(
     minimal_configuration: None,
     fake_workbench_without_outputs: dict[str, Any],

--- a/services/director-v2/tests/unit/with_dbs/test_route_computations.py
+++ b/services/director-v2/tests/unit/with_dbs/test_route_computations.py
@@ -177,7 +177,7 @@ async def test_start_computation(
     minimal_configuration: None,
     mocked_director_service_fcts,
     mocked_catalog_service_fcts,
-    product_name: str,
+    osparc_product_name: str,
     fake_workbench_without_outputs: dict[str, Any],
     registered_user: Callable[..., dict[str, Any]],
     project: Callable[..., ProjectAtDB],
@@ -193,7 +193,7 @@ async def test_start_computation(
                 user_id=user["id"],
                 project_id=proj.uuid,
                 start_pipeline=True,
-                product_name=product_name,
+                product_name=osparc_product_name,
             )
         ),
     )
@@ -204,7 +204,7 @@ async def test_start_computation_with_deprecated_services_raises_406(
     minimal_configuration: None,
     mocked_director_service_fcts,
     mocked_catalog_service_fcts_deprecated,
-    product_name: str,
+    osparc_product_name: str,
     fake_workbench_without_outputs: dict[str, Any],
     fake_workbench_adjacency: dict[str, Any],
     registered_user: Callable[..., dict[str, Any]],
@@ -221,7 +221,7 @@ async def test_start_computation_with_deprecated_services_raises_406(
                 user_id=user["id"],
                 project_id=proj.uuid,
                 start_pipeline=True,
-                product_name=product_name,
+                product_name=osparc_product_name,
             )
         ),
     )

--- a/services/director-v2/tests/unit/with_dbs/test_route_computations.py
+++ b/services/director-v2/tests/unit/with_dbs/test_route_computations.py
@@ -135,6 +135,28 @@ def mocked_catalog_service_fcts(
                 r"services/(simcore)%2F(services)%2F(comp|dynamic|frontend)%2F.+/(.+)"
             ),
             name="get_service",
+        ).respond(json=fake_service_details.dict(by_alias=True))
+
+        yield respx_mock
+
+
+@pytest.fixture
+def mocked_catalog_service_fcts_deprecated(
+    minimal_app: FastAPI,
+    fake_service_details: ServiceDockerData,
+    fake_service_extras: ServiceExtras,
+):
+    # pylint: disable=not-context-manager
+    with respx.mock(
+        base_url=minimal_app.state.settings.DIRECTOR_V2_CATALOG.api_base_url,
+        assert_all_called=False,
+        assert_all_mocked=True,
+    ) as respx_mock:
+        respx_mock.get(
+            re.compile(
+                r"services/(simcore)%2F(services)%2F(comp|dynamic|frontend)%2F.+/(.+)"
+            ),
+            name="get_service",
         ).respond(
             json=fake_service_details.copy(
                 update={
@@ -154,6 +176,7 @@ def product_name(faker: Faker) -> str:
 async def test_start_computation(
     minimal_configuration: None,
     mocked_director_service_fcts,
+    mocked_catalog_service_fcts,
     product_name: str,
     fake_workbench_without_outputs: dict[str, Any],
     registered_user: Callable[..., dict[str, Any]],
@@ -180,7 +203,7 @@ async def test_start_computation(
 async def test_start_computation_with_deprecated_services_raises_406(
     minimal_configuration: None,
     mocked_director_service_fcts,
-    mocked_catalog_service_fcts,
+    mocked_catalog_service_fcts_deprecated,
     product_name: str,
     fake_workbench_without_outputs: dict[str, Any],
     fake_workbench_adjacency: dict[str, Any],

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -514,10 +514,10 @@ qx.Class.define("osparc.data.model.Node", {
           this.startDynamicService();
         })
         .catch(err => {
-          let errorMsg = "Error when starting " + key + ":" + version;
+          let errorMsg = this.tr("Error when starting ") + key + ":" + version;
           this.getStatus().setInteractive("failed");
           if ("status" in err && err.status === 406) {
-            errorMsg = this.getKey() + ":" + this.getVersion() + "is deprecated";
+            errorMsg = this.getKey() + ":" + this.getVersion() + this.tr(" is deprecated");
             this.getStatus().setInteractive("deprecated");
           }
           const errorMsgData = {
@@ -526,7 +526,7 @@ qx.Class.define("osparc.data.model.Node", {
             level: "ERROR"
           };
           this.fireDataEvent("showInLogger", errorMsgData);
-          osparc.component.message.FlashMessenger.getInstance().logAs(this.tr(errorMsg), "ERROR");
+          osparc.component.message.FlashMessenger.getInstance().logAs(errorMsg, "ERROR");
         });
     },
 
@@ -618,7 +618,7 @@ qx.Class.define("osparc.data.model.Node", {
         const data = this.__settingsForm.getData();
         form.setData(data);
       }, this);
-      propsForm.addListener("linkFieldModified", e => {
+      propsForm.addListener("linkFieldModified", e => {this.tr(
         const linkFieldModified = e.getData();
         const {
           portId,

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -618,7 +618,7 @@ qx.Class.define("osparc.data.model.Node", {
         const data = this.__settingsForm.getData();
         form.setData(data);
       }, this);
-      propsForm.addListener("linkFieldModified", e => {this.tr(
+      propsForm.addListener("linkFieldModified", e => {
         const linkFieldModified = e.getData();
         const {
           portId,

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -1175,9 +1175,9 @@ qx.Class.define("osparc.data.model.Node", {
       osparc.data.Resources.fetch("studies", "getNode", params)
         .then(data => this.__onNodeState(data))
         .catch(err => {
-          const errorMsg = `Error retrieving ${this.getLabel()} status: ${err}`;
+          let errorMsg = `Error retrieving ${this.getLabel()} status: ${err}`;
           if ("status" in err && err.status === 406) {
-            const errorMsg = this.getKey() + ":" + this.getVersion() + "is deprecated";
+            errorMsg = this.getKey() + ":" + this.getVersion() + "is deprecated";
           }
           const errorMsgData = {
             nodeId: this.getNodeId(),
@@ -1188,8 +1188,7 @@ qx.Class.define("osparc.data.model.Node", {
           if ("status" in err && err.status === 406) {
             this.getStatus().setInteractive("deprecated");
             osparc.component.message.FlashMessenger.getInstance().logAs(this.tr(errorMsg), "ERROR");
-          }
-          else if (this.__unresponsiveRetries > 0) {
+          } else if (this.__unresponsiveRetries > 0) {
             const retryMsg = `Retrying (${this.__unresponsiveRetries})`;
             const retryMsgData = {
               nodeId: this.getNodeId(),

--- a/services/web/client/source/class/osparc/data/model/Node.js
+++ b/services/web/client/source/class/osparc/data/model/Node.js
@@ -1176,13 +1176,20 @@ qx.Class.define("osparc.data.model.Node", {
         .then(data => this.__onNodeState(data))
         .catch(err => {
           const errorMsg = `Error retrieving ${this.getLabel()} status: ${err}`;
+          if ("status" in err && err.status === 406) {
+            const errorMsg = this.getKey() + ":" + this.getVersion() + "is deprecated";
+          }
           const errorMsgData = {
             nodeId: this.getNodeId(),
             msg: errorMsg,
             level: "ERROR"
           };
           this.fireDataEvent("showInLogger", errorMsgData);
-          if (this.__unresponsiveRetries > 0) {
+          if ("status" in err && err.status === 406) {
+            this.getStatus().setInteractive("deprecated");
+            osparc.component.message.FlashMessenger.getInstance().logAs(this.tr(errorMsg), "ERROR");
+          }
+          else if (this.__unresponsiveRetries > 0) {
             const retryMsg = `Retrying (${this.__unresponsiveRetries})`;
             const retryMsgData = {
               nodeId: this.getNodeId(),

--- a/services/web/client/source/class/osparc/data/model/NodeStatus.js
+++ b/services/web/client/source/class/osparc/data/model/NodeStatus.js
@@ -53,7 +53,7 @@ qx.Class.define("osparc.data.model.NodeStatus", {
     },
 
     interactive: {
-      check: ["idle", "starting", "pulling", "pending", "connecting", "ready", "failed"],
+      check: ["idle", "starting", "pulling", "pending", "connecting", "ready", "failed", "deprecated"],
       nullable: true,
       init: null,
       event: "changeInteractive",

--- a/services/web/client/source/class/osparc/utils/StatusUI.js
+++ b/services/web/client/source/class/osparc/utils/StatusUI.js
@@ -51,6 +51,7 @@ qx.Class.define("osparc.utils.StatusUI", {
         case "pulling":
         case "connecting":
           return "@FontAwesome5Solid/circle-notch/12";
+        case "deprecated":
         case "failed":
           return "@FontAwesome5Solid/exclamation-circle/12";
 
@@ -90,6 +91,8 @@ qx.Class.define("osparc.utils.StatusUI", {
           return qx.locale.Manager.tr("Ready");
         case "failed":
           return qx.locale.Manager.tr("Error");
+        case "deprecated":
+          return qx.locale.Manager.tr("Deprecated");
         case "starting":
           return qx.locale.Manager.tr("Starting...");
         case "pending":
@@ -131,6 +134,7 @@ qx.Class.define("osparc.utils.StatusUI", {
         case "pending":
         case "connecting":
           return "busy-orange";
+        case "deprecated":
         case "failed":
           return "failed-red";
 

--- a/services/web/server/src/simcore_service_webserver/catalog.py
+++ b/services/web/server/src/simcore_service_webserver/catalog.py
@@ -2,7 +2,6 @@
 
 """
 import logging
-from typing import List, Tuple
 
 from aiohttp import web
 from aiohttp.web_routedef import RouteDef
@@ -36,7 +35,7 @@ def setup_catalog(app: web.Application):
     # TODO: remove option disable_auth and replace by mocker.patch
 
     # resolve url
-    exclude: List[str] = []
+    exclude: list[str] = []
     route_def: RouteDef
     for route_def in catalog_handlers.routes:
         route_def.kwargs["name"] = operation_id = route_def.handler.__name__
@@ -60,7 +59,7 @@ def setup_catalog(app: web.Application):
     app[UnitRegistry.__name__] = UnitRegistry()
 
 
-__all__: Tuple[str] = (
+__all__ = (
     "get_services_for_user_in_product",
     "is_catalog_service_responsive",
     "setup_catalog",

--- a/services/web/server/src/simcore_service_webserver/director_v2_core_computations.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_core_computations.py
@@ -50,13 +50,20 @@ class ComputationsApi:
         assert isinstance(computation_task_out, dict)  # nosec
         return computation_task_out
 
-    async def start(self, project_id: ProjectID, user_id: UserID, **options) -> str:
+    async def start(
+        self, project_id: ProjectID, user_id: UserID, product_name: str, **options
+    ) -> str:
         computation_task_out = await request_director_v2(
             self._app,
             "POST",
             self._settings.base_url / "computations",
             expected_status=web.HTTPCreated,
-            data={"user_id": user_id, "project_id": project_id, **options},
+            data={
+                "user_id": user_id,
+                "project_id": project_id,
+                "product_name": product_name,
+                **options,
+            },
         )
         assert isinstance(computation_task_out, dict)  # nosec
         return computation_task_out["id"]
@@ -90,12 +97,15 @@ def set_client(app: web.Application, obj: ComputationsApi):
 
 @log_decorator(logger=log)
 async def create_or_update_pipeline(
-    app: web.Application, user_id: PositiveInt, project_id: UUID
+    app: web.Application, user_id: UserID, project_id: ProjectID
 ) -> Optional[DataType]:
     settings: DirectorV2Settings = get_plugin_settings(app)
 
     backend_url = settings.base_url / "computations"
-    body = {"user_id": user_id, "project_id": f"{project_id}"}
+    body = {
+        "user_id": user_id,
+        "project_id": f"{project_id}",
+    }
     # request to director-v2
     try:
         computation_task_out = await request_director_v2(

--- a/services/web/server/src/simcore_service_webserver/director_v2_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_handlers.py
@@ -78,7 +78,7 @@ async def start_computation(request: web.Request) -> web.Response:
             else True
         )
 
-        _started_pipelines_ids: tuple[str] = await asyncio.gather(
+        _started_pipelines_ids: list[str] = await asyncio.gather(
             *[
                 computations.start(pid, user_id, **options)
                 for pid in running_project_ids

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -13,6 +13,7 @@ import json
 import logging
 from collections import defaultdict
 from contextlib import suppress
+from datetime import datetime
 from pprint import pformat
 from typing import Any, Optional
 from uuid import UUID, uuid4
@@ -33,7 +34,7 @@ from models_library.projects_state import (
 from models_library.services_resources import ServiceResourcesDict
 from models_library.users import UserID
 from models_library.utils.fastapi_encoders import jsonable_encoder
-from pydantic.types import PositiveInt
+from pydantic import parse_obj_as
 from servicelib.aiohttp.application_keys import (
     APP_FIRE_AND_FORGET_TASKS_KEY,
     APP_JSONSCHEMA_SPECS_KEY,
@@ -179,6 +180,7 @@ async def add_project_node(
     service_key: str,
     service_version: str,
     service_id: Optional[str],
+    product_name: str,
 ) -> str:
     log.debug(
         "starting node %s:%s in project %s for user %s",
@@ -225,17 +227,22 @@ async def add_project_node(
             },
             node_id=NodeID(node_uuid),
         )
-        await director_v2_api.run_dynamic_service(
-            request.app,
-            project_id=project["uuid"],
-            user_id=user_id,
-            service_key=service_key,
-            service_version=service_version,
-            service_uuid=node_uuid,
-            request_dns=extract_dns_without_default_port(request.url),
-            request_scheme=request.headers.get("X-Forwarded-Proto", request.url.scheme),
-            service_resources=service_resources,
-        )
+        if not await is_service_deprecated(
+            request.app, user_id, service_key, service_version, product_name
+        ):
+            await director_v2_api.run_dynamic_service(
+                request.app,
+                project_id=project["uuid"],
+                user_id=user_id,
+                service_key=service_key,
+                service_version=service_version,
+                service_uuid=node_uuid,
+                request_dns=extract_dns_without_default_port(request.url),
+                request_scheme=request.headers.get(
+                    "X-Forwarded-Proto", request.url.scheme
+                ),
+                service_resources=service_resources,
+            )
     return node_uuid
 
 
@@ -726,6 +733,36 @@ async def add_project_states_for_user(
 #
 
 
+async def is_service_deprecated(
+    app: web.Application,
+    user_id: UserID,
+    service_key: str,
+    service_version: str,
+    product_name: str,
+) -> bool:
+    service = await catalog_client.get_service(
+        app, user_id, service_key, service_version, product_name
+    )
+    if deprecation_date := service.get("deprecated"):
+        deprecation_date = parse_obj_as(datetime, deprecation_date)
+        return datetime.utcnow() > deprecation_date
+    return False
+
+
+async def is_project_node_deprecated(
+    app: web.Application,
+    user_id: UserID,
+    project: dict[str, Any],
+    node_id: NodeID,
+    product_name: str,
+) -> bool:
+    if project_node := project.get("workbench", {}).get(f"{node_id}"):
+        return await is_service_deprecated(
+            app, user_id, project_node["key"], project_node["version"], product_name
+        )
+    raise NodeNotFoundError(project["uuid"], f"{node_id}")
+
+
 async def get_project_node_resources(
     app: web.Application, project: dict[str, Any], node_id: NodeID
 ) -> ServiceResourcesDict:
@@ -748,7 +785,7 @@ async def set_project_node_resources(
 
 
 async def run_project_dynamic_services(
-    request: web.Request, project: dict, user_id: PositiveInt
+    request: web.Request, project: dict, user_id: UserID, product_name: str
 ) -> None:
     # first get the services if they already exist
     log.debug(
@@ -776,10 +813,26 @@ async def run_project_dynamic_services(
     log.debug("Starting services: %s", f"{project_needed_services=}")
 
     unique_project_needed_services = set(project_needed_services.keys())
+    deprecated_services: list[bool] = await logged_gather(
+        *(
+            is_service_deprecated(
+                request.app,
+                user_id,
+                project_needed_services[service_uuid]["key"],
+                project_needed_services[service_uuid]["version"],
+                product_name,
+            )
+            for service_uuid in unique_project_needed_services
+        ),
+        reraise=True,
+    )
     service_resources_result: list[ServiceResourcesDict] = await logged_gather(
         *[
             get_project_node_resources(request.app, project=project, node_id=node_uuid)
-            for node_uuid in unique_project_needed_services
+            for node_uuid, is_deprecated in zip(
+                unique_project_needed_services, deprecated_services
+            )
+            if not is_deprecated
         ],
         reraise=True,
     )

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -13,6 +13,7 @@ import json
 import logging
 from collections import defaultdict
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime
 from pprint import pformat
 from typing import Any, Optional
@@ -22,7 +23,7 @@ from aiohttp import web
 from models_library.errors import ErrorDict
 from models_library.projects import ProjectID
 from models_library.projects_nodes import Node
-from models_library.projects_nodes_io import NodeID
+from models_library.projects_nodes_io import NodeID, NodeIDStr
 from models_library.projects_state import (
     Owner,
     ProjectLocked,
@@ -804,13 +805,19 @@ async def run_project_dynamic_services(
 
     running_service_uuids = [d["service_uuid"] for d in running_services]
     # now start them if needed
-    project_needed_services = {
+    project_needed_services: dict[NodeIDStr, dict[str, Any]] = {
         service_uuid: service
         for service_uuid, service in project["workbench"].items()
         if _is_node_dynamic(service["key"])
         and service_uuid not in running_service_uuids
     }
     log.debug("Starting services: %s", f"{project_needed_services=}")
+
+    @dataclass
+    class _ServiceParams:
+        node_id: NodeIDStr
+        resources: ServiceResourcesDict
+        deprecated: bool
 
     unique_project_needed_services = set(project_needed_services.keys())
     deprecated_services: list[bool] = await logged_gather(
@@ -828,17 +835,22 @@ async def run_project_dynamic_services(
     )
     service_resources_result: list[ServiceResourcesDict] = await logged_gather(
         *[
-            get_project_node_resources(request.app, project=project, node_id=node_uuid)
-            for node_uuid, is_deprecated in zip(
-                unique_project_needed_services, deprecated_services
+            get_project_node_resources(
+                request.app, project=project, node_id=NodeID(node_uuid)
             )
-            if not is_deprecated
+            for node_uuid in unique_project_needed_services
         ],
         reraise=True,
     )
-    service_resources_search: dict[str, ServiceResourcesDict] = dict(
-        zip(unique_project_needed_services, service_resources_result)
-    )
+
+    service_resources_search = {
+        n: _ServiceParams(n, r, d)
+        for n, r, d in zip(
+            unique_project_needed_services,
+            service_resources_result,
+            deprecated_services,
+        )
+    }
 
     start_service_tasks = [
         director_v2_api.run_dynamic_service(
@@ -850,9 +862,10 @@ async def run_project_dynamic_services(
             service_uuid=service_uuid,
             request_dns=extract_dns_without_default_port(request.url),
             request_scheme=request.headers.get("X-Forwarded-Proto", request.url.scheme),
-            service_resources=service_resources_search[service_uuid],
+            service_resources=service_resources_search[service_uuid].resources,
         )
         for service_uuid, service in project_needed_services.items()
+        if service_resources_search[service_uuid].deprecated is False
     ]
     results = await logged_gather(*start_service_tasks, reraise=True)
     log.debug("Services start result %s", results)

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -65,7 +65,7 @@ async def open_project(request: web.Request) -> web.Response:
 
         # user id opened project uuid
         await projects_api.run_project_dynamic_services(
-            request, project, req_ctx.user_id
+            request, project, req_ctx.user_id, req_ctx.product_name
         )
 
         # notify users that project is now opened

--- a/services/web/server/src/simcore_service_webserver/projects/projects_nodes_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_nodes_handlers.py
@@ -4,11 +4,20 @@
 
 import json
 import logging
-from typing import Union
+from typing import Optional, Union
 
 from aiohttp import web
 from models_library.projects_nodes import NodeID
-from servicelib.aiohttp.requests_validation import parse_request_path_parameters_as
+from models_library.services import ServiceKey, ServiceVersion
+
+#
+# projects/*/nodes COLLECTION -------------------------
+#
+from pydantic import BaseModel
+from servicelib.aiohttp.requests_validation import (
+    parse_request_body_as,
+    parse_request_path_parameters_as,
+)
 from servicelib.json_serialization import json_dumps
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
 
@@ -25,9 +34,11 @@ log = logging.getLogger(__name__)
 
 routes = web.RouteTableDef()
 
-#
-# projects/*/nodes COLLECTION -------------------------
-#
+
+class _CreateNodeBody(BaseModel):
+    service_key: ServiceKey
+    service_version: ServiceVersion
+    service_id: Optional[str] = None
 
 
 @routes.post(f"/{VTAG}/projects/{{project_id}}/nodes")
@@ -36,23 +47,20 @@ routes = web.RouteTableDef()
 async def create_node(request: web.Request) -> web.Response:
     req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(ProjectPathParams, request)
+    body = await parse_request_body_as(_CreateNodeBody, request)
 
-    try:
-        body = await request.json()
-        for required_key in ["service_key", "service_version"]:
-            if required_key not in body:
-                raise web.HTTPUnprocessableEntity(
-                    reason=f"{required_key} is missing from request body"
-                )
-
-    except json.JSONDecodeError as exc:
-        raise web.HTTPUnprocessableEntity(
-            reason=f"Invalid request body: {exc}"
-        ) from exc
-
+    if await projects_api.is_service_deprecated(
+        request.app,
+        req_ctx.user_id,
+        body.service_key,
+        body.service_version,
+        req_ctx.product_name,
+    ):
+        raise web.HTTPNotAcceptable(
+            reason=f"Service {body.service_key}:{body.service_version} is deprecated"
+        )
     try:
         # ensure the project exists
-
         project_data = await projects_api.get_project_for_user(
             request.app,
             project_uuid=f"{path_params.project_id}",
@@ -64,10 +72,9 @@ async def create_node(request: web.Request) -> web.Response:
                 request,
                 project_data,
                 req_ctx.user_id,
-                body["service_key"],
-                body["service_version"],
-                body["service_id"] if "service_id" in body else None,
-                req_ctx.product_name,
+                body.service_key,
+                body.service_version,
+                body.service_id,
             )
         }
         return web.json_response(

--- a/services/web/server/src/simcore_service_webserver/projects/projects_nodes_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_nodes_handlers.py
@@ -107,7 +107,7 @@ async def get_node(request: web.Request) -> web.Response:
             req_ctx.product_name,
         ):
             project_node = project["workbench"][f"{path_params.node_id}"]
-            raise web.HTTPNotFound(
+            raise web.HTTPNotAcceptable(
                 reason=f"Service {project_node['key']}:{project_node['version']} is deprecated!"
             )
 

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__delete.py
@@ -5,6 +5,7 @@
 
 
 from typing import Any, Callable
+from unittest import mock
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -96,7 +97,7 @@ async def test_delete_project(
     ],
 )
 async def test_delete_multiple_opened_project_forbidden(
-    mock_catalog_api: None,
+    mock_catalog_api: dict[str, mock.Mock],
     client,
     logged_user,
     user_project,

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__list.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__list.py
@@ -139,7 +139,7 @@ async def test_list_projects_with_invalid_pagination_parameters(
 ):
     await _list_projects(
         client,
-        web.HTTPBadRequest,
+        web.HTTPUnprocessableEntity,
         query_parameters={"limit": limit, "offset": offset},
         expected_error_msg=expected_error_msg,
         expected_error_code="value_error.number.not_ge",

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
@@ -297,7 +297,7 @@ async def test_open_project(
     mocked_director_v2_api,
     mock_service_resources: ServiceResourcesDict,
     mock_orphaned_services,
-    mock_catalog_api: None,
+    mock_catalog_api: dict[str, mock.Mock],
     disable_gc_manual_guest_users,
 ):
     # POST /v0/projects/{project_id}:open
@@ -418,7 +418,7 @@ async def test_get_active_project(
     expected,
     socketio_client_factory: Callable,
     mocked_director_v2_api,
-    mock_catalog_api: None,
+    mock_catalog_api: dict[str, mock.Mock],
     disable_gc_manual_guest_users,
 ):
     # login with socket using client session id
@@ -516,7 +516,7 @@ async def test_project_node_lifetime(
     expected_response_on_Delete,
     mocked_director_v2_api,
     storage_subsystem_mock,
-    mock_catalog_api: None,
+    mock_catalog_api: dict[str, mock.Mock],
     mocker,
     faker: Faker,
     disable_gc_manual_guest_users,
@@ -697,7 +697,7 @@ async def test_open_shared_project_2_users_locked(
     disable_gc_manual_guest_users,
     mocked_director_v2_api,
     mock_orphaned_services,
-    mock_catalog_api: None,
+    mock_catalog_api: dict[str, mock.Mock],
     clean_redis_table,
 ):
     # Use-case: user 1 opens a shared project, user 2 tries to open it as well
@@ -878,7 +878,7 @@ async def test_open_shared_project_at_same_time(
     disable_gc_manual_guest_users,
     mocked_director_v2_api,
     mock_orphaned_services,
-    mock_catalog_api: None,
+    mock_catalog_api: dict[str, mock.Mock],
     clean_redis_table,
 ):
     NUMBER_OF_ADDITIONAL_CLIENTS = 20
@@ -962,7 +962,7 @@ async def test_opened_project_can_still_be_opened_after_refreshing_tab(
     expected: ExpectedResponse,
     mocked_director_v2_api: dict[str, mock.MagicMock],
     mock_orphaned_services,
-    mock_catalog_api: None,
+    mock_catalog_api: dict[str, mock.Mock],
     disable_gc_manual_guest_users,
     clean_redis_table,
 ):

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
@@ -6,6 +6,7 @@
 import re
 from collections import UserDict
 from copy import deepcopy
+from datetime import datetime, timedelta
 from typing import Any
 from unittest import mock
 from uuid import UUID, uuid4
@@ -160,6 +161,7 @@ async def test_create_node_properly_upgrade_database(
     expected: ExpectedResponse,
     faker: Faker,
     mocked_director_v2_api: dict[str, mock.MagicMock],
+    mock_catalog_api: dict[str, mock.Mock],
     catalog_subsystem_mock,
     mocker: MockerFixture,
 ):
@@ -230,6 +232,86 @@ async def test_create_node_returns_422_if_body_is_missing(
         },
     ]:
         response = await client.post(url.path, json=partial_body)
-        await assert_status(response, expected.unprocessable)
+        assert response.status == expected.unprocessable.status_code
     # this does not start anything in the backend
+    mocked_director_v2_api["director_v2_api.run_dynamic_service"].assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "node_class, expect_run_service_call",
+    [("dynamic", True), ("comp", False), ("frontend", False)],
+)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
+async def test_create_node(
+    node_class: str,
+    expect_run_service_call: bool,
+    client: TestClient,
+    user_project: ProjectDict,
+    expected: ExpectedResponse,
+    faker: Faker,
+    mocked_director_v2_api: dict[str, mock.MagicMock],
+    mock_catalog_api: dict[str, mock.Mock],
+    mocker: MockerFixture,
+):
+    create_or_update_mock = mocker.patch(
+        "simcore_service_webserver.director_v2_api.create_or_update_pipeline",
+        autospec=True,
+        return_value=None,
+    )
+
+    assert client.app
+    url = client.app.router["create_node"].url_for(project_id=user_project["uuid"])
+
+    # Use-case 1.: not passing a service UUID will generate a new one on the fly
+    body = {
+        "service_key": f"simcore/services/{node_class}/{faker.pystr()}",
+        "service_version": f"{faker.random_int()}.{faker.random_int()}.{faker.random_int()}",
+    }
+    response = await client.post(url.path, json=body)
+    data, error = await assert_status(response, expected.created)
+    if data:
+        assert not error
+        create_or_update_mock.assert_called_once()
+        if expect_run_service_call:
+            mocked_director_v2_api[
+                "director_v2_api.run_dynamic_service"
+            ].assert_called_once()
+        else:
+            mocked_director_v2_api[
+                "director_v2_api.run_dynamic_service"
+            ].assert_not_called()
+    else:
+        assert error
+
+
+@pytest.mark.parametrize(
+    "node_class",
+    [("dynamic"), ("comp"), ("frontend")],
+)
+@pytest.mark.parametrize(*standard_role_response(), ids=str)
+async def test_creating_deprecated_node_returns_406_not_acceptable(
+    client: TestClient,
+    user_project: ProjectDict,
+    expected: ExpectedResponse,
+    faker: Faker,
+    mocked_director_v2_api: dict[str, mock.MagicMock],
+    mock_catalog_api: dict[str, mock.Mock],
+    node_class: str,
+):
+    mock_catalog_api["get_service"].return_value["deprecated"] = (
+        datetime.utcnow() - timedelta(days=1)
+    ).isoformat()
+    assert client.app
+    url = client.app.router["create_node"].url_for(project_id=user_project["uuid"])
+
+    # Use-case 1.: not passing a service UUID will generate a new one on the fly
+    body = {
+        "service_key": f"simcore/services/{node_class}/{faker.pystr()}",
+        "service_version": f"{faker.random_int()}.{faker.random_int()}.{faker.random_int()}",
+    }
+    response = await client.post(url.path, json=body)
+    data, error = await assert_status(response, expected.not_acceptable)
+    assert error
+    assert not data
+    # this does not start anything in the backend since this node is deprecated
     mocked_director_v2_api["director_v2_api.run_dynamic_service"].assert_not_called()

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
@@ -72,7 +72,7 @@ async def test_get_node_resources(
     mock_catalog_service_api_responses: None,
     mocked_director_v2_api: dict[str, mock.MagicMock],
     mock_orphaned_services,
-    mock_catalog_api: None,
+    mock_catalog_api: dict[str, mock.Mock],
     expected: type[web.HTTPException],
 ):
     assert client.app

--- a/services/web/server/tests/unit/with_dbs/03/meta_modeling/test_meta_modeling_iterations.py
+++ b/services/web/server/tests/unit/with_dbs/03/meta_modeling/test_meta_modeling_iterations.py
@@ -111,7 +111,7 @@ async def test_iterators_workflow(
     # TODO: create iterations, so user could explore parametrizations?
 
     # RUN metaproject ----------------------------------------------------------
-    async def _mock_start(project_id, user_id, **options):
+    async def _mock_start(project_id, user_id, product_name, **options):
         return f"{project_id}"
 
     mocker.patch(

--- a/services/web/server/tests/unit/with_dbs/_helpers.py
+++ b/services/web/server/tests/unit/with_dbs/_helpers.py
@@ -37,6 +37,9 @@ class ExpectedResponse(NamedTuple):
         type[web.HTTPForbidden],
         type[web.HTTPUnprocessableEntity],
     ]
+    not_acceptable: Union[
+        type[web.HTTPUnauthorized], type[web.HTTPForbidden], type[web.HTTPNotAcceptable]
+    ]
 
     def __str__(self) -> str:
         items = ",".join(f"{k}={v.__name__}" for k, v in self._asdict().items())
@@ -58,6 +61,7 @@ def standard_role_response() -> tuple[str, list[tuple[UserRole, ExpectedResponse
                     locked=web.HTTPUnauthorized,
                     accepted=web.HTTPUnauthorized,
                     unprocessable=web.HTTPUnauthorized,
+                    not_acceptable=web.HTTPUnauthorized,
                 ),
             ),
             (
@@ -71,6 +75,7 @@ def standard_role_response() -> tuple[str, list[tuple[UserRole, ExpectedResponse
                     locked=web.HTTPForbidden,
                     accepted=web.HTTPForbidden,
                     unprocessable=web.HTTPForbidden,
+                    not_acceptable=web.HTTPForbidden,
                 ),
             ),
             (
@@ -84,6 +89,7 @@ def standard_role_response() -> tuple[str, list[tuple[UserRole, ExpectedResponse
                     locked=HTTPLocked,
                     accepted=web.HTTPAccepted,
                     unprocessable=web.HTTPUnprocessableEntity,
+                    not_acceptable=web.HTTPNotAcceptable,
                 ),
             ),
             (
@@ -97,6 +103,7 @@ def standard_role_response() -> tuple[str, list[tuple[UserRole, ExpectedResponse
                     locked=HTTPLocked,
                     accepted=web.HTTPAccepted,
                     unprocessable=web.HTTPUnprocessableEntity,
+                    not_acceptable=web.HTTPNotAcceptable,
                 ),
             ),
         ],


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

Disallow starting deprecated dynamic services by returning a 406 status code (e.g. NotAcceptable). 
Opening a study with a deprecated dynamic service shows an error as well. But still allows to copy out the data of the service.

Starting a pipeline with deprecated computational services also returns a 406 but will need some frontend changes (@odeimaiz) in order to show a proper message.

<!-- Explain REVIEWERS what is this PR about -->
![image](https://user-images.githubusercontent.com/35365065/190977580-46107719-05b8-4064-a8a7-e29fdbe11245.png)

https://user-images.githubusercontent.com/35365065/190977837-64d29d7d-c193-40e7-9709-acc8aa06f0a7.mp4


## Some details
- director-v2 now needs to know the product name to check whether services in a pipeline are deprecated (NOTE: this is only check when starting the pipeline)
- api-server now has an ENV defining its default product name (was previously hard-coded)



## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
