### PR TITLE
♻️ Fixes flaky test_update_profile and cleanup tests

### DIFF
--- a/packages/postgres-database/tests/test_services_consume_filetypes.py
+++ b/packages/postgres-database/tests/test_services_consume_filetypes.py
@@ -6,7 +6,6 @@
 
 import pytest
 import sqlalchemy as sa
-from _pytest.fixtures import fixture
 from aiopg.sa.engine import Engine
 from aiopg.sa.exc import ResourceClosedError
 from aiopg.sa.result import ResultProxy, RowProxy
@@ -57,7 +56,7 @@ def make_table():
     return _make
 
 
-@fixture
+@pytest.fixture
 async def conn(pg_engine: Engine, make_table):
     async with pg_engine.acquire() as conn:
         await make_table(conn)

--- a/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
@@ -20,9 +20,8 @@ from typing import Any, Iterator
 
 import pytest
 import yaml
-from _pytest.config import ExitCode
 from dotenv import dotenv_values, set_key
-from pytest import MonkeyPatch
+from pytest import ExitCode, MonkeyPatch
 
 from .helpers import (
     FIXTURE_CONFIG_CORE_SERVICES_SELECTION,

--- a/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
@@ -21,8 +21,8 @@ from typing import Any, Iterator
 import pytest
 import yaml
 from _pytest.config import ExitCode
-from _pytest.monkeypatch import MonkeyPatch
 from dotenv import dotenv_values, set_key
+from pytest import MonkeyPatch
 
 from .helpers import (
     FIXTURE_CONFIG_CORE_SERVICES_SELECTION,

--- a/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
+++ b/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import dotenv
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 
 
 @pytest.fixture(scope="session")

--- a/packages/pytest-simcore/src/pytest_simcore/minio_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/minio_service.py
@@ -6,11 +6,11 @@ import logging
 from typing import Any, Iterator
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from minio import Minio
 from minio.datatypes import Object
 from minio.deleteobjects import DeleteError, DeleteObject
 from pydantic import parse_obj_as
+from pytest import MonkeyPatch
 from tenacity import Retrying
 from tenacity.before_sleep import before_sleep_log
 from tenacity.stop import stop_after_attempt

--- a/packages/pytest-simcore/src/pytest_simcore/monkeypatch_extra.py
+++ b/packages/pytest-simcore/src/pytest_simcore/monkeypatch_extra.py
@@ -6,8 +6,7 @@ import warnings
 from typing import Iterator
 
 import pytest
-from _pytest.fixtures import FixtureRequest
-from pytest import MonkeyPatch
+from pytest import FixtureRequest, MonkeyPatch
 
 warnings.warn(
     f"{__name__} is deprecated, we highly recommend to use pytest.monkeypatch at function-scope level."

--- a/packages/pytest-simcore/src/pytest_simcore/monkeypatch_extra.py
+++ b/packages/pytest-simcore/src/pytest_simcore/monkeypatch_extra.py
@@ -7,7 +7,7 @@ from typing import Iterator
 
 import pytest
 from _pytest.fixtures import FixtureRequest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 
 warnings.warn(
     f"{__name__} is deprecated, we highly recommend to use pytest.monkeypatch at function-scope level."

--- a/packages/pytest-simcore/src/pytest_simcore/simcore_services.py
+++ b/packages/pytest-simcore/src/pytest_simcore/simcore_services.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass
 
 import aiohttp
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from aiohttp.client import ClientTimeout
+from pytest import MonkeyPatch
 from tenacity._asyncio import AsyncRetrying
 from tenacity.before_sleep import before_sleep_log
 from tenacity.stop import stop_after_delay

--- a/packages/pytest-simcore/src/pytest_simcore/tmp_path_extra.py
+++ b/packages/pytest-simcore/src/pytest_simcore/tmp_path_extra.py
@@ -12,8 +12,7 @@
 from pathlib import Path
 
 import pytest
-from _pytest.tmpdir import TempPathFactory
-from pytest import FixtureRequest
+from pytest import FixtureRequest, TempPathFactory
 
 
 @pytest.fixture(scope="module")

--- a/packages/pytest-simcore/src/pytest_simcore/tmp_path_extra.py
+++ b/packages/pytest-simcore/src/pytest_simcore/tmp_path_extra.py
@@ -12,8 +12,8 @@
 from pathlib import Path
 
 import pytest
-from _pytest.fixtures import FixtureRequest
 from _pytest.tmpdir import TempPathFactory
+from pytest import FixtureRequest
 
 
 @pytest.fixture(scope="module")

--- a/packages/settings-library/tests/test_docker_registry.py
+++ b/packages/settings-library/tests/test_docker_registry.py
@@ -4,7 +4,7 @@
 from copy import deepcopy
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 from settings_library.docker_registry import RegistrySettings
 
 MOCKED_BASE_REGISTRY_ENV_VARS: dict[str, str] = {

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
@@ -12,10 +12,10 @@ from uuid import uuid4
 
 import aioboto3
 import pytest
-from _pytest.fixtures import FixtureRequest
 from faker import Faker
 from models_library.api_schemas_storage import FileUploadLinks, FileUploadSchema
 from pydantic import AnyUrl, ByteSize, parse_obj_as
+from pytest import FixtureRequest
 from settings_library.r_clone import RCloneSettings
 from simcore_sdk.node_ports_common import r_clone
 

--- a/services/agent/tests/conftest.py
+++ b/services/agent/tests/conftest.py
@@ -9,12 +9,11 @@ from uuid import uuid4
 import aiodocker
 import pytest
 import simcore_service_agent
-from _pytest.logging import LogCaptureFixture
 from aiodocker.volumes import DockerVolume
 from models_library.basic_types import BootModeEnum
 from moto.server import ThreadedMotoServer
 from pydantic import HttpUrl, parse_obj_as
-from pytest import MonkeyPatch
+from pytest import LogCaptureFixture, MonkeyPatch
 from pytest_simcore.helpers.utils_docker import get_localhost_ip
 from settings_library.r_clone import S3Provider
 from simcore_service_agent.core.settings import ApplicationSettings

--- a/services/agent/tests/unit/test_modules_volumes_cleanup.py
+++ b/services/agent/tests/unit/test_modules_volumes_cleanup.py
@@ -5,8 +5,8 @@
 from pathlib import Path
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from aiodocker.volumes import DockerVolume
+from pytest import LogCaptureFixture
 from pytest_mock.plugin import MockerFixture
 from simcore_service_agent.core.settings import ApplicationSettings
 from simcore_service_agent.modules.volumes_cleanup import backup_and_remove_volumes

--- a/services/catalog/tests/unit/test_services_director.py
+++ b/services/catalog/tests/unit/test_services_director.py
@@ -5,13 +5,13 @@
 # pylint:disable=not-context-manager
 
 
-from typing import Dict, Iterator
+from typing import Iterator
 
 import pytest
 import respx
-from _pytest.monkeypatch import MonkeyPatch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 from respx.router import MockRouter
 from simcore_service_catalog.api.dependencies.director import get_director_api
 from simcore_service_catalog.core.application import init_app
@@ -20,7 +20,7 @@ from simcore_service_catalog.services.director import DirectorApi
 
 @pytest.fixture
 def minimal_app(
-    monkeypatch: MonkeyPatch, testing_environ_vars: Dict[str, str]
+    monkeypatch: MonkeyPatch, testing_environ_vars: dict[str, str]
 ) -> Iterator[FastAPI]:
     # disable a couple of subsystems
     monkeypatch.setenv("CATALOG_POSTGRES", "null")

--- a/services/catalog/tests/unit/with_dbs/conftest.py
+++ b/services/catalog/tests/unit/with_dbs/conftest.py
@@ -13,11 +13,11 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Iterable, Iterator, 
 import pytest
 import respx
 import sqlalchemy as sa
-from _pytest.monkeypatch import MonkeyPatch
 from faker import Faker
 from fastapi import FastAPI
 from models_library.services import ServiceDockerData
 from models_library.users import UserID
+from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from simcore_postgres_database.models.products import products
 from simcore_postgres_database.models.users import UserRole, UserStatus, users

--- a/services/dask-sidecar/tests/unit/conftest.py
+++ b/services/dask-sidecar/tests/unit/conftest.py
@@ -4,18 +4,18 @@
 
 from pathlib import Path
 from pprint import pformat
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional
+from typing import Any, Callable, Iterable, Iterator, Optional
 
 import dask
 import distributed
 import fsspec
 import pytest
 import simcore_service_dask_sidecar
-from _pytest.monkeypatch import MonkeyPatch
 from _pytest.tmpdir import TempPathFactory
 from faker import Faker
 from minio import Minio
 from pydantic import AnyUrl, parse_obj_as
+from pytest import MonkeyPatch
 from pytest_localftpserver.servers import ProcessFTPServer
 from pytest_mock.plugin import MockerFixture
 from settings_library.s3 import S3Settings
@@ -53,7 +53,7 @@ def installed_package_dir() -> Path:
 
 @pytest.fixture()
 def mock_service_envs(
-    mock_env_devel_environment: Dict[str, Optional[str]],
+    mock_env_devel_environment: dict[str, Optional[str]],
     monkeypatch: MonkeyPatch,
     mocker: MockerFixture,
     tmp_path_factory: TempPathFactory,
@@ -91,7 +91,7 @@ def dask_client(mock_service_envs: None) -> Iterable[distributed.Client]:
 
 
 @pytest.fixture(scope="module")
-def ftp_server(ftpserver: ProcessFTPServer) -> List[URL]:
+def ftp_server(ftpserver: ProcessFTPServer) -> list[URL]:
     faker = Faker()
 
     files = ["file_1", "file_2", "file_3"]

--- a/services/dask-sidecar/tests/unit/conftest.py
+++ b/services/dask-sidecar/tests/unit/conftest.py
@@ -1,6 +1,7 @@
-# pylint:disable=unused-variable
-# pylint:disable=unused-argument
-# pylint:disable=redefined-outer-name
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+# pylint: disable=too-many-arguments
 
 from pathlib import Path
 from pprint import pformat
@@ -11,11 +12,10 @@ import distributed
 import fsspec
 import pytest
 import simcore_service_dask_sidecar
-from _pytest.tmpdir import TempPathFactory
 from faker import Faker
 from minio import Minio
 from pydantic import AnyUrl, parse_obj_as
-from pytest import MonkeyPatch
+from pytest import MonkeyPatch, TempPathFactory
 from pytest_localftpserver.servers import ProcessFTPServer
 from pytest_mock.plugin import MockerFixture
 from settings_library.s3 import S3Settings

--- a/services/dask-sidecar/tests/unit/test_file_utils.py
+++ b/services/dask-sidecar/tests/unit/test_file_utils.py
@@ -12,10 +12,10 @@ from unittest import mock
 
 import fsspec
 import pytest
-from _pytest.fixtures import FixtureRequest
 from faker import Faker
 from minio import Minio
 from pydantic import AnyUrl, parse_obj_as
+from pytest import FixtureRequest
 from pytest_localftpserver.servers import ProcessFTPServer
 from pytest_mock.plugin import MockerFixture
 from settings_library.s3 import S3Settings

--- a/services/dask-sidecar/tests/unit/test_settings.py
+++ b/services/dask-sidecar/tests/unit/test_settings.py
@@ -2,16 +2,16 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
-from typing import Dict, Optional
+from typing import Optional
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 from simcore_service_dask_sidecar.settings import Settings
 
 
 @pytest.fixture
 def mock_service_envs(
-    mock_env_devel_environment: Dict[str, Optional[str]], monkeypatch: MonkeyPatch
+    mock_env_devel_environment: dict[str, Optional[str]], monkeypatch: MonkeyPatch
 ) -> None:
 
     # Variables directly define inside Dockerfile

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -19,7 +19,6 @@ from uuid import uuid4
 
 import fsspec
 import pytest
-from _pytest.logging import LogCaptureFixture
 from dask_task_models_library.container_tasks.docker import DockerBasicAuth
 from dask_task_models_library.container_tasks.events import (
     TaskLogEvent,
@@ -38,7 +37,7 @@ from models_library.projects_nodes_io import NodeID
 from models_library.users import UserID
 from packaging import version
 from pydantic import AnyUrl, SecretStr
-from pytest import FixtureRequest
+from pytest import FixtureRequest, LogCaptureFixture
 from pytest_mock.plugin import MockerFixture
 from settings_library.s3 import S3Settings
 from simcore_service_dask_sidecar.computational_sidecar.docker_utils import (

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -13,13 +13,12 @@ import re
 from dataclasses import dataclass
 from pprint import pformat
 from random import randint
-from typing import Callable, Coroutine, Dict, Iterable, List
+from typing import Callable, Coroutine, Iterable
 from unittest import mock
 from uuid import uuid4
 
 import fsspec
 import pytest
-from _pytest.fixtures import FixtureRequest
 from _pytest.logging import LogCaptureFixture
 from dask_task_models_library.container_tasks.docker import DockerBasicAuth
 from dask_task_models_library.container_tasks.events import (
@@ -39,6 +38,7 @@ from models_library.projects_nodes_io import NodeID
 from models_library.users import UserID
 from packaging import version
 from pydantic import AnyUrl, SecretStr
+from pytest import FixtureRequest
 from pytest_mock.plugin import MockerFixture
 from settings_library.s3 import S3Settings
 from simcore_service_dask_sidecar.computational_sidecar.docker_utils import (
@@ -78,7 +78,7 @@ def node_id() -> NodeID:
 
 
 @pytest.fixture()
-def dask_subsystem_mock(mocker: MockerFixture) -> Dict[str, MockerFixture]:
+def dask_subsystem_mock(mocker: MockerFixture) -> dict[str, MockerFixture]:
     # mock dask client
     dask_client_mock = mocker.patch("distributed.Client", autospec=True)
 
@@ -129,12 +129,12 @@ class ServiceExampleParam:
     docker_basic_auth: DockerBasicAuth
     service_key: str
     service_version: str
-    command: List[str]
+    command: list[str]
     input_data: TaskInputData
     output_data_keys: TaskOutputDataSchema
     log_file_url: AnyUrl
     expected_output_data: TaskOutputData
-    expected_logs: List[str]
+    expected_logs: list[str]
     integration_version: version.Version
 
 
@@ -328,7 +328,7 @@ def test_run_computational_sidecar_real_fct(
     caplog_info_level: LogCaptureFixture,
     event_loop: asyncio.AbstractEventLoop,
     mock_service_envs: None,
-    dask_subsystem_mock: Dict[str, MockerFixture],
+    dask_subsystem_mock: dict[str, MockerFixture],
     ubuntu_task: ServiceExampleParam,
     mocker: MockerFixture,
     s3_settings: S3Settings,
@@ -500,7 +500,7 @@ def test_failing_service_raises_exception(
     caplog_info_level: LogCaptureFixture,
     event_loop: asyncio.AbstractEventLoop,
     mock_service_envs: None,
-    dask_subsystem_mock: Dict[str, MockerFixture],
+    dask_subsystem_mock: dict[str, MockerFixture],
     ubuntu_task_fail: ServiceExampleParam,
     s3_settings: S3Settings,
 ):
@@ -521,7 +521,7 @@ def test_running_service_that_generates_unexpected_data_raises_exception(
     caplog_info_level: LogCaptureFixture,
     event_loop: asyncio.AbstractEventLoop,
     mock_service_envs: None,
-    dask_subsystem_mock: Dict[str, MockerFixture],
+    dask_subsystem_mock: dict[str, MockerFixture],
     ubuntu_task_unexpected_output: ServiceExampleParam,
     s3_settings: S3Settings,
 ):

--- a/services/dask-sidecar/tests/unit/test_utils.py
+++ b/services/dask-sidecar/tests/unit/test_utils.py
@@ -4,19 +4,19 @@
 
 
 import asyncio
-from typing import Dict, List, Optional
+from typing import Optional
 from unittest import mock
 
 import aiodocker
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from simcore_service_dask_sidecar.utils import num_available_gpus
 
 
 @pytest.fixture
 def mock_service_envs(
-    mock_env_devel_environment: Dict[str, Optional[str]], monkeypatch: MonkeyPatch
+    mock_env_devel_environment: dict[str, Optional[str]], monkeypatch: MonkeyPatch
 ) -> None:
     monkeypatch.setenv(
         "SIDECAR_COMP_SERVICES_SHARED_VOLUME_NAME", "simcore_computational_shared_data"
@@ -99,7 +99,7 @@ def test_num_available_gpus_returns_0_when_container_wait_timesout(
 def test_num_available_gpus(
     event_loop: asyncio.events.AbstractEventLoop,
     mock_service_envs: None,
-    container_logs: List[str],
+    container_logs: list[str],
     expected_num_gpus: int,
     mock_aiodocker: mock.MagicMock,
 ):

--- a/services/datcore-adapter/tests/unit/conftest.py
+++ b/services/datcore-adapter/tests/unit/conftest.py
@@ -12,9 +12,9 @@ import httpx
 import pytest
 import respx
 import simcore_service_datcore_adapter
-from _pytest.monkeypatch import MonkeyPatch
 from asgi_lifespan import LifespanManager
 from fastapi.applications import FastAPI
+from pytest import MonkeyPatch
 from pytest_mock import MockFixture
 from simcore_service_datcore_adapter.modules.pennsieve import (
     PennsieveAuthorizationHeaders,

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -15,7 +15,6 @@ from typing import Any, Callable
 import httpx
 import pytest
 import sqlalchemy as sa
-from _pytest.monkeypatch import MonkeyPatch
 from httpx import AsyncClient
 from models_library.clusters import DEFAULT_CLUSTER_ID
 from models_library.projects import ProjectAtDB
@@ -23,6 +22,7 @@ from models_library.projects_nodes import NodeState
 from models_library.projects_nodes_io import NodeID
 from models_library.projects_pipeline import PipelineDetails
 from models_library.projects_state import RunningState
+from pytest import MonkeyPatch
 from settings_library.rabbit import RabbitSettings
 from shared_comp_utils import (
     COMPUTATION_URL,

--- a/services/director-v2/tests/integration/02/test_mixed_dynamic_sidecar_and_legacy_project.py
+++ b/services/director-v2/tests/integration/02/test_mixed_dynamic_sidecar_and_legacy_project.py
@@ -12,11 +12,11 @@ import aiodocker
 import httpx
 import pytest
 import sqlalchemy as sa
-from _pytest.monkeypatch import MonkeyPatch
 from asgi_lifespan import LifespanManager
 from faker import Faker
 from models_library.projects import ProjectAtDB
 from models_library.services_resources import ServiceResourcesDict
+from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.utils_docker import get_localhost_ip
 from settings_library.rabbit import RabbitSettings

--- a/services/director-v2/tests/unit/conftest.py
+++ b/services/director-v2/tests/unit/conftest.py
@@ -20,7 +20,6 @@ import pytest
 import respx
 import traitlets.config
 from _dask_helpers import DaskGatewayServer
-from _pytest.logging import LogCaptureFixture
 from dask.distributed import Scheduler, Worker
 from dask_gateway_server.app import DaskGateway
 from dask_gateway_server.backends.local import UnsafeLocalBackend
@@ -33,7 +32,7 @@ from models_library.service_settings_labels import SimcoreServiceLabels
 from models_library.services import RunID, ServiceKeyVersion
 from pydantic import parse_obj_as
 from pydantic.types import NonNegativeInt
-from pytest import MonkeyPatch
+from pytest import LogCaptureFixture, MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.s3 import S3Settings

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -16,7 +16,6 @@ import distributed
 import pytest
 import respx
 from _dask_helpers import DaskGatewayServer
-from _pytest.monkeypatch import MonkeyPatch
 from dask.distributed import get_worker
 from dask_task_models_library.container_tasks.docker import DockerBasicAuth
 from dask_task_models_library.container_tasks.errors import TaskCancelledError
@@ -42,6 +41,7 @@ from models_library.projects_state import RunningState
 from models_library.users import UserID
 from pydantic import AnyUrl, ByteSize, SecretStr
 from pydantic.tools import parse_obj_as
+from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.s3 import S3Settings

--- a/services/director-v2/tests/unit/test_modules_dask_clients_pool.py
+++ b/services/director-v2/tests/unit/test_modules_dask_clients_pool.py
@@ -9,7 +9,6 @@ from unittest import mock
 
 import pytest
 from _dask_helpers import DaskGatewayServer
-from _pytest.monkeypatch import MonkeyPatch
 from distributed.deploy.spec import SpecCluster
 from faker import Faker
 from models_library.clusters import (
@@ -22,6 +21,7 @@ from models_library.clusters import (
     SimpleAuthentication,
 )
 from pydantic import SecretStr
+from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.utils_cli import create_json_encoder_wo_secrets

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_base.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_base.py
@@ -1,7 +1,6 @@
 # pylint:disable=redefined-outer-name
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from httpx import (
     ConnectError,
     HTTPError,
@@ -12,6 +11,7 @@ from httpx import (
     codes,
 )
 from pydantic import AnyHttpUrl, parse_obj_as
+from pytest import LogCaptureFixture
 from respx import MockRouter
 from simcore_service_director_v2.modules.dynamic_sidecar.api_client._base import (
     BaseThinClient,

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_public.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_public.py
@@ -7,10 +7,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 from _pytest.logging import LogCaptureFixture
-from _pytest.monkeypatch import MonkeyPatch
 from fastapi import FastAPI, status
 from httpx import HTTPError, Response
 from pydantic import AnyHttpUrl, parse_obj_as
+from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_service_director_v2.core.settings import AppSettings

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_public.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_public.py
@@ -6,11 +6,10 @@ from typing import Any, AsyncIterable, Callable, Iterator, Optional
 from unittest.mock import AsyncMock
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from fastapi import FastAPI, status
 from httpx import HTTPError, Response
 from pydantic import AnyHttpUrl, parse_obj_as
-from pytest import MonkeyPatch
+from pytest import LogCaptureFixture, MonkeyPatch
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_service_director_v2.core.settings import AppSettings

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_thin.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_thin.py
@@ -5,10 +5,10 @@ import json
 from typing import Any, Callable, Optional
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from fastapi import FastAPI, status
 from httpx import Response
 from pydantic import AnyHttpUrl, parse_obj_as
+from pytest import MonkeyPatch
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from respx import MockRouter, Route
 from respx.types import SideEffectTypes

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_events.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_events.py
@@ -6,9 +6,9 @@ from typing import Final
 
 import pytest
 from _pytest.logging import LogCaptureFixture
-from _pytest.monkeypatch import MonkeyPatch
 from fastapi import FastAPI
 from pydantic import PositiveFloat, PositiveInt
+from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_events.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_events.py
@@ -5,10 +5,9 @@ import asyncio
 from typing import Final
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from fastapi import FastAPI
 from pydantic import PositiveFloat, PositiveInt
-from pytest import MonkeyPatch
+from pytest import LogCaptureFixture, MonkeyPatch
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_scheduler.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_scheduler.py
@@ -13,9 +13,9 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 import respx
-from _pytest.monkeypatch import MonkeyPatch
 from fastapi import FastAPI
 from models_library.service_settings_labels import SimcoreServiceLabels
+from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from respx.router import MockRouter

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_scheduler_task.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_scheduler_task.py
@@ -10,9 +10,8 @@ from typing import Final, Iterator
 import httpx
 import pytest
 import respx
-from _pytest.monkeypatch import MonkeyPatch
 from fastapi import FastAPI
-from pytest import FixtureRequest
+from pytest import FixtureRequest, MonkeyPatch
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict

--- a/services/director-v2/tests/unit/with_dbs/test_api_route_clusters.py
+++ b/services/director-v2/tests/unit/with_dbs/test_api_route_clusters.py
@@ -10,7 +10,6 @@ import httpx
 import pytest
 import sqlalchemy as sa
 from _dask_helpers import DaskGatewayServer
-from _pytest.monkeypatch import MonkeyPatch
 from distributed.deploy.spec import SpecCluster
 from faker import Faker
 from httpx import URL
@@ -25,6 +24,7 @@ from models_library.clusters import (
     SimpleAuthentication,
 )
 from pydantic import AnyHttpUrl, SecretStr, parse_obj_as
+from pytest import MonkeyPatch
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.utils_cli import create_json_encoder_wo_secrets
 from simcore_postgres_database.models.clusters import ClusterType, clusters

--- a/services/director-v2/tests/unit/with_dbs/test_api_route_clusters_details.py
+++ b/services/director-v2/tests/unit/with_dbs/test_api_route_clusters_details.py
@@ -9,7 +9,6 @@ import httpx
 import pytest
 import sqlalchemy as sa
 from _dask_helpers import DaskGatewayServer
-from _pytest.monkeypatch import MonkeyPatch
 from dask_gateway import Gateway, GatewayCluster, auth
 from distributed import Client as DaskClient
 from distributed.deploy.spec import SpecCluster
@@ -17,6 +16,7 @@ from faker import Faker
 from models_library.clusters import Cluster, ClusterID, SimpleAuthentication
 from models_library.users import UserID
 from pydantic import SecretStr
+from pytest import MonkeyPatch
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_service_director_v2.models.schemas.clusters import ClusterDetailsGet
 from starlette import status

--- a/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
@@ -23,7 +23,6 @@ from _helpers import (
     manually_run_comp_scheduler,
     set_comp_task_state,
 )
-from _pytest.monkeypatch import MonkeyPatch
 from dask.distributed import SpecCluster
 from dask_task_models_library.container_tasks.errors import TaskCancelledError
 from dask_task_models_library.container_tasks.io import TaskOutputData
@@ -31,6 +30,7 @@ from fastapi.applications import FastAPI
 from models_library.clusters import DEFAULT_CLUSTER_ID
 from models_library.projects import ProjectAtDB
 from models_library.projects_state import RunningState
+from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_postgres_database.models.comp_pipeline import StateType

--- a/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
@@ -11,7 +11,6 @@ from uuid import UUID, uuid4
 
 import aiodocker
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from aiodocker.utils import clean_filters
 from aiodocker.volumes import DockerVolume
 from faker import Faker
@@ -19,7 +18,7 @@ from fastapi.encoders import jsonable_encoder
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.users import UserID
-from pytest import FixtureRequest
+from pytest import FixtureRequest, MonkeyPatch
 from pytest_simcore.helpers.utils_envs import EnvVarsDict
 from simcore_service_director_v2.core.settings import DynamicSidecarSettings
 from simcore_service_director_v2.models.schemas.constants import (

--- a/services/director-v2/tests/unit/with_dbs/test_modules_redis.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_redis.py
@@ -8,11 +8,11 @@ from contextlib import suppress
 from typing import Any, AsyncIterable, Final
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from asgi_lifespan import LifespanManager
 from faker import Faker
 from fastapi import FastAPI
 from pydantic import PositiveFloat
+from pytest import MonkeyPatch
 from redis.exceptions import LockError, LockNotOwnedError
 from settings_library.redis import RedisSettings
 from simcore_service_director_v2.core.errors import NodeRightsAcquireError

--- a/services/director-v2/tests/unit/with_dbs/test_utils_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/test_utils_dask.py
@@ -15,7 +15,6 @@ import aiopg
 import httpx
 import pytest
 from _helpers import PublishedProject, set_comp_task_inputs, set_comp_task_outputs
-from _pytest.monkeypatch import MonkeyPatch
 from dask_task_models_library.container_tasks.io import (
     FilePortSchema,
     FileUrl,
@@ -29,6 +28,7 @@ from models_library.users import UserID
 from pydantic import ByteSize
 from pydantic.networks import AnyUrl
 from pydantic.tools import parse_obj_as
+from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_sdk.node_ports_v2 import FileLinkType

--- a/services/dynamic-sidecar/tests/unit/test_api_containers_long_running_tasks.py
+++ b/services/dynamic-sidecar/tests/unit/test_api_containers_long_running_tasks.py
@@ -20,7 +20,6 @@ from typing import (
 import aiodocker
 import faker
 import pytest
-from _pytest.fixtures import FixtureRequest
 from aiodocker.containers import DockerContainer
 from aiodocker.volumes import DockerVolume
 from asgi_lifespan import LifespanManager
@@ -28,6 +27,7 @@ from fastapi import FastAPI
 from fastapi.routing import APIRoute
 from httpx import AsyncClient
 from pydantic import AnyHttpUrl, parse_obj_as
+from pytest import FixtureRequest
 from pytest_mock.plugin import MockerFixture
 from servicelib.fastapi.long_running_tasks.client import (
     Client,

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
@@ -5,10 +5,10 @@ from typing import AsyncIterable, AsyncIterator
 
 import aiodocker
 import pytest
-from _pytest.fixtures import FixtureRequest
 from faker import Faker
 from models_library.services import RunID
 from pydantic import PositiveInt
+from pytest import FixtureRequest
 from simcore_service_dynamic_sidecar.core.docker_utils import (
     get_running_containers_count_from_names,
     get_volume_by_label,

--- a/services/web/server/tests/conftest.py
+++ b/services/web/server/tests/conftest.py
@@ -18,6 +18,7 @@ from aiohttp.test_utils import TestClient
 from models_library.projects_networks import PROJECT_NETWORK_PREFIX
 from models_library.projects_state import ProjectState
 from pytest import MonkeyPatch
+from pytest_mock import MockerFixture
 from pytest_simcore.helpers.utils_assert import assert_status
 from pytest_simcore.helpers.utils_dict import ConfigDict
 from pytest_simcore.helpers.utils_login import LoggedUser, UserInfoDict
@@ -115,7 +116,9 @@ def fake_project(tests_data_dir: Path) -> ProjectDict:
 
 
 @pytest.fixture()
-async def logged_user(client, user_role: UserRole) -> AsyncIterator[UserInfoDict]:
+async def logged_user(
+    client: TestClient, user_role: UserRole
+) -> AsyncIterator[UserInfoDict]:
     """adds a user in db and logs in with client
 
     NOTE: `user_role` fixture is defined as a parametrization below!!!
@@ -157,7 +160,7 @@ def monkeypatch_setenv_from_app_config(
 
 
 @pytest.fixture
-def mock_projects_networks_network_name(mocker) -> None:
+def mock_projects_networks_network_name(mocker: MockerFixture) -> None:
     remove_orphaned_services = mocker.patch(
         "simcore_service_webserver.projects_networks._network_name",
         return_value=f"{PROJECT_NETWORK_PREFIX}_{UUID(int=0)}_mocked",

--- a/services/web/server/tests/conftest.py
+++ b/services/web/server/tests/conftest.py
@@ -13,11 +13,11 @@ from uuid import UUID
 
 import pytest
 import simcore_service_webserver
-from _pytest.monkeypatch import MonkeyPatch
 from aiohttp import web
 from aiohttp.test_utils import TestClient
 from models_library.projects_networks import PROJECT_NETWORK_PREFIX
 from models_library.projects_state import ProjectState
+from pytest import MonkeyPatch
 from pytest_simcore.helpers.utils_assert import assert_status
 from pytest_simcore.helpers.utils_dict import ConfigDict
 from pytest_simcore.helpers.utils_login import LoggedUser, UserInfoDict

--- a/services/web/server/tests/integration/01/test_exporter.py
+++ b/services/web/server/tests/integration/01/test_exporter.py
@@ -25,12 +25,12 @@ import aiopg
 import aiopg.sa
 import pytest
 import redis.asyncio as aioredis
-from _pytest.monkeypatch import MonkeyPatch
 from aiohttp.test_utils import TestClient
 from models_library.api_schemas_storage import LinkType
 from models_library.projects_nodes_io import LocationID, StorageFileID
 from models_library.users import UserID
 from pydantic import AnyUrl, parse_obj_as
+from pytest import MonkeyPatch
 from pytest_simcore.docker_registry import _pull_push_service
 from pytest_simcore.helpers.utils_login import log_client_in
 from servicelib.aiohttp.application import create_safe_application

--- a/services/web/server/tests/unit/with_dbs/01/clusters/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/01/clusters/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 
 
 @pytest.fixture

--- a/services/web/server/tests/unit/with_dbs/01/test_resource_manager_redis_registry.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_resource_manager_redis_registry.py
@@ -8,8 +8,8 @@ from uuid import uuid4
 
 import pytest
 import redis.asyncio as aioredis
-from _pytest.monkeypatch import MonkeyPatch
 from aiohttp import web
+from pytest import MonkeyPatch
 from servicelib.aiohttp.application import create_safe_application
 from servicelib.aiohttp.application_setup import is_setup_completed
 from simcore_service_webserver.application_settings import setup_settings

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -26,10 +26,10 @@ import simcore_service_webserver.db_models as orm
 import simcore_service_webserver.utils
 import sqlalchemy as sa
 from _helpers import MockedStorageSubsystem
-from _pytest.monkeypatch import MonkeyPatch
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 from pydantic import ByteSize, parse_obj_as
+from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.utils_dict import ConfigDict
 from pytest_simcore.helpers.utils_login import NewUser


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

- replacing all ``from _pytest.* `` imports
- Fixes flaky  [``tests/unit/with_dbs/03/test_users.py::test_update_profile[UserRole.USER-HTTPNoContent]``](https://github.com/ITISFoundation/osparc-simcore/issues/3421#issuecomment-1270431160)

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
