### PR TITLE
♻️ user services can no longer contact the dynamic sidecar

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/sidecar.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/sidecar.py
@@ -88,7 +88,6 @@ def _get_environment_variables(
 def get_dynamic_sidecar_spec(
     scheduler_data: SchedulerData,
     dynamic_sidecar_settings: DynamicSidecarSettings,
-    dynamic_sidecar_network_id: str,
     swarm_network_id: str,
     settings: SimcoreServiceSettingsLabel,
     app_settings: AppSettings,
@@ -234,10 +233,7 @@ def get_dynamic_sidecar_spec(
             "service_image": dynamic_sidecar_settings.DYNAMIC_SIDECAR_IMAGE,
         },
         "name": scheduler_data.service_name,
-        "networks": [
-            {"Target": swarm_network_id},
-            {"Target": dynamic_sidecar_network_id},
-        ],
+        "networks": [{"Target": swarm_network_id}],
         "task_template": {
             "ContainerSpec": {
                 "Env": _get_environment_variables(

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/events.py
@@ -157,7 +157,6 @@ class CreateSidecars(DynamicSchedulerEvent):
             get_dynamic_sidecar_spec(
                 scheduler_data=scheduler_data,
                 dynamic_sidecar_settings=dynamic_sidecar_settings,
-                dynamic_sidecar_network_id=dynamic_sidecar_network_id,
                 swarm_network_id=swarm_network_id,
                 settings=settings,
                 app_settings=app.state.settings,

--- a/services/director-v2/tests/unit/test_api_route_dynamic_scheduler.py
+++ b/services/director-v2/tests/unit/test_api_route_dynamic_scheduler.py
@@ -6,12 +6,12 @@ import asyncio
 from typing import AsyncIterator
 
 import pytest
-from requests import Response
 import respx
 from fastapi import status
 from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
+from requests import Response
 from simcore_service_director_v2.models.schemas.dynamic_services.scheduler import (
     SchedulerData,
 )

--- a/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_service_specs.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_service_specs.py
@@ -73,11 +73,6 @@ def dynamic_sidecar_settings(mock_env: dict[str, str]) -> DynamicSidecarSettings
 
 
 @pytest.fixture
-def dynamic_sidecar_network_id() -> str:
-    return "mocked_dynamic_sidecar_network_id"
-
-
-@pytest.fixture
 def swarm_network_id() -> str:
     return "mocked_swarm_network_id"
 
@@ -169,10 +164,7 @@ def expected_dynamic_sidecar_spec(run_id: RunID) -> dict[str, Any]:
             "uuid": "75c7f3f4-18f9-4678-8610-54a2ade78eaa",
         },
         "name": "dy-sidecar_75c7f3f4-18f9-4678-8610-54a2ade78eaa",
-        "networks": [
-            {"Target": "mocked_swarm_network_id"},
-            {"Target": "mocked_dynamic_sidecar_network_id"},
-        ],
+        "networks": [{"Target": "mocked_swarm_network_id"}],
         "task_template": {
             "ContainerSpec": {
                 "Env": {
@@ -343,7 +335,6 @@ def test_get_dynamic_proxy_spec(
     minimal_app: FastAPI,
     scheduler_data: SchedulerData,
     dynamic_sidecar_settings: DynamicSidecarSettings,
-    dynamic_sidecar_network_id: str,
     swarm_network_id: str,
     simcore_service_labels: SimcoreServiceLabels,
     expected_dynamic_sidecar_spec: dict[str, Any],
@@ -367,7 +358,6 @@ def test_get_dynamic_proxy_spec(
         dynamic_sidecar_spec: AioDockerServiceSpec = get_dynamic_sidecar_spec(
             scheduler_data=scheduler_data,
             dynamic_sidecar_settings=dynamic_sidecar_settings,
-            dynamic_sidecar_network_id=dynamic_sidecar_network_id,
             swarm_network_id=swarm_network_id,
             settings=cast(SimcoreServiceSettingsLabel, simcore_service_labels.settings),
             app_settings=minimal_app.state.settings,
@@ -430,7 +420,6 @@ async def test_merge_dynamic_sidecar_specs_with_user_specific_specs(
     minimal_app: FastAPI,
     scheduler_data: SchedulerData,
     dynamic_sidecar_settings: DynamicSidecarSettings,
-    dynamic_sidecar_network_id: str,
     swarm_network_id: str,
     simcore_service_labels: SimcoreServiceLabels,
     expected_dynamic_sidecar_spec: dict[str, Any],
@@ -440,7 +429,6 @@ async def test_merge_dynamic_sidecar_specs_with_user_specific_specs(
     dynamic_sidecar_spec: AioDockerServiceSpec = get_dynamic_sidecar_spec(
         scheduler_data=scheduler_data,
         dynamic_sidecar_settings=dynamic_sidecar_settings,
-        dynamic_sidecar_network_id=dynamic_sidecar_network_id,
         swarm_network_id=swarm_network_id,
         settings=cast(SimcoreServiceSettingsLabel, simcore_service_labels.settings),
         app_settings=minimal_app.state.settings,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

The dy-sidecar was accidentally expoed to the user services instead of only exposing the proxy.
It is no longer possible to contact the dy-sidecar from a user service (like from a jupyter-notebook).

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

- fixes https://github.com/ITISFoundation/osparc-simcore/issues/3390


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist