### PR TITLE
♻️ Expired confirmation tokens are logged and INVITATION tokens do not expire

### DIFF
--- a/services/web/server/src/simcore_service_webserver/login/_confirmation.py
+++ b/services/web/server/src/simcore_service_webserver/login/_confirmation.py
@@ -29,12 +29,11 @@ async def validate_confirmation_code(
         {"code": code}
     )
     if confirmation and is_confirmation_expired(cfg, confirmation):
-        log.info(
-            "Confirmation code '%s' %s. Deleting ...",
-            code,
-            "consumed" if confirmation else "expired",
-        )
         await db.delete_confirmation(confirmation)
+        log.warning(
+            "Used expired token [%s]. Deleted from confirmations table.",
+            confirmation,
+        )
         return None
     return confirmation
 
@@ -68,6 +67,10 @@ async def is_confirmation_allowed(
         return True
     if is_confirmation_expired(cfg, confirmation):
         await db.delete_confirmation(confirmation)
+        log.warning(
+            "Used expired token [%s]. Deleted from confirmations table.",
+            confirmation,
+        )
         return True
 
 

--- a/services/web/server/src/simcore_service_webserver/login/_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/_registration.py
@@ -80,7 +80,7 @@ async def check_registration(
     confirm: Optional[str],
     db: AsyncpgStorage,
     cfg: LoginOptions,
-):
+) -> None:
     # email : required & formats
     # password: required & secure[min length, ...]
 
@@ -115,6 +115,12 @@ async def check_registration(
             if is_confirmation_expired(cfg, _confirmation):
                 await db.delete_confirmation(_confirmation)
                 await db.delete_user(user)
+                log.warning(
+                    "Time to confirm a registration is overdue. Used expired token [%s]."
+                    "Deleted token from confirmations table and %s from users table.",
+                    _confirmation,
+                    f"{user=}",
+                )
                 return
 
         # If the email is already taken, return a 409 - HTTPConflict

--- a/services/web/server/src/simcore_service_webserver/login/settings.py
+++ b/services/web/server/src/simcore_service_webserver/login/settings.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Literal, Optional
+from typing import Final, Literal, Optional
 
 from aiohttp import web
 from pydantic import BaseModel, validator
@@ -10,9 +10,10 @@ from settings_library.twilio import TwilioSettings
 
 from .._constants import APP_SETTINGS_KEY
 
-_DAYS = 1.0  # in days
-_MINUTES = 1.0 / 24.0 / 60.0  # in days
-
+_DAYS: Final[float] = 1.0  # in days
+_MINUTES: Final[float] = 1.0 / 24.0 / 60.0  # in days
+_YEARS: Final[float] = 365 * _DAYS
+_UNLIMITED: Final[float] = 99 * _YEARS
 
 APP_LOGIN_OPTIONS_KEY = f"{__name__}.APP_LOGIN_OPTIONS_KEY"
 
@@ -76,9 +77,9 @@ class LoginOptions(BaseModel):
     SMTP_USERNAME: Optional[str] = Field(...)
     SMTP_PASSWORD: Optional[SecretStr] = Field(...)
 
-    # lifetime limits are in days
+    # NOTE: lifetime limits are expressed in days (use constants above)
     REGISTRATION_CONFIRMATION_LIFETIME: PositiveFloat = 5 * _DAYS
-    INVITATION_CONFIRMATION_LIFETIME: PositiveFloat = 15 * _DAYS
+    INVITATION_CONFIRMATION_LIFETIME: PositiveFloat = _UNLIMITED
     RESET_PASSWORD_CONFIRMATION_LIFETIME: PositiveFloat = 20 * _MINUTES
     CHANGE_EMAIL_CONFIRMATION_LIFETIME: PositiveFloat = 5 * _DAYS
 
@@ -89,7 +90,6 @@ class LoginOptions(BaseModel):
         value = getattr(self, f"{action.upper()}_CONFIRMATION_LIFETIME")
         return timedelta(days=value)
 
-    # TODO: translation?
     MSG_LOGGED_IN: str = "You are logged in"
     MSG_LOGGED_OUT: str = "You are logged out"
     MSG_2FA_CODE_SENT: str = "Code sent by SMS to {phone_number}"


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

During a demo today, an invitation link did not work and was reported as "expired". At first glance, we did not understand why this happened and took us some time to recall that actually **all** confirmation tokens are time-limited. The problem was that the invitations that we were using were already expired but it was not obvious from the info available (no logs, no indication in the database, etc)  

This PR aims to avoid this problem in the future by:
- logging as WARNING when a given confirmation token in use is expired and therefore removed from the database
- INVITATION tokens are now unlimited (i.e. they do not expire)


### Some insights:

Some actions in a login require some sort of confirmation/validation step. For those we create confirmation tokens that, due to security reasons, have a limited lifetime. These tokens are used for actions like invitations, confirmation of emails, etc.  The expiration date is based on the creation timestamp and a ``LIFETIME`` variable under ``login.settings.LoginOptions``. 


## Related issue/s


## How to test

```cmd
cd services/web/server
make install-dev
pytest tests/unit/with_dbs/03/test_login_registration.py
```

