### PR TITLE
🐛 Bugfix: Anonymous start

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -92,7 +92,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
               // given by the url or active study
               const loadStudyId = osparc.store.Store.getInstance().getCurrentStudyId();
               if (loadStudyId) {
-                this.__getStudyAndStart(loadStudyId);
+                this.__startStudyById(loadStudyId);
               } else {
                 this.reloadResources();
               }
@@ -607,20 +607,6 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     },
     // LAYOUT //
 
-    __getStudyAndStart: function(loadStudyId) {
-      const params = {
-        url: {
-          "studyId": loadStudyId
-        }
-      };
-      osparc.data.Resources.getOne("studies", params)
-        .then(studyData => this.__startStudy(studyData))
-        .catch(() => {
-          const msg = this.tr("Study unavailable or inaccessible");
-          osparc.component.message.FlashMessenger.getInstance().logAs(msg, "ERROR");
-        });
-    },
-
     __studyStateReceived: function(studyId, state, errors) {
       osparc.store.Store.getInstance().setStudyState(studyId, state);
       const idx = this._resourcesList.findIndex(study => study["uuid"] === studyId);
@@ -651,7 +637,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       templateData.name = title;
       this._showLoadingPage(this.tr("Creating ") + (templateData.name || this.tr("Study")));
       osparc.utils.Study.createStudyFromTemplate(templateData, this._loadingPage)
-        .then(studyId => this.__getStudyAndStart(studyId))
+        .then(studyId => this.__startStudyById(studyId))
         .catch(err => {
           this._hideLoadingPage();
           osparc.component.message.FlashMessenger.getInstance().logAs(err.message, "ERROR");

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -89,7 +89,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
           this.__attachEventHandlers();
           this.__getActiveStudy()
             .then(() => {
-              // given by the url or active study
+              // set by the url or active study
               const loadStudyId = osparc.store.Store.getInstance().getCurrentStudyId();
               if (loadStudyId) {
                 this.__startStudyById(loadStudyId);

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -89,7 +89,6 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
           this.__attachEventHandlers();
           this.__getActiveStudy()
             .then(() => {
-              this._hideLoadingPage();
               // given by the url or active study
               const loadStudyId = osparc.store.Store.getInstance().getCurrentStudyId();
               if (loadStudyId) {
@@ -97,6 +96,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
               } else {
                 this.reloadResources();
               }
+              this._hideLoadingPage();
             });
         })
         .catch(console.error);

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -89,13 +89,13 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
           this.__attachEventHandlers();
           this.__getActiveStudy()
             .then(() => {
+              this._hideLoadingPage();
               // given by the url or active study
               const loadStudyId = osparc.store.Store.getInstance().getCurrentStudyId();
               if (loadStudyId) {
                 this.__getStudyAndStart(loadStudyId);
               } else {
                 this.reloadResources();
-                this._hideLoadingPage();
               }
             });
         })
@@ -299,7 +299,6 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         return;
       }
 
-      this._hideLoadingPage();
       const data = {
         studyId,
         pageContext

--- a/services/static-webserver/client/source/class/osparc/utils/Clusters.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Clusters.js
@@ -113,7 +113,7 @@ qx.Class.define("osparc.utils.Clusters", {
         })
         .finally(() => {
           if (this.__clusterIds.includes(cid)) {
-            const interval = 5000;
+            const interval = 10000;
             qx.event.Timer.once(() => this.__fetchDetails(cid), this, interval);
           }
         });


### PR DESCRIPTION
## What do these changes do?

The startup sequence of the frontend was buggy when it had to load a given studyId. This was the case for anonymous users.

Fixed:
![Anonymous](https://user-images.githubusercontent.com/33152403/212553054-ba342924-7fba-42c1-b378-7a425688a45d.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
