### PR TITLE
🐛 Fixes invitation_required value in /config 

### DIFF
--- a/services/web/server/src/simcore_service_webserver/_constants.py
+++ b/services/web/server/src/simcore_service_webserver/_constants.py
@@ -14,13 +14,16 @@ from servicelib.aiohttp.application_keys import (
 from servicelib.request_keys import RQT_USERID_KEY
 
 # Application storage keys
-APP_PRODUCTS_KEY: Final[str] = f"{__name__ }.products"
+APP_PRODUCTS_KEY: Final[str] = f"{__name__ }.APP_PRODUCTS_KEY"
 
 # Request storage keys
-RQ_PRODUCT_KEY: Final[str] = f"{__name__}.product"
+RQ_PRODUCT_KEY: Final[str] = f"{__name__}.RQ_PRODUCT_KEY"
 
 # Headers keys
 X_PRODUCT_NAME_HEADER: Final[str] = "X-Simcore-Products-Name"
 
 # main index route name = front-end
 INDEX_RESOURCE_NAME: Final[str] = "statics.index"
+
+# Public config per product returned in /config
+APP_PUBLIC_CONFIG_PER_PRODUCT: Final[str] = f"{__name__}.APP_PUBLIC_CONFIG_PER_PRODUCT"

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -287,15 +287,16 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
         return data
 
     def public_dict(self) -> dict[str, Any]:
-        """Data publicaly available"""
+        """Config publicaly available"""
 
-        data = {"invitation_required": False}
+        config = {"invitation_required": False}
         if self.WEBSERVER_LOGIN:
-            data[
+            # NOTE: overriden in _resolve_login_settings_per_product (I know ... :-( )
+            config[
                 "invitation_required"
             ] = self.WEBSERVER_LOGIN.LOGIN_REGISTRATION_INVITATION_REQUIRED
 
-        data.update(
+        config.update(
             self._export_by_alias(
                 include={
                     "API_VERSION",
@@ -307,7 +308,7 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
                 exclude_none=True,
             )
         )
-        return data
+        return config
 
     def to_client_statics(self) -> dict[str, Any]:
         data = self._export_by_alias(

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -286,7 +286,7 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
                 data[new_key] = data.pop(key)
         return data
 
-    def public_dict(self) -> dict[str, Any]:
+    def public_config_dict(self) -> dict[str, Any]:
         """Config publicaly available"""
 
         config = {"invitation_required": False}

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -286,7 +286,7 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
                 data[new_key] = data.pop(key)
         return data
 
-    def public_config_dict(self) -> dict[str, Any]:
+    def public_dict(self) -> dict[str, Any]:
         """Config publicaly available"""
 
         config = {"invitation_required": False}

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -289,13 +289,7 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
     def public_dict(self) -> dict[str, Any]:
         """Config publicaly available"""
 
-        config = {"invitation_required": False}
-        if self.WEBSERVER_LOGIN:
-            # NOTE: overriden in _resolve_login_settings_per_product (I know ... :-( )
-            config[
-                "invitation_required"
-            ] = self.WEBSERVER_LOGIN.LOGIN_REGISTRATION_INVITATION_REQUIRED
-
+        config = {"invitation_required": False}  # SEE APP_PUBLIC_CONFIG_PER_PRODUCT
         config.update(
             self._export_by_alias(
                 include={

--- a/services/web/server/src/simcore_service_webserver/rest_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/rest_handlers.py
@@ -71,7 +71,9 @@ async def get_config(request: web.Request):
     register but the server has been setup to require an invitation. This option is setup
     at runtime and the front-end can only get it upon request to /config
     """
-    app_public_config: dict[str, Any] = request.app[APP_SETTINGS_KEY].public_dict()
+    app_public_config: dict[str, Any] = request.app[
+        APP_SETTINGS_KEY
+    ].public_config_dict()
 
     product_name = get_product_name(request=request)
     product_public_config = request.app.get(APP_PUBLIC_CONFIG_PER_PRODUCT, {}).get(

--- a/services/web/server/src/simcore_service_webserver/rest_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/rest_handlers.py
@@ -3,11 +3,14 @@
 
 """
 import logging
+from typing import Any
 
 from aiohttp import web
 
+from ._constants import APP_PUBLIC_CONFIG_PER_PRODUCT
 from ._meta import api_version_prefix
 from .application_settings import APP_SETTINGS_KEY
+from .products import get_product_name
 from .redis import get_redis_scheduled_maintenance_client
 from .rest_healthcheck import HealthCheck, HealthCheckFailed
 
@@ -68,10 +71,19 @@ async def get_config(request: web.Request):
     register but the server has been setup to require an invitation. This option is setup
     at runtime and the front-end can only get it upon request to /config
     """
-    return web.json_response(data={"data": request.app[APP_SETTINGS_KEY].public_dict()})
+    app_public_config: dict[str, Any] = request.app[APP_SETTINGS_KEY].public_dict()
+
+    product_name = get_product_name(request=request)
+    product_public_config = request.app.get(APP_PUBLIC_CONFIG_PER_PRODUCT, {}).get(
+        product_name, {}
+    )
+
+    return web.json_response(data={"data": app_public_config | product_public_config})
 
 
-@routes.get(f"/{api_version_prefix}/scheduled_maintenance", name="get_scheduled_maintenance")
+@routes.get(
+    f"/{api_version_prefix}/scheduled_maintenance", name="get_scheduled_maintenance"
+)
 async def get_scheduled_maintenance(request: web.Request):
     """Check scheduled_maintenance table in redis"""
 

--- a/services/web/server/src/simcore_service_webserver/rest_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/rest_handlers.py
@@ -8,7 +8,7 @@ from typing import Any
 from aiohttp import web
 
 from ._constants import APP_PUBLIC_CONFIG_PER_PRODUCT
-from ._meta import api_version_prefix
+from ._meta import API_VTAG
 from .application_settings import APP_SETTINGS_KEY
 from .products import get_product_name
 from .redis import get_redis_scheduled_maintenance_client
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 routes = web.RouteTableDef()
 
 
-@routes.get(f"/{api_version_prefix}/health", name="healthcheck_liveness_probe")
+@routes.get(f"/{API_VTAG}/health", name="healthcheck_liveness_probe")
 async def healthcheck_liveness_probe(request: web.Request):
     """Liveness probe: "Check if the container is alive"
 
@@ -40,7 +40,7 @@ async def healthcheck_liveness_probe(request: web.Request):
     return web.json_response(data={"data": health_report})
 
 
-@routes.get(f"/{api_version_prefix}/", name="healthcheck_readiness_probe")
+@routes.get(f"/{API_VTAG}/", name="healthcheck_readiness_probe")
 async def healthcheck_readiness_probe(request: web.Request):
     """Readiness probe: "Check if the container is ready to receive traffic"
 
@@ -59,7 +59,7 @@ async def healthcheck_readiness_probe(request: web.Request):
     return web.json_response(data={"data": health_report})
 
 
-@routes.get(f"/{api_version_prefix}/config", name="get_config")
+@routes.get(f"/{API_VTAG}/config", name="get_config")
 async def get_config(request: web.Request):
     """
     This entrypoint aims to provide an extra configuration mechanism for
@@ -81,9 +81,7 @@ async def get_config(request: web.Request):
     return web.json_response(data={"data": app_public_config | product_public_config})
 
 
-@routes.get(
-    f"/{api_version_prefix}/scheduled_maintenance", name="get_scheduled_maintenance"
-)
+@routes.get(f"/{API_VTAG}/scheduled_maintenance", name="get_scheduled_maintenance")
 async def get_scheduled_maintenance(request: web.Request):
     """Check scheduled_maintenance table in redis"""
 

--- a/services/web/server/src/simcore_service_webserver/rest_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/rest_handlers.py
@@ -71,9 +71,7 @@ async def get_config(request: web.Request):
     register but the server has been setup to require an invitation. This option is setup
     at runtime and the front-end can only get it upon request to /config
     """
-    app_public_config: dict[str, Any] = request.app[
-        APP_SETTINGS_KEY
-    ].public_config_dict()
+    app_public_config: dict[str, Any] = request.app[APP_SETTINGS_KEY].public_dict()
 
     product_name = get_product_name(request=request)
     product_public_config = request.app.get(APP_PUBLIC_CONFIG_PER_PRODUCT, {}).get(

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -193,14 +193,14 @@ def test_app_settings_with_prod_config(
 
 
 def test_settings_constructs(app_settings: ApplicationSettings):
-    assert "vcs_url" in app_settings.public_config_dict()
+    assert "vcs_url" in app_settings.public_dict()
     assert (
-        app_settings.public_config_dict()["vcs_url"]
+        app_settings.public_dict()["vcs_url"]
         == "git@github.com:ITISFoundation/osparc-simcore.git"
     )
 
-    assert "app_name" in app_settings.public_config_dict()
-    assert "api_version" in app_settings.public_config_dict()
+    assert "app_name" in app_settings.public_dict()
+    assert "api_version" in app_settings.public_dict()
 
 
 def test_settings_to_client_statics(app_settings: ApplicationSettings):
@@ -240,6 +240,6 @@ def test_settings_to_client_statics_plugins(
 
 def test_avoid_sensitive_info_in_public(app_settings: ApplicationSettings):
     # avoids display of sensitive info
-    assert not any("pass" in key for key in app_settings.public_config_dict().keys())
-    assert not any("token" in key for key in app_settings.public_config_dict().keys())
-    assert not any("secret" in key for key in app_settings.public_config_dict().keys())
+    assert not any("pass" in key for key in app_settings.public_dict().keys())
+    assert not any("token" in key for key in app_settings.public_dict().keys())
+    assert not any("secret" in key for key in app_settings.public_dict().keys())

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -193,14 +193,14 @@ def test_app_settings_with_prod_config(
 
 
 def test_settings_constructs(app_settings: ApplicationSettings):
-    assert "vcs_url" in app_settings.public_dict()
+    assert "vcs_url" in app_settings.public_config_dict()
     assert (
-        app_settings.public_dict()["vcs_url"]
+        app_settings.public_config_dict()["vcs_url"]
         == "git@github.com:ITISFoundation/osparc-simcore.git"
     )
 
-    assert "app_name" in app_settings.public_dict()
-    assert "api_version" in app_settings.public_dict()
+    assert "app_name" in app_settings.public_config_dict()
+    assert "api_version" in app_settings.public_config_dict()
 
 
 def test_settings_to_client_statics(app_settings: ApplicationSettings):
@@ -240,6 +240,6 @@ def test_settings_to_client_statics_plugins(
 
 def test_avoid_sensitive_info_in_public(app_settings: ApplicationSettings):
     # avoids display of sensitive info
-    assert not any("pass" in key for key in app_settings.public_dict().keys())
-    assert not any("token" in key for key in app_settings.public_dict().keys())
-    assert not any("secret" in key for key in app_settings.public_dict().keys())
+    assert not any("pass" in key for key in app_settings.public_config_dict().keys())
+    assert not any("token" in key for key in app_settings.public_config_dict().keys())
+    assert not any("secret" in key for key in app_settings.public_config_dict().keys())

--- a/services/web/server/tests/unit/isolated/test_rest.py
+++ b/services/web/server/tests/unit/isolated/test_rest.py
@@ -17,6 +17,7 @@ from pytest_simcore.helpers.utils_assert import assert_status
 from servicelib.aiohttp.application import create_safe_application
 from simcore_service_webserver._resources import resources
 from simcore_service_webserver.application_settings import setup_settings
+from simcore_service_webserver.products import setup_products
 from simcore_service_webserver.rest import setup_rest
 from simcore_service_webserver.security import setup_security
 
@@ -51,6 +52,7 @@ def client(
     # activates only security+restAPI sub-modules
     setup_settings(app)
     setup_security(app)
+    setup_products(app)
     setup_rest(app)
 
     app.router.add_get("/slow", slow_handler)

--- a/services/web/server/tests/unit/isolated/test_rest.py
+++ b/services/web/server/tests/unit/isolated/test_rest.py
@@ -62,6 +62,8 @@ def client(
 
 
 async def test_frontend_config(client: TestClient, api_version_prefix: str):
+    assert client.app
+
     url = client.app.router["get_config"].url_for()
     assert str(url) == f"/{api_version_prefix}/config"
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

Fixes value of ``invitation_required``  in ``/config``. This configuration depends on the product now and it was returned the app-level config instead.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
