### PR TITLE
🐛 Fixes ``Retry-After`` header in global_rate_limit_route

### DIFF
--- a/services/web/server/tests/unit/isolated/test_utils_rate_limiting.py
+++ b/services/web/server/tests/unit/isolated/test_utils_rate_limiting.py
@@ -4,12 +4,16 @@
 
 import asyncio
 import time
+from typing import Callable
 
 import pytest
 from aiohttp import web
+from aiohttp.test_utils import TestClient
 from aiohttp.web_exceptions import HTTPTooManyRequests
+from pydantic import ValidationError, conint, parse_obj_as
 from simcore_service_webserver.utils_rate_limiting import global_rate_limit_route
 
+TOTAL_TEST_TIME = 1  # secs
 MAX_NUM_REQUESTS = 3
 MEASURE_INTERVAL = 0.5
 MAX_REQUEST_RATE = MAX_NUM_REQUESTS / MEASURE_INTERVAL
@@ -22,35 +26,39 @@ async def get_ok_handler(_request: web.Request):
     return web.json_response({"value": 1})
 
 
+@pytest.fixture
+def client(event_loop, aiohttp_client: Callable) -> TestClient:
+    app = web.Application()
+    app.router.add_get("/", get_ok_handler)
+
+    return event_loop.run_until_complete(aiohttp_client(app))
+
+
+def test_rate_limit_route_decorator():
+    # decorated function keeps setup
+    assert get_ok_handler.rate_limit_setup == (MAX_NUM_REQUESTS, MEASURE_INTERVAL)
+
+
 @pytest.mark.parametrize(
     "requests_per_second",
     [0.5 * MAX_REQUEST_RATE, MAX_REQUEST_RATE, 2 * MAX_REQUEST_RATE],
 )
-async def test_global_rate_limit_route(requests_per_second, aiohttp_client):
-    #
-    app = web.Application()
-    app.router.add_get("/", get_ok_handler)
-
-    client = await aiohttp_client(app)
-    # ---
-
-    # decorated function keeps setup
-    assert get_ok_handler.rate_limit_setup == (MAX_NUM_REQUESTS, MEASURE_INTERVAL)
+async def test_global_rate_limit_route(requests_per_second: float, client: TestClient):
+    # WARNING: this test has some timings and might fail when using breakpoints
 
     # Creates desired stream of requests for 1 second
-    TOTAL_TEST_TIME = 1  # secs
     num_requests = int(requests_per_second * TOTAL_TEST_TIME)
     time_between_requests = 1.0 / requests_per_second
 
-    futures = []
+    tasks = []
     t0 = time.time()
-    while len(futures) < num_requests:
+    while len(tasks) < num_requests:
         t1 = time.time()
-        futures.append(asyncio.create_task(client.get("/")))
+        tasks.append(asyncio.create_task(client.get("/")))
         time.sleep(time_between_requests - (time.time() - t1))
 
     elapsed = time.time() - t0
-    count = len(futures)
+    count = len(tasks)
     print(
         count,
         "requests in",
@@ -63,20 +71,42 @@ async def test_global_rate_limit_route(requests_per_second, aiohttp_client):
     assert count == num_requests
     assert elapsed == pytest.approx(TOTAL_TEST_TIME, abs=0.1)
 
-    for i, fut in enumerate(futures):
-        while not fut.done():
+    msg = []
+    for i, task in enumerate(tasks):
+        while not task.done():
             await asyncio.sleep(0.1)
-        assert not fut.cancelled()
-        assert not fut.exception()
-        print("%2d" % i, fut.result().status)
+        assert not task.cancelled()
+        assert not task.exception()
+        msg.append(
+            (
+                "%2d" % i,
+                f"status={task.result().status}",
+                f"retry-after={task.result().headers.get('Retry-After')}",
+            )
+        )
+        print(*msg[-1])
 
     expected_status = 200
 
     # first requests are OK
-    assert all(f.result().status == expected_status for f in futures[:MAX_NUM_REQUESTS])
+    assert all(
+        t.result().status == expected_status for t in tasks[:MAX_NUM_REQUESTS]
+    ), f" Failed with { msg[:MAX_NUM_REQUESTS]}"
 
     if requests_per_second >= MAX_REQUEST_RATE:
         expected_status = HTTPTooManyRequests.status_code
 
     # after ...
-    assert all(f.result().status == expected_status for f in futures[MAX_NUM_REQUESTS:])
+    assert all(
+        t.result().status == expected_status for t in tasks[MAX_NUM_REQUESTS:]
+    ), f" Failed with { msg[MAX_NUM_REQUESTS:]}"
+
+    # checks Retry-After header
+    failed = []
+    for t in tasks:
+        if retry_after := t.result().headers.get("Retry-After"):
+            try:
+                parse_obj_as(conint(ge=1), retry_after)
+            except ValidationError as err:
+                failed.append((retry_after, f"{err}"))
+    assert not failed


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

- 🐛 Fixes ``Retry-After`` header in global_rate_limit_route
   - ``Retry-After`` is a relative time in secs, not absolute: see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429 
- ♻️ cleanup tests and updated implementation



## How to test

```cmd
cd services/web/server
make install-dev
pytest -vv tests/unit/isolated/test_utils_rate_limiting.py
```
