### PR TITLE
e2e: More reliable output files check

### DIFF
--- a/tests/e2e/portal/Kember.js
+++ b/tests/e2e/portal/Kember.js
@@ -66,7 +66,7 @@ async function runTutorial () {
       "Parasympathetic_Cell_Activity.csv",
       "Table_Data.csv"
     ];
-    await tutorial.checkNodeOutputs(1, outFiles2, false);
+    await tutorial.checkNodeOutputs(1, outFiles2);
   }
   catch(err) {
     await tutorial.setTutorialFailed(true);

--- a/tests/e2e/tutorials/jupyterlabs.js
+++ b/tests/e2e/tutorials/jupyterlabs.js
@@ -73,7 +73,7 @@ async function runTutorial() {
         "TheNumber.txt",
         "workspace.zip"
       ];
-      await tutorial.checkNodeOutputs(j, outFiles, true);
+      await tutorial.checkNodeOutputs(j, outFiles);
     }
   }
   catch (err) {

--- a/tests/e2e/tutorials/jupyterlabs.js
+++ b/tests/e2e/tutorials/jupyterlabs.js
@@ -73,7 +73,7 @@ async function runTutorial() {
         "TheNumber.txt",
         "workspace.zip"
       ];
-      await tutorial.checkNodeOutputs(j, outFiles, true, false);
+      await tutorial.checkNodeOutputs(j, outFiles, true);
     }
   }
   catch (err) {

--- a/tests/e2e/tutorials/sleepers.js
+++ b/tests/e2e/tutorials/sleepers.js
@@ -32,7 +32,7 @@ async function runTutorial() {
       "logs.zip",
       "out_1"
     ];
-    await tutorial.checkNodeOutputs(0, outFiles, true, false);
+    await tutorial.checkNodeOutputs(0, outFiles, true);
   }
   catch(err) {
     await tutorial.setTutorialFailed(true);

--- a/tests/e2e/tutorials/sleepers.js
+++ b/tests/e2e/tutorials/sleepers.js
@@ -32,7 +32,7 @@ async function runTutorial() {
       "logs.zip",
       "out_1"
     ];
-    await tutorial.checkNodeOutputs(0, outFiles, true);
+    await tutorial.checkNodeOutputs(0, outFiles);
   }
   catch(err) {
     await tutorial.setTutorialFailed(true);

--- a/tests/e2e/tutorials/ti-plan.js
+++ b/tests/e2e/tutorials/ti-plan.js
@@ -114,7 +114,7 @@ async function runTutorial() {
       "TIP_report.pdf",
       "results.csv"
     ];
-    await tutorial.checkNodeOutputsAppMode(tiId, outFiles, true, false);
+    await tutorial.checkNodeOutputsAppMode(tiId, outFiles, true);
 
     // Check s4l
     await tutorial.waitAndClick("AppMode_NextBtn");

--- a/tests/e2e/tutorials/ti-plan.js
+++ b/tests/e2e/tutorials/ti-plan.js
@@ -114,7 +114,7 @@ async function runTutorial() {
       "TIP_report.pdf",
       "results.csv"
     ];
-    await tutorial.checkNodeOutputsAppMode(tiId, outFiles, true);
+    await tutorial.checkNodeOutputsAppMode(tiId, outFiles);
 
     // Check s4l
     await tutorial.waitAndClick("AppMode_NextBtn");

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -449,7 +449,8 @@ class TutorialBase {
 
   async __checkNItemsInFolder(fileNames) {
     await this.takeScreenshot("checkNodeOutputs_before");
-    const files = await this.__page.$$eval('[osparc-test-id="FolderViewerItem"]');
+    const files = await this.__page.$$eval('[osparc-test-id="FolderViewerItem"]',
+        elements => elements.map(el => el.textContent));
     if (files.length === fileNames.length) {
       console.log("Number of files is correct")
       await this.takeScreenshot("checkNodeOutputs_after");

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -448,7 +448,7 @@ class TutorialBase {
     await this.waitAndClick("nodeDataManagerCloseBtn");
   }
 
-  async checkNodeOutputs(nodePos, fileNames, checkNFiles = true, checkFileNames = true) {
+  async checkNodeOutputs(nodePos, fileNames, checkNFiles = true) {
     try {
       await this.openNodeFiles(nodePos);
       await this.takeScreenshot("checkNodeOutputs_before");
@@ -457,13 +457,6 @@ class TutorialBase {
       if (checkNFiles) {
         assert(files.length === fileNames.length, 'Number of files is incorrect')
         console.log('Number of files is correct')
-      }
-      if (checkFileNames) {
-        assert(
-          fileNames.every(fileName => files.some(file => file.includes(fileName))),
-          'File names are incorrect'
-        )
-        console.log('File names are correct')
       }
     }
     catch (err) {
@@ -476,7 +469,7 @@ class TutorialBase {
     }
   }
 
-  async checkNodeOutputsAppMode(nodeId, fileNames, checkNFiles = true, checkFileNames = true) {
+  async checkNodeOutputsAppMode(nodeId, fileNames, checkNFiles = true) {
     try {
       await this.openNodeFilesAppMode(nodeId);
       await this.takeScreenshot("checkNodeOutputs_before");
@@ -485,13 +478,6 @@ class TutorialBase {
       if (checkNFiles) {
         assert(files.length === fileNames.length, 'Number of files is incorrect')
         console.log('Number of files is correct')
-      }
-      if (checkFileNames) {
-        assert(
-          fileNames.every(fileName => files.some(file => file.includes(fileName))),
-          'File names are incorrect'
-        )
-        console.log('File names are correct')
       }
     }
     catch (err) {

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -453,6 +453,7 @@ class TutorialBase {
     if (files.length === fileNames.length) {
       console.log("Number of files is correct")
       await this.takeScreenshot("checkNodeOutputs_after");
+      await this.closeNodeFiles();
     }
     else {
       await this.takeScreenshot("checkNodeOutputs_after");

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -449,8 +449,10 @@ class TutorialBase {
 
   async __checkNItemsInFolder(fileNames) {
     await this.takeScreenshot("checkNodeOutputs_before");
+    console.log("N items in folder. Expected:", fileNames);
     const files = await this.__page.$$eval('[osparc-test-id="FolderViewerItem"]',
         elements => elements.map(el => el.textContent));
+    console.log("N items in folder. Received:", files);
     if (files.length === fileNames.length) {
       console.log("Number of files is correct")
       await this.takeScreenshot("checkNodeOutputs_after");
@@ -459,7 +461,7 @@ class TutorialBase {
     else {
       await this.takeScreenshot("checkNodeOutputs_after");
       await this.closeNodeFiles();
-      throw("Number of files is incorrect. Items in folder" + files);
+      throw("Number of files is incorrect");
     }
   }
 

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -415,8 +415,7 @@ class TutorialBase {
     return nodeIframe;
   }
 
-  async openNodeFiles(nodePosInTree = 0) {
-    const nodeId = await auto.openNode(this.__page, nodePosInTree);
+  async openNodeFiles(nodeId) {
     this.__responsesQueue.addResponseListener("storage/locations/0/files/metadata?uuid_filter=" + nodeId);
     await auto.openNodeFiles(this.__page);
     try {
@@ -448,45 +447,39 @@ class TutorialBase {
     await this.waitAndClick("nodeDataManagerCloseBtn");
   }
 
-  async checkNodeOutputs(nodePos, fileNames, checkNFiles = true) {
-    try {
-      await this.openNodeFiles(nodePos);
-      await this.takeScreenshot("checkNodeOutputs_before");
-      const files = await this.__page.$$eval('[osparc-test-id="FolderViewerItem"]',
-        elements => elements.map(el => el.textContent.trim()));
-      if (checkNFiles) {
-        assert(files.length === fileNames.length, 'Number of files is incorrect')
-        console.log('Number of files is correct')
-      }
-    }
-    catch (err) {
-      console.error("Results don't match", err);
-      throw (err)
-    }
-    finally {
+  async __checkNItemsInFolder(fileNames) {
+    await this.takeScreenshot("checkNodeOutputs_before");
+    const files = await this.__page.$$eval('[osparc-test-id="FolderViewerItem"]');
+    if (files.length === fileNames.length) {
+      console.log("Number of files is correct")
       await this.takeScreenshot("checkNodeOutputs_after");
-      await this.closeNodeFiles();
+    }
+    else {
+      await this.takeScreenshot("checkNodeOutputs_after");
+      throw("Number of files is incorrect")
     }
   }
 
-  async checkNodeOutputsAppMode(nodeId, fileNames, checkNFiles = true) {
+  async checkNodeOutputs(nodePos, fileNames) {
     try {
-      await this.openNodeFilesAppMode(nodeId);
-      await this.takeScreenshot("checkNodeOutputs_before");
-      const files = await this.__page.$$eval('[osparc-test-id="FolderViewerItem"]',
-        elements => elements.map(el => el.textContent.trim()));
-      if (checkNFiles) {
-        assert(files.length === fileNames.length, 'Number of files is incorrect')
-        console.log('Number of files is correct')
-      }
+      const nodeId = await auto.openNode(this.__page, nodePos);
+      await this.openNodeFiles(nodeId);
+      await this.__checkNItemsInFolder(fileNames);
     }
     catch (err) {
       console.error("Results don't match", err);
       throw (err)
     }
-    finally {
-      await this.takeScreenshot("checkNodeOutputs_after");
-      await this.closeNodeFiles();
+  }
+
+  async checkNodeOutputsAppMode(nodeId, fileNames) {
+    try {
+      await this.openNodeFilesAppMode(nodeId);
+      await this.__checkNItemsInFolder(fileNames);
+    }
+    catch (err) {
+      console.error("Results don't match", err);
+      throw (err)
     }
   }
 

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -457,7 +457,8 @@ class TutorialBase {
     }
     else {
       await this.takeScreenshot("checkNodeOutputs_after");
-      throw("Number of files is incorrect")
+      await this.closeNodeFiles();
+      throw("Number of files is incorrect. Items in folder" + files);
     }
   }
 


### PR DESCRIPTION
## What do these changes do?

There are some e2e and p2e tests that fail checking output files and the tests still pass. This PR tries to fix those false positives. 
Funny enough, I don't see why these error show up in the first place. Therefore, I also print the expected vs received.


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
