### PR TITLE
⚗️🐛 Add a test for reproducing potential 400 issue with upload to AWS

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/aws_services.py
+++ b/packages/pytest-simcore/src/pytest_simcore/aws_services.py
@@ -1,0 +1,83 @@
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+import asyncio
+from typing import AsyncIterator, Iterator
+
+import pytest
+from aiobotocore.session import get_session
+from aiohttp.test_utils import unused_port
+from moto.server import ThreadedMotoServer
+from pytest_simcore.helpers.utils_docker import get_localhost_ip
+
+
+@pytest.fixture(scope="module")
+def mocked_s3_server() -> Iterator[ThreadedMotoServer]:
+    """creates a moto-server that emulates AWS services in place
+    NOTE: Never use a bucket with underscores it fails!!
+    """
+    server = ThreadedMotoServer(ip_address=get_localhost_ip(), port=unused_port())
+    # pylint: disable=protected-access
+    print(f"--> started mock S3 server on {server._ip_address}:{server._port}")
+    print(
+        f"--> Dashboard available on [http://{server._ip_address}:{server._port}/moto-api/]"
+    )
+    server.start()
+    yield server
+    server.stop()
+    print(f"<-- stopped mock S3 server on {server._ip_address}:{server._port}")
+
+
+async def _clean_bucket_content(aiobotore_s3_client, bucket: str):
+    response = await aiobotore_s3_client.list_objects_v2(Bucket=bucket)
+    while response["KeyCount"] > 0:
+        await aiobotore_s3_client.delete_objects(
+            Bucket=bucket,
+            Delete={
+                "Objects": [
+                    {"Key": obj["Key"]} for obj in response["Contents"] if "Key" in obj
+                ]
+            },
+        )
+        response = await aiobotore_s3_client.list_objects_v2(Bucket=bucket)
+
+
+async def _remove_all_buckets(aiobotore_s3_client):
+    response = await aiobotore_s3_client.list_buckets()
+    bucket_names = [
+        bucket["Name"] for bucket in response["Buckets"] if "Name" in bucket
+    ]
+    await asyncio.gather(
+        *(_clean_bucket_content(aiobotore_s3_client, bucket) for bucket in bucket_names)
+    )
+    await asyncio.gather(
+        *(aiobotore_s3_client.delete_bucket(Bucket=bucket) for bucket in bucket_names)
+    )
+
+
+@pytest.fixture
+async def mocked_s3_server_envs(
+    mocked_s3_server: ThreadedMotoServer, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[None]:
+    monkeypatch.setenv("S3_SECURE", "false")
+    monkeypatch.setenv(
+        "S3_ENDPOINT",
+        f"{mocked_s3_server._ip_address}:{mocked_s3_server._port}",  # pylint: disable=protected-access
+    )
+    monkeypatch.setenv("S3_ACCESS_KEY", "xxx")
+    monkeypatch.setenv("S3_SECRET_KEY", "xxx")
+    monkeypatch.setenv("S3_BUCKET_NAME", "pytestbucket")
+
+    yield
+
+    # cleanup the buckets
+    session = get_session()
+    async with session.create_client(
+        "s3",
+        endpoint_url=f"http://{mocked_s3_server._ip_address}:{mocked_s3_server._port}",  # pylint: disable=protected-access
+        aws_secret_access_key="xxx",
+        aws_access_key_id="xxx",
+    ) as client:
+        await _remove_all_buckets(client)

--- a/packages/simcore-sdk/requirements/_base.in
+++ b/packages/simcore-sdk/requirements/_base.in
@@ -2,6 +2,7 @@
 # Specifies third-party dependencies for 'simcore-sdk'
 #
 --constraint ../../../requirements/constraints.txt
+--constraint ./constraints.txt
 --requirement ../../../packages/postgres-database/requirements/_base.in
 --requirement ../../../packages/service-library/requirements/_base.in
 --requirement ../../../packages/settings-library/requirements/_base.in

--- a/packages/simcore-sdk/requirements/_test.in
+++ b/packages/simcore-sdk/requirements/_test.in
@@ -17,6 +17,7 @@ docker
 faker
 flaky
 minio
+moto
 pytest
 pytest-aiohttp
 pytest-cov

--- a/packages/simcore-sdk/requirements/_test.in
+++ b/packages/simcore-sdk/requirements/_test.in
@@ -2,6 +2,7 @@
 # Specifies dependencies required to run 'simcore-sdk'
 #
 --constraint ../../../requirements/constraints.txt
+--constraint ./constraints.txt
 # Adds base AS CONSTRAINT specs, not requirement.
 #  - Resulting _text.txt is a frozen list of EXTRA packages for testing, besides _base.txt
 #
@@ -17,7 +18,7 @@ docker
 faker
 flaky
 minio
-moto
+moto[server]
 pytest
 pytest-aiohttp
 pytest-cov

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -37,16 +37,21 @@ attrs==21.4.0
     #   aiohttp
     #   pytest
 boto3==1.24.59
-    # via aiobotocore
+    # via
+    #   aiobotocore
+    #   moto
 botocore==1.27.59
     # via
     #   aiobotocore
     #   boto3
+    #   moto
     #   s3transfer
 certifi==2022.9.24
     # via
     #   minio
     #   requests
+cffi==1.15.1
+    # via cryptography
 charset-normalizer==2.1.1
     # via
     #   -c requirements/_base.txt
@@ -63,6 +68,10 @@ coverage==6.5.0
     #   pytest-cov
 coveralls==3.3.1
     # via -r requirements/_test.in
+cryptography==38.0.3
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   moto
 docker==6.0.1
     # via -r requirements/_test.in
 docopt==0.6.2
@@ -93,6 +102,10 @@ idna==3.4
     #   yarl
 iniconfig==1.1.1
     # via pytest
+jinja2==3.1.2
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   moto
 jmespath==1.0.1
     # via
     #   boto3
@@ -105,11 +118,16 @@ mako==1.2.3
 markupsafe==2.1.1
     # via
     #   -c requirements/_base.txt
+    #   jinja2
     #   mako
+    #   moto
+    #   werkzeug
 minio==7.0.4
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
+moto==4.0.9
+    # via -r requirements/_test.in
 multidict==6.0.2
     # via
     #   -c requirements/_base.txt
@@ -129,6 +147,8 @@ psycopg2-binary==2.9.5
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
+pycparser==2.21
+    # via cffi
 pyparsing==3.0.9
     # via
     #   -c requirements/_base.txt
@@ -169,13 +189,20 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   faker
+    #   moto
 python-dotenv==0.21.0
     # via -r requirements/_test.in
+pytz==2022.6
+    # via moto
 requests==2.28.1
     # via
     #   -r requirements/_test.in
     #   coveralls
     #   docker
+    #   moto
+    #   responses
+responses==0.22.0
+    # via moto
 s3transfer==0.6.0
     # via boto3
 six==1.16.0
@@ -189,10 +216,14 @@ sqlalchemy==1.4.43
     #   alembic
 termcolor==2.1.0
     # via pytest-sugar
+toml==0.10.2
+    # via responses
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
+types-toml==0.10.8
+    # via responses
 typing-extensions==4.4.0
     # via
     #   -c requirements/_base.txt
@@ -204,10 +235,15 @@ urllib3==1.26.12
     #   docker
     #   minio
     #   requests
+    #   responses
 websocket-client==1.4.2
     # via docker
+werkzeug==2.2.2
+    # via moto
 wrapt==1.14.1
     # via aiobotocore
+xmltodict==0.13.0
+    # via moto
 yarl==1.8.1
     # via
     #   -c requirements/_base.txt

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -35,14 +35,23 @@ attrs==21.4.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
+    #   jschema-to-python
+    #   jsonschema
     #   pytest
+    #   sarif-om
+aws-sam-translator==1.53.0
+    # via cfn-lint
+aws-xray-sdk==2.10.0
+    # via moto
 boto3==1.24.59
     # via
     #   aiobotocore
+    #   aws-sam-translator
     #   moto
 botocore==1.27.59
     # via
     #   aiobotocore
+    #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
@@ -52,6 +61,8 @@ certifi==2022.9.24
     #   requests
 cffi==1.15.1
     # via cryptography
+cfn-lint==0.71.0
+    # via moto
 charset-normalizer==2.1.1
     # via
     #   -c requirements/_base.txt
@@ -61,6 +72,7 @@ click==8.1.3
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
+    #   flask
 coverage==6.5.0
     # via
     #   -r requirements/_test.in
@@ -72,10 +84,19 @@ cryptography==38.0.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   moto
+    #   python-jose
+    #   sshpubkeys
 docker==6.0.1
-    # via -r requirements/_test.in
+    # via
+    #   -r requirements/_test.in
+    #   moto
 docopt==0.6.2
     # via coveralls
+ecdsa==0.18.0
+    # via
+    #   moto
+    #   python-jose
+    #   sshpubkeys
 exceptiongroup==1.0.1
     # via pytest
 execnet==1.9.0
@@ -84,11 +105,19 @@ faker==15.2.0
     # via -r requirements/_test.in
 flaky==3.7.0
     # via -r requirements/_test.in
+flask==2.1.3
+    # via
+    #   flask-cors
+    #   moto
+flask-cors==3.0.10
+    # via moto
 frozenlist==1.3.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
+graphql-core==3.2.3
+    # via moto
 greenlet==2.0.1
     # via
     #   -c requirements/_base.txt
@@ -98,18 +127,43 @@ icdiff==2.0.5
 idna==3.4
     # via
     #   -c requirements/_base.txt
+    #   moto
     #   requests
     #   yarl
+importlib-metadata==5.0.0
+    # via flask
 iniconfig==1.1.1
     # via pytest
+itsdangerous==2.1.2
+    # via flask
 jinja2==3.1.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
+    #   flask
     #   moto
 jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+jschema-to-python==1.2.3
+    # via cfn-lint
+jsondiff==2.0.0
+    # via moto
+jsonpatch==1.32
+    # via cfn-lint
+jsonpickle==2.2.0
+    # via jschema-to-python
+jsonpointer==2.3
+    # via jsonpatch
+jsonschema==3.2.0
+    # via
+    #   -c requirements/_base.txt
+    #   aws-sam-translator
+    #   cfn-lint
+    #   openapi-schema-validator
+    #   openapi-spec-validator
+junit-xml==1.9
+    # via cfn-lint
 mako==1.2.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -121,24 +175,37 @@ markupsafe==2.1.1
     #   jinja2
     #   mako
     #   moto
-    #   werkzeug
 minio==7.0.4
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-moto==4.0.9
-    # via -r requirements/_test.in
+moto==4.0.1
+    # via
+    #   -c requirements/./constraints.txt
+    #   -r requirements/_test.in
 multidict==6.0.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
+networkx==2.8.8
+    # via cfn-lint
+openapi-schema-validator==0.2.3
+    # via openapi-spec-validator
+openapi-spec-validator==0.4.0
+    # via
+    #   -c requirements/./constraints.txt
+    #   moto
 packaging==21.3
     # via
     #   -c requirements/_base.txt
     #   docker
     #   pytest
     #   pytest-sugar
+pbr==5.11.0
+    # via
+    #   jschema-to-python
+    #   sarif-om
 pluggy==1.0.0
     # via pytest
 pprintpp==0.4.0
@@ -147,12 +214,21 @@ psycopg2-binary==2.9.5
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
+pyasn1==0.4.8
+    # via
+    #   python-jose
+    #   rsa
 pycparser==2.21
     # via cffi
 pyparsing==3.0.9
     # via
     #   -c requirements/_base.txt
+    #   moto
     #   packaging
+pyrsistent==0.19.2
+    # via
+    #   -c requirements/_base.txt
+    #   jsonschema
 pytest==7.2.0
     # via
     #   -r requirements/_test.in
@@ -192,8 +268,17 @@ python-dateutil==2.8.2
     #   moto
 python-dotenv==0.21.0
     # via -r requirements/_test.in
+python-jose==3.3.0
+    # via moto
 pytz==2022.6
     # via moto
+pyyaml==5.4.1
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   cfn-lint
+    #   moto
+    #   openapi-spec-validator
 requests==2.28.1
     # via
     #   -r requirements/_test.in
@@ -203,17 +288,29 @@ requests==2.28.1
     #   responses
 responses==0.22.0
     # via moto
+rsa==4.9
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   python-jose
 s3transfer==0.6.0
     # via boto3
+sarif-om==1.0.4
+    # via cfn-lint
 six==1.16.0
     # via
     #   -c requirements/_base.txt
+    #   ecdsa
+    #   flask-cors
+    #   jsonschema
+    #   junit-xml
     #   python-dateutil
 sqlalchemy==1.4.43
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   alembic
+sshpubkeys==3.3.1
+    # via moto
 termcolor==2.1.0
     # via pytest-sugar
 toml==0.10.2
@@ -238,13 +335,22 @@ urllib3==1.26.12
     #   responses
 websocket-client==1.4.2
     # via docker
-werkzeug==2.2.2
-    # via moto
+werkzeug==2.1.2
+    # via
+    #   flask
+    #   moto
 wrapt==1.14.1
-    # via aiobotocore
+    # via
+    #   aiobotocore
+    #   aws-xray-sdk
 xmltodict==0.13.0
     # via moto
 yarl==1.8.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
+zipp==3.10.0
+    # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -69,6 +69,7 @@ pyyaml==5.4.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   pre-commit
 toml==0.10.2
     # via

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -71,7 +71,9 @@ pyyaml==5.4.1
     #   -c requirements/_base.txt
     #   pre-commit
 toml==0.10.2
-    # via pre-commit
+    # via
+    #   -c requirements/_test.txt
+    #   pre-commit
 tomli==2.0.1
     # via
     #   -c requirements/_test.txt

--- a/packages/simcore-sdk/requirements/constraints.txt
+++ b/packages/simcore-sdk/requirements/constraints.txt
@@ -1,0 +1,14 @@
+# There are incompatible versions in the resolved dependencies:
+#   jsonschema~=3.2 (from -c requirements/./constraints.txt (line 14))
+#   jsonschema==3.2.0 (from -c requirements/_base.txt (line 159))
+#   jsonschema<5.0.0,>=4.0.0 (from openapi-spec-validator==0.5.1->moto[server]==4.0.2->-r requirements/_test.in (line 21))
+#   jsonschema<5,>=3.0 (from cfn-lint==0.64.1->moto[server]==4.0.2->-r requirements/_test.in (line 21))
+moto<4.0.2
+
+# Not specified in openapi-core setup, but it breaks openapi-core==0.12.0
+# we have a very old version of openapi-core that is causing further troubles
+# specifically when we want to have nullable objects
+# It does not follow standard 3.0 correctly
+# SEE how to specify nullable object in https://stackoverflow.com/questions/40920441/how-to-specify-a-property-can-be-null-or-a-reference-with-swagger
+
+openapi-spec-validator<0.5.0

--- a/packages/simcore-sdk/tests/conftest.py
+++ b/packages/simcore-sdk/tests/conftest.py
@@ -17,6 +17,7 @@ sys.path.append(str(current_dir / "helpers"))
 
 
 pytest_plugins = [
+    "pytest_simcore.aws_services",
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_swarm",
     "pytest_simcore.file_extra",

--- a/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
+++ b/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
@@ -37,7 +37,7 @@ async def test_push_folder(
     node_uuid: str,
     mocker,
     tmpdir: Path,
-    create_files: Callable,
+    create_files: Callable[..., list[Path]],
 ):
     # create some files
     assert tmpdir.exists()
@@ -107,7 +107,7 @@ async def test_push_file(
     node_uuid: str,
     mocker,
     tmpdir: Path,
-    create_files: Callable,
+    create_files: Callable[..., list[Path]],
 ):
     mock_filemanager = mocker.patch(
         "simcore_sdk.node_data.data_manager.filemanager", spec=True
@@ -143,7 +143,7 @@ async def test_pull_folder(
     node_uuid: str,
     mocker,
     tmpdir: Path,
-    create_files: Callable,
+    create_files: Callable[..., list[Path]],
 ):
     assert tmpdir.exists()
     # create a folder to compress from
@@ -213,7 +213,7 @@ async def test_pull_file(
     node_uuid: str,
     mocker,
     tmpdir: Path,
-    create_files: Callable,
+    create_files: Callable[..., list[Path]],
 ):
     file_path = create_files(1, Path(tmpdir))[0]
     assert file_path.exists()

--- a/packages/simcore-sdk/tests/unit/test_node_ports_common_file_io_utils.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_common_file_io_utils.py
@@ -1,16 +1,28 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 
+import asyncio
 from dataclasses import dataclass
-from typing import AsyncIterable
+from pathlib import Path
+from typing import AsyncIterable, AsyncIterator, Awaitable, Callable
 
 import pytest
+from aiobotocore.session import AioBaseClient, get_session
 from aiohttp import ClientResponse, ClientSession
 from aioresponses import aioresponses
+from faker import Faker
+from models_library.api_schemas_storage import (
+    FileUploadLinks,
+    FileUploadSchema,
+    UploadedPart,
+)
+from moto.server import ThreadedMotoServer
+from pydantic import AnyUrl, ByteSize, parse_obj_as
 from simcore_sdk.node_ports_common.file_io_utils import (
     ExtendedClientResponseError,
     _check_for_aws_http_errors,
     _raise_for_status,
+    upload_file_to_presigned_links,
 )
 
 A_TEST_ROUTE = "http://a-fake-address:1249/test-route"
@@ -79,3 +91,140 @@ async def test_check_for_aws_http_errors(
             await _raise_for_status(resp)
         except ExtendedClientResponseError as exception:
             assert _check_for_aws_http_errors(exception) is test_params.will_retry
+
+
+@pytest.fixture
+async def aiobotocore_s3_client(
+    mocked_s3_server: ThreadedMotoServer,
+) -> AsyncIterator[AioBaseClient]:
+    session = get_session()
+    async with session.create_client(
+        "s3",
+        endpoint_url=f"http://{mocked_s3_server._ip_address}:{mocked_s3_server._port}",  # pylint: disable=protected-access
+        aws_secret_access_key="xxx",
+        aws_access_key_id="xxx",
+    ) as client:
+        yield client
+
+
+async def _clean_bucket_content(s3_client: AioBaseClient, bucket: str):
+    response = await s3_client.list_objects_v2(Bucket=bucket)
+    while response["KeyCount"] > 0:
+        await s3_client.delete_objects(
+            Bucket=bucket,
+            Delete={
+                "Objects": [
+                    {"Key": obj["Key"]} for obj in response["Contents"] if "Key" in obj
+                ]
+            },
+        )
+        response = await s3_client.list_objects_v2(Bucket=bucket)
+
+
+@pytest.fixture
+async def bucket(aiobotocore_s3_client: AioBaseClient, faker: Faker) -> str:
+    response = await aiobotocore_s3_client.create_bucket(Bucket=faker.pystr())
+    assert "ResponseMetadata" in response
+    assert "HTTPStatusCode" in response["ResponseMetadata"]
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    response = await aiobotocore_s3_client.list_buckets()
+    assert response["Buckets"]
+    assert len(response["Buckets"]) == 1
+    bucket_name = response["Buckets"][0]["Name"]
+    yield bucket_name
+    await _clean_bucket_content(aiobotocore_s3_client, bucket_name)
+
+
+@pytest.fixture
+def file_id(faker: Faker) -> str:
+    return faker.pystr()
+
+
+@pytest.fixture
+async def create_upload_links(
+    mocked_s3_server: ThreadedMotoServer,
+    aiobotocore_s3_client: AioBaseClient,
+    faker: Faker,
+    bucket: str,
+    file_id: str,
+) -> AsyncIterator[Callable[[Path, int, ByteSize], Awaitable[FileUploadSchema]]]:
+    file_id = "fake2"
+
+    async def _creator(
+        local_file: Path, num_upload_links: int, chunk_size: ByteSize
+    ) -> FileUploadSchema:
+        local_file.stat().st_size / num_upload_links
+        response = await aiobotocore_s3_client.create_multipart_upload(
+            Bucket=bucket, Key=file_id
+        )
+        assert "UploadId" in response
+        upload_id = response["UploadId"]
+
+        upload_links = parse_obj_as(
+            list[AnyUrl],
+            await asyncio.gather(
+                *[
+                    aiobotocore_s3_client.generate_presigned_url(
+                        "upload_part",
+                        Params={
+                            "Bucket": bucket,
+                            "Key": file_id,
+                            "PartNumber": i + 1,
+                            "UploadId": upload_id,
+                        },
+                    )
+                    for i in range(num_upload_links)
+                ],
+            ),
+        )
+
+        return FileUploadSchema(
+            chunk_size=chunk_size,
+            urls=upload_links,
+            links=FileUploadLinks(
+                abort_upload=parse_obj_as(AnyUrl, faker.uri()),
+                complete_upload=parse_obj_as(AnyUrl, faker.uri()),
+            ),
+        )
+
+    yield _creator
+
+
+@pytest.mark.skip(reason="this will allow to reproduce an issue")
+@pytest.mark.parametrize(
+    "file_size,used_chunk_size",
+    [(parse_obj_as(ByteSize, "8.78Gib"), parse_obj_as(ByteSize, "10Mib"))],
+)
+async def test_upload_file_to_presigned_links(
+    client_session: ClientSession,
+    create_upload_links: Callable[[Path, int, ByteSize], Awaitable[FileUploadSchema]],
+    create_file_of_size: Callable[[ByteSize], Path],
+    file_size: ByteSize,
+    used_chunk_size: ByteSize,
+):
+    """This test is here to reproduce the issue https://github.com/ITISFoundation/osparc-simcore/issues/3531
+    One theory is that something might be wrong in how the chunking is done and that AWS times out
+    as it is waiting for more data.
+
+    Until this can be reproduced this shall stay here.
+    Mind also this link https://github.com/aws/aws-sdk-js/issues/281 where it seems removing the Content-length header helped:
+    this could be done and tested by: packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py:274-276
+
+    For this we need the EXACT size of the file that is uploaded. Therefore according changes to output the size
+    in bytes of the problematic file were added.
+    """
+    local_file = create_file_of_size(file_size)
+    num_links = 900
+    effective_chunk_size = parse_obj_as(ByteSize, local_file.stat().st_size / num_links)
+    assert effective_chunk_size <= used_chunk_size
+    upload_links = await create_upload_links(local_file, num_links, used_chunk_size)
+    assert len(upload_links.urls) == num_links
+    uploaded_parts: list[UploadedPart] = await upload_file_to_presigned_links(
+        session=client_session,
+        file_upload_links=upload_links,
+        file_to_upload=local_file,
+        num_retries=0,
+        io_log_redirect_cb=None,
+    )
+    assert uploaded_parts

--- a/services/storage/tests/unit/test_handlers_files.py
+++ b/services/storage/tests/unit/test_handlers_files.py
@@ -290,6 +290,16 @@ class MultiPartParam:
         ),
         pytest.param(
             MultiPartParam(
+                link_type=LinkType.PRESIGNED,
+                file_size=parse_obj_as(ByteSize, "9431773844"),
+                expected_response=web.HTTPOk,
+                expected_num_links=900,
+                expected_chunk_size=parse_obj_as(ByteSize, "10MiB"),
+            ),
+            id="9431773844B (8.8Gib) file,presigned",
+        ),
+        pytest.param(
+            MultiPartParam(
                 link_type=LinkType.S3,
                 file_size=parse_obj_as(ByteSize, "255GiB"),
                 expected_response=web.HTTPOk,
@@ -316,7 +326,9 @@ async def test_create_upload_file_presigned_with_file_size_returns_multipart_lin
         file_size=f"{test_param.file_size}",
     )
     # number of links
-    assert len(received_file_upload.urls) == test_param.expected_num_links
+    assert (
+        len(received_file_upload.urls) == test_param.expected_num_links
+    ), f"{len(received_file_upload.urls)} vs {test_param.expected_num_links=}"
     # all links are unique
     assert len(set(received_file_upload.urls)) == len(received_file_upload.urls)
     assert received_file_upload.chunk_size == test_param.expected_chunk_size

--- a/services/storage/tests/unit/test_s3_utils.py
+++ b/services/storage/tests/unit/test_s3_utils.py
@@ -26,6 +26,7 @@ from simcore_service_storage.s3_utils import (
         (parse_obj_as(ByteSize, "560Gib"), 5735, parse_obj_as(ByteSize, "100Mib")),
         (parse_obj_as(ByteSize, "5Tib"), 8739, parse_obj_as(ByteSize, "600Mib")),
         (parse_obj_as(ByteSize, "15Tib"), 7680, parse_obj_as(ByteSize, "2Gib")),
+        (parse_obj_as(ByteSize, "9431773844"), 900, parse_obj_as(ByteSize, "10Mib")),
     ],
     ids=byte_size_ids,
 )


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?
These are the results of some testing with regard to https://github.com/ITISFoundation/osparc-simcore/issues/3531
Currently this cannot be reproduced but a test is now ready to be able to assess whether the chunk upload might be at fault.

also some additional information were added to the error log such as exact file size in bytes, number of upload links and chunk size so that in case this happens again we should have everything to test whether this is really the issue or not.

Another option would be maybe to remove the Content-Length header as found in some forums, but this does not look very solid.
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
