### PR TITLE
✨ Sort files and NodeTreeItem menu's bgColor

### DIFF
--- a/services/static-webserver/client/source/class/osparc/component/widget/NodeTreeItem.js
+++ b/services/static-webserver/client/source/class/osparc/component/widget/NodeTreeItem.js
@@ -205,6 +205,7 @@ qx.Class.define("osparc.component.widget.NodeTreeItem", {
         }
         case "start-button": {
           control = new qx.ui.menu.Button().set({
+            backgroundColor: "background-main",
             label: this.tr("Start"),
             icon: "@FontAwesome5Solid/play/10",
             visibility: "excluded"
@@ -215,6 +216,7 @@ qx.Class.define("osparc.component.widget.NodeTreeItem", {
         }
         case "stop-button": {
           control = new qx.ui.menu.Button().set({
+            backgroundColor: "background-main",
             label: this.tr("Stop"),
             icon: "@FontAwesome5Solid/stop/10",
             visibility: "excluded"
@@ -225,6 +227,7 @@ qx.Class.define("osparc.component.widget.NodeTreeItem", {
         }
         case "rename-button": {
           control = new qx.ui.menu.Button().set({
+            backgroundColor: "background-main",
             label: this.tr("Rename"),
             icon: "@FontAwesome5Solid/i-cursor/10"
           });
@@ -236,6 +239,7 @@ qx.Class.define("osparc.component.widget.NodeTreeItem", {
         }
         case "marker-button": {
           control = new qx.ui.menu.Button().set({
+            backgroundColor: "background-main",
             icon: "@FontAwesome5Solid/bookmark/10",
             visibility: "excluded"
           });
@@ -246,6 +250,7 @@ qx.Class.define("osparc.component.widget.NodeTreeItem", {
         }
         case "info-button": {
           control = new qx.ui.menu.Button().set({
+            backgroundColor: "background-main",
             label: this.tr("Information..."),
             icon: "@FontAwesome5Solid/info/10"
           });
@@ -257,6 +262,7 @@ qx.Class.define("osparc.component.widget.NodeTreeItem", {
         }
         case "delete-button": {
           control = new qx.ui.menu.Button().set({
+            backgroundColor: "background-main",
             label: this.tr("Delete"),
             icon: "@FontAwesome5Solid/trash/10"
           });

--- a/services/static-webserver/client/source/class/osparc/data/Converters.js
+++ b/services/static-webserver/client/source/class/osparc/data/Converters.js
@@ -39,7 +39,7 @@ qx.Class.define("osparc.data.Converters", {
       }
     },
 
-    sortByLabel: function(model) {
+    sortModelByLabel: function(model) {
       model.getChildren().sort((a, b) => {
         if (a.getLabel() > b.getLabel()) {
           return 1;
@@ -52,6 +52,15 @@ qx.Class.define("osparc.data.Converters", {
     },
 
     fromDSMToVirtualTreeModel: function(datasetId, files) {
+      files.sort((a, b) => {
+        if (a["file_uuid"] > b["file_uuid"]) {
+          return 1;
+        }
+        if (a["file_uuid"] < b["file_uuid"]) {
+          return -1;
+        }
+        return 0;
+      });
       let children = [];
       for (let i=0; i<files.length; i++) {
         const file = files[i];

--- a/services/static-webserver/client/source/class/osparc/data/Converters.js
+++ b/services/static-webserver/client/source/class/osparc/data/Converters.js
@@ -74,9 +74,11 @@ qx.Class.define("osparc.data.Converters", {
           parent.children.push(newItem);
           parent = newItem;
         }
+        // sort folders
+        console.log("sort folders", parent.children);
 
         // create file
-        const fileInfo = this.createFileEntry(
+        const fileInfo = this.__createFileEntry(
           splitted[splitted.length-1],
           file["location_id"],
           datasetId,
@@ -85,6 +87,8 @@ qx.Class.define("osparc.data.Converters", {
           file["file_size"]);
         parent.children.push(fileInfo);
         this.__mergeFileTreeChildren(children, fileInTree);
+        // sort folders
+        console.log("sort folders", parent.children);
       }
 
       return children;
@@ -103,7 +107,7 @@ qx.Class.define("osparc.data.Converters", {
       };
     },
 
-    createFileEntry: function(label, location, datasetId, fileId, lastModified, size) {
+    __createFileEntry: function(label, location, datasetId, fileId, lastModified, size) {
       if (label === undefined) {
         label = "Unknown label";
       }
@@ -128,84 +132,6 @@ qx.Class.define("osparc.data.Converters", {
         lastModified,
         size
       };
-    },
-
-    __mergeAPITreeChildren: function(one, two) {
-      let newDir = true;
-      for (let i=0; i<one.length; i++) {
-        if (one[i].key === two.key) {
-          newDir = false;
-          if ("children" in two) {
-            this.__mergeAPITreeChildren(one[i].children, two.children[0]);
-          }
-        }
-      }
-      // if (one.length === 0 || "fileId" in two || newDir) {
-      if (one.length === 0 || newDir) {
-        one.push(two);
-      }
-    },
-
-    fromAPITreeToVirtualTreeModel: function(treeItems, showLeavesAsDirs, portKey) {
-      let children = [];
-      for (let i=0; i<treeItems.length; i++) {
-        const treeItem = treeItems[i];
-        let splitted = treeItem.label.split("/");
-        let newItem = {
-          label: splitted[0],
-          open: false,
-          portKey
-        };
-        if (splitted.length === 1) {
-          // leaf already
-          newItem.key = treeItem.key;
-          if (showLeavesAsDirs) {
-            newItem.children = [];
-          }
-        } else {
-          // branch
-          newItem.key = splitted[0];
-          newItem.children = [];
-          let parent = newItem;
-          for (let j=1; j<splitted.length-1; j++) {
-            let branch = {
-              label: splitted[j],
-              key: parent.key +"/"+ splitted[j],
-              open: false,
-              children: []
-            };
-            parent.children.push(branch);
-            parent = branch;
-          }
-          let leaf = {
-            label: splitted[splitted.length-1],
-            open: false,
-            key: parent.key +"/"+ splitted[splitted.length-1]
-          };
-          if (showLeavesAsDirs) {
-            leaf.children = [];
-          }
-          parent.children.push(leaf);
-        }
-        this.__mergeAPITreeChildren(children, newItem);
-      }
-      return children;
-    },
-
-    fromAPIListToVirtualListModel: function(listItems) {
-      let list = [];
-      for (let i=0; i<listItems.length; i++) {
-        const listItem = listItems[i];
-        let item = {
-          key: listItem["key"],
-          label: listItem["label"]
-        };
-        if (listItem.thumbnail) {
-          item["thumbnail"] = listItem["thumbnail"];
-        }
-        list.push(item);
-      }
-      return list;
     },
 
     fromTypeToIcon: function(type) {

--- a/services/static-webserver/client/source/class/osparc/data/Converters.js
+++ b/services/static-webserver/client/source/class/osparc/data/Converters.js
@@ -39,6 +39,25 @@ qx.Class.define("osparc.data.Converters", {
       }
     },
 
+    sortFiles: function(children) {
+      if (children && children.length) {
+        children.sort((a, b) => {
+          if (a["label"] > b["label"]) {
+            return 1;
+          }
+          if (a["label"] < b["label"]) {
+            return -1;
+          }
+          return 0;
+        });
+        children.forEach(child => {
+          if ("children" in child) {
+            this.sortFiles(child["children"]);
+          }
+        });
+      }
+    },
+
     sortModelByLabel: function(model) {
       model.getChildren().sort((a, b) => {
         if (a.getLabel() > b.getLabel()) {
@@ -52,15 +71,6 @@ qx.Class.define("osparc.data.Converters", {
     },
 
     fromDSMToVirtualTreeModel: function(datasetId, files) {
-      files.sort((a, b) => {
-        if (a["file_uuid"] > b["file_uuid"]) {
-          return 1;
-        }
-        if (a["file_uuid"] < b["file_uuid"]) {
-          return -1;
-        }
-        return 0;
-      });
       let children = [];
       for (let i=0; i<files.length; i++) {
         const file = files[i];
@@ -103,11 +113,13 @@ qx.Class.define("osparc.data.Converters", {
           datasetId,
           file["file_id"],
           file["last_modified"],
-          file["file_size"]);
+          file["file_size"]
+        );
         parent.children.push(fileInfo);
         this.__mergeFileTreeChildren(children, fileInTree);
       }
 
+      this.sortFiles(children);
       return children;
     },
 

--- a/services/static-webserver/client/source/class/osparc/data/Converters.js
+++ b/services/static-webserver/client/source/class/osparc/data/Converters.js
@@ -39,6 +39,18 @@ qx.Class.define("osparc.data.Converters", {
       }
     },
 
+    sortByLabel: function(model) {
+      model.getChildren().sort((a, b) => {
+        if (a.getLabel() > b.getLabel()) {
+          return 1;
+        }
+        if (a.getLabel() < b.getLabel()) {
+          return -1;
+        }
+        return 0;
+      });
+    },
+
     fromDSMToVirtualTreeModel: function(datasetId, files) {
       let children = [];
       for (let i=0; i<files.length; i++) {
@@ -74,8 +86,6 @@ qx.Class.define("osparc.data.Converters", {
           parent.children.push(newItem);
           parent = newItem;
         }
-        // sort folders
-        console.log("sort folders", parent.children);
 
         // create file
         const fileInfo = this.__createFileEntry(
@@ -87,8 +97,6 @@ qx.Class.define("osparc.data.Converters", {
           file["file_size"]);
         parent.children.push(fileInfo);
         this.__mergeFileTreeChildren(children, fileInTree);
-        // sort folders
-        console.log("sort folders", parent.children);
       }
 
       return children;

--- a/services/static-webserver/client/source/class/osparc/data/model/Slideshow.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Slideshow.js
@@ -71,7 +71,7 @@ qx.Class.define("osparc.data.model.Slideshow", {
 
   members: {
     isEmpty: function() {
-      return !Object.keys(this.getData()).length;
+      return Object.values(this.getData()).every(node => node.position === -1);
     },
 
     getSortedNodes: function() {

--- a/services/static-webserver/client/source/class/osparc/data/model/Slideshow.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Slideshow.js
@@ -48,10 +48,12 @@ qx.Class.define("osparc.data.model.Slideshow", {
       const nodes = [];
       for (let nodeId in slideshow) {
         const node = slideshow[nodeId];
-        nodes.push({
-          ...node,
-          nodeId
-        });
+        if (node["position"] !== -1) {
+          nodes.push({
+            ...node,
+            nodeId
+          });
+        }
       }
       nodes.sort((a, b) => (a.position > b.position) ? 1 : -1);
       return nodes;

--- a/services/static-webserver/client/source/class/osparc/desktop/SlideshowView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/SlideshowView.js
@@ -360,11 +360,10 @@ qx.Class.define("osparc.desktop.SlideshowView", {
           });
         }
       }
-      const slideshowData = slideshow.getData();
       this.setPageContext(context);
       this.__slideshowToolbar.populateButtons(true);
       const currentNodeId = this.getStudy().getUi().getCurrentNodeId();
-      const isValid = Object.keys(slideshowData).indexOf(currentNodeId) !== -1;
+      const isValid = slideshow.getPosition(currentNodeId) !== -1;
       if (isValid && currentNodeId) {
         this.__moveToNode(currentNodeId);
       } else {

--- a/services/static-webserver/client/source/class/osparc/file/FilesTree.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilesTree.js
@@ -475,7 +475,7 @@ qx.Class.define("osparc.file.FilesTree", {
         }
       });
       // sort datasets
-      osparc.data.Converters.sortByLabel(locationModel);
+      osparc.data.Converters.sortModelByLabel(locationModel);
 
       this.__rerender(locationModel);
 
@@ -504,7 +504,7 @@ qx.Class.define("osparc.file.FilesTree", {
           });
         }
         // sort files
-        osparc.data.Converters.sortByLabel(datasetModel);
+        osparc.data.Converters.sortModelByLabel(datasetModel);
 
         this.__rerender(datasetModel);
 

--- a/services/static-webserver/client/source/class/osparc/file/FilesTree.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilesTree.js
@@ -216,6 +216,125 @@ qx.Class.define("osparc.file.FilesTree", {
       }
     },
 
+    __resetTree: function(treeName) {
+      // FIXME: It is not reseting the model
+      this.resetModel();
+      const rootData = {
+        label: treeName,
+        itemId: treeName.replace(/\s/g, ""), // remove all whitespaces
+        location: null,
+        path: null,
+        pathLabel: [treeName],
+        children: []
+      };
+      const root = qx.data.marshal.Json.createModel(rootData, true);
+
+      this.setModel(root);
+      this.setDelegate({
+        createItem: () => new osparc.file.FileTreeItem(),
+        bindItem: (c, item, id) => {
+          c.bindDefaultProperties(item, id);
+          c.bindProperty("itemId", "itemId", null, item, id);
+          c.bindProperty("fileId", "fileId", null, item, id);
+          c.bindProperty("location", "location", null, item, id);
+          c.bindProperty("isDataset", "isDataset", null, item, id);
+          c.bindProperty("datasetId", "datasetId", null, item, id);
+          c.bindProperty("loaded", "loaded", null, item, id);
+          c.bindProperty("path", "path", null, item, id);
+          c.bindProperty("pathLabel", "pathLabel", null, item, id);
+          c.bindProperty("lastModified", "lastModified", null, item, id);
+          c.bindProperty("size", "size", null, item, id);
+          c.bindProperty("icon", "icon", null, item, id);
+        },
+        configureItem: item => {
+          const openButton = item.getChildControl("open");
+          openButton.addListener("tap", e => {
+            if (item.isOpen() && !item.getLoaded() && item.getIsDataset()) {
+              item.setLoaded(true);
+              const locationId = item.getLocation();
+              const datasetId = item.getPath();
+              this.requestDatasetFiles(locationId, datasetId);
+            }
+          }, this);
+          item.addListener("dbltap", e => {
+            this.__itemSelected();
+          }, this);
+          this.__addDragAndDropMechanisms(item);
+        }
+      });
+    },
+
+    __populateLocations: function() {
+      this.resetChecks();
+
+      const treeName = "My Data";
+      this.__resetTree(treeName);
+      const rootModel = this.getModel();
+      rootModel.getChildren().removeAll();
+      this.self().addLoadingChild(rootModel);
+
+      this.set({
+        hideRoot: true
+      });
+      const dataStore = osparc.store.Data.getInstance();
+      dataStore.getLocations()
+        .then(locations => {
+          if (this.__locations.size === 0) {
+            this.resetChecks();
+            this.__locationsToRoot(locations);
+            for (let i=0; i<locations.length; i++) {
+              const locationId = locations[i]["id"];
+              this.__populateLocation(locationId);
+            }
+          }
+        });
+    },
+
+    __locationsToRoot: function(locations) {
+      const rootModel = this.getModel();
+      rootModel.getChildren().removeAll();
+      let openThis = null;
+      for (let i=0; i<locations.length; i++) {
+        const location = locations[i];
+        const locationData = osparc.data.Converters.createDirEntry(
+          location.name,
+          location.id,
+          ""
+        );
+        locationData["pathLabel"] = rootModel.getPathLabel().concat(locationData["label"]);
+        const locationModel = qx.data.marshal.Json.createModel(locationData, true);
+        rootModel.getChildren().append(locationModel);
+        if (this.__hasLocationNeedToBeLoaded(location.id)) {
+          openThis = locationModel;
+        }
+      }
+      if (openThis) {
+        this.openNodeAndParents(openThis);
+      }
+    },
+
+    __populateLocation: function(locationId = null) {
+      if (locationId !== null) {
+        const locationModel = this.__getLocationModel(locationId);
+        if (locationModel) {
+          locationModel.getChildren().removeAll();
+          this.self().addLoadingChild(locationModel);
+        }
+      }
+
+      const dataStore = osparc.store.Data.getInstance();
+      dataStore.getDatasetsByLocation(locationId)
+        .then(data => {
+          const {
+            location,
+            datasets
+          } = data;
+          if (location === locationId && !this.__locations.has(locationId)) {
+            this.__datasetsToLocation(location, datasets);
+          }
+        });
+    },
+
     __populateStudyFiles: function(studyId) {
       const treeName = "Study Files";
       this.__resetTree(treeName);
@@ -269,102 +388,6 @@ qx.Class.define("osparc.file.FilesTree", {
         });
     },
 
-    __populateLocations: function() {
-      this.resetChecks();
-
-      const treeName = "My Data";
-      this.__resetTree(treeName);
-      const rootModel = this.getModel();
-      rootModel.getChildren().removeAll();
-      this.self().addLoadingChild(rootModel);
-
-      this.set({
-        hideRoot: true
-      });
-      const dataStore = osparc.store.Data.getInstance();
-      dataStore.getLocations()
-        .then(locations => {
-          if (this.__locations.size === 0) {
-            this.resetChecks();
-            this.__locationsToRoot(locations);
-            for (let i=0; i<locations.length; i++) {
-              const locationId = locations[i]["id"];
-              this.__populateLocation(locationId);
-            }
-          }
-        });
-    },
-
-    __populateLocation: function(locationId = null) {
-      if (locationId !== null) {
-        const locationModel = this.__getLocationModel(locationId);
-        if (locationModel) {
-          locationModel.getChildren().removeAll();
-          this.self().addLoadingChild(locationModel);
-        }
-      }
-
-      const dataStore = osparc.store.Data.getInstance();
-      dataStore.getDatasetsByLocation(locationId)
-        .then(data => {
-          const {
-            location,
-            datasets
-          } = data;
-          if (location === locationId && !this.__locations.has(locationId)) {
-            this.__datasetsToLocation(location, datasets);
-          }
-        });
-    },
-
-    __resetTree: function(treeName) {
-      // FIXME: It is not reseting the model
-      this.resetModel();
-      const rootData = {
-        label: treeName,
-        itemId: treeName.replace(/\s/g, ""), // remove all whitespaces
-        location: null,
-        path: null,
-        pathLabel: [treeName],
-        children: []
-      };
-      const root = qx.data.marshal.Json.createModel(rootData, true);
-
-      this.setModel(root);
-      this.setDelegate({
-        createItem: () => new osparc.file.FileTreeItem(),
-        bindItem: (c, item, id) => {
-          c.bindDefaultProperties(item, id);
-          c.bindProperty("itemId", "itemId", null, item, id);
-          c.bindProperty("fileId", "fileId", null, item, id);
-          c.bindProperty("location", "location", null, item, id);
-          c.bindProperty("isDataset", "isDataset", null, item, id);
-          c.bindProperty("datasetId", "datasetId", null, item, id);
-          c.bindProperty("loaded", "loaded", null, item, id);
-          c.bindProperty("path", "path", null, item, id);
-          c.bindProperty("pathLabel", "pathLabel", null, item, id);
-          c.bindProperty("lastModified", "lastModified", null, item, id);
-          c.bindProperty("size", "size", null, item, id);
-          c.bindProperty("icon", "icon", null, item, id);
-        },
-        configureItem: item => {
-          const openButton = item.getChildControl("open");
-          openButton.addListener("tap", e => {
-            if (item.isOpen() && !item.getLoaded() && item.getIsDataset()) {
-              item.setLoaded(true);
-              const locationId = item.getLocation();
-              const datasetId = item.getPath();
-              this.requestDatasetFiles(locationId, datasetId);
-            }
-          }, this);
-          item.addListener("dbltap", e => {
-            this.__itemSelected();
-          }, this);
-          this.__addDragAndDropMechanisms(item);
-        }
-      });
-    },
-
     requestDatasetFiles: function(locationId, datasetId) {
       if (this.__datasets.has(datasetId)) {
         return;
@@ -404,29 +427,6 @@ qx.Class.define("osparc.file.FilesTree", {
         }
       }
       return null;
-    },
-
-    __locationsToRoot: function(locations) {
-      const rootModel = this.getModel();
-      rootModel.getChildren().removeAll();
-      let openThis = null;
-      for (let i=0; i<locations.length; i++) {
-        const location = locations[i];
-        const locationData = osparc.data.Converters.createDirEntry(
-          location.name,
-          location.id,
-          ""
-        );
-        locationData["pathLabel"] = rootModel.getPathLabel().concat(locationData["label"]);
-        const locationModel = qx.data.marshal.Json.createModel(locationData, true);
-        rootModel.getChildren().append(locationModel);
-        if (this.__hasLocationNeedToBeLoaded(location.id)) {
-          openThis = locationModel;
-        }
-      }
-      if (openThis) {
-        this.openNodeAndParents(openThis);
-      }
     },
 
     __itemsToNode: function(files) {

--- a/services/static-webserver/client/source/class/osparc/file/FilesTree.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilesTree.js
@@ -248,7 +248,7 @@ qx.Class.define("osparc.file.FilesTree", {
         },
         configureItem: item => {
           const openButton = item.getChildControl("open");
-          openButton.addListener("tap", e => {
+          openButton.addListener("tap", () => {
             if (item.isOpen() && !item.getLoaded() && item.getIsDataset()) {
               item.setLoaded(true);
               const locationId = item.getLocation();
@@ -256,9 +256,7 @@ qx.Class.define("osparc.file.FilesTree", {
               this.requestDatasetFiles(locationId, datasetId);
             }
           }, this);
-          item.addListener("dbltap", e => {
-            this.__itemSelected();
-          }, this);
+          item.addListener("dbltap", () => this.__itemSelected(), this);
           this.__addDragAndDropMechanisms(item);
         }
       });
@@ -476,6 +474,8 @@ qx.Class.define("osparc.file.FilesTree", {
           openThis = datasetModel;
         }
       });
+      // sort datasets
+      osparc.data.Converters.sortByLabel(locationModel);
 
       this.__rerender(locationModel);
 
@@ -503,6 +503,8 @@ qx.Class.define("osparc.file.FilesTree", {
             datasetModel.getChildren().append(filesModel);
           });
         }
+        // sort files
+        osparc.data.Converters.sortByLabel(datasetModel);
 
         this.__rerender(datasetModel);
 


### PR DESCRIPTION
## What do these changes do?

- [x] Sort items in trees:
  - Studies/Datasets
  - Nodes
  - Files

- [x] Force NodeTreeItem menu's bgColor

![image](https://user-images.githubusercontent.com/33152403/200331710-215fe6bb-b09e-4bfd-b257-06f05a345435.png)
![image](https://user-images.githubusercontent.com/33152403/200336458-5eaf5919-fcdc-4e84-92c2-9b9e214ea392.png)


## Related issue/s
closes https://github.com/ITISFoundation/osparc-simcore/issues/3226
closes https://github.com/ITISFoundation/osparc-simcore/issues/3518
closes https://github.com/ITISFoundation/osparc-simcore/issues/3520


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
