### PR TITLE
🐛 Bugfixes Lock on Study card & Update card

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
@@ -129,6 +129,12 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
       this.__viewMenuButton = new qx.ui.form.MenuButton(this.tr("View"), "@FontAwesome5Solid/chevron-down/10", viewByMenu);
 
       const resourcesContainer = this._resourcesContainer = new osparc.dashboard.ResourceContainerManager();
+
+      resourcesContainer.addListener("updateStudy", e => this._updateStudyData(e.getData()));
+      resourcesContainer.addListener("updateTemplate", e => this._updateTemplateData(e.getData()));
+      resourcesContainer.addListener("updateService", e => this._updateServiceData(e.getData()));
+      resourcesContainer.addListener("publishTemplate", e => this.fireDataEvent("publishTemplate", e.getData()));
+
       this._add(resourcesContainer);
     },
 
@@ -253,25 +259,6 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
       }
     },
 
-    _createStudyItem: function(resourceData) {
-      const item = this._resourcesContainer.getMode() === "grid" ? new osparc.dashboard.GridButtonItem() : new osparc.dashboard.ListButtonItem();
-
-      const tags = resourceData.tags ? osparc.store.Store.getInstance().getTags().filter(tag => resourceData.tags.includes(tag.id)) : [];
-      item.set({
-        resourceData,
-        tags
-      });
-
-      const menu = new qx.ui.menu.Menu().set({
-        position: "bottom-right"
-      });
-      item.setMenu(menu);
-      this._populateCardMenu(menu, resourceData);
-      item.subscribeToFilterGroup("searchBarFilter");
-
-      return item;
-    },
-
     _taskDataReceived: function(taskData) {
       throw new Error("Abstract method called!");
     },
@@ -303,18 +290,9 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
         const moreOpts = new osparc.dashboard.ResourceMoreOptions(resourceData);
         const title = this.tr("More options");
         const win = osparc.ui.window.Window.popUpInWindow(moreOpts, title, 750, 725);
-        moreOpts.addListener("updateStudy", e => {
-          const updatedStudyData = e.getData();
-          this._updateStudyData(updatedStudyData);
-        });
-        moreOpts.addListener("updateTemplate", e => {
-          const updatedTemplateData = e.getData();
-          this._updateTemplateData(updatedTemplateData);
-        });
-        moreOpts.addListener("updateService", e => {
-          const updatedServiceData = e.getData();
-          this._updateServiceData(updatedServiceData);
-        });
+        moreOpts.addListener("updateStudy", e => this._updateStudyData(e.getData()));
+        moreOpts.addListener("updateTemplate", e => this._updateTemplateData(e.getData()));
+        moreOpts.addListener("updateService", e => this._updateServiceData(e.getData()));
         moreOpts.addListener("publishTemplate", e => {
           win.close();
           this.fireDataEvent("publishTemplate", e.getData());

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
@@ -54,6 +54,10 @@ qx.Class.define("osparc.dashboard.ResourceContainerManager", {
   },
 
   events: {
+    "updateStudy": "qx.event.type.Data",
+    "updateTemplate": "qx.event.type.Data",
+    "updateService": "qx.event.type.Data",
+    "publishTemplate": "qx.event.type.Data",
     "changeSelection": "qx.event.type.Data",
     "changeVisibility": "qx.event.type.Data"
   },

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
@@ -197,6 +197,14 @@ qx.Class.define("osparc.dashboard.ResourceContainerManager", {
       });
       card.setMenu(menu);
       card.subscribeToFilterGroup("searchBarFilter");
+
+      [
+        "updateStudy",
+        "updateTemplate",
+        "updateService",
+        "publishTemplate"
+      ].forEach(ev => card.addListener(ev, e => this.fireDataEvent(ev, e.getData())));
+
       return card;
     },
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -271,12 +271,9 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     },
 
     __attachEventHandlers: function() {
-      // Listen to socket
       const socket = osparc.wrapper.WebSocket.getInstance();
-      // callback for incoming logs
       const slotName = "projectStateUpdated";
-      socket.removeSlot(slotName);
-      socket.on(slotName, function(jsonString) {
+      socket.on(slotName, jsonString => {
         const data = JSON.parse(jsonString);
         if (data) {
           const studyId = data["project_uuid"];

--- a/services/static-webserver/client/source/class/osparc/dashboard/TemplateBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/TemplateBrowser.js
@@ -50,8 +50,7 @@ qx.Class.define("osparc.dashboard.TemplateBrowser", {
     __attachEventHandlers: function() {
       const socket = osparc.wrapper.WebSocket.getInstance();
       const slotName = "projectStateUpdated";
-      socket.removeSlot(slotName);
-      socket.on(slotName, function(jsonString) {
+      socket.on(slotName, jsonString => {
         const data = JSON.parse(jsonString);
         if (data) {
           const templateId = data["project_uuid"];


### PR DESCRIPTION
## What do these changes do?

This PR fixes:
- [x] When we added the locking support for templates, I stopped listening to (lock) state updates in the Study Browser.
- [x] Update card after changing metadata

![Bugfixes](https://user-images.githubusercontent.com/33152403/208912000-585bf980-691c-42c8-aa7c-e5eedcfdb28d.gif)


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
