### PR TITLE
🐛 Fixes CI test issues introduced by faulty #3524

### DIFF
--- a/services/director-v2/requirements/_test.in
+++ b/services/director-v2/requirements/_test.in
@@ -22,6 +22,7 @@ docker
 Faker
 flaky
 minio
+pylint
 pytest
 pytest-aiohttp
 pytest-cov

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -39,6 +39,8 @@ anyio==3.6.1
     #   httpcore
 asgi-lifespan==1.0.1
     # via -r requirements/_test.in
+astroid==2.12.12
+    # via pylint
 async-asgi-testclient==1.4.11
     # via -r requirements/_test.in
 async-timeout==4.0.2
@@ -51,7 +53,7 @@ attrs==21.4.0
     #   aiohttp
     #   pytest
     #   pytest-docker
-bokeh==3.0.1
+bokeh==2.4.3
     # via -r requirements/_test.in
 boto3==1.24.59
     # via aiobotocore
@@ -78,8 +80,6 @@ codecov==2.1.12
     # via -r requirements/_test.in
 colorlog==6.7.0
     # via dask-gateway-server
-contourpy==1.0.6
-    # via bokeh
 coverage==6.5.0
     # via
     #   codecov
@@ -87,21 +87,23 @@ coverage==6.5.0
     #   pytest-cov
 coveralls==3.3.1
     # via -r requirements/_test.in
-cryptography==38.0.3
+cryptography==38.0.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   dask-gateway-server
 dask-gateway-server==2022.10.0
     # via -r requirements/_test.in
-docker==6.0.1
+dill==0.3.5.1
+    # via pylint
+docker==6.0.0
     # via -r requirements/_test.in
 docopt==0.6.2
     # via coveralls
-exceptiongroup==1.0.1
+exceptiongroup==1.0.0
     # via pytest
 execnet==1.9.0
     # via pytest-xdist
-faker==15.2.0
+faker==15.1.0
     # via -r requirements/_test.in
 flaky==3.7.0
     # via -r requirements/_test.in
@@ -138,6 +140,8 @@ idna==2.10
     #   yarl
 iniconfig==1.1.1
     # via pytest
+isort==5.10.1
+    # via pylint
 jinja2==3.1.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -147,6 +151,8 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+lazy-object-proxy==1.7.1
+    # via astroid
 mako==1.2.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -157,6 +163,8 @@ markupsafe==2.1.1
     #   -c requirements/_base.txt
     #   jinja2
     #   mako
+mccabe==0.7.0
+    # via pylint
 minio==7.0.4
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -168,10 +176,7 @@ multidict==6.0.2
     #   async-asgi-testclient
     #   yarl
 numpy==1.23.4
-    # via
-    #   bokeh
-    #   contourpy
-    #   pandas
+    # via bokeh
 packaging==21.3
     # via
     #   -c requirements/_base.txt
@@ -182,10 +187,10 @@ pamqp==3.2.1
     # via
     #   -c requirements/_base.txt
     #   aiormq
-pandas==1.5.1
-    # via bokeh
 pillow==9.3.0
     # via bokeh
+platformdirs==2.5.2
+    # via pylint
 pluggy==1.0.0
     # via pytest
 pprintpp==0.4.0
@@ -194,8 +199,12 @@ psycopg2-binary==2.9.3
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
+py==1.11.0
+    # via pytest-forked
 pycparser==2.21
     # via cffi
+pylint==2.15.5
+    # via -r requirements/_test.in
 pyparsing==3.0.9
     # via
     #   -c requirements/_base.txt
@@ -207,32 +216,32 @@ pytest==7.2.0
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-docker
+    #   pytest-forked
     #   pytest-icdiff
     #   pytest-mock
     #   pytest-xdist
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
-pytest-asyncio==0.20.1
+pytest-asyncio==0.19.0
     # via pytest-aiohttp
 pytest-cov==4.0.0
     # via -r requirements/_test.in
 pytest-docker==1.0.1
     # via -r requirements/_test.in
+pytest-forked==1.4.0
+    # via pytest-xdist
 pytest-icdiff==0.6
     # via -r requirements/_test.in
 pytest-mock==3.10.0
     # via -r requirements/_test.in
 pytest-runner==6.0.0
     # via -r requirements/_test.in
-pytest-xdist==3.0.2
+pytest-xdist==2.5.0
     # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via
     #   botocore
     #   faker
-    #   pandas
-pytz==2022.6
-    # via pandas
 pyyaml==5.4.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -273,17 +282,23 @@ sqlalchemy==1.4.37
 tomli==2.0.1
     # via
     #   coverage
+    #   pylint
     #   pytest
+tomlkit==0.11.5
+    # via pylint
 tornado==6.1
     # via
     #   -c requirements/_base.txt
     #   bokeh
-traitlets==5.5.0
+traitlets==5.4.0
     # via dask-gateway-server
 typing-extensions==4.3.0
     # via
     #   -c requirements/_base.txt
     #   aioitertools
+    #   astroid
+    #   bokeh
+    #   pylint
 urllib3==1.26.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -292,14 +307,13 @@ urllib3==1.26.9
     #   docker
     #   minio
     #   requests
-websocket-client==1.4.2
+websocket-client==1.4.1
     # via docker
 wrapt==1.14.1
     # via
     #   -c requirements/_base.txt
     #   aiobotocore
-xyzservices==2022.9.0
-    # via bokeh
+    #   astroid
 yarl==1.7.2
     # via
     #   -c requirements/_base.txt

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -4,11 +4,9 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==2.12.12
-    # via pylint
 black==22.10.0
     # via -r requirements/../../../requirements/devenv.txt
-build==0.9.0
+build==0.8.0
     # via pip-tools
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -19,22 +17,16 @@ click==8.1.3
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-dill==0.3.6
-    # via pylint
 distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
     # via virtualenv
-identify==2.5.8
+identify==2.5.6
     # via pre-commit
 isort==5.10.1
     # via
+    #   -c requirements/_test.txt
     #   -r requirements/../../../requirements/devenv.txt
-    #   pylint
-lazy-object-proxy==1.8.0
-    # via astroid
-mccabe==0.7.0
-    # via pylint
 mypy-extensions==0.4.3
     # via black
 nodeenv==1.7.0
@@ -50,14 +42,12 @@ pep517==0.13.0
     # via build
 pip-tools==6.9.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==2.5.3
+platformdirs==2.5.2
     # via
+    #   -c requirements/_test.txt
     #   black
-    #   pylint
     #   virtualenv
 pre-commit==2.20.0
-    # via -r requirements/../../../requirements/devenv.txt
-pylint==2.15.5
     # via -r requirements/../../../requirements/devenv.txt
 pyparsing==3.0.9
     # via
@@ -79,27 +69,17 @@ tomli==2.0.1
     #   black
     #   build
     #   pep517
-    #   pylint
-tomlkit==0.11.6
-    # via pylint
 typing-extensions==4.3.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
-    #   astroid
     #   black
-    #   pylint
-virtualenv==20.16.6
+virtualenv==20.16.5
     # via pre-commit
 watchdog==2.1.9
     # via -r requirements/_tools.in
-wheel==0.38.2
+wheel==0.37.1
     # via pip-tools
-wrapt==1.14.1
-    # via
-    #   -c requirements/_base.txt
-    #   -c requirements/_test.txt
-    #   astroid
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
+++ b/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
@@ -18,7 +18,6 @@ import aiopg.sa
 import httpx
 import pytest
 import sqlalchemy as sa
-from _pytest.monkeypatch import MonkeyPatch
 from aiodocker.containers import DockerContainer
 from aiopg.sa import Engine
 from fastapi import FastAPI
@@ -34,7 +33,7 @@ from models_library.projects_nodes_io import NodeID, NodeIDStr
 from models_library.projects_pipeline import PipelineDetails
 from models_library.projects_state import RunningState
 from models_library.users import UserID
-from py._path.local import LocalPath
+from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.utils_docker import get_localhost_ip
 from settings_library.rabbit import RabbitSettings
@@ -390,11 +389,6 @@ async def cleanup_services_and_networks(
         # remove pending volumes for service
         for node_uuid in workbench_dynamic_services:
             await ensure_volume_cleanup(docker_client, node_uuid)
-
-
-@pytest.fixture
-def temp_dir(tmpdir: LocalPath) -> Path:
-    return Path(tmpdir)
 
 
 @pytest.fixture
@@ -826,7 +820,7 @@ async def test_nodeports_integration(
     services_node_uuids: ServicesNodeUUIDs,
     fake_dy_success: dict[str, Any],
     fake_dy_published: dict[str, Any],
-    temp_dir: Path,
+    tmp_path: Path,
     mocker: MockerFixture,
     osparc_product_name: str,
 ) -> None:
@@ -959,20 +953,20 @@ async def test_nodeports_integration(
         await _fetch_data_via_aioboto(
             r_clone_settings=r_clone_settings,
             dir_tag="dy",
-            temp_dir=temp_dir,
+            temp_dir=tmp_path,
             node_id=services_node_uuids.dy,
             project_id=current_study.uuid,
         )
         if app_settings.DIRECTOR_V2_DEV_FEATURE_R_CLONE_MOUNTS_ENABLED
         else await _fetch_data_from_container(
-            dir_tag="dy", service_uuid=services_node_uuids.dy, temp_dir=temp_dir
+            dir_tag="dy", service_uuid=services_node_uuids.dy, temp_dir=tmp_path
         )
     )
     dy_compose_spec_path_volume_before = (
         await _fetch_data_via_aioboto(
             r_clone_settings=r_clone_settings,
             dir_tag="dy_compose_spec",
-            temp_dir=temp_dir,
+            temp_dir=tmp_path,
             node_id=services_node_uuids.dy_compose_spec,
             project_id=current_study.uuid,
         )
@@ -980,7 +974,7 @@ async def test_nodeports_integration(
         else await _fetch_data_from_container(
             dir_tag="dy_compose_spec",
             service_uuid=services_node_uuids.dy_compose_spec,
-            temp_dir=temp_dir,
+            temp_dir=tmp_path,
         )
     )
 
@@ -1009,7 +1003,7 @@ async def test_nodeports_integration(
         await _fetch_data_via_aioboto(
             r_clone_settings=r_clone_settings,
             dir_tag="dy",
-            temp_dir=temp_dir,
+            temp_dir=tmp_path,
             node_id=services_node_uuids.dy,
             project_id=current_study.uuid,
         )
@@ -1019,7 +1013,7 @@ async def test_nodeports_integration(
             user_id=current_user["id"],
             project_id=str(current_study.uuid),
             service_uuid=services_node_uuids.dy,
-            temp_dir=temp_dir,
+            temp_dir=tmp_path,
         )
     )
 
@@ -1027,7 +1021,7 @@ async def test_nodeports_integration(
         await _fetch_data_via_aioboto(
             r_clone_settings=r_clone_settings,
             dir_tag="dy_compose_spec",
-            temp_dir=temp_dir,
+            temp_dir=tmp_path,
             node_id=services_node_uuids.dy_compose_spec,
             project_id=current_study.uuid,
         )
@@ -1037,7 +1031,7 @@ async def test_nodeports_integration(
             user_id=current_user["id"],
             project_id=str(current_study.uuid),
             service_uuid=services_node_uuids.dy_compose_spec,
-            temp_dir=temp_dir,
+            temp_dir=tmp_path,
         )
     )
 
@@ -1055,20 +1049,20 @@ async def test_nodeports_integration(
         await _fetch_data_via_aioboto(
             r_clone_settings=r_clone_settings,
             dir_tag="dy",
-            temp_dir=temp_dir,
+            temp_dir=tmp_path,
             node_id=services_node_uuids.dy,
             project_id=current_study.uuid,
         )
         if app_settings.DIRECTOR_V2_DEV_FEATURE_R_CLONE_MOUNTS_ENABLED
         else await _fetch_data_from_container(
-            dir_tag="dy", service_uuid=services_node_uuids.dy, temp_dir=temp_dir
+            dir_tag="dy", service_uuid=services_node_uuids.dy, temp_dir=tmp_path
         )
     )
     dy_compose_spec_path_volume_after = (
         await _fetch_data_via_aioboto(
             r_clone_settings=r_clone_settings,
             dir_tag="dy_compose_spec",
-            temp_dir=temp_dir,
+            temp_dir=tmp_path,
             node_id=services_node_uuids.dy_compose_spec,
             project_id=current_study.uuid,
         )
@@ -1076,7 +1070,7 @@ async def test_nodeports_integration(
         else await _fetch_data_from_container(
             dir_tag="dy_compose_spec",
             service_uuid=services_node_uuids.dy_compose_spec,
-            temp_dir=temp_dir,
+            temp_dir=tmp_path,
         )
     )
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

PR #3524 got merged into master with some failures that we correct here. 

- Fixes``[int] director-v2 02`` : all dependencies to ``py`` were removed

```cmd
_ ERROR collecting tests/integration/02/test_dynamic_sidecar_nodeports_integration.py _
ImportError while importing test module '/home/runner/work/osparc-simcore/osparc-simcore/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/integration/02/test_dynamic_sidecar_nodeports_integration.py:37: in <module>
    from py._path.local import LocalPath
E   ModuleNotFoundError: No module named 'py._path'; 'py' is not a package
```
- Fixes ``[unit] director-v2`` job:  reverts director-v2 tests & tools requirements upgrade: made dask tests fail. Worker errored with ``importlib.metadata does not exists``