### PR TITLE
e2e: close Preparing Inputs window

### DIFF
--- a/tests/e2e/tutorials/ti-plan.js
+++ b/tests/e2e/tutorials/ti-plan.js
@@ -138,6 +138,14 @@ async function runTutorial() {
     }
   }
   catch (err) {
+    // if it fails because the optimizer times out, close the "Preparing Inputs" view first
+    const id = '[osparc-test-id=preparingInputsCloseBtn]';
+    await page.waitForSelector(id, {
+      timeout: 1000
+    })
+      .then(() => page.click(id))
+      .catch(() => console.log("Preparing Inputs window not found"));
+
     tutorial.setTutorialFailed(true, false);
     console.log('Tutorial error: ' + err);
     throw "Tutorial Failed";


### PR DESCRIPTION
## What do these changes do?

In order not to accumulate too many TIP studies in puppeteer's account, if TIP e2e test fails because the optimizer times out, close the "Preparing Inputs" view before going back to the dashboard
