### PR TITLE
✨ is3453/fail boot if invalid product setup

### DIFF
--- a/packages/service-library/src/servicelib/exceptions.py
+++ b/packages/service-library/src/servicelib/exceptions.py
@@ -1,0 +1,4 @@
+class InvalidConfig(ValueError):
+    # NOTE: If your service can’t load the config on startup for any reason, it should just crash
+    # SEE https://www.willett.io/posts/precepts/
+    pass

--- a/services/web/server/src/simcore_service_webserver/products_events.py
+++ b/services/web/server/src/simcore_service_webserver/products_events.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from aiohttp import web
 from aiopg.sa.engine import Engine
 from pydantic import ValidationError
+from servicelib.exceptions import InvalidConfig
 
 from ._constants import APP_DB_ENGINE_KEY, APP_PRODUCTS_KEY
 from .products_db import Product, iter_products
@@ -46,9 +47,9 @@ async def load_products_on_startup(app: web.Application):
                 log.warning("There is not front-end registered for this product")
 
         except ValidationError as err:
-            log.error(
-                "Invalid product in db '%s'. Skipping product info:\n %s", row, err
-            )
+            raise InvalidConfig(
+                f"Invalid product configuration in db '{row}':\n {err}"
+            ) from err
 
     if FRONTEND_APP_DEFAULT not in app_products.keys():
         log.warning("Default front-end app is not in the products table")


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

After the experience with releases, when a ``product`` config is wrong, the webserver will fail startup and stop. Up to know we logged but it produced a chain effect that was more difficult to debug. Now, if products validation fail upon startup, the web-server stops with error.

Quoting [Willet ](https://www.willett.io/posts/precepts/)
> If your service can’t load the config on startup for any reason, it should just crash – that’s much easier to diagnose than the result of one broked instance going down an ancient code path


## Related issue/s

- closes #3453 

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
