### PR TITLE
✨ Autoscaling: scale down nodes

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/core/errors.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/errors.py
@@ -14,7 +14,7 @@ class Ec2NotConnectedError(AutoscalingRuntimeError):
 
 
 class Ec2InstanceNotFoundError(AutoscalingRuntimeError):
-    msg_template: str = "Needed instance was not found"
+    msg_template: str = "EC2 instance was not found"
 
 
 class Ec2TooManyInstancesError(AutoscalingRuntimeError):

--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -67,8 +67,17 @@ class EC2InstancesSettings(BaseCustomSettings):
 
     EC2_INSTANCES_TIME_BEFORE_TERMINATION: datetime.timedelta = Field(
         default=datetime.timedelta(minutes=55),
-        description="Defines the time an instance must be empty before the instance termination procedure may begin",
+        description="Time after which an EC2 instance may be terminated (repeat every hour, min 0, max 59 minutes)",
     )
+
+    @validator("EC2_INSTANCES_TIME_BEFORE_TERMINATION")
+    @classmethod
+    def check_valid_time_set(cls, value):
+        if value < datetime.timedelta(minutes=0):
+            value = datetime.timedelta(minutes=0)
+        elif value > datetime.timedelta(minutes=59):
+            value = datetime.timedelta(minutes=59)
+        return value
 
     @validator("EC2_INSTANCES_ALLOWED_TYPES")
     @classmethod

--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -65,6 +65,11 @@ class EC2InstancesSettings(BaseCustomSettings):
         "this is required to start a new EC2 instance",
     )
 
+    EC2_INSTANCES_TIME_BEFORE_TERMINATION: datetime.timedelta = Field(
+        default=datetime.timedelta(minutes=55),
+        description="Defines the time an instance must be empty before the instance termination procedure may begin",
+    )
+
     @validator("EC2_INSTANCES_ALLOWED_TYPES")
     @classmethod
     def check_valid_intance_names(cls, value):

--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -72,7 +72,7 @@ class EC2InstancesSettings(BaseCustomSettings):
 
     @validator("EC2_INSTANCES_TIME_BEFORE_TERMINATION")
     @classmethod
-    def check_valid_time_set(cls, value):
+    def ensure_time_is_in_range(cls, value):
         if value < datetime.timedelta(minutes=0):
             value = datetime.timedelta(minutes=0)
         elif value > datetime.timedelta(minutes=59):

--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -40,7 +40,7 @@ class EC2InstancesSettings(BaseCustomSettings):
         description="Defines the AMI (Amazon Machine Image) ID used to start a new EC2 instance",
     )
     EC2_INSTANCES_MAX_INSTANCES: int = Field(
-        10,
+        default=10,
         description="Defines the maximum number of instances the autoscaling app may create",
     )
     EC2_INSTANCES_SECURITY_GROUP_IDS: list[str] = Field(

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -185,6 +185,12 @@ async def _try_scale_up_with_drained_nodes(
                 logger.info(
                     "Activated former drained node '%s'", node.Description.Hostname
                 )
+                await rabbitmq.post_log_message(
+                    app,
+                    task,
+                    "cluster was scaled up and is now ready to run service",
+                    logging.INFO,
+                )
                 return True
     logger.info("There are no available drained node for the pending tasks")
     return False

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -220,7 +220,6 @@ async def _scale_up_cluster(app: FastAPI, pending_tasks: list[Task]) -> None:
                     InstanceTypeType, ec2_instances_needed[0].name
                 ),
                 tags={
-                    "io.simcore.autoscaling.created": f"{datetime.utcnow()}",
                     "io.simcore.autoscaling.version": f"{VERSION}",
                     "io.simcore.autoscaling.monitored_nodes_labels": json.dumps(
                         app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NODE_LABELS

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -213,7 +213,6 @@ async def check_dynamic_resources(app: FastAPI) -> None:
 
     if not pending_tasks:
         logger.debug("no pending tasks with insufficient resources at the moment")
-        await _scale_down_cluster(app)
-        return
-
-    await _scale_up_cluster(app, pending_tasks)
+        await _scale_down_cluster(app, monitored_nodes)
+    else:
+        await _scale_up_cluster(app, pending_tasks)

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -150,7 +150,7 @@ async def _try_scale_down_cluster(app: FastAPI, monitored_nodes: list[Node]) -> 
         # since these nodes are being terminated, remove them from the swarm
         await utils_docker.remove_nodes(
             get_docker_client(app),
-            [(node for node, _ in terminateable_nodes)],
+            [node for node, _ in terminateable_nodes],
             force=True,
         )
 

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -94,7 +94,6 @@ async def _find_terminateable_nodes(
             ec2_client.get_running_instance(
                 app_settings.AUTOSCALING_EC2_INSTANCES,
                 tag_keys=[
-                    "io.simcore.autoscaling.created",
                     "io.simcore.autoscaling.version",
                 ],
                 instance_host_name=node.Description.Hostname,

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -48,10 +48,11 @@ async def _mark_empty_active_nodes_to_drain(
             if (node.Spec) and (node.Spec.Labels)
         )
     )
-    logger.info(
-        "The following nodes set to drain: '%s'",
-        f"{node.Description.Hostname for node in active_empty_nodes}",
-    )
+    if active_empty_nodes:
+        logger.info(
+            "The following nodes set to drain: '%s'",
+            f"{node.Description.Hostname for node in active_empty_nodes}",
+        )
 
 
 async def _find_terminateable_nodes(
@@ -102,10 +103,11 @@ async def _find_terminateable_nodes(
         ):
             # let's terminate that one
             terminateable_nodes.append((node, ec2_instance_data))
-    logger.info(
-        "the following nodes were found to be terminateable: '%s'",
-        f"{node.Description.Hostname for node,_ in terminateable_nodes}",
-    )
+    if terminateable_nodes:
+        logger.info(
+            "the following nodes were found to be terminateable: '%s'",
+            f"{node.Description.Hostname for node,_ in terminateable_nodes}",
+        )
     return terminateable_nodes
 
 

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -118,9 +118,9 @@ async def _find_terminateable_nodes(
             datetime.utcnow().replace(tzinfo=timezone.utc)
             - ec2_instance_data.launch_time
         )
-        elapsed_minutes = elapsed_time_since_launched % timedelta(hours=1)
+        elapsed_time_since_full_hour = elapsed_time_since_launched % timedelta(hours=1)
         if (
-            elapsed_minutes
+            elapsed_time_since_full_hour
             >= app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
         ):
             # let's terminate that one

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -145,6 +145,7 @@ async def _activate_drained_nodes(
         # check if there is some node with enough resources
         for node in monitored_nodes:
             assert node.Spec  # nosec
+            assert node.Description  # nosec
             if (node.Spec.Availability == Availability.drain) and (
                 utils_docker.get_node_total_resources(node)
                 >= utils_docker.get_max_resources_from_docker_task(task)
@@ -153,8 +154,11 @@ async def _activate_drained_nodes(
                 await utils_docker.tag_node(
                     docker_client, node, tags=node.Spec.Labels, available=True
                 )
+                logger.info(
+                    "Activated formed drain node '%s'", node.Description.Hostname
+                )
                 return True
-
+    logger.info("There are no available drained node for the pending tasks")
     return False
 
 

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -52,13 +52,13 @@ async def _mark_empty_active_nodes_to_drain(
                 available=False,
             )
             for node in active_empty_nodes
-            if (node.Spec) and (node.Spec.Labels)
+            if (node.Spec) and (node.Spec.Labels is not None)
         )
     )
     if active_empty_nodes:
         logger.info(
             "The following nodes set to drain: '%s'",
-            f"{(node.Description.Hostname for node in active_empty_nodes if node.Description)}",
+            f"{[node.Description.Hostname for node in active_empty_nodes if node.Description]}",
         )
 
 
@@ -144,7 +144,7 @@ async def _try_scale_down_cluster(app: FastAPI, monitored_nodes: list[Node]) -> 
         )
         logger.info(
             "terminated the following machines: '%s'",
-            f"{(node.Description.Hostname for node,_ in terminateable_nodes if node.Description)}",
+            f"{[node.Description.Hostname for node,_ in terminateable_nodes if node.Description]}",
         )
         # since these nodes are being terminated, remove them from the swarm
         await utils_docker.remove_nodes(

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -134,7 +134,7 @@ async def _find_terminateable_nodes(
 
 
 async def _try_scale_down_cluster(app: FastAPI, monitored_nodes: list[Node]) -> None:
-    # 2. once it is in draining mode and we are nearing a modulo of an hour we can start the termination procedure (parametrize this)
+    # 2. once it is in draining mode and we are nearing a modulo of an hour we can start the termination procedure
     # NOTE: the nodes that were just changed to drain above will be eventually terminated on the next iteration
     if terminateable_nodes := await _find_terminateable_nodes(app, monitored_nodes):
         await asyncio.gather(

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -84,6 +84,9 @@ async def _find_terminateable_nodes(
         and (node.Spec.Availability == Availability.drain)
     ]
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
+    if not drained_empty_nodes:
+        # there is nothing to terminate here
+        return []
 
     # get the corresponding ec2 instance data
     # NOTE: some might be in the process of terminating and will not be found

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -138,5 +138,7 @@ async def check_dynamic_resources(app: FastAPI) -> None:
             logger.error(
                 "Task %s needs more resources than any EC2 instance "
                 "can provide with the current configuration. Please check.",
-                {f"{task.Name=}:{task.ServiceID=}"},
+                {
+                    f"{task.Name if task.Name else 'unknown task name'}:{task.ServiceID if task.ServiceID else 'unknown service ID'}"
+                },
             )

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -38,7 +38,7 @@ async def _mark_empty_active_nodes_to_drain(
                 node,
                 service_labels=app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_SERVICE_LABELS,
             )
-            == Resources.empty_resources()
+            == Resources.create_as_empty()
         )
         and (node.Spec is not None)
         and (node.Spec.Availability == Availability.active)
@@ -78,7 +78,7 @@ async def _find_terminateable_nodes(
                 node,
                 service_labels=app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_SERVICE_LABELS,
             )
-            == Resources.empty_resources()
+            == Resources.create_as_empty()
         )
         and (node.Spec is not None)
         and (node.Spec.Availability == Availability.drain)

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -16,6 +16,14 @@ class Resources(BaseModel):
     def __ge__(self, other: "Resources") -> bool:
         return self.cpus >= other.cpus and self.ram >= other.ram
 
+    def __add__(self, other: "Resources") -> "Resources":
+        return Resources.construct(
+            **{
+                key: a + b
+                for (key, a), b in zip(self.dict().items(), other.dict().values())
+            }
+        )
+
 
 class EC2Instance(BaseModel):
     name: str

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -13,6 +13,9 @@ class Resources(BaseModel):
     def empty_resources(cls) -> "Resources":
         return cls(cpus=0, ram=ByteSize(0))
 
+    def __ge__(self, other: "Resources") -> bool:
+        return self.cpus >= other.cpus and self.ram >= other.ram
+
 
 class EC2Instance(BaseModel):
     name: str

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -9,6 +9,10 @@ class Resources(BaseModel):
     cpus: NonNegativeFloat
     ram: ByteSize
 
+    @classmethod
+    def empty_resources(cls) -> "Resources":
+        return cls(cpus=0, ram=ByteSize(0))
+
 
 class EC2Instance(BaseModel):
     name: str

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -10,7 +10,7 @@ class Resources(BaseModel):
     ram: ByteSize
 
     @classmethod
-    def empty_resources(cls) -> "Resources":
+    def create_as_empty(cls) -> "Resources":
         return cls(cpus=0, ram=ByteSize(0))
 
     def __ge__(self, other: "Resources") -> bool:

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -40,7 +40,7 @@ def _is_ec2_instance_running(instance: ReservationTypeDef):
     )
 
 
-@dataclass
+@dataclass(frozen=True)
 class EC2InstanceData:
     launch_time: datetime.datetime
     id: str
@@ -48,7 +48,7 @@ class EC2InstanceData:
     type: InstanceTypeType
 
 
-@dataclass
+@dataclass(frozen=True)
 class AutoscalingEC2:
     client: EC2Client
     session: aioboto3.Session

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -76,7 +76,7 @@ class AutoscalingEC2:
 
     async def ping(self) -> bool:
         try:
-            await self.client.describe_account_attributes(DryRun=True)
+            await self.client.describe_account_attributes()
             return True
         except Exception:  # pylint: disable=broad-except
             return False

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -170,14 +170,6 @@ class AutoscalingEC2:
             await waiter.wait(InstanceIds=[instance_id])
             logger.info("instance %s is now running", instance_id)
 
-            # NOTE: this is currently deactivated as this makes starting an instance
-            # take between 2-4 minutes more and it seems to be responsive much before
-            # nevertheless if we get weird errors, this should be activated again!
-
-            # waiter = client.get_waiter("instance_status_ok")
-            # await waiter.wait(InstanceIds=[instance_id])
-            # logger.info("instance %s status is OK...", instance_id)
-
             # get the private IP
             instances = await self.client.describe_instances(InstanceIds=[instance_id])
             instance = instances["Reservations"][0]["Instances"][0]

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -110,7 +110,7 @@ class AutoscalingEC2:
         instance_type: InstanceTypeType,
         tags: dict[str, str],
         startup_script: str,
-    ) -> InstancePrivateDNSName:
+    ) -> EC2InstanceData:
         with log_context(
             logger,
             logging.INFO,
@@ -179,15 +179,18 @@ class AutoscalingEC2:
 
             # get the private IP
             instances = await self.client.describe_instances(InstanceIds=[instance_id])
-            private_dns_name: str = instances["Reservations"][0]["Instances"][0][
-                "PrivateDnsName"
-            ]
-            logger.info(
-                "instance %s is available on %s, happy computing!!",
-                instance_id,
-                private_dns_name,
+            instance = instances["Reservations"][0]["Instances"][0]
+            instance_data = EC2InstanceData(
+                launch_time=instance["LaunchTime"],
+                id=instance["InstanceId"],
+                aws_private_dns=instance["PrivateDnsName"],
+                type=instance["InstanceType"],
             )
-            return private_dns_name
+            logger.info(
+                "%s is available, happy computing!!",
+                f"{instance_data=}",
+            )
+            return instance_data
 
     async def get_running_instance(
         self,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -227,6 +227,17 @@ class AutoscalingEC2:
             type=instance["InstanceType"],
         )
 
+    async def terminate_instance(self, instance_data: EC2InstanceData) -> None:
+        await self.client.terminate_instances(InstanceIds=[instance_data.id])
+        # shall we wait here?
+        # waiter = self.client.get_waiter("instance_terminated")
+        # await waiter.wait(
+        #     InstanceIds=[
+        #         instance["InstanceId"]
+        #         for instance in terminating_instances["TerminatingInstances"]
+        #     ]
+        # )
+
 
 def setup(app: FastAPI) -> None:
     async def on_startup() -> None:

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
@@ -1,40 +1,14 @@
 import logging
 
 from fastapi import FastAPI
-from models_library.generated_models.docker_rest_api import Node, Task
-from models_library.rabbitmq_messages import (
-    AutoscalingStatus,
-    LoggerRabbitMessage,
-    RabbitAutoscalingMessage,
-)
+from models_library.generated_models.docker_rest_api import Task
+from models_library.rabbitmq_messages import LoggerRabbitMessage
 from servicelib.logging_utils import log_catch
 
-from ..models import Resources, SimcoreServiceDockerLabelKeys
+from ..models import SimcoreServiceDockerLabelKeys
 from ..modules.rabbitmq import post_message
 
 logger = logging.getLogger(__name__)
-
-
-async def post_state_message(
-    app: FastAPI,
-    monitored_nodes: list[Node],
-    cluster_total_resources: Resources,
-    cluster_used_resources: Resources,
-    pending_tasks: list[Task],
-) -> None:
-    with log_catch(logger, reraise=False):
-        message = RabbitAutoscalingMessage(
-            origin=app.title,
-            number_monitored_nodes=len(monitored_nodes),
-            cluster_total_resources=cluster_total_resources.dict(),
-            cluster_used_resources=cluster_used_resources.dict(),
-            number_pending_tasks_without_resources=len(pending_tasks),
-            status=AutoscalingStatus.SCALING_UP
-            if pending_tasks
-            else AutoscalingStatus.IDLE,
-        )
-        logger.debug("autoscaling state: %s", message)
-        await post_message(app, message)
 
 
 async def post_log_message(app: FastAPI, task: Task, log: str, level: int):

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -121,6 +121,17 @@ async def pending_service_tasks_with_insufficient_resources(
     return pending_tasks
 
 
+def get_node_total_resources(node: Node) -> Resources:
+    assert node.Description  # nosec
+    assert node.Description.Resources  # nosec
+    assert node.Description.Resources.NanoCPUs  # nosec
+    assert node.Description.Resources.MemoryBytes  # nosec
+    return Resources(
+        cpus=node.Description.Resources.NanoCPUs / _NANO_CPU,
+        ram=ByteSize(node.Description.Resources.MemoryBytes),
+    )
+
+
 async def compute_cluster_total_resources(nodes: list[Node]) -> Resources:
     """
     Returns the nodes total resources.

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -299,3 +299,12 @@ async def tag_node(
                 "Role": node.Spec.Role.value,
             },
         )
+
+
+async def set_node_availability(
+    docker_client: AutoscalingDocker, node: Node, *, available: bool
+) -> None:
+    assert node.Spec  # nosec
+    return await tag_node(
+        docker_client, node, tags=node.Spec.Labels, available=available
+    )

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -52,10 +52,10 @@ async def get_monitored_nodes(
     return nodes
 
 
-async def remove_monitored_down_nodes(
-    docker_client: AutoscalingDocker, nodes: list[Node]
+async def remove_nodes(
+    docker_client: AutoscalingDocker, nodes: list[Node], force: bool = False
 ) -> list[Node]:
-    """removes docker nodes that are in the down state"""
+    """removes docker nodes that are in the down state (unless force is used and they will be forcibly removed)"""
 
     def _check_if_node_is_removable(node: Node) -> bool:
         if node.Status and node.Status.State:
@@ -71,7 +71,9 @@ async def remove_monitored_down_nodes(
         # we do not remove a node that has a weird state, let it be done by someone smarter.
         return False
 
-    nodes_that_need_removal = [n for n in nodes if _check_if_node_is_removable(n)]
+    nodes_that_need_removal = [
+        n for n in nodes if (force is True) or _check_if_node_is_removable(n)
+    ]
     for node in nodes_that_need_removal:
         assert node.ID  # nosec
         with log_context(logger, logging.INFO, msg=f"remove {node.ID=}"):

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -45,7 +45,6 @@ from simcore_service_autoscaling.models import SimcoreServiceDockerLabelKeys
 from simcore_service_autoscaling.modules.docker import AutoscalingDocker
 from simcore_service_autoscaling.modules.ec2 import AutoscalingEC2, EC2InstanceData
 from tenacity import retry
-from tenacity._asyncio import AsyncRetrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_fixed
@@ -347,46 +346,43 @@ async def create_service(
     await asyncio.sleep(0)
 
 
+SUCCESS_STABLE_TIME_S: Final[float] = 3
+WAIT_TIME: Final[float] = 0.5
+
+
+@retry(
+    retry=retry_if_exception_type(AssertionError),
+    reraise=True,
+    wait=wait_fixed(WAIT_TIME),
+    stop=stop_after_delay(10 * SUCCESS_STABLE_TIME_S),
+)
 async def assert_for_service_state(
     async_docker_client: aiodocker.Docker, service: Service, expected_states: list[str]
 ) -> None:
-    SUCCESS_STABLE_TIME_S: Final[float] = 3
-    WAIT_TIME: Final[float] = 0.5
     number_of_success = 0
-    async for attempt in AsyncRetrying(
-        retry=retry_if_exception_type(AssertionError),
-        reraise=True,
-        wait=wait_fixed(WAIT_TIME),
-        stop=stop_after_delay(10 * SUCCESS_STABLE_TIME_S),
-    ):
-        with attempt:
-            print(
-                f"--> waiting for service {service.ID} to become {expected_states}..."
-            )
-            services = await async_docker_client.services.list(
-                filters={"id": service.ID}
-            )
-            assert services, f"no service with {service.ID}!"
-            assert len(services) == 1
-            found_service = services[0]
+    print(f"--> waiting for service {service.ID} to become {expected_states}...")
+    services = await async_docker_client.services.list(filters={"id": service.ID})
+    assert services, f"no service with {service.ID}!"
+    assert len(services) == 1
+    found_service = services[0]
 
-            tasks = await async_docker_client.tasks.list(
-                filters={"service": found_service["Spec"]["Name"]}
-            )
-            assert tasks, f"no tasks available for {found_service['Spec']['Name']}"
-            assert len(tasks) == 1
-            service_task = tasks[0]
-            assert (
-                service_task["Status"]["State"] in expected_states
-            ), f"service {found_service['Spec']['Name']}'s task is {service_task['Status']['State']}"
-            print(
-                f"<-- service {found_service['Spec']['Name']} is now {service_task['Status']['State']} {'.'*number_of_success}"
-            )
-            number_of_success += 1
-            assert (number_of_success * WAIT_TIME) >= SUCCESS_STABLE_TIME_S
-            print(
-                f"<-- service {found_service['Spec']['Name']} is now {service_task['Status']['State']} after {SUCCESS_STABLE_TIME_S} seconds"
-            )
+    tasks = await async_docker_client.tasks.list(
+        filters={"service": found_service["Spec"]["Name"]}
+    )
+    assert tasks, f"no tasks available for {found_service['Spec']['Name']}"
+    assert len(tasks) == 1
+    service_task = tasks[0]
+    assert (
+        service_task["Status"]["State"] in expected_states
+    ), f"service {found_service['Spec']['Name']}'s task is {service_task['Status']['State']}"
+    print(
+        f"<-- service {found_service['Spec']['Name']} is now {service_task['Status']['State']} {'.'*number_of_success}"
+    )
+    number_of_success += 1
+    assert (number_of_success * WAIT_TIME) >= SUCCESS_STABLE_TIME_S
+    print(
+        f"<-- service {found_service['Spec']['Name']} is now {service_task['Status']['State']} after {SUCCESS_STABLE_TIME_S} seconds"
+    )
 
 
 @pytest.fixture(scope="module")

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -45,6 +45,7 @@ from simcore_service_autoscaling.models import SimcoreServiceDockerLabelKeys
 from simcore_service_autoscaling.modules.docker import AutoscalingDocker
 from simcore_service_autoscaling.modules.ec2 import AutoscalingEC2, EC2InstanceData
 from tenacity import retry
+from tenacity._asyncio import AsyncRetrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_fixed
@@ -346,43 +347,46 @@ async def create_service(
     await asyncio.sleep(0)
 
 
-SUCCESS_STABLE_TIME_S: Final[float] = 3
-WAIT_TIME: Final[float] = 0.5
-
-
-@retry(
-    retry=retry_if_exception_type(AssertionError),
-    reraise=True,
-    wait=wait_fixed(WAIT_TIME),
-    stop=stop_after_delay(10 * SUCCESS_STABLE_TIME_S),
-)
 async def assert_for_service_state(
     async_docker_client: aiodocker.Docker, service: Service, expected_states: list[str]
 ) -> None:
+    SUCCESS_STABLE_TIME_S: Final[float] = 3
+    WAIT_TIME: Final[float] = 0.5
     number_of_success = 0
-    print(f"--> waiting for service {service.ID} to become {expected_states}...")
-    services = await async_docker_client.services.list(filters={"id": service.ID})
-    assert services, f"no service with {service.ID}!"
-    assert len(services) == 1
-    found_service = services[0]
+    async for attempt in AsyncRetrying(
+        retry=retry_if_exception_type(AssertionError),
+        reraise=True,
+        wait=wait_fixed(WAIT_TIME),
+        stop=stop_after_delay(10 * SUCCESS_STABLE_TIME_S),
+    ):
+        with attempt:
+            print(
+                f"--> waiting for service {service.ID} to become {expected_states}..."
+            )
+            services = await async_docker_client.services.list(
+                filters={"id": service.ID}
+            )
+            assert services, f"no service with {service.ID}!"
+            assert len(services) == 1
+            found_service = services[0]
 
-    tasks = await async_docker_client.tasks.list(
-        filters={"service": found_service["Spec"]["Name"]}
-    )
-    assert tasks, f"no tasks available for {found_service['Spec']['Name']}"
-    assert len(tasks) == 1
-    service_task = tasks[0]
-    assert (
-        service_task["Status"]["State"] in expected_states
-    ), f"service {found_service['Spec']['Name']}'s task is {service_task['Status']['State']}"
-    print(
-        f"<-- service {found_service['Spec']['Name']} is now {service_task['Status']['State']} {'.'*number_of_success}"
-    )
-    number_of_success += 1
-    assert (number_of_success * WAIT_TIME) >= SUCCESS_STABLE_TIME_S
-    print(
-        f"<-- service {found_service['Spec']['Name']} is now {service_task['Status']['State']} after {SUCCESS_STABLE_TIME_S} seconds"
-    )
+            tasks = await async_docker_client.tasks.list(
+                filters={"service": found_service["Spec"]["Name"]}
+            )
+            assert tasks, f"no tasks available for {found_service['Spec']['Name']}"
+            assert len(tasks) == 1
+            service_task = tasks[0]
+            assert (
+                service_task["Status"]["State"] in expected_states
+            ), f"service {found_service['Spec']['Name']}'s task is {service_task['Status']['State']}"
+            print(
+                f"<-- service {found_service['Spec']['Name']} is now {service_task['Status']['State']} {'.'*number_of_success}"
+            )
+            number_of_success += 1
+            assert (number_of_success * WAIT_TIME) >= SUCCESS_STABLE_TIME_S
+            print(
+                f"<-- service {found_service['Spec']['Name']} is now {service_task['Status']['State']} after {SUCCESS_STABLE_TIME_S} seconds"
+            )
 
 
 @pytest.fixture(scope="module")

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -41,7 +41,7 @@ from simcore_service_autoscaling.core.application import create_app
 from simcore_service_autoscaling.core.settings import ApplicationSettings, EC2Settings
 from simcore_service_autoscaling.models import SimcoreServiceDockerLabelKeys
 from simcore_service_autoscaling.modules.docker import AutoscalingDocker
-from simcore_service_autoscaling.modules.ec2 import AutoscalingEC2
+from simcore_service_autoscaling.modules.ec2 import AutoscalingEC2, EC2InstanceData
 from tenacity import retry
 from tenacity._asyncio import AsyncRetrying
 from tenacity.retry import retry_if_exception_type
@@ -565,4 +565,19 @@ def osparc_docker_label_keys(
 ) -> SimcoreServiceDockerLabelKeys:
     return SimcoreServiceDockerLabelKeys.parse_obj(
         dict(user_id=faker.pyint(), project_id=faker.uuid4(), node_id=faker.uuid4())
+    )
+
+
+@pytest.fixture
+def aws_instance_private_dns() -> str:
+    return "ip-10-23-40-12.ec2.internal"
+
+
+@pytest.fixture
+def ec2_instance_data(faker: Faker, aws_instance_private_dns: str) -> EC2InstanceData:
+    return EC2InstanceData(
+        launch_time=faker.date_time(),
+        id=faker.uuid4(),
+        aws_private_dns=aws_instance_private_dns,
+        type=faker.pystr(),
     )

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -30,8 +30,9 @@ from asgi_lifespan import LifespanManager
 from deepdiff import DeepDiff
 from faker import Faker
 from fastapi import FastAPI
+from models_library.generated_models.docker_rest_api import Node
 from moto.server import ThreadedMotoServer
-from pydantic import ByteSize, PositiveInt
+from pydantic import ByteSize, PositiveInt, parse_obj_as
 from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.utils_docker import get_localhost_ip
@@ -177,6 +178,16 @@ async def autoscaling_docker() -> AsyncIterator[AutoscalingDocker]:
 async def async_docker_client() -> AsyncIterator[aiodocker.Docker]:
     async with aiodocker.Docker() as docker_client:
         yield docker_client
+
+
+@pytest.fixture
+async def host_node(
+    docker_swarm: None,
+    async_docker_client: aiodocker.Docker,
+) -> Node:
+    nodes = parse_obj_as(list[Node], await async_docker_client.nodes.list())
+    assert len(nodes) == 1
+    return nodes[0]
 
 
 @pytest.fixture

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -104,6 +104,13 @@ def app_environment(
             "EC2_INSTANCES_SUBNET_ID": faker.pystr(),
             "EC2_INSTANCES_AMI_ID": faker.pystr(),
             "EC2_INSTANCES_ALLOWED_TYPES": json.dumps(ec2_instances),
+            "NODES_MONITORING_NODE_LABELS": json.dumps(["pytest.fake-node-label"]),
+            "NODES_MONITORING_SERVICE_LABELS": json.dumps(
+                ["pytest.fake-service-label"]
+            ),
+            "NODES_MONITORING_NEW_NODES_LABELS": json.dumps(
+                ["pytest.fake-new-node-label"]
+            ),
         },
     )
     return mock_env_devel_environment | envs

--- a/services/autoscaling/tests/unit/test_core_settings.py
+++ b/services/autoscaling/tests/unit/test_core_settings.py
@@ -2,6 +2,9 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
+import datetime
+
+import pytest
 from pytest_simcore.helpers.utils_envs import EnvVarsDict
 from simcore_service_autoscaling.core.settings import ApplicationSettings
 
@@ -11,3 +14,23 @@ def test_settings(app_environment: EnvVarsDict):
     assert settings.AUTOSCALING_EC2_ACCESS
     assert settings.AUTOSCALING_EC2_INSTANCES
     assert settings.AUTOSCALING_NODES_MONITORING
+
+
+def test_invalid_EC2_INSTANCES_TIME_BEFORE_TERMINATION(
+    app_environment: EnvVarsDict, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("EC2_INSTANCES_TIME_BEFORE_TERMINATION", "1:05:00")
+    settings = ApplicationSettings.create_from_envs()
+    assert settings.AUTOSCALING_EC2_INSTANCES
+    assert (
+        settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
+        == datetime.timedelta(minutes=59)
+    )
+
+    monkeypatch.setenv("EC2_INSTANCES_TIME_BEFORE_TERMINATION", "-1:05:00")
+    settings = ApplicationSettings.create_from_envs()
+    assert settings.AUTOSCALING_EC2_INSTANCES
+    assert (
+        settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
+        == datetime.timedelta(minutes=0)
+    )

--- a/services/autoscaling/tests/unit/test_core_settings.py
+++ b/services/autoscaling/tests/unit/test_core_settings.py
@@ -22,6 +22,7 @@ def test_invalid_EC2_INSTANCES_TIME_BEFORE_TERMINATION(
     monkeypatch.setenv("EC2_INSTANCES_TIME_BEFORE_TERMINATION", "1:05:00")
     settings = ApplicationSettings.create_from_envs()
     assert settings.AUTOSCALING_EC2_INSTANCES
+    assert settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
     assert (
         settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
         == datetime.timedelta(minutes=59)

--- a/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
@@ -82,24 +82,18 @@ async def test_check_dynamic_resources_with_service_with_too_much_resources_star
     minimal_configuration: None,
     async_docker_client: aiodocker.Docker,
     initialized_app: FastAPI,
-    create_service: Callable[[dict[str, Any]], Awaitable[Mapping[str, Any]]],
+    create_service: Callable[
+        [dict[str, Any], dict[str, Any], str], Awaitable[Mapping[str, Any]]
+    ],
     task_template: dict[str, Any],
     create_task_reservations: Callable[[int, int], dict[str, Any]],
-    assert_for_service_state: Callable[
-        [aiodocker.Docker, Mapping[str, Any], list[str]], Awaitable[None]
-    ],
     mock_start_aws_instance: mock.Mock,
 ):
     task_template_with_too_many_resource = task_template | create_task_reservations(
         1000, 0
     )
     service_with_too_many_resources = await create_service(
-        task_template_with_too_many_resource
-    )
-    await assert_for_service_state(
-        async_docker_client,
-        service_with_too_many_resources,
-        ["pending"],
+        task_template_with_too_many_resource, {}, "pending"
     )
 
     await check_dynamic_resources(initialized_app)
@@ -111,12 +105,11 @@ async def test_check_dynamic_resources_with_pending_resources_starts_r5n_4xlarge
     app_settings: ApplicationSettings,
     async_docker_client: aiodocker.Docker,
     initialized_app: FastAPI,
-    create_service: Callable[[dict[str, Any]], Awaitable[Mapping[str, Any]]],
+    create_service: Callable[
+        [dict[str, Any], dict[str, Any], str], Awaitable[Mapping[str, Any]]
+    ],
     task_template: dict[str, Any],
     create_task_reservations: Callable[[int, int], dict[str, Any]],
-    assert_for_service_state: Callable[
-        [aiodocker.Docker, Mapping[str, Any], list[str]], Awaitable[None]
-    ],
     mock_start_aws_instance: mock.Mock,
     mock_wait_for_node: mock.Mock,
     mock_tag_node: mock.Mock,
@@ -126,12 +119,7 @@ async def test_check_dynamic_resources_with_pending_resources_starts_r5n_4xlarge
         task_template | create_task_reservations(4, parse_obj_as(ByteSize, "128GiB"))
     )
     service_with_too_many_resources = await create_service(
-        task_template_for_r5n_4x_large_with_256Gib
-    )
-    await assert_for_service_state(
-        async_docker_client,
-        service_with_too_many_resources,
-        ["pending"],
+        task_template_for_r5n_4x_large_with_256Gib, {}, "pending"
     )
 
     await check_dynamic_resources(initialized_app)
@@ -153,12 +141,11 @@ async def test_check_dynamic_resources_with_pending_resources_actually_starts_ne
     minimal_configuration: None,
     async_docker_client: aiodocker.Docker,
     initialized_app: FastAPI,
-    create_service: Callable[[dict[str, Any]], Awaitable[Mapping[str, Any]]],
+    create_service: Callable[
+        [dict[str, Any], dict[str, Any], str], Awaitable[Mapping[str, Any]]
+    ],
     task_template: dict[str, Any],
     create_task_reservations: Callable[[int, int], dict[str, Any]],
-    assert_for_service_state: Callable[
-        [aiodocker.Docker, Mapping[str, Any], list[str]], Awaitable[None]
-    ],
     ec2_client: EC2Client,
     mock_wait_for_node: mock.Mock,
     mock_tag_node: mock.Mock,
@@ -170,13 +157,8 @@ async def test_check_dynamic_resources_with_pending_resources_actually_starts_ne
     task_template_for_r5n_8x_large_with_256Gib = (
         task_template | create_task_reservations(4, parse_obj_as(ByteSize, "128GiB"))
     )
-    service_with_too_many_resources = await create_service(
-        task_template_for_r5n_8x_large_with_256Gib
-    )
-    await assert_for_service_state(
-        async_docker_client,
-        service_with_too_many_resources,
-        ["pending"],
+    _service_with_too_many_resources = await create_service(
+        task_template_for_r5n_8x_large_with_256Gib, {}, "pending"
     )
 
     await check_dynamic_resources(initialized_app)

--- a/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
@@ -10,7 +10,6 @@ from unittest import mock
 
 import aiodocker
 import pytest
-from faker import Faker
 from fastapi import FastAPI
 from pydantic import ByteSize, parse_obj_as
 from pytest_mock.plugin import MockerFixture
@@ -19,21 +18,6 @@ from simcore_service_autoscaling.dynamic_scaling_core import check_dynamic_resou
 from simcore_service_autoscaling.modules.docker import get_docker_client
 from simcore_service_autoscaling.modules.ec2 import EC2InstanceData, get_ec2_client
 from types_aiobotocore_ec2.client import EC2Client
-
-
-@pytest.fixture
-def aws_instance_private_dns() -> str:
-    return "ip-10-23-40-12.ec2.internal"
-
-
-@pytest.fixture
-def ec2_instance_data(faker: Faker, aws_instance_private_dns: str) -> EC2InstanceData:
-    return EC2InstanceData(
-        launch_time=faker.date_time(),
-        id=faker.uuid4(),
-        aws_private_dns=aws_instance_private_dns,
-        type=faker.pystr(),
-    )
 
 
 @pytest.fixture

--- a/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
@@ -10,7 +10,9 @@ from unittest import mock
 
 import aiodocker
 import pytest
+from faker import Faker
 from fastapi import FastAPI
+from models_library.generated_models.docker_rest_api import Node, ObjectVersion
 from pydantic import ByteSize, parse_obj_as
 from pytest_mock.plugin import MockerFixture
 from simcore_service_autoscaling.core.settings import ApplicationSettings
@@ -18,6 +20,15 @@ from simcore_service_autoscaling.dynamic_scaling_core import check_dynamic_resou
 from simcore_service_autoscaling.modules.docker import get_docker_client
 from simcore_service_autoscaling.modules.ec2 import EC2InstanceData, get_ec2_client
 from types_aiobotocore_ec2.client import EC2Client
+
+
+@pytest.fixture
+def mock_terminate_aws_instance(mocker: MockerFixture) -> Iterator[mock.Mock]:
+    mocked_terminate_instance = mocker.patch(
+        "simcore_service_autoscaling.modules.ec2.AutoscalingEC2.terminate_instance",
+        autospec=True,
+    )
+    yield mocked_terminate_instance
 
 
 @pytest.fixture
@@ -33,10 +44,21 @@ def mock_start_aws_instance(
 
 
 @pytest.fixture
-def mock_wait_for_node(mocker: MockerFixture) -> Iterator[mock.Mock]:
+def fake_node(faker: Faker) -> Node:
+    return Node(
+        ID=faker.uuid4(),
+        Version=ObjectVersion(Index=faker.pyint()),
+        CreatedAt=faker.date_time().isoformat(),
+        UpdatedAt=faker.date_time().isoformat(),
+    )
+
+
+@pytest.fixture
+def mock_wait_for_node(mocker: MockerFixture, fake_node: Node) -> Iterator[mock.Mock]:
     mocked_wait_for_node = mocker.patch(
         "simcore_service_autoscaling.dynamic_scaling_core.utils_docker.wait_for_node",
         autospec=True,
+        return_value=fake_node,
     )
     yield mocked_wait_for_node
 
@@ -67,9 +89,11 @@ async def test_check_dynamic_resources_with_no_services_does_nothing(
     minimal_configuration: None,
     initialized_app: FastAPI,
     mock_start_aws_instance: mock.Mock,
+    mock_terminate_aws_instance: mock.Mock,
 ):
     await check_dynamic_resources(initialized_app)
     mock_start_aws_instance.assert_not_called()
+    mock_terminate_aws_instance.assert_not_called()
 
 
 async def test_check_dynamic_resources_with_service_with_too_much_resources_starts_nothing(
@@ -82,6 +106,7 @@ async def test_check_dynamic_resources_with_service_with_too_much_resources_star
     task_template: dict[str, Any],
     create_task_reservations: Callable[[int, int], dict[str, Any]],
     mock_start_aws_instance: mock.Mock,
+    mock_terminate_aws_instance: mock.Mock,
 ):
     task_template_with_too_many_resource = task_template | create_task_reservations(
         1000, 0
@@ -92,6 +117,7 @@ async def test_check_dynamic_resources_with_service_with_too_much_resources_star
 
     await check_dynamic_resources(initialized_app)
     mock_start_aws_instance.assert_not_called()
+    mock_terminate_aws_instance.assert_not_called()
 
 
 async def test_check_dynamic_resources_with_pending_resources_starts_r5n_4xlarge_instance(
@@ -105,10 +131,14 @@ async def test_check_dynamic_resources_with_pending_resources_starts_r5n_4xlarge
     task_template: dict[str, Any],
     create_task_reservations: Callable[[int, int], dict[str, Any]],
     mock_start_aws_instance: mock.Mock,
+    mock_terminate_aws_instance: mock.Mock,
     mock_wait_for_node: mock.Mock,
     mock_tag_node: mock.Mock,
     aws_instance_private_dns: str,
+    fake_node: Node,
 ):
+    """In this test we start on the host (1 node), start a service that needs
+    resources that can be covered by a r5n_4x_large ec2 instance"""
     task_template_for_r5n_4x_large_with_256Gib = (
         task_template | create_task_reservations(4, parse_obj_as(ByteSize, "128GiB"))
     )
@@ -117,6 +147,7 @@ async def test_check_dynamic_resources_with_pending_resources_starts_r5n_4xlarge
     )
 
     await check_dynamic_resources(initialized_app)
+    # we expect a new instance to be started
     mock_start_aws_instance.assert_called_once_with(
         get_ec2_client(initialized_app),
         app_settings.AUTOSCALING_EC2_INSTANCES,
@@ -124,11 +155,17 @@ async def test_check_dynamic_resources_with_pending_resources_starts_r5n_4xlarge
         tags=mock.ANY,
         startup_script=mock.ANY,
     )
+    # after the instance has booted, then we wait for the node to appear in the swarm
     mock_wait_for_node.assert_called_once_with(
         get_docker_client(initialized_app),
         aws_instance_private_dns[: aws_instance_private_dns.find(".")],
     )
-    mock_tag_node.assert_called_once()
+    # once the instance is in the swarm it shall be tagged as such
+    mock_tag_node.assert_called_once_with(
+        get_docker_client(initialized_app), fake_node, tags=mock.ANY, available=True
+    )
+    # there shall be no termination
+    mock_terminate_aws_instance.assert_not_called()
 
 
 async def test_check_dynamic_resources_with_pending_resources_actually_starts_new_instances(
@@ -143,7 +180,9 @@ async def test_check_dynamic_resources_with_pending_resources_actually_starts_ne
     ec2_client: EC2Client,
     mock_wait_for_node: mock.Mock,
     mock_tag_node: mock.Mock,
+    fake_node: Node,
 ):
+    """same test as above but with moto mocked server"""
     # we have nothing running now
     all_instances = await ec2_client.describe_instances()
     assert not all_instances["Reservations"]
@@ -174,4 +213,6 @@ async def test_check_dynamic_resources_with_pending_resources_actually_starts_ne
         get_docker_client(initialized_app),
         instance_private_dns_name[: instance_private_dns_name.find(".")],
     )
-    mock_tag_node.assert_called_once()
+    mock_tag_node.assert_called_once_with(
+        get_docker_client(initialized_app), fake_node, tags=mock.ANY, available=True
+    )

--- a/services/autoscaling/tests/unit/test_models.py
+++ b/services/autoscaling/tests/unit/test_models.py
@@ -52,14 +52,14 @@ def test_resources_ge_operator(
     "a,b,result",
     [
         (
-            Resources(cpus=0, ram=0),
-            Resources(cpus=1, ram=34),
-            Resources(cpus=1, ram=34),
+            Resources(cpus=0, ram=ByteSize(0)),
+            Resources(cpus=1, ram=ByteSize(34)),
+            Resources(cpus=1, ram=ByteSize(34)),
         ),
         (
-            Resources(cpus=0.1, ram=-1),
-            Resources(cpus=1, ram=34),
-            Resources(cpus=1.1, ram=33),
+            Resources(cpus=0.1, ram=ByteSize(-1)),
+            Resources(cpus=1, ram=ByteSize(34)),
+            Resources(cpus=1.1, ram=ByteSize(33)),
         ),
     ],
 )

--- a/services/autoscaling/tests/unit/test_models.py
+++ b/services/autoscaling/tests/unit/test_models.py
@@ -48,6 +48,27 @@ def test_resources_ge_operator(
     assert (a >= b) is a_greater_or_equal_than_b
 
 
+@pytest.mark.parametrize(
+    "a,b,result",
+    [
+        (
+            Resources(cpus=0, ram=0),
+            Resources(cpus=1, ram=34),
+            Resources(cpus=1, ram=34),
+        ),
+        (
+            Resources(cpus=0.1, ram=-1),
+            Resources(cpus=1, ram=34),
+            Resources(cpus=1.1, ram=33),
+        ),
+    ],
+)
+def test_resources_add(a: Resources, b: Resources, result: Resources):
+    assert a + b == result
+    a += b
+    assert a == result
+
+
 async def test_get_simcore_service_docker_labels_from_task_with_missing_labels_raises(
     async_docker_client: aiodocker.Docker,
     create_service: Callable[

--- a/services/autoscaling/tests/unit/test_models.py
+++ b/services/autoscaling/tests/unit/test_models.py
@@ -14,10 +14,12 @@ from simcore_service_autoscaling.models import SimcoreServiceDockerLabelKeys
 
 async def test_task_ownership_from_task_with_missing_labels_raises(
     async_docker_client: aiodocker.Docker,
-    create_service: Callable[[dict[str, Any]], Awaitable[Mapping[str, Any]]],
+    create_service: Callable[
+        [dict[str, Any], dict[str, Any], str], Awaitable[Mapping[str, Any]]
+    ],
     task_template: dict[str, Any],
 ):
-    service_missing_osparc_labels = await create_service(task_template)
+    service_missing_osparc_labels = await create_service(task_template, {}, "running")
     service_tasks = parse_obj_as(
         list[Task],
         await async_docker_client.tasks.list(
@@ -41,14 +43,13 @@ def test_osparc_docker_label_keys_to_docker_labels(
 async def test_task_ownership_from_task(
     async_docker_client: aiodocker.Docker,
     create_service: Callable[
-        [dict[str, Any], dict[str, str]], Awaitable[Mapping[str, Any]]
+        [dict[str, Any], dict[str, str], str], Awaitable[Mapping[str, Any]]
     ],
     task_template: dict[str, Any],
     osparc_docker_label_keys: SimcoreServiceDockerLabelKeys,
 ):
     service_with_labels = await create_service(
-        task_template,
-        osparc_docker_label_keys.to_docker_labels(),
+        task_template, osparc_docker_label_keys.to_docker_labels(), "running"
     )
     service_tasks = parse_obj_as(
         list[Task],

--- a/services/autoscaling/tests/unit/test_modules_ec2.py
+++ b/services/autoscaling/tests/unit/test_modules_ec2.py
@@ -203,6 +203,7 @@ async def test_get_running_instance(
     # we have nothing running now in ec2
     all_instances = await ec2_client.describe_instances()
     assert not all_instances["Reservations"]
+    # create some instance there
 
 
 async def test_terminate_instance():

--- a/services/autoscaling/tests/unit/test_modules_ec2.py
+++ b/services/autoscaling/tests/unit/test_modules_ec2.py
@@ -185,3 +185,25 @@ async def test_start_aws_instance_is_limited_in_number_of_instances(
             tags=tags,
             startup_script=startup_script,
         )
+
+
+async def test_get_running_instance(
+    mocked_aws_server_envs: None,
+    aws_vpc_id: str,
+    aws_subnet_id: str,
+    aws_security_group_id: str,
+    aws_ami_id: str,
+    ec2_client: EC2Client,
+    autoscaling_ec2: AutoscalingEC2,
+    app_settings: ApplicationSettings,
+    faker: Faker,
+):
+    assert app_settings.AUTOSCALING_EC2_ACCESS
+    assert app_settings.AUTOSCALING_EC2_INSTANCES
+    # we have nothing running now in ec2
+    all_instances = await ec2_client.describe_instances()
+    assert not all_instances["Reservations"]
+
+
+async def test_terminate_instance():
+    ...

--- a/services/autoscaling/tests/unit/test_modules_ec2.py
+++ b/services/autoscaling/tests/unit/test_modules_ec2.py
@@ -10,10 +10,15 @@ from moto.server import ThreadedMotoServer
 from pytest_simcore.helpers.utils_envs import EnvVarsDict
 from simcore_service_autoscaling.core.errors import (
     ConfigurationError,
+    Ec2InstanceNotFoundError,
     Ec2TooManyInstancesError,
 )
 from simcore_service_autoscaling.core.settings import ApplicationSettings, EC2Settings
-from simcore_service_autoscaling.modules.ec2 import AutoscalingEC2, get_ec2_client
+from simcore_service_autoscaling.modules.ec2 import (
+    AutoscalingEC2,
+    EC2InstanceData,
+    get_ec2_client,
+)
 from types_aiobotocore_ec2 import EC2Client
 
 
@@ -187,6 +192,30 @@ async def test_start_aws_instance_is_limited_in_number_of_instances(
         )
 
 
+async def test_get_running_instance_raises_if_not_found(
+    mocked_aws_server_envs: None,
+    aws_vpc_id: str,
+    aws_subnet_id: str,
+    aws_security_group_id: str,
+    aws_ami_id: str,
+    ec2_client: EC2Client,
+    autoscaling_ec2: AutoscalingEC2,
+    app_settings: ApplicationSettings,
+    faker: Faker,
+):
+    assert app_settings.AUTOSCALING_EC2_INSTANCES
+    # we have nothing running now in ec2
+    all_instances = await ec2_client.describe_instances()
+    assert not all_instances["Reservations"]
+
+    with pytest.raises(Ec2InstanceNotFoundError):
+        await autoscaling_ec2.get_running_instance(
+            app_settings.AUTOSCALING_EC2_INSTANCES,
+            tag_keys=[],
+            instance_host_name=faker.pystr(),
+        )
+
+
 async def test_get_running_instance(
     mocked_aws_server_envs: None,
     aws_vpc_id: str,
@@ -198,13 +227,76 @@ async def test_get_running_instance(
     app_settings: ApplicationSettings,
     faker: Faker,
 ):
-    assert app_settings.AUTOSCALING_EC2_ACCESS
     assert app_settings.AUTOSCALING_EC2_INSTANCES
     # we have nothing running now in ec2
     all_instances = await ec2_client.describe_instances()
     assert not all_instances["Reservations"]
-    # create some instance there
+
+    # create some instance
+    instance_type = faker.pystr()
+    tags = faker.pydict(allowed_types=(str,))
+    startup_script = faker.pystr()
+    created_instance = await autoscaling_ec2.start_aws_instance(
+        app_settings.AUTOSCALING_EC2_INSTANCES,
+        instance_type,
+        tags=tags,
+        startup_script=startup_script,
+    )
+
+    instance_received = await autoscaling_ec2.get_running_instance(
+        app_settings.AUTOSCALING_EC2_INSTANCES,
+        tag_keys=list(tags.keys()),
+        instance_host_name=created_instance.aws_private_dns.split(".ec2.internal")[0],
+    )
+    assert created_instance == instance_received
 
 
-async def test_terminate_instance():
-    ...
+async def test_terminate_instance(
+    mocked_aws_server_envs: None,
+    aws_vpc_id: str,
+    aws_subnet_id: str,
+    aws_security_group_id: str,
+    aws_ami_id: str,
+    ec2_client: EC2Client,
+    autoscaling_ec2: AutoscalingEC2,
+    app_settings: ApplicationSettings,
+    faker: Faker,
+):
+    assert app_settings.AUTOSCALING_EC2_INSTANCES
+    # we have nothing running now in ec2
+    all_instances = await ec2_client.describe_instances()
+    assert not all_instances["Reservations"]
+    # create some instance
+    instance_type = faker.pystr()
+    tags = faker.pydict(allowed_types=(str,))
+    startup_script = faker.pystr()
+    created_instance = await autoscaling_ec2.start_aws_instance(
+        app_settings.AUTOSCALING_EC2_INSTANCES,
+        instance_type,
+        tags=tags,
+        startup_script=startup_script,
+    )
+
+    # terminate the instance
+    await autoscaling_ec2.terminate_instance(created_instance)
+    # calling it several times is ok, the instance stays a while
+    await autoscaling_ec2.terminate_instance(created_instance)
+
+
+async def test_terminate_instance_not_existing_raises(
+    mocked_aws_server_envs: None,
+    aws_vpc_id: str,
+    aws_subnet_id: str,
+    aws_security_group_id: str,
+    aws_ami_id: str,
+    ec2_client: EC2Client,
+    autoscaling_ec2: AutoscalingEC2,
+    app_settings: ApplicationSettings,
+    ec2_instance_data: EC2InstanceData,
+):
+    assert app_settings.AUTOSCALING_EC2_INSTANCES
+    # we have nothing running now in ec2
+    all_instances = await ec2_client.describe_instances()
+    assert not all_instances["Reservations"]
+    with pytest.raises(Ec2InstanceNotFoundError):
+        await autoscaling_ec2.terminate_instance(ec2_instance_data)

--- a/services/autoscaling/tests/unit/test_utils_docker.py
+++ b/services/autoscaling/tests/unit/test_utils_docker.py
@@ -28,6 +28,7 @@ from simcore_service_autoscaling.utils.utils_docker import (
     get_docker_swarm_join_bash_command,
     get_max_resources_from_docker_task,
     get_monitored_nodes,
+    get_node_total_resources,
     pending_service_tasks_with_insufficient_resources,
     remove_monitored_down_nodes,
     tag_node,
@@ -316,6 +317,15 @@ async def test_pending_service_task_with_insufficient_resources_with_labelled_se
         },
     )
     assert not diff, f"{diff}"
+
+
+def test_get_node_total_resources(host_node: Node):
+    resources = get_node_total_resources(host_node)
+    assert host_node.Description
+    assert host_node.Description.Resources
+    assert host_node.Description.Resources.NanoCPUs
+    assert resources.cpus == (host_node.Description.Resources.NanoCPUs / 10**9)
+    assert resources.ram == host_node.Description.Resources.MemoryBytes
 
 
 async def test_compute_cluster_total_resources_with_no_nodes_returns_0(

--- a/services/autoscaling/tests/unit/test_utils_docker.py
+++ b/services/autoscaling/tests/unit/test_utils_docker.py
@@ -38,16 +38,6 @@ from simcore_service_autoscaling.utils.utils_docker import (
 
 
 @pytest.fixture
-async def host_node(
-    docker_swarm: None,
-    async_docker_client: aiodocker.Docker,
-) -> Node:
-    nodes = parse_obj_as(list[Node], await async_docker_client.nodes.list())
-    assert len(nodes) == 1
-    return nodes[0]
-
-
-@pytest.fixture
 async def create_node_labels(
     host_node: Node,
     async_docker_client: aiodocker.Docker,

--- a/services/autoscaling/tests/unit/test_utils_docker.py
+++ b/services/autoscaling/tests/unit/test_utils_docker.py
@@ -31,7 +31,7 @@ from simcore_service_autoscaling.utils.utils_docker import (
     get_monitored_nodes,
     get_node_total_resources,
     pending_service_tasks_with_insufficient_resources,
-    remove_monitored_down_nodes,
+    remove_nodes,
     tag_node,
     wait_for_node,
 )
@@ -137,14 +137,14 @@ async def test_get_monitored_nodes_with_valid_label(
 async def test_remove_monitored_down_nodes_with_empty_list_does_nothing(
     autoscaling_docker: AutoscalingDocker,
 ):
-    assert await remove_monitored_down_nodes(autoscaling_docker, []) == []
+    assert await remove_nodes(autoscaling_docker, []) == []
 
 
 async def test_remove_monitored_down_nodes_of_non_down_node_does_nothing(
     autoscaling_docker: AutoscalingDocker,
     host_node: Node,
 ):
-    assert await remove_monitored_down_nodes(autoscaling_docker, [host_node]) == []
+    assert await remove_nodes(autoscaling_docker, [host_node]) == []
 
 
 @pytest.fixture
@@ -166,9 +166,9 @@ async def test_remove_monitored_down_nodes_of_down_node(
     assert fake_docker_node.Status
     fake_docker_node.Status.State = NodeState.down
     assert fake_docker_node.Status.State == NodeState.down
-    assert await remove_monitored_down_nodes(
-        autoscaling_docker, [fake_docker_node]
-    ) == [fake_docker_node]
+    assert await remove_nodes(autoscaling_docker, [fake_docker_node]) == [
+        fake_docker_node
+    ]
     # NOTE: this is the same as calling with aiodocker.Docker() as docker: docker.nodes.remove()
     mocked_aiodocker.remove.assert_called_once_with(node_id=fake_docker_node.ID)
 
@@ -180,9 +180,7 @@ async def test_remove_monitored_down_node_with_unexpected_state_does_nothing(
     assert fake_docker_node.Status
     fake_docker_node.Status = None
     assert not fake_docker_node.Status
-    assert (
-        await remove_monitored_down_nodes(autoscaling_docker, [fake_docker_node]) == []
-    )
+    assert await remove_nodes(autoscaling_docker, [fake_docker_node]) == []
 
 
 async def test_pending_service_task_with_insufficient_resources_with_no_service(

--- a/services/autoscaling/tests/unit/test_utils_rabbitmq.py
+++ b/services/autoscaling/tests/unit/test_utils_rabbitmq.py
@@ -47,7 +47,7 @@ async def test_post_log_message(
     mocker: MockerFixture,
     async_docker_client: aiodocker.Docker,
     create_service: Callable[
-        [dict[str, Any], dict[str, str]], Awaitable[Mapping[str, Any]]
+        [dict[str, Any], dict[str, str], str], Awaitable[Mapping[str, Any]]
     ],
     task_template: dict[str, Any],
     osparc_docker_label_keys: SimcoreServiceDockerLabelKeys,
@@ -59,8 +59,7 @@ async def test_post_log_message(
     )
 
     service_with_labels = await create_service(
-        task_template,
-        osparc_docker_label_keys.to_docker_labels(),
+        task_template, osparc_docker_label_keys.to_docker_labels(), "running"
     )
     service_tasks = parse_obj_as(
         list[Task],
@@ -98,11 +97,13 @@ async def test_post_log_message_does_not_raise_if_service_has_no_labels(
     disabled_ec2: None,
     initialized_app: FastAPI,
     async_docker_client: aiodocker.Docker,
-    create_service: Callable[[dict[str, Any]], Awaitable[Mapping[str, Any]]],
+    create_service: Callable[
+        [dict[str, Any], dict[str, Any], str], Awaitable[Mapping[str, Any]]
+    ],
     task_template: dict[str, Any],
     faker: Faker,
 ):
-    service_without_labels = await create_service(task_template)
+    service_without_labels = await create_service(task_template, {}, "running")
     service_tasks = parse_obj_as(
         list[Task],
         await async_docker_client.tasks.list(

--- a/services/autoscaling/tests/unit/test_utils_rabbitmq.py
+++ b/services/autoscaling/tests/unit/test_utils_rabbitmq.py
@@ -4,7 +4,7 @@
 # pylint:disable=too-many-arguments
 
 
-from typing import Any, Awaitable, Callable, Mapping
+from typing import Any, Awaitable, Callable
 
 import aiodocker
 from faker import Faker
@@ -47,9 +47,7 @@ async def test_post_log_message(
     rabbit_client: RabbitMQClient,
     mocker: MockerFixture,
     async_docker_client: aiodocker.Docker,
-    create_service: Callable[
-        [dict[str, Any], dict[str, str], str], Awaitable[Mapping[str, Any]]
-    ],
+    create_service: Callable[[dict[str, Any], dict[str, str], str], Awaitable[Service]],
     task_template: dict[str, Any],
     osparc_docker_label_keys: SimcoreServiceDockerLabelKeys,
     faker: Faker,
@@ -62,10 +60,11 @@ async def test_post_log_message(
     service_with_labels = await create_service(
         task_template, osparc_docker_label_keys.to_docker_labels(), "running"
     )
+    assert service_with_labels.Spec
     service_tasks = parse_obj_as(
         list[Task],
         await async_docker_client.tasks.list(
-            filters={"service": service_with_labels["Spec"]["Name"]}
+            filters={"service": service_with_labels.Spec.Name}
         ),
     )
     assert service_tasks


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?
This PR brings a mechanism to scale down the nodes created by the autoscaling application. (concerns only AWS deployments).

The following concepts were already known:
- A monitored node is a node with labels defined as in ```NODES_MONITORING_NODE_LABELS```
- An observed service is a service with labels defined as in ```NODES_MONITORING_SERVICE_LABELS``` (also its tasks are labeled the same)
- The autoscaling service scales up the cluster with fitting machines when it detects observed services that are pending resources (one at a time for now)
- The new EC2 instances are connected to the swarm in ```drain``` mode, labelled accordingly  and then made ```active``` so that the swarm can schedule the services on them

The following concepts are new:
- When a node is not running any observed service anymore, it is first set to ```drain``` (this will prevent the swarm from scheduling anything there)
- A drained node is kept around until the time since its start is above ```EC2_INSTANCES_TIME_BEFORE_TERMINATION``` (defaults to 55 minutes) modulo one hour. E.G. every started hour costs the same amount of money, therefore we can keep the instance around.
- If a drained node exceeds the ```EC2_INSTANCES_TIME_BEFORE_TERMINATION``` then it will be terminated and removed from the swarm
- If a new pending service appears, and there are still some drained nodes around that could handle the service, then they will be used before scaling up --> no need to wait 3 minutes in that case
<!-- Explain REVIEWERS what is this PR about -->


### NOTE: this is not yet sending a message in rabbit MQ prior to termination. this will come later.

test coverage kept at around 99%

## Related issue/s

#3627 
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
