### PR TITLE
🐛 Metrics: ensure instrumentation messages are treated only once

### DIFF
--- a/services/web/server/src/simcore_service_webserver/computation_subscribe.py
+++ b/services/web/server/src/simcore_service_webserver/computation_subscribe.py
@@ -119,22 +119,22 @@ EXCHANGE_TO_PARSER_CONFIG = (
     (
         LoggerRabbitMessage.get_channel_name(),
         log_message_parser,
-        {"no_ack": True},
+        {},
     ),
     (
         ProgressRabbitMessage.get_channel_name(),
         progress_message_parser,
-        {"no_ack": True},
+        {},
     ),
     (
         InstrumentationRabbitMessage.get_channel_name(),
         instrumentation_message_parser,
-        {"no_ack": False},
+        dict(exclusive_queue=False),
     ),
     (
         EventRabbitMessage.get_channel_name(),
         events_message_parser,
-        {"no_ack": False},
+        {},
     ),
 )
 
@@ -151,9 +151,9 @@ async def setup_rabbitmq_consumer(app: web.Application) -> AsyncIterator[None]:
     ):
         rabbit_client = RabbitMQClient("webserver", settings)
 
-        for exchange_name, parser_fct, _exchange_kwargs in EXCHANGE_TO_PARSER_CONFIG:
+        for exchange_name, parser_fct, queue_kwargs in EXCHANGE_TO_PARSER_CONFIG:
             await rabbit_client.subscribe(
-                exchange_name, functools.partial(parser_fct, app)
+                exchange_name, functools.partial(parser_fct, app), **queue_kwargs
             )
 
     yield


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?
Since @mrnicegyu11 fixed how prometheus scrapes instances of the webserver, the metrics coming out of it were multiplied by the number of instances. The bugfix was correct, but then the metrics were wrong.
The final issue was identified as being a flaw in how the webserver gets the metrics out of RabbitMQ.
It was using ```exclusive``` queues (1 per instance of the webserver), thus replicating the metrics in all instances.
Now it uses a non-exclusive queue to this end.

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s
fixes https://github.com/ITISFoundation/osparc-simcore/issues/3472
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
