### PR TITLE
✨Autoscaling: automatically cleanup nodes from the docker swarm

### DIFF
--- a/services/autoscaling/requirements/_test.in
+++ b/services/autoscaling/requirements/_test.in
@@ -28,4 +28,3 @@ pytest-mock
 pytest-runner
 python-dotenv
 respx
-types-aiobotocore[s3] # s3 storage

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -33,10 +33,6 @@ botocore==1.27.59
     #   boto3
     #   moto
     #   s3transfer
-botocore-stubs==1.29.16
-    # via
-    #   -c requirements/_base.txt
-    #   types-aiobotocore
 certifi==2022.9.24
     # via
     #   -c requirements/_base.txt
@@ -279,23 +275,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-types-aiobotocore==2.4.0.post1
-    # via
-    #   -c requirements/_base.txt
-    #   -r requirements/_test.in
-types-aiobotocore-s3==2.4.0.post1
-    # via types-aiobotocore
-types-awscrt==0.15.3
-    # via
-    #   -c requirements/_base.txt
-    #   botocore-stubs
 types-toml==0.10.8.1
     # via responses
-typing-extensions==4.4.0
-    # via
-    #   -c requirements/_base.txt
-    #   types-aiobotocore
-    #   types-aiobotocore-s3
 urllib3==1.26.13
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/autoscaling/requirements/_tools.txt
+++ b/services/autoscaling/requirements/_tools.txt
@@ -88,7 +88,6 @@ tomlkit==0.11.6
 typing-extensions==4.4.0
     # via
     #   -c requirements/_base.txt
-    #   -c requirements/_test.txt
     #   astroid
     #   black
     #   pylint

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -229,6 +229,7 @@ async def create_service(
         return service
 
     yield _creator
+
     await asyncio.gather(
         *(async_docker_client.services.delete(s["ID"]) for s in created_services)
     )
@@ -244,9 +245,10 @@ async def create_service(
             f"--> checking if service {service['ID']}:{service['Spec']['Name']} is really gone..."
         )
         assert not await async_docker_client.containers.list(
+            all=True,
             filters={
                 "label": [f"com.docker.swarm.service.id={service['ID']}"],
-            }
+            },
         )
         print(f"<-- service {service['ID']}:{service['Spec']['Name']} is gone.")
 

--- a/services/autoscaling/tests/unit/test_utils_docker.py
+++ b/services/autoscaling/tests/unit/test_utils_docker.py
@@ -11,8 +11,13 @@ import aiodocker
 import pytest
 from deepdiff import DeepDiff
 from faker import Faker
-from models_library.generated_models.docker_rest_api import Availability, Task
+from models_library.generated_models.docker_rest_api import (
+    Availability,
+    NodeState,
+    Task,
+)
 from pydantic import ByteSize, parse_obj_as
+from pytest_mock.plugin import MockerFixture
 from simcore_service_autoscaling.models import Resources
 from simcore_service_autoscaling.utils_docker import (
     Node,
@@ -23,6 +28,7 @@ from simcore_service_autoscaling.utils_docker import (
     get_max_resources_from_docker_task,
     get_monitored_nodes,
     pending_service_tasks_with_insufficient_resources,
+    remove_monitored_down_nodes,
     tag_node,
     wait_for_node,
 )
@@ -119,6 +125,32 @@ async def test_get_monitored_nodes_with_valid_label(
     }
     assert host_node.dict(exclude=EXCLUDED_KEYS) == monitored_nodes[0].dict(
         exclude=EXCLUDED_KEYS
+    )
+
+
+async def test_remove_monitored_down_nodes_with_empty_list_does_nothing():
+    assert await remove_monitored_down_nodes([]) == []
+
+
+async def test_remove_monitored_down_nodes_of_non_down_node_does_nothing(
+    host_node: Node,
+):
+    assert await remove_monitored_down_nodes([host_node]) == []
+
+
+async def test_remove_monitored_down_nodes_of_down_node(
+    host_node: Node, faker: Faker, mocker: MockerFixture
+):
+    mocked_aiodocker = mocker.patch("aiodocker.Docker", autospec=True)
+    fake_node = host_node.copy(deep=True)
+    fake_node.ID = faker.uuid4()
+    assert fake_node.Status
+    fake_node.Status.State = NodeState.down
+    assert fake_node.Status.State == NodeState.down
+    assert await remove_monitored_down_nodes([fake_node]) == [fake_node]
+    # NOTE: this is the same as calling with aiodocker.Docker() as docker: docker.nodes.remove()
+    mocked_aiodocker.return_value.__aenter__.return_value.nodes.remove.assert_called_once_with(
+        node_id=fake_node.ID
     )
 
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
This PR removes the "Down" monitored nodes from the docker node list on the manager, to keep things tidy.

![image](https://user-images.githubusercontent.com/35365065/204539198-96962f62-121e-40d3-979d-d0a41b727738.png)

Bonus: better wait for services to go down (should remove flakyness in autoscaling tests)

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
