### PR TITLE
♻️ Refactoring: Revise docker networks

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     image: ${DOCKER_REGISTRY:-itisfoundation}/autoscaling:${DOCKER_IMAGE_TAG:-latest}
     init: true
     hostname: "{{.Node.Hostname}}-{{.Service.Name}}-{{.Task.Slot}}"
+    networks:
+      - default
     environment:
       - LOG_LEVEL=${LOG_LEVEL:-WARNING}
     env_file:
@@ -282,6 +284,8 @@ services:
         limits:
           cpus: "1.0"
           memory: 200M
+    networks:
+      - default
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/volumes/:/var/lib/docker/volumes/
@@ -327,7 +331,6 @@ services:
       DASK_START_AS_SCHEDULER: 1
 
     networks:
-      - interactive_services_subnet
       - computational_services_subnet
 
   datcore-adapter:
@@ -368,7 +371,6 @@ services:
     networks:
       - default
       - interactive_services_subnet
-      - computational_services_subnet
       - storage_subnet
 
   rabbit:
@@ -380,7 +382,6 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBIT_PASSWORD}
     networks:
       - default
-      - computational_services_subnet
       - interactive_services_subnet
     healthcheck:
       # see https://www.rabbitmq.com/monitoring.html#individual-checks for info about health-checks available in rabbitmq
@@ -402,7 +403,7 @@ services:
       - POSTGRES_PORT=${POSTGRES_PORT}
       - POSTGRES_USER=${POSTGRES_USER}
     networks:
-      - default
+      - default # actually needed for the postgres service only
 
   postgres:
     image: "postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce"
@@ -421,7 +422,6 @@ services:
     networks:
       - default
       - interactive_services_subnet
-      - computational_services_subnet
     healthcheck:
       test:
         [
@@ -539,10 +539,9 @@ services:
         - traefik.http.middlewares.ratelimit-${SWARM_STACK_NAME}_api-server.ratelimit.burst=10
         # X-Forwarded-For header extracts second IP from the right, count starts at one
         - traefik.http.middlewares.ratelimit-${SWARM_STACK_NAME}_api-server.ratelimit.sourcecriterion.ipstrategy.depth=2
-
     networks:
       - default
-      - interactive_services_subnet
+      - interactive_services_subnet # for legacy dynamic services
     #healthcheck:
     #  test: wget --quiet --tries=1 --spider http://localhost:9082/ping || exit 1
     #  interval: 3s
@@ -571,12 +570,4 @@ networks:
       config:
         - subnet: "172.8.0.0/16"
   computational_services_subnet:
-    driver: overlay
     attachable: true
-    internal: false
-    labels:
-      com.simcore.description: "computational services network"
-    ipam:
-      driver: default
-      config:
-        - subnet: "172.9.0.0/16"


### PR DESCRIPTION
This PR revises docket networks given in the `docker-compose.yml` file.

The computational_services_subnet was made less custom and now uses a default attachable docker network.
The interactive services subnet is left pretty much as-is for legacy services backwards compatability
The default network is explicitly added where it is present by default for notional clarity.


These changes should ideally not change or impact simcore microservice communication.