### PR TITLE
Request service frontend after successful ping

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -1344,7 +1344,7 @@ qx.Class.define("osparc.data.model.Node", {
       // ping for some time until it is really ready
       const pingRequest = new qx.io.request.Xhr(srvUrl);
       pingRequest.addListenerOnce("success", () => {
-        this.__serviceReadyIn(srvUrl);
+        this.__waitForServiceWebsite(srvUrl);
       }, this);
       pingRequest.addListenerOnce("fail", e => {
         const error = e.getTarget().getResponse();
@@ -1360,6 +1360,33 @@ qx.Class.define("osparc.data.model.Node", {
       pingRequest.send();
     },
 
+    __waitForServiceWebsite: function(srvUrl) {
+      // request the frontend to make sure it is ready
+      let retries = 5;
+      const request = new XMLHttpRequest();
+      const openAndSend = () => {
+        if (retries === 0) {
+          return;
+        }
+        retries--;
+        request.open("GET", srvUrl);
+        request.send();
+      };
+      const retry = () => {
+        setTimeout(() => openAndSend(), 2000);
+      };
+      request.onerror = () => retry();
+      request.ontimeout = () => retry();
+      request.onload = () => {
+        if (request.status < 200 || request.status >= 300) {
+          retry();
+        } else {
+          this.__serviceReadyIn(srvUrl);
+        }
+      };
+      openAndSend();
+    },
+
     __serviceReadyIn: function(srvUrl) {
       this.setServiceUrl(srvUrl);
       this.getStatus().setInteractive("ready");
@@ -1369,14 +1396,7 @@ qx.Class.define("osparc.data.model.Node", {
         msg: msg
       };
       this.fireDataEvent("showInLogger", msgData);
-
-      // FIXME: Apparently no all services are inmediately ready when they publish the port
-      // ping the service until it is accessible through the platform
-      const waitFor = 500;
-      qx.event.Timer.once(ev => {
-        this.__restartIFrame();
-      }, this, waitFor);
-
+      this.__restartIFrame();
       this.callRetrieveInputs();
     },
 

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -1001,6 +1001,10 @@ qx.Class.define("osparc.data.model.Node", {
     __initLoadingPage: function() {
       const showZoomMaximizeButton = !osparc.utils.Utils.isProduct("s4llite");
       const loadingPage = new osparc.ui.message.Loading(this.__getLoadingPageHeader(), this.__getExtraMessages(), showZoomMaximizeButton);
+      const thumbnail = this.getMetaData()["thumbnail"];
+      if (thumbnail) {
+        loadingPage.setLogo(thumbnail);
+      }
       this.addListener("changeLabel", () => loadingPage.setHeader(this.__getLoadingPageHeader()), this);
       this.getStatus().addListener("changeInteractive", () => {
         loadingPage.setHeader(this.__getLoadingPageHeader());

--- a/services/static-webserver/client/source/class/osparc/ui/message/Loading.js
+++ b/services/static-webserver/client/source/class/osparc/ui/message/Loading.js
@@ -54,6 +54,12 @@ qx.Class.define("osparc.ui.message.Loading", {
   },
 
   properties: {
+    logo: {
+      check: "String",
+      nullable: true,
+      apply: "__applyLogo"
+    },
+
     header: {
       check: "String",
       nullable: true,
@@ -77,19 +83,22 @@ qx.Class.define("osparc.ui.message.Loading", {
 
   statics: {
     LOGO_WIDTH: 260,
+    LOGO_HEIGHT: 110,
     STATUS_ICON_SIZE: 32
   },
 
   members: {
+    __logo: null,
     __header: null,
     __messages: null,
+    __loadingWidget: null,
 
     __maxButton: null,
 
     __buildLayout: function(showMaximize) {
-      const image = new osparc.ui.basic.Logo().set({
+      const image = this.__logo = new osparc.ui.basic.Logo().set({
         width: this.self().LOGO_WIDTH,
-        height: 110
+        height: this.self().LOGO_HEIGHT
       });
 
       const atom = this.__header = new qx.ui.basic.Atom().set({
@@ -108,7 +117,7 @@ qx.Class.define("osparc.ui.message.Loading", {
         padding: 20
       });
 
-      const loadingWidget = new qx.ui.container.Composite(new qx.ui.layout.VBox(5).set({
+      const loadingWidget = this.__loadingWidget = new qx.ui.container.Composite(new qx.ui.layout.VBox(20).set({
         alignX: "center",
         alignY: "middle"
       }));
@@ -140,6 +149,17 @@ qx.Class.define("osparc.ui.message.Loading", {
         flex: 1
       });
       this._add(maximizeLayout);
+    },
+
+    __applyLogo: function(value) {
+      this.__loadingWidget.remove(this.__logo);
+
+      this.__logo = new osparc.ui.basic.Thumbnail(null, this.self().LOGO_WIDTH, this.self().LOGO_HEIGHT);
+      const image = this.__logo.getChildControl("image");
+      image.set({
+        source: value
+      });
+      this.__loadingWidget.addAt(this.__logo, 0);
     },
 
     __applyHeader: function(value) {

--- a/services/static-webserver/client/source/class/osparc/ui/message/Loading.js
+++ b/services/static-webserver/client/source/class/osparc/ui/message/Loading.js
@@ -120,7 +120,9 @@ qx.Class.define("osparc.ui.message.Loading", {
       const loadingWidget = this.__loadingWidget = new qx.ui.container.Composite(new qx.ui.layout.VBox(20).set({
         alignX: "center",
         alignY: "middle"
-      }));
+      })).set({
+        maxWidth: this.self().LOGO_WIDTH*2
+      });
       loadingWidget.add(image);
       loadingWidget.add(atom);
       loadingWidget.add(messages);


### PR DESCRIPTION
## What do these changes do?

Once the backend tells the frontend that a dynamic service is ready and provides the service url, the frontend pings it to really make sure that it is responsive.

In some cases this is not enough, this PR adds one more check after the successful ping.

The process is the following
- The backend set the service state to ready
- The backend provides the service url
- The frontend pings the service url until it receives a successful response
- **New**: In order to make sure that everything is set, the frontend requests (and retries) the service website.
- The iframe is loaded and it requests the service website

### Bonus:
While the service is loading, show service's thumbnail instead of vendor's logo

![RetryAndLogo](https://user-images.githubusercontent.com/33152403/203787673-53411e2c-7d56-43b7-bf73-167438436983.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
