### PR TITLE
✨🐛 Autoscaling: async creation of machines

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/core/errors.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/errors.py
@@ -23,6 +23,10 @@ class Ec2TooManyInstancesError(AutoscalingRuntimeError):
     )
 
 
+class Ec2InvalidDnsNameError(AutoscalingRuntimeError):
+    msg_template: str = "Invalid EC2 private DNS name {aws_private_dns_name}"
+
+
 class RedisNotConnectedError(AutoscalingRuntimeError):
     msg_template: str = (
         "Cannot connect with redis server on {dsn}, please check configuration"

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -16,9 +16,8 @@ from .core.settings import ApplicationSettings
 from .models import EC2Instance, Resources
 from .modules.docker import get_docker_client
 from .modules.ec2 import EC2InstanceData, get_ec2_client
-from .modules.rabbitmq import post_message
 from .utils import ec2, rabbitmq, utils_docker
-from .utils.rabbitmq import create_autoscaling_status_message
+from .utils.rabbitmq import post_autoscaling_status_message
 
 logger = logging.getLogger(__name__)
 
@@ -498,9 +497,4 @@ async def cluster_scaling_from_labelled_services(app: FastAPI) -> None:
         await _try_scale_down_cluster(app, monitored_nodes)
 
     # 4. Notify anyone interested of current state
-    await post_message(
-        app,
-        await create_autoscaling_status_message(
-            docker_client, get_ec2_client(app), app_settings, monitored_nodes
-        ),
-    )
+    await post_autoscaling_status_message(app, monitored_nodes)

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -323,7 +323,7 @@ async def _start_instances(
             continue
     log_message = f"{sum(n for n in needed_instances.values())} new machines launched, it might take up to 3 minutes to start, Please wait..."
     if last_issue:
-        log_message += f"\nUnexpected issues detected, probably due to high load, please contact support"
+        log_message += "\nUnexpected issues detected, probably due to high load, please contact support"
     await _log_tasks_message(
         app,
         tasks,

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -398,15 +398,15 @@ async def _scale_up_cluster(
         app, pending_tasks, allowed_instance_types, pending_ec2_instances
     )
 
-    await _log_tasks_message(
-        app,
-        pending_tasks,
-        "service is pending due to missing resources, scaling up cluster now\n"
-        f"{sum(n for n in needed_ec2_instances.values())} new machines will be added, please wait...",
-    )
-
     # let's start these
-    await _start_instances(app, needed_ec2_instances, pending_tasks)
+    if needed_ec2_instances:
+        await _log_tasks_message(
+            app,
+            pending_tasks,
+            "service is pending due to missing resources, scaling up cluster now\n"
+            f"{sum(n for n in needed_ec2_instances.values())} new machines will be added, please wait...",
+        )
+        await _start_instances(app, needed_ec2_instances, pending_tasks)
 
 
 async def _attach_new_ec2_instances(
@@ -443,7 +443,7 @@ async def _attach_new_ec2_instances(
             get_docker_client(app), docker_node_name
         ):
             # it is attached, let's label it, but keep it as drained
-            await utils_docker.tag_node(
+            new_node = await utils_docker.tag_node(
                 get_docker_client(app),
                 new_node,
                 tags=_get_docker_tags(app_settings),

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -259,6 +259,11 @@ async def _find_needed_instances(
     list_of_new_instance_to_tasks: list[tuple[EC2Instance, list[Task]]] = []
     for task in pending_tasks:
         if _try_assigning_task_to_instances(task, list_of_existing_instance_to_tasks):
+            await _log_tasks_message(
+                app,
+                [task],
+                f"scaling up of cluster in progress...awaiting {len(pending_ec2_instances)} new machines...please wait...",
+            )
             continue
 
         if _try_assigning_task_to_instances(task, list_of_new_instance_to_tasks):

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -3,13 +3,15 @@ import collections
 import logging
 import re
 from datetime import datetime, timedelta, timezone
+from typing import cast
 
 from fastapi import FastAPI
+from models_library.docker import DockerLabelKey
 from models_library.generated_models.docker_rest_api import Availability, Node, Task
 from pydantic import parse_obj_as
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
-from .core.errors import Ec2InstanceNotFoundError
+from .core.errors import Ec2InstanceNotFoundError, Ec2InvalidDnsNameError
 from .core.settings import ApplicationSettings
 from .models import EC2Instance, Resources
 from .modules.docker import get_docker_client
@@ -183,7 +185,6 @@ async def _try_scale_up_with_drained_nodes(
     docker_client = get_docker_client(app)
     if not pending_tasks:
         return True
-
     activatable_nodes: list[tuple[Node, list[Task]]] = [
         (
             node,
@@ -192,6 +193,7 @@ async def _try_scale_up_with_drained_nodes(
         for node in monitored_nodes
         if node.Spec and (node.Spec.Availability == Availability.drain)
     ]
+
     for task in pending_tasks:
         if _try_assigning_task_to_node(task, activatable_nodes):
             continue
@@ -239,22 +241,35 @@ def _try_assigning_task_to_instances(
 
 
 async def _find_needed_instances(
+    app: FastAPI,
     pending_tasks: list[Task],
-    available_ec2s: list[EC2Instance],
+    available_ec2_types: list[EC2Instance],
+    pending_ec2_instances: list[EC2InstanceData],
 ) -> dict[EC2Instance, int]:
-    list_of_instance_to_tasks: list[tuple[EC2Instance, list[Task]]] = []
+    existing_instance_types = await get_ec2_client(app).get_ec2_instance_capabilities(
+        {i.type for i in pending_ec2_instances}
+    )
+    type_to_instance_map = {t.name: t for t in existing_instance_types}
+
+    list_of_existing_instance_to_tasks: list[tuple[EC2Instance, list[Task]]] = [
+        (type_to_instance_map[i.type], []) for i in pending_ec2_instances
+    ]
+    list_of_new_instance_to_tasks: list[tuple[EC2Instance, list[Task]]] = []
     for task in pending_tasks:
-        if _try_assigning_task_to_instances(task, list_of_instance_to_tasks):
+        if _try_assigning_task_to_instances(task, list_of_existing_instance_to_tasks):
+            continue
+
+        if _try_assigning_task_to_instances(task, list_of_new_instance_to_tasks):
             continue
 
         try:
             # we need a new instance, let's find one
             best_ec2_instance = ec2.find_best_fitting_ec2_instance(
-                available_ec2s,
+                available_ec2_types,
                 utils_docker.get_max_resources_from_docker_task(task),
                 score_type=ec2.closest_instance_policy,
             )
-            list_of_instance_to_tasks.append((best_ec2_instance, [task]))
+            list_of_new_instance_to_tasks.append((best_ec2_instance, [task]))
         except Ec2InstanceNotFoundError:
             logger.error(
                 "Task %s needs more resources than any EC2 instance "
@@ -263,14 +278,22 @@ async def _find_needed_instances(
             )
 
     num_instances_per_type = dict(
-        collections.Counter(t for t, _ in list_of_instance_to_tasks)
+        collections.Counter(t for t, _ in list_of_new_instance_to_tasks)
     )
     return num_instances_per_type
 
 
+def _get_docker_node_name_from_aws_private_dns_name(
+    ec2_instance_data: EC2InstanceData,
+) -> str:
+    if match := re.match(_EC2_INTERNAL_DNS_RE, ec2_instance_data.aws_private_dns):
+        return match.group(1)
+    raise Ec2InvalidDnsNameError(aws_private_dns_name=ec2_instance_data.aws_private_dns)
+
+
 async def _start_instances(
-    app: FastAPI, needed_instances: dict[EC2Instance, int]
-) -> list[str]:
+    app: FastAPI, needed_instances: dict[EC2Instance, int], tasks: list[Task]
+) -> None:
     ec2_client = get_ec2_client(app)
     app_settings: ApplicationSettings = app.state.settings
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
@@ -292,44 +315,31 @@ async def _start_instances(
         return_exceptions=True,
     )
     # parse results
-    docker_node_names: list[str] = []
+    last_issue = ""
     for r in results:
         if isinstance(r, Exception):
             logger.error("Unexpected error happened when starting EC2 instance: %s", r)
+            last_issue = f"{r}"
             continue
-        assert isinstance(r, list)  # nosec
-        for ec2_instance_data in r:
-            assert isinstance(ec2_instance_data, EC2InstanceData)  # nosec
-            if match := re.match(
-                _EC2_INTERNAL_DNS_RE, ec2_instance_data.aws_private_dns
-            ):
-                docker_node_names.append(match.group(1))
-            else:
-                logger.error(
-                    "Please check: unexpected ec2 instance dns name: %s",
-                    ec2_instance_data,
-                )
-    return docker_node_names
-
-
-async def _wait_and_tag_node(
-    app: FastAPI, app_settings: ApplicationSettings, node_name: str
-) -> None:
-    assert app_settings.AUTOSCALING_NODES_MONITORING  # nosec
-    new_node = await utils_docker.wait_for_node(get_docker_client(app), node_name)
-    await utils_docker.tag_node(
-        get_docker_client(app),
-        new_node,
-        tags={
-            tag_key: "true"
-            for tag_key in app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NODE_LABELS
-        }
-        | {
-            tag_key: "true"
-            for tag_key in app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NEW_NODES_LABELS
-        },
-        available=True,
+    log_message = f"{sum(n for n in needed_instances.values())} new machines launched, it might take up to 3 minutes to start, Please wait..."
+    if last_issue:
+        log_message += f"\nUnexpected issues detected, probably due to high load, please contact support"
+    await _log_tasks_message(
+        app,
+        tasks,
+        log_message,
     )
+
+
+def _get_docker_tags(app_settings: ApplicationSettings) -> dict[DockerLabelKey, str]:
+    assert app_settings.AUTOSCALING_NODES_MONITORING  # nosec
+    return {
+        tag_key: "true"
+        for tag_key in app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NODE_LABELS
+    } | {
+        tag_key: "true"
+        for tag_key in app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NEW_NODES_LABELS
+    }
 
 
 async def _log_tasks_message(app: FastAPI, tasks: list[Task], message: str) -> None:
@@ -342,60 +352,105 @@ async def _log_tasks_message(app: FastAPI, tasks: list[Task], message: str) -> N
     )
 
 
-async def _scale_up_cluster(app: FastAPI, pending_tasks: list[Task]) -> None:
+async def _scale_up_cluster(
+    app: FastAPI, monitored_nodes: list[Node], pending_tasks: list[Task]
+) -> None:
     app_settings: ApplicationSettings = app.state.settings
     assert app_settings.AUTOSCALING_EC2_ACCESS  # nosec
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
+    assert app_settings.AUTOSCALING_NODES_MONITORING  # nosec
     ec2_client = get_ec2_client(app)
-    list_of_ec2_instances = await ec2_client.get_ec2_instance_capabilities(
-        app_settings.AUTOSCALING_EC2_INSTANCES
+
+    # check if scaling up is not already ongoing
+    existing_ec2_instances: list[EC2InstanceData] = await ec2_client.get_instances(
+        app_settings.AUTOSCALING_EC2_INSTANCES,
+        tag_keys=list(
+            ec2.get_ec2_tags(app_settings.AUTOSCALING_NODES_MONITORING).keys()
+        ),
     )
-    # get the task in larger cpu resources to smaller
-    pending_tasks.sort(
-        key=lambda t: utils_docker.get_max_resources_from_docker_task(t).cpus
+    # find the currently starting instances (aka not connected to docker swarm yet)
+    pending_ec2_instances: list[EC2InstanceData] = []
+    all_monitored_node_names = [
+        n.Description.Hostname for n in monitored_nodes if n.Description
+    ]
+    for instance_data in existing_ec2_instances:
+        try:
+            docker_node_name = _get_docker_node_name_from_aws_private_dns_name(
+                instance_data
+            )
+        except Ec2InvalidDnsNameError:
+            logger.exception("Unexcepted EC2 private dns name")
+            continue
+        if docker_node_name in all_monitored_node_names:
+            continue
+        pending_ec2_instances.append(instance_data)
+
+    allowed_instance_types = await ec2_client.get_ec2_instance_capabilities(
+        cast(
+            set[InstanceTypeType],
+            set(
+                app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES,
+            ),
+        )
     )
-    await _log_tasks_message(
-        app,
-        pending_tasks,
-        "service is pending due to missing resources, scaling up cluster now, please wait...",
+    # some instances might be able to run several tasks
+    needed_ec2_instances = await _find_needed_instances(
+        app, pending_tasks, allowed_instance_types, pending_ec2_instances
     )
 
-    # some instances might be able to run several tasks
-    needed_instances = await _find_needed_instances(
-        pending_tasks, list_of_ec2_instances
-    )
     await _log_tasks_message(
         app,
         pending_tasks,
-        f"{sum(n for n in needed_instances.values())} new machines will be added, please wait...",
+        "service is pending due to missing resources, scaling up cluster now\n"
+        f"{sum(n for n in needed_ec2_instances.values())} new machines will be added, please wait...",
     )
 
     # let's start these
-    if started_instances_node_names := await _start_instances(app, needed_instances):
-        await _log_tasks_message(
-            app,
-            pending_tasks,
-            f"{sum(n for n in needed_instances.values())} new machines created, attaching now, please wait...",
-        )
-        # and tag them make them available
-        await asyncio.gather(
-            *(
-                _wait_and_tag_node(app, app_settings, n)
-                for n in started_instances_node_names
-            ),
-            return_exceptions=True,
-        )
-        await _log_tasks_message(
-            app,
-            pending_tasks,
-            f"cluster was now up-scaled with {sum(n for n in needed_instances.values())} new machines, service should start shortly...",
-        )
-    else:
-        await _log_tasks_message(
-            app,
-            pending_tasks,
-            "Issue while up-scaling cluster, please contact support!",
-        )
+    await _start_instances(app, needed_ec2_instances, pending_tasks)
+
+
+async def _attach_new_ec2_instances(
+    app: FastAPI, monitored_nodes: list[Node]
+) -> list[Node]:
+    """label the instances that connected to the swarm that are missing the monitoring labels"""
+    app_settings: ApplicationSettings = app.state.settings
+    assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
+    assert app_settings.AUTOSCALING_NODES_MONITORING  # nosec
+    running_ec2_instances = await get_ec2_client(app).get_instances(
+        app_settings.AUTOSCALING_EC2_INSTANCES,
+        list(ec2.get_ec2_tags(app_settings.AUTOSCALING_NODES_MONITORING).keys()),
+        state_names=["running"],
+    )
+    # check that all running instances are already labelled correctly
+    newly_attached_nodes = []
+    all_monitored_node_names = [
+        n.Description.Hostname for n in monitored_nodes if n.Description
+    ]
+    for instance_data in running_ec2_instances:
+        try:
+            docker_node_name = _get_docker_node_name_from_aws_private_dns_name(
+                instance_data
+            )
+        except Ec2InvalidDnsNameError:
+            logger.exception("Unexcepted EC2 private dns name")
+            continue
+
+        # already monitored then we skip
+        if docker_node_name in all_monitored_node_names:
+            continue
+        # this one is missing, let's check if it attached already
+        if new_node := await utils_docker.try_get_node_with_name(
+            get_docker_client(app), docker_node_name
+        ):
+            # it is attached, let's label it, but keep it as drained
+            await utils_docker.tag_node(
+                get_docker_client(app),
+                new_node,
+                tags=_get_docker_tags(app_settings),
+                available=False,
+            )
+            newly_attached_nodes.append(new_node)
+    return newly_attached_nodes
 
 
 async def cluster_scaling_from_labelled_services(app: FastAPI) -> None:
@@ -405,32 +460,44 @@ async def cluster_scaling_from_labelled_services(app: FastAPI) -> None:
     """
     app_settings: ApplicationSettings = app.state.settings
     assert app_settings.AUTOSCALING_NODES_MONITORING  # nosec
-
-    # 1. get monitored nodes information and resources
     docker_client = get_docker_client(app)
 
+    # 1. get monitored nodes information and resources
     monitored_nodes = await utils_docker.get_monitored_nodes(
         docker_client,
         node_labels=app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NODE_LABELS,
     )
 
-    # 2. Cleanup nodes that are gone
-    await utils_docker.remove_nodes(docker_client, monitored_nodes)
+    # 2. Cleanup nodes that are gone or were terminated
+    removed_nodes = await utils_docker.remove_nodes(docker_client, monitored_nodes)
+    monitored_nodes = [n for n in monitored_nodes if n not in removed_nodes]
 
-    # 3. Scale up the cluster if there are pending tasks, else see if we shall scale down
+    # 3. Label new connected instances
+    new_nodes = await _attach_new_ec2_instances(app, monitored_nodes)
+    monitored_nodes.extend(new_nodes)
+
+    # 4. Scale up the cluster if there are pending tasks, else see if we shall scale down
     if pending_tasks := await utils_docker.pending_service_tasks_with_insufficient_resources(
         docker_client,
         service_labels=app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_SERVICE_LABELS,
     ):
-        if not await _try_scale_up_with_drained_nodes(
-            app, monitored_nodes, pending_tasks
+        # we have a number of pending tasks, try to resolve them with drained nodes if possible
+        await _try_scale_up_with_drained_nodes(app, monitored_nodes, pending_tasks)
+        # give the swarm tasks some time to adjust
+        await asyncio.sleep(2)
+
+        # let's check if there are still pending tasks
+        if pending_tasks := await utils_docker.pending_service_tasks_with_insufficient_resources(
+            docker_client,
+            service_labels=app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_SERVICE_LABELS,
         ):
-            # no? then scale up
-            await _scale_up_cluster(app, pending_tasks)
+            # yes? then scale up
+            await _scale_up_cluster(app, monitored_nodes, pending_tasks)
     else:
         await _mark_empty_active_nodes_to_drain(app, monitored_nodes)
         await _try_scale_down_cluster(app, monitored_nodes)
 
+    # 4. Notify anyone interested of current state
     await post_message(
         app,
         await create_autoscaling_status_message(

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -393,7 +393,7 @@ async def _scale_up_cluster(
         pending_ec2_instances.append(instance_data)
 
     allowed_instance_types = await ec2_client.get_ec2_instance_capabilities(
-        cast(
+        cast(  # type: ignore
             set[InstanceTypeType],
             set(
                 app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES,

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -319,7 +319,7 @@ async def _start_instances(
         if isinstance(r, Exception):
             logger.error("Unexpected error happened when starting EC2 instance: %s", r)
             last_issue = f"{r}"
-            continue
+
     log_message = f"{sum(n for n in needed_instances.values())} new machines launched, it might take up to 3 minutes to start, Please wait..."
     if last_issue:
         log_message += "\nUnexpected issues detected, probably due to high load, please contact support"

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -176,7 +176,7 @@ class AutoscalingEC2:
         instance_settings: EC2InstancesSettings,
         tag_keys: list[str],
         *,
-        state_names: Optional[list[str]] = None,
+        state_names: Optional[list[InstanceStateNameType]] = None,
     ) -> list[EC2InstanceData]:
         if state_names is None:
             state_names = ["pending", "running"]

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -152,9 +152,6 @@ class AutoscalingEC2:
             waiter = self.client.get_waiter("instance_exists")
             await waiter.wait(InstanceIds=instance_ids)
             logger.info("instances %s exists now.", instance_ids)
-            # waiter = self.client.get_waiter("instance_running")
-            # await waiter.wait(InstanceIds=instance_ids)
-            # logger.info("instances %s is now running", instance_ids)
 
             # get the private IPs
             instances = await self.client.describe_instances(InstanceIds=instance_ids)

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -142,18 +142,16 @@ class AutoscalingEC2:
                 SecurityGroupIds=instance_settings.EC2_INSTANCES_SECURITY_GROUP_IDS,
             )
             instance_ids = [i["InstanceId"] for i in instances["Instances"]]
-            # logger.info(
-            #     "New instances launched: %s, waiting for them to start now...",
-            #     instance_ids,
-            # )
+            logger.info(
+                "New instances launched: %s, waiting for them to start now...",
+                instance_ids,
+            )
 
-            # # wait for the instance to be in a running state
-            # # NOTE: reference to EC2 states https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html
-            # waiter = self.client.get_waiter("instance_exists")
-            # await waiter.wait(InstanceIds=instance_ids)
-            # logger.info(
-            #     "instances %s exists now, waiting for running state...", instance_ids
-            # )
+            # wait for the instance to be in a pending state
+            # NOTE: reference to EC2 states https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html
+            waiter = self.client.get_waiter("instance_exists")
+            await waiter.wait(InstanceIds=instance_ids)
+            logger.info("instances %s exists now.", instance_ids)
             # waiter = self.client.get_waiter("instance_running")
             # await waiter.wait(InstanceIds=instance_ids)
             # logger.info("instances %s is now running", instance_ids)

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -76,14 +76,12 @@ class AutoscalingEC2:
 
     async def get_ec2_instance_capabilities(
         self,
-        instance_settings: EC2InstancesSettings,
+        instance_type_names: set[InstanceTypeType],
     ) -> list[EC2Instance]:
+        """instance_type_names must be a set of unique values"""
         instance_types = await self.client.describe_instance_types(
-            InstanceTypes=cast(
-                list[InstanceTypeType], instance_settings.EC2_INSTANCES_ALLOWED_TYPES
-            )
+            InstanceTypes=list(instance_type_names)
         )
-
         list_instances: list[EC2Instance] = []
         for instance in instance_types.get("InstanceTypes", []):
             with contextlib.suppress(KeyError):
@@ -112,7 +110,7 @@ class AutoscalingEC2:
             msg=f"launching {number_of_instances} AWS instance(s) {instance_type} with {tags=}",
         ):
             # first check the max amount is not already reached
-            current_instances = await self.get_all_pending_running_instances(
+            current_instances = await self.get_instances(
                 instance_settings, list(tags.keys())
             )
             if (
@@ -144,21 +142,21 @@ class AutoscalingEC2:
                 SecurityGroupIds=instance_settings.EC2_INSTANCES_SECURITY_GROUP_IDS,
             )
             instance_ids = [i["InstanceId"] for i in instances["Instances"]]
-            logger.info(
-                "New instances launched: %s, waiting for them to start now...",
-                instance_ids,
-            )
+            # logger.info(
+            #     "New instances launched: %s, waiting for them to start now...",
+            #     instance_ids,
+            # )
 
-            # wait for the instance to be in a running state
-            # NOTE: reference to EC2 states https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html
-            waiter = self.client.get_waiter("instance_exists")
-            await waiter.wait(InstanceIds=instance_ids)
-            logger.info(
-                "instances %s exists now, waiting for running state...", instance_ids
-            )
-            waiter = self.client.get_waiter("instance_running")
-            await waiter.wait(InstanceIds=instance_ids)
-            logger.info("instances %s is now running", instance_ids)
+            # # wait for the instance to be in a running state
+            # # NOTE: reference to EC2 states https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html
+            # waiter = self.client.get_waiter("instance_exists")
+            # await waiter.wait(InstanceIds=instance_ids)
+            # logger.info(
+            #     "instances %s exists now, waiting for running state...", instance_ids
+            # )
+            # waiter = self.client.get_waiter("instance_running")
+            # await waiter.wait(InstanceIds=instance_ids)
+            # logger.info("instances %s is now running", instance_ids)
 
             # get the private IPs
             instances = await self.client.describe_instances(InstanceIds=instance_ids)
@@ -178,18 +176,23 @@ class AutoscalingEC2:
             )
             return instance_datas
 
-    async def get_all_pending_running_instances(
+    async def get_instances(
         self,
         instance_settings: EC2InstancesSettings,
         tag_keys: list[str],
+        *,
+        state_names: Optional[list[str]] = None,
     ) -> list[EC2InstanceData]:
+        if state_names is None:
+            state_names = ["pending", "running"]
+
         instances = await self.client.describe_instances(
             Filters=[
                 {
                     "Name": "key-name",
                     "Values": [instance_settings.EC2_INSTANCES_KEY_NAME],
                 },
-                {"Name": "instance-state-name", "Values": ["pending", "running"]},
+                {"Name": "instance-state-name", "Values": state_names},
                 {"Name": "tag-key", "Values": tag_keys} if tag_keys else {},
             ]
         )

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
@@ -44,7 +44,7 @@ async def create_autoscaling_status_message(
         *(
             utils_docker.compute_cluster_total_resources(monitored_nodes),
             utils_docker.compute_cluster_used_resources(docker_client, monitored_nodes),
-            ec2_client.get_all_pending_running_instances(
+            ec2_client.get_instances(
                 app_settings.AUTOSCALING_EC2_INSTANCES,
                 list(
                     ec2.get_ec2_tags(app_settings.AUTOSCALING_NODES_MONITORING).keys()

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -286,7 +286,7 @@ async def tag_node(
     *,
     tags: dict[DockerLabelKey, str],
     available: bool,
-) -> None:
+) -> Node:
     with log_context(
         logger, logging.DEBUG, msg=f"tagging {node.ID=} with {tags=} and {available=}"
     ):
@@ -304,11 +304,12 @@ async def tag_node(
                 "Role": node.Spec.Role.value,
             },
         )
+        return parse_obj_as(Node, await docker_client.nodes.inspect(node_id=node.ID))
 
 
 async def set_node_availability(
     docker_client: AutoscalingDocker, node: Node, *, available: bool
-) -> None:
+) -> Node:
     assert node.Spec  # nosec
     return await tag_node(
         docker_client,

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -7,7 +7,7 @@ import collections
 import logging
 import re
 from datetime import datetime
-from typing import Final, Optional
+from typing import Final, Optional, cast
 
 from models_library.docker import DockerLabelKey
 from models_library.generated_models.docker_rest_api import (
@@ -311,5 +311,8 @@ async def set_node_availability(
 ) -> None:
     assert node.Spec  # nosec
     return await tag_node(
-        docker_client, node, tags=node.Spec.Labels, available=available
+        docker_client,
+        node,
+        tags=cast(dict[DockerLabelKey, str], node.Spec.Labels),
+        available=available,
     )

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -157,7 +157,10 @@ async def pending_service_tasks_with_insufficient_resources(
     )
 
     sorted_tasks = sorted(
-        tasks, key=lambda task: to_datetime(task.CreatedAt or f"{datetime.utcnow()}")
+        tasks,
+        key=lambda task: cast(  # NOTE: some mypy fun here
+            datetime, (to_datetime(task.CreatedAt or f"{datetime.utcnow()}"))
+        ),
     )
 
     pending_tasks = [
@@ -323,7 +326,7 @@ async def try_get_node_with_name(
 ) -> Optional[Node]:
     list_of_nodes = await docker_client.nodes.list(filters={"name": name})
     if not list_of_nodes:
-        return
+        return None
     return parse_obj_as(Node, list_of_nodes[0])
 
 

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -109,13 +109,13 @@ def _is_task_waiting_for_resources(task: Task) -> bool:
 async def _associated_service_has_no_node_placement_contraints(
     docker_client: AutoscalingDocker, task: Task
 ) -> bool:
-    if not task.ServiceID:
-        return False
+    assert task.ServiceID  # nosec
     service_inspect = parse_obj_as(
         Service, await docker_client.services.inspect(task.ServiceID)
     )
-    if not service_inspect.Spec or not service_inspect.Spec.TaskTemplate:
-        return False
+    assert service_inspect.Spec  # nosec
+    assert service_inspect.Spec.TaskTemplate  # nosec
+
     if (
         not service_inspect.Spec.TaskTemplate.Placement
         or not service_inspect.Spec.TaskTemplate.Placement.Constraints

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -32,7 +32,15 @@ from faker import Faker
 from fakeredis.aioredis import FakeRedis
 from fastapi import FastAPI
 from models_library.docker import DockerLabelKey
-from models_library.generated_models.docker_rest_api import Node, Service
+from models_library.generated_models.docker_rest_api import (
+    Availability,
+    Node,
+    NodeDescription,
+    NodeSpec,
+    ObjectVersion,
+    ResourceObject,
+    Service,
+)
 from moto.server import ThreadedMotoServer
 from pydantic import ByteSize, PositiveInt, parse_obj_as
 from pytest import MonkeyPatch
@@ -208,6 +216,28 @@ async def host_node(
     nodes = parse_obj_as(list[Node], await async_docker_client.nodes.list())
     assert len(nodes) == 1
     return nodes[0]
+
+
+@pytest.fixture
+def fake_node(faker: Faker) -> Node:
+    return Node(
+        ID=faker.uuid4(),
+        Version=ObjectVersion(Index=faker.pyint()),
+        CreatedAt=faker.date_time().isoformat(),
+        UpdatedAt=faker.date_time().isoformat(),
+        Description=NodeDescription(
+            Hostname=faker.pystr(),
+            Resources=ResourceObject(
+                NanoCPUs=int(9 * 1e9), MemoryBytes=256 * 1024 * 1024 * 1024
+            ),
+        ),
+        Spec=NodeSpec(
+            Name=None,
+            Labels=None,
+            Role=None,
+            Availability=Availability.drain,
+        ),
+    )
 
 
 @pytest.fixture

--- a/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
@@ -82,7 +82,7 @@ def mock_get_running_instance(
 @pytest.fixture
 def mock_rabbitmq_post_message(mocker: MockerFixture) -> Iterator[mock.Mock]:
     mocked_post_message = mocker.patch(
-        "simcore_service_autoscaling.dynamic_scaling_core.post_message", autospec=True
+        "simcore_service_autoscaling.utils.rabbitmq.post_message", autospec=True
     )
     yield mocked_post_message
 

--- a/services/autoscaling/tests/unit/test_modules_ec2.py
+++ b/services/autoscaling/tests/unit/test_modules_ec2.py
@@ -2,6 +2,8 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
+from typing import cast
+
 import botocore.exceptions
 import pytest
 from faker import Faker
@@ -21,6 +23,7 @@ from simcore_service_autoscaling.modules.ec2 import (
     get_ec2_client,
 )
 from types_aiobotocore_ec2 import EC2Client
+from types_aiobotocore_ec2.literals import InstanceTypeType
 
 
 @pytest.fixture
@@ -111,8 +114,12 @@ async def test_get_ec2_instance_capabilities(
     autoscaling_ec2: AutoscalingEC2,
 ):
     assert app_settings.AUTOSCALING_EC2_INSTANCES
+    assert app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES
     instance_types = await autoscaling_ec2.get_ec2_instance_capabilities(
-        app_settings.AUTOSCALING_EC2_INSTANCES
+        cast(
+            list[InstanceTypeType],
+            app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES,
+        )
     )
     assert instance_types
     assert len(instance_types) == len(
@@ -127,6 +134,30 @@ async def test_get_ec2_instance_capabilities(
     for (
         instance_type_name
     ) in app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES:
+        assert any(i.name == instance_type_name for i in instance_types)
+
+
+async def test_get_ec2_instance_capabilities_with_multiple_same_names_return_them_all(
+    mocked_aws_server_envs: None,
+    aws_allowed_ec2_instance_type_names: list[str],
+    app_settings: ApplicationSettings,
+    autoscaling_ec2: AutoscalingEC2,
+):
+    list_of_types_with_multiple_same_names = ["a1.medium", "a1.medium"]
+
+    instance_types = await autoscaling_ec2.get_ec2_instance_capabilities(
+        cast(
+            list[InstanceTypeType],
+            list_of_types_with_multiple_same_names,
+        )
+    )
+
+    assert instance_types
+    assert len(instance_types) == len(list_of_types_with_multiple_same_names)
+
+    # all the instance names are found and valid
+    assert all(i.name in list_of_types_with_multiple_same_names for i in instance_types)
+    for instance_type_name in list_of_types_with_multiple_same_names:
         assert any(i.name == instance_type_name for i in instance_types)
 
 

--- a/services/autoscaling/tests/unit/test_modules_ec2.py
+++ b/services/autoscaling/tests/unit/test_modules_ec2.py
@@ -137,30 +137,6 @@ async def test_get_ec2_instance_capabilities(
         assert any(i.name == instance_type_name for i in instance_types)
 
 
-async def test_get_ec2_instance_capabilities_with_multiple_same_names_return_them_all(
-    mocked_aws_server_envs: None,
-    aws_allowed_ec2_instance_type_names: list[str],
-    app_settings: ApplicationSettings,
-    autoscaling_ec2: AutoscalingEC2,
-):
-    list_of_types_with_multiple_same_names = ["a1.medium", "a1.medium"]
-
-    instance_types = await autoscaling_ec2.get_ec2_instance_capabilities(
-        cast(
-            list[InstanceTypeType],
-            list_of_types_with_multiple_same_names,
-        )
-    )
-
-    assert instance_types
-    assert len(instance_types) == len(list_of_types_with_multiple_same_names)
-
-    # all the instance names are found and valid
-    assert all(i.name in list_of_types_with_multiple_same_names for i in instance_types)
-    for instance_type_name in list_of_types_with_multiple_same_names:
-        assert any(i.name == instance_type_name for i in instance_types)
-
-
 async def test_start_aws_instance(
     mocked_aws_server_envs: None,
     aws_vpc_id: str,

--- a/services/autoscaling/tests/unit/test_modules_ec2.py
+++ b/services/autoscaling/tests/unit/test_modules_ec2.py
@@ -117,8 +117,8 @@ async def test_get_ec2_instance_capabilities(
     assert app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES
     instance_types = await autoscaling_ec2.get_ec2_instance_capabilities(
         cast(
-            list[InstanceTypeType],
-            app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES,
+            set[InstanceTypeType],
+            set(app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES),
         )
     )
     assert instance_types


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?
This PR changes the way autoscaling app treats services with pending tasks.

BEFORE:
- runs every X seconds
- if there are pending tasks needing resources, it would create a number of machines to accommodate them
- **waits for the launched machine to appear (e.g. about 3 minutes)**
--> If there new tasks needing resources in the meantime they have to wait that additional time+X

AFTER:
- runs every X seconds
- if there are pending tasks needing resources, it would create a number of machines to accommodate them
- **only waits until the new EC2 instances exist (e.g. a few seconds)**
--> If there are new tasks needing resources in the meantime, they only wait a few seconds+X


Also fix the problem that dy-sidecar are pinned down to a node with specific ID and become pending with resources again if the underlying docker node is terminated:
- the tasks which associated service are contsrained to some ```node.id``` or ```node.hostname``` or ```node.role``` are now skipped as they will never start.

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
