### PR TITLE
🐛 dy-volume removal service fixes and improvements

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/volume_remover.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/volume_remover.py
@@ -47,7 +47,7 @@ set -e;
 error_counter=0
 
 function retry {{
-  local retries={retries}
+  local retries=$1
   shift
 
   local count=0
@@ -69,7 +69,7 @@ function retry {{
 
 for volume_name in {volume_names_seq}
 do
-    retry 3 docker volume rm "$volume_name"
+    retry {retries} docker volume rm "$volume_name"
 done
 
 if [ "$error_counter" -ne "0" ]; then

--- a/services/director-v2/tests/unit/conftest.py
+++ b/services/director-v2/tests/unit/conftest.py
@@ -15,6 +15,7 @@ from typing import (
     Mapping,
 )
 
+import aiodocker
 import pytest
 import respx
 import traitlets.config
@@ -30,6 +31,7 @@ from models_library.generated_models.docker_rest_api import (
 )
 from models_library.service_settings_labels import SimcoreServiceLabels
 from models_library.services import RunID, ServiceKeyVersion
+from pydantic import parse_obj_as
 from pydantic.types import NonNegativeInt
 from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
@@ -47,6 +49,9 @@ from simcore_service_director_v2.models.schemas.dynamic_services import (
     SchedulerData,
     ServiceDetails,
     ServiceState,
+)
+from simcore_service_director_v2.modules.dynamic_sidecar.docker_service_specs.volume_remover import (
+    DockerVersion,
 )
 from yarl import URL
 
@@ -420,3 +425,17 @@ def mock_docker_api(mocker: MockerFixture) -> None:
         "simcore_service_director_v2.modules.dynamic_sidecar.scheduler.task.get_dynamic_sidecar_state",
         return_value=(ServiceState.PENDING, ""),
     )
+
+
+@pytest.fixture
+async def docker() -> AsyncIterable[aiodocker.Docker]:
+    async with aiodocker.Docker() as docker_client:
+        yield docker_client
+
+
+@pytest.fixture
+async def docker_version(docker: aiodocker.Docker) -> DockerVersion:
+    version_request = await docker._query_json(  # pylint: disable=protected-access
+        "version", versioned_api=False
+    )
+    return parse_obj_as(DockerVersion, version_request["Version"])

--- a/services/director-v2/tests/unit/conftest.py
+++ b/services/director-v2/tests/unit/conftest.py
@@ -428,14 +428,16 @@ def mock_docker_api(mocker: MockerFixture) -> None:
 
 
 @pytest.fixture
-async def docker() -> AsyncIterable[aiodocker.Docker]:
+async def async_docker_client() -> AsyncIterable[aiodocker.Docker]:
     async with aiodocker.Docker() as docker_client:
         yield docker_client
 
 
 @pytest.fixture
-async def docker_version(docker: aiodocker.Docker) -> DockerVersion:
-    version_request = await docker._query_json(  # pylint: disable=protected-access
-        "version", versioned_api=False
+async def docker_version(async_docker_client: aiodocker.Docker) -> DockerVersion:
+    version_request = (
+        await async_docker_client._query_json(  # pylint: disable=protected-access
+            "version", versioned_api=False
+        )
     )
     return parse_obj_as(DockerVersion, version_request["Version"])

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs_volume_remover.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs_volume_remover.py
@@ -1,9 +1,201 @@
 # pylint: disable=redefined-outer-name
+
+from pathlib import Path
+from typing import AsyncIterator
+
+import aiodocker
 import pytest
+from aiodocker.volumes import DockerVolume
+from faker import Faker
 from pydantic import parse_obj_as
 from simcore_service_director_v2.modules.dynamic_sidecar.docker_service_specs.volume_remover import (
+    SH_SCRIPT_REMOVE_VOLUMES,
     DockerVersion,
 )
+
+# UTILS
+
+
+def _get_source(run_id: str, node_uuid: str, volume_path: Path) -> str:
+    reversed_path = f"{volume_path}"[::-1].replace("/", "_")
+    return f"dyv_{run_id}_{node_uuid}_{reversed_path}"
+
+
+async def run_command(
+    docker_version: DockerVersion, volume_names: list[str]
+) -> list[str]:
+    async with aiodocker.Docker() as docker_client:
+        volume_names_seq = " ".join(volume_names)
+        formatted_command = SH_SCRIPT_REMOVE_VOLUMES.format(
+            volume_names_seq=volume_names_seq, retries=5, sleep=1
+        )
+        print("Container will run:\n%s", formatted_command)
+        command = ["sh", "-c", formatted_command]
+
+        container = await docker_client.containers.run(
+            config={
+                "Cmd": command,
+                "Image": f"docker:{docker_version}-dind",
+                "HostConfig": {"Binds": ["/var/run/docker.sock:/var/run/docker.sock"]},
+            },
+        )
+        await container.start()
+        await container.wait()
+
+        logs = await container.log(stderr=True, stdout=True)
+
+        await container.delete(force=True)
+
+        return "".join(logs)
+
+
+# FIXTURES
+
+
+@pytest.fixture
+def swarm_stack_name() -> str:
+    return "test_stack"
+
+
+@pytest.fixture
+def study_id(faker: Faker) -> str:
+    return faker.uuid4()
+
+
+@pytest.fixture
+def node_uuid(faker: Faker) -> str:
+    return faker.uuid4()
+
+
+@pytest.fixture
+def run_id(faker: Faker) -> str:
+    return faker.uuid4()
+
+
+@pytest.fixture
+def used_volume_path(tmp_path: Path) -> Path:
+    return tmp_path / "used_volume"
+
+
+@pytest.fixture
+def unused_volume_path(tmp_path: Path) -> Path:
+    return tmp_path / "unused_volume"
+
+
+@pytest.fixture
+async def unused_volume(
+    swarm_stack_name: str,
+    study_id: str,
+    node_uuid: str,
+    run_id: str,
+    unused_volume_path: Path,
+) -> AsyncIterator[DockerVolume]:
+    async with aiodocker.Docker() as docker_client:
+        source = _get_source(run_id, node_uuid, unused_volume_path)
+        volume = await docker_client.volumes.create(
+            {
+                "Name": source,
+                "Labels": {
+                    "node_uuid": node_uuid,
+                    "run_id": run_id,
+                    "source": source,
+                    "study_id": study_id,
+                    "swarm_stack_name": swarm_stack_name,
+                    "user_id": "1",
+                },
+            }
+        )
+
+        # attach to volume and create some files!!!
+
+        yield volume
+
+        try:
+            await volume.delete()
+        except aiodocker.DockerError:
+            pass
+
+
+@pytest.fixture
+async def used_volume(
+    swarm_stack_name: str,
+    study_id: str,
+    node_uuid: str,
+    run_id: str,
+    used_volume_path: Path,
+) -> AsyncIterator[DockerVolume]:
+    async with aiodocker.Docker() as docker_client:
+        source = _get_source(run_id, node_uuid, used_volume_path)
+        volume = await docker_client.volumes.create(
+            {
+                "Name": source,
+                "Labels": {
+                    "node_uuid": node_uuid,
+                    "run_id": run_id,
+                    "source": source,
+                    "study_id": study_id,
+                    "swarm_stack_name": swarm_stack_name,
+                    "user_id": "1",
+                },
+            }
+        )
+
+        container = await docker_client.containers.run(
+            config={
+                "Cmd": ["/bin/ash", "-c", "sleep 10000"],
+                "Image": "alpine:latest",
+                "HostConfig": {"Binds": [f"{volume.name}:{used_volume_path}"]},
+            },
+            name=f"using_volume_{volume.name}",
+        )
+        await container.start()
+
+        yield volume
+
+        await container.delete(force=True)
+        await volume.delete()
+
+
+@pytest.fixture
+async def used_volume_name(used_volume: DockerVolume) -> str:
+    volume = await used_volume.show()
+    return volume["Name"]
+
+
+@pytest.fixture
+async def unused_volume_name(unused_volume: DockerVolume) -> str:
+    volume = await unused_volume.show()
+    return volume["Name"]
+
+
+@pytest.fixture
+def missing_volume_name(run_id: str, node_uuid: str) -> str:
+    return _get_source(run_id, node_uuid, Path("/MISSING/PATH"))
+
+
+# TESTS
+
+
+async def test_sh_script_error_if_volume_is_used(
+    used_volume_name: str, docker_version: DockerVersion
+):
+    result = await run_command(docker_version, volume_names=[used_volume_name])
+    assert "ERROR: Please check above logs, there was/were 1 error/s." in result
+
+
+async def test_sh_script_removes_unused_volume(
+    unused_volume_name: str, docker_version: DockerVersion
+):
+    result = await run_command(docker_version, volume_names=[unused_volume_name])
+    assert "ERROR: Please check above logs, there was/were" not in result
+    assert result == f"{unused_volume_name}\n"
+
+
+async def test_sh_script_no_error_if_volume_does_not_exist(
+    missing_volume_name: str, docker_version: DockerVersion
+):
+    result = await run_command(docker_version, volume_names=[missing_volume_name])
+    assert "ERROR: Please check above logs, there was/were" not in result
 
 
 @pytest.mark.parametrize(

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs_volume_remover.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs_volume_remover.py
@@ -180,6 +180,7 @@ async def test_sh_script_error_if_volume_is_used(
     used_volume_name: str, docker_version: DockerVersion
 ):
     result = await run_command(docker_version, volume_names=[used_volume_name])
+    print(result)
     assert "ERROR: Please check above logs, there was/were 1 error/s." in result
 
 
@@ -187,6 +188,7 @@ async def test_sh_script_removes_unused_volume(
     unused_volume_name: str, docker_version: DockerVersion
 ):
     result = await run_command(docker_version, volume_names=[unused_volume_name])
+    print(result)
     assert "ERROR: Please check above logs, there was/were" not in result
     assert result == f"{unused_volume_name}\n"
 
@@ -195,6 +197,7 @@ async def test_sh_script_no_error_if_volume_does_not_exist(
     missing_volume_name: str, docker_version: DockerVersion
 ):
     result = await run_command(docker_version, volume_names=[missing_volume_name])
+    print(result)
     assert "ERROR: Please check above logs, there was/were" not in result
 
 

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs_volume_remover.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_docker_service_specs_volume_remover.py
@@ -106,8 +106,6 @@ async def unused_volume(
         }
     )
 
-    # attach to volume and create some files!!!
-
     yield volume
 
     try:
@@ -125,7 +123,6 @@ async def used_volume(
     run_id: str,
     used_volume_path: Path,
 ) -> AsyncIterator[DockerVolume]:
-
     source = _get_source(run_id, node_uuid, used_volume_path)
     volume = await async_docker_client.volumes.create(
         {

--- a/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
@@ -903,7 +903,7 @@ async def test_remove_volume_from_node_no_volume_found(
         volume_removal_attempts=2,
         sleep_between_attempts_s=1,
     )
-    assert volume_removal_result is False
+    assert volume_removal_result is True
     assert await is_volume_present(docker, missing_volume_name) is False
     for named_volume in named_volumes:
         assert await is_volume_present(docker, named_volume) is False

--- a/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
@@ -71,12 +71,6 @@ pytest_simcore_ops_services_selection = [
 
 
 @pytest.fixture
-async def async_docker_client() -> AsyncIterator[aiodocker.docker.Docker]:
-    async with aiodocker.Docker() as client:
-        yield client
-
-
-@pytest.fixture
 def dynamic_sidecar_settings(
     monkeypatch: MonkeyPatch, mock_env: EnvVarsDict
 ) -> DynamicSidecarSettings:
@@ -106,7 +100,7 @@ def network_config(simcore_services_network_name: str, faker: Faker) -> dict[str
 @pytest.fixture
 async def ensure_swarm_network(
     network_config: dict[str, Any],
-    async_docker_client: aiodocker.docker.Docker,
+    async_docker_client: aiodocker.Docker,
 ) -> AsyncIterator[None]:
     network_id = await docker_api.create_network(network_config)
     yield
@@ -127,7 +121,7 @@ async def ensure_swarm_network(
 @pytest.fixture
 async def cleanup_swarm_network(
     simcore_services_network_name: str,
-    async_docker_client: aiodocker.docker.Docker,
+    async_docker_client: aiodocker.Docker,
 ) -> AsyncIterator[None]:
     yield
     # docker containers must be gone before network removal is functional
@@ -163,7 +157,7 @@ def service_spec(test_service_name: str) -> dict[str, Any]:
 @pytest.fixture
 async def cleanup_test_service_name(
     test_service_name: str,
-    async_docker_client: aiodocker.docker.Docker,
+    async_docker_client: aiodocker.Docker,
     docker_swarm: None,
 ) -> AsyncIterator[None]:
     yield
@@ -206,7 +200,7 @@ def dynamic_sidecar_service_spec(
 @pytest.fixture
 async def cleanup_test_dynamic_sidecar_service(
     dynamic_sidecar_service_name: str,
-    async_docker_client: aiodocker.docker.Docker,
+    async_docker_client: aiodocker.Docker,
 ) -> AsyncIterator[None]:
     yield
     assert (
@@ -269,7 +263,7 @@ def dynamic_sidecar_stack_specs(
 @pytest.fixture
 async def cleanup_dynamic_sidecar_stack(
     dynamic_sidecar_stack_specs: list[dict[str, Any]],
-    async_docker_client: aiodocker.docker.Docker,
+    async_docker_client: aiodocker.Docker,
 ) -> AsyncIterator[None]:
     yield
     for dynamic_sidecar_spec in dynamic_sidecar_stack_specs:
@@ -281,7 +275,7 @@ async def cleanup_dynamic_sidecar_stack(
 
 @pytest.fixture
 async def project_id_labeled_network(
-    async_docker_client: aiodocker.docker.Docker, project_id: ProjectID
+    async_docker_client: aiodocker.Docker, project_id: ProjectID
 ) -> AsyncIterable[str]:
     network_config = {
         "Name": "test_network_by_project_id",
@@ -298,7 +292,7 @@ async def project_id_labeled_network(
 
 @pytest.fixture
 async def test_networks(
-    async_docker_client: aiodocker.docker.Docker, docker_swarm: None
+    async_docker_client: aiodocker.Docker, docker_swarm: None
 ) -> AsyncIterator[list[str]]:
     network_names = [f"test_network_name__{k}" for k in range(5)]
 
@@ -311,7 +305,7 @@ async def test_networks(
 
 @pytest.fixture
 async def existing_network(
-    async_docker_client: aiodocker.docker.Docker, project_id: ProjectID
+    async_docker_client: aiodocker.Docker, project_id: ProjectID
 ) -> AsyncIterable[str]:
     name = "test_with_existing_network_by_project_id"
     network_config = {
@@ -372,16 +366,16 @@ def mock_scheduler_data(
 
 @pytest.fixture
 async def mock_service(
-    docker: aiodocker.Docker, service_name: str
+    async_docker_client: aiodocker.Docker, service_name: str
 ) -> AsyncIterable[str]:
-    service_data = await docker.services.create(
+    service_data = await async_docker_client.services.create(
         {"ContainerSpec": {"Image": "joseluisq/static-web-server:1.16.0-alpine"}},
         name=service_name,
     )
 
     yield service_name
 
-    await docker.services.delete(service_data["ID"])
+    await async_docker_client.services.delete(service_data["ID"])
 
 
 @pytest.mark.parametrize(
@@ -594,12 +588,12 @@ async def test_remove_dynamic_sidecar_stack(
     dynamic_sidecar_settings: DynamicSidecarSettings,
     dynamic_sidecar_stack_specs: list[dict[str, Any]],
     docker_swarm: None,
-    async_docker_client: aiodocker.docker.Docker,
+    async_docker_client: aiodocker.Docker,
 ):
     async def _count_services_in_stack(
         node_uuid: UUID,
         dynamic_sidecar_settings: DynamicSidecarSettings,
-        async_docker_client: aiodocker.docker.Docker,
+        async_docker_client: aiodocker.Docker,
     ) -> int:
         services = await async_docker_client.services.list(
             filters={
@@ -708,7 +702,7 @@ async def test_is_dynamic_service_running(
 
 
 async def test_get_projects_networks_containers(
-    async_docker_client: aiodocker.docker.Docker,
+    async_docker_client: aiodocker.Docker,
     project_id_labeled_network: str,
     project_id: ProjectID,
     docker_swarm: None,
@@ -744,7 +738,7 @@ async def test_get_or_create_networks_ids(
 
 
 async def test_update_scheduler_data_label(
-    docker: aiodocker.Docker,
+    async_docker_client: aiodocker.Docker,
     mock_service: str,
     mock_scheduler_data: SchedulerData,
     docker_swarm: None,
@@ -752,7 +746,7 @@ async def test_update_scheduler_data_label(
     await docker_api.update_scheduler_data_label(mock_scheduler_data)
 
     # fetch stored data in labels
-    service_inspect = await docker.services.inspect(mock_service)
+    service_inspect = await async_docker_client.services.inspect(mock_service)
     labels = service_inspect["Spec"]["Labels"]
     scheduler_data = SchedulerData.parse_raw(
         labels[DYNAMIC_SIDECAR_SCHEDULER_DATA_LABEL]
@@ -761,7 +755,7 @@ async def test_update_scheduler_data_label(
 
 
 async def test_update_scheduler_data_label_skip_if_service_is_missing(
-    docker: aiodocker.Docker, mock_scheduler_data: SchedulerData
+    async_docker_client: aiodocker.Docker, mock_scheduler_data: SchedulerData
 ):
     # NOTE: checks that docker engine replies with
     # `service mock-service-name not found`
@@ -771,7 +765,7 @@ async def test_update_scheduler_data_label_skip_if_service_is_missing(
 
 @pytest.mark.flaky(max_runs=3)
 async def test_regression_update_service_update_out_of_sequence(
-    docker: aiodocker.Docker, mock_service: str, docker_swarm: None
+    async_docker_client: aiodocker.Docker, mock_service: str, docker_swarm: None
 ):
     # NOTE: checks that the docker engine replies with
     # `rpc error: code = Unknown desc = update out of sequence`
@@ -791,22 +785,25 @@ async def test_regression_update_service_update_out_of_sequence(
 
 
 @pytest.fixture
-async def target_node_id(docker: aiodocker.Docker) -> str:
+async def target_node_id(async_docker_client: aiodocker.Docker) -> str:
     # get a node's ID
-    docker_nodes = await docker.nodes.list()
+    docker_nodes = await async_docker_client.nodes.list()
     target_node_id = docker_nodes[0]["ID"]
     return target_node_id
 
 
 async def test_constrain_service_to_node(
-    docker: aiodocker.Docker, mock_service: str, target_node_id: str, docker_swarm: None
+    async_docker_client: aiodocker.Docker,
+    mock_service: str,
+    target_node_id: str,
+    docker_swarm: None,
 ):
     await docker_api.constrain_service_to_node(
         mock_service, docker_node_id=target_node_id
     )
 
     # check constraint was added
-    service_inspect = await docker.services.inspect(mock_service)
+    service_inspect = await async_docker_client.services.inspect(mock_service)
     constraints: list[str] = service_inspect["Spec"]["TaskTemplate"]["Placement"][
         "Constraints"
     ]
@@ -819,12 +816,12 @@ async def test_constrain_service_to_node(
 
 @pytest.fixture
 async def named_volumes(
-    docker: aiodocker.Docker, faker: Faker
+    async_docker_client: aiodocker.Docker, faker: Faker
 ) -> AsyncIterator[list[str]]:
     named_volumes: list[DockerVolume] = []
     volume_names: list[str] = []
     for _ in range(10):
-        named_volume: DockerVolume = await docker.volumes.create(
+        named_volume: DockerVolume = await async_docker_client.volumes.create(
             {"Name": f"named-volume-{faker.uuid4()}"}
         )
         volume_names.append(named_volume.name)
@@ -840,8 +837,10 @@ async def named_volumes(
             pass
 
 
-async def is_volume_present(docker: aiodocker.Docker, volume_name: str) -> bool:
-    docker_volume = DockerVolume(docker, volume_name)
+async def is_volume_present(
+    async_docker_client: aiodocker.Docker, volume_name: str
+) -> bool:
+    docker_volume = DockerVolume(async_docker_client, volume_name)
     try:
         await docker_volume.show()
         return True
@@ -852,7 +851,7 @@ async def is_volume_present(docker: aiodocker.Docker, volume_name: str) -> bool:
 
 async def test_remove_volume_from_node_ok(
     docker_swarm: None,
-    docker: aiodocker.Docker,
+    async_docker_client: aiodocker.Docker,
     named_volumes: list[str],
     target_node_id: str,
     user_id: UserID,
@@ -861,7 +860,7 @@ async def test_remove_volume_from_node_ok(
     dynamic_sidecar_settings: DynamicSidecarSettings,
 ):
     for named_volume in named_volumes:
-        assert await is_volume_present(docker, named_volume) is True
+        assert await is_volume_present(async_docker_client, named_volume) is True
 
     volume_removal_result = await docker_api.remove_volumes_from_node(
         dynamic_sidecar_settings=dynamic_sidecar_settings,
@@ -874,12 +873,12 @@ async def test_remove_volume_from_node_ok(
     assert volume_removal_result is True
 
     for named_volume in named_volumes:
-        assert await is_volume_present(docker, named_volume) is False
+        assert await is_volume_present(async_docker_client, named_volume) is False
 
 
 async def test_remove_volume_from_node_no_volume_found(
     docker_swarm: None,
-    docker: aiodocker.Docker,
+    async_docker_client: aiodocker.Docker,
     named_volumes: list[str],
     target_node_id: str,
     user_id: UserID,
@@ -888,7 +887,7 @@ async def test_remove_volume_from_node_no_volume_found(
     dynamic_sidecar_settings: DynamicSidecarSettings,
 ):
     missing_volume_name = "nope-i-am-fake-and-do-not-exist"
-    assert await is_volume_present(docker, missing_volume_name) is False
+    assert await is_volume_present(async_docker_client, missing_volume_name) is False
 
     # put the missing one in the middle of the sequence
     volumes_to_remove = named_volumes[:1] + [missing_volume_name] + named_volumes[1:]
@@ -904,9 +903,9 @@ async def test_remove_volume_from_node_no_volume_found(
         sleep_between_attempts_s=1,
     )
     assert volume_removal_result is True
-    assert await is_volume_present(docker, missing_volume_name) is False
+    assert await is_volume_present(async_docker_client, missing_volume_name) is False
     for named_volume in named_volumes:
-        assert await is_volume_present(docker, named_volume) is False
+        assert await is_volume_present(async_docker_client, named_volume) is False
 
 
 @pytest.fixture
@@ -921,7 +920,7 @@ def service_timeout_s(request: FixtureRequest) -> int:
 
 @pytest.fixture
 async def ensure_fake_volume_removal_services(
-    docker: aiodocker.Docker,
+    async_docker_client: aiodocker.Docker,
     docker_version: DockerVersion,
     target_node_id: str,
     user_id: UserID,
@@ -953,7 +952,7 @@ async def ensure_fake_volume_removal_services(
         # use very long sleep command
         service_spec.TaskTemplate.ContainerSpec.Command = ["sh", "-c", "sleep 3600"]
 
-        started_service = await docker.services.create(
+        started_service = await async_docker_client.services.create(
             **jsonable_encoder(service_spec, by_alias=True, exclude_unset=True)
         )
         started_services_ids.append(started_service["ID"])
@@ -962,21 +961,22 @@ async def ensure_fake_volume_removal_services(
 
     for service_id in started_services_ids:
         try:
-            await docker.services.delete(service_id)
+            await async_docker_client.services.delete(service_id)
         except aiodocker.exceptions.DockerError as e:
             assert e.message == f"service {service_id} not found"
 
 
-async def _get_pending_services(docker: aiodocker.Docker) -> list[str]:
+async def _get_pending_services(async_docker_client: aiodocker.Docker) -> list[str]:
     service_filters = {"name": [f"{DYNAMIC_VOLUME_REMOVER_PREFIX}"]}
     return [
-        x["Spec"]["Name"] for x in await docker.services.list(filters=service_filters)
+        x["Spec"]["Name"]
+        for x in await async_docker_client.services.list(filters=service_filters)
     ]
 
 
 async def test_get_volume_removal_services(
     ensure_fake_volume_removal_services: None,
-    docker: aiodocker.Docker,
+    async_docker_client: aiodocker.Docker,
     volume_removal_services_names: set[str],
     dynamic_sidecar_settings: DynamicSidecarSettings,
     service_timeout_s: int,
@@ -985,7 +985,7 @@ async def test_get_volume_removal_services(
     sleep_for = 1.01
     await asyncio.sleep(sleep_for)
 
-    pending_service_names = await _get_pending_services(docker)
+    pending_service_names = await _get_pending_services(async_docker_client)
     assert len(pending_service_names) == len(volume_removal_services_names)
 
     # check services are present before removing timed out services
@@ -995,7 +995,7 @@ async def test_get_volume_removal_services(
     await docker_api.remove_pending_volume_removal_services(dynamic_sidecar_settings)
 
     # check that timed out services have been removed
-    pending_service_names = await _get_pending_services(docker)
+    pending_service_names = await _get_pending_services(async_docker_client)
     services_have_timed_out = sleep_for > service_timeout_s
     if services_have_timed_out:
         assert len(pending_service_names) == 0

--- a/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
@@ -19,7 +19,6 @@ from fastapi.encoders import jsonable_encoder
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.users import UserID
-from pydantic import parse_obj_as
 from pytest import FixtureRequest
 from pytest_simcore.helpers.utils_envs import EnvVarsDict
 from simcore_service_director_v2.core.settings import DynamicSidecarSettings
@@ -369,12 +368,6 @@ def mock_scheduler_data(
     ]
     scheduler_data.service_name = service_name
     return scheduler_data
-
-
-@pytest.fixture
-async def docker() -> AsyncIterable[aiodocker.Docker]:
-    async with aiodocker.Docker() as docker_client:
-        yield docker_client
 
 
 @pytest.fixture
@@ -919,14 +912,6 @@ async def test_remove_volume_from_node_no_volume_found(
 @pytest.fixture
 def volume_removal_services_names(faker: Faker) -> set[str]:
     return {f"{DYNAMIC_VOLUME_REMOVER_PREFIX}_{faker.uuid4()}" for _ in range(10)}
-
-
-@pytest.fixture
-async def docker_version(docker: aiodocker.Docker) -> DockerVersion:
-    version_request = await docker._query_json(  # pylint: disable=protected-access
-        "version", versioned_api=False
-    )
-    return parse_obj_as(DockerVersion, version_request["Version"])
 
 
 @pytest.fixture(params=[0, 2])


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Addresses issues with the bash script responsible for removing dyv-volumes
- Added tests covering all use cases for the bash script.
- If a volume is missing no error should be raised.
- Enhances runtime of the volume removal service. It will no longer wait if the volume is not present.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist