### PR TITLE
🐛Introduce timeout in project lock (a la aioredlock)

### DIFF
--- a/packages/service-library/src/servicelib/background_task.py
+++ b/packages/service-library/src/servicelib/background_task.py
@@ -73,13 +73,13 @@ async def periodic_task(
     interval: datetime.timedelta,
     task_name: str,
     **kwargs,
-) -> AsyncIterator[None]:
+) -> AsyncIterator[asyncio.Task]:
     asyncio_task = None
     try:
         asyncio_task = await start_periodic_task(
             task, interval=interval, task_name=task_name, **kwargs
         )
-        yield
+        yield asyncio_task
     finally:
         if asyncio_task is not None:
             await stop_periodic_task(asyncio_task)

--- a/services/web/server/tests/unit/with_dbs/03/test_redis.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_redis.py
@@ -3,11 +3,14 @@
 # pylint:disable=redefined-outer-name
 
 import asyncio
+import datetime
 
 import pytest
 import redis
 import redis.asyncio as aioredis
 from faker import Faker
+from redis.asyncio.lock import Lock
+from servicelib.background_task import periodic_task
 
 
 async def test_aioredis(redis_client: aioredis.Redis, faker: Faker):
@@ -19,12 +22,29 @@ async def test_aioredis(redis_client: aioredis.Redis, faker: Faker):
 
 
 async def test_lock_acquisition(redis_client: aioredis.Redis, faker: Faker):
-    lock = redis_client.lock(faker.pystr())
+    lock_name = faker.pystr()
+    lock = redis_client.lock(lock_name)
     assert not await lock.locked()
 
     # Try to acquire the lock:
     lock_acquired = await lock.acquire(blocking=False)
-    assert lock_acquired, "Lock not acquired"
+    assert lock_acquired is True
+    assert await lock.locked() is True
+    assert await lock.owned() is True
+    with pytest.raises(redis.exceptions.LockError):
+        # a lock with no timeout cannot be reacquired
+        await lock.reacquire()
+    with pytest.raises(redis.exceptions.LockError):
+        # a lock with no timeout cannot be extended
+        await lock.extend(2)
+
+    # try to acquire the lock a second time
+    same_lock = redis_client.lock(lock_name)
+    assert await same_lock.locked() is True
+    assert await same_lock.owned() is False
+    assert await same_lock.acquire(blocking=False) is False
+
+    # now release the lock
     await lock.release()
     assert not await lock.locked()
     assert not await lock.owned()
@@ -38,9 +58,14 @@ async def test_lock_context_manager(redis_client: aioredis.Redis, faker: Faker):
     async with lock:
         assert await lock.locked()
         assert await lock.owned()
-        # a lock with no timeout cannot be extended
         with pytest.raises(redis.exceptions.LockError):
+            # a lock with no timeout cannot be reacquired
+            await lock.reacquire()
+
+        with pytest.raises(redis.exceptions.LockError):
+            # a lock with no timeout cannot be extended
             await lock.extend(2)
+
         # try to acquire the lock a second time
         same_lock = redis_client.lock(lock_name, blocking_timeout=1)
         assert await same_lock.locked()
@@ -52,8 +77,15 @@ async def test_lock_context_manager(redis_client: aioredis.Redis, faker: Faker):
     assert not await lock.locked()
 
 
-async def test_lock_with_ttl(redis_client: aioredis.Redis, faker: Faker):
-    ttl_lock = redis_client.lock(faker.pystr(), timeout=2, blocking_timeout=1)
+@pytest.fixture
+def lock_timeout() -> datetime.timedelta:
+    return datetime.timedelta(seconds=2)
+
+
+async def test_lock_with_ttl(
+    redis_client: aioredis.Redis, faker: Faker, lock_timeout: datetime.timedelta
+):
+    ttl_lock = redis_client.lock(faker.pystr(), timeout=lock_timeout.total_seconds())
     assert not await ttl_lock.locked()
 
     with pytest.raises(redis.exceptions.LockNotOwnedError):
@@ -61,5 +93,27 @@ async def test_lock_with_ttl(redis_client: aioredis.Redis, faker: Faker):
         async with ttl_lock:
             assert await ttl_lock.locked()
             assert await ttl_lock.owned()
-            await asyncio.sleep(3)
+            await asyncio.sleep(2 * lock_timeout.total_seconds())
             assert not await ttl_lock.locked()
+
+
+async def test_lock_with_auto_extent(
+    redis_client: aioredis.Redis, faker: Faker, lock_timeout: datetime.timedelta
+):
+    ttl_lock = redis_client.lock(faker.pystr(), timeout=lock_timeout.total_seconds())
+    assert not await ttl_lock.locked()
+
+    async def _auto_extend_lock(lock: Lock) -> None:
+        assert await lock.reacquire() is True
+
+    async with ttl_lock, periodic_task(
+        _auto_extend_lock,
+        interval=0.6 * lock_timeout,
+        task_name=f"{ttl_lock.name}_auto_extend",
+        lock=ttl_lock,
+    ):
+        assert await ttl_lock.locked()
+        assert await ttl_lock.owned()
+        await asyncio.sleep(5 * lock_timeout.total_seconds())
+        assert await ttl_lock.locked()
+        assert await ttl_lock.owned()

--- a/services/web/server/tests/unit/with_dbs/03/test_redis.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_redis.py
@@ -7,17 +7,19 @@ import asyncio
 import pytest
 import redis
 import redis.asyncio as aioredis
+from faker import Faker
 
 
-async def test_aioredis(redis_client: aioredis.Redis):
-    await redis_client.set("my-key", "value")
-    val = await redis_client.get("my-key")
-    assert val == "value"
+async def test_aioredis(redis_client: aioredis.Redis, faker: Faker):
+    key = faker.pystr()
+    value = faker.pystr()
+    await redis_client.set(key, value)
+    val = await redis_client.get(key)
+    assert val == value
 
 
-async def test_redlocks_features(redis_client: aioredis.Redis):
-    # Check wether a resourece acquired by any other redlock instance:
-    lock = redis_client.lock("resource_name")
+async def test_lock_acquisition(redis_client: aioredis.Redis, faker: Faker):
+    lock = redis_client.lock(faker.pystr())
     assert not await lock.locked()
 
     # Try to acquire the lock:
@@ -27,7 +29,12 @@ async def test_redlocks_features(redis_client: aioredis.Redis):
     assert not await lock.locked()
     assert not await lock.owned()
 
-    # use as context manager
+
+async def test_lock_context_manager(redis_client: aioredis.Redis, faker: Faker):
+    lock_name = faker.pystr()
+    lock = redis_client.lock(lock_name)
+    assert not await lock.locked()
+
     async with lock:
         assert await lock.locked()
         assert await lock.owned()
@@ -35,7 +42,7 @@ async def test_redlocks_features(redis_client: aioredis.Redis):
         with pytest.raises(redis.exceptions.LockError):
             await lock.extend(2)
         # try to acquire the lock a second time
-        same_lock = redis_client.lock("resource_name", blocking_timeout=1)
+        same_lock = redis_client.lock(lock_name, blocking_timeout=1)
         assert await same_lock.locked()
         assert not await same_lock.owned()
         assert await same_lock.acquire() == False
@@ -44,9 +51,11 @@ async def test_redlocks_features(redis_client: aioredis.Redis):
                 ...
     assert not await lock.locked()
 
-    # now create a lock with a ttl
-    ttl_lock = redis_client.lock("ttl_resource", timeout=2, blocking_timeout=1)
+
+async def test_lock_with_ttl(redis_client: aioredis.Redis, faker: Faker):
+    ttl_lock = redis_client.lock(faker.pystr(), timeout=2, blocking_timeout=1)
     assert not await ttl_lock.locked()
+
     with pytest.raises(redis.exceptions.LockNotOwnedError):
         # this raises as the lock is lost
         async with ttl_lock:

--- a/services/web/server/tests/unit/with_dbs/03/test_redis.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_redis.py
@@ -112,8 +112,10 @@ async def test_lock_with_auto_extent(
         task_name=f"{ttl_lock.name}_auto_extend",
         lock=ttl_lock,
     ):
-        assert await ttl_lock.locked()
-        assert await ttl_lock.owned()
+        assert await ttl_lock.locked() is True
+        assert await ttl_lock.owned() is True
         await asyncio.sleep(5 * lock_timeout.total_seconds())
-        assert await ttl_lock.locked()
-        assert await ttl_lock.owned()
+        assert await ttl_lock.locked() is True
+        assert await ttl_lock.owned() is True
+    assert await ttl_lock.locked() is False
+    assert await ttl_lock.owned() is False


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?
Previously we were using aioredlock to lock projects. When we migrated to redis-py, we lost the automatic timeout extension of distributed locks. This probably led to the following issues:
https://github.com/ITISFoundation/osparc-issues/issues/724
https://github.com/ITISFoundation/osparc-simcore/issues/3145

in case of a crash in the webserver, these locks would never timeout.

This PR aims to fix this by mimicking the behavior of aioredlock (default timeout of 10 seconds, with auto-extension every 6 seconds). In case the webserver would restart/crash without having the time to release the lock, this would ensure the lock is released at some point.
This PR just fixes the ProjectLock, all the other locks are not concerned with this change.

just looking at master's redis-commander shows how this is a problem, most of these locks are lost:
![image](https://user-images.githubusercontent.com/35365065/207461940-a7734ebb-6d75-4f47-9a82-4c0921a116b5.png)

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
