### PR TITLE
✨ Ensure memory swap for computational services is same as memory (⚠️ devops)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,5 +3,7 @@
     "eamodio.gitlens",
     "ms-python.python",
     "samuelcolvin.jinjahtml",
+    "timonwong.shellcheck",
+    "exiasr.hadolint"
   ]
 }

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -59,7 +59,7 @@
   },
   "python.testing.pytestEnabled": true,
   "autoDocstring.docstringFormat": "sphinx",
-  "hadolint.hadolintPath": "scripts/hadolint.bash",
+  "hadolint.hadolintPath": "${workspaceFolder}/scripts/hadolint.bash",
   "hadolint.cliOptions": [],
   "shellcheck.executablePath": "${workspaceFolder}/scripts/shellcheck.bash",
   "shellcheck.run": "onSave",

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/models.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/models.py
@@ -27,8 +27,21 @@ class ContainerHostConfig(BaseModel):
 
     @validator("memory_swap", pre=True, always=True)
     @classmethod
-    def ensure_memory_swap_is_same_as_memory_when_empty(cls, v, values):
+    def ensure_no_memory_swap_means_no_swap(cls, v, values):
         if v is None:
+            # if not set it will be the same value as memory to ensure swap is disabled
+            return values["memory"]
+        return v
+
+    @validator("memory_swap")
+    @classmethod
+    def ensure_memory_swap_is_either_disabled_or_greater_or_equal_to_memory(
+        cls, v, values
+    ):
+        if v <= -1:
+            # if not set it will be the same value as memory to ensure swap is disabled
+            return -1
+        if v < values["memory"]:
             return values["memory"]
         return v
 

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/models.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/models.py
@@ -40,14 +40,9 @@ class ContainerHostConfig(BaseModel):
 
     @validator("memory_swap")
     @classmethod
-    def ensure_memory_swap_is_either_disabled_or_greater_or_equal_to_memory(
-        cls, v, values
-    ):
-        if v <= -1:
-            # if not set it will be the same value as memory to ensure swap is disabled
-            return -1
+    def ensure_memory_swap_cannot_be_unlimited_nor_smaller_than_memory(cls, v, values):
         if v < values["memory"]:
-            return values["memory"]
+            raise ValueError("Memory swap cannot be set to a smaller value than memory")
         return v
 
 

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/models.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/models.py
@@ -1,29 +1,41 @@
-from typing import Dict, List
+from typing import Optional
 
 from packaging import version
-from pydantic import BaseModel, ByteSize, Field
+from pydantic import BaseModel, ByteSize, Field, validator
 
 LEGACY_INTEGRATION_VERSION = version.Version("0")
 
 
 class ContainerHostConfig(BaseModel):
-    binds: List[str] = Field(
+    binds: list[str] = Field(
         ..., alias="Binds", description="A list of volume bindings for this container"
     )
     init: bool = Field(
-        True,
+        default=True,
         alias="Init",
         description="Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used",
     )
     memory: ByteSize = Field(..., alias="Memory", description="Memory limit in bytes")
+    memory_swap: Optional[ByteSize] = Field(
+        default=None,
+        alias="MemorySwap",
+        description="Total memory limit (memory + swap). Set as -1 to enable unlimited swap.",
+    )
     nano_cpus: int = Field(
         ..., alias="NanoCPUs", description="CPU quota in units of 10-9 CPUs"
     )
 
+    @validator("memory_swap", pre=True, always=True)
+    @classmethod
+    def ensure_memory_swap_is_same_as_memory_when_empty(cls, v, values):
+        if v is None:
+            return values["memory"]
+        return v
+
 
 class DockerContainerConfig(BaseModel):
-    env: List[str] = Field(..., alias="Env")
-    cmd: List[str] = Field(..., alias="Cmd")
+    env: list[str] = Field(..., alias="Env")
+    cmd: list[str] = Field(..., alias="Cmd")
     image: str = Field(..., alias="Image")
-    labels: Dict[str, str] = Field(..., alias="Labels")
+    labels: dict[str, str] = Field(..., alias="Labels")
     host_config: ContainerHostConfig = Field(..., alias="HostConfig")

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/models.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/models.py
@@ -7,6 +7,11 @@ LEGACY_INTEGRATION_VERSION = version.Version("0")
 
 
 class ContainerHostConfig(BaseModel):
+    # NOTE: https://github.com/ITISFoundation/osparc-simcore/issues/3506
+    # Be careful! --priviledged, --pid=host --cap-add XXX should never be usable here!!
+    # at the moment they are not part of the possible configuration but if they were
+    # to, ensure they are properly validated
+
     binds: list[str] = Field(
         ..., alias="Binds", description="A list of volume bindings for this container"
     )

--- a/services/dask-sidecar/tests/unit/test_docker_utils.py
+++ b/services/dask-sidecar/tests/unit/test_docker_utils.py
@@ -4,7 +4,7 @@
 # pylint: disable=no-member
 
 import asyncio
-from typing import Any, Dict, List, Tuple
+from typing import Any
 from unittest.mock import call
 
 import aiodocker
@@ -36,7 +36,7 @@ def service_version() -> str:
 
 
 @pytest.fixture()
-def command() -> List[str]:
+def command() -> list[str]:
     return ["sh", "-c", "some_app"]
 
 
@@ -53,10 +53,10 @@ async def test_create_container_config(
     docker_registry: str,
     service_key: str,
     service_version: str,
-    command: List[str],
+    command: list[str],
     comp_volume_mount_point: str,
     boot_mode: BootMode,
-    task_max_resources: Dict[str, Any],
+    task_max_resources: dict[str, Any],
 ):
 
     container_config = await create_container_config(
@@ -89,6 +89,7 @@ async def test_create_container_config(
                 ],
                 "Init": True,
                 "Memory": task_max_resources.get("RAM", 1024**3),
+                "MemorySwap": task_max_resources.get("RAM", 1024**3),
                 "NanoCPUs": task_max_resources.get("CPU", 1) * 1e9,
             },
         }
@@ -188,7 +189,7 @@ async def test_create_container_config(
         ),
     ],
 )
-async def test_parse_line(log_line: str, expected_parsing: Tuple[LogType, str, str]):
+async def test_parse_line(log_line: str, expected_parsing: tuple[LogType, str, str]):
     assert await parse_line(log_line) == expected_parsing
 
 
@@ -204,7 +205,7 @@ async def test_managed_container_always_removes_container(
     docker_registry: str,
     service_key: str,
     service_version: str,
-    command: List[str],
+    command: list[str],
     comp_volume_mount_point: str,
     mocker: MockerFixture,
     exception_type: Exception,

--- a/services/dask-sidecar/tests/unit/test_models.py
+++ b/services/dask-sidecar/tests/unit/test_models.py
@@ -46,7 +46,7 @@ def test_container_host_config_sets_swap_if_set_bigger_than_memory(
         Binds=[faker.pystr() for _ in range(5)],
         Memory=ByteSize(faker.pyint(min_value=234, max_value=434234)),
         NanoCPUs=faker.pyfloat(min_value=0.1),
-        MemorySwap=ByteSize(faker.pyint(min_value=434235)),
+        MemorySwap=ByteSize(faker.pyint(min_value=434235, max_value=12343424234)),
     )
     assert instance.memory_swap
     assert instance.memory < instance.memory_swap

--- a/services/dask-sidecar/tests/unit/test_models.py
+++ b/services/dask-sidecar/tests/unit/test_models.py
@@ -1,5 +1,6 @@
+import pytest
 from faker import Faker
-from pydantic import ByteSize
+from pydantic import ByteSize, ValidationError
 from simcore_service_dask_sidecar.computational_sidecar.models import (
     ContainerHostConfig,
 )
@@ -14,29 +15,35 @@ def test_container_host_config_sets_swap_same_as_memory_if_not_set(faker: Faker)
     assert instance.memory == instance.memory_swap
 
 
-def test_container_host_config_sets_swap_same_as_memory_if_smaller_than_memory(
+def test_container_host_config_raises_if_set_negative(
     faker: Faker,
 ):
-    instance = ContainerHostConfig(
-        Binds=[faker.pystr() for _ in range(5)],
-        Memory=ByteSize(faker.pyint(min_value=234)),
-        NanoCPUs=faker.pyfloat(min_value=0.1),
-        MemorySwap=ByteSize(faker.pyint(min_value=0, max_value=233)),
-    )
-    assert instance.memory == instance.memory_swap
+    with pytest.raises(ValidationError):
+        ContainerHostConfig(
+            Binds=[faker.pystr() for _ in range(5)],
+            Memory=ByteSize(faker.pyint(min_value=234)),
+            NanoCPUs=faker.pyfloat(min_value=0.1),
+            MemorySwap=ByteSize(faker.pyint(min_value=-84654, max_value=-1)),
+        )
 
 
-def test_container_host_config_sets_swap_disabled_if_set_negative(
+def test_container_host_config_raises_if_set_smaller_than_memory(
     faker: Faker,
 ):
-    instance = ContainerHostConfig(
-        Binds=[faker.pystr() for _ in range(5)],
-        Memory=ByteSize(faker.pyint(min_value=234)),
-        NanoCPUs=faker.pyfloat(min_value=0.1),
-        MemorySwap=ByteSize(faker.pyint(min_value=-84654, max_value=-1)),
-    )
-    assert instance.memory != instance.memory_swap
-    assert instance.memory_swap == -1
+    with pytest.raises(ValidationError):
+        ContainerHostConfig(
+            Binds=[faker.pystr() for _ in range(5)],
+            Memory=ByteSize(faker.pyint(min_value=234)),
+            NanoCPUs=faker.pyfloat(min_value=0.1),
+            MemorySwap=ByteSize(0),
+        )
+    with pytest.raises(ValidationError):
+        ContainerHostConfig(
+            Binds=[faker.pystr() for _ in range(5)],
+            Memory=ByteSize(faker.pyint(min_value=234)),
+            NanoCPUs=faker.pyfloat(min_value=0.1),
+            MemorySwap=ByteSize(faker.pyint(min_value=1, max_value=233)),
+        )
 
 
 def test_container_host_config_sets_swap_if_set_bigger_than_memory(

--- a/services/dask-sidecar/tests/unit/test_models.py
+++ b/services/dask-sidecar/tests/unit/test_models.py
@@ -1,0 +1,52 @@
+from faker import Faker
+from pydantic import ByteSize
+from simcore_service_dask_sidecar.computational_sidecar.models import (
+    ContainerHostConfig,
+)
+
+
+def test_container_host_config_sets_swap_same_as_memory_if_not_set(faker: Faker):
+    instance = ContainerHostConfig(
+        Binds=[faker.pystr() for _ in range(5)],
+        Memory=ByteSize(faker.pyint()),
+        NanoCPUs=faker.pyfloat(min_value=0.1),
+    )
+    assert instance.memory == instance.memory_swap
+
+
+def test_container_host_config_sets_swap_same_as_memory_if_smaller_than_memory(
+    faker: Faker,
+):
+    instance = ContainerHostConfig(
+        Binds=[faker.pystr() for _ in range(5)],
+        Memory=ByteSize(faker.pyint(min_value=234)),
+        NanoCPUs=faker.pyfloat(min_value=0.1),
+        MemorySwap=ByteSize(faker.pyint(min_value=0, max_value=233)),
+    )
+    assert instance.memory == instance.memory_swap
+
+
+def test_container_host_config_sets_swap_disabled_if_set_negative(
+    faker: Faker,
+):
+    instance = ContainerHostConfig(
+        Binds=[faker.pystr() for _ in range(5)],
+        Memory=ByteSize(faker.pyint(min_value=234)),
+        NanoCPUs=faker.pyfloat(min_value=0.1),
+        MemorySwap=ByteSize(faker.pyint(min_value=-84654, max_value=-1)),
+    )
+    assert instance.memory != instance.memory_swap
+    assert instance.memory_swap == -1
+
+
+def test_container_host_config_sets_swap_if_set_bigger_than_memory(
+    faker: Faker,
+):
+    instance = ContainerHostConfig(
+        Binds=[faker.pystr() for _ in range(5)],
+        Memory=ByteSize(faker.pyint(min_value=234, max_value=434234)),
+        NanoCPUs=faker.pyfloat(min_value=0.1),
+        MemorySwap=ByteSize(faker.pyint(min_value=434235)),
+    )
+    assert instance.memory_swap
+    assert instance.memory < instance.memory_swap


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
ensure memory-swap is set to the same value as memory limit if not set.
-1 disables it and any other value is equal to memory
MemorySwap = memory + swap

The PR effectively disables swapping for computational services.



Also @mrnicegyu11 concerning this [https://github.com/ITISFoundation/osparc-simcore/issues/3506](https://github.com/ITISFoundation/osparc-simcore/issues/3506), this can to the best of my knowledge not happen in the dask-sidecar as it validates through pydantic and the 3 parameters in the use-case are not part of the pydantic model.
see [https://github.com/itisfoundation/osparc-simcore/blob/59c34d86136ad0d4a2f584f2afc013ae32921ab7/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py](https://github.com/itisfoundation/osparc-simcore/blob/59c34d86136ad0d4a2f584f2afc013ae32921ab7/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py)

## Related issue/s
resolves https://github.com/ITISFoundation/osparc-simcore/issues/3507
https://github.com/ITISFoundation/osparc-simcore/issues/3506
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


Bonus:
- added shellcheck/hadolint extensions as recommended ones in vscode settings.template

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->

##  ⚠️ devops:
Assert that the kernel feature for cgroup swap memory limits is enabled on all machines where this is rolled out. Run `docker info` to check. See gitlab ops issue 307
