### PR TITLE
🐛 agent rclone configuration fixes

### DIFF
--- a/packages/settings-library/src/settings_library/catalog.py
+++ b/packages/settings-library/src/settings_library/catalog.py
@@ -1,8 +1,7 @@
 from functools import cached_property
 
-
-from settings_library.basic_types import PortInt, VersionTag
 from settings_library.base import BaseCustomSettings
+from settings_library.basic_types import PortInt, VersionTag
 from settings_library.utils_service import (
     DEFAULT_FASTAPI_PORT,
     MixinServiceSettings,

--- a/packages/settings-library/src/settings_library/r_clone.py
+++ b/packages/settings-library/src/settings_library/r_clone.py
@@ -9,7 +9,7 @@ from .s3 import S3Settings
 class S3Provider(str, Enum):
     AWS = "AWS"
     CEPH = "Ceph"
-    MINIO = "MINIO"
+    MINIO = "Minio"
 
 
 class RCloneSettings(BaseCustomSettings):

--- a/packages/settings-library/src/settings_library/r_clone.py
+++ b/packages/settings-library/src/settings_library/r_clone.py
@@ -8,7 +8,7 @@ from .s3 import S3Settings
 
 class S3Provider(str, Enum):
     AWS = "AWS"
-    CEPH = "CEPH"
+    CEPH = "Ceph"
     MINIO = "MINIO"
 
 

--- a/packages/settings-library/src/settings_library/r_clone.py
+++ b/packages/settings-library/src/settings_library/r_clone.py
@@ -8,8 +8,8 @@ from .s3 import S3Settings
 
 class S3Provider(str, Enum):
     AWS = "AWS"
-    CEPH = "Ceph"
-    MINIO = "Minio"
+    CEPH = "CEPH"
+    MINIO = "MINIO"
 
 
 class RCloneSettings(BaseCustomSettings):

--- a/packages/settings-library/src/settings_library/utils_r_clone.py
+++ b/packages/settings-library/src/settings_library/utils_r_clone.py
@@ -44,3 +44,7 @@ def get_r_clone_config(r_clone_settings: RCloneSettings) -> str:
         aws_region=r_clone_settings.R_CLONE_S3.S3_REGION,
     )
     return r_clone_config
+
+
+def resolve_provider(s3_provider: S3Provider) -> str:
+    return _PROVIDER_ENTRIES[s3_provider]["provider"]

--- a/packages/settings-library/tests/test_utils_r_clone.py
+++ b/packages/settings-library/tests/test_utils_r_clone.py
@@ -2,7 +2,11 @@
 
 import pytest
 from settings_library.r_clone import RCloneSettings, S3Provider
-from settings_library.utils_r_clone import _COMMON_ENTRIES, get_r_clone_config
+from settings_library.utils_r_clone import (
+    _COMMON_ENTRIES,
+    get_r_clone_config,
+    resolve_provider,
+)
 
 
 @pytest.fixture(params=list(S3Provider))
@@ -26,3 +30,15 @@ def test_r_clone_config_template_replacement(r_clone_settings: RCloneSettings) -
 
     for key in _COMMON_ENTRIES.keys():
         assert key in r_clone_config
+
+
+@pytest.mark.parametrize(
+    "s3_provider, expected",
+    [
+        (S3Provider.AWS, "AWS"),
+        (S3Provider.CEPH, "Ceph"),
+        (S3Provider.MINIO, "Minio"),
+    ],
+)
+def test_resolve_provider(s3_provider: S3Provider, expected: str) -> None:
+    assert resolve_provider(s3_provider) == expected

--- a/services/agent/src/simcore_service_agent/modules/volumes_cleanup/_s3.py
+++ b/services/agent/src/simcore_service_agent/modules/volumes_cleanup/_s3.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Final
 
 from settings_library.r_clone import S3Provider
+from settings_library.utils_r_clone import resolve_provider
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ def get_config_file_path(
     s3_provider: S3Provider,
 ) -> Path:
     config_content = R_CLONE_CONFIG.format(
-        destination_provider=s3_provider,
+        destination_provider=resolve_provider(s3_provider),
         destination_access_key=s3_access_key,
         destination_secret_key=s3_secret_key,
         destination_endpoint=s3_endpoint,

--- a/services/agent/src/simcore_service_agent/modules/volumes_cleanup/_s3.py
+++ b/services/agent/src/simcore_service_agent/modules/volumes_cleanup/_s3.py
@@ -129,7 +129,7 @@ async def store_to_s3(  # pylint:disable=too-many-locals,too-many-arguments
 
     output = await _read_stream(process.stdout)
     await process.wait()
-    logger.info(output)
+    logger.info(f"Command stdout\n%s", output)
 
     if process.returncode != 0:
         raise RuntimeError(

--- a/services/agent/src/simcore_service_agent/modules/volumes_cleanup/_s3.py
+++ b/services/agent/src/simcore_service_agent/modules/volumes_cleanup/_s3.py
@@ -130,7 +130,7 @@ async def store_to_s3(  # pylint:disable=too-many-locals,too-many-arguments
 
     output = await _read_stream(process.stdout)
     await process.wait()
-    logger.info(f"Command stdout\n%s", output)
+    logger.info("Command stdout\n%s", output)
 
     if process.returncode != 0:
         raise RuntimeError(

--- a/services/agent/tests/unit/test_modules_volumes_cleanup_s3.py
+++ b/services/agent/tests/unit/test_modules_volumes_cleanup_s3.py
@@ -171,17 +171,15 @@ async def test_store_to_s3(
     assert hashes_on_disk == hashes_in_s3
 
 
-async def test_regression_test_ceph_is_wrong(
+@pytest.mark.parametrize("provider", [S3Provider.CEPH, S3Provider.MINIO])
+async def test_regression_non_aws_providers(
     unused_volume: DockerVolume,
     mocked_s3_server_url: HttpUrl,
     unused_volume_path: Path,
-    save_to: Path,
-    study_id: str,
-    node_uuid: str,
-    run_id: str,
     bucket: str,
     settings: ApplicationSettings,
     caplog_info_debug: LogCaptureFixture,
+    provider: S3Provider,
 ):
     _create_data(unused_volume_path)
     dyv_volume = await unused_volume.show()
@@ -198,10 +196,10 @@ async def test_regression_test_ceph_is_wrong(
         s3_bucket=bucket,
         s3_endpoint=mocked_s3_server_url,
         s3_region="us-east-1",
-        s3_provider=S3Provider.CEPH,
+        s3_provider=provider,
         s3_parallelism=3,
         s3_retries=1,
         exclude_files=settings.AGENT_VOLUMES_CLEANUP_EXCLUDE_FILES,
     )
 
-    assert 'provider "CEPH" not known' not in caplog_info_debug.text
+    assert f'provider "{provider}" not known' not in caplog_info_debug.text


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying

-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Agent clone configuration appears not to be correct in master, which runs with a CEPH backend.

- ♻️ rlcone output afet sync command is more helpful (states what files it synced)
- 🐛 Fiexed issues with `MINIO` and `CEPH` in `S3Provider` enum that caused warnings in the logs. (unsure if these also blocked transfers)

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist
