### PR TITLE
✨ Is3683/invitations webserver check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ printf "$$rows" "Portainer" "http://$(get_my_ip).nip.io:9000" admin adminadmin;\
 printf "$$rows" "Redis" "http://$(get_my_ip).nip.io:18081";\
 printf "$$rows" "Dask Dashboard" "http://$(get_my_ip).nip.io:8787";\
 printf "$$rows" "Docker Registry" "$${REGISTRY_URL}" $${REGISTRY_USER} $${REGISTRY_PW};\
+printf "$$rows" "Invitations" "http://$(get_my_ip).nip.io:8008/dev/doc" $${INVITATIONS_USERNAME} $${INVITATIONS_PASSWORD};\
 printf "$$rows" "Rabbit Dashboard" "http://$(get_my_ip).nip.io:15672" admin adminadmin;\
 printf "$$rows" "Traefik Dashboard" "http://$(get_my_ip).nip.io:8080/dashboard/";\
 printf "$$rows" "Storage S3 Filestash" "http://$(get_my_ip).nip.io:9002" 12345678 12345678;\

--- a/README.md
+++ b/README.md
@@ -5,23 +5,24 @@
 </p>
 
 
-<!-- NOTE: when branched replace `master` in urls -->
-[![Code style: black]](https://github.com/psf/black)
-[![CI](https://github.com/ITISFoundation/osparc-simcore/actions/workflows/ci-testing-deploy.yml/badge.svg)](https://github.com/ITISFoundation/osparc-simcore/actions/workflows/ci-testing-deploy.yml)
-[![codecov](https://codecov.io/gh/ITISFoundation/osparc-simcore/branch/master/graph/badge.svg?token=h1rOE8q7ic)](https://codecov.io/gh/ITISFoundation/osparc-simcore)
-[![github.io]](https://itisfoundation.github.io/)
-[![itis.dockerhub]](https://hub.docker.com/u/itisfoundation)
-[![license]](./LICENSE)
+<!-- BADGES: LINKS ON CLICK --------------------------------------------------------------->
+[![black_badge]](https://github.com/psf/black)
+[![ci_badge]](https://github.com/ITISFoundation/osparc-simcore/actions/workflows/ci-testing-deploy.yml)
+[![codecov_badge]](https://codecov.io/gh/ITISFoundation/osparc-simcore)
+[![doc_badge]](https://itisfoundation.github.io/)
+[![dockerhub_badge]](https://hub.docker.com/u/itisfoundation)
+[![license_badge]](./LICENSE)
+[![sonarcloud_badge]](https://sonarcloud.io/summary/new_code?id=ITISFoundation_osparc-simcore)
 
-
-<!-- ADD HERE ALL BADGE URLS. Use https://shields.io/ -->
-[Code style: black]:https://img.shields.io/badge/code%20style-black-000000.svg
-[github.io]:https://img.shields.io/website-up-down-green-red/https/itisfoundation.github.io.svg?label=documentation
-[itis.dockerhub]:https://img.shields.io/website/https/hub.docker.com/u/itisfoundation.svg?down_color=red&label=dockerhub%20repos&up_color=green
-[license]:https://img.shields.io/github/license/ITISFoundation/osparc-simcore
-[Github-CI Push/PR]:https://github.com/ITISFoundation/osparc-simcore/workflows/Github-CI%20Push/PR/badge.svg
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ITISFoundation_osparc-simcore&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ITISFoundation_osparc-simcore)
-<!------------------------------------------------------>
+<!-- BADGES: LINKS TO IMAGES. Default to https://shields.io/ ------------------------------>
+[black_badge]:https://img.shields.io/badge/code%20style-black-000000.svg
+[ci_badge]:https://github.com/ITISFoundation/osparc-simcore/actions/workflows/ci-testing-deploy.yml/badge.svg
+[codecov_badge]:https://codecov.io/gh/ITISFoundation/osparc-simcore/branch/master/graph/badge.svg?token=h1rOE8q7ic
+[doc_badge]:https://img.shields.io/website-up-down-green-red/https/itisfoundation.github.io.svg?label=documentation
+[dockerhub_badge]:https://img.shields.io/website/https/hub.docker.com/u/itisfoundation.svg?down_color=red&label=docker%20images&up_color=blue
+[license_badge]:https://img.shields.io/github/license/ITISFoundation/osparc-simcore
+[sonarcloud_badge]:https://sonarcloud.io/api/project_badges/measure?project=ITISFoundation_osparc-simcore&metric=alert_status
+<!------------------------------------------------------------------------------------------>
 
 
 

--- a/services/api-server/src/simcore_service_api_server/utils/client_base.py
+++ b/services/api-server/src/simcore_service_api_server/utils/client_base.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Optional, Type
+from typing import Optional
 
 import httpx
 from fastapi import FastAPI
@@ -33,13 +33,15 @@ class BaseServiceClientApi(AppDataMixin):
             log.error("%s not responsive: %s", self.service_name, err)
             return False
 
+    ping = is_responsive  # alias
+
 
 # HELPERS -------------------------------------------------------------
 
 
 def setup_client_instance(
     app: FastAPI,
-    api_cls: Type[BaseServiceClientApi],
+    api_cls: type[BaseServiceClientApi],
     api_baseurl,
     service_name: str,
     **extra_fields

--- a/services/api-server/src/simcore_service_api_server/utils/client_base.py
+++ b/services/api-server/src/simcore_service_api_server/utils/client_base.py
@@ -48,7 +48,7 @@ def setup_client_instance(
 ) -> None:
     """Helper to add init/cleanup of ServiceClientApi instances in the app lifespam"""
 
-    assert issubclass(api_cls, BaseServiceClientApi)
+    assert issubclass(api_cls, BaseServiceClientApi)  # nosec
 
     def _create_instance() -> None:
         api_cls.create_once(

--- a/services/invitations/Makefile
+++ b/services/invitations/Makefile
@@ -7,7 +7,7 @@ include ../../scripts/common-service.Makefile
 
 
 .env:
-	$(APP_CLI_NAME) generate-dotenv > $@
+	$(APP_CLI_NAME) generate-dotenv --auto-password > $@
 
 
 .PHONY: openapi.json
@@ -20,7 +20,18 @@ openapi.json: .env ## produces openapi.json
 	python3 -c "import json; from $(APP_PACKAGE_NAME).web_main import *; print( json.dumps(the_app.openapi(), indent=2) )" > $@
 
 
+#
+# docker container
+#
 
+DOCKER_REGISTRY ?=local
+DOCKER_IMAGE_TAG ?=production
+DOCKER_IMAGE_NAME :=$(DOCKER_REGISTRY)/$(APP_NAME):$(DOCKER_IMAGE_TAG)
 
-run: .env build ## runs (development)
-	docker run -it --env-file .env -p 8000:8000 local/$(APP_NAME):production $(APP_CLI_NAME) serve
+.PHONY: run
+run: .env build ## [docker] runs in container
+	docker run --interactive --tty \
+	--env-file .env \
+	--publish 8000:8000 \
+	$(DOCKER_IMAGE_NAME) \
+	$(APP_CLI_NAME) serve

--- a/services/invitations/README.md
+++ b/services/invitations/README.md
@@ -54,21 +54,21 @@ simcore-service-invitations serve
 and then open http://127.0.0.1:8000/dev/doc
 
 
-### With docker image ``itisfoundation/invitations:latest``
+### With docker image ``itisfoundation/invitations`
 
-Here we assume the image ``itisfoundation/invitations:latest`` is published in dockerhub. It can be tested by
+Here we assume the image ``itisfoundation/invitations:release-github-latest ` is published in dockerhub (see all [tags available](https://registry.hub.docker.com/r/itisfoundation/invitations/tags)). It can be tested by
 ```cmd
-docker run -it itisfoundation/invitations:latest simcore-service-invitations --version
+docker run -it itisfoundation/invitations:release-github-latest simcore-service-invitations --version
 ```
 Otherwise, you can build the image tagged as ``local/invitations:production`` using ``make build``. Then check help
 ```cmd
-docker run -it itisfoundation/invitations:latest simcore-service-invitations --help
+docker run -it itisfoundation/invitations:release-github-latest simcore-service-invitations --help
 ```
 #### Setup
 
 Create ``.env`` file
 ```
-docker run -it itisfoundation/invitations:latest simcore-service-invitations generate-dotenv --auto-password > .env
+docker run -it itisfoundation/invitations:release-github-latest simcore-service-invitations generate-dotenv --auto-password > .env
 ```
 and modify the ``.env`` if needed
 
@@ -78,7 +78,7 @@ and modify the ``.env`` if needed
 
 Create an invitation for ``guest@company.com`` as
 ```
-docker run -it --env-file .env  itisfoundation/invitations:latest simcore-service-invitations invite guest@company.com --issuer=me
+docker run -it --env-file .env  itisfoundation/invitations:release-github-latest simcore-service-invitations invite guest@company.com --issuer=me
 ```
 and will produce a link
 
@@ -88,7 +88,7 @@ and will produce a link
 
 Start it as a web app as
 ```
-docker run -it --env-file .env -p 8000:8000 itisfoundation/invitations:latest simcore-service-invitations serve
+docker run -it --env-file .env -p 8000:8000 itisfoundation/invitations:release-github-latest simcore-service-invitations serve
 ```
 and then open http://127.0.0.1:8000/dev/doc.
 

--- a/services/invitations/src/simcore_service_invitations/cli.py
+++ b/services/invitations/src/simcore_service_invitations/cli.py
@@ -91,7 +91,7 @@ def generate_dotenv(ctx: typer.Context, auto_password: bool = False):
     ) or generate_password(length=32)
 
     settings = ApplicationSettings(
-        INVITATIONS_OSPARC_URL="https://osparc.io",
+        INVITATIONS_OSPARC_URL="http://127.0.0.1:8000",
         INVITATIONS_SECRET_KEY=Fernet.generate_key().decode(),
         INVITATIONS_USERNAME=getpass.getuser(),
         INVITATIONS_PASSWORD=password,

--- a/services/web/server/src/simcore_service_webserver/application.py
+++ b/services/web/server/src/simcore_service_webserver/application.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from aiohttp import web
 from servicelib.aiohttp.application import create_safe_application
+from simcore_service_webserver.invitations import setup_invitations
 
 from ._meta import WELCOME_GC_MSG, WELCOME_MSG
 from .activity.plugin import setup_activity
@@ -81,6 +82,7 @@ def create_application() -> web.Application:
 
     # login
     setup_email(app)
+    setup_invitations(app)
     setup_login(app)
 
     # interaction with other backend services

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -32,6 +32,7 @@ from .director.settings import DirectorSettings
 from .director_v2_settings import DirectorV2Settings
 from .exporter.settings import ExporterSettings
 from .garbage_collector_settings import GarbageCollectorSettings
+from .invitations_settings import InvitationsSettings
 from .login.settings import LoginSettings
 from .projects.projects_settings import ProjectsSettings
 from .resource_manager.settings import ResourceManagerSettings
@@ -136,6 +137,10 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
 
     WEBSERVER_GARBAGE_COLLECTOR: Optional[GarbageCollectorSettings] = Field(
         auto_default_from_env=True, description="garbage collector plugin"
+    )
+
+    WEBSERVER_INVITATIONS: Optional[InvitationsSettings] = Field(
+        auto_default_from_env=True, description="invitations plugin"
     )
 
     WEBSERVER_LOGIN: Optional[LoginSettings] = Field(

--- a/services/web/server/src/simcore_service_webserver/invitations.py
+++ b/services/web/server/src/simcore_service_webserver/invitations.py
@@ -53,7 +53,9 @@ class InvalidInvitationError(InvitationsErrors):
 
 
 class InvitationServiceUnavailable(InvitationsErrors):
-    msg_template = "Invitations service is currently unavailable"
+    msg_template = (
+        "Invitations service is currently unavailable. Please try again later."
+    )
 
 
 @contextmanager

--- a/services/web/server/src/simcore_service_webserver/invitations.py
+++ b/services/web/server/src/simcore_service_webserver/invitations.py
@@ -3,126 +3,21 @@
 """
 
 import logging
-from contextlib import contextmanager
 
-import sqlalchemy as sa
-from aiohttp import ClientError, ClientResponseError, web
-from pydantic import ValidationError
-from pydantic.errors import PydanticErrorMixin
+from aiohttp import web
 from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
-from simcore_postgres_database.models.users import users
 
 from ._constants import APP_SETTINGS_KEY
-from .db import get_database_engine, setup_db
-from .invitations_client import (
-    InvitationContent,
-    InvitationsServiceApi,
-    get_invitations_service_api,
-    invitations_service_api_cleanup_ctx,
+from .db import setup_db
+from .invitations_client import invitations_service_api_cleanup_ctx
+from .invitations_core import (
+    InvalidInvitation,
+    InvitationsServiceUnavailable,
+    is_service_invitation_code,
+    validate_invitation_url,
 )
 
 logger = logging.getLogger(__name__)
-
-
-#
-# database
-#
-
-
-async def _is_user_registered(app: web.Application, email: str) -> bool:
-    pg_engine = get_database_engine(app=app)
-
-    async with pg_engine.acquire() as conn:
-        user_id = await conn.scalar(
-            sa.select([users.c.id]).where(users.c.email == email)
-        )
-        return user_id is not None
-
-
-#
-# API plugin errors
-#
-
-
-class InvitationsErrors(PydanticErrorMixin, ValueError):
-    ...
-
-
-class InvalidInvitation(InvitationsErrors):
-    msg_template = "Invalid invitation: {reason}"
-
-
-class InvitationsServiceUnavailable(InvitationsErrors):
-    msg_template = (
-        "Invitations service is currently unavailable. Please try again later."
-    )
-
-
-@contextmanager
-def _handle_exceptions_as_invitations_errors():
-    try:
-
-        yield  # API function calls happen
-
-    except ClientResponseError as err:
-        # check possible errors
-        if err.status == web.HTTPUnprocessableEntity.status_code:
-            raise InvalidInvitation(reason=err.message) from err
-
-        # some validation or other error?
-        raise InvitationsServiceUnavailable() from err
-
-    except ValidationError as err:
-        raise InvitationsServiceUnavailable() from err
-
-    except ClientError as err:
-        raise InvitationsServiceUnavailable() from err
-
-    except InvitationsErrors:
-        # bypass
-        raise
-
-    except Exception as err:
-        logger.exception("Unexpected error in invitations plugin")
-        raise InvitationsServiceUnavailable() from err
-
-
-#
-# API plugin calls
-#
-
-
-def can_be_service_invitation_code(code: str):
-    """Fast check to distinguish from confirmation-type of invitation code"""
-    return len(code) > 100
-
-
-async def validate_invitation_url(
-    app: web.Application, invitation_url: str
-) -> InvitationContent:
-    """Validates invitation and returns content
-
-    raises InvitationsError
-    """
-    invitations_service: InvitationsServiceApi = get_invitations_service_api(app=app)
-
-    with _handle_exceptions_as_invitations_errors():
-
-        # check with service
-        invitation = await invitations_service.extract_invitation(
-            invitation_url=invitation_url
-        )
-
-        # existing users cannot be re-invited
-        if await _is_user_registered(app=app, email=invitation.guest):
-            raise InvalidInvitation(reason="This invitation was already used")
-
-    return invitation
-
-
-#
-# SETUP
-#
 
 
 @app_module_setup(
@@ -139,20 +34,15 @@ def setup_invitations(app: web.Application):
     app.cleanup_ctx.append(invitations_service_api_cleanup_ctx)
 
 
-# TODO:
-# login plugin ensures setup_invitations are in place (if not, deactivates invitations?)
-# - ``check_and_consume_invitation``: Check in this order:
-#     - invitation in confirmation table
-#     - invitation in invitations service
-#
-#
-
 #
 # API plugin
 #
+
 __all__: tuple[str, ...] = (
-    "setup_invitations",
-    "validate_invitation_url",
+    "is_service_invitation_code",
     "InvalidInvitation",
     "InvitationsServiceUnavailable",
+    "setup_invitations",
+    "validate_invitation_url",
 )
+# nopycln: file

--- a/services/web/server/src/simcore_service_webserver/invitations.py
+++ b/services/web/server/src/simcore_service_webserver/invitations.py
@@ -31,12 +31,14 @@ class InvalidInvitationError(InvitationsErrors):
 
 
 class InvitationServiceUnavailable(InvitationsErrors):
-    msg_template = "Invitations service currently unavailable"
+    msg_template = "Invitations service is currently unavailable"
 
 
 #
 # API plugin calls
 #
+
+
 async def validate_invitation_url(request: web.Request, invitation_url: str):
     # extract invitation
     invitations_api: InvitationsServiceApi = get_invitations_service_api(
@@ -75,13 +77,10 @@ async def validate_invitation_url(request: web.Request, invitation_url: str):
 def setup_invitations(app: web.Application):
     assert app[APP_SETTINGS_KEY].WEBSERVER_INVITATIONS  # nosec
 
-    # TODO: might be a client ONLY for this??
     app.cleanup_ctx.append(invitations_service_api_cleanup_ctx)
 
 
-# module to setup_invitations service
-# client API class to trigger calls
-#
+# TODO:
 # login plugin ensures setup_invitations are in place (if not, deactivates invitations?)
 # - ``check_and_consume_invitation``: Check in this order:
 #     - invitation in confirmation table
@@ -89,9 +88,12 @@ def setup_invitations(app: web.Application):
 #
 #
 
-
-# API
-__all__ = tuple[str, ...] = (
+#
+# API plugin
+#
+__all__: tuple[str, ...] = (
     "setup_invitations",
     "validate_invitation_url",
+    "InvalidInvitationError",
+    "InvitationServiceUnavailable",
 )

--- a/services/web/server/src/simcore_service_webserver/invitations.py
+++ b/services/web/server/src/simcore_service_webserver/invitations.py
@@ -1,0 +1,97 @@
+"""
+    Plugin to interact with the invitations service
+"""
+
+import logging
+
+from aiohttp import ClientResponseError, web
+from pydantic.errors import PydanticErrorMixin
+from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
+
+from ._constants import APP_SETTINGS_KEY
+from .invitations_client import (
+    InvitationsServiceApi,
+    get_invitations_service_api,
+    invitations_service_api_cleanup_ctx,
+)
+
+logger = logging.getLogger(__name__)
+
+#
+# API plugin errors
+#
+
+
+class InvitationsErrors(PydanticErrorMixin, ValueError):
+    ...
+
+
+class InvalidInvitationError(InvitationsErrors):
+    msg_template = "Invalid invitation: {reason}"
+
+
+class InvitationServiceUnavailable(InvitationsErrors):
+    msg_template = "Invitations service currently unavailable"
+
+
+#
+# API plugin calls
+#
+async def validate_invitation_url(request: web.Request, invitation_url: str):
+    # extract invitation
+    invitations_api: InvitationsServiceApi = get_invitations_service_api(
+        app=request.app
+    )
+
+    # check possible errors
+    try:
+        invitation = await invitations_api.extract_invitation(
+            invitation_url=invitation_url
+        )
+
+    except ClientResponseError as err:
+        if err.status == web.HTTPUnprocessableEntity.status_code:
+            raise InvalidInvitationError(reason=err.message) from err
+        raise InvitationServiceUnavailable() from err
+
+    # TODO: expired?
+
+    if not invitation.guest:
+        # TODO: check if user exists or not
+        raise InvalidInvitationError(reason="This user was already invited")
+
+
+#
+# SETUP
+#
+
+
+@app_module_setup(
+    __name__,
+    ModuleCategory.ADDON,
+    settings_name="WEBSERVER_INVITATIONS",
+    logger=logger,
+)
+def setup_invitations(app: web.Application):
+    assert app[APP_SETTINGS_KEY].WEBSERVER_INVITATIONS  # nosec
+
+    # TODO: might be a client ONLY for this??
+    app.cleanup_ctx.append(invitations_service_api_cleanup_ctx)
+
+
+# module to setup_invitations service
+# client API class to trigger calls
+#
+# login plugin ensures setup_invitations are in place (if not, deactivates invitations?)
+# - ``check_and_consume_invitation``: Check in this order:
+#     - invitation in confirmation table
+#     - invitation in invitations service
+#
+#
+
+
+# API
+__all__ = tuple[str, ...] = (
+    "setup_invitations",
+    "validate_invitation_url",
+)

--- a/services/web/server/src/simcore_service_webserver/invitations.py
+++ b/services/web/server/src/simcore_service_webserver/invitations.py
@@ -40,11 +40,9 @@ class InvitationServiceUnavailable(InvitationsErrors):
 #
 
 
-async def validate_invitation_url(request: web.Request, invitation_url: str):
+async def validate_invitation_url(app: web.Application, invitation_url: str):
     # extract invitation
-    invitations_api: InvitationsServiceApi = get_invitations_service_api(
-        app=request.app
-    )
+    invitations_api: InvitationsServiceApi = get_invitations_service_api(app=app)
 
     # check possible errors
     try:

--- a/services/web/server/src/simcore_service_webserver/invitations.py
+++ b/services/web/server/src/simcore_service_webserver/invitations.py
@@ -9,6 +9,7 @@ from pydantic.errors import PydanticErrorMixin
 from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
 
 from ._constants import APP_SETTINGS_KEY
+from .db import setup_db
 from .invitations_client import (
     InvitationsServiceApi,
     get_invitations_service_api,
@@ -76,6 +77,8 @@ async def validate_invitation_url(request: web.Request, invitation_url: str):
 )
 def setup_invitations(app: web.Application):
     assert app[APP_SETTINGS_KEY].WEBSERVER_INVITATIONS  # nosec
+
+    setup_db(app)
 
     app.cleanup_ctx.append(invitations_service_api_cleanup_ctx)
 

--- a/services/web/server/src/simcore_service_webserver/invitations.py
+++ b/services/web/server/src/simcore_service_webserver/invitations.py
@@ -3,20 +3,41 @@
 """
 
 import logging
+from contextlib import contextmanager
 
-from aiohttp import ClientResponseError, web
+import sqlalchemy as sa
+from aiohttp import ClientError, ClientResponseError, web
+from pydantic import ValidationError
 from pydantic.errors import PydanticErrorMixin
 from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
+from simcore_postgres_database.models.users import users
 
 from ._constants import APP_SETTINGS_KEY
-from .db import setup_db
+from .db import get_database_engine, setup_db
 from .invitations_client import (
+    InvitationContent,
     InvitationsServiceApi,
     get_invitations_service_api,
     invitations_service_api_cleanup_ctx,
 )
 
 logger = logging.getLogger(__name__)
+
+
+#
+# database
+#
+
+
+async def _is_user_registered(app: web.Application, email: str) -> bool:
+    pg_engine = get_database_engine(app=app)
+
+    async with pg_engine.acquire() as conn:
+        user_id = await conn.scalar(
+            sa.select([users.c.id]).where(users.c.email == email)
+        )
+        return user_id is not None
+
 
 #
 # API plugin errors
@@ -35,31 +56,61 @@ class InvitationServiceUnavailable(InvitationsErrors):
     msg_template = "Invitations service is currently unavailable"
 
 
+@contextmanager
+def _handle_exceptions_as_invitations_errors():
+    try:
+
+        yield  # API function calls happen
+
+    except ClientResponseError as err:
+        # check possible errors
+        if err.status == web.HTTPUnprocessableEntity.status_code:
+            raise InvalidInvitationError(reason=err.message) from err
+
+        # some validation or other error?
+        raise InvitationServiceUnavailable() from err
+
+    except ValidationError as err:
+        raise InvitationServiceUnavailable() from err
+
+    except ClientError as err:
+        raise InvitationServiceUnavailable() from err
+
+    except InvitationsErrors:
+        # bypass
+        raise
+
+    except Exception as err:
+        logger.exception("Unexpected error in invitations plugin")
+        raise InvitationServiceUnavailable() from err
+
+
 #
 # API plugin calls
 #
 
 
-async def validate_invitation_url(app: web.Application, invitation_url: str):
-    # extract invitation
-    invitations_api: InvitationsServiceApi = get_invitations_service_api(app=app)
+async def validate_invitation_url(
+    app: web.Application, invitation_url: str
+) -> InvitationContent:
+    """Validates invitation and returns content
 
-    # check possible errors
-    try:
-        invitation = await invitations_api.extract_invitation(
+    raises InvitationsError
+    """
+    invitations_service: InvitationsServiceApi = get_invitations_service_api(app=app)
+
+    with _handle_exceptions_as_invitations_errors():
+
+        # check with service
+        invitation = await invitations_service.extract_invitation(
             invitation_url=invitation_url
         )
 
-    except ClientResponseError as err:
-        if err.status == web.HTTPUnprocessableEntity.status_code:
-            raise InvalidInvitationError(reason=err.message) from err
-        raise InvitationServiceUnavailable() from err
+        # existing users cannot be re-invited
+        if await _is_user_registered(app=app, email=invitation.guest):
+            raise InvalidInvitationError(reason="This invitation was already used")
 
-    # TODO: expired?
-
-    if not invitation.guest:
-        # TODO: check if user exists or not
-        raise InvalidInvitationError(reason="This user was already invited")
+    return invitation
 
 
 #

--- a/services/web/server/src/simcore_service_webserver/invitations_client.py
+++ b/services/web/server/src/simcore_service_webserver/invitations_client.py
@@ -15,11 +15,21 @@ from .invitations_settings import InvitationsSettings
 logger = logging.getLogger(__name__)
 
 
+#
+# MODELS
+#
+
+
 class InvitationContent(BaseModel):
     issuer: str
     guest: EmailStr
     trial_account_days: Optional[int] = None
     created: datetime
+
+
+#
+# CLIENT
+#
 
 
 @dataclass(frozen=True)
@@ -46,14 +56,17 @@ class InvitationsServiceApi:
     #
     # common SDK
     #
-    # NOTE: due to limitations in aioresponses https://github.com/pnuckowski/aioresponses/issues/230
-    # we will avoid using ClientSession(base_url=settings.base_url, ... ) and use insteald self._url("/v0/foo")
 
     def _url(self, rel_url: str):
         return URL(self.settings.base_url) / rel_url.lstrip("/")
 
     def _url_vtag(self, rel_url: str):
         return URL(self.settings.api_base_url) / rel_url.lstrip("/")
+
+    # NOTE: the functions above are added due to limitations in
+    # aioresponses https://github.com/pnuckowski/aioresponses/issues/230
+    # we will avoid using ClientSession(base_url=settings.base_url, ... ) and
+    # use insteald self._url("/v0/foo")
 
     async def close(self) -> None:
         """Releases underlying connector from ClientSession [client]"""

--- a/services/web/server/src/simcore_service_webserver/invitations_client.py
+++ b/services/web/server/src/simcore_service_webserver/invitations_client.py
@@ -75,9 +75,9 @@ class InvitationsServiceApi:
     async def ping(self) -> bool:
         try:
             response = await self.client.get(self._url(self.healthcheck_path))
-            return response.status == web.HTTPOk.status_code
+            return response.ok
         except ClientError as err:
-            logger.debug("failed to connect %s", err)
+            logger.debug("Invitations service is not responsive: %s", err)
         return False
 
     is_responsive = ping

--- a/services/web/server/src/simcore_service_webserver/invitations_client.py
+++ b/services/web/server/src/simcore_service_webserver/invitations_client.py
@@ -1,0 +1,95 @@
+import contextlib
+import logging
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from aiohttp import BasicAuth, ClientSession, web
+from aiohttp.client_exceptions import ClientError
+from pydantic import BaseModel, EmailStr, parse_obj_as
+
+from ._constants import APP_SETTINGS_KEY
+from .invitations_settings import InvitationsSettings
+
+logger = logging.getLogger(__name__)
+
+
+class InvitationContent(BaseModel):
+    issuer: str
+    guest: EmailStr
+    trial_account_days: Optional[int] = None
+    created: datetime
+
+
+@dataclass(frozen=True)
+class InvitationsServiceApi:
+    client: ClientSession
+    settings: InvitationsSettings
+    exit_stack: contextlib.AsyncExitStack
+    healthcheck_path: str = "/"
+
+    @classmethod
+    async def create(cls, settings: InvitationsSettings) -> "InvitationsServiceApi":
+        exit_stack = contextlib.AsyncExitStack()
+        client_session = await exit_stack.enter_async_context(
+            ClientSession(
+                base_url=settings.base_url,
+                auth=BasicAuth(
+                    login=settings.INVITATIONS_USERNAME,
+                    password=settings.INVITATIONS_PASSWORD.get_secret_value(),
+                ),
+                raise_for_status=True,
+            )
+        )
+        return cls(client=client_session, exit_stack=exit_stack, settings=settings)
+
+    #
+    # common SDK
+    #
+
+    async def close(self) -> None:
+        await self.exit_stack.aclose()
+
+    async def ping(self) -> bool:
+        with suppress(ClientError):
+            response = await self.client.get(self.healthcheck_path)
+            return response.status == web.HTTPOk.status_code
+        return False
+
+    is_responsive = ping
+
+    #
+    # service API
+    #
+
+    async def extract_invitation(self, invitation_url: str) -> InvitationContent:
+        response = await self.client.post(
+            url=f"/{self.settings.INVITATIONS_VTAG}/invitations:extract",
+            data={"invitation_url": invitation_url},
+        )
+        invitation = parse_obj_as(InvitationContent, await response.json())
+        return invitation
+
+
+#
+# EVENTS
+#
+
+_APP_KEY = f"{__name__}.{InvitationsServiceApi.__name__}"
+
+
+async def invitations_service_api_cleanup_ctx(app: web.Application):
+
+    app[_APP_KEY] = service_api = InvitationsServiceApi.create(
+        settings=app[APP_SETTINGS_KEY].WEBSERVER_INVITATIONS
+    )
+
+    yield
+
+    await service_api.close()
+
+
+def get_invitations_service_api(app: web.Application) -> InvitationsServiceApi:
+    assert app[_APP_KEY]  # nosec
+    return app[_APP_KEY]

--- a/services/web/server/src/simcore_service_webserver/invitations_client.py
+++ b/services/web/server/src/simcore_service_webserver/invitations_client.py
@@ -56,6 +56,7 @@ class InvitationsServiceApi:
         return URL(self.settings.api_base_url) / rel_url.lstrip("/")
 
     async def close(self) -> None:
+        """Releases underlying connector from ClientSession [client]"""
         await self.exit_stack.aclose()
 
     async def ping(self) -> bool:
@@ -98,7 +99,10 @@ async def invitations_service_api_cleanup_ctx(app: web.Application):
 
     yield
 
-    await service_api.close()
+    try:
+        await service_api.close()
+    except Exception:  # pylint: disable=broad-except
+        logger.warning("Ignoring error while closing service-api")
 
 
 def get_invitations_service_api(app: web.Application) -> InvitationsServiceApi:

--- a/services/web/server/src/simcore_service_webserver/invitations_client.py
+++ b/services/web/server/src/simcore_service_webserver/invitations_client.py
@@ -76,14 +76,16 @@ class InvitationsServiceApi:
 # EVENTS
 #
 
-_APP_KEY = f"{__name__}.{InvitationsServiceApi.__name__}"
+_APP_INVITATIONS_SERVICE_API_KEY = f"{__name__}.{InvitationsServiceApi.__name__}"
 
 
 async def invitations_service_api_cleanup_ctx(app: web.Application):
 
-    app[_APP_KEY] = service_api = InvitationsServiceApi.create(
+    service_api = await InvitationsServiceApi.create(
         settings=app[APP_SETTINGS_KEY].WEBSERVER_INVITATIONS
     )
+
+    app[_APP_INVITATIONS_SERVICE_API_KEY] = service_api
 
     yield
 
@@ -91,5 +93,5 @@ async def invitations_service_api_cleanup_ctx(app: web.Application):
 
 
 def get_invitations_service_api(app: web.Application) -> InvitationsServiceApi:
-    assert app[_APP_KEY]  # nosec
-    return app[_APP_KEY]
+    assert app[_APP_INVITATIONS_SERVICE_API_KEY]  # nosec
+    return app[_APP_INVITATIONS_SERVICE_API_KEY]

--- a/services/web/server/src/simcore_service_webserver/invitations_core.py
+++ b/services/web/server/src/simcore_service_webserver/invitations_core.py
@@ -1,0 +1,118 @@
+"""
+    Plugin to interact with the invitations service
+"""
+
+import logging
+from contextlib import contextmanager
+
+import sqlalchemy as sa
+from aiohttp import ClientError, ClientResponseError, web
+from pydantic import ValidationError
+from pydantic.errors import PydanticErrorMixin
+from simcore_postgres_database.models.users import users
+
+from .db import get_database_engine
+from .invitations_client import (
+    InvitationContent,
+    InvitationsServiceApi,
+    get_invitations_service_api,
+)
+
+logger = logging.getLogger(__name__)
+
+
+#
+# DATABASE
+#
+
+
+async def _is_user_registered(app: web.Application, email: str) -> bool:
+    pg_engine = get_database_engine(app=app)
+
+    async with pg_engine.acquire() as conn:
+        user_id = await conn.scalar(
+            sa.select([users.c.id]).where(users.c.email == email)
+        )
+        return user_id is not None
+
+
+#
+# API plugin ERRORS
+#
+
+
+class InvitationsErrors(PydanticErrorMixin, ValueError):
+    ...
+
+
+class InvalidInvitation(InvitationsErrors):
+    msg_template = "Invalid invitation: {reason}"
+
+
+class InvitationsServiceUnavailable(InvitationsErrors):
+    msg_template = (
+        "Unable to process your invitation since the invitations service is currently unavailable. "
+        "Please try again later."
+    )
+
+
+@contextmanager
+def _handle_exceptions_as_invitations_errors():
+    try:
+
+        yield  # API function calls happen
+
+    except ClientResponseError as err:
+        # check possible errors
+        if err.status == web.HTTPUnprocessableEntity.status_code:
+            raise InvalidInvitation(reason=err.message) from err
+
+        # some validation or other error?
+        raise InvitationsServiceUnavailable() from err
+
+    except ValidationError as err:
+        raise InvitationsServiceUnavailable() from err
+
+    except ClientError as err:
+        raise InvitationsServiceUnavailable() from err
+
+    except InvitationsErrors:
+        # bypass
+        raise
+
+    except Exception as err:
+        logger.exception("Unexpected error in invitations plugin")
+        raise InvitationsServiceUnavailable() from err
+
+
+#
+# API plugin CALLS
+#
+
+
+def is_service_invitation_code(code: str):
+    """Fast check to distinguish from confirmation-type of invitation code"""
+    return len(code) > 100  # typically long strings
+
+
+async def validate_invitation_url(
+    app: web.Application, invitation_url: str
+) -> InvitationContent:
+    """Validates invitation and returns content
+
+    raises InvitationsError
+    """
+    invitations_service: InvitationsServiceApi = get_invitations_service_api(app=app)
+
+    with _handle_exceptions_as_invitations_errors():
+
+        # check with service
+        invitation = await invitations_service.extract_invitation(
+            invitation_url=invitation_url
+        )
+
+        # existing users cannot be re-invited
+        if await _is_user_registered(app=app, email=invitation.guest):
+            raise InvalidInvitation(reason="This invitation was already used")
+
+    return invitation

--- a/services/web/server/src/simcore_service_webserver/invitations_core.py
+++ b/services/web/server/src/simcore_service_webserver/invitations_core.py
@@ -67,17 +67,15 @@ def _handle_exceptions_as_invitations_errors():
         if err.status == web.HTTPUnprocessableEntity.status_code:
             raise InvalidInvitation(reason=err.message) from err
 
-        # some validation or other error?
+        assert 400 <= err.status  # nosec
+        # any other error status code
         raise InvitationsServiceUnavailable() from err
 
-    except ValidationError as err:
-        raise InvitationsServiceUnavailable() from err
-
-    except ClientError as err:
+    except (ValidationError, ClientError) as err:
         raise InvitationsServiceUnavailable() from err
 
     except InvitationsErrors:
-        # bypass
+        # bypass: prevents that the Exceptions handler catches this exception
         raise
 
     except Exception as err:

--- a/services/web/server/src/simcore_service_webserver/invitations_core.py
+++ b/services/web/server/src/simcore_service_webserver/invitations_core.py
@@ -94,7 +94,7 @@ def is_service_invitation_code(code: str):
 
 
 async def validate_invitation_url(
-    app: web.Application, invitation_url: str
+    app: web.Application, guest_email: str, invitation_url: str
 ) -> InvitationContent:
     """Validates invitation and returns content
 
@@ -108,6 +108,11 @@ async def validate_invitation_url(
         invitation = await invitations_service.extract_invitation(
             invitation_url=invitation_url
         )
+
+        if invitation.guest != guest_email:
+            raise InvalidInvitation(
+                reason="This invitation was issued for a different email"
+            )
 
         # existing users cannot be re-invited
         if await _is_user_registered(app=app, email=invitation.guest):

--- a/services/web/server/src/simcore_service_webserver/invitations_settings.py
+++ b/services/web/server/src/simcore_service_webserver/invitations_settings.py
@@ -1,0 +1,61 @@
+""" Settings for the invitations plugin
+
+NOTE: do not move them to settings_library since (so far) only the
+webserver should interact with this
+"""
+
+from functools import cached_property
+
+from aiohttp import web
+from pydantic import Field, SecretStr
+from settings_library.base import BaseCustomSettings
+from settings_library.basic_types import PortInt, VersionTag
+from settings_library.utils_service import (
+    DEFAULT_FASTAPI_PORT,
+    MixinServiceSettings,
+    URLPart,
+)
+
+from ._constants import APP_SETTINGS_KEY
+
+
+class InvitationsSettings(BaseCustomSettings, MixinServiceSettings):
+    INVITATIONS_HOST: str = "invitations"
+    INVITATIONS_PORT: PortInt = DEFAULT_FASTAPI_PORT
+    INVITATIONS_VTAG: VersionTag = "v1"
+
+    INVITATIONS_USERNAME: str = Field(
+        ...,
+        description="Username for HTTP Basic Auth. Required if started as a web app.",
+        min_length=3,
+    )
+    INVITATIONS_PASSWORD: SecretStr = Field(
+        ...,
+        description="Password for HTTP Basic Auth. Required if started as a web app.",
+        min_length=10,
+    )
+
+    @cached_property
+    def api_base_url(self) -> str:
+        # http://invitations:8000/v1
+        return self._compose_url(
+            prefix="INVITATIONS",
+            port=URLPart.REQUIRED,
+            vtag=URLPart.REQUIRED,
+        )
+
+    @cached_property
+    def base_url(self) -> str:
+        # http://invitations:8000
+        return self._compose_url(
+            prefix="INVITATIONS",
+            port=URLPart.REQUIRED,
+            vtag=URLPart.EXCLUDE,
+        )
+
+
+def get_plugin_settings(app: web.Application) -> InvitationsSettings:
+    settings = app[APP_SETTINGS_KEY].WEBSERVER_INVITATIONS
+    assert settings, "setup_settings not called?"  # nosec
+    assert isinstance(settings, InvitationsSettings)  # nosec
+    return settings

--- a/services/web/server/src/simcore_service_webserver/login/_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/_registration.py
@@ -157,7 +157,11 @@ async def create_invitation_token(
 
 
 async def check_and_consume_invitation(
-    invitation_code: str, db: AsyncpgStorage, cfg: LoginOptions, app=web.Application
+    invitation_code: str,
+    guest_email: str,
+    db: AsyncpgStorage,
+    cfg: LoginOptions,
+    app=web.Application,
 ) -> InvitationData:
     """Consumes invitation: the code is validated, the invitation retrieives and then deleted
        since it only has one use
@@ -178,9 +182,13 @@ async def check_and_consume_invitation(
                 confirmation=ConfirmationTokenDict(
                     code=invitation_code, action=ConfirmationAction.INVITATION.name
                 ),
-                origin=URL("https://127.0.0.1:8000"),
+                origin=URL("https://fakehost.io:8000"),
             )
-            content = await validate_invitation_url(app, invitation_url=f"{url}")
+            content = await validate_invitation_url(
+                app,
+                guest_email=guest_email,
+                invitation_url=f"{url}",
+            )
 
             log.info("Consuming invitation from service:\n%s", content.json(indent=1))
             return InvitationData(

--- a/services/web/server/src/simcore_service_webserver/login/_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/_registration.py
@@ -187,28 +187,6 @@ async def check_and_consume_invitation(
     )
 
 
-def get_confirmation_info(
-    cfg: LoginOptions, confirmation: ConfirmationTokenDict
-) -> ConfirmationTokenInfoDict:
-    """
-    Extends ConfirmationTokenDict by adding extra info and
-    deserializing action's data entry
-    """
-    info = ConfirmationTokenInfoDict(**confirmation)
-
-    action = ConfirmationAction(confirmation["action"])
-    if (data_type := ACTION_TO_DATA_TYPE[action]) and (data := confirmation["data"]):
-        info["data"] = parse_raw_as(data_type, data)
-
-    # extra
-    info["expires"] = get_expiration_date(cfg, confirmation)
-
-    if confirmation["action"] == ConfirmationAction.INVITATION.name:
-        info["url"] = f"{get_invitation_url(confirmation)}"
-
-    return info
-
-
 def get_invitation_url(
     confirmation: ConfirmationTokenDict, origin: Optional[URL] = None
 ) -> URL:
@@ -230,3 +208,26 @@ def get_invitation_url(
     # https://some-web-url.io/#/registration/?invitation={code}
     # NOTE: Uniform encoding in front-end fragments https://github.com/ITISFoundation/osparc-simcore/issues/1975
     return origin.with_fragment(f"/registration/?invitation={code}")
+
+
+def get_confirmation_info(
+    cfg: LoginOptions, confirmation: ConfirmationTokenDict
+) -> ConfirmationTokenInfoDict:
+    """
+    Extends ConfirmationTokenDict by adding extra info and
+    deserializing action's data entry
+    """
+    # TODO: move to _confirmation.py??
+    info = ConfirmationTokenInfoDict(**confirmation)
+
+    action = ConfirmationAction(confirmation["action"])
+    if (data_type := ACTION_TO_DATA_TYPE[action]) and (data := confirmation["data"]):
+        info["data"] = parse_raw_as(data_type, data)
+
+    # extra
+    info["expires"] = get_expiration_date(cfg, confirmation)
+
+    if confirmation["action"] == ConfirmationAction.INVITATION.name:
+        info["url"] = f"{get_invitation_url(confirmation)}"
+
+    return info

--- a/services/web/server/src/simcore_service_webserver/login/_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/_registration.py
@@ -266,7 +266,6 @@ def get_confirmation_info(
     Extends ConfirmationTokenDict by adding extra info and
     deserializing action's data entry
     """
-    # TODO: move to _confirmation.py??
     info = ConfirmationTokenInfoDict(**confirmation)
 
     action = ConfirmationAction(confirmation["action"])

--- a/services/web/server/src/simcore_service_webserver/login/_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/_registration.py
@@ -189,15 +189,9 @@ async def check_and_consume_invitation(
                 trial_account_days=content.trial_account_days,
             )
 
-        except ValidationError as err:
+        except (ValidationError, InvalidInvitation) as err:
             raise web.HTTPForbidden(
                 reason=f"{err}. {MSG_CONTACT_SUPPORT_SUFFIX}",
-                content_type=MIMETYPE_APPLICATION_JSON,
-            )
-
-        except InvalidInvitation as err:
-            raise web.HTTPForbidden(
-                reason=f"{err}. {MSG_CONTACT_SUPPORT_SUFFIX}.",
                 content_type=MIMETYPE_APPLICATION_JSON,
             )
 

--- a/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
@@ -109,7 +109,9 @@ async def register(request: web.Request):
                 content_type=MIMETYPE_APPLICATION_JSON,
             )
 
-        invitation = await check_and_consume_invitation(invitation_code, db=db, cfg=cfg)
+        invitation = await check_and_consume_invitation(
+            invitation_code, db=db, cfg=cfg, app=request.app
+        )
         if invitation.trial_account_days:
             expires_at = datetime.utcnow() + timedelta(invitation.trial_account_days)
 

--- a/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
@@ -110,7 +110,11 @@ async def register(request: web.Request):
             )
 
         invitation = await check_and_consume_invitation(
-            invitation_code, db=db, cfg=cfg, app=request.app
+            invitation_code,
+            guest_email=registration.email,
+            db=db,
+            cfg=cfg,
+            app=request.app,
         )
         if invitation.trial_account_days:
             expires_at = datetime.utcnow() + timedelta(invitation.trial_account_days)

--- a/services/web/server/src/simcore_service_webserver/login/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/login/plugin.py
@@ -20,6 +20,7 @@ from ..db_settings import get_plugin_settings as get_db_plugin_settings
 from ..email import setup_email
 from ..email_settings import SMTPSettings
 from ..email_settings import get_plugin_settings as get_email_plugin_settings
+from ..invitations import setup_invitations
 from ..products import ProductName, list_products, setup_products
 from ..redis import setup_redis
 from ..rest import setup_rest
@@ -145,6 +146,7 @@ def setup_login(app: web.Application):
     setup_products(app)
     setup_rest(app)
     setup_email(app)
+    setup_invitations(app)
 
     # routes
     specs = app[APP_OPENAPI_SPECS_KEY]

--- a/services/web/server/tests/unit/with_dbs/03/test_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_invitations.py
@@ -4,23 +4,110 @@
 # pylint: disable=too-many-arguments
 
 
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
 import pytest
+from aiohttp import web
 from aiohttp.test_utils import TestClient
 from pytest import MonkeyPatch
+from pytest_simcore.aioresponses_mocker import AioResponsesMock
 from pytest_simcore.helpers.utils_envs import EnvVarsDict
-from simcore_service_webserver.invitations import setup_invitations
-from simcore_service_webserver.invitations_settings import InvitationsSettings
+from simcore_service_webserver.invitations import (
+    InvitationServiceUnavailable,
+    validate_invitation_url,
+)
+from simcore_service_webserver.invitations_client import (
+    InvitationsServiceApi,
+    get_invitations_service_api,
+)
+from simcore_service_webserver.invitations_settings import (
+    InvitationsSettings,
+    get_plugin_settings,
+)
+from yarl import URL
 
 
 @pytest.fixture
 def app_environment(app_environment: EnvVarsDict, monkeypatch: MonkeyPatch):
-    assert InvitationsSettings.create_from_envs()
-
+    plugin_settings = InvitationsSettings.create_from_envs()
+    print("InvitationsSettings=", plugin_settings.json(indent=1))
     return app_environment
 
 
-def test_setup_invitations(client: TestClient):
-    setup_invitations(app=client.app)
+@pytest.fixture(scope="module")
+def invitations_service_openapi_specs(
+    osparc_simcore_services_dir: Path,
+) -> dict[str, Any]:
+    oas_path = osparc_simcore_services_dir / "invitations" / "openapi.json"
+    openapi_specs = json.loads(oas_path.read_text())
+    return openapi_specs
+
+
+@pytest.fixture
+def app_invitation_plugin_settings(client: TestClient) -> InvitationsSettings:
+    settings = get_plugin_settings(app=client.app)
+    assert settings
+    return settings
+
+
+@pytest.fixture
+def mock_invitations_service_http_api(
+    aioresponses_mocker: AioResponsesMock,
+    app_invitation_plugin_settings: InvitationsSettings,
+    invitations_service_openapi_specs: dict[str, Any],
+) -> AioResponsesMock:
+    oas = deepcopy(invitations_service_openapi_specs)
+    base_url = URL(app_invitation_plugin_settings.base_url)
+
+    # healthcheck
+    assert "/" in oas["paths"]
+    aioresponses_mocker.get(
+        f"{base_url}/",
+        status=web.HTTPOk.status_code,
+    )
+
+    # meta
+    assert "/v1/meta" in oas["paths"]
+    aioresponses_mocker.get(
+        f"{base_url}/v1/meta",
+        status=web.HTTPOk.status_code,
+        payload={"name": "string", "version": "string", "docs_url": "string"},
+        repeat=True,
+    )
+
+    # extract
+    assert "/v1/invitations:extract" in oas["paths"]
+    aioresponses_mocker.post(
+        f"{base_url}/v1/invitations:extract",
+        status=web.HTTPOk.status_code,
+        payload=oas["components"]["schemas"]["_ApiInvitationContent"]["example"],
+        repeat=True,
+    )
+
+    return aioresponses_mocker
+
+
+async def test_invitation_service_unavailable(client: TestClient):
+
+    invitations_api: InvitationsServiceApi = get_invitations_service_api(app=client.app)
+
+    assert not await invitations_api.ping()
+
+    with pytest.raises(InvitationServiceUnavailable):
+        await validate_invitation_url(
+            app=client.app, invitation_url="https://osparc.io#register?invitation=1234"
+        )
+
+
+async def test_invitation_service_api_ping(
+    client: TestClient, mock_invitations_service_http_api: AioResponsesMock
+):
+    invitations_api: InvitationsServiceApi = get_invitations_service_api(app=client.app)
+
+    assert await invitations_api.ping()
 
 
 # create fake invitation service

--- a/services/web/server/tests/unit/with_dbs/03/test_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_invitations.py
@@ -136,7 +136,7 @@ async def test_invitation_service_unavailable(client: TestClient):
 
     with pytest.raises(InvitationServiceUnavailable):
         await validate_invitation_url(
-            app=client.app, invitation_url="https://osparc.io#register?invitation=1234"
+            app=client.app, invitation_url="https://server.com#register?invitation=1234"
         )
 
 
@@ -150,7 +150,7 @@ async def test_invitation_service_api_ping(
     assert await invitations_api.ping()
 
     invitation = await validate_invitation_url(
-        app=client.app, invitation_url="https://osparc.io#register?invitation=1234"
+        app=client.app, invitation_url="https://server.com#register?invitation=1234"
     )
     assert invitation
 
@@ -162,18 +162,3 @@ async def test_invitation_service_api_ping(
 # invalid invitation
 
 # confirmation-type of invitations
-
-
-@pytest.mark.testit
-async def test_it(
-    # client: TestClient,
-    mock_invitations_service_http_api: AioResponsesMock,
-):
-    # invitations_api: InvitationsServiceApi = get_invitations_service_api(app=client.app)
-
-    from aiohttp import ClientSession
-
-    async with ClientSession(base_url="http://invitations:8000") as session:
-        async with session.get("/v1/meta") as response:
-            body = await response.text()
-            assert response.status == 200

--- a/services/web/server/tests/unit/with_dbs/03/test_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_invitations.py
@@ -120,6 +120,7 @@ def mock_invitations_service_http_api(
     aioresponses_mocker.get(
         f"{base_url}/",
         status=web.HTTPOk.status_code,
+        repeat=True,
     )
 
     # meta

--- a/services/web/server/tests/unit/with_dbs/03/test_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_invitations.py
@@ -1,0 +1,33 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+# pylint: disable=too-many-arguments
+
+
+import pytest
+from aiohttp.test_utils import TestClient
+from pytest import MonkeyPatch
+from pytest_simcore.helpers.utils_envs import EnvVarsDict
+from simcore_service_webserver.invitations import setup_invitations
+from simcore_service_webserver.invitations_settings import InvitationsSettings
+
+
+@pytest.fixture
+def app_environment(app_environment: EnvVarsDict, monkeypatch: MonkeyPatch):
+    assert InvitationsSettings.create_from_envs()
+
+    return app_environment
+
+
+def test_setup_invitations(client: TestClient):
+    setup_invitations(app=client.app)
+
+
+# create fake invitation service
+
+
+# valid invitation
+
+# invalid invitation
+
+# confirmation-type of invitations

--- a/services/web/server/tests/unit/with_dbs/03/test_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_invitations.py
@@ -162,3 +162,18 @@ async def test_invitation_service_api_ping(
 # invalid invitation
 
 # confirmation-type of invitations
+
+
+@pytest.mark.testit
+async def test_it(
+    # client: TestClient,
+    mock_invitations_service_http_api: AioResponsesMock,
+):
+    # invitations_api: InvitationsServiceApi = get_invitations_service_api(app=client.app)
+
+    from aiohttp import ClientSession
+
+    async with ClientSession(base_url="http://invitations:8000") as session:
+        async with session.get("/v1/meta") as response:
+            body = await response.text()
+            assert response.status == 200

--- a/services/web/server/tests/unit/with_dbs/03/test_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_invitations.py
@@ -124,6 +124,7 @@ def mock_invitations_service_http_api(
     aioresponses_mocker.get(
         f"{base_url}/",
         status=web.HTTPOk.status_code,
+        repeat=False,  # NOTE: this is only usable once!
     )
 
     # meta
@@ -158,6 +159,7 @@ async def test_invitation_service_unavailable(client: TestClient):
         )
 
 
+@pytest.mark.testit
 async def test_invitation_service_api_ping(
     client: TestClient,
     mock_invitations_service_http_api: AioResponsesMock,
@@ -170,12 +172,7 @@ async def test_invitation_service_api_ping(
     # first request is mocked to pass
     assert await invitations_api.ping()
 
-    mock_invitations_service_http_api.get(
-        f"{base_url}/",
-        status=web.HTTPServiceUnavailable.status_code,
-    )
-
-    # second request is mocked to fail
+    # second request is mocked to fail (since mock only works once)
     assert not await invitations_api.is_responsive()
 
 

--- a/services/web/server/tests/unit/with_dbs/03/test_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_invitations.py
@@ -37,6 +37,13 @@ def app_environment(app_environment: EnvVarsDict, monkeypatch: MonkeyPatch):
     return app_environment
 
 
+@pytest.fixture
+def app_invitation_plugin_settings(client: TestClient) -> InvitationsSettings:
+    settings = get_plugin_settings(app=client.app)
+    assert settings
+    return settings
+
+
 @pytest.fixture(scope="module")
 def invitations_service_openapi_specs(
     osparc_simcore_services_dir: Path,
@@ -47,17 +54,10 @@ def invitations_service_openapi_specs(
 
 
 @pytest.fixture
-def app_invitation_plugin_settings(client: TestClient) -> InvitationsSettings:
-    settings = get_plugin_settings(app=client.app)
-    assert settings
-    return settings
-
-
-@pytest.fixture
 def mock_invitations_service_http_api(
     aioresponses_mocker: AioResponsesMock,
-    app_invitation_plugin_settings: InvitationsSettings,
     invitations_service_openapi_specs: dict[str, Any],
+    app_invitation_plugin_settings: InvitationsSettings,
 ) -> AioResponsesMock:
     oas = deepcopy(invitations_service_openapi_specs)
     base_url = URL(app_invitation_plugin_settings.base_url)
@@ -107,11 +107,17 @@ async def test_invitation_service_api_ping(
 ):
     invitations_api: InvitationsServiceApi = get_invitations_service_api(app=client.app)
 
+    print(mock_invitations_service_http_api)
+
     assert await invitations_api.ping()
+
+    invitation = await validate_invitation_url(
+        app=client.app, invitation_url="https://osparc.io#register?invitation=1234"
+    )
+    assert invitation
 
 
 # create fake invitation service
-
 
 # valid invitation
 

--- a/services/web/server/tests/unit/with_dbs/03/test_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_invitations.py
@@ -120,7 +120,10 @@ def mock_invitations_service_http_api(
     aioresponses_mocker.get(
         f"{base_url}/",
         status=web.HTTPOk.status_code,
-        repeat=True,
+    )
+    aioresponses_mocker.get(
+        f"{base_url}/",
+        status=web.HTTPServiceUnavailable.status_code,
     )
 
     # meta
@@ -129,7 +132,6 @@ def mock_invitations_service_http_api(
         f"{base_url}/v1/meta",
         status=web.HTTPOk.status_code,
         payload={"name": "string", "version": "string", "docs_url": "string"},
-        repeat=True,
     )
 
     # extract
@@ -138,7 +140,6 @@ def mock_invitations_service_http_api(
         f"{base_url}/v1/invitations:extract",
         status=web.HTTPOk.status_code,
         payload=jsonable_encoder(expected_invitation.dict()),
-        repeat=True,
     )
 
     return aioresponses_mocker
@@ -164,8 +165,11 @@ async def test_invitation_service_api_ping(
 
     print(mock_invitations_service_http_api)
 
+    # first request is mocked to pass
     assert await invitations_api.ping()
-    assert await invitations_api.is_responsive()
+
+    # second request is mocked to fail
+    assert not await invitations_api.is_responsive()
 
 
 async def test_valid_invitation(
@@ -199,12 +203,3 @@ async def test_invalid_invitation_if_already_registered(
                 app=client.app,
                 invitation_url="https://server.com#register?invitation=1234",
             )
-
-
-# create fake invitation service
-
-# valid invitation
-
-# invalid invitation
-
-# confirmation-type of invitations

--- a/services/web/server/tests/unit/with_dbs/03/test_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_invitations.py
@@ -12,6 +12,7 @@ from typing import Any
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient
+from models_library.utils.fastapi_encoders import jsonable_encoder
 from pytest import MonkeyPatch
 from pytest_simcore.aioresponses_mocker import AioResponsesMock
 from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_dict
@@ -19,11 +20,11 @@ from pytest_simcore.helpers.utils_login import NewUser
 from simcore_service_webserver.application_settings import ApplicationSettings
 from simcore_service_webserver.invitations import (
     InvalidInvitation,
-    InvitationContent,
     InvitationsServiceUnavailable,
     validate_invitation_url,
 )
 from simcore_service_webserver.invitations_client import (
+    InvitationContent,
     InvitationsServiceApi,
     get_invitations_service_api,
 )
@@ -135,7 +136,7 @@ def mock_invitations_service_http_api(
     aioresponses_mocker.post(
         f"{base_url}/v1/invitations:extract",
         status=web.HTTPOk.status_code,
-        payload=expected_invitation.dict(),
+        payload=jsonable_encoder(expected_invitation.dict()),
         repeat=True,
     )
 
@@ -163,6 +164,7 @@ async def test_invitation_service_api_ping(
     print(mock_invitations_service_http_api)
 
     assert await invitations_api.ping()
+    assert await invitations_api.is_responsive()
 
 
 async def test_valid_invitation(


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

Implements new invitations check on the web-server

- ✨ New ``web/server/invitations`` plugin to interact with the ``invitations`` service
  - ``invitations_settings.py``: plugin settings
  - ``invitations_client.py``: SDK to interact with the service http API. 
     - setup/tear-down client session
     - exposes service API
  - ``invitations.py``: exposes plugin API (free functions and exceptions) and ``setup_*`` function
- ✨ Adds new invitations check in ``web/server/login`` plugin
- 🔨 Cleanup scripts in ``invitations`` service
- 📝 Cleanup badges in README

## Related issue/s

- ITISFoundation/osparc-simcore#3683: webserver side of the invitations


## How to test

- unit tested with coverage >85%
- manually
1. set  ``WEBSERVER_LOGIN_REGISTRATION_CONFIRMATION_REQUIRED=1`` and ``WEBSERVER_LOGIN_REGISTRATION_INVITATION_REQUIRED=1`` in ``.env`` file.
1. Generate invitation link (e.g. use ``invitations service API``. Link and credentials are listed in the table after ``make up`` as ``Invitations``)
1. Add link in browser and follow instructions in the UI to register a user

## Checklist

- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes
