### PR TITLE
Revert "⬆️ Maintenance: Upgrade python-socketio + flakyness (#3622)"

### DIFF
--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -22,7 +22,7 @@
 # From 5.0.0, https://github.com/miguelgrinberg/python-socketio/blob/main/CHANGES.md
 # test_resource_manager.py::test_websocket_resource_management fails because
 # socket_id saved in redis does not correspond to client's sio
-python-socketio
+python-socketio~=4.6.1
 
 
 

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -5,11 +5,7 @@
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
 aio-pika==8.2.4
-    # via
-    #   -c requirements/../../../../packages/service-library/requirements/./_base.in
-    #   -r requirements/../../../../packages/service-library/requirements/_base.in
-    #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/_base.in
+    # via -r requirements/_base.in
 aiocache==0.11.1
     # via -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
 aiodebug==2.3.0
@@ -88,8 +84,6 @@ attrs==21.4.0
     #   aiohttp
     #   jsonschema
     #   openapi-core
-bidict==0.22.0
-    # via python-socketio
 certifi==2022.6.15
     # via requests
 cffi==1.15.0
@@ -204,7 +198,6 @@ openapi-spec-validator==0.4.0
     #   -c requirements/../../../../packages/service-library/requirements/././constraints.txt
     #   -c requirements/../../../../packages/service-library/requirements/./constraints.txt
     #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
-    #   -c requirements/../../../../packages/simcore-sdk/requirements/./constraints.txt
     #   openapi-core
 openpyxl==3.0.9
     # via -r requirements/_base.in
@@ -269,11 +262,11 @@ pyparsing==3.0.9
     # via packaging
 pyrsistent==0.18.1
     # via jsonschema
-python-engineio==4.3.4
+python-engineio==3.14.2
     # via python-socketio
 python-magic==0.4.25
     # via -r requirements/_base.in
-python-socketio==5.7.2
+python-socketio==4.6.1
     # via -r requirements/_base.in
 pytz==2022.1
     # via twilio
@@ -309,6 +302,8 @@ six==1.16.0
     #   isodate
     #   jsonschema
     #   openapi-core
+    #   python-engineio
+    #   python-socketio
 sqlalchemy==1.4.37
     # via
     #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -155,7 +155,6 @@ ptvsd==4.3.2
     # via -r requirements/_test.in
 py==1.11.0
     # via
-    #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/_test.in
     #   pytest-forked
 pylint==2.15.5
@@ -260,7 +259,7 @@ urllib3==1.26.11
     #   requests
 websocket-client==1.4.1
     # via docker
-websockets==10.4
+websockets==10.3
     # via -r requirements/_test.in
 wrapt==1.14.1
     # via

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -4,10 +4,6 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==2.12.12
-    # via
-    #   -c requirements/_test.txt
-    #   pylint
 black==22.10.0
     # via -r requirements/../../../../requirements/devenv.txt
 build==0.8.0
@@ -22,10 +18,6 @@ click==8.1.3
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-dill==0.3.5.1
-    # via
-    #   -c requirements/_test.txt
-    #   pylint
 distlib==0.3.6
     # via virtualenv
 filelock==3.8.0
@@ -38,16 +30,6 @@ isort==5.10.1
     # via
     #   -c requirements/_test.txt
     #   -r requirements/../../../../requirements/devenv.txt
-    #   pylint
-lazy-object-proxy==1.7.1
-    # via
-    #   -c requirements/_base.txt
-    #   -c requirements/_test.txt
-    #   astroid
-mccabe==0.7.0
-    # via
-    #   -c requirements/_test.txt
-    #   pylint
 mypy-extensions==0.4.3
     # via black
 nodeenv==1.7.0
@@ -69,14 +51,9 @@ platformdirs==2.5.2
     # via
     #   -c requirements/_test.txt
     #   black
-    #   pylint
     #   virtualenv
 pre-commit==2.20.0
     # via -r requirements/../../../../requirements/devenv.txt
-pylint==2.15.5
-    # via
-    #   -c requirements/_test.txt
-    #   -r requirements/../../../../requirements/devenv.txt
 pyparsing==3.0.9
     # via
     #   -c requirements/_base.txt
@@ -96,27 +73,15 @@ tomli==2.0.1
     #   black
     #   build
     #   pep517
-    #   pylint
-tomlkit==0.11.5
-    # via
-    #   -c requirements/_test.txt
-    #   pylint
 typing-extensions==4.3.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
-    #   astroid
     #   black
-    #   pylint
 virtualenv==20.16.5
     # via pre-commit
 wheel==0.37.1
     # via pip-tools
-wrapt==1.14.1
-    # via
-    #   -c requirements/_base.txt
-    #   -c requirements/_test.txt
-    #   astroid
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/web/server/src/simcore_service_webserver/socketio/server.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/server.py
@@ -1,6 +1,4 @@
-import asyncio
 import logging
-from typing import AsyncIterator
 
 from aiohttp import web
 from socketio import AsyncServer
@@ -15,40 +13,14 @@ def get_socket_server(app: web.Application) -> AsyncServer:
     return app[APP_CLIENT_SOCKET_SERVER_KEY]
 
 
-async def _socketio_server_cleanup_ctx(_app: web.Application) -> AsyncIterator[None]:
-    yield
-    # NOTE: this is ugly. It seems though that python-enginio does not
-    # cleanup its background tasks properly.
-    # https://github.com/miguelgrinberg/python-socketio/discussions/1092
-    current_tasks = asyncio.tasks.all_tasks()
-    cancelled_tasks = []
-    for task in current_tasks:
-        coro = task.get_coro()
-        if any(
-            coro_name in coro.__qualname__  # type: ignore
-            for coro_name in [
-                "AsyncServer._service_task",
-                "AsyncSocket.schedule_ping",
-            ]
-        ):
-            task.cancel()
-            cancelled_tasks.append(task)
-    await asyncio.gather(*cancelled_tasks, return_exceptions=True)
-
-
 def setup_socketio_server(app: web.Application):
     if app.get(APP_CLIENT_SOCKET_SERVER_KEY) is None:
         # SEE https://github.com/miguelgrinberg/python-socketio/blob/v4.6.1/docs/server.rst#aiohttp
         # TODO: ujson to speed up?
         # TODO: client_manager= to socketio.AsyncRedisManager/AsyncAioPikaManager for horizontal scaling (shared sessions)
-        sio = AsyncServer(
-            async_mode="aiohttp",
-            logger=log,  # type: ignore
-            engineio_logger=False,
-        )
+        sio = AsyncServer(async_mode="aiohttp", logger=log, engineio_logger=False)
         sio.attach(app)
 
         app[APP_CLIENT_SOCKET_SERVER_KEY] = sio
-        app.cleanup_ctx.append(_socketio_server_cleanup_ctx)
 
     return get_socket_server(app)

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -279,12 +279,8 @@ async def connect_to_socketio(client, user, socketio_client_factory: Callable):
         "user_id": str(user["id"]),
         "client_session_id": cur_client_session_id,
     }
-    assert await socket_registry.find_keys(("socket_id", sio.get_sid())) == [
-        resource_key
-    ]
-    assert sio.get_sid() in await socket_registry.find_resources(
-        resource_key, "socket_id"
-    )
+    assert await socket_registry.find_keys(("socket_id", sio.sid)) == [resource_key]
+    assert sio.sid in await socket_registry.find_resources(resource_key, "socket_id")
     assert len(await socket_registry.find_resources(resource_key, "socket_id")) == 1
     sio_connection_data = sio, resource_key
     return sio_connection_data
@@ -293,12 +289,12 @@ async def connect_to_socketio(client, user, socketio_client_factory: Callable):
 async def disconnect_user_from_socketio(client, sio_connection_data):
     """disconnect a previously connected socket.io connection"""
     sio, resource_key = sio_connection_data
-    sid = sio.get_sid()
+    sid = sio.sid
     socket_registry = get_registry(client.server.app)
     await sio.disconnect()
     assert not sio.sid
     await asyncio.sleep(0)  # just to ensure there is a context switch
-    assert not await socket_registry.find_keys(("socket_id", sio.get_sid()))
+    assert not await socket_registry.find_keys(("socket_id", sio.sid))
     assert not sid in await socket_registry.find_resources(resource_key, "socket_id")
     assert not await socket_registry.find_resources(resource_key, "socket_id")
 

--- a/services/web/server/tests/integration/02/test_rabbit.py
+++ b/services/web/server/tests/integration/02/test_rabbit.py
@@ -5,6 +5,7 @@
 import asyncio
 import json
 import logging
+from asyncio import sleep
 from dataclasses import dataclass
 from typing import Any, AsyncIterator, Awaitable, Callable
 from unittest import mock
@@ -28,7 +29,6 @@ from models_library.rabbitmq_messages import (
 from models_library.users import UserID
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.utils_login import UserInfoDict
-from redis import Redis
 from servicelib.aiohttp.application import create_safe_application
 from settings_library.rabbit import RabbitSettings
 from simcore_postgres_database.models.comp_tasks import NodeClass
@@ -185,10 +185,9 @@ async def _publish_in_rabbit(
 def client(
     event_loop: asyncio.AbstractEventLoop,
     aiohttp_client: Callable,
-    app_config: dict[str, Any],
-    rabbit_service: RabbitSettings,
+    app_config: dict[str, Any],  ## waits until swarm with *_services are up
+    rabbit_service: RabbitSettings,  ## waits until rabbit is responsive and set env vars
     postgres_db: sa.engine.Engine,
-    redis_client: Redis,
     monkeypatch_setenv_from_app_config: Callable,
 ):
     app_config["storage"]["enabled"] = False
@@ -258,7 +257,7 @@ async def socketio_subscriber_handlers(
     socketio_client_factory: Callable,
     client_session_id: UUIDStr,
     mocker: MockerFixture,
-) -> AsyncIterator[SocketIoHandlers]:
+) -> SocketIoHandlers:
 
     """socketio SUBSCRIBER
 
@@ -283,7 +282,7 @@ async def socketio_subscriber_handlers(
     # called on event
     mock_event_handler = mocker.Mock()
     sio.on(SOCKET_IO_EVENT, handler=mock_event_handler)
-    yield SocketIoHandlers(
+    return SocketIoHandlers(
         mock_log_handler, mock_node_update_handler, mock_event_handler
     )
 
@@ -316,7 +315,7 @@ def user_role() -> UserRole:
     return UserRole.USER
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 async def rabbit_exchanges(
     rabbit_settings: RabbitSettings,
     rabbit_channel: aio_pika.Channel,
@@ -373,9 +372,10 @@ async def rabbit_exchanges(
 #   to them
 #
 
+POLLING_TIME = 0.2
 TIMEOUT_S = 10
 RETRY_POLICY = dict(
-    wait=wait_fixed(0.2),
+    wait=wait_fixed(POLLING_TIME),
     stop=stop_after_delay(TIMEOUT_S),
     before_sleep=before_sleep_log(logger, log_level=logging.WARNING),
     retry=retry_if_exception_type(AssertionError),
@@ -389,6 +389,7 @@ USER_ROLES = [
 ]
 
 
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize("user_role", USER_ROLES)
 async def test_publish_to_other_user(
     not_logged_user_id: UserID,
@@ -409,13 +410,14 @@ async def test_publish_to_other_user(
         not_in_project_node_uuid,
         NUMBER_OF_MESSAGES,
     )
+    await sleep(TIMEOUT_S)
 
-    await asyncio.sleep(TIMEOUT_S)
     socketio_subscriber_handlers.mock_log.assert_not_called()
     socketio_subscriber_handlers.mock_node_updated.assert_not_called()
     socketio_subscriber_handlers.mock_event.assert_not_called()
 
 
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize("user_role", USER_ROLES)
 async def test_publish_to_user(
     logged_user: UserInfoDict,
@@ -442,22 +444,21 @@ async def test_publish_to_user(
                 NUMBER_OF_MESSAGES
             )
 
-    async for attempt in AsyncRetrying(**RETRY_POLICY):
-        with attempt:
-            for mock_call, expected_message in zip(
-                socketio_subscriber_handlers.mock_log.mock_log_handler.call_args_list,
-                log_messages,
-            ):
-                value = mock_call[0]
-                deserialized_value = json.loads(value[0])
-                assert deserialized_value == json.loads(
-                    expected_message.json(exclude={"user_id"})
-                )
-            socketio_subscriber_handlers.mock_node_updated.assert_not_called()
-            socketio_subscriber_handlers.mock_event.assert_called_once()
+    for mock_call, expected_message in zip(
+        socketio_subscriber_handlers.mock_log.mock_log_handler.call_args_list,
+        log_messages,
+    ):
+        value = mock_call[0]
+        deserialized_value = json.loads(value[0])
+        assert deserialized_value == json.loads(
+            expected_message.json(exclude={"user_id"})
+        )
+    socketio_subscriber_handlers.mock_node_updated.assert_not_called()
+    socketio_subscriber_handlers.mock_event.assert_called_once()
 
 
 @pytest.mark.parametrize("user_role", USER_ROLES)
+@pytest.mark.flaky(max_runs=3)
 async def test_publish_about_users_project(
     logged_user: UserInfoDict,
     user_project: dict[str, Any],
@@ -483,20 +484,19 @@ async def test_publish_about_users_project(
                 NUMBER_OF_MESSAGES
             )
 
-    async for attempt in AsyncRetrying(**RETRY_POLICY):
-        with attempt:
-            for mock_call, expected_message in zip(
-                socketio_subscriber_handlers.mock_log.call_args_list, log_messages
-            ):
-                value = mock_call[0]
-                deserialized_value = json.loads(value[0])
-                assert deserialized_value == json.loads(
-                    expected_message.json(exclude={"user_id"})
-                )
-            socketio_subscriber_handlers.mock_node_updated.assert_not_called()
-            socketio_subscriber_handlers.mock_event.assert_called_once()
+    for mock_call, expected_message in zip(
+        socketio_subscriber_handlers.mock_log.call_args_list, log_messages
+    ):
+        value = mock_call[0]
+        deserialized_value = json.loads(value[0])
+        assert deserialized_value == json.loads(
+            expected_message.json(exclude={"user_id"})
+        )
+    socketio_subscriber_handlers.mock_node_updated.assert_not_called()
+    socketio_subscriber_handlers.mock_event.assert_called_once()
 
 
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize("user_role", USER_ROLES)
 async def test_publish_about_users_projects_node(
     logged_user: UserInfoDict,
@@ -535,11 +535,9 @@ async def test_publish_about_users_projects_node(
             expected_message.json(exclude={"user_id"})
         )
 
-    async for attempt in AsyncRetrying(**RETRY_POLICY):
-        with attempt:
-            # mock_log_handler.assert_has_calls(log_calls, any_order=True)
-            socketio_subscriber_handlers.mock_node_updated.assert_called()
-            assert socketio_subscriber_handlers.mock_node_updated.call_count == (
-                NUMBER_OF_MESSAGES
-            )
-            socketio_subscriber_handlers.mock_event.assert_called_once()
+    # mock_log_handler.assert_has_calls(log_calls, any_order=True)
+    socketio_subscriber_handlers.mock_node_updated.assert_called()
+    assert socketio_subscriber_handlers.mock_node_updated.call_count == (
+        NUMBER_OF_MESSAGES
+    )
+    socketio_subscriber_handlers.mock_event.assert_called_once()


### PR DESCRIPTION
This reverts commit db03a28713d14aa64698ba6deffa339e95ed2803.

Reason: Frontend needs an update before that can go in


<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
