### PR TITLE
🐛 Fix/storage skip invalid projects while listing

### DIFF
--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -100,7 +100,7 @@ class SimcoreS3DataManager(BaseDataManager):
                     dataset_id=prj_data.uuid,
                     display_name=prj_data.name,
                 )
-                async for prj_data in db_projects.list_projects(
+                async for prj_data in db_projects.list_valid_projects_in(
                     conn, readable_projects_ids
                 )
             ]
@@ -144,7 +144,7 @@ class SimcoreS3DataManager(BaseDataManager):
 
             # now parse the project to search for node/project names
             prj_names_mapping: dict[Union[ProjectID, NodeID], str] = {}
-            async for proj_data in db_projects.list_projects(
+            async for proj_data in db_projects.list_valid_projects_in(
                 conn, accesible_projects_ids
             ):
                 prj_names_mapping |= {proj_data.uuid: proj_data.name} | {


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

@drniiken could not copy a template project that he owned. This was a side effect of having corrupted data in both ``projects`` and ``meta_data`` tables. The copy routine was failing because a validation error on some data owned by the same user.  The corrupt data had nothing to do with this operation but the error was not handled properly which resulted in a confusing 400 error with ``message=Invalid header token`` 

![image](https://user-images.githubusercontent.com/32402063/211338646-e97d30db-50ed-498b-ba89-792051c3662e.png)


Running the same request from storage i.e. ``GET http://storage:8080/v0/locations/0/files/metadata?user_id=5&uuid_filter=b7...`` revealed the validation error.

Two actions were taken:
1.  fixed corrupted data in staging
2. create this PR that skips corrupted data in the database

This should prevent for the moment this error but does not completely solves the problem. Follow up should consider adding validation tests against deployed databases:
- https://github.com/ITISFoundation/osparc-simcore/issues/3739

