### PR TITLE
✨ Computational services integration version 1.1.0

### DIFF
--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/io.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/io.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import suppress
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 from models_library.basic_regex import MIME_TYPE_RE
 from models_library.generics import DictModel
@@ -26,7 +26,7 @@ class PortSchema(BaseModel):
 
     class Config:
         extra = Extra.forbid
-        schema_extra: Dict[str, Any] = {
+        schema_extra: dict[str, Any] = {
             "examples": [
                 {
                     "required": True,
@@ -61,11 +61,11 @@ class FilePortSchema(PortSchema):
 class FileUrl(BaseModel):
     url: AnyUrl
     file_mapping: Optional[str] = Field(
-        None,
+        default=None,
         description="Local file relpath name (if given), otherwise it takes the url filename",
     )
     file_mime_type: Optional[str] = Field(
-        None, description="the file MIME type", regex=MIME_TYPE_RE
+        default=None, description="the file MIME type", regex=MIME_TYPE_RE
     )
 
     class Config:
@@ -89,8 +89,8 @@ PortValue = Union[
     StrictFloat,
     StrictStr,
     FileUrl,
-    List[Any],
-    Dict[str, Any],
+    list[Any],
+    dict[str, Any],
     None,
 ]
 

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/models.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/models.py
@@ -1,13 +1,27 @@
-from typing import Dict, List
-
 from packaging import version
 from pydantic import BaseModel, ByteSize, Field
 
 LEGACY_INTEGRATION_VERSION = version.Version("0")
 
+# CHANGELOG:
+# INPUT_FOLDER/input.json --> INPUT_FOLDER/inputs.json
+# OUTPUT_FOLDER/output.json --> OUTPUT_FOLDER/outputs.json
+# logs folder removed since docker already provides a logging system
+VERSION_1_0_0 = version.Version("1.0.0")
+
+# CHANGELOG:
+# removes flat filesystem
+# /inputs/inputs.json --> contains non file data (strings, numbers, ...)
+# /inputs/input_1/... -> contains file data for input_1
+# /inputs/input_2/... -> contains file data for input_2
+# /outputs/outputs.json --> contains non file data
+# /outputs/output_1 --> contains non file data for output_1
+# /outputs/output_2 --> contains non file data for output_2
+VERSION_1_1_0 = version.Version("1.1.0")
+
 
 class ContainerHostConfig(BaseModel):
-    binds: List[str] = Field(
+    binds: list[str] = Field(
         ..., alias="Binds", description="A list of volume bindings for this container"
     )
     init: bool = Field(
@@ -22,8 +36,8 @@ class ContainerHostConfig(BaseModel):
 
 
 class DockerContainerConfig(BaseModel):
-    env: List[str] = Field(..., alias="Env")
-    cmd: List[str] = Field(..., alias="Cmd")
+    env: list[str] = Field(..., alias="Env")
+    cmd: list[str] = Field(..., alias="Cmd")
     image: str = Field(..., alias="Image")
-    labels: Dict[str, str] = Field(..., alias="Labels")
+    labels: dict[str, str] = Field(..., alias="Labels")
     host_config: ContainerHostConfig = Field(..., alias="HostConfig")


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
Brings version 1.1.0 integration of computational services

Before service input folders:
```bash
$INPUT_FOLDER/input_file_1
$INPUT_FOLDER/input_file_2
$INPUT_FOLDER/input_file_3
```
After
```bash
$INPUT_FOLDER/input_1/input_file_1
$INPUT_FOLDER/input_2/input_file_2
$INPUT_FOLDER/input_3/input_file_3
```

same goes with outputs

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
