### PR TITLE
🐛 agent running in production now has access to rclone

### DIFF
--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -44,6 +44,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # those from our virtualenv.
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
+# rclone installation
+COPY  --chown=scu:scu scripts/install_rclone.bash .
+RUN ./install_rclone.bash
+
 # -------------------------- Build stage -------------------
 # Installs build/package management tools and third party dependencies
 #
@@ -76,10 +80,6 @@ WORKDIR /build
 # NOTE: copies to /build to avoid overwriting later which would invalidate this layer
 COPY  --chown=scu:scu services/agent/requirements/_base.txt .
 RUN pip --no-cache-dir install -r _base.txt
-
-# rclone installation
-COPY  --chown=scu:scu scripts/install_rclone.bash .
-RUN ./install_rclone.bash
 
 
 # --------------------------Prod-depends-only stage -------------------

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -13,7 +13,9 @@ LABEL maintainer=GitHK
 
 RUN set -eux; \
   apt-get update; \
-  apt-get install -y --no-install-recommends gosu; \
+  apt-get install -y --no-install-recommends \
+  gosu \
+  curl; \
   rm -rf /var/lib/apt/lists/*; \
   # verify that the binary works
   gosu nobody true
@@ -45,8 +47,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 # rclone installation
-COPY  --chown=scu:scu scripts/install_rclone.bash .
-RUN ./install_rclone.bash
+COPY --chown=scu:scu scripts/install_rclone.bash /tmp/install_rclone.bash
+RUN ./tmp/install_rclone.bash && rm /tmp/install_rclone.bash
 
 # -------------------------- Build stage -------------------
 # Installs build/package management tools and third party dependencies
@@ -60,7 +62,6 @@ ENV SC_BUILD_TARGET=build
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
   build-essential \
-  curl \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -78,7 +79,7 @@ WORKDIR /build
 
 # install base 3rd party dependencies
 # NOTE: copies to /build to avoid overwriting later which would invalidate this layer
-COPY  --chown=scu:scu services/agent/requirements/_base.txt .
+COPY --chown=scu:scu services/agent/requirements/_base.txt .
 RUN pip --no-cache-dir install -r _base.txt
 
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

`rclone` was installed in the wrong docker image layer and was not available when running in production mode.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
