### PR TITLE
🐛 Project copy failing when pennsieve token is active

### DIFF
--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -489,7 +489,7 @@ class SimcoreS3DataManager(BaseDataManager):
                     )
                     for output in node.get("outputs", {}).values()
                     if isinstance(output, dict)
-                    and int(output.get("store", self.location_id)) == DATCORE_ID
+                    and (int(output.get("store", self.location_id)) == DATCORE_ID)
                 ]
             )
         await logged_gather(*copy_tasks, max_concurrency=MAX_CONCURRENT_S3_TASKS)

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers_crud.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers_crud.py
@@ -40,7 +40,10 @@ from ..resource_manager.websocket_manager import PROJECT_ID_KEY, managed_resourc
 from ..rest_constants import RESPONSE_MODEL_POLICY
 from ..security_api import check_permission
 from ..security_decorators import permission_required
-from ..storage_api import copy_data_folders_from_project, get_project_total_size
+from ..storage_api import (
+    copy_data_folders_from_project,
+    get_project_total_size_simcore_s3,
+)
 from ..users_api import get_user_name
 from . import projects_api
 from .project_models import ProjectDict, ProjectTypeAPI
@@ -164,7 +167,9 @@ async def _prepare_project_copy(
     assert settings  # nosec
     if max_bytes := settings.PROJECTS_MAX_COPY_SIZE_BYTES:
         # get project total data size
-        project_data_size = await get_project_total_size(app, user_id, src_project_uuid)
+        project_data_size = await get_project_total_size_simcore_s3(
+            app, user_id, src_project_uuid
+        )
         if project_data_size >= max_bytes:
             raise web.HTTPUnprocessableEntity(
                 reason=f"Source project data size is {project_data_size.human_readable()}."

--- a/services/web/server/src/simcore_service_webserver/storage_api.py
+++ b/services/web/server/src/simcore_service_webserver/storage_api.py
@@ -85,11 +85,7 @@ async def get_project_total_size_simcore_s3(
             for file_metadata in list_of_files_enveloped.data:
                 project_size_bytes += file_metadata.file_size
         project_size = parse_obj_as(ByteSize, project_size_bytes)
-        log.info(
-            "%s total size in S3 is %s",
-            f"{project_uuid}",
-            f"{project_size.human_readable()}",
-        )
+
         return project_size
 
 

--- a/services/web/server/src/simcore_service_webserver/storage_api.py
+++ b/services/web/server/src/simcore_service_webserver/storage_api.py
@@ -6,7 +6,11 @@ import logging
 from typing import Any, AsyncGenerator
 
 from aiohttp import ClientError, ClientSession, ClientTimeout, web
-from models_library.api_schemas_storage import FileLocationArray, FileMetaDataGet
+from models_library.api_schemas_storage import (
+    FileLocation,
+    FileLocationArray,
+    FileMetaDataGet,
+)
 from models_library.generics import Envelope
 from models_library.projects import ProjectID
 from models_library.users import UserID
@@ -18,6 +22,7 @@ from servicelib.aiohttp.long_running_tasks.client import (
     LRTask,
     long_running_task_request,
 )
+from servicelib.logging_utils import log_context
 from simcore_service_webserver.projects.project_models import ProjectDict
 from simcore_service_webserver.projects.projects_utils import NodesMap
 from yarl import URL
@@ -54,31 +59,38 @@ async def get_storage_locations(
         return locations_enveloped.data
 
 
-async def get_project_total_size(
+async def get_project_total_size_simcore_s3(
     app: web.Application, user_id: UserID, project_uuid: ProjectID
 ) -> ByteSize:
-    log.debug("getting %s total size for %s", f"{project_uuid=}", f"{user_id=}")
-    user_accessible_locations = await get_storage_locations(app, user_id)
-    session, api_endpoint = _get_storage_client(app)
+    with log_context(
+        log,
+        logging.DEBUG,
+        msg=f"getting {project_uuid=} total size in S3 for {user_id=}",
+    ):
+        # NOTE: datcore does not handle filtering and is too slow for this, so for now this is hard-coded
+        user_accessible_locations = [FileLocation(name="simcore.s3", id=0)]
+        session, api_endpoint = _get_storage_client(app)
 
-    project_size_bytes = 0
-    for location in user_accessible_locations:
-        files_metadata_url = (
-            api_endpoint / "locations" / f"{location.id}" / "files" / "metadata"
-        ).with_query(user_id=user_id, uuid_filter=f"{project_uuid}")
-        async with session.get(f"{files_metadata_url}") as response:
-            response.raise_for_status()
-            list_of_files_enveloped = Envelope[list[FileMetaDataGet]].parse_obj(
-                await response.json()
-            )
-            assert list_of_files_enveloped.data is not None  # nosec
-        for file_metadata in list_of_files_enveloped.data:
-            project_size_bytes += file_metadata.file_size
-    project_size = parse_obj_as(ByteSize, project_size_bytes)
-    log.info(
-        "%s total size is %s", f"{project_uuid}", f"{project_size.human_readable()}"
-    )
-    return project_size
+        project_size_bytes = 0
+        for location in user_accessible_locations:
+            files_metadata_url = (
+                api_endpoint / "locations" / f"{location.id}" / "files" / "metadata"
+            ).with_query(user_id=user_id, uuid_filter=f"{project_uuid}")
+            async with session.get(f"{files_metadata_url}") as response:
+                response.raise_for_status()
+                list_of_files_enveloped = Envelope[list[FileMetaDataGet]].parse_obj(
+                    await response.json()
+                )
+                assert list_of_files_enveloped.data is not None  # nosec
+            for file_metadata in list_of_files_enveloped.data:
+                project_size_bytes += file_metadata.file_size
+        project_size = parse_obj_as(ByteSize, project_size_bytes)
+        log.info(
+            "%s total size in S3 is %s",
+            f"{project_uuid}",
+            f"{project_size.human_readable()}",
+        )
+        return project_size
 
 
 async def copy_data_folders_from_project(

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_cancellations.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_cancellations.py
@@ -271,8 +271,8 @@ async def test_copying_too_large_project_returns_422(
     large_project_total_size = (
         app_settings.WEBSERVER_PROJECTS.PROJECTS_MAX_COPY_SIZE_BYTES + 1
     )
-    storage_subsystem_mock.get_project_total_size.return_value = parse_obj_as(
-        ByteSize, large_project_total_size
+    storage_subsystem_mock.get_project_total_size_simcore_s3.return_value = (
+        parse_obj_as(ByteSize, large_project_total_size)
     )
 
     # POST /v0/projects

--- a/services/web/server/tests/unit/with_dbs/_helpers.py
+++ b/services/web/server/tests/unit/with_dbs/_helpers.py
@@ -122,4 +122,4 @@ class MockedStorageSubsystem(NamedTuple):
     copy_data_folders_from_project: mock.MagicMock
     delete_project: mock.MagicMock
     delete_node: mock.MagicMock
-    get_project_total_size: mock.MagicMock
+    get_project_total_size_simcore_s3: mock.MagicMock

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -275,7 +275,7 @@ async def storage_subsystem_mock(mocker) -> MockedStorageSubsystem:
     )
 
     mock3 = mocker.patch(
-        "simcore_service_webserver.projects.projects_handlers_crud.get_project_total_size",
+        "simcore_service_webserver.projects.projects_handlers_crud.get_project_total_size_simcore_s3",
         autospec=True,
         return_value=parse_obj_as(ByteSize, "1Gib"),
     )


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
This PR changes the call to compute the project size.
BEFORE: would check every storage location to get the total size of the project
AFTER: only computes the project total size reported by the internal Simcore S3 storage location

Rationale: in the way this is currently implemented we cannot ask the Pennsieve to give us this information (missing API, and others)

This problem prevents copying any project or opening templates.

@pcrespov this will need to be hotfixed to production

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
