### PR TITLE
e2e: Increase S4L startup time

### DIFF
--- a/tests/e2e/tutorials/isolve-gpu.js
+++ b/tests/e2e/tutorials/isolve-gpu.js
@@ -19,7 +19,7 @@ const templateName = "isolve-gpu";
 
 async function runTutorial() {
   const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode);
-  let studyId
+  let studyId;
   try {
     await tutorial.start();
     const studyData = await tutorial.openTemplate(1000);
@@ -42,10 +42,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    await tutorial.toDashboard()
-    await tutorial.removeStudy(studyId);
-    await tutorial.logOut();
-    await tutorial.close();
+    tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/isolve-gpu.js
+++ b/tests/e2e/tutorials/isolve-gpu.js
@@ -42,7 +42,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    tutorial.leave(studyId);
+    await tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/isolve-mpi.js
+++ b/tests/e2e/tutorials/isolve-mpi.js
@@ -50,7 +50,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    tutorial.leave(studyId);
+    await tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/isolve-mpi.js
+++ b/tests/e2e/tutorials/isolve-mpi.js
@@ -17,7 +17,7 @@ const templateName = "isolve-mpi";
 
 async function runTutorial() {
   const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode);
-  let studyId
+  let studyId;
   try {
     await tutorial.start();
     const studyData = await tutorial.openTemplate(1000);
@@ -50,10 +50,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    await tutorial.toDashboard()
-    await tutorial.removeStudy(studyId);
-    await tutorial.logOut();
-    await tutorial.close();
+    tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/jupyterlabs.js
+++ b/tests/e2e/tutorials/jupyterlabs.js
@@ -17,7 +17,7 @@ const templateName = "JupyterLabs";
 
 async function runTutorial() {
   const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode);
-  let studyId
+  let studyId;
   try {
     await tutorial.start();
     const studyData = await tutorial.openTemplate(1000);
@@ -80,10 +80,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    await tutorial.toDashboard()
-    await tutorial.removeStudy(studyId);
-    await tutorial.logOut();
-    await tutorial.close();
+    tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/jupyterlabs.js
+++ b/tests/e2e/tutorials/jupyterlabs.js
@@ -80,7 +80,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    tutorial.leave(studyId);
+    await tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/mattward.js
+++ b/tests/e2e/tutorials/mattward.js
@@ -48,7 +48,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    tutorial.leave(studyId);
+    await tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/mattward.js
+++ b/tests/e2e/tutorials/mattward.js
@@ -17,7 +17,7 @@ const templateName = "Mattward";
 
 async function runTutorial() {
   const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode);
-  let studyId
+  let studyId;
   try {
     await tutorial.start();
     const studyData = await tutorial.openTemplate(1000);
@@ -48,10 +48,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    await tutorial.toDashboard()
-    await tutorial.removeStudy(studyId);
-    await tutorial.logOut();
-    await tutorial.close();
+    tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/sim4life-light.js
+++ b/tests/e2e/tutorials/sim4life-light.js
@@ -1,4 +1,4 @@
-// node ti-plan.js [url] [user] [password] [timeout] [--demo]
+// node sim4life-light.js [url] [user] [password] [timeout] [--demo]
 
 const utils = require('../utils/utils');
 const tutorialBase = require('./tutorialBase');
@@ -44,21 +44,7 @@ async function runTutorial() {
       false
     );
 
-    await tutorial.waitFor(15000, 'Wait for some time');
-
-    // do some basic interaction
-    const s4lIframe = await tutorial.getIframe(s4lNodeId);
-    const modelTree = await s4lIframe.$('.model-tree');
-    const modelItems = await modelTree.$$('.MuiTreeItem-label');
-    const nLabels = modelItems.length;
-    if (nLabels > 1) {
-      modelItems[0].click();
-      await tutorial.waitFor(2000, 'Model clicked');
-      await tutorial.takeScreenshot('ModelClicked');
-      modelItems[1].click();
-      await tutorial.waitFor(2000, 'Grid clicked');
-      await tutorial.takeScreenshot('GridlClicked');
-    }
+    await tutorial.testS4L(s4lNodeId);
   }
   catch (err) {
     tutorial.setTutorialFailed(true);

--- a/tests/e2e/tutorials/sim4life-light.js
+++ b/tests/e2e/tutorials/sim4life-light.js
@@ -52,12 +52,7 @@ async function runTutorial() {
     throw "Tutorial Failed";
   }
   finally {
-    if (studyId) {
-      await tutorial.toDashboard()
-      await tutorial.removeStudy(studyId);
-    }
-    await tutorial.logOut();
-    await tutorial.close();
+    tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/sim4life-light.js
+++ b/tests/e2e/tutorials/sim4life-light.js
@@ -52,7 +52,7 @@ async function runTutorial() {
     throw "Tutorial Failed";
   }
   finally {
-    tutorial.leave(studyId);
+    await tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/sim4life.js
+++ b/tests/e2e/tutorials/sim4life.js
@@ -17,8 +17,7 @@ const serviceName = "sim4life-dy";
 
 async function runTutorial() {
   const tutorial = new tutorialBase.TutorialBase(url, serviceName, user, pass, newUser, enableDemoMode);
-  let studyId
-
+  let studyId;
   try {
     await tutorial.start();
 
@@ -43,10 +42,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    await tutorial.toDashboard()
-    await tutorial.removeStudy(studyId);
-    await tutorial.logOut();
-    await tutorial.close();
+    tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/sim4life.js
+++ b/tests/e2e/tutorials/sim4life.js
@@ -1,4 +1,4 @@
-// node sim4life.js [url] [user] [password] [--demo]
+// node sim4life.js [url] [user] [password] [timeout] [--demo]
 
 const utils = require('../utils/utils');
 const tutorialBase = require('./tutorialBase');
@@ -35,21 +35,7 @@ async function runTutorial() {
       false
     );
 
-    await tutorial.waitFor(15000, 'Wait for some time');
-
-    // do some basic interaction
-    const s4lIframe = await tutorial.getIframe(s4lNodeId);
-    const modelTree = await s4lIframe.$('.model-tree');
-    const modelItems = await modelTree.$$('.MuiTreeItem-label');
-    const nLabels = modelItems.length;
-    if (nLabels > 1) {
-      modelItems[0].click();
-      await tutorial.waitFor(2000, 'Model clicked');
-      await tutorial.takeScreenshot('ModelClicked');
-      modelItems[1].click();
-      await tutorial.waitFor(2000, 'Grid clicked');
-      await tutorial.takeScreenshot('GridlClicked');
-    }
+    await tutorial.testS4L(s4lNodeId);
   }
   catch (err) {
     await tutorial.setTutorialFailed(true);

--- a/tests/e2e/tutorials/sim4life.js
+++ b/tests/e2e/tutorials/sim4life.js
@@ -15,13 +15,14 @@ const {
 
 const serviceName = "sim4life-dy";
 
-
 async function runTutorial() {
   const tutorial = new tutorialBase.TutorialBase(url, serviceName, user, pass, newUser, enableDemoMode);
   let studyId
 
   try {
     await tutorial.start();
+
+    // start sim4life-dy service
     const studyData = await tutorial.openService(1000);
     studyId = studyData["data"]["uuid"];
 

--- a/tests/e2e/tutorials/sim4life.js
+++ b/tests/e2e/tutorials/sim4life.js
@@ -42,7 +42,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    tutorial.leave(studyId);
+    await tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/sleepers.js
+++ b/tests/e2e/tutorials/sleepers.js
@@ -39,7 +39,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    tutorial.leave(studyId);
+    await tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/sleepers.js
+++ b/tests/e2e/tutorials/sleepers.js
@@ -17,7 +17,7 @@ const templateName = "Sleepers";
 
 async function runTutorial() {
   const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode);
-  let studyId
+  let studyId;
   try {
     await tutorial.start();
     const studyData = await tutorial.openTemplate(1000);
@@ -39,10 +39,7 @@ async function runTutorial() {
     console.log('Tutorial error: ' + err);
   }
   finally {
-    await tutorial.toDashboard()
-    await tutorial.removeStudy(studyId);
-    await tutorial.logOut();
-    await tutorial.close();
+    tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/ti-plan.js
+++ b/tests/e2e/tutorials/ti-plan.js
@@ -142,12 +142,7 @@ async function runTutorial() {
     throw "Tutorial Failed";
   }
   finally {
-    if (studyId) {
-      await tutorial.toDashboard()
-      await tutorial.removeStudy(studyId, 20000);
-    }
-    await tutorial.logOut();
-    await tutorial.close();
+    tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/ti-plan.js
+++ b/tests/e2e/tutorials/ti-plan.js
@@ -142,7 +142,7 @@ async function runTutorial() {
     throw "Tutorial Failed";
   }
   finally {
-    tutorial.leave(studyId);
+    await tutorial.leave(studyId);
   }
 
   if (tutorial.getTutorialFailed()) {

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -572,7 +572,7 @@ class TutorialBase {
       for (i = 0; i < nTries; i++) {
         const cardUnlocked = await auto.deleteFirstStudy(this.__page, this.__templateName);
         if (cardUnlocked) {
-          console.log("Study Card unlocked in " + (waitFor + intervalWait*i) + "s");
+          console.log("Study Card unlocked in " + ((waitFor + intervalWait*i)/1000) + "s");
           break;
         }
         console.log(studyId, "study card still locked");

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -532,6 +532,15 @@ class TutorialBase {
     }
   }
 
+  async leave(studyId) {
+    if (studyId) {
+      await this.toDashboard()
+      await this.removeStudy(studyId);
+    }
+    await this.logOut();
+    await this.close();
+  }
+
   async toDashboard() {
     await this.takeScreenshot("toDashboard_before");
     this.__responsesQueue.addResponseListener("projects");
@@ -546,20 +555,6 @@ class TutorialBase {
       throw (err);
     }
     await this.takeScreenshot("toDashboard_after");
-  }
-
-  async closeStudy() {
-    await this.takeScreenshot("closeStudy_before");
-    this.__responsesQueue.addResponseListener(":close");
-    try {
-      await auto.toDashboard(this.__page);
-      await this.__responsesQueue.waitUntilResponse(":close");
-    }
-    catch (err) {
-      console.error("Failed closing study", err);
-      throw (err);
-    }
-    await this.takeScreenshot("closeStudy_after");
   }
 
   async removeStudy(studyId, waitFor = 5000) {

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -607,6 +607,24 @@ class TutorialBase {
     await this.takeScreenshot('waitFor_finished')
   }
 
+  async testS4L(s4lNodeId) {
+    await this.waitFor(20000, 'Wait for the spash screen to disappear');
+
+    // do some basic interaction
+    const s4lIframe = await this.getIframe(s4lNodeId);
+    const modelTree = await s4lIframe.$('.model-tree');
+    const modelItems = await modelTree.$$('.MuiTreeItem-label');
+    const nLabels = modelItems.length;
+    if (nLabels > 1) {
+      modelItems[0].click();
+      await this.waitFor(2000, 'Model clicked');
+      await this.takeScreenshot('ModelClicked');
+      modelItems[1].click();
+      await this.waitFor(2000, 'Grid clicked');
+      await this.takeScreenshot('GridlClicked');
+    }
+  }
+
   async takeScreenshot(screenshotTitle) {
     // Generates an URL that points to the backend logs at this time
     const snapshotUrl = utils.getGrayLogSnapshotUrl(this.__url, 30);

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -608,7 +608,7 @@ class TutorialBase {
   }
 
   async testS4L(s4lNodeId) {
-    await this.waitFor(20000, 'Wait for the spash screen to disappear');
+    await this.waitFor(20000, 'Wait for the splash screen to disappear');
 
     // do some basic interaction
     const s4lIframe = await this.getIframe(s4lNodeId);


### PR DESCRIPTION
## What do these changes do?

The splash screen can stay there for just a bit longer than the hardcoded 15" (increased to 20").


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
