### PR TITLE
🐛 Fix/sanitize old data for usergroups.thumbnail

### DIFF
--- a/services/web/server/src/simcore_service_webserver/groups_models.py
+++ b/services/web/server/src/simcore_service_webserver/groups_models.py
@@ -1,6 +1,15 @@
+from contextlib import suppress
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel, EmailStr, Field
+from pydantic import (
+    AnyUrl,
+    BaseModel,
+    EmailStr,
+    Field,
+    ValidationError,
+    parse_obj_as,
+    validator,
+)
 
 #
 # GROUPS MODELS defined in OPENAPI specs
@@ -39,6 +48,15 @@ class UsersGroup(BaseModel):
         description="Maps user's column and regular expression",
         alias="inclusionRules",
     )
+
+    @validator("thumbnail", pre=True)
+    @classmethod
+    def sanitize_legacy_data(cls, v):
+        if v:
+            # Enforces null if thumbnail is not valid URL or empty
+            with suppress(ValidationError):
+                return parse_obj_as(AnyUrl, v)
+        return None
 
     class Config:
         schema_extra = {

--- a/services/web/server/tests/unit/isolated/test_groups_models.py
+++ b/services/web/server/tests/unit/isolated/test_groups_models.py
@@ -48,3 +48,31 @@ def test_group_models_examples(
 
         assert model_enveloped.error is None
         assert model_array_enveloped.error is None
+
+
+def test_sanitize_legacy_data():
+    users_group_1 = UsersGroup.parse_obj(
+        {
+            "gid": "27",
+            "label": "A user",
+            "description": "A very special user",
+            "thumbnail": "",  # <--- empty strings
+            "accessRights": {"read": True, "write": False, "delete": False},
+        }
+    )
+
+    assert users_group_1.thumbnail is None
+
+    users_group_2 = UsersGroup.parse_obj(
+        {
+            "gid": "27",
+            "label": "A user",
+            "description": "A very special user",
+            "thumbnail": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPgAAADMCAMAAABp5J",  # <--- encoded thumbnail are discarded
+            "accessRights": {"read": True, "write": False, "delete": False},
+        }
+    )
+
+    assert users_group_2.thumbnail is None
+
+    assert users_group_1 == users_group_2


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

The ``thumbnail`` column in the ``groups`` table contains old data that does not validate as an url. I have found empty strings, or embedded images. From now on, any invalid thumbnail (i.e. a valud that does not match ``Optional[AnyUrl]``) is automatically nullified. 

This error happens while ``get_profile``: The database has an old thumbnail that when parsed into ``ProfileGet`` a ``ValidationError`` is raised which is converted by the middle-ware into 500. Since ``WEBSERVER_DIAGNOSTICS=`` the error is logged in the backend:
![image](https://user-images.githubusercontent.com/32402063/199316113-4bf43b84-fb3b-43ce-9606-f835bfa55534.png)


**why?**: The problem is that ``groups`` resources are NOT validated (handlers are pretty old) when created but the ``Profile`` resource IS validated when read. That lead to a paradoxical situation in which you could write "invalid" group data but could not read it via the ``Profile``. We can take care of that after the review https://github.com/ITISFoundation/osparc-simcore/issues/3499


@odeimaiz : I found entries with embedded images like ``"thumbnail": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPgAAADMCAMAAABp5J ...`` . Do we really want to have embedded thumbnails or only URL? Does the front-end support both?



## How to test



``services/web/server/tests/unit/isolated/test_groups_models.py::test_sanitize_legacy_data``
