### PR TITLE
✨ Groups Templates (and Services!) by Shared with

### DIFF
--- a/services/static-webserver/client/source/class/osparc/component/permissions/ShareWith.js
+++ b/services/static-webserver/client/source/class/osparc/component/permissions/ShareWith.js
@@ -35,17 +35,17 @@ qx.Class.define("osparc.component.permissions.ShareWith", {
     const store = osparc.store.Store.getInstance();
     Promise.all([
       store.getGroupsMe(),
-      store.getGroupsAll()
+      store.getGroupEveryone()
     ])
       .then(values => {
         const groupMe = values[0];
-        const groupAll = values[1];
+        const groupEveryone = values[1];
         this.__rbManager.getChildren().forEach(rb => {
           if (rb.contextId === this.self().SharingOpts["me"].contextId) {
             rb.gid = groupMe["gid"];
           }
           if (rb.contextId === this.self().SharingOpts["all"].contextId) {
-            rb.gid = groupAll["gid"];
+            rb.gid = groupEveryone["gid"];
           }
         });
       });

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
@@ -217,19 +217,19 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
 
         const store = osparc.store.Store.getInstance();
         Promise.all([
-          store.getGroupsAll(),
+          store.getGroupEveryone(),
           store.getVisibleMembers(),
           store.getGroupsOrganizations()
         ])
           .then(values => {
-            const all = values[0];
+            const everyone = values[0];
             const orgMembs = [];
             const orgMembers = values[1];
             for (const gid of Object.keys(orgMembers)) {
               orgMembs.push(orgMembers[gid]);
             }
             const orgs = values.length === 3 ? values[2] : [];
-            const groups = [orgMembs, orgs, [all]];
+            const groups = [orgMembs, orgs, [everyone]];
             this.__setSharedIcon(sharedIcon, value, groups);
           });
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/GroupedToggleButtonContainer.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GroupedToggleButtonContainer.js
@@ -89,6 +89,15 @@ qx.Class.define("osparc.dashboard.GroupedToggleButtonContainer", {
             allowGrowX: false,
             backgroundColor: "background-main-1"
           });
+          control.getChildControl("icon").set({
+            scale: true,
+            allowGrowX: true,
+            allowGrowY: true,
+            allowShrinkX: true,
+            allowShrinkY: true,
+            maxWidth: 32,
+            maxHeight: 32
+          });
           control.getContentElement().setStyles({
             "border-top-left-radius": "4px",
             "border-top-right-radius": "4px"

--- a/services/static-webserver/client/source/class/osparc/dashboard/ListButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ListButtonItem.js
@@ -209,19 +209,19 @@ qx.Class.define("osparc.dashboard.ListButtonItem", {
 
         const store = osparc.store.Store.getInstance();
         Promise.all([
-          store.getGroupsAll(),
+          store.getGroupEveryone(),
           store.getVisibleMembers(),
           store.getGroupsOrganizations()
         ])
           .then(values => {
-            const all = values[0];
+            const everyone = values[0];
             const orgMembs = [];
             const orgMembers = values[1];
             for (const gid of Object.keys(orgMembers)) {
               orgMembs.push(orgMembers[gid]);
             }
             const orgs = values.length === 3 ? values[2] : [];
-            const groups = [orgMembs, orgs, [all]];
+            const groups = [orgMembs, orgs, [everyone]];
             this.__setSharedIcon(sharedIcon, value, groups);
           });
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
@@ -177,6 +177,8 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
         viewByMenu.add(btn);
         groupOptions.add(btn);
       });
+
+      this._secondaryBar.add(this.__viewMenuButton);
     },
 
     /**

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
@@ -161,6 +161,38 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
       this._reloadCards();
     },
 
+    _addGroupByButton: function() {
+      const groupByMenu = new qx.ui.menu.Menu().set({
+        font: "text-14"
+      });
+      const groupByButton = new qx.ui.form.MenuButton(this.tr("Group"), "@FontAwesome5Solid/chevron-down/10", groupByMenu);
+      osparc.utils.Utils.setIdToWidget(groupByButton, "groupByButton");
+
+      const dontGroup = new qx.ui.menu.RadioButton(this.tr("None"));
+      osparc.utils.Utils.setIdToWidget(dontGroup, "groupByNone");
+      dontGroup.addListener("execute", () => this._groupByChanged(null));
+      const tagByGroup = new qx.ui.menu.RadioButton(this.tr("Tags"));
+      tagByGroup.addListener("execute", () => this._groupByChanged("tags"));
+      const groupByShared = new qx.ui.menu.RadioButton(this.tr("Shared with"));
+      groupByShared.addListener("execute", () => this._groupByChanged("shared"));
+
+      const groupOptions = new qx.ui.form.RadioGroup();
+      [
+        dontGroup,
+        tagByGroup,
+        groupByShared
+      ].forEach(btn => {
+        groupByMenu.add(btn);
+        groupOptions.add(btn);
+      });
+
+      if (osparc.utils.Utils.isProduct("s4llite")) {
+        tagByGroup.execute();
+      }
+
+      this._secondaryBar.add(groupByButton);
+    },
+
     _addViewModeButton: function() {
       const viewByMenu = this.__viewMenuButton.getMenu();
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
@@ -280,7 +280,14 @@ qx.Class.define("osparc.dashboard.ResourceContainerManager", {
           });
         }
       } else if (this.getGroupBy() === "shared") {
-        const orgIds = resourceData.accessRights ? Object.keys(resourceData.accessRights) : [];
+        let orgIds = [];
+        if ("accessRights" in resourceData) {
+          // study or templates
+          orgIds = Object.keys(resourceData["accessRights"]);
+        } else if ("access_rights" in resourceData) {
+          // services
+          orgIds = Object.keys(resourceData["access_rights"]);
+        }
         if (orgIds.length === 0) {
           let noGroupContainer = this.__getGroupContainer("no-group");
           const card = this.__createCard(resourceData, tags);

--- a/services/static-webserver/client/source/class/osparc/dashboard/ServiceBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ServiceBrowser.js
@@ -156,6 +156,7 @@ qx.Class.define("osparc.dashboard.ServiceBrowser", {
         flex: 1
       });
       this.__addSortingButtons();
+      this._addGroupByButton();
       this._addViewModeButton();
 
       return this._resourcesContainer;

--- a/services/static-webserver/client/source/class/osparc/dashboard/TemplateBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/TemplateBrowser.js
@@ -155,11 +155,14 @@ qx.Class.define("osparc.dashboard.TemplateBrowser", {
       dontGroup.addListener("execute", () => this._groupByChanged(null));
       const tagByGroup = new qx.ui.menu.RadioButton(this.tr("Tags"));
       tagByGroup.addListener("execute", () => this._groupByChanged("tags"));
+      const groupByShared = new qx.ui.menu.RadioButton(this.tr("Shared with"));
+      groupByShared.addListener("execute", () => this._groupByChanged("shared"));
 
       const groupOptions = new qx.ui.form.RadioGroup();
       [
         dontGroup,
-        tagByGroup
+        tagByGroup,
+        groupByShared
       ].forEach(btn => {
         groupByMenu.add(btn);
         groupOptions.add(btn);

--- a/services/static-webserver/client/source/class/osparc/dashboard/TemplateBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/TemplateBrowser.js
@@ -135,44 +135,10 @@ qx.Class.define("osparc.dashboard.TemplateBrowser", {
       this._secondaryBar.add(new qx.ui.core.Spacer(), {
         flex: 1
       });
-      const groupByButton = this.__createGroupByButton();
-      this._secondaryBar.add(groupByButton);
-
+      this._addGroupByButton();
       this._addViewModeButton();
 
       return this._resourcesContainer;
-    },
-
-    __createGroupByButton: function() {
-      const groupByMenu = new qx.ui.menu.Menu().set({
-        font: "text-14"
-      });
-      const groupByButton = new qx.ui.form.MenuButton(this.tr("Group"), "@FontAwesome5Solid/chevron-down/10", groupByMenu);
-      osparc.utils.Utils.setIdToWidget(groupByButton, "groupByButton");
-
-      const dontGroup = new qx.ui.menu.RadioButton(this.tr("None"));
-      osparc.utils.Utils.setIdToWidget(dontGroup, "groupByNone");
-      dontGroup.addListener("execute", () => this._groupByChanged(null));
-      const tagByGroup = new qx.ui.menu.RadioButton(this.tr("Tags"));
-      tagByGroup.addListener("execute", () => this._groupByChanged("tags"));
-      const groupByShared = new qx.ui.menu.RadioButton(this.tr("Shared with"));
-      groupByShared.addListener("execute", () => this._groupByChanged("shared"));
-
-      const groupOptions = new qx.ui.form.RadioGroup();
-      [
-        dontGroup,
-        tagByGroup,
-        groupByShared
-      ].forEach(btn => {
-        groupByMenu.add(btn);
-        groupOptions.add(btn);
-      });
-
-      if (osparc.utils.Utils.isProduct("s4llite")) {
-        tagByGroup.execute();
-      }
-
-      return groupByButton;
     },
     // LAYOUT //
 

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -369,14 +369,12 @@ qx.Class.define("osparc.store.Store", {
     },
 
     __getGroups: function(group) {
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         osparc.data.Resources.getOne("profile")
           .then(profile => {
             resolve(profile["groups"][group]);
           })
-          .catch(err => {
-            console.error(err);
-          });
+          .catch(err => console.error(err));
       });
     },
 
@@ -392,7 +390,7 @@ qx.Class.define("osparc.store.Store", {
       return this.__getGroups("all");
     },
 
-    getAllGroups: function() {
+    __getAllGroups: function() {
       return new Promise(resolve => {
         const promises = [];
         promises.push(this.getGroupsMe());
@@ -401,10 +399,30 @@ qx.Class.define("osparc.store.Store", {
         Promise.all(promises)
           .then(values => {
             const groups = [];
-            groups.push(values[0]);
-            values[1].forEach(org => groups.push(org));
-            groups.push(values[2]);
+            const groupMe = values[0];
+            groupMe["groupType"] = 2;
+            groups.push(groupMe);
+            values[1].forEach(org => {
+              org["groupType"] = 1;
+              groups.push(org);
+            });
+            const groupEveryone = values[2];
+            groupEveryone["groupType"] = 0;
+            groups.push(groupEveryone);
             resolve(groups);
+          });
+      });
+    },
+
+    getOrganization: function(orgId) {
+      return new Promise(resolve => {
+        this.__getAllGroups()
+          .then(orgs => {
+            const idx = orgs.findIndex(org => org.gid === parseInt(orgId));
+            if (idx > -1) {
+              resolve(orgs[idx]);
+            }
+            resolve(null);
           });
       });
     },

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -388,28 +388,22 @@ qx.Class.define("osparc.store.Store", {
       return this.__getGroups("organizations");
     },
 
-    getGroupsAll: function() {
+    getGroupEveryone: function() {
       return this.__getGroups("all");
     },
 
-    getGroups: function(withMySelf = true) {
-      return new Promise((resolve, reject) => {
+    getAllGroups: function() {
+      return new Promise(resolve => {
         const promises = [];
+        promises.push(this.getGroupsMe());
         promises.push(this.getGroupsOrganizations());
-        promises.push(this.getGroupsAll());
-        if (withMySelf) {
-          promises.push(this.getGroupsMe());
-        }
+        promises.push(this.getGroupEveryone());
         Promise.all(promises)
           .then(values => {
             const groups = [];
-            values[0].forEach(value => {
-              groups.push(value);
-            });
-            groups.push(values[1]);
-            if (withMySelf) {
-              groups.push(values[2]);
-            }
+            groups.push(values[0]);
+            values[1].forEach(org => groups.push(org));
+            groups.push(values[2]);
             resolve(groups);
           });
       });


### PR DESCRIPTION
## What do these changes do?

We can now group Templates by "Shared with"

The grouping functionality is also available for Services!

Group by "Shared with"
![SharedWith](https://user-images.githubusercontent.com/33152403/207339637-f22d6125-cf1e-46c0-b108-0fd5f63175ad.gif)

Group Services
![GroupServices](https://user-images.githubusercontent.com/33152403/207360850-ec97a556-63ec-4e52-84ea-9832c4fca088.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
