### PR TITLE
WIP: ♻️ Improve concurrent run by not overwhelming the event loop

### DIFF
--- a/packages/service-library/tests/test_utils.py
+++ b/packages/service-library/tests/test_utils.py
@@ -67,7 +67,8 @@ async def test_logged_gather(event_loop, coros, mock_logger):
     assert isinstance(excinfo.value, ValueError)
 
     for task in asyncio.all_tasks(event_loop):
-        if task is not asyncio.current_task():
+
+        if task is not asyncio.current_task() and task.get_coro().__name__ != "_worker":
             # info
             task.print_stack()
 

--- a/packages/service-library/tests/test_utils.py
+++ b/packages/service-library/tests/test_utils.py
@@ -60,8 +60,8 @@ async def test_logged_gather(event_loop, coros, mock_logger):
     with pytest.raises(ValueError) as excinfo:
         await logged_gather(*coros, reraise=True, log=mock_logger)
 
-    # NOTE: #4 fails first, the one raised in #1
-    assert "task#1" in str(excinfo.value)
+    # NOTE: #4 fails first
+    assert "task#4" in str(excinfo.value)
 
     # NOTE: only first error in the list is raised, since it is not RuntimeError, that task
     assert isinstance(excinfo.value, ValueError)


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
Instead of using a gather call to run 1000s of coroutines and limiting their runtime number with a semaphore, one can use a queuing system that would prevent too many task to overwhelm the asyncio event loop.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
