### PR TITLE
🐛 Bugfix#2: datcore-adapter stops calling into pennsieve after too many requests are done?

### DIFF
--- a/services/datcore-adapter/src/simcore_service_datcore_adapter/utils/client_base.py
+++ b/services/datcore-adapter/src/simcore_service_datcore_adapter/utils/client_base.py
@@ -53,6 +53,7 @@ def setup_client_instance(
     assert issubclass(api_cls, BaseServiceClientApi)
 
     def _create_instance() -> None:
+        # NOTE: http2 is explicitely disabled due to the issue https://github.com/encode/httpx/discussions/2112
         api_cls.create_once(
             app,
             client=httpx.AsyncClient(

--- a/services/datcore-adapter/src/simcore_service_datcore_adapter/utils/client_base.py
+++ b/services/datcore-adapter/src/simcore_service_datcore_adapter/utils/client_base.py
@@ -56,7 +56,7 @@ def setup_client_instance(
         api_cls.create_once(
             app,
             client=httpx.AsyncClient(
-                http2=True, base_url=api_baseurl, timeout=api_general_timeout
+                http2=False, base_url=api_baseurl, timeout=api_general_timeout
             ),
             service_name=service_name,
             **extra_fields

--- a/services/docker-compose.devel.yml
+++ b/services/docker-compose.devel.yml
@@ -37,7 +37,7 @@ services:
   datcore-adapter:
     environment:
       - SC_BOOT_MODE=debug-ptvsd
-      - DATCORE_ADAPTER_LOG_LEVEL=DEBUG
+      - LOG_LEVEL=DEBUG
     volumes:
       - ./datcore-adapter:/devel/services/datcore-adapter
       - ../packages:/devel/packages


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
This PR disable http/2 on the httpx client used in the datcore-adapter.
It seems we are impacted by this: [https://github.com/encode/httpx/discussions/2112](https://github.com/encode/httpx/discussions/2112) in httpx

current workaround is to disable http/2 protocol. sad.

should fix #3464 

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
