### PR TITLE
🐛 fixes CORS issue in puppeteer while testing with X-Simcore-User-Agent header

### DIFF
--- a/tests/e2e/utils/startPuppe.js
+++ b/tests/e2e/utils/startPuppe.js
@@ -3,20 +3,24 @@ const puppeteer = require('puppeteer');
 const LOGS_DIR = "../logs/";
 
 async function getBrowser(demo) {
-  let options = {};
+  let options = {
+    defaultViewport: null, // Defaults to an 800x600 viewport. null disables the default viewport.
+  };
   if (demo) {
     const visibleOptions = {
       headless: false,
       devTools: true,
-      defaultViewport: null, // Defaults to an 800x600 viewport. null disables the default viewport.
       slowMo: 80, // Slows down Puppeteer operations by the specified amount of milliseconds.
+      args: [
+        // https://github.com/puppeteer/puppeteer/issues/4889 : adding extra headers make CORS fail
+        '--disable-web-security',
+      ],
     };
     Object.assign(options, visibleOptions);
   }
   else {
     // https://github.com/puppeteer/puppeteer/issues/4889 : adding extra headers make CORS fail
     const woSandbox = {
-      defaultViewport: null,
       args: [
         '--no-sandbox',
         '--disable-setuid-sandbox',

--- a/tests/e2e/utils/startPuppe.js
+++ b/tests/e2e/utils/startPuppe.js
@@ -14,13 +14,15 @@ async function getBrowser(demo) {
     Object.assign(options, visibleOptions);
   }
   else {
+    // https://github.com/puppeteer/puppeteer/issues/4889 : adding extra headers make CORS fail
     const woSandbox = {
       defaultViewport: null,
       args: [
         '--no-sandbox',
         '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
-        '--start-maximized'
+        '--start-maximized',
+        '--disable-web-security'
       ]
     };
     Object.assign(options, woSandbox);

--- a/tests/e2e/utils/startPuppe.js
+++ b/tests/e2e/utils/startPuppe.js
@@ -13,20 +13,22 @@ async function getBrowser(demo) {
       slowMo: 80, // Slows down Puppeteer operations by the specified amount of milliseconds.
       args: [
         // https://github.com/puppeteer/puppeteer/issues/4889 : adding extra headers make CORS fail
+        // https://github.com/ITISFoundation/osparc-simcore/pull/3410
         '--disable-web-security',
       ],
     };
     Object.assign(options, visibleOptions);
   }
   else {
-    // https://github.com/puppeteer/puppeteer/issues/4889 : adding extra headers make CORS fail
     const woSandbox = {
       args: [
         '--no-sandbox',
         '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
         '--start-maximized',
-        '--disable-web-security'
+        // https://github.com/puppeteer/puppeteer/issues/4889 : adding extra headers make CORS fail
+        // https://github.com/ITISFoundation/osparc-simcore/pull/3410
+        '--disable-web-security',
       ]
     };
     Object.assign(options, woSandbox);


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
PR #3410 brought usage of setExtraHTTPHeaders in order to make all puppeteer requests to add some additional headers to make these requests detectable for metrics.

It seems puppeteer has an issue when this is enabled, that makes it fail in some way with CORS error see [this](https://github.com/puppeteer/puppeteer/issues/4889)

Therefore, and following that thread, the flag to disable security in the puppet was added.

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
