### PR TITLE
⚗️ Truncate DB instead of downgrading each time

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_postgres.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_postgres.py
@@ -8,7 +8,26 @@ from simcore_postgres_database.models.base import metadata
 
 
 @contextmanager
+def _foreign_key_checks(engine, enabled=True):
+    # Disable foreign key constraints
+    with engine.begin() as conn:
+        conn.execute("SET CONSTRAINTS ALL DEFERRED")
+    try:
+        yield
+    finally:
+        # Enable foreign key constraints
+        with engine.begin() as conn:
+            conn.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+
+from sqlalchemy import MetaData
+from simcore_postgres_database.models.groups import GroupType, groups
+from simcore_postgres_database.models.products import products
+
+
+@contextmanager
 def migrated_pg_tables_context(
+    engine,
     postgres_config: dict[str, str],
 ) -> Iterator[dict[str, Any]]:
     """
@@ -28,20 +47,42 @@ def migrated_pg_tables_context(
 
     yield cfg
 
+    metadata = MetaData()
+    metadata.reflect(bind=engine)
+    tables = metadata.tables.values()
+
+    # Truncate all the tables
+    with _foreign_key_checks(engine, enabled=False):
+        with engine.begin() as conn:
+            for table in tables:
+                if table.name == groups.name:
+                    # everyone group cannot be deleted
+                    conn.execute(
+                        groups.delete().where(groups.c.type != GroupType.EVERYONE)
+                    )
+                elif table.name == products.name:
+                    # there is a default entry
+                    conn.execute(products.delete().where(products.c.name != "osparc"))
+                elif table.name == "alembic_version":
+                    # this should not be touched
+                    continue
+                else:
+                    conn.execute(table.delete())
+
     # downgrades database to zero ---
     #
     # NOTE: This step CANNOT be avoided since it would leave the db in an invalid state
     # E.g. 'alembic_version' table is not deleted and keeps head version or routines
     # like 'notify_comp_tasks_changed' remain undeleted
     #
-    simcore_postgres_database.cli.downgrade.callback("base")
-    simcore_postgres_database.cli.clean.callback()  # just cleans discover cache
+    # simcore_postgres_database.cli.downgrade.callback("base")
+    # simcore_postgres_database.cli.clean.callback()  # just cleans discover cache
 
     # FIXME: migration downgrade fails to remove User types
     # SEE https://github.com/ITISFoundation/osparc-simcore/issues/1776
     # Added drop_all as tmp fix
-    postgres_engine = sa.create_engine(cfg["dsn"])
-    metadata.drop_all(bind=postgres_engine)
+    # postgres_engine = sa.create_engine(cfg["dsn"])
+    # metadata.drop_all(bind=postgres_engine)
 
 
 def is_postgres_responsive(url) -> bool:

--- a/packages/pytest-simcore/src/pytest_simcore/postgres_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/postgres_service.py
@@ -191,7 +191,7 @@ def postgres_db(
 ) -> Iterator[sa.engine.Engine]:
     """An postgres database init with empty tables and an sqlalchemy engine connected to it"""
 
-    with migrated_pg_tables_context(postgres_dsn.copy()):
+    with migrated_pg_tables_context(postgres_engine, postgres_dsn.copy()):
         yield postgres_engine
 
 

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -531,11 +531,6 @@ async def post_trigger_connected_service_retrieve(
     )
 
 
-#
-# OPEN PROJECT -------------------------------------------------------------------
-#
-
-
 async def _user_has_another_client_open(
     user_session_id_list: list[UserSessionID], app: web.Application
 ) -> bool:

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -24,7 +24,6 @@ import pytest
 import redis
 import redis.asyncio as aioredis
 import simcore_postgres_database.cli as pg_cli
-import simcore_service_webserver.db_models as orm
 import simcore_service_webserver.utils
 import sqlalchemy as sa
 from aiohttp import web


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
