### PR TITLE
🐛 Fixes: Load More card, Cookie text, Text on Tag and Edit template

### DIFF
--- a/services/static-webserver/client/source/class/osparc/CookiePolicy.js
+++ b/services/static-webserver/client/source/class/osparc/CookiePolicy.js
@@ -92,9 +92,9 @@ qx.Class.define("osparc.CookiePolicy", {
               if (licenseLink) {
                 const color = qx.theme.manager.Color.getInstance().resolve("text");
                 const textLink = `<a href=${licenseLink} style='color: ${color}' target='_blank'>Licensing.</a>`;
-                control.setLabel(lbl + textLink);
+                control.setValue(lbl + textLink);
               } else {
-                control.setLabel(lbl + this.tr("Licensing."));
+                control.setValue(lbl + this.tr("Licensing."));
               }
             });
           this._add(control, {

--- a/services/static-webserver/client/source/class/osparc/component/form/ColorPicker.js
+++ b/services/static-webserver/client/source/class/osparc/component/form/ColorPicker.js
@@ -36,7 +36,7 @@ qx.Class.define("osparc.component.form.ColorPicker", {
           control.addListener("execute", () => this.setColor(osparc.utils.Utils.getRandomColor()), this);
           this.bind("color", control, "backgroundColor");
           this.bind("color", control, "textColor", {
-            converter: value => osparc.utils.Utils.getContrastedTextColor(qx.theme.manager.Color.getInstance().resolve(value))
+            converter: value => qx.theme.manager.Color.getInstance().resolve(osparc.utils.Utils.getContrastedTextColor(value))
           });
           break;
         case "selector-button":
@@ -44,7 +44,7 @@ qx.Class.define("osparc.component.form.ColorPicker", {
           control.addListener("execute", () => this.__openColorSelector(), this);
           this.bind("color", control, "backgroundColor");
           this.bind("color", control, "textColor", {
-            converter: value => osparc.utils.Utils.getContrastedTextColor(qx.theme.manager.Color.getInstance().resolve(value))
+            converter: value => qx.theme.manager.Color.getInstance().resolve(osparc.utils.Utils.getContrastedTextColor(value))
           });
           break;
         case "color-input":

--- a/services/static-webserver/client/source/class/osparc/component/form/tag/TagItem.js
+++ b/services/static-webserver/client/source/class/osparc/component/form/tag/TagItem.js
@@ -175,7 +175,7 @@ qx.Class.define("osparc.component.form.tag.TagItem", {
             });
             this.__colorInput.bind("value", this.getChildControl("colorbutton"), "backgroundColor");
             this.__colorInput.bind("value", this.getChildControl("colorbutton"), "textColor", {
-              converter: value => osparc.utils.Utils.getContrastedTextColor(qx.theme.manager.Color.getInstance().resolve(value))
+              converter: value => qx.theme.manager.Color.getInstance().resolve(osparc.utils.Utils.getContrastedTextColor(value))
             });
             this.__validationManager.add(this.__colorInput, osparc.utils.Validators.hexColor);
           }

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonLoadMore.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonLoadMore.js
@@ -34,16 +34,15 @@ qx.Class.define("osparc.dashboard.GridButtonLoadMore", {
     _applyFetching: function(value) {
       const title = this.getChildControl("title");
       const desc = this.getChildControl("subtitle-text");
+      this.setIcon(osparc.dashboard.CardBase.LOADING_ICON);
       if (value) {
         title.setValue(this.tr("Loading..."));
         desc.setValue("");
-        this.setIcon(osparc.dashboard.CardBase.LOADING_ICON);
         this.getChildControl("icon").getChildControl("image").getContentElement()
           .addClass("rotate");
       } else {
         title.setValue(this.tr("Load More"));
         desc.setValue(this.tr("Click to load more").toString());
-        this.setIcon("@FontAwesome5Solid/paw/");
         this.getChildControl("icon").getChildControl("image").getContentElement()
           .removeClass("rotate");
       }

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
@@ -72,8 +72,7 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
       return (card instanceof osparc.dashboard.GridButtonItem || card instanceof osparc.dashboard.ListButtonItem);
     },
 
-    PAGINATED_STUDIES: 10,
-    MIN_FILTERED_STUDIES: 15
+    PAGINATED_STUDIES: 10
   },
 
   members: {

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -203,6 +203,8 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         fetching,
         visibility
       });
+      this._moreResourcesRequired();
+
       this._resourcesContainer.addNonResourceCard(loadMoreBtn);
 
       osparc.component.filter.UIFilterController.dispatch("searchBarFilter");
@@ -491,10 +493,8 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       loadMoreBtn.setCardKey("load-more");
       osparc.utils.Utils.setIdToWidget(loadMoreBtn, "studiesLoading");
       loadMoreBtn.addListener("execute", () => {
-        if (this._resourcesContainer.getFlatList().nextRequest !== null) {
-          this.resetSelection();
-          this.reloadResources();
-        }
+        this.setValue(false);
+        this._moreResourcesRequired();
       });
       return loadMoreBtn;
     },

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -187,12 +187,8 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     },
 
     _reloadCards: function() {
-      let fetching = false;
-      let visibility = "excluded";
-      if (this._loadingResourcesBtn) {
-        fetching = this._loadingResourcesBtn.getFetching();
-        visibility = this._loadingResourcesBtn.getVisibility();
-      }
+      const fetching = this._loadingResourcesBtn ? this._loadingResourcesBtn.getFetching() : false;
+      const visibility = this._loadingResourcesBtn ? this._loadingResourcesBtn.getVisibility() : "excluded";
 
       this._resourcesContainer.setResourcesToList(this._resourcesList);
       const cards = this._resourcesContainer.reloadCards("studiesList");

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -193,14 +193,15 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       this._resourcesContainer.setResourcesToList(this._resourcesList);
       const cards = this._resourcesContainer.reloadCards("studiesList");
       this.__configureCards(cards);
+
       this.__addNewStudyButtons();
+
       const loadMoreBtn = this.__createLoadMoreButton();
       loadMoreBtn.set({
         fetching,
         visibility
       });
       loadMoreBtn.addListener("appear", () => this._moreResourcesRequired());
-
       this._resourcesContainer.addNonResourceCard(loadMoreBtn);
 
       osparc.component.filter.UIFilterController.dispatch("searchBarFilter");

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -458,7 +458,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
 
       this.__addNewStudyButtons();
 
-      const loadMoreBtn = this.__createLoadMoreButton("studiesLoading");
+      const loadMoreBtn = this.__createLoadMoreButton();
       this._resourcesContainer.addNonResourceCard(loadMoreBtn);
 
       this.addListener("changeMultiSelection", e => {
@@ -490,6 +490,12 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       const loadMoreBtn = this._loadingResourcesBtn = (mode === "grid") ? new osparc.dashboard.GridButtonLoadMore() : new osparc.dashboard.ListButtonLoadMore();
       loadMoreBtn.setCardKey("load-more");
       osparc.utils.Utils.setIdToWidget(loadMoreBtn, "studiesLoading");
+      loadMoreBtn.addListener("execute", () => {
+        if (this._resourcesContainer.getFlatList().nextRequest !== null) {
+          this.resetSelection();
+          this.reloadResources();
+        }
+      });
       return loadMoreBtn;
     },
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -203,7 +203,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         fetching,
         visibility
       });
-      this._moreResourcesRequired();
+      loadMoreBtn.addListener("appear", () => this._moreResourcesRequired());
 
       this._resourcesContainer.addNonResourceCard(loadMoreBtn);
 
@@ -493,7 +493,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       loadMoreBtn.setCardKey("load-more");
       osparc.utils.Utils.setIdToWidget(loadMoreBtn, "studiesLoading");
       loadMoreBtn.addListener("execute", () => {
-        this.setValue(false);
+        loadMoreBtn.setValue(false);
         this._moreResourcesRequired();
       });
       return loadMoreBtn;

--- a/services/static-webserver/client/source/class/osparc/dashboard/ToggleButtonContainer.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ToggleButtonContainer.js
@@ -97,15 +97,6 @@ qx.Class.define("osparc.dashboard.ToggleButtonContainer", {
     },
 
     areMoreResourcesRequired: function(loadingResourcesBtn) {
-      // OM check this
-      /*
-      if (this.nextRequest !== null && loadingResourcesBtn &&
-        (this.__getVisibles().length < osparc.dashboard.ResourceBrowserBase.MIN_FILTERED_STUDIES ||
-        osparc.utils.Utils.checkIsOnScreen(loadingResourcesBtn))
-      ) {
-        return true;
-      }
-      */
       if (this.nextRequest !== null && loadingResourcesBtn && osparc.utils.Utils.checkIsOnScreen(loadingResourcesBtn)) {
         return true;
       }

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -118,18 +118,16 @@ qx.Class.define("osparc.desktop.MainPage", {
       const dashboardBtn = this.__navBar.getChildControl("dashboard-button");
       dashboardBtn.setFetching(true);
       if (this.__studyEditor.didStudyChange()) {
+        // make sure very latest changes are saved
         await this.__studyEditor.updateStudyDocument(false);
       }
       const studyId = this.__studyEditor.getStudy().getUuid();
       this.__studyEditor.closeEditor();
+      this.__closeStudy(studyId);
       this.__showDashboard();
       this.__dashboard.getStudyBrowser().invalidateStudies();
       this.__dashboard.getStudyBrowser().reloadResources();
       this.__dashboard.getStudyBrowser().resetSelection();
-      this.__dashboard.getStudyBrowser().reloadStudy(studyId)
-        .then(() => {
-          this.__closeStudy(studyId);
-        });
       dashboardBtn.setFetching(false);
     },
 

--- a/services/static-webserver/client/source/class/osparc/ui/basic/Tag.js
+++ b/services/static-webserver/client/source/class/osparc/ui/basic/Tag.js
@@ -48,7 +48,7 @@ qx.Class.define("osparc.ui.basic.Tag", {
     _applyColor: function(color) {
       this.setBackgroundColor(color);
       // Set the right color for the font
-      const textColor = osparc.utils.Utils.getContrastedTextColor(qx.theme.manager.Color.getInstance().resolve(color));
+      const textColor = qx.theme.manager.Color.getInstance().resolve(osparc.utils.Utils.getContrastedTextColor(color));
       this.setTextColor(textColor);
     }
   }


### PR DESCRIPTION
## What do these changes do?

- [x] Fix Load More card bug when going back to the dashboard
- [x] Cookie Policy ending text
- [x] Text color on Tag
- [x] After editing a template, the template appears on the Studies tab as well

Before (tags and edit template):
![Before](https://user-images.githubusercontent.com/33152403/210601165-2705796b-7c06-4c9f-b992-a30228155781.gif)

After (tags and edit template):
![After](https://user-images.githubusercontent.com/33152403/210601175-7c104c26-c60b-42ee-9b65-f849f1b98795.gif)

Before (Load More):
![Before](https://user-images.githubusercontent.com/33152403/210601949-c70237e0-faa7-4035-9019-23e41acd3117.gif)

After (Load More):
![After](https://user-images.githubusercontent.com/33152403/210601961-50559325-b6d8-4496-867b-581cedef7a7f.gif)


## Related issue/s

closes https://github.com/ITISFoundation/osparc-issues/issues/817
closes https://github.com/ITISFoundation/osparc-issues/issues/818


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
