### PR TITLE
✨Metrics: Webserver provides a label for Simcore-User-Agent

### DIFF
--- a/packages/service-library/tests/aiohttp/test_monitoring.py
+++ b/packages/service-library/tests/aiohttp/test_monitoring.py
@@ -1,0 +1,142 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+
+from asyncio import AbstractEventLoop
+from typing import Any, Callable
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient
+from faker import Faker
+from prometheus_client.parser import text_string_to_metric_families
+from servicelib.aiohttp.monitoring import (
+    SIMCORE_USER_AGENT_HEADER,
+    UNDEFINED_REGULAR_USER_AGENT,
+    setup_monitoring,
+)
+
+
+@pytest.fixture
+def client(
+    event_loop: AbstractEventLoop,
+    aiohttp_client: Callable,
+    unused_tcp_port_factory: Callable,
+) -> TestClient:
+    ports = [unused_tcp_port_factory() for _ in range(2)]
+
+    async def monitored_request(request: web.Request) -> web.Response:
+        return web.json_response(data={"data": "OK"})
+
+    app = web.Application()
+    app.add_routes([web.get("/monitored_request", monitored_request)])
+
+    print("Resources:")
+    for resource in app.router.resources():
+        print(resource)
+
+    setup_monitoring(app, app_name="pytest_app", version="0.0.1")
+
+    return event_loop.run_until_complete(
+        aiohttp_client(app, server_kwargs={"port": ports[0]})
+    )
+
+
+def _assert_metrics_contain_entry(
+    metrics_as_text: str,
+    metric_name: str,
+    sample_name: str,
+    labels: dict[str, str],
+    value: Any,
+) -> None:
+    for metric_family in filter(
+        lambda family: family.name == metric_name,
+        text_string_to_metric_families(metrics_as_text),
+    ):
+        assert len(metric_family.samples) > 0
+        # NOTE: there might be any number of samples
+        filtered_samples = list(
+            filter(
+                lambda sample: sample.name == sample_name and sample.labels == labels,
+                metric_family.samples,
+            )
+        )
+        assert len(filtered_samples) == 1
+        sample = filtered_samples[0]
+        assert sample.value == value
+        print(f"Found {metric_name=} with expected {value=}")
+        return
+
+    assert False, f"Could not find metric with {metric_name=}"
+
+
+async def test_setup_monitoring(client: TestClient):
+    NUM_CALLS = 12
+    for _ in range(NUM_CALLS):
+        response = await client.get("/monitored_request")
+        assert response.status == web.HTTPOk.status_code
+        data = await response.json()
+        assert data
+        assert "data" in data
+        assert data["data"] == "OK"
+
+    response = await client.get("/metrics")
+    assert response.status == web.HTTPOk.status_code
+    # by calling it twice, the metrics endpoint should also be incremented
+    response = await client.get("/metrics")
+    assert response.status == web.HTTPOk.status_code
+    metrics_as_text = await response.text()
+    _assert_metrics_contain_entry(
+        metrics_as_text,
+        metric_name="http_requests",
+        sample_name="http_requests_total",
+        labels={
+            "app_name": "pytest_app",
+            "endpoint": "/monitored_request",
+            "http_status": "200",
+            "method": "GET",
+            "simcore_user_agent": UNDEFINED_REGULAR_USER_AGENT,
+        },
+        value=NUM_CALLS,
+    )
+
+    _assert_metrics_contain_entry(
+        metrics_as_text,
+        metric_name="http_requests",
+        sample_name="http_requests_total",
+        labels={
+            "app_name": "pytest_app",
+            "endpoint": "/metrics",
+            "http_status": "200",
+            "method": "GET",
+            "simcore_user_agent": UNDEFINED_REGULAR_USER_AGENT,
+        },
+        value=1,
+    )
+
+
+async def test_request_with_simcore_user_agent(client: TestClient, faker: Faker):
+    faker_simcore_user_agent = faker.name()
+    response = await client.get(
+        "/monitored_request",
+        headers={SIMCORE_USER_AGENT_HEADER: faker_simcore_user_agent},
+    )
+    assert response.status == web.HTTPOk.status_code
+
+    response = await client.get("/metrics")
+    assert response.status == web.HTTPOk.status_code
+    metrics_as_text = await response.text()
+    _assert_metrics_contain_entry(
+        metrics_as_text,
+        metric_name="http_requests",
+        sample_name="http_requests_total",
+        labels={
+            "app_name": "pytest_app",
+            "endpoint": "/monitored_request",
+            "http_status": "200",
+            "method": "GET",
+            "simcore_user_agent": faker_simcore_user_agent,
+        },
+        value=1,
+    )


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
This enhance the labels created by the **webserver** with the *simcore-user-agent* header added in #3410 

therefore http_requests_total now provide a lable **simcore_user_agent** which may be used in prometheus to filter out e2e/p2p tests, where the header is set to "puppeteer". The default is set to "undefined".


Important NOTE: This is currently only for metrics created by the **webserver**, i.e. not for number of service created/stopped.
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
