### PR TITLE
⬆️ Update datcore-adapter requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ packages/service-integration/compose-spec.json
 
 # temporary files by vscode
 Untitled*
+
+# snyk extension cache
+.dccache

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -8,41 +8,39 @@ aiodebug==2.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiofiles==0.8.0
+aiofiles==22.1.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-anyio==3.5.0
+anyio==3.6.2
     # via
     #   httpcore
     #   starlette
-    #   watchgod
-asgiref==3.5.0
-    # via uvicorn
+    #   watchfiles
 attrs==21.4.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   jsonschema
-boto3==1.21.33
+boto3==1.24.95
     # via pennsieve
-botocore==1.24.33
+botocore==1.27.95
     # via
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.9.24
     # via
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via
     #   typer
     #   uvicorn
-configparser==5.2.0
+configparser==5.3.0
     # via pennsieve
 deprecated==1.2.13
     # via pennsieve
@@ -52,9 +50,9 @@ docopt==0.6.2
     # via pennsieve
 ecdsa==0.14.1
     # via python-jose
-email-validator==1.2.1
+email-validator==1.3.0
     # via pydantic
-fastapi==0.85.0
+fastapi==0.85.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
@@ -62,7 +60,7 @@ fastapi==0.85.0
     #   fastapi-pagination
 fastapi-contrib==0.2.11
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-fastapi-pagination==0.9.1
+fastapi-pagination==0.10.0
     # via -r requirements/_base.in
 future==0.18.2
     # via pennsieve
@@ -78,7 +76,7 @@ hpack==4.0.0
     # via h2
 httpcore==0.15.0
     # via httpx
-httptools==0.4.0
+httptools==0.5.0
     # via uvicorn
 httpx==0.23.0
     # via
@@ -91,7 +89,7 @@ httpx==0.23.0
     #   -r requirements/_base.in
 hyperframe==6.0.1
     # via h2
-idna==3.3
+idna==3.4
     # via
     #   anyio
     #   email-validator
@@ -99,7 +97,7 @@ idna==3.3
     #   rfc3986
 jaeger-client==4.8.0
     # via fastapi-contrib
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
@@ -114,15 +112,15 @@ opentracing==2.4.0
     #   jaeger-client
 pennsieve==6.2.0
     # via -r requirements/_base.in
-protobuf==3.20.0
+protobuf==3.20.1
     # via pennsieve
-psutil==5.9.0
+psutil==5.9.3
     # via pennsieve
 pyasn1==0.4.8
     # via
     #   python-jose
     #   rsa
-pydantic==1.9.0
+pydantic==1.10.2
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
@@ -136,7 +134,7 @@ pydantic==1.9.0
     #   -r requirements/_base.in
     #   fastapi
     #   fastapi-pagination
-pyinstrument==4.1.1
+pyinstrument==4.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -146,13 +144,13 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   pennsieve
-python-dotenv==0.20.0
+python-dotenv==0.21.0
     # via uvicorn
 python-jose==3.2.0
     # via pennsieve
 python-multipart==0.0.5
     # via -r requirements/_base.in
-pytz==2022.1
+pytz==2022.5
     # via pennsieve
 pyyaml==5.4.1
     # via
@@ -166,7 +164,7 @@ pyyaml==5.4.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   uvicorn
-requests==2.27.1
+requests==2.28.1
     # via pennsieve
 rfc3986==1.5.0
     # via httpx
@@ -179,7 +177,7 @@ rsa==4.9
     #   -c requirements/../../../requirements/constraints.txt
     #   pennsieve
     #   python-jose
-s3transfer==0.5.2
+s3transfer==0.6.0
     # via boto3
 semver==2.13.0
     # via pennsieve
@@ -191,14 +189,14 @@ six==1.16.0
     #   python-jose
     #   python-multipart
     #   thrift
-sniffio==1.2.0
+sniffio==1.3.0
     # via
     #   anyio
     #   httpcore
     #   httpx
 starlette==0.20.4
     # via fastapi
-tenacity==8.0.1
+tenacity==8.1.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -206,22 +204,22 @@ threadloop==1.0.2
     # via jaeger-client
 thrift==0.16.0
     # via jaeger-client
-tornado==6.1
+tornado==6.2
     # via
     #   jaeger-client
     #   threadloop
-tqdm==4.64.0
+tqdm==4.64.1
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.4.1
+typer==0.6.1
     # via -r requirements/../../../packages/settings-library/requirements/_base.in
-typing-extensions==4.3.0
+typing-extensions==4.4.0
     # via
     #   aiodebug
     #   pydantic
     #   starlette
-urllib3==1.26.9
+urllib3==1.26.12
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
@@ -230,19 +228,19 @@ urllib3==1.26.9
     #   -c requirements/../../../requirements/constraints.txt
     #   botocore
     #   requests
-uvicorn==0.17.6
+uvicorn==0.19.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-uvloop==0.16.0
+uvloop==0.17.0
     # via uvicorn
-watchgod==0.8.2
+watchfiles==0.18.0
     # via uvicorn
-websocket-client==1.3.2
+websocket-client==1.4.1
     # via pennsieve
-websockets==10.2
+websockets==10.3
     # via uvicorn
-wrapt==1.14.0
+wrapt==1.14.1
     # via deprecated
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/datcore-adapter/requirements/_test.txt
+++ b/services/datcore-adapter/requirements/_test.txt
@@ -4,25 +4,25 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-anyio==3.5.0
+anyio==3.6.2
     # via
     #   -c requirements/_base.txt
     #   httpcore
 asgi-lifespan==1.0.1
     # via -r requirements/_test.in
-astroid==2.12.11
+astroid==2.12.12
     # via pylint
 attrs==21.4.0
     # via
     #   -c requirements/_base.txt
     #   pytest
-certifi==2021.10.8
+certifi==2022.9.24
     # via
     #   -c requirements/_base.txt
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via
     #   -c requirements/_base.txt
     #   requests
@@ -44,7 +44,7 @@ docopt==0.6.2
     #   coveralls
 execnet==1.9.0
     # via pytest-xdist
-faker==15.1.0
+faker==15.1.1
     # via -r requirements/_test.in
 h11==0.12.0
     # via
@@ -61,7 +61,7 @@ httpx==0.23.0
     #   respx
 icdiff==2.0.5
     # via pytest-icdiff
-idna==3.3
+idna==3.4
     # via
     #   -c requirements/_base.txt
     #   anyio
@@ -104,7 +104,7 @@ pytest==7.1.3
     #   pytest-mock
     #   pytest-sugar
     #   pytest-xdist
-pytest-asyncio==0.19.0
+pytest-asyncio==0.20.0
     # via -r requirements/_test.in
 pytest-cov==4.0.0
     # via -r requirements/_test.in
@@ -126,7 +126,7 @@ python-dateutil==2.8.2
     # via
     #   -c requirements/_base.txt
     #   faker
-requests==2.27.1
+requests==2.28.1
     # via
     #   -c requirements/_base.txt
     #   codecov
@@ -141,7 +141,7 @@ six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil
-sniffio==1.2.0
+sniffio==1.3.0
     # via
     #   -c requirements/_base.txt
     #   anyio
@@ -157,17 +157,17 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.11.5
     # via pylint
-typing-extensions==4.3.0
+typing-extensions==4.4.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   pylint
-urllib3==1.26.9
+urllib3==1.26.12
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   requests
-wrapt==1.14.0
+wrapt==1.14.1
     # via
     #   -c requirements/_base.txt
     #   astroid

--- a/services/datcore-adapter/requirements/_tools.txt
+++ b/services/datcore-adapter/requirements/_tools.txt
@@ -66,7 +66,7 @@ tomli==2.0.1
     #   black
     #   build
     #   pep517
-typing-extensions==4.3.0
+typing-extensions==4.4.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

general requirements upgrade of datcore-adapter micro-service

<!-- Explain REVIEWERS what is this PR about -->
###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 38
- #packages after : 37

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aiofiles                  | 0.8.0           | 22.1.0     | **MAJOR**  | 1 | datcore-adapter⬆️ |
|   2 | anyio                     | 3.5.0           | 3.6.2      | *minor*    | 2 | datcore-adapter⬆️🧪 |
|   3 | asgiref                   | 3.5.0           | 🗑️ removed |  | 1 | datcore-adapter⬆️ |
|   4 | astroid                   | 2.12.11         | 2.12.12    |            | 1 | datcore-adapter🧪 |
|   5 | boto3                     | 1.21.33         | 1.24.95    | *minor*    | 1 | datcore-adapter⬆️ |
|   6 | botocore                  | 1.24.33         | 1.27.95    | *minor*    | 1 | datcore-adapter⬆️ |
|   7 | certifi                   | 2021.10.8       | 2022.9.24  | **MAJOR**  | 2 | datcore-adapter⬆️🧪 |
|   8 | charset-normalizer        | 2.0.12          | 2.1.1      | *minor*    | 2 | datcore-adapter⬆️🧪 |
|   9 | configparser              | 5.2.0           | 5.3.0      | *minor*    | 1 | datcore-adapter⬆️ |
|  10 | email-validator           | 1.2.1           | 1.3.0      | *minor*    | 1 | datcore-adapter⬆️ |
|  11 | faker                     | 15.1.0          | 15.1.1     |            | 1 | datcore-adapter🧪 |
|  12 | fastapi                   | 0.85.0          | 0.85.1     |            | 1 | datcore-adapter⬆️ |
|  13 | fastapi-pagination        | 0.9.1           | 0.10.0     | *minor*    | 1 | datcore-adapter⬆️ |
|  14 | httptools                 | 0.4.0           | 0.5.0      | *minor*    | 1 | datcore-adapter⬆️ |
|  15 | idna                      | 3.3             | 3.4        | *minor*    | 2 | datcore-adapter⬆️🧪 |
|  16 | jmespath                  | 1.0.0           | 1.0.1      |            | 1 | datcore-adapter⬆️ |
|  17 | protobuf                  | 3.20.0          | 3.20.1     |            | 1 | datcore-adapter⬆️ |
|  18 | psutil                    | 5.9.0           | 5.9.3      |            | 1 | datcore-adapter⬆️ |
|  19 | pydantic                  | 1.9.0           | 1.10.2     | *minor*    | 1 | datcore-adapter⬆️ |
|  20 | pyinstrument              | 4.1.1           | 4.3.0      | *minor*    | 1 | datcore-adapter⬆️ |
|  21 | pytest-asyncio            | 0.19.0          | 0.20.0     | *minor*    | 1 | datcore-adapter🧪 |
|  22 | python-dotenv             | 0.20.0          | 0.21.0     | *minor*    | 1 | datcore-adapter⬆️ |
|  23 | pytz                      | 2022.1          | 2022.5     | *minor*    | 1 | datcore-adapter⬆️ |
|  24 | requests                  | 2.27.1          | 2.28.1     | *minor*    | 2 | datcore-adapter⬆️🧪 |
|  25 | s3transfer                | 0.5.2           | 0.6.0      | *minor*    | 1 | datcore-adapter⬆️ |
|  26 | sniffio                   | 1.2.0           | 1.3.0      | *minor*    | 2 | datcore-adapter⬆️🧪 |
|  27 | tenacity                  | 8.0.1           | 8.1.0      | *minor*    | 1 | datcore-adapter⬆️ |
|  28 | tornado                   | 6.1             | 6.2        | *minor*    | 1 | datcore-adapter⬆️ |
|  29 | tqdm                      | 4.64.0          | 4.64.1     |            | 1 | datcore-adapter⬆️ |
|  30 | typer                     | 0.4.1           | 0.6.1      | *minor*    | 1 | datcore-adapter⬆️ |
|  31 | typing-extensions         | 4.3.0           | 4.4.0      | *minor*    | 3 | datcore-adapter⬆️🧪🔧 |
|  32 | urllib3                   | 1.26.9          | 1.26.12    |            | 2 | datcore-adapter⬆️🧪 |
|  33 | uvicorn                   | 0.17.6          | 0.19.0     | *minor*    | 1 | datcore-adapter⬆️ |
|  34 | uvloop                    | 0.16.0          | 0.17.0     | *minor*    | 1 | datcore-adapter⬆️ |
|  35 | watchgod                  | 0.8.2           | 🗑️ removed |  | 1 | datcore-adapter⬆️ |
|  36 | websocket-client          | 1.3.2           | 1.4.1      | *minor*    | 1 | datcore-adapter⬆️ |
|  37 | websockets                | 10.2            | 10.3       | *minor*    | 1 | datcore-adapter⬆️ |
|  38 | wrapt                     | 1.14.0          | 1.14.1     |            | 2 | datcore-adapter⬆️🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 59

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 6.8.0, 7.2.0              | 6.8.0, 8.2.4              |                           |
|   2 | aioboto3                  | 9.6.0                     | 10.1.0                    |                           |
|   3 | aiobotocore               | 2.3.0, 2.3.3              | 2.4.0                     |                           |
|   4 | aiocache                  | 0.11.1                    | 0.11.1                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.19.1, 0.21.0            | 0.21.0                    |                           |
|   7 | aiofiles                  | 0.8.0, 22.1.0             | 22.1.0                    |                           |
|   8 | aiohttp                   | 3.8.1, 3.8.3              | 3.8.1, 3.8.3              |                           |
|   9 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  10 | aiohttp-security          | 0.4.0                     |                           |                           |
|  11 | aiohttp-session           | 2.11.0                    |                           |                           |
|  12 | aiohttp-swagger           | 1.0.16                    |                           |                           |
|  13 | aioitertools              | 0.10.0                    | 0.11.0                    |                           |
|  14 | aiopg                     | 1.3.3, 1.3.5              | 1.3.5                     |                           |
|  15 | aioredis                  | 2.0.1                     |                           |                           |
|  16 | aioresponses              |                           | 0.7.3                     |                           |
|  17 | aiormq                    | 3.3.1, 6.2.3              | 3.3.1, 6.4.2              |                           |
|  18 | aiosignal                 | 1.2.0                     | 1.2.0                     |                           |
|  19 | aiosmtplib                | 1.1.6                     |                           |                           |
|  20 | aiozipkin                 | 1.1.1                     |                           |                           |
|  21 | alembic                   | 1.8.1                     | 1.8.1                     |                           |
|  22 | anyio                     | 3.6.1, 3.6.2              | 3.6.1, 3.6.2              |                           |
|  23 | argon2-cffi               | 20.1.0                    |                           |                           |
|  24 | asgi-lifespan             |                           | 1.0.1                     |                           |
|  25 | asgiref                   | 3.5.2                     |                           |                           |
|  26 | astroid                   |                           | 2.12.11, 2.12.12          | 2.12.11                   |
|  27 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  28 | async-generator           | 1.10                      |                           |                           |
|  29 | async-timeout             | 4.0.2                     | 4.0.2                     |                           |
|  30 | asyncpg                   | 0.25.0                    |                           |                           |
|  31 | attrs                     | 21.4.0, 22.1.0            | 21.4.0, 22.1.0            |                           |
|  32 | aws-sam-translator        |                           | 1.53.0                    |                           |
|  33 | aws-xray-sdk              |                           | 2.10.0                    |                           |
|  34 | bcrypt                    | 3.2.0                     | 4.0.1                     |                           |
|  35 | beautifulsoup4            | 4.10.0                    |                           |                           |
|  36 | black                     |                           |                           | 22.10.0                   |
|  37 | bleach                    | 3.3.0                     |                           |                           |
|  38 | blosc                     | 1.10.6                    |                           |                           |
|  39 | bokeh                     | 2.4.3                     | 2.4.3                     |                           |
|  40 | boto3                     | 1.21.21, 1.24.80, 1.24.95 | 1.21.21, 1.24.59, 1.24.89 |                           |
|  41 | boto3-stubs               |                           | 1.24.89                   |                           |
|  42 | botocore                  | 1.24.21, 1.27.80, 1.27.95 | 1.24.21, 1.27.59, 1.27.89 |                           |
|  43 | botocore-stubs            | 1.27.17                   | 1.27.89                   |                           |
|  44 | build                     |                           |                           | 0.8.0                     |
|  45 | bump2version              |                           |                           | 1.0.1                     |
|  46 | certifi                   | 2022.5.18.1, 2022.6.15, 2022.9.14, 2022.9.24 | 2022.5.18.1, 2022.6.15, 2022.9.14, 2022.9.24 |                           |
|  47 | cffi                      | 1.15.0                    | 1.15.0, 1.15.1            |                           |
|  48 | cfgv                      |                           |                           | 3.3.1                     |
|  49 | cfn-lint                  |                           | 0.67.0                    |                           |
|  50 | change-case               |                           |                           | 0.5.2                     |
|  51 | charset-normalizer        | 2.0.12, 2.1.1             | 2.0.12, 2.1.1             |                           |
|  52 | click                     | 8.1.3                     | 8.1.3                     | 8.1.3                     |
|  53 | cloudpickle               | 2.0.0, 2.2.0              |                           |                           |
|  54 | codecov                   |                           | 2.1.12                    |                           |
|  55 | colorama                  | 0.4.5                     |                           |                           |
|  56 | colorlog                  |                           | 6.7.0                     |                           |
|  57 | commonmark                | 0.9.1                     |                           |                           |
|  58 | configparser              | 5.3.0                     |                           |                           |
|  59 | coverage                  |                           | 6.5.0                     |                           |
|  60 | coveralls                 |                           | 3.3.1                     |                           |
|  61 | cryptography              | 3.4.7, 36.0.2, 37.0.2     | 36.0.2, 38.0.1            |                           |
|  62 | cytoolz                   | 0.11.0                    |                           |                           |
|  63 | dask                      | 2022.9.2                  |                           |                           |
|  64 | dask-gateway              | 2022.10.0                 |                           |                           |
|  65 | dask-gateway-server       |                           | 2022.10.0                 |                           |
|  66 | decorator                 | 4.4.2                     |                           |                           |
|  67 | defusedxml                | 0.7.1                     |                           |                           |
|  68 | deprecated                | 1.2.13                    | 1.2.13                    |                           |
|  69 | dill                      |                           | 0.3.5.1                   | 0.3.5.1                   |
|  70 | distlib                   |                           |                           | 0.3.6                     |
|  71 | distributed               | 2022.9.2                  |                           |                           |
|  72 | distro                    | 1.5.0                     |                           |                           |
|  73 | dnspython                 | 2.0.0, 2.1.0, 2.2.1       | 2.2.1                     |                           |
|  74 | docker                    | 5.0.3, 6.0.0              | 6.0.0                     |                           |
|  75 | docker-compose            | 1.29.1                    |                           |                           |
|  76 | dockerpty                 | 0.4.1                     |                           |                           |
|  77 | docopt                    | 0.6.2                     | 0.6.2                     |                           |
|  78 | ecdsa                     | 0.14.1                    | 0.18.0                    |                           |
|  79 | email-validator           | 1.2.1, 1.3.0              | 1.3.0                     |                           |
|  80 | et-xmlfile                | 1.1.0                     |                           |                           |
|  81 | exceptiongroup            |                           | 1.0.0                     |                           |
|  82 | execnet                   |                           | 1.9.0                     |                           |
|  83 | expiringdict              | 1.2.1                     |                           |                           |
|  84 | faker                     |                           | 15.1.0, 15.1.1            |                           |
|  85 | fastapi                   | 0.85.0, 0.85.1            |                           |                           |
|  86 | fastapi-contrib           | 0.2.11                    |                           |                           |
|  87 | fastapi-pagination        | 0.10.0                    |                           |                           |
|  88 | fastjsonschema            | 2.15.3                    |                           |                           |
|  89 | filelock                  |                           |                           | 3.8.0                     |
|  90 | flaky                     |                           | 3.7.0                     |                           |
|  91 | flask                     |                           | 2.1.3                     |                           |
|  92 | flask-cors                |                           | 3.0.10                    |                           |
|  93 | frozenlist                | 1.3.0, 1.3.1              | 1.3.0, 1.3.1              |                           |
|  94 | fsspec                    | 2022.5.0, 2022.8.2        |                           |                           |
|  95 | future                    | 0.18.2                    |                           |                           |
|  96 | futures                   | 3.0.5                     |                           |                           |
|  97 | graphql-core              |                           | 3.2.3                     |                           |
|  98 | greenlet                  | 1.1.2, 1.1.3.post0        | 1.1.2, 1.1.3.post0        |                           |
|  99 | gunicorn                  | 20.1.0                    |                           |                           |
| 100 | h11                       | 0.12.0                    | 0.12.0                    |                           |
| 101 | h2                        | 4.1.0                     |                           |                           |
| 102 | heapdict                  | 1.0.1                     |                           |                           |
| 103 | hpack                     | 4.0.0                     |                           |                           |
| 104 | httpcore                  | 0.15.0                    | 0.15.0                    |                           |
| 105 | httptools                 | 0.2.0, 0.5.0              |                           |                           |
| 106 | httpx                     | 0.23.0                    | 0.23.0                    |                           |
| 107 | hyperframe                | 6.0.1                     |                           |                           |
| 108 | hypothesis                |                           | 6.56.2                    |                           |
| 109 | icdiff                    |                           | 2.0.5                     |                           |
| 110 | identify                  |                           |                           | 2.5.6                     |
| 111 | idna                      | 2.10, 3.3, 3.4            | 2.10, 3.3, 3.4            |                           |
| 112 | importlib-metadata        | 5.0.0                     | 5.0.0                     |                           |
| 113 | iniconfig                 | 1.1.1                     | 1.1.1                     |                           |
| 114 | inotify                   |                           |                           | 0.2.10                    |
| 115 | isodate                   | 0.6.1                     |                           |                           |
| 116 | isort                     |                           | 5.10.1                    | 5.10.1                    |
| 117 | itsdangerous              | 1.1.0, 2.1.2              | 2.1.2                     |                           |
| 118 | jaeger-client             | 4.8.0                     |                           |                           |
| 119 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 120 | jinja2                    | 3.1.2                     | 3.1.2                     | 3.1.2                     |
| 121 | jmespath                  | 1.0.0, 1.0.1              | 1.0.0, 1.0.1              |                           |
| 122 | jschema-to-python         |                           | 1.2.3                     |                           |
| 123 | json2html                 | 1.3.0                     |                           |                           |
| 124 | jsondiff                  | 2.0.0                     | 2.0.0                     |                           |
| 125 | jsonpatch                 |                           | 1.32                      |                           |
| 126 | jsonpickle                |                           | 2.2.0                     |                           |
| 127 | jsonpointer               |                           | 2.3                       |                           |
| 128 | jsonschema                | 3.2.0, 4.16.0             | 3.2.0, 4.16.0             |                           |
| 129 | junit-xml                 |                           | 1.9                       |                           |
| 130 | jupyter-client            | 6.1.12                    |                           |                           |
| 131 | jupyter-core              | 4.7.1                     |                           |                           |
| 132 | jupyter-server            | 1.18.1                    |                           |                           |
| 133 | jupyter-server-proxy      | 3.2.1                     |                           |                           |
| 134 | jupyterlab-pygments       | 0.1.2                     |                           |                           |
| 135 | lazy-object-proxy         | 1.7.1                     | 1.7.1                     | 1.7.1                     |
| 136 | locket                    | 1.0.0                     |                           |                           |
| 137 | lz4                       | 4.0.0                     |                           |                           |
| 138 | mako                      | 1.2.2, 1.2.3              | 1.2.2, 1.2.3              |                           |
| 139 | markupsafe                | 2.1.1                     | 2.1.1                     | 2.1.1                     |
| 140 | mccabe                    |                           | 0.7.0                     | 0.7.0                     |
| 141 | minio                     |                           | 7.0.4                     |                           |
| 142 | mistune                   | 2.0.4                     |                           |                           |
| 143 | moto                      |                           | 4.0.1, 4.0.7              |                           |
| 144 | msgpack                   | 1.0.3, 1.0.4              |                           |                           |
| 145 | multidict                 | 6.0.2                     | 6.0.2                     |                           |
| 146 | mypy-extensions           |                           |                           | 0.4.3                     |
| 147 | nbclient                  | 0.5.3                     |                           |                           |
| 148 | nbconvert                 | 7.2.1                     |                           |                           |
| 149 | nbformat                  | 5.3.0                     |                           |                           |
| 150 | nest-asyncio              | 1.5.1                     |                           |                           |
| 151 | networkx                  | 2.5.1                     | 2.8.7                     |                           |
| 152 | nodeenv                   |                           |                           | 1.7.0                     |
| 153 | nose                      |                           |                           | 1.3.7                     |
| 154 | numpy                     | 1.22.3                    | 1.23.4                    |                           |
| 155 | openapi-core              | 0.12.0                    |                           |                           |
| 156 | openapi-schema-validator  | 0.2.3                     | 0.2.3                     |                           |
| 157 | openapi-spec-validator    | 0.4.0                     | 0.4.0                     |                           |
| 158 | openpyxl                  | 3.0.9                     |                           |                           |
| 159 | opentracing               | 2.4.0                     |                           |                           |
| 160 | orjson                    | 3.7.2                     |                           |                           |
| 161 | packaging                 | 21.3                      | 21.3                      | 21.3                      |
| 162 | pamqp                     | 2.3.0, 3.1.0              | 2.3.0, 3.2.1              |                           |
| 163 | pandas                    | 1.2.4                     | 1.5.0                     |                           |
| 164 | pandocfilters             | 1.4.3                     |                           |                           |
| 165 | paramiko                  | 2.11.0                    |                           |                           |
| 166 | parfive                   | 1.5.1                     |                           |                           |
| 167 | partd                     | 1.2.0, 1.3.0              |                           |                           |
| 168 | passlib                   | 1.7.4                     | 1.7.4                     |                           |
| 169 | pathspec                  |                           |                           | 0.10.1                    |
| 170 | pbr                       |                           | 5.10.0                    |                           |
| 171 | pennsieve                 | 6.2.0                     |                           |                           |
| 172 | pep517                    |                           |                           | 0.13.0                    |
| 173 | pillow                    | 9.0.1                     | 9.2.0                     |                           |
| 174 | pint                      | 0.19.2                    | 0.19.2                    |                           |
| 175 | pip-tools                 |                           |                           | 6.9.0                     |
| 176 | platformdirs              |                           | 2.5.2                     | 2.5.2                     |
| 177 | pluggy                    | 1.0.0                     | 1.0.0                     |                           |
| 178 | pprintpp                  |                           | 0.4.0                     |                           |
| 179 | pre-commit                |                           |                           | 2.20.0                    |
| 180 | prometheus-client         | 0.14.1                    |                           |                           |
| 181 | protobuf                  | 3.20.1                    |                           |                           |
| 182 | psutil                    | 5.9.1, 5.9.2, 5.9.3       |                           |                           |
| 183 | psycopg2-binary           | 2.9.3, 2.9.4              | 2.9.3, 2.9.4              |                           |
| 184 | ptvsd                     |                           | 4.3.2                     |                           |
| 185 | ptyprocess                | 0.7.0                     |                           |                           |
| 186 | py                        | 1.11.0                    | 1.11.0                    |                           |
| 187 | py-cpuinfo                |                           | 8.0.0                     |                           |
| 188 | pyasn1                    | 0.4.8                     | 0.4.8                     |                           |
| 189 | pycparser                 | 2.20, 2.21                | 2.20, 2.21                |                           |
| 190 | pydantic                  | 1.9.0, 1.10.2             | 1.10.2                    |                           |
| 191 | pyftpdlib                 |                           | 1.5.7                     |                           |
| 192 | pygments                  | 2.9.0, 2.13.0             |                           |                           |
| 193 | pyinstrument              | 3.4.2, 4.1.1, 4.3.0       | 4.3.0                     |                           |
| 194 | pyinstrument-cext         | 0.2.4                     |                           |                           |
| 195 | pyjwt                     | 2.4.0                     |                           |                           |
| 196 | pylint                    |                           | 2.15.4                    | 2.15.4                    |
| 197 | pynacl                    | 1.4.0                     |                           |                           |
| 198 | pyopenssl                 |                           | 22.1.0                    |                           |
| 199 | pyparsing                 | 3.0.9                     | 3.0.9                     | 3.0.9                     |
| 200 | pyrsistent                | 0.18.1                    | 0.18.1                    |                           |
| 201 | pytest                    | 7.1.3                     | 7.1.3                     |                           |
| 202 | pytest-aiohttp            |                           | 1.0.4                     |                           |
| 203 | pytest-asyncio            |                           | 0.19.0, 0.20.0            |                           |
| 204 | pytest-benchmark          |                           | 3.4.1                     |                           |
| 205 | pytest-cov                |                           | 4.0.0                     |                           |
| 206 | pytest-docker             |                           | 1.0.1                     |                           |
| 207 | pytest-forked             |                           | 1.4.0                     |                           |
| 208 | pytest-icdiff             |                           | 0.6                       |                           |
| 209 | pytest-instafail          |                           | 0.4.2                     |                           |
| 210 | pytest-lazy-fixture       |                           | 0.6.3                     |                           |
| 211 | pytest-localftpserver     |                           | 1.1.4                     |                           |
| 212 | pytest-mock               |                           | 3.10.0                    |                           |
| 213 | pytest-runner             |                           | 6.0.0                     |                           |
| 214 | pytest-sugar              |                           | 0.9.5                     |                           |
| 215 | pytest-xdist              |                           | 2.5.0                     |                           |
| 216 | python-dateutil           | 2.8.1, 2.8.2              | 2.8.1, 2.8.2              |                           |
| 217 | python-dotenv             | 0.20.0, 0.21.0            | 0.20.0, 0.21.0            |                           |
| 218 | python-engineio           | 3.14.2                    |                           |                           |
| 219 | python-jose               | 3.2.0                     | 3.3.0                     |                           |
| 220 | python-magic              | 0.4.25                    |                           |                           |
| 221 | python-multipart          | 0.0.5                     |                           |                           |
| 222 | python-socketio           | 4.6.1                     |                           |                           |
| 223 | pytz                      | 2020.1, 2022.1, 2022.5    | 2022.4                    |                           |
| 224 | pyyaml                    | 5.4.1, 6.0                | 5.4.1, 6.0                | 5.4.1, 6.0                |
| 225 | pyzmq                     | 22.1.0                    |                           |                           |
| 226 | redis                     | 4.3.1, 4.3.4              | 4.3.1                     |                           |
| 227 | requests                  | 2.27.1, 2.28.1            | 2.27.1, 2.28.1            |                           |
| 228 | responses                 |                           | 0.22.0                    |                           |
| 229 | respx                     |                           | 0.20.0                    |                           |
| 230 | rfc3986                   | 1.4.0, 1.5.0              | 1.4.0, 1.5.0              |                           |
| 231 | rich                      | 12.5.1, 12.6.0            |                           |                           |
| 232 | rsa                       | 4.9                       | 4.9                       |                           |
| 233 | s3fs                      | 2022.5.0                  |                           |                           |
| 234 | s3transfer                | 0.5.2, 0.6.0              | 0.5.2, 0.6.0              |                           |
| 235 | sarif-om                  |                           | 1.0.4                     |                           |
| 236 | semantic-version          | 2.9.0                     |                           |                           |
| 237 | semver                    | 2.13.0                    |                           |                           |
| 238 | send2trash                | 1.7.1                     |                           |                           |
| 239 | setproctitle              | 1.2.3                     |                           |                           |
| 240 | shellingham               | 1.5.0                     |                           |                           |
| 241 | simpervisor               | 0.4                       |                           |                           |
| 242 | six                       | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            |                           |
| 243 | sniffio                   | 1.2.0, 1.3.0              | 1.2.0, 1.3.0              |                           |
| 244 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 245 | soupsieve                 | 2.3.2                     |                           |                           |
| 246 | sqlalchemy                | 1.4.37, 1.4.41            | 1.4.37, 1.4.41            |                           |
| 247 | sshpubkeys                |                           | 3.3.1                     |                           |
| 248 | starlette                 | 0.20.4                    |                           |                           |
| 249 | strict-rfc3339            | 0.7                       |                           |                           |
| 250 | tblib                     | 1.7.0                     |                           |                           |
| 251 | tenacity                  | 8.0.1, 8.1.0              | 8.0.1, 8.1.0              |                           |
| 252 | termcolor                 |                           | 2.0.1                     |                           |
| 253 | terminado                 | 0.10.1                    |                           |                           |
| 254 | texttable                 | 1.6.3                     |                           |                           |
| 255 | threadloop                | 1.0.2                     |                           |                           |
| 256 | thrift                    | 0.16.0                    |                           |                           |
| 257 | tinycss2                  | 1.1.1                     |                           |                           |
| 258 | toml                      |                           | 0.10.2                    | 0.10.2                    |
| 259 | tomli                     | 2.0.1                     | 2.0.1                     | 2.0.1                     |
| 260 | tomlkit                   |                           | 0.11.5                    | 0.11.5                    |
| 261 | toolz                     | 0.11.1, 0.12.0            |                           |                           |
| 262 | tornado                   | 6.1, 6.2                  | 6.1                       |                           |
| 263 | tqdm                      | 4.64.0, 4.64.1            | 4.64.1                    |                           |
| 264 | traitlets                 | 5.1.1                     | 5.4.0                     |                           |
| 265 | twilio                    | 7.12.0                    |                           |                           |
| 266 | typer                     | 0.4.1, 0.6.1              | 0.6.1                     | 0.6.1                     |
| 267 | types-aiobotocore         | 2.3.3                     | 2.4.0.post1               |                           |
| 268 | types-aiobotocore-s3      | 2.3.3                     | 2.4.0.post1               |                           |
| 269 | types-aiofiles            |                           | 22.1.0                    |                           |
| 270 | types-awscrt              |                           | 0.14.7                    |                           |
| 271 | types-boto3               |                           | 1.0.2                     |                           |
| 272 | types-pkg-resources       |                           | 0.1.3                     |                           |
| 273 | types-pyyaml              |                           | 6.0.12                    |                           |
| 274 | types-s3transfer          |                           | 0.6.0.post4               |                           |
| 275 | types-toml                |                           | 0.10.8                    |                           |
| 276 | typing-extensions         | 4.3.0, 4.4.0              | 4.3.0, 4.4.0              | 4.3.0, 4.4.0              |
| 277 | ujson                     | 5.5.0                     |                           |                           |
| 278 | urllib3                   | 1.26.9, 1.26.11, 1.26.12  | 1.26.9, 1.26.11, 1.26.12  |                           |
| 279 | uvicorn                   | 0.15.0, 0.17.0, 0.18.3, 0.19.0 |                           |                           |
| 280 | uvloop                    | 0.16.0, 0.17.0            |                           |                           |
| 281 | virtualenv                |                           |                           | 20.16.5                   |
| 282 | watchdog                  | 2.1.5                     |                           | 2.1.9                     |
| 283 | watchfiles                | 0.18.0                    |                           |                           |
| 284 | watchgod                  | 0.8.2                     |                           |                           |
| 285 | webencodings              | 0.5.1                     |                           |                           |
| 286 | websocket-client          | 0.59.0, 1.4.1             | 0.59.0, 1.4.1             |                           |
| 287 | websockets                | 10.1, 10.2, 10.3          | 10.3                      |                           |
| 288 | werkzeug                  | 2.0.3, 2.1.2              | 2.0.3, 2.1.2              |                           |
| 289 | wheel                     |                           |                           | 0.37.1                    |
| 290 | wrapt                     | 1.14.1                    | 1.14.1                    | 1.14.1                    |
| 291 | xmltodict                 |                           | 0.13.0                    |                           |
| 292 | yarl                      | 1.5.1, 1.7.2, 1.8.1       | 1.5.1, 1.7.2, 1.8.1       |                           |
| 293 | zict                      | 2.2.0                     |                           |                           |
| 294 | zipp                      | 3.9.0                     | 3.9.0                     |                           |


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
