### PR TITLE
🐛 Fix/confirmation codes

### DIFF
--- a/services/web/server/src/simcore_service_webserver/login/_confirmation.py
+++ b/services/web/server/src/simcore_service_webserver/login/_confirmation.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import Optional
 
 from aiohttp import web
+from yarl import URL
 
 from ..db_models import ConfirmationAction
 from .settings import LoginOptions
@@ -36,8 +37,12 @@ async def validate_confirmation_code(
     return confirmation
 
 
+def _url_for_confirmation(app: web.Application, code: str) -> URL:
+    return app.router["auth_confirmation"].url_for(code=code)
+
+
 def make_confirmation_link(request: web.Request, confirmation: ConfirmationDict) -> str:
-    link = request.app.router["auth_confirmation"].url_for(code=confirmation["code"])
+    link = _url_for_confirmation(request.app, code=confirmation["code"])
     return f"{request.scheme}://{request.host}{link}"
 
 

--- a/services/web/server/src/simcore_service_webserver/login/_confirmation.py
+++ b/services/web/server/src/simcore_service_webserver/login/_confirmation.py
@@ -7,6 +7,7 @@
 """
 import logging
 from datetime import datetime
+from typing import Optional
 
 from aiohttp import web
 
@@ -17,8 +18,13 @@ from .storage import AsyncpgStorage, ConfirmationDict
 log = logging.getLogger(__name__)
 
 
-async def validate_confirmation_code(code: str, db: AsyncpgStorage, cfg: LoginOptions):
-    confirmation: ConfirmationDict = await db.get_confirmation({"code": code})
+async def validate_confirmation_code(
+    code: str, db: AsyncpgStorage, cfg: LoginOptions
+) -> Optional[ConfirmationDict]:
+    """
+    Returns None if validation fails
+    """
+    confirmation: Optional[ConfirmationDict] = await db.get_confirmation({"code": code})
     if confirmation and is_confirmation_expired(cfg, confirmation):
         log.info(
             "Confirmation code '%s' %s. Deleting ...",
@@ -26,7 +32,7 @@ async def validate_confirmation_code(code: str, db: AsyncpgStorage, cfg: LoginOp
             "consumed" if confirmation else "expired",
         )
         await db.delete_confirmation(confirmation)
-        confirmation = None
+        return None
     return confirmation
 
 

--- a/services/web/server/src/simcore_service_webserver/login/handlers_confirmation.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_confirmation.py
@@ -54,7 +54,10 @@ async def email_confirmation(request: web.Request):
             )
 
         elif action == CHANGE_EMAIL:
+            #
             # TODO: compose error and send to front-end using fragments in the redirection
+            # But first we need to implement this refactoring https://github.com/ITISFoundation/osparc-simcore/issues/1975
+            #
             user_update = {"email": parse_obj_as(EmailStr, confirmation["data"])}
             user = await db.get_user({"id": confirmation["user_id"]})
             await db.update_user(user, user_update)

--- a/services/web/server/src/simcore_service_webserver/login/handlers_confirmation.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_confirmation.py
@@ -1,6 +1,7 @@
 import logging
 
 from aiohttp import web
+from pydantic import EmailStr, parse_obj_as
 from servicelib.aiohttp.rest_utils import extract_and_validate
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
 from yarl import URL
@@ -38,28 +39,40 @@ async def email_confirmation(request: web.Request):
     code = params["code"]
 
     confirmation = await validate_confirmation_code(code, db, cfg)
+    redirect_url = URL(cfg.LOGIN_REDIRECT)
 
-    if confirmation:
-        action = confirmation["action"]
-        redirect_url = URL(cfg.LOGIN_REDIRECT)
-
+    if confirmation and (action := confirmation["action"]):
         if action == REGISTRATION:
             user = await db.get_user({"id": confirmation["user_id"]})
             await db.update_user(user, {"status": ACTIVE})
             await db.delete_confirmation(confirmation)
-            log.debug("User %s registered", user)
             redirect_url = redirect_url.with_fragment("?registered=true")
+            log.debug(
+                "%s registered -> %s",
+                f"{user=}",
+                f"{redirect_url=}",
+            )
 
         elif action == CHANGE_EMAIL:
+            # TODO: compose error and send to front-end using fragments in the redirection
+            user_update = {"email": parse_obj_as(EmailStr, confirmation["data"])}
             user = await db.get_user({"id": confirmation["user_id"]})
-            await db.update_user(user, {"email": confirmation["data"]})
+            await db.update_user(user, user_update)
             await db.delete_confirmation(confirmation)
-            log.debug("User %s changed email", user)
+            log.debug(
+                "%s updated %s",
+                f"{user=}",
+                f"{user_update}",
+            )
 
         elif action == RESET_PASSWORD:
             # NOTE: By using fragments (instead of queries or path parameters), the browser does NOT reloads page
             redirect_url = redirect_url.with_fragment("reset-password?code=%s" % code)
-            log.debug("Reset password requested %s", confirmation)
+            log.debug(
+                "Reset password requested %s. %s",
+                f"{confirmation=}",
+                f"{redirect_url=}",
+            )
 
     raise web.HTTPFound(location=redirect_url)
 

--- a/services/web/server/src/simcore_service_webserver/login/storage.py
+++ b/services/web/server/src/simcore_service_webserver/login/storage.py
@@ -72,7 +72,10 @@ class AsyncpgStorage:
                 "data": data,
                 "created_at": datetime.utcnow(),
             }
-            await _sql.insert(conn, self.confirm_tbl, confirmation)
+            c = await _sql.insert(
+                conn, self.confirm_tbl, confirmation, returning="code"
+            )
+            assert code == c  # nosec
             return confirmation
 
     async def get_confirmation(self, filter_dict) -> asyncpg.Record:

--- a/services/web/server/src/simcore_service_webserver/login/storage.py
+++ b/services/web/server/src/simcore_service_webserver/login/storage.py
@@ -1,12 +1,10 @@
-import enum
 from datetime import datetime
 from logging import getLogger
-from typing import TypedDict
+from typing import Literal, Optional, TypedDict
 
 import asyncpg
 from aiohttp import web
 
-from ..db_models import ConfirmationAction, UserRole, UserStatus
 from . import _sql
 from .utils import get_random_string
 
@@ -15,16 +13,20 @@ log = getLogger(__name__)
 APP_LOGIN_STORAGE_KEY = f"{__name__}.APP_LOGIN_STORAGE_KEY"
 
 
-# SEE packages/postgres-database/src/simcore_postgres_database/models/confirmations.py
-class _ConfirmationDictRequired(TypedDict):
+## MODELS
+
+
+class ConfirmationDict(TypedDict):
+    # SEE packages/postgres-database/src/simcore_postgres_database/models/confirmations.py
     code: str
     user_id: int
-    action: str
-
-
-class ConfirmationDict(_ConfirmationDictRequired, total=False):
-    data: dict
+    action: Literal["REGISTRATION", "INVITATION", "RESET_PASSWORD", "CHANGE_EMAIL"]
     created_at: datetime
+    # SEE handlers_confirmation.py::email_confirmation to determine what type is associated to each action
+    data: Optional[str]
+
+
+## REPOSITORY
 
 
 class AsyncpgStorage:
@@ -70,7 +72,7 @@ class AsyncpgStorage:
                 "data": data,
                 "created_at": datetime.utcnow(),
             }
-            await _sql.insert(conn, self.confirm_tbl, confirmation, None)
+            await _sql.insert(conn, self.confirm_tbl, confirmation)
             return confirmation
 
     async def get_confirmation(self, filter_dict) -> asyncpg.Record:
@@ -89,29 +91,3 @@ def get_plugin_storage(app: web.Application) -> AsyncpgStorage:
     storage = app.get(APP_LOGIN_STORAGE_KEY)
     assert storage, "login plugin was not initialized"  # nosec
     return storage
-
-
-# helpers ----------------------------
-def _to_enum(data):
-    # FIXME: cannot modify asyncpg.Record:
-
-    # TODO: ensure columns names and types! User tables for that
-    # See https://docs.sqlalchemy.org/en/latest/core/metadata.html
-    if data:
-        for key, enumtype in (
-            ("status", UserStatus),
-            ("role", UserRole),
-            ("action", ConfirmationAction),
-        ):
-            if key in data:
-                data[key] = getattr(enumtype, data[key])
-    return data
-
-
-def _to_name(data):
-    if data:
-        for key in ("status", "role", "action"):
-            if key in data:
-                if isinstance(data[key], enum.Enum):
-                    data[key] = data[key].name
-    return data

--- a/services/web/server/tests/unit/with_dbs/03/test_login_registration.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_login_registration.py
@@ -207,11 +207,13 @@ async def test_registration_with_invitation(
     expected_response,
     mocker,
 ):
+    assert client.app
     mocker.patch(
         "simcore_service_webserver.login.handlers.get_plugin_settings",
         return_value=LoginSettings(
             LOGIN_REGISTRATION_CONFIRMATION_REQUIRED=False,
             LOGIN_REGISTRATION_INVITATION_REQUIRED=is_invitation_required,
+            LOGIN_TWILIO=None,
         ),
     )
 
@@ -227,7 +229,7 @@ async def test_registration_with_invitation(
         url = client.app.router["auth_register"].url_for()
 
         r = await client.post(
-            url,
+            f"{url}",
             json={
                 "email": EMAIL,
                 "password": PASSWORD,
@@ -242,7 +244,7 @@ async def test_registration_with_invitation(
         # check optional fields in body
         if not has_valid_invitation or not is_invitation_required:
             r = await client.post(
-                url, json={"email": "new-user" + EMAIL, "password": PASSWORD}
+                f"{url}", json={"email": "new-user" + EMAIL, "password": PASSWORD}
             )
             await assert_status(r, expected_response)
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

During manual tests today in TIP, found the following error
```log
ERROR: [2022-09-14 12:24:45,308/MainProcess] [servicelib.aiohttp.monitoring:middleware_handler(210)]  -  Unexpected server error "<class 'aiohttp.web_exceptions.HTTPInternalServerError'>" from access: 10.0.83.25 "GET /v0/auth/confirmation/1" done in 0.01 secs. Responding with status 500
Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.9/site-packages/servicelib/aiohttp/rest_middlewares.py", line 75, in _middleware_handler
    response = await handler(request)
  File "/home/scu/.venv/lib/python3.9/site-packages/servicelib/aiohttp/rest_middlewares.py", line 203, in _middleware_handler
    resp: _ResponseOrBodyData = await handler(request)
  File "/home/scu/.venv/lib/python3.9/site-packages/simcore_service_webserver/products_middlewares.py", line 57, in discover_product_middleware
    response = await handler(request)
  File "/home/scu/.venv/lib/python3.9/site-packages/servicelib/aiohttp/long_running_tasks/_error_handlers.py", line 14, in base_long_running_error_handler
    return await handler(request)
  File "/home/scu/.venv/lib/python3.9/site-packages/simcore_service_webserver/login/handlers_confirmation.py", line 64, in email_confirmation
    raise web.HTTPFound(location=redirect_url)
UnboundLocalError: local variable 'redirect_url' referenced before assignment
```

- 🐛  fixes``UnboundLocalError`` in the confirmation handler
- ♻️ improved confirmation model
- ✨ Adds ``server_default`` to ``confirmations.created_at`` column (does not require migration script) and docs all table

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

```cmd
cd services/web/services
make install-dev
pytest -vv tests/**/test_login_*.py
```

## Checklist

- [x] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [x] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [x] Unit tests for the changes exist
- [ ] Runs in the swarm
- [x] Documentation reflects the changes
- [x] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
