### PR TITLE
✨ Add capability to use basicauth flags to e2e puppeteer

### DIFF
--- a/tests/e2e/portal/2D_Plot.js
+++ b/tests/e2e/portal/2D_Plot.js
@@ -8,9 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -18,7 +18,7 @@ const screenshotPrefix = "2DPlot_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, basicauthUsername, basicauthPassword, enableDemoMode);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/2D_Plot.js
+++ b/tests/e2e/portal/2D_Plot.js
@@ -8,7 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -16,7 +18,7 @@ const screenshotPrefix = "2DPlot_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/3D_Anatomical.js
+++ b/tests/e2e/portal/3D_Anatomical.js
@@ -8,9 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -18,7 +18,7 @@ const screenshotPrefix = "3DAnatomical_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, basicauthUsername, basicauthPassword, enableDemoMode);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/3D_Anatomical.js
+++ b/tests/e2e/portal/3D_Anatomical.js
@@ -8,7 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -16,7 +18,7 @@ const screenshotPrefix = "3DAnatomical_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/3D_EM.js
+++ b/tests/e2e/portal/3D_EM.js
@@ -8,9 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -18,7 +18,7 @@ const screenshotPrefix = "3DEM_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, basicauthUsername, basicauthPassword, enableDemoMode);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/3D_EM.js
+++ b/tests/e2e/portal/3D_EM.js
@@ -8,7 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -16,7 +18,7 @@ const screenshotPrefix = "3DEM_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/Bornstein.js
+++ b/tests/e2e/portal/Bornstein.js
@@ -8,9 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -18,7 +18,7 @@ const screenshotPrefix = "Bornstein_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, basicauthUsername, basicauthPassword, enableDemoMode);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/Bornstein.js
+++ b/tests/e2e/portal/Bornstein.js
@@ -8,7 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -16,7 +18,7 @@ const screenshotPrefix = "Bornstein_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/CC_Human.js
+++ b/tests/e2e/portal/CC_Human.js
@@ -8,9 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -18,7 +18,7 @@ const screenshotPrefix = "CCHuman_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, basicauthUsername, basicauthPassword, enableDemoMode);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/CC_Human.js
+++ b/tests/e2e/portal/CC_Human.js
@@ -8,7 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -16,7 +18,7 @@ const screenshotPrefix = "CCHuman_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/CC_Rabbit.js
+++ b/tests/e2e/portal/CC_Rabbit.js
@@ -8,9 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -18,7 +18,7 @@ const screenshotPrefix = "CCRabbit_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, basicauthUsername, basicauthPassword, enableDemoMode);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/CC_Rabbit.js
+++ b/tests/e2e/portal/CC_Rabbit.js
@@ -8,7 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -16,7 +18,7 @@ const screenshotPrefix = "CCRabbit_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/Kember.js
+++ b/tests/e2e/portal/Kember.js
@@ -8,9 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -18,7 +18,7 @@ const screenshotPrefix = "Kember_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, basicauthUsername, basicauthPassword, enableDemoMode);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/Kember.js
+++ b/tests/e2e/portal/Kember.js
@@ -8,7 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -16,7 +18,7 @@ const screenshotPrefix = "Kember_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/Mattward.js
+++ b/tests/e2e/portal/Mattward.js
@@ -8,9 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -18,7 +18,7 @@ const screenshotPrefix = "Mattward_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, basicauthUsername, basicauthPassword, enableDemoMode);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/Mattward.js
+++ b/tests/e2e/portal/Mattward.js
@@ -8,7 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid;
@@ -16,7 +18,7 @@ const screenshotPrefix = "Mattward_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/opencor.js
+++ b/tests/e2e/portal/opencor.js
@@ -8,9 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid + "?stimulation_mode=1&stimulation_level=0.5";
@@ -18,7 +18,7 @@ const screenshotPrefix = "Opencor_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, basicauthUsername, basicauthPassword, enableDemoMode);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/portal/opencor.js
+++ b/tests/e2e/portal/opencor.js
@@ -8,7 +8,9 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
 const anonURL = urlPrefix + templateUuid + "?stimulation_mode=1&stimulation_level=0.5";
@@ -16,7 +18,7 @@ const screenshotPrefix = "Opencor_";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode, basicauth_username, basicauth_password);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/publications/Voila.js
+++ b/tests/e2e/publications/Voila.js
@@ -8,6 +8,8 @@ const {
   urlPrefix,
   templateUuid,
   startTimeout,
+  basicauthUsername,
+  basicauthPassword,
   enableDemoMode
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
@@ -16,7 +18,7 @@ const screenshotPrefix = "Voila";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, basicauthUsername, basicauthPassword, enableDemoMode);
 
   try {
     const page = await tutorial.beforeScript();

--- a/tests/e2e/s4l/sim4life-dipole.js
+++ b/tests/e2e/s4l/sim4life-dipole.js
@@ -10,15 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
 const tutorialName = "Dipole Antenna";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, tutorialName, user, pass, newUser, enableDemoMode, basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(url, tutorialName, user, pass, newUser, basicauthUsername, basicauthPassword, enableDemoMode);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/s4l/sim4life-dipole.js
+++ b/tests/e2e/s4l/sim4life-dipole.js
@@ -10,13 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArguments(args)
 
 const tutorialName = "Dipole Antenna";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, tutorialName, user, pass, newUser, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(url, tutorialName, user, pass, newUser, basicauth_username, basicauth_password, enableDemoMode);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/s4l/sim4life-dipole.js
+++ b/tests/e2e/s4l/sim4life-dipole.js
@@ -18,7 +18,7 @@ const {
 const tutorialName = "Dipole Antenna";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, tutorialName, user, pass, newUser, basicauth_username, basicauth_password, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(url, tutorialName, user, pass, newUser, enableDemoMode, basicauth_username, basicauth_password);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/s4l/sim4life-lite.js
+++ b/tests/e2e/s4l/sim4life-lite.js
@@ -13,15 +13,25 @@ const {
   userPrefix,
   userSuffix,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
 const studyName = "sim4life";
 
 async function runTutorial(user, pass, newUser, parallelUserIdx) {
-  const tutorial = new tutorialBase.TutorialBase(url, studyName, user, pass, newUser, enableDemoMode, basicauth_username, basicauth_password, parallelUserIdx);
+  const tutorial = new tutorialBase.TutorialBase(
+    url,
+    studyName,
+    user,
+    pass,
+    newUser,
+    basicauthUsername,
+    basicauthPassword,
+    enableDemoMode,
+    parallelUserIdx
+  );
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/s4l/sim4life-lite.js
+++ b/tests/e2e/s4l/sim4life-lite.js
@@ -13,13 +13,15 @@ const {
   userPrefix,
   userSuffix,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArguments(args)
 
 const studyName = "sim4life";
 
 async function runTutorial(user, pass, newUser, parallelUserIdx) {
-  const tutorial = new tutorialBase.TutorialBase(url, studyName, user, pass, newUser, enableDemoMode, parallelUserIdx);
+  const tutorial = new tutorialBase.TutorialBase(url, studyName, user, pass, newUser, enableDemoMode, basicauth_username, basicauth_password, parallelUserIdx);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/s4l/sim4life.js
+++ b/tests/e2e/s4l/sim4life.js
@@ -10,15 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
 const serviceName = "sim4life";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, serviceName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(url, serviceName, user, pass, newUser, basicauthUsername, basicauthPassword, enableDemoMode);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/s4l/sim4life.js
+++ b/tests/e2e/s4l/sim4life.js
@@ -10,13 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArguments(args)
 
 const serviceName = "sim4life";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, serviceName, user, pass, newUser, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(url, serviceName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/tutorials/isolve-gpu.js
+++ b/tests/e2e/tutorials/isolve-gpu.js
@@ -12,15 +12,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
 const templateName = "isolve-gpu";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, basicauthUsername, basicauthPassword, enableDemoMode);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/tutorials/isolve-gpu.js
+++ b/tests/e2e/tutorials/isolve-gpu.js
@@ -12,13 +12,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArguments(args)
 
 const templateName = "isolve-gpu";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/tutorials/isolve-mpi.js
+++ b/tests/e2e/tutorials/isolve-mpi.js
@@ -10,15 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
 const templateName = "isolve-mpi";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, basicauthUsername, basicauthPassword, enableDemoMode);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/tutorials/isolve-mpi.js
+++ b/tests/e2e/tutorials/isolve-mpi.js
@@ -10,13 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArguments(args)
 
 const templateName = "isolve-mpi";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/tutorials/jupyterlabs.js
+++ b/tests/e2e/tutorials/jupyterlabs.js
@@ -10,15 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
 const templateName = "JupyterLabs";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, basicauthUsername, basicauthPassword, enableDemoMode);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/tutorials/jupyterlabs.js
+++ b/tests/e2e/tutorials/jupyterlabs.js
@@ -10,13 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArguments(args)
 
 const templateName = "JupyterLabs";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/tutorials/sleepers.js
+++ b/tests/e2e/tutorials/sleepers.js
@@ -10,15 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
 const templateName = "Sleepers";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, basicauthUsername, basicauthPassword, enableDemoMode);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/tutorials/sleepers.js
+++ b/tests/e2e/tutorials/sleepers.js
@@ -10,13 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArguments(args)
 
 const templateName = "Sleepers";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(url, templateName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/tutorials/ti-plan.js
+++ b/tests/e2e/tutorials/ti-plan.js
@@ -10,15 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode,
-  basicauth_username,
-  basicauth_password
+  basicauthUsername,
+  basicauthPassword,
+  enableDemoMode
 } = utils.parseCommandLineArguments(args)
 
 const studyName = "TI Planning Tool";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, studyName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
+  const tutorial = new tutorialBase.TutorialBase(url, studyName, user, pass, newUser, basicauthUsername, basicauthPassword, enableDemoMode);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/tutorials/ti-plan.js
+++ b/tests/e2e/tutorials/ti-plan.js
@@ -10,13 +10,15 @@ const {
   pass,
   newUser,
   startTimeout,
-  enableDemoMode
+  enableDemoMode,
+  basicauth_username,
+  basicauth_password
 } = utils.parseCommandLineArguments(args)
 
 const studyName = "TI Planning Tool";
 
 async function runTutorial() {
-  const tutorial = new tutorialBase.TutorialBase(url, studyName, user, pass, newUser, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(url, studyName, user, pass, newUser, enableDemoMode,basicauth_username, basicauth_password);
   let studyId;
   try {
     await tutorial.start();

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -6,7 +6,7 @@ const utils = require('../utils/utils');
 const responses = require('../utils/responsesQueue');
 
 class TutorialBase {
-  constructor(url, templateName, user, pass, newUser, enableDemoMode = false, basicauthuser = "", basicauthpass= "", parallelUserIdx = null) {
+  constructor(url, templateName, user, pass, newUser, basicauthuser = "", basicauthpass= "", enableDemoMode = false, parallelUserIdx = null) {
     this.__demo = enableDemoMode;
     this.__templateName = templateName;
     this.__screenshotText = templateName;
@@ -59,7 +59,10 @@ class TutorialBase {
       "X-Simcore-User-Agent": "puppeteer"
     });
     if (this.__basicauthuser != "" && this.__basicauthpass != "") {
-      await this.__page.authenticate({'username':this.__basicauthuser, 'password': this.__basicauthpass});
+      await this.__page.authenticate({
+        "username": this.__basicauthuser,
+        "password": this.__basicauthpass
+      });
     }
     this.__responsesQueue = new responses.ResponsesQueue(this.__page);
 

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -6,7 +6,7 @@ const utils = require('../utils/utils');
 const responses = require('../utils/responsesQueue');
 
 class TutorialBase {
-  constructor(url, templateName, user, pass, newUser, enableDemoMode = false, parallelUserIdx = null) {
+  constructor(url, templateName, user, pass, newUser, enableDemoMode = false, basicauthuser = "", basicauthpass= "", parallelUserIdx = null) {
     this.__demo = enableDemoMode;
     this.__templateName = templateName;
     this.__screenshotText = templateName;
@@ -17,6 +17,8 @@ class TutorialBase {
     this.__url = url;
     this.__user = user;
     this.__pass = pass;
+    this.__basicauthuser = basicauthuser;
+    this.__basicauthpass = basicauthpass;
     this.__newUser = newUser;
 
     this.__browser = null;
@@ -56,6 +58,9 @@ class TutorialBase {
     this.__page.setExtraHTTPHeaders({
       "X-Simcore-User-Agent": "puppeteer"
     });
+    if (this.__basicauthuser != "" && this.__basicauthpass != "") {
+      await this.__page.authenticate({'username':this.__basicauthuser, 'password': this.__basicauthpass});
+    }
     this.__responsesQueue = new responses.ResponsesQueue(this.__page);
 
     return this.__page;

--- a/tests/e2e/utils/utils.js
+++ b/tests/e2e/utils/utils.js
@@ -7,18 +7,18 @@ const DEFAULT_TIMEOUT = 60000;
 function parseCommandLineArguments(args) {
   // node $tutorial.js
   // url
-  // --user [user]
-  // --pass [pass]
-  // --n_users [nUsers]
-  // --user_prefix [userPrefix]
-  // --user_suffix [userSuffix]
-  // --start_timeout [startTimeout]
-  // --basicauth_user [basicauth_username]
-  // --basicauth_pass [basicauth_password]
-  // --demo
+  // [--user user]
+  // [--pass pass]
+  // [--n_users nUsers]
+  // [--user_prefix userPrefix]
+  // [--user_suffix userSuffix]
+  // [--start_timeout startTimeout]
+  // [--basicauth_user basicauthUsername]
+  // [--basicauth_pass basicauthPassword]
+  // [--demo]
 
   if (args.length < 1) {
-    console.log('More arguments expected');
+    console.log('Minimum arguments expected: $tutorial.js url');
     process.exit(1);
   }
 
@@ -60,16 +60,16 @@ function parseCommandLineArguments(args) {
     startTimeout = args[startTimeoutIdx + 1];
   }
 
-  let basicauth_username = "";
-  const basicauth_usernameIdx = args.indexOf('--basicauth_user');
-  if (basicauth_usernameIdx > -1) {
-    basicauth_username = args[basicauth_usernameIdx + 1];
+  let basicauthUsername = "";
+  const basicauthUsernameIdx = args.indexOf('--basicauth_user');
+  if (basicauthUsernameIdx > -1) {
+    basicauthUsername = args[basicauthUsernameIdx + 1];
   }
 
-  let basicauth_password = "";
-  const basicauth_passwordIdx = args.indexOf('--basicauth_pass');
-  if (basicauth_passwordIdx > -1) {
-    basicauth_password = args[basicauth_passwordIdx + 1];
+  let basicauthPassword = "";
+  const basicauthPasswordIdx = args.indexOf('--basicauth_pass');
+  if (basicauthPasswordIdx > -1) {
+    basicauthPassword = args[basicauthPasswordIdx + 1];
   }
   const enableDemoMode = (args.indexOf("--demo") > -1);
 
@@ -90,44 +90,51 @@ function parseCommandLineArguments(args) {
     userPrefix,
     userSuffix,
     startTimeout,
-    enableDemoMode,
-    basicauth_username,
-    basicauth_password
+    basicauthUsername,
+    basicauthPassword,
+    enableDemoMode
   }
 }
 
 function parseCommandLineArgumentsAnonymous(args) {
-  // node $template.js [url_prefix] [template_uuid] [start_timeout] [--demo] [basicauth_username] [basicauth_password]
+  // node $template.js
+  // url_prefix
+  // template_uuid
+  // start_timeout
+  // [--basicauth_user basicauthUsername]
+  // [--basicauth_pass basicauthPassword]
+  // [--demo]
 
   if (args.length < 3) {
-    console.log('More arguments expected: $template.js [url_prefix] [template_uuid] [start_timeout] [--demo]');
+    console.log('Minimum arguments expected: $template.js url_prefix template_uuid, start_timeout');
     process.exit(1);
   }
 
   const urlPrefix = args[0];
   const templateUuid = args[1];
   const startTimeout = args[2];
+
+  let basicauthUsername = "";
+  const basicauthUsernameIdx = args.indexOf('--basicauth_user');
+  if (basicauthUsernameIdx > -1) {
+    basicauthUsername = args[basicauthUsernameIdx + 1];
+  }
+
+  let basicauthPassword = "";
+  const basicauthPasswordIdx = args.indexOf('--basicauth_pass');
+  if (basicauthPasswordIdx > -1) {
+    basicauthPassword = args[basicauthPasswordIdx + 1];
+  }
+
   const enableDemoMode = args.includes("--demo");
-
-  let basicauth_username = "";
-  const basicauth_usernameIdx = args.indexOf('--basicauth_user');
-  if (basicauth_usernameIdx > -1) {
-    basicauth_username = args[basicauth_usernameIdx + 1];
-  }
-
-  let basicauth_password = "";
-  const basicauth_passwordIdx = args.indexOf('--basicauth_pass');
-  if (basicauth_passwordIdx > -1) {
-    basicauth_password = args[basicauth_passwordIdx + 1];
-  }
 
   return {
     urlPrefix,
     templateUuid,
     startTimeout,
-    enableDemoMode,
-    basicauth_username,
-    basicauth_password
+    basicauthUsername,
+    basicauthPassword,
+    enableDemoMode
   }
 }
 

--- a/tests/e2e/utils/utils.js
+++ b/tests/e2e/utils/utils.js
@@ -13,6 +13,8 @@ function parseCommandLineArguments(args) {
   // --user_prefix [userPrefix]
   // --user_suffix [userSuffix]
   // --start_timeout [startTimeout]
+  // --basicauth_user [basicauth_username]
+  // --basicauth_pass [basicauth_password]
   // --demo
 
   if (args.length < 1) {
@@ -58,6 +60,17 @@ function parseCommandLineArguments(args) {
     startTimeout = args[startTimeoutIdx + 1];
   }
 
+  let basicauth_username = "";
+  const basicauth_usernameIdx = args.indexOf('--basicauth_user');
+  if (basicauth_usernameIdx > -1) {
+    basicauth_username = args[basicauth_usernameIdx + 1];
+  }
+
+  let basicauth_password = "";
+  const basicauth_passwordIdx = args.indexOf('--basicauth_pass');
+  if (basicauth_passwordIdx > -1) {
+    basicauth_password = args[basicauth_passwordIdx + 1];
+  }
   const enableDemoMode = (args.indexOf("--demo") > -1);
 
   let newUser = false;
@@ -77,12 +90,14 @@ function parseCommandLineArguments(args) {
     userPrefix,
     userSuffix,
     startTimeout,
-    enableDemoMode
+    enableDemoMode,
+    basicauth_username,
+    basicauth_password
   }
 }
 
 function parseCommandLineArgumentsAnonymous(args) {
-  // node $template.js [url_prefix] [template_uuid] [start_timeout] [--demo]
+  // node $template.js [url_prefix] [template_uuid] [start_timeout] [--demo] [basicauth_username] [basicauth_password]
 
   if (args.length < 3) {
     console.log('More arguments expected: $template.js [url_prefix] [template_uuid] [start_timeout] [--demo]');
@@ -94,11 +109,25 @@ function parseCommandLineArgumentsAnonymous(args) {
   const startTimeout = args[2];
   const enableDemoMode = args.includes("--demo");
 
+  let basicauth_username = "";
+  const basicauth_usernameIdx = args.indexOf('--basicauth_user');
+  if (basicauth_usernameIdx > -1) {
+    basicauth_username = args[basicauth_usernameIdx + 1];
+  }
+
+  let basicauth_password = "";
+  const basicauth_passwordIdx = args.indexOf('--basicauth_pass');
+  if (basicauth_passwordIdx > -1) {
+    basicauth_password = args[basicauth_passwordIdx + 1];
+  }
+
   return {
     urlPrefix,
     templateUuid,
     startTimeout,
-    enableDemoMode
+    enableDemoMode,
+    basicauth_username,
+    basicauth_password
   }
 }
 
@@ -515,7 +544,7 @@ function extractWorkbenchData(data) {
       const nodeVersion = data["workbench"][nodeId]["version"];
       workbenchData.keyVersions.push(`${nodeKey}::${nodeVersion}`);
     })
-    
+
   }
   return workbenchData;
 }


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
This PR enables the puppeteer to run against `testing.osparc.io` routes with basic-authentication. The usecase for this is to check that oSparc is running correctly after a scheduled maintenance. Using the `testing.osparc.io` route, the maintenance page can be bypassed. E2E tests can then be run (manually from a console) against a deployment which is still showing a maintenance page.


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


*How to run against testing route:*
```
cd osparc-simcore
sudo apt-get install libxss1 #at least on wsl2 this is necessary
npm i tests/e2e
cd tests/e2e
for i in $(ls tutorials/ | grep -e '\.js$'); 
do 
    echo $i && node --trace-warnings tutorials/$i https://testing.osparc-master.speag.com --user XXXXXXX@example.org --pass XXXXXXXXX --start_timeout 12000 --basicauth_user XXXXXXXXX --basicauth_pass XXXXXXXXX > /dev/null; echo Return Code $?; echo "-----";
done
```

p2e tests can be ran as such, the UUID needs to be known in advance (can be looked up in git-speag p2e testing `.gitlab-ci` file):
```
node portal/CC_Human.js https://testing.osparc-master.speag.com/study/ 20ab7d30-43bd-11ed-807f-02420a1875ec 2400000 --basicauth_user XXXXXXXXX --basicauth_pass XXXXXXXXX
```
## Checklist

- [x] validated with `testing.osparc-master.speag.com`

