### PR TITLE
🐛 CI integration tests not run when they should

### DIFF
--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1192,7 +1192,7 @@ jobs:
 
   unit-tests:
     # NOTE: this is a github required status check!
-    if: ${{ always() && !contains(join(needs.*.result, ','), 'failure') }}
+    if: ${{ always() }}
     needs:
       [
         unit-test-agent,
@@ -1221,11 +1221,10 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - name: all unit tests were run or skipped
-        env:
-          NEEDS: ${{ toJSON(needs) }}
-        run: |
-          echo "$NEEDS"
+      - name: the job failed
+        if: ${{ contains(join(needs.*.result, ','), 'failure') }}
+        run: abort()
+
 
   integration-test-webserver-01:
     needs: [changes, build-test-images]

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1224,7 +1224,7 @@ jobs:
       - name: a previous job failed
         if: ${{ contains(join(needs.*.result, ','), 'failure') }}
         env:
-          NEEDS=${{ toJSON(needs) }}
+          NEEDS: ${{ toJSON(needs) }}
         run: |
           echo "::error  $NEEDS"
           abort()

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1238,7 +1238,7 @@ jobs:
 
   integration-test-webserver-01:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything-py == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything-py || needs.changes.outputs.webserver || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[int] webserver 01"
     runs-on: ${{ matrix.os }}
@@ -1296,7 +1296,7 @@ jobs:
 
   integration-test-webserver-02:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything-py == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything-py || needs.changes.outputs.webserver || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[int] webserver 02"
     runs-on: ${{ matrix.os }}
@@ -1356,7 +1356,7 @@ jobs:
 
   integration-test-director-v2-01:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything-py == 'true' || github.event_name == 'push'}}
+    if: ${{ needs.changes.outputs.anything-py || needs.changes.outputs.director-v2 || github.event_name == 'push'}}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[int] director-v2 01"
     runs-on: ${{ matrix.os }}
@@ -1416,7 +1416,7 @@ jobs:
 
   integration-test-director-v2-02:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything-py == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything-py || needs.changes.outputs.director-v2 || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[int] director-v2 02"
     runs-on: ${{ matrix.os }}
@@ -1479,7 +1479,7 @@ jobs:
 
   integration-test-simcore-sdk:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything-py == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything-py || needs.changes.outputs.simcore-sdk || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[int] simcore-sdk"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1224,7 +1224,7 @@ jobs:
       - name: a previous unit-test job failed
         if: ${{ contains(join(needs.*.result, ','), 'failure') }}
         run: |
-          echo "::error title={ERROR}::{one of the unit-tests failed!}"
+          echo "::error title=ERROR::one of the unit-tests failed!"
           exit 1
       - name: all the previous jobs were run successfully or skipped
         if: ${{ !contains(join(needs.*.result, ','), 'failure') }}

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -20,17 +20,17 @@ on:
       - "*"
 
   workflow_dispatch:
-    # inputs:
-    #   tests:
-    #     description: tests to run
-    #     required: true
-    #     default: 'all'
-    #     type: choice
-    #     options:
-    #       - unit-tests
-    #       - integration-tests
-    #       - system-tests
-    #       - all
+    inputs:
+      tests:
+        description: tests to run
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - unit-tests
+          - integration-tests
+          - system-tests
+          - all
 
 env:
   DEFAULT_MAX_NANO_CPUS: 10000000

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1223,11 +1223,13 @@ jobs:
     steps:
       - name: a previous job failed
         if: ${{ contains(join(needs.*.result, ','), 'failure') }}
+        uses: actions/github-script@v3
         env:
           NEEDS: ${{ toJSON(needs) }}
-        run: |
-          echo "::error  $NEEDS"
-          abort()
+        with:
+          script: |
+            core.setFailed('a previous job failed: $NEEDS')
+
       - name: all the previous jobs were run successfully or skipped
         if: ${{ !contains(join(needs.*.result, ','), 'failure') }}
         run: echo "::notice All good!"

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1192,7 +1192,7 @@ jobs:
 
   unit-tests:
     # NOTE: this is a github required status check!
-    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+    if: ${{ always() && not contains(join(needs.*.result, ','), 'failure') }}
     needs:
       [
         unit-test-agent,

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1192,6 +1192,7 @@ jobs:
 
   unit-tests:
     # NOTE: this is a github required status check!
+    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
     needs:
       [
         unit-test-agent,
@@ -1221,7 +1222,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: all unit tests were run or skipped
-        run: echo "all unit tests were run or skipped"
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS"
 
   integration-test-webserver-01:
     needs: [changes, build-test-images]

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1223,8 +1223,10 @@ jobs:
     steps:
       - name: a previous job failed
         if: ${{ contains(join(needs.*.result, ','), 'failure') }}
+        env:
+          NEEDS=${{ toJSON(needs) }}
         run: |
-          echo "::error  ${{ toJSON(needs) }}"
+          echo "::error  $NEEDS"
           abort()
       - name: all the previous jobs were run successfully or skipped
         if: ${{ !contains(join(needs.*.result, ','), 'failure') }}

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1221,9 +1221,14 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - name: the job failed
+      - name: a previous job failed
         if: ${{ contains(join(needs.*.result, ','), 'failure') }}
-        run: abort()
+        run: |
+          echo "::error  ${{ toJSON(needs) }}"
+          abort()
+      - name: all the previous jobs were run successfully or skipped
+        if: ${{ !contains(join(needs.*.result, ','), 'failure') }}
+        run: echo "::notice All good!"
 
 
   integration-test-webserver-01:

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1221,18 +1221,11 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - name: a previous job failed
+      - name: a previous unit-test job failed
         if: ${{ contains(join(needs.*.result, ','), 'failure') }}
-        env:
-          NEEDS: ${{ toJSON(needs) }}
         run: |
-          echo "::error file={name},line={line},endLine={endLine},title={ERROR}::{$NEEDS}"
+          echo "::error title={ERROR}::{one of the unit-tests failed!}"
           exit 1
-
-        # with:
-        #   script: |
-        #     core.setFailed('a previous job failed: $NEEDS')
-
       - name: all the previous jobs were run successfully or skipped
         if: ${{ !contains(join(needs.*.result, ','), 'failure') }}
         run: echo "::notice All good!"

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -15,37 +15,10 @@ on:
       - "*"
     tags-ignore:
       - "*"
-    paths:
-      - "!.vscode/**"
-      - "!*.md"
-      - "!*.png"
-      - "!*.svg"
-      - "!docs/**"
-      - ".github/workflows/ci-testing-deploy.yml"
-      - "**.js"
-      - "**.json"
-      - "**.Makefile"
-      - "**.py"
-      - "**/requirements/*.txt"
-      - "**/services/docker-compose*"
-      - "ci/**"
   pull_request:
     branches:
       - "*"
-    paths:
-      - "!*.md"
-      - "!*.png"
-      - "!*.svg"
-      - "!docs/**"
-      - "!.vscode/**"
-      - "!.vscode-template/**"
-      - "**.py"
-      - "**.js"
-      - "**/requirements/*.txt"
-      - "**.json"
-      - "**.Makefile"
-      - ".github/workflows/ci-testing-deploy.yml"
-      - "ci/**"
+
 env:
   DEFAULT_MAX_NANO_CPUS: 10000000
   DEFAULT_MAX_MEMORY: 268435456

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1192,7 +1192,7 @@ jobs:
 
   unit-tests:
     # NOTE: this is a github required status check!
-    if: ${{ always() && not contains(join(needs.*.result, ','), 'failure') }}
+    if: ${{ always() && !contains(join(needs.*.result, ','), 'failure') }}
     needs:
       [
         unit-test-agent,

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1223,7 +1223,6 @@ jobs:
     steps:
       - name: a previous job failed
         if: ${{ contains(join(needs.*.result, ','), 'failure') }}
-        uses: actions/github-script@v3
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1226,9 +1226,13 @@ jobs:
         uses: actions/github-script@v3
         env:
           NEEDS: ${{ toJSON(needs) }}
-        with:
-          script: |
-            core.setFailed('a previous job failed: $NEEDS')
+        run: |
+          echo "::error file={name},line={line},endLine={endLine},title={ERROR}::{$NEEDS}"
+          exit 1
+
+        # with:
+        #   script: |
+        #     core.setFailed('a previous job failed: $NEEDS')
 
       - name: all the previous jobs were run successfully or skipped
         if: ${{ !contains(join(needs.*.result, ','), 'failure') }}

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -191,7 +191,7 @@ jobs:
 
   unit-test-webserver-01:
     needs: changes
-    # if: ${{ needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] webserver 01"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -191,7 +191,7 @@ jobs:
 
   unit-test-webserver-01:
     needs: changes
-    if: ${{ needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.webserver || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] webserver 01"
     runs-on: ${{ matrix.os }}
@@ -235,7 +235,7 @@ jobs:
 
   unit-test-webserver-02:
     needs: changes
-    if: ${{ needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.webserver || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] webserver 02"
     runs-on: ${{ matrix.os }}
@@ -277,7 +277,7 @@ jobs:
 
   unit-test-webserver-03:
     needs: changes
-    if: ${{ needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.webserver || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] webserver 03"
     runs-on: ${{ matrix.os }}
@@ -319,7 +319,7 @@ jobs:
 
   unit-test-storage:
     needs: changes
-    if: ${{ needs.changes.outputs.storage == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.storage || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] storage"
     runs-on: ${{ matrix.os }}
@@ -361,7 +361,7 @@ jobs:
 
   unit-test-agent:
     needs: changes
-    if: ${{ needs.changes.outputs.agent == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.agent || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] agent"
     runs-on: ${{ matrix.os }}
@@ -408,7 +408,7 @@ jobs:
 
   unit-test-api:
     needs: changes
-    if: ${{ needs.changes.outputs.api == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.api || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] api"
     runs-on: ${{ matrix.os }}
@@ -447,7 +447,7 @@ jobs:
 
   unit-test-api-server:
     needs: changes
-    if: ${{ needs.changes.outputs.api-server == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.api-server || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] api-server"
     runs-on: ${{ matrix.os }}
@@ -489,7 +489,7 @@ jobs:
 
   unit-test-autoscaling:
     needs: changes
-    if: ${{ needs.changes.outputs.autoscaling == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.autoscaling || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] autoscaling"
     runs-on: ${{ matrix.os }}
@@ -531,7 +531,7 @@ jobs:
 
   unit-test-catalog:
     needs: changes
-    if: ${{ needs.changes.outputs.catalog == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.catalog || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] catalog"
     runs-on: ${{ matrix.os }}
@@ -579,7 +579,7 @@ jobs:
 
   unit-test-datcore-adapter:
     needs: changes
-    if: ${{ needs.changes.outputs.datcore-adapter == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.datcore-adapter || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] datcore-adapter"
     runs-on: ${{ matrix.os }}
@@ -630,7 +630,7 @@ jobs:
 
   unit-test-director:
     needs: changes
-    if: ${{ needs.changes.outputs.director == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.director || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] director"
     runs-on: ${{ matrix.os }}
@@ -673,7 +673,7 @@ jobs:
 
   unit-test-director-v2:
     needs: changes
-    if: ${{ needs.changes.outputs.director-v2 == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.director-v2 || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] director-v2"
     runs-on: ${{ matrix.os }}
@@ -721,7 +721,7 @@ jobs:
 
   unit-test-dask-task-models-library:
     needs: changes
-    if: ${{ needs.changes.outputs.dask-task-models-library == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.dask-task-models-library || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] dask-task-models-library"
     runs-on: ${{ matrix.os }}
@@ -766,7 +766,7 @@ jobs:
 
   unit-test-dask-sidecar:
     needs: changes
-    if: ${{ needs.changes.outputs.dask-sidecar == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.dask-sidecar || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] dask-sidecar"
     runs-on: ${{ matrix.os }}
@@ -808,7 +808,7 @@ jobs:
 
   unit-test-dynamic-sidecar:
     needs: changes
-    if: ${{ needs.changes.outputs.dynamic-sidecar == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.dynamic-sidecar || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] dynamic-sidecar"
     runs-on: ${{ matrix.os }}
@@ -853,7 +853,7 @@ jobs:
 
   unit-test-frontend:
     needs: changes
-    if: ${{ needs.changes.outputs.static-webserver == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.static-webserver || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] frontend"
     runs-on: ${{ matrix.os }}
@@ -894,7 +894,7 @@ jobs:
 
   unit-test-python-linting:
     needs: changes
-    if: ${{ needs.changes.outputs.anything-py == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything-py || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] python-linting"
     runs-on: ${{ matrix.os }}
@@ -933,7 +933,7 @@ jobs:
 
   unit-test-postgres-database:
     needs: changes
-    if: ${{ needs.changes.outputs.postgres-database == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.postgres-database || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] postgres-database"
     runs-on: ${{ matrix.os }}
@@ -978,7 +978,7 @@ jobs:
 
   unit-test-service-integration:
     needs: changes
-    if: ${{ needs.changes.outputs.service-integration == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.service-integration || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] service-integration"
     runs-on: ${{ matrix.os }}
@@ -1020,7 +1020,7 @@ jobs:
 
   unit-test-service-library:
     needs: changes
-    if: ${{ needs.changes.outputs.service-library == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.service-library || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] service-library"
     runs-on: ${{ matrix.os }}
@@ -1062,7 +1062,7 @@ jobs:
 
   unit-test-settings-library:
     needs: changes
-    if: ${{ needs.changes.outputs.settings-library == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.settings-library || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] settings-library"
     runs-on: ${{ matrix.os }}
@@ -1104,7 +1104,7 @@ jobs:
 
   unit-test-models-library:
     needs: changes
-    if: ${{ needs.changes.outputs.models-library == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.models-library || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] models-library"
     runs-on: ${{ matrix.os }}
@@ -1146,7 +1146,7 @@ jobs:
 
   unit-test-simcore-sdk:
     needs: changes
-    if: ${{ needs.changes.outputs.simcore-sdk == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.simcore-sdk || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] simcore-sdk"
     runs-on: ${{ matrix.os }}
@@ -1555,7 +1555,7 @@ jobs:
 
   system-test-public-api:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything || github.event_name == 'push' }}
     timeout-minutes: 25 # if this timeout gets too small, then split the tests
     name: "[sys] public api"
     runs-on: ${{ matrix.os }}
@@ -1612,7 +1612,7 @@ jobs:
 
   system-test-swarm-deploy:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[sys] deploy simcore"
     runs-on: ${{ matrix.os }}
@@ -1669,7 +1669,7 @@ jobs:
 
   system-test-e2e:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[sys] e2e"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -151,7 +151,7 @@ jobs:
     # this step comes first, so that it is executed as first job in push calls
     # in PR calls this step is anyway skipped
     needs: changes
-    if: ${{ needs.changes.outputs.anything || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -191,7 +191,7 @@ jobs:
 
   unit-test-webserver-01:
     needs: changes
-    if: ${{ needs.changes.outputs.webserver || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] webserver 01"
     runs-on: ${{ matrix.os }}
@@ -235,7 +235,7 @@ jobs:
 
   unit-test-webserver-02:
     needs: changes
-    if: ${{ needs.changes.outputs.webserver || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] webserver 02"
     runs-on: ${{ matrix.os }}
@@ -277,7 +277,7 @@ jobs:
 
   unit-test-webserver-03:
     needs: changes
-    if: ${{ needs.changes.outputs.webserver || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] webserver 03"
     runs-on: ${{ matrix.os }}
@@ -319,7 +319,7 @@ jobs:
 
   unit-test-storage:
     needs: changes
-    if: ${{ needs.changes.outputs.storage || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.storage == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] storage"
     runs-on: ${{ matrix.os }}
@@ -361,7 +361,7 @@ jobs:
 
   unit-test-agent:
     needs: changes
-    if: ${{ needs.changes.outputs.agent || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.agent == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] agent"
     runs-on: ${{ matrix.os }}
@@ -408,7 +408,7 @@ jobs:
 
   unit-test-api:
     needs: changes
-    if: ${{ needs.changes.outputs.api || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.api == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] api"
     runs-on: ${{ matrix.os }}
@@ -447,7 +447,7 @@ jobs:
 
   unit-test-api-server:
     needs: changes
-    if: ${{ needs.changes.outputs.api-server || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.api-server == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] api-server"
     runs-on: ${{ matrix.os }}
@@ -489,7 +489,7 @@ jobs:
 
   unit-test-autoscaling:
     needs: changes
-    if: ${{ needs.changes.outputs.autoscaling || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.autoscaling == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] autoscaling"
     runs-on: ${{ matrix.os }}
@@ -531,7 +531,7 @@ jobs:
 
   unit-test-catalog:
     needs: changes
-    if: ${{ needs.changes.outputs.catalog || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.catalog == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] catalog"
     runs-on: ${{ matrix.os }}
@@ -579,7 +579,7 @@ jobs:
 
   unit-test-datcore-adapter:
     needs: changes
-    if: ${{ needs.changes.outputs.datcore-adapter || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.datcore-adapter == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] datcore-adapter"
     runs-on: ${{ matrix.os }}
@@ -630,7 +630,7 @@ jobs:
 
   unit-test-director:
     needs: changes
-    if: ${{ needs.changes.outputs.director || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.director == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] director"
     runs-on: ${{ matrix.os }}
@@ -673,7 +673,7 @@ jobs:
 
   unit-test-director-v2:
     needs: changes
-    if: ${{ needs.changes.outputs.director-v2 || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.director-v2 == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] director-v2"
     runs-on: ${{ matrix.os }}
@@ -721,7 +721,7 @@ jobs:
 
   unit-test-dask-task-models-library:
     needs: changes
-    if: ${{ needs.changes.outputs.dask-task-models-library || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.dask-task-models-library == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] dask-task-models-library"
     runs-on: ${{ matrix.os }}
@@ -766,7 +766,7 @@ jobs:
 
   unit-test-dask-sidecar:
     needs: changes
-    if: ${{ needs.changes.outputs.dask-sidecar || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.dask-sidecar == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] dask-sidecar"
     runs-on: ${{ matrix.os }}
@@ -808,7 +808,7 @@ jobs:
 
   unit-test-dynamic-sidecar:
     needs: changes
-    if: ${{ needs.changes.outputs.dynamic-sidecar || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.dynamic-sidecar == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] dynamic-sidecar"
     runs-on: ${{ matrix.os }}
@@ -853,7 +853,7 @@ jobs:
 
   unit-test-frontend:
     needs: changes
-    if: ${{ needs.changes.outputs.static-webserver || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.static-webserver == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] frontend"
     runs-on: ${{ matrix.os }}
@@ -894,7 +894,7 @@ jobs:
 
   unit-test-python-linting:
     needs: changes
-    if: ${{ needs.changes.outputs.anything-py || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything-py == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] python-linting"
     runs-on: ${{ matrix.os }}
@@ -933,7 +933,7 @@ jobs:
 
   unit-test-postgres-database:
     needs: changes
-    if: ${{ needs.changes.outputs.postgres-database || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.postgres-database == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] postgres-database"
     runs-on: ${{ matrix.os }}
@@ -978,7 +978,7 @@ jobs:
 
   unit-test-service-integration:
     needs: changes
-    if: ${{ needs.changes.outputs.service-integration || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.service-integration == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] service-integration"
     runs-on: ${{ matrix.os }}
@@ -1020,7 +1020,7 @@ jobs:
 
   unit-test-service-library:
     needs: changes
-    if: ${{ needs.changes.outputs.service-library || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.service-library == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] service-library"
     runs-on: ${{ matrix.os }}
@@ -1062,7 +1062,7 @@ jobs:
 
   unit-test-settings-library:
     needs: changes
-    if: ${{ needs.changes.outputs.settings-library || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.settings-library == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] settings-library"
     runs-on: ${{ matrix.os }}
@@ -1104,7 +1104,7 @@ jobs:
 
   unit-test-models-library:
     needs: changes
-    if: ${{ needs.changes.outputs.models-library || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.models-library == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] models-library"
     runs-on: ${{ matrix.os }}
@@ -1146,7 +1146,7 @@ jobs:
 
   unit-test-simcore-sdk:
     needs: changes
-    if: ${{ needs.changes.outputs.simcore-sdk || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.simcore-sdk == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] simcore-sdk"
     runs-on: ${{ matrix.os }}
@@ -1231,7 +1231,7 @@ jobs:
 
   integration-test-webserver-01:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything-py || needs.changes.outputs.webserver || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything-py == 'true' || needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[int] webserver 01"
     runs-on: ${{ matrix.os }}
@@ -1289,7 +1289,7 @@ jobs:
 
   integration-test-webserver-02:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything-py || needs.changes.outputs.webserver || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything-py == 'true' || needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[int] webserver 02"
     runs-on: ${{ matrix.os }}
@@ -1349,7 +1349,7 @@ jobs:
 
   integration-test-director-v2-01:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything-py || needs.changes.outputs.director-v2 || github.event_name == 'push'}}
+    if: ${{ needs.changes.outputs.anything-py == 'true' || needs.changes.outputs.director-v2 == 'true' || github.event_name == 'push'}}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[int] director-v2 01"
     runs-on: ${{ matrix.os }}
@@ -1409,7 +1409,7 @@ jobs:
 
   integration-test-director-v2-02:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything-py || needs.changes.outputs.director-v2 || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything-py == 'true' || needs.changes.outputs.director-v2 == 'true' || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[int] director-v2 02"
     runs-on: ${{ matrix.os }}
@@ -1472,7 +1472,7 @@ jobs:
 
   integration-test-simcore-sdk:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything-py || needs.changes.outputs.simcore-sdk || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything-py == 'true' || needs.changes.outputs.simcore-sdk == 'true' || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[int] simcore-sdk"
     runs-on: ${{ matrix.os }}
@@ -1555,7 +1555,7 @@ jobs:
 
   system-test-public-api:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
     timeout-minutes: 25 # if this timeout gets too small, then split the tests
     name: "[sys] public api"
     runs-on: ${{ matrix.os }}
@@ -1612,7 +1612,7 @@ jobs:
 
   system-test-swarm-deploy:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[sys] deploy simcore"
     runs-on: ${{ matrix.os }}
@@ -1669,7 +1669,7 @@ jobs:
 
   system-test-e2e:
     needs: [changes, build-test-images]
-    if: ${{ needs.changes.outputs.anything || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[sys] e2e"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -191,7 +191,7 @@ jobs:
 
   unit-test-webserver-01:
     needs: changes
-    if: ${{ needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
+    # if: ${{ needs.changes.outputs.webserver == 'true' || github.event_name == 'push' }}
     timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] webserver 01"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -194,6 +194,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
+      - name: TEMPORARY failure
+        run: abort()
       - name: setup docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1192,7 +1192,6 @@ jobs:
 
   unit-tests:
     # NOTE: this is a github required status check!
-    if: always()
     needs:
       [
         unit-test-agent,

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1224,7 +1224,7 @@ jobs:
         run: |
           echo "::error title=ERROR::one of the unit-tests failed!"
           exit 1
-      - name: all the previous jobs were run successfully or skipped
+      - name: all the previous unit-tests were run successfully or skipped
         if: ${{ !contains(join(needs.*.result, ','), 'failure') }}
         run: echo "::notice All good!"
 
@@ -1543,8 +1543,15 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - name: all unit tests were run or skipped
-        run: echo "all unit tests were run or skipped"
+      - name: a previous integration-test job failed
+        if: ${{ contains(join(needs.*.result, ','), 'failure') }}
+        run: |
+          echo "::error title=ERROR::one of the unit-tests failed!"
+          exit 1
+      - name: all the previous integration-tests were run successfully or skipped
+        if: ${{ !contains(join(needs.*.result, ','), 'failure') }}
+        run: echo "::notice All good!"
+
 
   system-test-public-api:
     needs: [changes, build-test-images]
@@ -1791,8 +1798,14 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - name: all unit tests were run or skipped
-        run: echo "all unit tests were run or skipped"
+      - name: a previous system-test job failed
+        if: ${{ contains(join(needs.*.result, ','), 'failure') }}
+        run: |
+          echo "::error title=ERROR::one of the unit-tests failed!"
+          exit 1
+      - name: all the previous system-tests were run successfully or skipped
+        if: ${{ !contains(join(needs.*.result, ','), 'failure') }}
+        run: echo "::notice All good!"
 
   deploy:
     name: deploy to dockerhub

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -207,8 +207,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - name: TEMPORARY failure
-        run: abort()
       - name: setup docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -19,6 +19,19 @@ on:
     branches:
       - "*"
 
+  workflow_dispatch:
+    # inputs:
+    #   tests:
+    #     description: tests to run
+    #     required: true
+    #     default: 'all'
+    #     type: choice
+    #     options:
+    #       - unit-tests
+    #       - integration-tests
+    #       - system-tests
+    #       - all
+
 env:
   DEFAULT_MAX_NANO_CPUS: 10000000
   DEFAULT_MAX_MEMORY: 268435456
@@ -138,7 +151,7 @@ jobs:
     # this step comes first, so that it is executed as first job in push calls
     # in PR calls this step is anyway skipped
     needs: changes
-    if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything || github.event_name == 'push' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
This PR will ensure Github does not allow PRs with issues to be merged.

The aggregate jobs that are ```unit-tests```, ```integration-tests``` and ```system-tests``` were getting green even though some of their dependencies failed.
This PR fixes this and will make using the ```auto-merge``` feature safe.
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
