### PR TITLE
✨ CI: auto-cancel job with same name

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -11,6 +11,10 @@ env:
   DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: deploy release

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -11,6 +11,10 @@ env:
   DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: deploy staging

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1872,39 +1872,38 @@ jobs:
 
   deploy:
     name: deploy to dockerhub
-    # if: github.event_name == 'push'
+    if: github.event_name == 'push'
     needs:
       [
-        build-test-images,
-        # unit-test-api-server,
-        # unit-test-autoscaling,
-        # unit-test-api,
-        # unit-test-catalog,
-        # unit-test-dask-sidecar,
-        # unit-test-dask-task-models-library,
-        # unit-test-datcore-adapter,
-        # unit-test-director-v2,
-        # unit-test-director,
-        # unit-test-dynamic-sidecar,
-        # unit-test-frontend,
-        # unit-test-models-library,
-        # unit-test-postgres-database,
-        # unit-test-python-linting,
-        # unit-test-service-integration,
-        # unit-test-service-library,
-        # unit-test-settings-library,
-        # unit-test-simcore-sdk,
-        # unit-test-storage,
-        # unit-test-webserver-01,
-        # unit-test-webserver-02,
-        # unit-test-webserver-03,
-        # integration-test-director-v2-01,
-        # integration-test-director-v2-02,
-        # integration-test-simcore-sdk,
-        # integration-test-webserver-01,
-        # integration-test-webserver-02,
-        # system-test-public-api,
-        # system-test-swarm-deploy,
+        unit-test-api-server,
+        unit-test-autoscaling,
+        unit-test-api,
+        unit-test-catalog,
+        unit-test-dask-sidecar,
+        unit-test-dask-task-models-library,
+        unit-test-datcore-adapter,
+        unit-test-director-v2,
+        unit-test-director,
+        unit-test-dynamic-sidecar,
+        unit-test-frontend,
+        unit-test-models-library,
+        unit-test-postgres-database,
+        unit-test-python-linting,
+        unit-test-service-integration,
+        unit-test-service-library,
+        unit-test-settings-library,
+        unit-test-simcore-sdk,
+        unit-test-storage,
+        unit-test-webserver-01,
+        unit-test-webserver-02,
+        unit-test-webserver-03,
+        integration-test-director-v2-01,
+        integration-test-director-v2-02,
+        integration-test-simcore-sdk,
+        integration-test-webserver-01,
+        integration-test-webserver-02,
+        system-test-public-api,
+        system-test-swarm-deploy,
       ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -1933,14 +1932,9 @@ jobs:
           name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
           path: /${{ runner.temp }}/build
       - name: load docker images
-        run: |
-          make load-images local-src=/${{ runner.temp }}/build
+        run: make load-images local-src=/${{ runner.temp }}/build
       - name: set owner variable
         run: echo "OWNER=${GITHUB_REPOSITORY%/*}" >> $GITHUB_ENV
-      - name: temporary test to fake deployment
-        env:
-          TAG_PREFIX: master-github
-        run: ./ci/deploy/dockerhub-deploy.bash -n
       - if: github.ref == 'refs/heads/master'
         name: deploy master image
         env:

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -82,13 +82,13 @@ jobs:
       - name: build images
         run: |
           export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag.bash)
-          mkdir --parents /${{ runner. temp }}/build
-          make build local-dest=/${{ runner. temp }}/build
+          mkdir --parents /${{ runner.temp }}/build
+          make build local-dest=/${{ runner.temp }}/build
       - name: upload build artifacts
         uses: actions/upload-artifact@v3
         with:
           name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner. temp }}/build
+          path: /${{ runner.temp }}/build
 
   unit-test-webserver-01:
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
@@ -1222,9 +1222,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner. temp }}/build
+          path: /${{ runner.temp }}/build
       - name: load docker images
-        run: make load-images local-src=/${{ runner. temp }}/build
+        run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
         run: ./ci/helpers/show_system_versions.bash
       - name: install
@@ -1297,9 +1297,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner. temp }}/build
+          path: /${{ runner.temp }}/build
       - name: load docker images
-        run: make load-images local-src=/${{ runner. temp }}/build
+        run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
         run: ./ci/helpers/show_system_versions.bash
       - name: install
@@ -1372,9 +1372,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner. temp }}/build
+          path: /${{ runner.temp }}/build
       - name: load docker images
-        run: make load-images local-src=/${{ runner. temp }}/build
+        run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
         run: ./ci/helpers/show_system_versions.bash
       - name: install
@@ -1450,9 +1450,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner. temp }}/build
+          path: /${{ runner.temp }}/build
       - name: load docker images
-        run: make load-images local-src=/${{ runner. temp }}/build
+        run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
         run: ./ci/helpers/show_system_versions.bash
       - name: install
@@ -1527,9 +1527,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner. temp }}/build
+          path: /${{ runner.temp }}/build
       - name: load docker images
-        run: make load-images local-src=/${{ runner. temp }}/build
+        run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
         run: ./ci/helpers/show_system_versions.bash
       - name: install
@@ -1602,9 +1602,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner. temp }}/build
+          path: /${{ runner.temp }}/build
       - name: load docker images
-        run: make load-images local-src=/${{ runner. temp }}/build
+        run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
         run: ./ci/helpers/show_system_versions.bash
       - name: install
@@ -1664,9 +1664,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner. temp }}/build
+          path: /${{ runner.temp }}/build
       - name: load docker images
-        run: make load-images local-src=/${{ runner. temp }}/build
+        run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
         run: ./ci/helpers/show_system_versions.bash
       - name: install
@@ -1732,9 +1732,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner. temp }}/build
+          path: /${{ runner.temp }}/build
       - name: load docker images
-        run: make load-images local-src=/${{ runner. temp }}/build
+        run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
         run: ./ci/helpers/show_system_versions.bash
       - name: setup
@@ -1872,38 +1872,39 @@ jobs:
 
   deploy:
     name: deploy to dockerhub
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
     needs:
       [
-        unit-test-api-server,
-        unit-test-autoscaling,
-        unit-test-api,
-        unit-test-catalog,
-        unit-test-dask-sidecar,
-        unit-test-dask-task-models-library,
-        unit-test-datcore-adapter,
-        unit-test-director-v2,
-        unit-test-director,
-        unit-test-dynamic-sidecar,
-        unit-test-frontend,
-        unit-test-models-library,
-        unit-test-postgres-database,
-        unit-test-python-linting,
-        unit-test-service-integration,
-        unit-test-service-library,
-        unit-test-settings-library,
-        unit-test-simcore-sdk,
-        unit-test-storage,
-        unit-test-webserver-01,
-        unit-test-webserver-02,
-        unit-test-webserver-03,
-        integration-test-director-v2-01,
-        integration-test-director-v2-02,
-        integration-test-simcore-sdk,
-        integration-test-webserver-01,
-        integration-test-webserver-02,
-        system-test-public-api,
-        system-test-swarm-deploy,
+        build-test-images,
+        # unit-test-api-server,
+        # unit-test-autoscaling,
+        # unit-test-api,
+        # unit-test-catalog,
+        # unit-test-dask-sidecar,
+        # unit-test-dask-task-models-library,
+        # unit-test-datcore-adapter,
+        # unit-test-director-v2,
+        # unit-test-director,
+        # unit-test-dynamic-sidecar,
+        # unit-test-frontend,
+        # unit-test-models-library,
+        # unit-test-postgres-database,
+        # unit-test-python-linting,
+        # unit-test-service-integration,
+        # unit-test-service-library,
+        # unit-test-settings-library,
+        # unit-test-simcore-sdk,
+        # unit-test-storage,
+        # unit-test-webserver-01,
+        # unit-test-webserver-02,
+        # unit-test-webserver-03,
+        # integration-test-director-v2-01,
+        # integration-test-director-v2-02,
+        # integration-test-simcore-sdk,
+        # integration-test-webserver-01,
+        # integration-test-webserver-02,
+        # system-test-public-api,
+        # system-test-swarm-deploy,
       ]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -1926,20 +1927,29 @@ jobs:
           driver: docker-container
       - name: setup docker-compose
         run: sudo ./ci/github/helpers/setup_docker_compose.bash ${{ matrix.docker_compose }} ${{ matrix.docker_compose_sha }}
-      - name: set owner variable
-        run: echo "OWNER=${GITHUB_REPOSITORY%/*}" >> $GITHUB_ENV
-      - if: github.ref == 'refs/heads/master'
-        name: deploy master image
-        env:
-          TAG_PREFIX: master-github
-        run: ./ci/deploy/dockerhub-deploy.bash
-      - if: contains(github.ref, 'refs/heads/hotfix_v')
-        name: deploy release hotfix image
-        env:
-          TAG_PREFIX: hotfix-github
-        run: ./ci/deploy/dockerhub-deploy.bash
-      - if: contains(github.ref, 'refs/heads/hotfix_staging_')
-        name: deploy staging hotfix image
-        env:
-          TAG_PREFIX: hotfix-staging-github
-        run: ./ci/deploy/dockerhub-deploy.bash
+      - name: download docker images
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+          path: /${{ runner.temp }}/build
+      - name: load docker images
+        run: |
+          make load-images local-src=/${{ runner.temp }}/build
+          make info-images
+      # - name: set owner variable
+      #   run: echo "OWNER=${GITHUB_REPOSITORY%/*}" >> $GITHUB_ENV
+      # - if: github.ref == 'refs/heads/master'
+      #   name: deploy master image
+      #   env:
+      #     TAG_PREFIX: master-github
+      #   run: ./ci/deploy/dockerhub-deploy.bash
+      # - if: contains(github.ref, 'refs/heads/hotfix_v')
+      #   name: deploy release hotfix image
+      #   env:
+      #     TAG_PREFIX: hotfix-github
+      #   run: ./ci/deploy/dockerhub-deploy.bash
+      # - if: contains(github.ref, 'refs/heads/hotfix_staging_')
+      #   name: deploy staging hotfix image
+      #   env:
+      #     TAG_PREFIX: hotfix-staging-github
+      #   run: ./ci/deploy/dockerhub-deploy.bash

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1935,21 +1935,24 @@ jobs:
       - name: load docker images
         run: |
           make load-images local-src=/${{ runner.temp }}/build
-          make info-images
-      # - name: set owner variable
-      #   run: echo "OWNER=${GITHUB_REPOSITORY%/*}" >> $GITHUB_ENV
-      # - if: github.ref == 'refs/heads/master'
-      #   name: deploy master image
-      #   env:
-      #     TAG_PREFIX: master-github
-      #   run: ./ci/deploy/dockerhub-deploy.bash
-      # - if: contains(github.ref, 'refs/heads/hotfix_v')
-      #   name: deploy release hotfix image
-      #   env:
-      #     TAG_PREFIX: hotfix-github
-      #   run: ./ci/deploy/dockerhub-deploy.bash
-      # - if: contains(github.ref, 'refs/heads/hotfix_staging_')
-      #   name: deploy staging hotfix image
-      #   env:
-      #     TAG_PREFIX: hotfix-staging-github
-      #   run: ./ci/deploy/dockerhub-deploy.bash
+      - name: set owner variable
+        run: echo "OWNER=${GITHUB_REPOSITORY%/*}" >> $GITHUB_ENV
+      - name: temporary test to fake deployment
+        env:
+          TAG_PREFIX: master-github
+        run: ./ci/deploy/dockerhub-deploy.bash -n
+      - if: github.ref == 'refs/heads/master'
+        name: deploy master image
+        env:
+          TAG_PREFIX: master-github
+        run: ./ci/deploy/dockerhub-deploy.bash -n
+      - if: contains(github.ref, 'refs/heads/hotfix_v')
+        name: deploy release hotfix image
+        env:
+          TAG_PREFIX: hotfix-github
+        run: ./ci/deploy/dockerhub-deploy.bash -n
+      - if: contains(github.ref, 'refs/heads/hotfix_staging_')
+        name: deploy staging hotfix image
+        env:
+          TAG_PREFIX: hotfix-staging-github
+        run: ./ci/deploy/dockerhub-deploy.bash -n

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -45,6 +45,10 @@ env:
   DEFAULT_MAX_NANO_CPUS: 10000000
   DEFAULT_MAX_MEMORY: 268435456
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test-images:
     # this step comes first, so that it is executed as first job in push calls

--- a/ci/deploy/dockerhub-deploy.bash
+++ b/ci/deploy/dockerhub-deploy.bash
@@ -8,20 +8,63 @@ IFS=$'\n\t'
 my_dir="$(dirname "$0")"
 source "$my_dir/../../scripts/helpers/logger.bash"
 
+
+Help()
+{
+   # Display Help
+   echo "This scripts is a CI helper script to pull a stack of docker images"
+   echo "re-tag them and push them to dockerhub. (for example, from master to staging)"
+   echo
+   echo "Syntax: dockerhub-deploy.bash [-h|n]"
+   echo "options:"
+   echo "h     Print this Help."
+   echo "n     do not pull image, in case it is already available in the local docker registry."
+   echo "      The images must be set as local/webserver:production..."
+   echo
+}
+
+############################################################
+############################################################
+# Main program                                             #
+############################################################
+############################################################
+
+
 # check script needed variables
 if [ ! -v TAG_PREFIX ]; then
     error_exit "$LINENO" "incorrect use of script. TAG_PREFIX (e.g. master, staging) not defined!"
 fi
 
-log_info "logging in dockerhub..."
-bash ci/helpers/dockerhub_login.bash
 
-# pull the current tested build
+# Get the options
+skip_pulling=0
+while getopts ":nh:" option; do
+   case $option in
+      h) # display help
+        Help
+        exit;;
+      n) # skip image pulling
+        echo "skipping image pull"
+        skip_pulling=1
+        ;;
+      \?) # Invalid option
+         echo "Error: Invalid option"
+         exit;;
+   esac
+done
 
-DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag.bash)
-export DOCKER_IMAGE_TAG
-log_info "pulling build ${DOCKER_IMAGE_TAG}"
-make pull-version tag-local
+# log_info "logging in dockerhub..."
+# bash ci/helpers/dockerhub_login.bash
+echo $skip_pulling
+if [ $skip_pulling -eq 1 ]; then
+  log_info "skipping image pulling"
+else
+  # pull the current tested build
+  DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag.bash)
+  export DOCKER_IMAGE_TAG
+  log_info "pulling build ${DOCKER_IMAGE_TAG}"
+  make pull-version tag-local
+fi
 
 # show current images on system
 log_info "Before push"
@@ -31,10 +74,11 @@ make info-images
 DOCKER_IMAGE_TAG="$TAG_PREFIX-latest"
 export DOCKER_IMAGE_TAG
 log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}"
-make push-version
+make tag-version
 
 # re-tag build to master-github-DATE.GIT_SHA
 DOCKER_IMAGE_TAG=$TAG_PREFIX-$(date --utc +"%Y-%m-%d--%H-%M").$(git rev-parse HEAD)
 export DOCKER_IMAGE_TAG
 log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}"
-make push-version
+make tag-version
+make info-images

--- a/ci/deploy/dockerhub-deploy.bash
+++ b/ci/deploy/dockerhub-deploy.bash
@@ -53,11 +53,11 @@ while getopts ":nh:" option; do
    esac
 done
 
-# log_info "logging in dockerhub..."
-# bash ci/helpers/dockerhub_login.bash
-echo $skip_pulling
+log_info "logging in dockerhub..."
+bash ci/helpers/dockerhub_login.bash
+
 if [ $skip_pulling -eq 1 ]; then
-  log_info "skipping image pulling"
+  log_info "skipping image pulling (assuming the images are already available)"
 else
   # pull the current tested build
   DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag.bash)
@@ -67,18 +67,17 @@ else
 fi
 
 # show current images on system
-log_info "Before push"
+log_info "Locally available images before push:"
 make info-images
 
 # re-tag build
 DOCKER_IMAGE_TAG="$TAG_PREFIX-latest"
 export DOCKER_IMAGE_TAG
-log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}"
-make tag-version
+log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}..."
+make push-version
 
 # re-tag build to master-github-DATE.GIT_SHA
 DOCKER_IMAGE_TAG=$TAG_PREFIX-$(date --utc +"%Y-%m-%d--%H-%M").$(git rev-parse HEAD)
 export DOCKER_IMAGE_TAG
-log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}"
-make tag-version
-make info-images
+log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}..."
+make push-version


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
This PR adds the ```concurrency``` field in the CI workflows that will automatically cancel jobs when:
### CI (usual workflow after a push to a branch or pull_request)
- github workflow name is the same, and
- github ref is the same (see GITHUB_REF environment (example ref/heads/master or ref/pulls/3434/merge for this very PR)
In effect, this should auto-cancel the previous CI job when a developer pushes several commits to github and therefore reduce the time other developers must wait

### Github-CI-Staging (workflow for releasing to staging)
- github workflow name is the same
In effect only one staging workflow can run at the same time

### Github-CI-Release (workflow for releasing to production)
- github workflow name is the same
In effect only one release workflow can run at the same time


Bonus:
- fixes #3435 

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
