### PR TITLE
🐛 Edit templates: missing lock when opening dashboard

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -796,12 +796,10 @@ async def add_project_states_for_user(
         f"{project['uuid']=}",
     )
     # for templates: the project is never locked and never opened. also the running state is always unknown
-    lock_state = ProjectLocked(value=False, status=ProjectStatus.CLOSED)
+    lock_state = await _get_project_lock_state(user_id, project["uuid"], app)
     running_state = RunningState.UNKNOWN
 
     if not is_template:
-        lock_state = await _get_project_lock_state(user_id, project["uuid"], app)
-
         if computation_task := await director_v2_api.get_computation_task(
             app, user_id, project["uuid"]
         ):


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?
Ensure the lock state is passed to the frontend when listing projects.
![image](https://user-images.githubusercontent.com/35365065/208670683-5f954c81-04ef-46fe-b0e4-00e29225518a.png)

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
