### PR TITLE
🐛fixed test blocking CI in director-v2 unittests

### DIFF
--- a/services/director-v2/tests/unit/with_dbs/test_api_route_dynamic_services.py
+++ b/services/director-v2/tests/unit/with_dbs/test_api_route_dynamic_services.py
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture
 def minimal_config(
+    disable_rabbitmq: None,
     mock_env: EnvVarsDict,
     postgres_host_config: dict[str, str],
     monkeypatch: MonkeyPatch,

--- a/services/director-v2/tests/unit/with_dbs/test_api_route_dynamic_services.py
+++ b/services/director-v2/tests/unit/with_dbs/test_api_route_dynamic_services.py
@@ -78,7 +78,7 @@ def dynamic_sidecar_headers() -> dict[str, str]:
 
 
 @pytest.fixture(scope="function")
-def mock_env(monkeypatch: MonkeyPatch) -> None:
+def mock_env(disable_rabbitmq: None, monkeypatch: MonkeyPatch) -> None:
     # Works as below line in docker.compose.yml
     # ${DOCKER_REGISTRY:-itisfoundation}/dynamic-sidecar:${DOCKER_IMAGE_TAG:-latest}
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

How this test passed the CI is a complete mystery to me! @sanderegg or @pcrespov any ideas?

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

Not sure why the CI passed on this test.


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
