### PR TITLE
🐛 Bugfixes Frontend: Support null Tag description & Managers can Edit organization details

### DIFF
--- a/services/static-webserver/client/source/class/osparc/component/form/tag/TagItem.js
+++ b/services/static-webserver/client/source/class/osparc/component/form/tag/TagItem.js
@@ -33,6 +33,7 @@ qx.Class.define("osparc.component.form.tag.TagItem", {
     },
     description: {
       check: "String",
+      nullable: true,
       event: "changeDescription",
       init: ""
     },

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
@@ -179,7 +179,7 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
 
     // overridden
     _applyLastChangeDate: function(value, old) {
-      if (value && this.isResourceType("study")) {
+      if (value && (this.isResourceType("study") || this.isResourceType("template"))) {
         const label = this.getChildControl("subtitle-text");
         label.setValue(osparc.utils.Utils.formatDateAndTime(value));
       }
@@ -187,7 +187,7 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
 
     // overridden
     _applyOwner: function(value, old) {
-      if (this.isResourceType("service") || this.isResourceType("template")) {
+      if (this.isResourceType("service")) {
         const label = this.getChildControl("subtitle-text");
         if (value === osparc.auth.Data.getInstance().getEmail()) {
           label.setValue(this.tr("me"));

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -661,9 +661,8 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
 
     __newStudyFromServiceBtnClicked: function(button, key, version) {
       button.setValue(false);
-      console.log(key, version);
       this._showLoadingPage(this.tr("Creating Study"));
-      osparc.utils.Study.createStudyFromService(key, version)
+      osparc.utils.Study.createStudyFromService(key, version, this._resourcesList)
         .then(studyId => {
           this._hideLoadingPage();
           this.__startStudyById(studyId);

--- a/services/static-webserver/client/source/class/osparc/ui/list/MemberListItem.js
+++ b/services/static-webserver/client/source/class/osparc/ui/list/MemberListItem.js
@@ -83,7 +83,7 @@ qx.Class.define("osparc.ui.list.MemberListItem", {
       } else if (value.getRead()) {
         subtitle.setValue(this.tr("Member"));
       } else {
-        subtitle.setValue(this.tr("No Read access"));
+        subtitle.setValue(this.tr("User: no Read access"));
       }
 
       const menu = this.__getOptionsMenu();

--- a/services/static-webserver/client/source/class/osparc/ui/list/OrganizationListItem.js
+++ b/services/static-webserver/client/source/class/osparc/ui/list/OrganizationListItem.js
@@ -26,7 +26,7 @@ qx.Class.define("osparc.ui.list.OrganizationListItem", {
     accessRights: {
       check: "Object",
       nullable: false,
-      apply: "_applyAccessRights",
+      apply: "__applyAccessRights",
       event: "changeAccessRights"
     }
   },
@@ -67,33 +67,37 @@ qx.Class.define("osparc.ui.list.OrganizationListItem", {
       return control || this.base(arguments, id);
     },
 
-    _applyAccessRights: function(value) {
-      if (value === null) {
+    __applyAccessRights: function(accessRights) {
+      if (accessRights === null) {
         return;
       }
-      if (value.getDelete()) {
+      if (accessRights.getWrite()) {
         const optionsMenu = this.getChildControl("options");
-        const menu = this.__getOptionsMenu();
+        const menu = this.__getOptionsMenu(accessRights);
         optionsMenu.setMenu(menu);
       }
     },
 
-    __getOptionsMenu: function() {
+    __getOptionsMenu: function(accessRights) {
       const menu = new qx.ui.menu.Menu().set({
         position: "bottom-right"
       });
 
-      const editOrgButton = new qx.ui.menu.Button(this.tr("Edit details"));
-      editOrgButton.addListener("execute", () => {
-        this.fireDataEvent("openEditOrganization", this.getKey());
-      });
-      menu.add(editOrgButton);
+      if (accessRights.getWrite()) {
+        const editOrgButton = new qx.ui.menu.Button(this.tr("Edit details..."));
+        editOrgButton.addListener("execute", () => {
+          this.fireDataEvent("openEditOrganization", this.getKey());
+        });
+        menu.add(editOrgButton);
+      }
 
-      const deleteOrgButton = new qx.ui.menu.Button(this.tr("Delete"));
-      deleteOrgButton.addListener("execute", () => {
-        this.fireDataEvent("deleteOrganization", this.getKey());
-      });
-      menu.add(deleteOrgButton);
+      if (accessRights.getDelete()) {
+        const deleteOrgButton = new qx.ui.menu.Button(this.tr("Delete"));
+        deleteOrgButton.addListener("execute", () => {
+          this.fireDataEvent("deleteOrganization", this.getKey());
+        });
+        menu.add(deleteOrgButton);
+      }
 
       return menu;
     },

--- a/services/static-webserver/client/source/class/osparc/utils/Study.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Study.js
@@ -123,7 +123,7 @@ qx.Class.define("osparc.utils.Study", {
       return msg;
     },
 
-    createStudyFromService: function(key, version) {
+    createStudyFromService: function(key, version, existingStudies) {
       return new Promise((resolve, reject) => {
         const store = osparc.store.Store.getInstance();
         store.getAllServices()
@@ -132,7 +132,12 @@ qx.Class.define("osparc.utils.Study", {
               const service = version ? osparc.utils.Services.getFromObject(services, key, version) : osparc.utils.Services.getLatest(services, key);
               const newUuid = osparc.utils.Utils.uuidv4();
               const minStudyData = osparc.data.model.Study.createMyNewStudyObject();
-              minStudyData["name"] = service["name"];
+              if (existingStudies) {
+                const title = osparc.utils.Utils.getUniqueStudyName(service["name"], existingStudies);
+                minStudyData["name"] = title;
+              } else {
+                minStudyData["name"] = service["name"];
+              }
               if (service["thumbnail"]) {
                 minStudyData["thumbnail"] = service["thumbnail"];
               }


### PR DESCRIPTION
## What do these changes do?

Bugfixes:
- [x] Support null Tag description
- [x] Allow organization Managers edit organization details

#### Bonus
- [x] Give unique name to New Project
- [x] Show Last Change date on tutorial card

After (tags and manager bugfixes, unique name):
![bugfixes](https://user-images.githubusercontent.com/33152403/212359129-24c620b0-a727-4ba5-949a-3738c20089b6.gif)

Before (tags and manager bugs):
![Before](https://user-images.githubusercontent.com/33152403/212359716-09050d3a-7e58-47af-8bd4-2cf56b9d7692.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
