### PR TITLE
🐛⚗️ Bugfix/is3531/try disabling keep alive when uploading

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/client_session_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/client_session_manager.py
@@ -1,6 +1,6 @@
 import warnings
 
-from aiohttp import ClientSession, ClientTimeout
+from aiohttp import ClientSession, ClientTimeout, TCPConnector
 
 from ..config.http_clients import client_request_settings
 
@@ -17,11 +17,14 @@ class ClientSessionContextManager:
         # there is no timeout for file download operations
 
         self.active_session = session or ClientSession(
+            connector=TCPConnector(
+                force_close=True
+            ),  # NOTE: this disable keep-alive connections, this might be a potential fix for https://github.com/ITISFoundation/osparc-simcore/issues/3531
             timeout=ClientTimeout(
                 total=None,
                 connect=client_request_settings.HTTP_CLIENT_REQUEST_AIOHTTP_CONNECT_TIMEOUT,
                 sock_connect=client_request_settings.HTTP_CLIENT_REQUEST_AIOHTTP_SOCK_CONNECT_TIMEOUT,
-            )  # type: ignore
+            ),  # type: ignore
         )
         self.is_owned = self.active_session is not session
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
force aiohttp client to not keep connections alive. This might help when trying to re-upload a part.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->
might help with https://github.com/ITISFoundation/osparc-simcore/issues/3531

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
