### PR TITLE
⬆️ 🔨 Workaround to avoid test failures due to pytest-sugar

### DIFF
--- a/api/tests/requirements.in
+++ b/api/tests/requirements.in
@@ -8,4 +8,9 @@ pytest
 pytest-aiohttp
 pytest-cov
 pytest-instafail
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+
+
+
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/api/tests/requirements.in
+++ b/api/tests/requirements.in
@@ -8,4 +8,4 @@ pytest
 pytest-aiohttp
 pytest-cov
 pytest-instafail
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243

--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -62,11 +62,15 @@ openapi-schema-validator==0.2.3
 openapi-spec-validator==0.4.0
     # via openapi-core
 packaging==21.3
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-sugar
 parse==1.19.0
     # via openapi-core
 pluggy==1.0.0
     # via pytest
+py==1.11.0
+    # via -r requirements.in
 pyparsing==3.0.9
     # via packaging
 pyrsistent==0.18.1
@@ -78,6 +82,7 @@ pytest==7.2.0
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-instafail
+    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements.in
 pytest-asyncio==0.19.0
@@ -85,6 +90,8 @@ pytest-asyncio==0.19.0
 pytest-cov==4.0.0
     # via -r requirements.in
 pytest-instafail==0.4.2
+    # via -r requirements.in
+pytest-sugar==0.9.5
     # via -r requirements.in
 pyyaml==6.0
     # via
@@ -94,6 +101,8 @@ six==1.16.0
     # via
     #   isodate
     #   openapi-core
+termcolor==2.1.0
+    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -62,9 +62,7 @@ openapi-schema-validator==0.2.3
 openapi-spec-validator==0.4.0
     # via openapi-core
 packaging==21.3
-    # via
-    #   pytest
-    #   pytest-sugar
+    # via pytest
 parse==1.19.0
     # via openapi-core
 pluggy==1.0.0
@@ -80,7 +78,6 @@ pytest==7.2.0
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-instafail
-    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements.in
 pytest-asyncio==0.19.0
@@ -88,8 +85,6 @@ pytest-asyncio==0.19.0
 pytest-cov==4.0.0
     # via -r requirements.in
 pytest-instafail==0.4.2
-    # via -r requirements.in
-pytest-sugar==0.9.5
     # via -r requirements.in
 pyyaml==6.0
     # via
@@ -99,8 +94,6 @@ six==1.16.0
     # via
     #   isodate
     #   openapi-core
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/packages/dask-task-models-library/requirements/_test.in
+++ b/packages/dask-task-models-library/requirements/_test.in
@@ -10,18 +10,20 @@
 
 # testing
 
+coverage
+coveralls
+faker
+pint
+pylint  # NOTE: The version in pylint at _text.txt is used as a reference for ci/helpers/install_pylint.bash
 pytest
 pytest-aiohttp  # incompatible with pytest-asyncio. See https://github.com/pytest-dev/pytest-asyncio/issues/76
+pytest-cov
 pytest-icdiff
 pytest-instafail
-pytest-runner
 pytest-mock
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
-pytest-cov
-coveralls
-coverage
-
-pylint  # NOTE: The version in pylint at _text.txt is used as a reference for ci/helpers/install_pylint.bash
+pytest-runner
 pyyaml
-pint
-faker
+
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/packages/dask-task-models-library/requirements/_test.in
+++ b/packages/dask-task-models-library/requirements/_test.in
@@ -16,7 +16,7 @@ pytest-icdiff
 pytest-instafail
 pytest-runner
 pytest-mock
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 pytest-cov
 coveralls
 coverage

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -67,6 +67,7 @@ packaging==21.3
     # via
     #   -c requirements/_base.txt
     #   pytest
+    #   pytest-sugar
 pint==0.19.2
     # via -r requirements/_test.in
 platformdirs==2.5.2
@@ -75,6 +76,8 @@ pluggy==1.0.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
+py==1.11.0
+    # via -r requirements/_test.in
 pylint==2.15.5
     # via -r requirements/_test.in
 pyparsing==3.0.9
@@ -90,6 +93,7 @@ pytest==7.2.0
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
+    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
 pytest-asyncio==0.19.0
@@ -104,6 +108,8 @@ pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
     # via -r requirements/_test.in
+pytest-sugar==0.9.5
+    # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via faker
 pyyaml==6.0
@@ -115,6 +121,8 @@ requests==2.28.1
     # via coveralls
 six==1.16.0
     # via python-dateutil
+termcolor==2.1.0
+    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -67,7 +67,6 @@ packaging==21.3
     # via
     #   -c requirements/_base.txt
     #   pytest
-    #   pytest-sugar
 pint==0.19.2
     # via -r requirements/_test.in
 platformdirs==2.5.2
@@ -91,7 +90,6 @@ pytest==7.2.0
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
-    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
 pytest-asyncio==0.19.0
@@ -106,8 +104,6 @@ pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
     # via -r requirements/_test.in
-pytest-sugar==0.9.5
-    # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via faker
 pyyaml==6.0
@@ -119,8 +115,6 @@ requests==2.28.1
     # via coveralls
 six==1.16.0
     # via python-dateutil
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/packages/models-library/requirements/_test.in
+++ b/packages/models-library/requirements/_test.in
@@ -8,22 +8,18 @@
 #
 --constraint _base.txt
 
-# testing
-
+--requirement ../../../packages/postgres-database/requirements/_base.in
+coverage
+coveralls
+faker
+pint
+pylint  # NOTE: The version in pylint at _text.txt is used as a reference for ci/helpers/install_pylint.bash
 pytest
 pytest-aiohttp  # incompatible with pytest-asyncio. See https://github.com/pytest-dev/pytest-asyncio/issues/76
+pytest-cov
 pytest-icdiff
 pytest-instafail
-pytest-runner
 pytest-mock
-pytest-sugar
-
-pytest-cov
-coveralls
-coverage
-
---requirement ../../../packages/postgres-database/requirements/_base.in
-pylint  # NOTE: The version in pylint at _text.txt is used as a reference for ci/helpers/install_pylint.bash
+pytest-runner
 pyyaml
-pint
-faker
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243

--- a/packages/models-library/requirements/_test.in
+++ b/packages/models-library/requirements/_test.in
@@ -22,4 +22,7 @@ pytest-instafail
 pytest-mock
 pytest-runner
 pyyaml
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -76,7 +76,9 @@ multidict==6.0.2
     #   aiohttp
     #   yarl
 packaging==21.3
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-sugar
 pint==0.19.2
     # via -r requirements/_test.in
 platformdirs==2.5.2
@@ -87,6 +89,8 @@ pprintpp==0.4.0
     # via pytest-icdiff
 psycopg2-binary==2.9.4
     # via sqlalchemy
+py==1.11.0
+    # via -r requirements/_test.in
 pylint==2.15.5
     # via -r requirements/_test.in
 pyparsing==3.0.9
@@ -100,6 +104,7 @@ pytest==7.2.0
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
+    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
 pytest-asyncio==0.19.0
@@ -113,6 +118,8 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
+    # via -r requirements/_test.in
+pytest-sugar==0.9.5
     # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via faker
@@ -131,6 +138,8 @@ sqlalchemy==1.4.41
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   alembic
+termcolor==2.1.0
+    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -76,9 +76,7 @@ multidict==6.0.2
     #   aiohttp
     #   yarl
 packaging==21.3
-    # via
-    #   pytest
-    #   pytest-sugar
+    # via pytest
 pint==0.19.2
     # via -r requirements/_test.in
 platformdirs==2.5.2
@@ -102,7 +100,6 @@ pytest==7.2.0
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
-    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
 pytest-asyncio==0.19.0
@@ -116,8 +113,6 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
-    # via -r requirements/_test.in
-pytest-sugar==0.9.5
     # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via faker
@@ -136,8 +131,6 @@ sqlalchemy==1.4.41
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   alembic
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/packages/service-integration/requirements/_test.in
+++ b/packages/service-integration/requirements/_test.in
@@ -8,18 +8,14 @@
 #
 --constraint _base.txt
 
-# testing
-pytest
-
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
-pytest-runner
-pytest-instafail
-
-
-pytest-cov
 coverage
 coveralls
-
-
-# tools
 pylint  # NOTE: The version in pylint at _text.txt is used as a reference for ci/helpers/install_pylint.bash
+pytest
+pytest-cov
+pytest-instafail
+pytest-runner
+
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/packages/service-integration/requirements/_test.in
+++ b/packages/service-integration/requirements/_test.in
@@ -11,12 +11,10 @@
 # testing
 pytest
 
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 pytest-runner
 pytest-instafail
 
-# pytest-icdiff
-# pytest-mock
 
 pytest-cov
 coverage

--- a/packages/service-integration/requirements/_test.txt
+++ b/packages/service-integration/requirements/_test.txt
@@ -51,12 +51,15 @@ packaging==21.3
     # via
     #   -c requirements/_base.txt
     #   pytest
+    #   pytest-sugar
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
     # via
     #   -c requirements/_base.txt
     #   pytest
+py==1.11.0
+    # via -r requirements/_test.in
 pylint==2.15.5
     # via -r requirements/_test.in
 pyparsing==3.0.9
@@ -69,16 +72,21 @@ pytest==7.2.0
     #   -r requirements/_test.in
     #   pytest-cov
     #   pytest-instafail
+    #   pytest-sugar
 pytest-cov==4.0.0
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
 pytest-runner==6.0.0
     # via -r requirements/_test.in
+pytest-sugar==0.9.5
+    # via -r requirements/_test.in
 requests==2.28.1
     # via
     #   -c requirements/_base.txt
     #   coveralls
+termcolor==2.1.0
+    # via pytest-sugar
 tomli==2.0.1
     # via
     #   -c requirements/_base.txt

--- a/packages/service-integration/requirements/_test.txt
+++ b/packages/service-integration/requirements/_test.txt
@@ -51,7 +51,6 @@ packaging==21.3
     # via
     #   -c requirements/_base.txt
     #   pytest
-    #   pytest-sugar
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
@@ -70,21 +69,16 @@ pytest==7.2.0
     #   -r requirements/_test.in
     #   pytest-cov
     #   pytest-instafail
-    #   pytest-sugar
 pytest-cov==4.0.0
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
     # via -r requirements/_test.in
 pytest-runner==6.0.0
     # via -r requirements/_test.in
-pytest-sugar==0.9.5
-    # via -r requirements/_test.in
 requests==2.28.1
     # via
     #   -c requirements/_base.txt
     #   coveralls
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via
     #   -c requirements/_base.txt

--- a/packages/service-library/requirements/_test.in
+++ b/packages/service-library/requirements/_test.in
@@ -25,5 +25,5 @@ pytest-docker
 pytest-instafail
 pytest-mock
 pytest-runner
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 pytest-xdist

--- a/packages/service-library/requirements/_test.in
+++ b/packages/service-library/requirements/_test.in
@@ -25,5 +25,8 @@ pytest-docker
 pytest-instafail
 pytest-mock
 pytest-runner
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 pytest-xdist
+
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -96,13 +96,17 @@ openapi-spec-validator==0.4.0
     #   -c requirements/_aiohttp.txt
     #   -r requirements/_test.in
 packaging==21.3
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-sugar
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
     # via pytest
 py==1.11.0
-    # via pytest-forked
+    # via
+    #   -r requirements/_test.in
+    #   pytest-forked
 pylint==2.15.5
     # via -r requirements/_test.in
 pyparsing==3.0.9
@@ -121,6 +125,7 @@ pytest==7.2.0
     #   pytest-forked
     #   pytest-instafail
     #   pytest-mock
+    #   pytest-sugar
     #   pytest-xdist
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
@@ -137,6 +142,8 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
+    # via -r requirements/_test.in
+pytest-sugar==0.9.5
     # via -r requirements/_test.in
 pytest-xdist==2.5.0
     # via -r requirements/_test.in
@@ -160,6 +167,8 @@ sniffio==1.3.0
     # via
     #   -c requirements/_fastapi.txt
     #   asgi-lifespan
+termcolor==2.1.0
+    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -96,9 +96,7 @@ openapi-spec-validator==0.4.0
     #   -c requirements/_aiohttp.txt
     #   -r requirements/_test.in
 packaging==21.3
-    # via
-    #   pytest
-    #   pytest-sugar
+    # via pytest
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
@@ -123,7 +121,6 @@ pytest==7.2.0
     #   pytest-forked
     #   pytest-instafail
     #   pytest-mock
-    #   pytest-sugar
     #   pytest-xdist
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
@@ -140,8 +137,6 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
-    # via -r requirements/_test.in
-pytest-sugar==0.9.5
     # via -r requirements/_test.in
 pytest-xdist==2.5.0
     # via -r requirements/_test.in
@@ -165,8 +160,6 @@ sniffio==1.3.0
     # via
     #   -c requirements/_fastapi.txt
     #   asgi-lifespan
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/packages/settings-library/requirements/_test.in
+++ b/packages/settings-library/requirements/_test.in
@@ -15,7 +15,7 @@ pytest-cov
 pytest-instafail
 pytest-runner
 pytest-mock
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 
 # tools
 python-dotenv

--- a/packages/settings-library/requirements/_test.in
+++ b/packages/settings-library/requirements/_test.in
@@ -8,16 +8,16 @@
 #
 --constraint _base.txt
 
-# testing
 coverage
+coveralls
+pylint  # NOTE: The version in pylint at _text.txt is used as a reference for ci/helpers/install_pylint.bash
 pytest
 pytest-cov
 pytest-instafail
-pytest-runner
 pytest-mock
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
-
-# tools
+pytest-runner
 python-dotenv
-pylint  # NOTE: The version in pylint at _text.txt is used as a reference for ci/helpers/install_pylint.bash
-coveralls
+
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/packages/settings-library/requirements/_test.txt
+++ b/packages/settings-library/requirements/_test.txt
@@ -36,11 +36,15 @@ lazy-object-proxy==1.7.1
 mccabe==0.7.0
     # via pylint
 packaging==21.3
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-sugar
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
     # via pytest
+py==1.11.0
+    # via -r requirements/_test.in
 pylint==2.15.5
     # via -r requirements/_test.in
 pyparsing==3.0.9
@@ -51,6 +55,7 @@ pytest==7.2.0
     #   pytest-cov
     #   pytest-instafail
     #   pytest-mock
+    #   pytest-sugar
 pytest-cov==4.0.0
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
@@ -59,10 +64,14 @@ pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
     # via -r requirements/_test.in
+pytest-sugar==0.9.5
+    # via -r requirements/_test.in
 python-dotenv==0.21.0
     # via -r requirements/_test.in
 requests==2.28.1
     # via coveralls
+termcolor==2.1.0
+    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/packages/settings-library/requirements/_test.txt
+++ b/packages/settings-library/requirements/_test.txt
@@ -36,9 +36,7 @@ lazy-object-proxy==1.7.1
 mccabe==0.7.0
     # via pylint
 packaging==21.3
-    # via
-    #   pytest
-    #   pytest-sugar
+    # via pytest
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
@@ -53,7 +51,6 @@ pytest==7.2.0
     #   pytest-cov
     #   pytest-instafail
     #   pytest-mock
-    #   pytest-sugar
 pytest-cov==4.0.0
     # via -r requirements/_test.in
 pytest-instafail==0.4.2
@@ -62,14 +59,10 @@ pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
     # via -r requirements/_test.in
-pytest-sugar==0.9.5
-    # via -r requirements/_test.in
 python-dotenv==0.21.0
     # via -r requirements/_test.in
 requests==2.28.1
     # via coveralls
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/packages/simcore-sdk/requirements/_test.in
+++ b/packages/simcore-sdk/requirements/_test.in
@@ -26,7 +26,7 @@ pytest-instafail
 pytest-lazy-fixture
 pytest-mock
 pytest-runner
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 pytest-xdist
 python-dotenv
 requests

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -130,7 +130,6 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   docker
     #   pytest
-    #   pytest-sugar
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
@@ -160,7 +159,6 @@ pytest==7.2.0
     #   pytest-instafail
     #   pytest-lazy-fixture
     #   pytest-mock
-    #   pytest-sugar
     #   pytest-xdist
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
@@ -179,8 +177,6 @@ pytest-lazy-fixture==0.6.3
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
-    # via -r requirements/_test.in
-pytest-sugar==0.9.5
     # via -r requirements/_test.in
 pytest-xdist==2.5.0
     # via -r requirements/_test.in
@@ -206,8 +202,6 @@ sqlalchemy==1.4.41
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   alembic
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/services/dask-sidecar/requirements/_test.in
+++ b/services/dask-sidecar/requirements/_test.in
@@ -21,5 +21,8 @@ pytest-icdiff
 pytest-instafail
 pytest-localftpserver
 pytest-mock
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 python-dotenv
+
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/services/dask-sidecar/requirements/_test.in
+++ b/services/dask-sidecar/requirements/_test.in
@@ -21,5 +21,5 @@ pytest-icdiff
 pytest-instafail
 pytest-localftpserver
 pytest-mock
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 python-dotenv

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -93,7 +93,6 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   docker
     #   pytest
-    #   pytest-sugar
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
@@ -126,7 +125,6 @@ pytest==7.2.0
     #   pytest-instafail
     #   pytest-localftpserver
     #   pytest-mock
-    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
 pytest-asyncio==0.19.0
@@ -140,8 +138,6 @@ pytest-instafail==0.4.2
 pytest-localftpserver==1.1.4
     # via -r requirements/_test.in
 pytest-mock==3.10.0
-    # via -r requirements/_test.in
-pytest-sugar==0.9.5
     # via -r requirements/_test.in
 python-dateutil==2.8.1
     # via
@@ -161,8 +157,6 @@ six==1.15.0
     #   -c requirements/_base.txt
     #   python-dateutil
     #   websocket-client
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -93,6 +93,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   docker
     #   pytest
+    #   pytest-sugar
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
@@ -100,6 +101,8 @@ pluggy==1.0.0
 pprintpp==0.4.0
     # via pytest-icdiff
 ptvsd==4.3.2
+    # via -r requirements/_test.in
+py==1.11.0
     # via -r requirements/_test.in
 pycparser==2.20
     # via
@@ -125,6 +128,7 @@ pytest==7.2.0
     #   pytest-instafail
     #   pytest-localftpserver
     #   pytest-mock
+    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
 pytest-asyncio==0.19.0
@@ -138,6 +142,8 @@ pytest-instafail==0.4.2
 pytest-localftpserver==1.1.4
     # via -r requirements/_test.in
 pytest-mock==3.10.0
+    # via -r requirements/_test.in
+pytest-sugar==0.9.5
     # via -r requirements/_test.in
 python-dateutil==2.8.1
     # via
@@ -157,6 +163,8 @@ six==1.15.0
     #   -c requirements/_base.txt
     #   python-dateutil
     #   websocket-client
+termcolor==2.1.0
+    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/services/datcore-adapter/requirements/_test.in
+++ b/services/datcore-adapter/requirements/_test.in
@@ -18,6 +18,9 @@ pytest-icdiff
 pytest-instafail
 pytest-mock
 pytest-runner
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 pytest-xdist
 respx
+
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/services/datcore-adapter/requirements/_test.in
+++ b/services/datcore-adapter/requirements/_test.in
@@ -18,6 +18,6 @@ pytest-icdiff
 pytest-instafail
 pytest-mock
 pytest-runner
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 pytest-xdist
 respx

--- a/services/datcore-adapter/requirements/_test.txt
+++ b/services/datcore-adapter/requirements/_test.txt
@@ -74,7 +74,9 @@ lazy-object-proxy==1.7.1
 mccabe==0.7.0
     # via pylint
 packaging==21.3
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-sugar
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
@@ -82,7 +84,9 @@ pluggy==1.0.0
 pprintpp==0.4.0
     # via pytest-icdiff
 py==1.11.0
-    # via pytest-forked
+    # via
+    #   -r requirements/_test.in
+    #   pytest-forked
 pylint==2.15.5
     # via -r requirements/_test.in
 pyparsing==3.0.9
@@ -96,6 +100,7 @@ pytest==7.2.0
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
+    #   pytest-sugar
     #   pytest-xdist
 pytest-asyncio==0.20.1
     # via -r requirements/_test.in
@@ -110,6 +115,8 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
+    # via -r requirements/_test.in
+pytest-sugar==0.9.5
     # via -r requirements/_test.in
 pytest-xdist==2.5.0
     # via -r requirements/_test.in
@@ -138,6 +145,8 @@ sniffio==1.3.0
     #   asgi-lifespan
     #   httpcore
     #   httpx
+termcolor==2.1.0
+    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/services/datcore-adapter/requirements/_test.txt
+++ b/services/datcore-adapter/requirements/_test.txt
@@ -74,9 +74,7 @@ lazy-object-proxy==1.7.1
 mccabe==0.7.0
     # via pylint
 packaging==21.3
-    # via
-    #   pytest
-    #   pytest-sugar
+    # via pytest
 platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
@@ -98,7 +96,6 @@ pytest==7.2.0
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
-    #   pytest-sugar
     #   pytest-xdist
 pytest-asyncio==0.20.1
     # via -r requirements/_test.in
@@ -113,8 +110,6 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
-    # via -r requirements/_test.in
-pytest-sugar==0.9.5
     # via -r requirements/_test.in
 pytest-xdist==2.5.0
     # via -r requirements/_test.in
@@ -143,8 +138,6 @@ sniffio==1.3.0
     #   asgi-lifespan
     #   httpcore
     #   httpx
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/services/director/requirements/_test.in
+++ b/services/director/requirements/_test.in
@@ -29,5 +29,7 @@ pytest-cov
 pytest-instafail
 pytest-mock
 pytest-runner
-pytest-sugar
 python-dotenv
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/services/storage/requirements/_test.in
+++ b/services/storage/requirements/_test.in
@@ -24,5 +24,5 @@ pytest-icdiff
 pytest-instafail
 pytest-mock
 pytest-runner
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 python-dotenv

--- a/services/storage/requirements/_test.in
+++ b/services/storage/requirements/_test.in
@@ -24,5 +24,7 @@ pytest-icdiff
 pytest-instafail
 pytest-mock
 pytest-runner
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 python-dotenv
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -190,6 +190,7 @@ packaging==21.3
     # via
     #   docker
     #   pytest
+    #   pytest-sugar
 pandas==1.5.0
     # via -r requirements/_test.in
 pbr==5.10.0
@@ -202,6 +203,8 @@ pluggy==1.0.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
+py==1.11.0
+    # via -r requirements/_test.in
 pyasn1==0.4.8
     # via
     #   python-jose
@@ -227,6 +230,7 @@ pytest==7.2.0
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
+    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
 pytest-asyncio==0.19.0
@@ -240,6 +244,8 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
+    # via -r requirements/_test.in
+pytest-sugar==0.9.5
     # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via
@@ -296,6 +302,8 @@ six==1.16.0
     #   simcore-service-storage-sdk
 sshpubkeys==3.3.1
     # via moto
+termcolor==2.1.0
+    # via pytest-sugar
 toml==0.10.2
     # via responses
 tomli==2.0.1

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -190,7 +190,6 @@ packaging==21.3
     # via
     #   docker
     #   pytest
-    #   pytest-sugar
 pandas==1.5.0
     # via -r requirements/_test.in
 pbr==5.10.0
@@ -228,7 +227,6 @@ pytest==7.2.0
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
-    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
 pytest-asyncio==0.19.0
@@ -242,8 +240,6 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
-    # via -r requirements/_test.in
-pytest-sugar==0.9.5
     # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via
@@ -300,8 +296,6 @@ six==1.16.0
     #   simcore-service-storage-sdk
 sshpubkeys==3.3.1
     # via moto
-termcolor==2.0.1
-    # via pytest-sugar
 toml==0.10.2
     # via responses
 tomli==2.0.1

--- a/services/web/server/requirements/_test.in
+++ b/services/web/server/requirements/_test.in
@@ -30,7 +30,7 @@ pytest-icdiff
 pytest-instafail
 pytest-mock
 pytest-runner
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 pytest-xdist
 python-dotenv
 redis

--- a/services/web/server/requirements/_test.in
+++ b/services/web/server/requirements/_test.in
@@ -30,9 +30,11 @@ pytest-icdiff
 pytest-instafail
 pytest-mock
 pytest-runner
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 pytest-xdist
 python-dotenv
 redis
 tenacity
 websockets
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -139,6 +139,7 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   docker
     #   pytest
+    #   pytest-sugar
     #   redis
 platformdirs==2.5.2
     # via pylint
@@ -153,7 +154,9 @@ psycopg2-binary==2.9.3
 ptvsd==4.3.2
     # via -r requirements/_test.in
 py==1.11.0
-    # via pytest-forked
+    # via
+    #   -r requirements/_test.in
+    #   pytest-forked
 pylint==2.15.5
     # via -r requirements/_test.in
 pyparsing==3.0.9
@@ -175,6 +178,7 @@ pytest==7.2.0
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
+    #   pytest-sugar
     #   pytest-xdist
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
@@ -193,6 +197,8 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
+    # via -r requirements/_test.in
+pytest-sugar==0.9.5
     # via -r requirements/_test.in
 pytest-xdist==2.5.0
     # via -r requirements/_test.in
@@ -231,6 +237,8 @@ tenacity==8.0.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
+termcolor==2.1.0
+    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -139,7 +139,6 @@ packaging==21.3
     #   -c requirements/_base.txt
     #   docker
     #   pytest
-    #   pytest-sugar
     #   redis
 platformdirs==2.5.2
     # via pylint
@@ -176,7 +175,6 @@ pytest==7.2.0
     #   pytest-icdiff
     #   pytest-instafail
     #   pytest-mock
-    #   pytest-sugar
     #   pytest-xdist
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
@@ -195,8 +193,6 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
-    # via -r requirements/_test.in
-pytest-sugar==0.9.5
     # via -r requirements/_test.in
 pytest-xdist==2.5.0
     # via -r requirements/_test.in
@@ -235,8 +231,6 @@ tenacity==8.0.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/tests/environment-setup/requirements/requirements.in
+++ b/tests/environment-setup/requirements/requirements.in
@@ -6,5 +6,8 @@ pytest
 pytest-aiohttp
 pytest-instafail
 pytest-runner
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 pyyaml
+
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/tests/environment-setup/requirements/requirements.in
+++ b/tests/environment-setup/requirements/requirements.in
@@ -6,5 +6,5 @@ pytest
 pytest-aiohttp
 pytest-instafail
 pytest-runner
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 pyyaml

--- a/tests/environment-setup/requirements/requirements.txt
+++ b/tests/environment-setup/requirements/requirements.txt
@@ -36,9 +36,7 @@ multidict==6.0.2
     #   aiohttp
     #   yarl
 packaging==21.3
-    # via
-    #   pytest
-    #   pytest-sugar
+    # via pytest
 pluggy==1.0.0
     # via pytest
 pydantic==1.10.2
@@ -57,7 +55,6 @@ pytest==7.2.0
     #   pytest-aiohttp
     #   pytest-asyncio
     #   pytest-instafail
-    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/requirements.in
 pytest-asyncio==0.19.0
@@ -65,8 +62,6 @@ pytest-asyncio==0.19.0
 pytest-instafail==0.4.2
     # via -r requirements/requirements.in
 pytest-runner==6.0.0
-    # via -r requirements/requirements.in
-pytest-sugar==0.9.5
     # via -r requirements/requirements.in
 pyyaml==5.4.1
     # via
@@ -76,8 +71,6 @@ pyyaml==5.4.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/requirements.in
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via pytest
 typing-extensions==4.4.0

--- a/tests/environment-setup/requirements/requirements.txt
+++ b/tests/environment-setup/requirements/requirements.txt
@@ -36,9 +36,13 @@ multidict==6.0.2
     #   aiohttp
     #   yarl
 packaging==21.3
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-sugar
 pluggy==1.0.0
     # via pytest
+py==1.11.0
+    # via -r requirements/requirements.in
 pydantic==1.10.2
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
@@ -55,6 +59,7 @@ pytest==7.2.0
     #   pytest-aiohttp
     #   pytest-asyncio
     #   pytest-instafail
+    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/requirements.in
 pytest-asyncio==0.19.0
@@ -62,6 +67,8 @@ pytest-asyncio==0.19.0
 pytest-instafail==0.4.2
     # via -r requirements/requirements.in
 pytest-runner==6.0.0
+    # via -r requirements/requirements.in
+pytest-sugar==0.9.5
     # via -r requirements/requirements.in
 pyyaml==5.4.1
     # via
@@ -71,6 +78,8 @@ pyyaml==5.4.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/requirements.in
+termcolor==2.1.0
+    # via pytest-sugar
 tomli==2.0.1
     # via pytest
 typing-extensions==4.4.0

--- a/tests/swarm-deploy/requirements/_test.in
+++ b/tests/swarm-deploy/requirements/_test.in
@@ -20,7 +20,10 @@ pytest-cov
 pytest-instafail
 pytest-mock
 pytest-runner
-# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 python-dotenv
 pyyaml
 tenacity
+
+
+pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
+py>=1.11.0 ## NOTE: tmp enforced until pytest-sugar adds it. SEE https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807

--- a/tests/swarm-deploy/requirements/_test.in
+++ b/tests/swarm-deploy/requirements/_test.in
@@ -20,7 +20,7 @@ pytest-cov
 pytest-instafail
 pytest-mock
 pytest-runner
-pytest-sugar
+# pytest-sugar ## broken w/ pytest==7.2.0. SEE https://github.com/Teemu/pytest-sugar/issues/243
 python-dotenv
 pyyaml
 tenacity

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -146,7 +146,6 @@ packaging==21.3
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   docker
     #   pytest
-    #   pytest-sugar
 pamqp==3.2.1
     # via aiormq
 pint==0.19.2
@@ -194,7 +193,6 @@ pytest==7.2.0
     #   pytest-cov
     #   pytest-instafail
     #   pytest-mock
-    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
 pytest-asyncio==0.19.0
@@ -206,8 +204,6 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
-    # via -r requirements/_test.in
-pytest-sugar==0.9.5
     # via -r requirements/_test.in
 python-dotenv==0.21.0
     # via -r requirements/_test.in
@@ -258,8 +254,6 @@ tenacity==8.1.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_test.in
-termcolor==2.0.1
-    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -146,6 +146,7 @@ packaging==21.3
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   docker
     #   pytest
+    #   pytest-sugar
 pamqp==3.2.1
     # via aiormq
 pint==0.19.2
@@ -157,6 +158,8 @@ psycopg2-binary==2.9.4
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   aiopg
     #   sqlalchemy
+py==1.11.0
+    # via -r requirements/_test.in
 pydantic==1.10.2
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -193,6 +196,7 @@ pytest==7.2.0
     #   pytest-cov
     #   pytest-instafail
     #   pytest-mock
+    #   pytest-sugar
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
 pytest-asyncio==0.19.0
@@ -204,6 +208,8 @@ pytest-instafail==0.4.2
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
+    # via -r requirements/_test.in
+pytest-sugar==0.9.5
     # via -r requirements/_test.in
 python-dotenv==0.21.0
     # via -r requirements/_test.in
@@ -254,6 +260,8 @@ tenacity==8.1.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_test.in
+termcolor==2.1.0
+    # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🗑️    Deprecate code that needs to be cleaned up.
  ⚰️     Remove dead code.
  🔥    Remove code or files.
  🔨    Add or update development scripts.

or from https://gitmoji.dev/ and https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

``pytest-sugar`` fails with  ``pytest==7.2.0`` as reported in https://github.com/Teemu/pytest-sugar/issues/243 .

Until it is resolved, this workaround will add ``py>=1.11.0`` in the requirements (as deduced from https://github.com/Teemu/pytest-sugar/issues/243#issuecomment-1298658807).



## Related issue/s

 Maintenance
