### PR TITLE
🐛 observation cycle cancellation

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
@@ -257,12 +257,14 @@ class Scheduler(SchedulerInternalsMixin, SchedulerPublicInterface):
                 if isinstance(service_task, asyncio.Task):
                     service_task.cancel()
 
-                    async def _wait_task(task: asyncio.Task) -> None:
+                    async def _await_task(task: asyncio.Task) -> None:
                         await task
 
                     with suppress(asyncio.CancelledError):
                         try:
-                            await asyncio.wait_for(_wait_task(service_task), timeout=10)
+                            await asyncio.wait_for(
+                                _await_task(service_task), timeout=10
+                            )
                         except asyncio.TimeoutError:
                             pass
 
@@ -474,7 +476,7 @@ class Scheduler(SchedulerInternalsMixin, SchedulerPublicInterface):
                 dynamic_sidecar_settings=dynamic_sidecar_settings,
                 dynamic_scheduler=dynamic_scheduler,
             ),
-            name=f"observe_{service_name}",
+            name=f"{__name__}.observe_{service_name}",
         )
         observation_task.add_done_callback(
             functools.partial(

--- a/services/director-v2/tests/conftest.py
+++ b/services/director-v2/tests/conftest.py
@@ -161,7 +161,7 @@ def mock_env(
 
 
 @pytest.fixture(scope="function")
-def client(mock_env: EnvVarsDict) -> Iterable[TestClient]:
+async def client(mock_env: EnvVarsDict) -> Iterable[TestClient]:
     settings = AppSettings.create_from_envs()
     app = init_app(settings)
     print("Application settings\n", settings.json(indent=2))


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Adding cancellation of observation cycle. Allows for resources to be freed and services to close faster.

NOTE: by design, the legacy dynamic sidecar scheduler, never supported this. The observation cycle will raise some unexpected errors when cancelled. :hammer::hammer:

NOTE: upcoming, new version of the scheduler, already comes with proper cancellation and will avoid all this mess.


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

- fixes https://github.com/ITISFoundation/osparc-issues/issues/827
- https://github.com/ITISFoundation/osparc-issues/issues/638

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
