### PR TITLE
🐛 Storage: crash when not a file in the project

### DIFF
--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -488,7 +488,8 @@ class SimcoreS3DataManager(BaseDataManager):
                         bytes_transfered_cb=s3_transfered_data_cb.copy_transfer_cb,
                     )
                     for output in node.get("outputs", {}).values()
-                    if int(output.get("store", self.location_id)) == DATCORE_ID
+                    if isinstance(output, dict)
+                    and int(output.get("store", self.location_id)) == DATCORE_ID
                 ]
             )
         await logged_gather(*copy_tasks, max_concurrency=MAX_CONCURRENT_S3_TASKS)

--- a/services/storage/tests/unit/test_handlers_simcore_s3.py
+++ b/services/storage/tests/unit/test_handlers_simcore_s3.py
@@ -185,7 +185,7 @@ async def _get_updated_project(aiopg_engine: Engine, project_id: str) -> dict[st
 async def random_project_with_files(
     aiopg_engine: Engine,
     create_project: Callable[[], Awaitable[dict[str, Any]]],
-    create_project_node: Callable[[ProjectID], Awaitable[NodeID]],
+    create_project_node: Callable[..., Awaitable[NodeID]],
     create_simcore_file_id: Callable[[ProjectID, NodeID, str], SimcoreS3FileID],
     upload_file: Callable[
         [ByteSize, str, str], Awaitable[tuple[Path, SimcoreS3FileID]]
@@ -207,7 +207,11 @@ async def random_project_with_files(
         src_projects_list: dict[NodeID, dict[SimcoreS3FileID, Path]] = {}
         upload_tasks: deque[Awaitable] = deque()
         for _node_index in range(num_nodes):
-            src_node_id = await create_project_node(ProjectID(project["uuid"]))
+            # NOTE: we put some more outputs in there to simuate a real case better
+            src_node_id = await create_project_node(
+                ProjectID(project["uuid"]),
+                outputs={"output_1": faker.pyint(), "output_2": faker.pystr()},
+            )
             src_projects_list[src_node_id] = {}
 
             async def _upload_file_and_update_project(project, src_node_id):


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
fixes https://github.com/ITISFoundation/osparc-issues/issues/754#issuecomment-1295083982
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```bash
make devenv
source .venv/bin/activate
cd services/storage
make install-dev
make test-unit-dev
```

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Openapi changes? ``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Database migration script? ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
