### PR TITLE
🐛 is3372/fixes warning of alias in BaseSettings

### DIFF
--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -826,7 +826,7 @@ jobs:
           driver: docker-container
       - name: setup docker-compose
         run: sudo ./ci/github/helpers/setup_docker_compose.bash ${{ matrix.docker_compose }} ${{ matrix.docker_compose_sha }}
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/setup-node@v3.5.1
         with:
           node-version: ${{ matrix.node }}
           cache: "npm"
@@ -1724,7 +1724,7 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: "pip"
           cache-dependency-path: "tests/e2e/requirements/requirements.txt"
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/setup-node@v3.5.1
         with:
           node-version: ${{ matrix.node }}
           cache: "npm"

--- a/services/web/server/src/simcore_service_webserver/cli.py
+++ b/services/web/server/src/simcore_service_webserver/cli.py
@@ -13,7 +13,6 @@ Why does this file exist, and why not put this in __main__?
 
 """
 
-
 import logging
 import os
 
@@ -21,10 +20,7 @@ import typer
 from aiohttp import web
 from settings_library.utils_cli import create_settings_command
 
-from .application import create_application, run_service
 from .application_settings import ApplicationSettings
-from .application_settings_utils import convert_to_app_config
-from .log import setup_logging
 from .login import cli as login_cli
 
 # ptsvd cause issues with ProcessPoolExecutor
@@ -40,6 +36,9 @@ log = logging.getLogger(__name__)
 def _setup_app_from_settings(
     settings: ApplicationSettings,
 ) -> tuple[web.Application, dict]:
+    from .application import create_application
+    from .application_settings_utils import convert_to_app_config
+    from .log import setup_logging
 
     # NOTE: keeping an equivalent config allows us
     # to keep some of the code from the previous
@@ -60,7 +59,7 @@ def _setup_app_from_settings(
 
 async def app_factory() -> web.Application:
     """Created to launch app from gunicorn (see docker/boot.sh)"""
-    app_settings = ApplicationSettings()
+    app_settings = ApplicationSettings.create_from_envs()
     assert app_settings.SC_BUILD_TARGET  # nosec
 
     log.info("Application settings: %s", app_settings.json(indent=2, sort_keys=True))
@@ -82,6 +81,8 @@ main.command()(login_cli.invitations)
 @main.command()
 def run():
     """Runs web server"""
-    app_settings = ApplicationSettings()
+    from .application import run_service
+
+    app_settings = ApplicationSettings.create_from_envs()
     app, cfg = _setup_app_from_settings(app_settings)
     run_service(app, cfg)

--- a/services/web/server/src/simcore_service_webserver/cli.py
+++ b/services/web/server/src/simcore_service_webserver/cli.py
@@ -36,11 +36,12 @@ log = logging.getLogger(__name__)
 def _setup_app_from_settings(
     settings: ApplicationSettings,
 ) -> tuple[web.Application, dict]:
+    # NOTE: keeping imports here to reduce CLI load time
     from .application import create_application
     from .application_settings_utils import convert_to_app_config
     from .log import setup_logging
 
-    # NOTE: keeping an equivalent config allows us
+    # NOTE: By having an equivalent config allows us
     # to keep some of the code from the previous
     # design whose starting point was a validated
     # config. E.g. many test fixtures were based on
@@ -81,6 +82,7 @@ main.command()(login_cli.invitations)
 @main.command()
 def run():
     """Runs web server"""
+    # NOTE: keeping imports here to reduce CLI load time
     from .application import run_service
 
     app_settings = ApplicationSettings.create_from_envs()


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

Cannot use ``alias`` with ``BaseSettings``. Created instead a helper in ``webserver``'s ``ApplicationSettings`` **just** for the special export functions.

EXTRA: improved a bit speed of web-server's CLI ``simcore-service-webserver --help`` by reducing explicit imports

## Related issue/s

- closes ITISFoundation/osparc-simcore#3372


## How to test

```cmd
cd services/web/server
make install-dev
pytest -vv --pdb  tests/**/test_application*.py
```

