### PR TITLE
✨ Enhancement/dynamic sidecar/add progress pulling services

### DIFF
--- a/packages/models-library/src/models_library/basic_regex.py
+++ b/packages/models-library/src/models_library/basic_regex.py
@@ -71,5 +71,5 @@ DOCKER_LABEL_KEY_REGEX: Final[re.Pattern] = re.compile(
 DOCKER_IMAGE_KEY_RE = r"[\w/-]+"
 DOCKER_IMAGE_VERSION_RE = r"[\w/.]+"
 DOCKER_GENERIC_TAG_KEY_RE: Final[re.Pattern] = re.compile(
-    r"^(?P<registry_host>(?=[^:\/]{1,253})(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*(?::[0-9]{1,5})?/)?(?P<image_name>(?![._-])(?:[a-z0-9._-]*)(?<![._-])(?:/(?![._-])[a-z0-9._-]*(?<![._-]))*):(?P<tag_name>(?![.-])[a-zA-Z0-9_.-]{1,128})?$"
+    r"^(?P<registry_host>(?=[^:\/]{1,253})(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*(?::\d{1,5})?/)?(?P<image_name>(?![._-])(?:[a-z0-9._-]*)(?<![._-])(?:/(?![._-])[a-z0-9._-]*(?<![._-]))*):(?P<tag_name>(?![.-])[a-zA-Z0-9_.-]{1,128})?$"
 )

--- a/packages/models-library/src/models_library/basic_regex.py
+++ b/packages/models-library/src/models_library/basic_regex.py
@@ -70,3 +70,6 @@ DOCKER_LABEL_KEY_REGEX: Final[re.Pattern] = re.compile(
 )
 DOCKER_IMAGE_KEY_RE = r"[\w/-]+"
 DOCKER_IMAGE_VERSION_RE = r"[\w/.]+"
+DOCKER_GENERIC_TAG_KEY_RE: Final[re.Pattern] = re.compile(
+    r"^(?P<registry_host>(?=[^:\/]{1,253})(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*(?::[0-9]{1,5})?/)?(?P<image_name>(?![._-])(?:[a-z0-9._-]*)(?<![._-])(?:/(?![._-])[a-z0-9._-]*(?<![._-]))*):(?P<tag_name>(?![.-])[a-zA-Z0-9_.-]{1,128})?$"
+)

--- a/packages/models-library/src/models_library/docker.py
+++ b/packages/models-library/src/models_library/docker.py
@@ -4,6 +4,7 @@ from typing import Optional
 from pydantic import ConstrainedStr, constr
 
 from .basic_regex import (
+    DOCKER_GENERIC_TAG_KEY_RE,
     DOCKER_IMAGE_KEY_RE,
     DOCKER_IMAGE_VERSION_RE,
     DOCKER_LABEL_KEY_REGEX,
@@ -17,3 +18,7 @@ class DockerLabelKey(ConstrainedStr):
     # NOTE: https://docs.docker.com/config/labels-custom-metadata/#key-format-recommendations
     # good practice: use reverse DNS notation
     regex: Optional[re.Pattern[str]] = DOCKER_LABEL_KEY_REGEX
+
+
+class DockerGenericTag(ConstrainedStr):
+    regex: Optional[re.Pattern[str]] = DOCKER_GENERIC_TAG_KEY_RE

--- a/packages/models-library/src/models_library/docker.py
+++ b/packages/models-library/src/models_library/docker.py
@@ -21,4 +21,5 @@ class DockerLabelKey(ConstrainedStr):
 
 
 class DockerGenericTag(ConstrainedStr):
+    # NOTE: https://docs.docker.com/engine/reference/commandline/tag/#description
     regex: Optional[re.Pattern[str]] = DOCKER_GENERIC_TAG_KEY_RE

--- a/packages/models-library/tests/test_docker.py
+++ b/packages/models-library/tests/test_docker.py
@@ -3,7 +3,7 @@
 # pylint: disable=unused-variable
 
 import pytest
-from models_library.docker import DockerLabelKey
+from models_library.docker import DockerGenericTag, DockerLabelKey
 from pydantic import ValidationError, parse_obj_as
 
 
@@ -35,3 +35,61 @@ def test_docker_label_key(label_key: str, valid: bool):
     else:
         with pytest.raises(ValidationError):
             parse_obj_as(DockerLabelKey, label_key)
+
+
+@pytest.mark.parametrize(
+    "image_name, valid",
+    (
+        ("busybox:latest", True),
+        (
+            "registry.osparc-master.com/simcore/services/dynamic/jupyter-smash:2.3.4",
+            True,
+        ),
+        ("registry-1.docker.io/nginx:latest", True),
+        ("registry-1.docker.io/ngin34x:latest", True),
+        ("itisfoundation/dynamic-sidecar:release-github-latest", True),
+        (
+            "registry:5000/si.m--c_ore/services/1234/jupyter-smash:2.3.4",
+            True,
+        ),
+        (
+            "registry:5000/simcore/dyUPPER_CASE_FORBIDDEN_IN_NAME/jupyter-smash:2.3.4",
+            False,
+        ),
+        (
+            "registry:5000/si.m--c_ore/services/1234/jupyter-smash:.2.3.4",
+            False,
+        ),
+        (
+            "registry:5000/si.m--c_ore/services/1234/jupyter-smash:-2.3.4",
+            False,
+        ),
+        (
+            "registry:5000/si.m--c_ore/services/1234/jupyter-smash:_2.3.4",
+            True,
+        ),
+        (
+            "registry:5000/si.m--c_ore/services/1234/jupyter-smash:AUPPER_CASE_TAG_IS_OK_2.3.4",
+            True,
+        ),
+        (
+            "registry:5000/si.m--c_ore/services/1234/jupyter-smash:AUPPER_CASE_TAG_IS_OK_2.3.4",
+            True,
+        ),
+        (
+            f"registry:5000/si.m--c_ore/services/1234/jupyter-smash:{'A'*128}",
+            True,
+        ),
+        (
+            f"registry:5000/si.m--c_ore/services/1234/jupyter-smash:{'A'*129}",
+            False,
+        ),
+    ),
+)
+def test_docker_generic_tag(image_name: str, valid: bool):
+    if valid:
+        instance = parse_obj_as(DockerGenericTag, image_name)
+        assert instance
+    else:
+        with pytest.raises(ValidationError):
+            parse_obj_as(DockerGenericTag, image_name)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
@@ -105,7 +105,7 @@ async def docker_compose_pull(app: FastAPI, compose_spec_yaml: str) -> None:
             },
         ):
             await post_sidecar_log_message(
-                app, f"{pull_progress['status']}, id: {pull_progress['id']}..."
+                app, f"pulling {simplified_image_name}: {pull_progress}..."
             )
 
     list_of_images = get_docker_service_images(compose_spec_yaml)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
@@ -56,9 +56,9 @@ async def get_running_containers_count_from_names(
         return len(containers)
 
 
-def get_docker_service_images(compose_spec_yaml: str) -> list[str]:
+def get_docker_service_images(compose_spec_yaml: str) -> set[str]:
     docker_compose_spec = yaml.safe_load(compose_spec_yaml)
-    return [
+    return {
         service_data["image"]
         for service_data in docker_compose_spec["services"].values()
-    ]
+    }

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator
 
 import aiodocker
+import yaml
 from aiodocker.utils import clean_filters
 from models_library.services import RunID
 from pydantic import PositiveInt
@@ -53,3 +54,11 @@ async def get_running_containers_count_from_names(
         filters = clean_filters({"name": container_names})
         containers = await docker.containers.list(all=True, filters=filters)
         return len(containers)
+
+
+def get_docker_service_images(compose_spec_yaml: str) -> list[str]:
+    docker_compose_spec = yaml.safe_load(compose_spec_yaml)
+    return [
+        service_data["image"]
+        for service_data in docker_compose_spec["services"].values()
+    ]

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -101,7 +101,6 @@ async def task_create_service_containers(
 
     logger.info("Validated compose-spec:\n%s", f"{shared_store.compose_spec}")
 
-    await post_sidecar_log_message(app, "starting service containers")
     assert shared_store.compose_spec  # nosec
 
     with outputs_watcher_disabled(app):
@@ -111,7 +110,8 @@ async def task_create_service_containers(
 
         progress.update(message="pulling images", percent=0.01)
         await post_sidecar_log_message(app, "pulling service images")
-        await docker_compose_pull(app, shared_store.compose_spec, settings)
+        await docker_compose_pull(app, shared_store.compose_spec)
+        await post_sidecar_log_message(app, "service images ready")
 
         progress.update(message="creating and starting containers", percent=0.90)
         await post_sidecar_log_message(app, "starting service containers")

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -110,9 +110,11 @@ async def task_create_service_containers(
         await docker_compose_rm(shared_store.compose_spec, settings)
 
         progress.update(message="pulling images", percent=0.01)
-        await docker_compose_pull(shared_store.compose_spec, settings)
+        await post_sidecar_log_message(app, "pulling service images")
+        await docker_compose_pull(app, shared_store.compose_spec, settings)
 
         progress.update(message="creating and starting containers", percent=0.90)
+        await post_sidecar_log_message(app, "starting service containers")
         await _retry_docker_compose_create(shared_store.compose_spec, settings)
 
         progress.update(message="ensure containers are started", percent=0.95)

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_compose_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_compose_utils.py
@@ -76,7 +76,7 @@ async def test_docker_compose_workflow(
     # pulls containers before starting them
     fake_app = mocker.AsyncMock()
     fake_app.state.settings = settings
-    await docker_compose_pull(fake_app, compose_spec_yaml, settings)
+    await docker_compose_pull(fake_app, compose_spec_yaml)
 
     # creates containers
     r = await docker_compose_create(compose_spec_yaml, settings)

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_compose_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_compose_utils.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
+# pylint: disable=too-many-function-args
 
 import asyncio
 from typing import Any

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_compose_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_compose_utils.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 import yaml
 from faker import Faker
+from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_service_dynamic_sidecar.core.docker_compose_utils import (
     docker_compose_config,
@@ -50,6 +51,7 @@ async def test_docker_compose_workflow(
     mock_environment: EnvVarsDict,
     with_restart: bool,
     ensure_run_in_sequence_context_is_empty: None,
+    mocker: MockerFixture,
 ):
     settings = ApplicationSettings.create_from_envs()
 
@@ -71,9 +73,9 @@ async def test_docker_compose_workflow(
     assert r.success, r.message
 
     # pulls containers before starting them
-    r = await docker_compose_pull(compose_spec_yaml, settings)
-    _print_result(r)
-    assert r.success, r.message
+    fake_app = mocker.AsyncMock()
+    fake_app.state.settings = settings
+    await docker_compose_pull(fake_app, compose_spec_yaml, settings)
 
     # creates containers
     r = await docker_compose_create(compose_spec_yaml, settings)

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
@@ -124,8 +124,8 @@ def compose_spec_yaml() -> str:
 
 
 def test_get_docker_service_images(compose_spec_yaml: str):
-    assert get_docker_service_images(compose_spec_yaml) == [
+    assert get_docker_service_images(compose_spec_yaml) == {
         "busybox:latest",
         "nginx:latest",
         "simcore/services/dynamic/jupyter-math:2.1.3",
-    ]
+    }


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
use aiodocker and its integrated progress context to pull container service images

            
![image](https://user-images.githubusercontent.com/35365065/212929654-fcacf02b-d3df-43b4-87fd-83911eaa9d7c.png)

## Related issue/s
fixes #3229 
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
