### PR TITLE
✨ Enhancement/improve progress messages

### DIFF
--- a/packages/models-library/src/models_library/basic_regex.py
+++ b/packages/models-library/src/models_library/basic_regex.py
@@ -71,5 +71,5 @@ DOCKER_LABEL_KEY_REGEX: Final[re.Pattern] = re.compile(
 DOCKER_IMAGE_KEY_RE = r"[\w/-]+"
 DOCKER_IMAGE_VERSION_RE = r"[\w/.]+"
 DOCKER_GENERIC_TAG_KEY_RE: Final[re.Pattern] = re.compile(
-    r"^(?P<registry_host>(?:(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+(?::\d+)?)|(?:[a-zA-Z0-9-]+:\d+)))?(?:/)?(?P<docker_image>(?:[a-z0-9][a-z0-9_-.]*/)*[a-z0-9-_]+[a-z0-9])(?::(?P<docker_tag>[\w][\w.-]{0,126}[\w]))?$"
+    r"^(?P<registry_host>(?:(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+(?::\d+)?)|[a-zA-Z0-9-]+:\d+))?(?:/)?(?P<docker_image>(?:[a-z0-9][a-z0-9_.-]*/)*[a-z0-9-_]+[a-z0-9])(?::(?P<docker_tag>[\w][\w.-]{0,126}[\w]))?$"
 )

--- a/packages/models-library/src/models_library/basic_regex.py
+++ b/packages/models-library/src/models_library/basic_regex.py
@@ -71,5 +71,5 @@ DOCKER_LABEL_KEY_REGEX: Final[re.Pattern] = re.compile(
 DOCKER_IMAGE_KEY_RE = r"[\w/-]+"
 DOCKER_IMAGE_VERSION_RE = r"[\w/.]+"
 DOCKER_GENERIC_TAG_KEY_RE: Final[re.Pattern] = re.compile(
-    r"^(?P<registry_host>(?=[^:\/]{1,253})(?!-)[a-zA-Z0-9-]{1,63}(?<!-)(?:\.(?!-)[a-zA-Z0-9-]{1,63}(?<!-))*(?::\d{1,5})?/)?(?P<image_name>(?![._-])(?:[a-z0-9._-]*)(?<![._-])(?:/(?![._-])[a-z0-9._-]*(?<![._-]))*):(?P<tag_name>(?![.-])[a-zA-Z0-9_.-]{1,128})?$"
+    r"^(?P<registry_host>(?:(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+(?::\d+)?)|(?:[a-zA-Z0-9-]+:\d+)))?(?:/)?(?P<docker_image>(?:[a-z0-9][a-z0-9-_.]*/)*[a-z0-9-_]+[a-z0-9])(?::(?P<docker_tag>[a-zA-Z0-9_][a-zA-Z0-9._-]{0,126}[a-zA-Z0-9_]))?$"
 )

--- a/packages/models-library/src/models_library/basic_regex.py
+++ b/packages/models-library/src/models_library/basic_regex.py
@@ -71,5 +71,5 @@ DOCKER_LABEL_KEY_REGEX: Final[re.Pattern] = re.compile(
 DOCKER_IMAGE_KEY_RE = r"[\w/-]+"
 DOCKER_IMAGE_VERSION_RE = r"[\w/.]+"
 DOCKER_GENERIC_TAG_KEY_RE: Final[re.Pattern] = re.compile(
-    r"^(?P<registry_host>(?:(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+(?::\d+)?)|(?:[a-zA-Z0-9-]+:\d+)))?(?:/)?(?P<docker_image>(?:[a-z0-9][a-z0-9-_.]*/)*[a-z0-9-_]+[a-z0-9])(?::(?P<docker_tag>[a-zA-Z0-9_][a-zA-Z0-9._-]{0,126}[a-zA-Z0-9_]))?$"
+    r"^(?P<registry_host>(?:(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+(?::\d+)?)|(?:[a-zA-Z0-9-]+:\d+)))?(?:/)?(?P<docker_image>(?:[a-z0-9][a-z0-9_-.]*/)*[a-z0-9-_]+[a-z0-9])(?::(?P<docker_tag>[\w][\w.-]{0,126}[\w]))?$"
 )

--- a/packages/models-library/src/models_library/rabbitmq_messages.py
+++ b/packages/models-library/src/models_library/rabbitmq_messages.py
@@ -40,14 +40,16 @@ class EventRabbitMessage(RabbitMessageBase, NodeMessageBase):
 
 class ProgressType(Enum):
     COMPUTATION_RUNNING = auto()  # NOTE: this is the original only progress report
+
+    CLUSTER_UP_SCALING = auto()
     SIDECARS_PULLING = auto()
-    SERVICE_IMAGES_PULLING = auto()
     SERVICE_INPUTS_PULLING = auto()
     SERVICE_OUTPUTS_PULLING = auto()
-    SERVICE_OUTPUTS_PUSHING = auto()
     SERVICE_STATE_PULLING = auto()
+    SERVICE_IMAGES_PULLING = auto()
+
     SERVICE_STATE_PUSHING = auto()
-    CLUSTER_UP_SCALING = auto()
+    SERVICE_OUTPUTS_PUSHING = auto()
 
 
 class ProgressRabbitMessage(RabbitMessageBase, NodeMessageBase):

--- a/packages/models-library/src/models_library/rabbitmq_messages.py
+++ b/packages/models-library/src/models_library/rabbitmq_messages.py
@@ -39,7 +39,7 @@ class EventRabbitMessage(RabbitMessageBase, NodeMessageBase):
 
 
 class ProgressType(Enum):
-    COMPUTATION_RUNNING = auto()
+    COMPUTATION_RUNNING = auto()  # NOTE: this is the original only progress report
     SIDECARS_PULLING = auto()
     SERVICE_IMAGES_PULLING = auto()
     SERVICE_INPUTS_PULLING = auto()

--- a/packages/models-library/src/models_library/rabbitmq_messages.py
+++ b/packages/models-library/src/models_library/rabbitmq_messages.py
@@ -6,6 +6,7 @@ from models_library.projects import ProjectID
 from models_library.projects_nodes import NodeID
 from models_library.projects_state import RunningState
 from models_library.users import UserID
+from models_library.utils.enums import StrAutoEnum
 from pydantic import BaseModel, Field
 from pydantic.types import NonNegativeFloat
 
@@ -40,7 +41,7 @@ class EventRabbitMessage(RabbitMessageBase, NodeMessageBase):
     action: RabbitEventMessageType
 
 
-class ProgressType(Enum):
+class ProgressType(StrAutoEnum):
     COMPUTATION_RUNNING = auto()  # NOTE: this is the original only progress report
 
     CLUSTER_UP_SCALING = auto()

--- a/packages/models-library/src/models_library/rabbitmq_messages.py
+++ b/packages/models-library/src/models_library/rabbitmq_messages.py
@@ -43,6 +43,7 @@ class ProgressType(Enum):
     SIDECARS_PULLING = auto()
     SERVICE_IMAGES_PULLING = auto()
     SERVICE_INPUTS_PULLING = auto()
+    SERVICE_OUTPUTS_PULLING = auto()
     SERVICE_OUTPUTS_PUSHING = auto()
     SERVICE_STATE_PULLING = auto()
     SERVICE_STATE_PUSHING = auto()

--- a/packages/models-library/src/models_library/rabbitmq_messages.py
+++ b/packages/models-library/src/models_library/rabbitmq_messages.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, auto
 from typing import Any, Literal, Optional
 
 from models_library.projects import ProjectID
@@ -38,8 +38,22 @@ class EventRabbitMessage(RabbitMessageBase, NodeMessageBase):
     action: RabbitEventMessageType
 
 
+class ProgressType(Enum):
+    COMPUTATION_RUNNING = auto()
+    SIDECARS_PULLING = auto()
+    SERVICE_IMAGES_PULLING = auto()
+    SERVICE_INPUTS_PULLING = auto()
+    SERVICE_OUTPUTS_PUSHING = auto()
+    SERVICE_STATE_PULLING = auto()
+    SERVICE_STATE_PUSHING = auto()
+    CLUSTER_UP_SCALING = auto()
+
+
 class ProgressRabbitMessage(RabbitMessageBase, NodeMessageBase):
     channel_name: Literal["simcore.services.progress"] = "simcore.services.progress"
+    progress_type: ProgressType = (
+        ProgressType.COMPUTATION_RUNNING
+    )  # NOTE: backwards compatible
     progress: NonNegativeFloat
 
 

--- a/packages/models-library/src/models_library/rabbitmq_messages.py
+++ b/packages/models-library/src/models_library/rabbitmq_messages.py
@@ -1,3 +1,4 @@
+import logging
 from enum import Enum, auto
 from typing import Any, Literal, Optional
 
@@ -31,6 +32,7 @@ class NodeMessageBase(BaseModel):
 class LoggerRabbitMessage(RabbitMessageBase, NodeMessageBase):
     channel_name: Literal["simcore.services.logs"] = "simcore.services.logs"
     messages: list[str]
+    log_level: int = logging.INFO
 
 
 class EventRabbitMessage(RabbitMessageBase, NodeMessageBase):

--- a/packages/models-library/src/models_library/utils/enums.py
+++ b/packages/models-library/src/models_library/utils/enums.py
@@ -1,0 +1,8 @@
+from enum import Enum, unique
+
+
+@unique
+class StrAutoEnum(str, Enum):
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):
+        return name.upper()

--- a/packages/models-library/tests/test_utils_enums.py
+++ b/packages/models-library/tests/test_utils_enums.py
@@ -1,0 +1,14 @@
+from enum import auto
+
+from models_library.utils.enums import StrAutoEnum
+
+
+class _Ordinal(StrAutoEnum):
+    NORTH = auto()
+    EAST = auto()
+    SOUTH = auto()
+    WEST = auto()
+
+
+def test_strautoenum():
+    assert list(f"{n}" for n in _Ordinal) == ["NORTH", "EAST", "SOUTH", "WEST"]

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
@@ -151,11 +151,8 @@ async def _file_chunk_writer(
     async with aiofiles.open(file, "wb") as file_pointer:
         while chunk := await response.content.read(CHUNK_SIZE):
             await file_pointer.write(chunk)
-            if pbar.update(len(chunk)):
-                if io_log_redirect_cb:
-                    await io_log_redirect_cb(
-                        f"{pbar}", ProgressData(pbar.n, pbar.total)
-                    )
+            if io_log_redirect_cb and pbar.update(len(chunk)):
+                await io_log_redirect_cb(f"{pbar}", ProgressData(pbar.n, pbar.total))
 
 
 log = logging.getLogger(__name__)
@@ -287,11 +284,10 @@ async def _upload_file_part(
                 },
             ) as response:
                 await _raise_for_status(response)
-                if pbar.update(file_part_size):
-                    if io_log_redirect_cb:
-                        await io_log_redirect_cb(
-                            f"{pbar}", ProgressData(pbar.n, pbar.total)
-                        )
+                if io_log_redirect_cb and pbar.update(file_part_size):
+                    await io_log_redirect_cb(
+                        f"{pbar}", ProgressData(pbar.n, pbar.total)
+                    )
 
                 # NOTE: the response from minio does not contain a json body
                 assert response.status == web.HTTPOk.status_code  # nosec

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
@@ -5,6 +5,8 @@ from fastapi import FastAPI
 from models_library.generated_models.docker_rest_api import Availability, Node, Task
 from models_library.rabbitmq_messages import (
     LoggerRabbitMessage,
+    ProgressRabbitMessage,
+    ProgressType,
     RabbitAutoscalingStatusMessage,
 )
 from servicelib.logging_utils import log_catch
@@ -17,6 +19,19 @@ from ..modules.rabbitmq import post_message
 from . import ec2, utils_docker
 
 logger = logging.getLogger(__name__)
+
+
+async def post_task_progress_message(app: FastAPI, task: Task, progress: float) -> None:
+    with log_catch(logger, reraise=False):
+        simcore_label_keys = SimcoreServiceDockerLabelKeys.from_docker_task(task)
+        message = ProgressRabbitMessage(
+            node_id=simcore_label_keys.node_id,
+            user_id=simcore_label_keys.user_id,
+            project_id=simcore_label_keys.project_id,
+            progress_type=ProgressType.CLUSTER_UP_SCALING,
+            progress=progress,
+        )
+        await post_message(app, message)
 
 
 async def post_task_log_message(app: FastAPI, task: Task, log: str, level: int) -> None:

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 async def post_task_progress_message(app: FastAPI, task: Task, progress: float) -> None:
     with log_catch(logger, reraise=False):
         simcore_label_keys = SimcoreServiceDockerLabelKeys.from_docker_task(task)
-        message = ProgressRabbitMessage(
+        message = ProgressRabbitMessage.construct(
             node_id=simcore_label_keys.node_id,
             user_id=simcore_label_keys.user_id,
             project_id=simcore_label_keys.project_id,
@@ -37,11 +37,12 @@ async def post_task_progress_message(app: FastAPI, task: Task, progress: float) 
 async def post_task_log_message(app: FastAPI, task: Task, log: str, level: int) -> None:
     with log_catch(logger, reraise=False):
         simcore_label_keys = SimcoreServiceDockerLabelKeys.from_docker_task(task)
-        message = LoggerRabbitMessage(
+        message = LoggerRabbitMessage.construct(
             node_id=simcore_label_keys.node_id,
             user_id=simcore_label_keys.user_id,
             project_id=simcore_label_keys.project_id,
             messages=[f"[cluster] {log}"],
+            log_level=level,
         )
         logger.log(level, message)
         await post_message(app, message)

--- a/services/autoscaling/tests/unit/test_utils_rabbitmq.py
+++ b/services/autoscaling/tests/unit/test_utils_rabbitmq.py
@@ -85,6 +85,7 @@ async def test_post_task_log_message(
                     project_id=osparc_docker_label_keys.project_id,
                     user_id=osparc_docker_label_keys.user_id,
                     messages=[f"[cluster] {log_message}"],
+                    log_level=0,
                 )
                 .json()
                 .encode()

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
@@ -253,6 +253,7 @@ class DaskScheduler(BaseCompScheduler):
             project_id=project_id,
             node_id=node_id,
             messages=[task_log_event.log],
+            log_level=logging.INFO,
         )
 
         await self.rabbitmq_client.publish(message.channel_name, message.json())

--- a/services/director-v2/src/simcore_service_director_v2/modules/projects_networks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/projects_networks.py
@@ -211,10 +211,11 @@ async def _get_networks_with_aliases_for_default_network(
                         "identified on service network due to invalid name. "
                         "To communicate over the network, please rename the "
                         "service alphanumeric characters <64 characters, "
-                        "e.g. re.sub(r'\W+', '', SERVICE_NAME). "
+                        r"e.g. re.sub(r'\W+', '', SERVICE_NAME). "
                         f"Network name is {default_network}"
                     )
                 ],
+                log_level=logging.INFO,
             )
             await rabbitmq_client.publish(message.channel_name, message.json())
             continue

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -34,7 +34,6 @@ RUN  --mount=type=cache,id=basecache,target=/var/cache/apt,mode=0755,sharing=loc
   docker-ce-cli \
   && ./install_rclone.bash \
   && apt-get remove -y\
-  ca-certificates \
   curl \
   gnupg \
   lsb-release \

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -20,23 +20,11 @@ RUN  --mount=type=cache,id=basecache,target=/var/cache/apt,mode=0755,sharing=loc
   curl \
   gosu \
   ca-certificates \
-  gnupg \
-  lsb-release \
   # required by python-magic
   libmagic1 \
-  && mkdir -p /etc/apt/keyrings \
-  && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  # only the cli is needed and we remove the unnecessary stuff again
-  docker-ce-cli \
   && ./install_rclone.bash \
   && apt-get remove -y\
   curl \
-  gnupg \
-  lsb-release \
   && apt-get autoclean -y\
   && apt-get autoremove -y\
   && rm -rf /var/lib/apt/lists/* \

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.9.12"
 FROM python:${PYTHON_VERSION}-slim-buster as base
 #
@@ -10,17 +11,38 @@ FROM python:${PYTHON_VERSION}-slim-buster as base
 
 LABEL maintainer="Andrei Neagu <neagu@itis.swiss>"
 
-RUN set -eux && \
+COPY  --chown=scu:scu scripts/install_rclone.bash .
+RUN  --mount=type=cache,id=basecache,target=/var/cache/apt,mode=0755,sharing=locked \
+  --mount=type=cache,id=baseapt,target=/var/lib/apt,mode=0755,sharing=locked \
+  set -eux && \
   apt-get update && \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends\
   curl \
   gosu \
+  ca-certificates \
+  gnupg \
+  lsb-release \
   # required by python-magic
   libmagic1 \
-  && \
-  rm -rf /var/lib/apt/lists/* && \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+  # only the cli is needed and we remove the unnecessary stuff again
+  docker-ce-cli \
+  && ./install_rclone.bash \
+  && apt-get remove -y\
+  ca-certificates \
+  curl \
+  gnupg \
+  lsb-release \
+  && apt-get autoclean -y\
+  && apt-get autoremove -y\
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
-  gosu nobody true
+  && gosu nobody true
 
 # simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
 ENV SC_USER_ID=8004 \
@@ -48,10 +70,6 @@ ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 # volumes between itself and the spawned containers
 ENV DYNAMIC_SIDECAR_DY_VOLUMES_MOUNT_DIR="/dy-volumes"
 
-# rclone installation
-COPY  --chown=scu:scu scripts/install_rclone.bash .
-RUN ./install_rclone.bash
-
 # create direcotry to persist SharedStore data accessiable
 # between dynamic-sidecar reboots
 ENV DYNAMIC_SIDECAR_SHARED_STORE_DIR="/shared-store"
@@ -67,16 +85,22 @@ FROM base as build
 
 ENV SC_BUILD_TARGET=build
 
-RUN apt-get update &&\
-  apt-get install -y --no-install-recommends \
-  build-essential
+RUN --mount=type=cache,id=basecache,target=/var/cache/apt,mode=0755,sharing=locked \
+  --mount=type=cache,id=baseapt,target=/var/lib/apt,mode=0755,sharing=locked \
+  set -eux \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+  build-essential \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # NOTE: python virtualenv is used here such that installed
 # packages may be moved to production image easily by copying the venv
 RUN python -m venv "${VIRTUAL_ENV}" \
   && mkdir -p "${DYNAMIC_SIDECAR_DY_VOLUMES_MOUNT_DIR}"
 
-RUN pip install --upgrade --no-cache-dir \
+RUN --mount=type=cache,mode=0777,target=/root/.cache/pip \
+  pip --no-cache-dir install --upgrade  \
   pip~=22.0  \
   wheel \
   setuptools
@@ -107,7 +131,9 @@ COPY --chown=scu:scu services/dynamic-sidecar /build/services/dynamic-sidecar
 
 WORKDIR /build/services/dynamic-sidecar
 
-RUN pip --no-cache-dir install -r requirements/prod.txt &&\
+RUN --mount=type=cache,mode=0777,target=/root/.cache/pip \
+  pip --no-cache-dir install \
+  --requirement requirements/prod.txt &&\
   pip --no-cache-dir list -v
 
 # --------------------------Production stage -------------------

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
@@ -186,7 +186,7 @@ async def docker_compose_pull(app: FastAPI, compose_spec_yaml: str) -> None:
             )
 
     list_of_images = get_docker_service_images(compose_spec_yaml)
-    all_image_pulling_data = {}
+    all_image_pulling_data: dict[str, dict[str, tuple[int, int]]] = {}
     async with docker_client() as docker:
         await asyncio.gather(
             *(

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
@@ -1,12 +1,15 @@
+import asyncio
 import logging
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Awaitable, Callable, Final
 
 import aiodocker
 import yaml
 from aiodocker.utils import clean_filters
+from models_library.basic_regex import DOCKER_GENERIC_TAG_KEY_RE
 from models_library.services import RunID
 from pydantic import PositiveInt
+from settings_library.docker_registry import RegistrySettings
 
 from .errors import UnexpectedDockerError, VolumeNotFoundError
 
@@ -62,3 +65,112 @@ def get_docker_service_images(compose_spec_yaml: str) -> set[str]:
         service_data["image"]
         for service_data in docker_compose_spec["services"].values()
     }
+
+
+ProgressCB = Callable[[int, int], Awaitable[None]]
+LogCB = Callable[[str], Awaitable[None]]
+
+
+async def pull_images(
+    images: set[str],
+    registry_settings: RegistrySettings,
+    progress_cb: ProgressCB,
+    log_cb: LogCB,
+) -> None:
+    images_pulling_data: dict[str, dict[str, tuple[int, int]]] = {}
+    async with docker_client() as docker:
+        await asyncio.gather(
+            *(
+                _pull_image_with_progress(
+                    docker,
+                    image,
+                    registry_settings,
+                    images_pulling_data,
+                    progress_cb,
+                    log_cb,
+                )
+                for image in images
+            )
+        )
+
+
+_DOWNLOAD_RATIO: Final[float] = 0.75
+
+
+async def _pull_image_with_progress(
+    client: aiodocker.Docker,
+    registry_settings: RegistrySettings,
+    image: str,
+    all_image_pulling_data: dict[str, Any],
+    progress_cb: ProgressCB,
+    log_cb: LogCB,
+) -> None:
+    # NOTE: if there is no registry_host, then there is no auth allowed,
+    # which is typical for dockerhub or local images
+    # NOTE: progress is such that downloading is taking 3/4 of the time,
+    # Extracting 1/4
+    match = DOCKER_GENERIC_TAG_KEY_RE.match(image)
+    registry_host = ""
+    if match:
+        registry_host = match.group("registry_host")
+    else:
+        logger.error(
+            "%s does not match typical docker image pattern, please check! Image pulling will still be attempted but may fail.",
+            f"{image=}",
+        )
+
+    simplified_image_name = image.rsplit("/", maxsplit=1)[-1]
+    all_image_pulling_data[image] = {}
+    async for pull_progress in client.images.pull(
+        image,
+        stream=True,
+        auth={
+            "username": registry_settings.REGISTRY_USER,
+            "password": registry_settings.REGISTRY_PW.get_secret_value(),
+        }
+        if registry_host
+        else None,
+    ):
+        if pull_progress.get("status") == "Downloading":
+            # NOTE: this takes the bulk of the time
+            layer_id = pull_progress["id"]
+            all_image_pulling_data[image][layer_id] = (
+                _DOWNLOAD_RATIO * pull_progress["progressDetail"]["current"],
+                pull_progress["progressDetail"]["total"],
+            )
+        elif pull_progress.get("status") == "Download complete":
+            layer_id = pull_progress["id"]
+            _, layer_total_size = all_image_pulling_data[image][layer_id]
+            all_image_pulling_data[image][layer_id] = (
+                _DOWNLOAD_RATIO * layer_total_size,
+                layer_total_size,
+            )
+        elif pull_progress.get("status") == "Extracting":
+            layer_id = pull_progress["id"]
+            _, layer_total_size = all_image_pulling_data[image][layer_id]
+            all_image_pulling_data[image][layer_id] = (
+                _DOWNLOAD_RATIO * layer_total_size
+                + (1 - _DOWNLOAD_RATIO) * pull_progress["progressDetail"]["current"],
+                layer_total_size,
+            )
+        elif pull_progress.get("status") == "Pull complete":
+            layer_id = pull_progress["id"]
+            _, layer_total_size = all_image_pulling_data[image][layer_id]
+            all_image_pulling_data[image][layer_id] = (
+                layer_total_size,
+                layer_total_size,
+            )
+
+        def _compute_sizes(
+            all_images: dict[str, dict[str, tuple[int, int]]]
+        ) -> tuple[int, int]:
+            total_current_size = total_total_size = 0
+            for layer in all_images.values():
+                for current_size, total_size in layer.values():
+                    total_current_size += current_size
+                    total_total_size += total_size
+            return (total_current_size, total_total_size)
+
+        total_current, total_total = _compute_sizes(all_image_pulling_data)
+        await progress_cb(total_current, total_total)
+        await log_cb(f"pulling {simplified_image_name}: {pull_progress}...")

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
@@ -1,12 +1,14 @@
+import asyncio
+import json
 import logging
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Final
 
 import aiodocker
 import yaml
 from aiodocker.utils import clean_filters
 from models_library.services import RunID
-from pydantic import PositiveInt
+from pydantic import ByteSize, PositiveInt, parse_obj_as
 
 from .errors import UnexpectedDockerError, VolumeNotFoundError
 
@@ -62,3 +64,52 @@ def get_docker_service_images(compose_spec_yaml: str) -> set[str]:
         service_data["image"]
         for service_data in docker_compose_spec["services"].values()
     }
+
+
+DEFAULT_DOCKER_MANIFEST_CMD_TIMEOUT_S: Final[int] = 30
+
+
+async def get_image_size_on_remote(image_name: str) -> ByteSize:
+    async with aiodocker.Docker() as docker:
+        docker_platform_info = await docker.system.info()
+    local_arch = docker_platform_info.get("Architecture", "amd64")
+    local_os = docker_platform_info.get("OSType", "linux")
+    if local_arch == "x86_64":
+        local_arch = "amd64"
+    command = ["docker", "manifest", "inspect", "--verbose", f"{image_name}"]
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    await asyncio.wait_for(
+        process.wait(), timeout=DEFAULT_DOCKER_MANIFEST_CMD_TIMEOUT_S
+    )
+    assert process.returncode is not None  # nosec
+    if process.returncode > 0:
+        raise RuntimeError(
+            f"unexpected error running '{' '.join(command)}': {stderr.decode()}"
+        )
+
+    all_manifests = json.loads(stdout.decode())
+    local_arch_manifest = next(
+        iter(
+            filter(
+                lambda x: (
+                    x.get("Descriptor", {}).get("platform", {}).get("architecture")
+                    == local_arch
+                )
+                and (x.get("Descriptor", {}).get("platform", {}).get("os") == local_os),
+                all_manifests,
+            )
+        )
+    )
+    image_layers = local_arch_manifest.get("SchemaV2Manifest", {}).get("layers", [])
+    layer_to_sizes = {
+        layer["digest"]: layer["size"]
+        for layer in image_layers
+        if all(x in layer for x in ["digest", "size"])
+    }
+    image_size = parse_obj_as(ByteSize, sum(layer_to_sizes.values()))
+    return image_size

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
@@ -114,20 +114,25 @@ def _parse_docker_pull_progress(
 
         if docker_pull_progress["status"] == "Downloading":
             all_image_pulling_data[image_name][layer_id] = (
-                _DOWNLOAD_RATIO * docker_pull_progress["progressDetail"]["current"],
+                round(
+                    _DOWNLOAD_RATIO * docker_pull_progress["progressDetail"]["current"]
+                ),
                 docker_pull_progress["progressDetail"]["total"],
             )
         elif docker_pull_progress["status"] == "Downloading complete":
+            _, layer_total_size = all_image_pulling_data[image_name][layer_id]
             all_image_pulling_data[image_name][layer_id] = (
-                _DOWNLOAD_RATIO * docker_pull_progress["progressDetail"]["current"],
-                docker_pull_progress["progressDetail"]["total"],
+                round(_DOWNLOAD_RATIO * layer_total_size),
+                layer_total_size,
             )
         elif docker_pull_progress["status"] == "Extracting":
             _, layer_total_size = all_image_pulling_data[image_name][layer_id]
             all_image_pulling_data[image_name][layer_id] = (
-                _DOWNLOAD_RATIO * layer_total_size
-                + (1 - _DOWNLOAD_RATIO)
-                * docker_pull_progress["progressDetail"]["current"],
+                round(
+                    _DOWNLOAD_RATIO * layer_total_size
+                    + (1 - _DOWNLOAD_RATIO)
+                    * docker_pull_progress["progressDetail"]["current"]
+                ),
                 layer_total_size,
             )
         elif docker_pull_progress["status"] == "Pull complete":

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
@@ -1,14 +1,12 @@
-import asyncio
-import json
 import logging
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator, Final
+from typing import Any, AsyncGenerator
 
 import aiodocker
 import yaml
 from aiodocker.utils import clean_filters
 from models_library.services import RunID
-from pydantic import ByteSize, PositiveInt, parse_obj_as
+from pydantic import PositiveInt
 
 from .errors import UnexpectedDockerError, VolumeNotFoundError
 
@@ -64,60 +62,3 @@ def get_docker_service_images(compose_spec_yaml: str) -> set[str]:
         service_data["image"]
         for service_data in docker_compose_spec["services"].values()
     }
-
-
-DEFAULT_DOCKER_MANIFEST_CMD_TIMEOUT_S: Final[int] = 30
-
-
-async def get_image_size_on_remote(image_name: str) -> ByteSize:
-    async with aiodocker.Docker() as docker:
-        docker_platform_info = await docker.system.info()
-    local_arch = docker_platform_info.get("Architecture", "amd64")
-    local_os = docker_platform_info.get("OSType", "linux")
-    if local_arch == "x86_64":
-        local_arch = "amd64"
-    logger.debug("getting image size on remote using %s", f"{local_arch=}, {local_os=}")
-    command = ["docker", "manifest", "inspect", "--verbose", f"{image_name}"]
-    process = await asyncio.create_subprocess_exec(
-        *command,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, stderr = await process.communicate()
-    await asyncio.wait_for(
-        process.wait(), timeout=DEFAULT_DOCKER_MANIFEST_CMD_TIMEOUT_S
-    )
-    assert process.returncode is not None  # nosec
-    logger.debug(
-        "getting image size on remote using %s, completed process with %s",
-        f"{local_arch=}, {local_os=}",
-        f"{process.returncode=}",
-    )
-    if process.returncode > 0:
-        raise RuntimeError(
-            f"unexpected error running '{' '.join(command)}': {stderr.decode()}"
-        )
-
-    all_manifests = json.loads(stdout.decode())
-    local_arch_manifest = next(
-        iter(
-            filter(
-                lambda x: (
-                    x.get("Descriptor", {}).get("platform", {}).get("architecture")
-                    == local_arch
-                )
-                and (x.get("Descriptor", {}).get("platform", {}).get("os") == local_os),
-                all_manifests,
-            )
-        )
-    )
-    logger.debug("found %s", f"{local_arch_manifest=}")
-    image_layers = local_arch_manifest.get("SchemaV2Manifest", {}).get("layers", [])
-    layer_to_sizes = {
-        layer["digest"]: layer["size"]
-        for layer in image_layers
-        if all(x in layer for x in ["digest", "size"])
-    }
-    logger.debug("found %s", f"{layer_to_sizes=}")
-    image_size = parse_obj_as(ByteSize, sum(layer_to_sizes.values()))
-    return image_size

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
@@ -39,6 +39,7 @@ async def post_log_message(app: FastAPI, logs: Union[str, list[str]]) -> None:
         user_id=app_settings.DY_SIDECAR_USER_ID,
         project_id=app_settings.DY_SIDECAR_PROJECT_ID,
         messages=logs,
+        log_level=logging.INFO,
     )
 
     await _post_rabbit_message(app, message)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
@@ -55,8 +55,7 @@ async def post_progress_message(
         progress_type=progress_type,
         progress=progress_value,
     )
-    if _is_rabbitmq_initialized(app):
-        await get_rabbitmq_client(app).publish(message.channel_name, message.json())
+    await _post_rabbit_message(app, message)
 
 
 async def post_sidecar_log_message(app: FastAPI, logs: str) -> None:

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -222,7 +222,9 @@ async def task_restore_state(
                 project_id=str(settings.DY_SIDECAR_PROJECT_ID),
                 node_uuid=str(settings.DY_SIDECAR_NODE_ID),
                 file_or_folder=path,
-                io_log_redirect_cb=functools.partial(_logs_cb, app, ProgressType.SERVICE_STATE_PULLING),  # type: ignore
+                io_log_redirect_cb=functools.partial(
+                    _logs_cb, app, ProgressType.SERVICE_STATE_PULLING
+                ),
             )
             for path, exists in zip(mounted_volumes.disk_state_paths(), existing_files)
             if exists
@@ -255,7 +257,9 @@ async def task_save_state(
                 file_or_folder=state_path,
                 r_clone_settings=settings.rclone_settings_for_nodeports,
                 archive_exclude_patterns=mounted_volumes.state_exclude,
-                io_log_redirect_cb=functools.partial(_logs_cb, app, ProgressType.SERVICE_STATE_PUSHING),  # type: ignore
+                io_log_redirect_cb=functools.partial(
+                    _logs_cb, app, ProgressType.SERVICE_STATE_PUSHING
+                ),
             )
         )
 
@@ -281,7 +285,9 @@ async def task_ports_inputs_pull(
         nodeports.PortTypeName.INPUTS,
         mounted_volumes.disk_inputs_path,
         port_keys=port_keys,
-        io_log_redirect_cb=functools.partial(_logs_cb, app, ProgressType.SERVICE_INPUTS_PULLING),  # type: ignore
+        io_log_redirect_cb=functools.partial(
+            _logs_cb, app, ProgressType.SERVICE_INPUTS_PULLING
+        ),
     )
     await post_sidecar_log_message(app, "Finished pulling inputs")
     progress.update(message="finished inputs pulling", percent=0.99)
@@ -302,7 +308,9 @@ async def task_ports_outputs_pull(
         nodeports.PortTypeName.OUTPUTS,
         mounted_volumes.disk_outputs_path,
         port_keys=port_keys,
-        io_log_redirect_cb=functools.partial(_logs_cb, app, ProgressType.SERVICE_OUTPUTS_PULLING),  # type: ignore
+        io_log_redirect_cb=functools.partial(
+            _logs_cb, app, ProgressType.SERVICE_OUTPUTS_PULLING
+        ),
     )
     await post_sidecar_log_message(app, "Finished pulling outputs")
     progress.update(message="finished outputs pulling", percent=0.99)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -4,6 +4,7 @@ from collections import deque
 from typing import Any, Awaitable, Final, Optional
 
 from fastapi import FastAPI
+from models_library.rabbitmq_messages import ProgressType
 from servicelib.fastapi.long_running_tasks.server import TaskProgress
 from servicelib.utils import logged_gather
 from simcore_sdk.node_data import data_manager
@@ -22,7 +23,11 @@ from ..core.docker_compose_utils import (
 )
 from ..core.docker_logs import start_log_fetching, stop_log_fetching
 from ..core.docker_utils import get_running_containers_count_from_names
-from ..core.rabbitmq import post_event_reload_iframe, post_sidecar_log_message
+from ..core.rabbitmq import (
+    post_event_reload_iframe,
+    post_progress_message,
+    post_sidecar_log_message,
+)
 from ..core.settings import ApplicationSettings
 from ..core.utils import CommandResult, assemble_container_names
 from ..core.validation import parse_compose_spec, validate_compose_spec
@@ -167,6 +172,12 @@ async def task_runs_docker_compose_down(
     progress.update(message="done", percent=0.99)
 
 
+async def _progress_cb(app: FastAPI, progress_type: ProgressType, msg: str) -> None:
+    await post_sidecar_log_message(app, msg)
+    # TODO: convert to progress message
+    await post_progress_message(app, 0, progress_type)
+
+
 async def task_restore_state(
     progress: TaskProgress,
     settings: ApplicationSettings,
@@ -193,6 +204,7 @@ async def task_restore_state(
         app,
         f"Downloading state files for {existing_files}...",
     )
+
     await logged_gather(
         *(
             data_manager.pull(
@@ -200,7 +212,9 @@ async def task_restore_state(
                 project_id=str(settings.DY_SIDECAR_PROJECT_ID),
                 node_uuid=str(settings.DY_SIDECAR_NODE_ID),
                 file_or_folder=path,
-                io_log_redirect_cb=functools.partial(post_sidecar_log_message, app),
+                io_log_redirect_cb=functools.partial(
+                    _progress_cb, app, ProgressType.SERVICE_STATE_PULLING
+                ),
             )
             for path, exists in zip(mounted_volumes.disk_state_paths(), existing_files)
             if exists
@@ -233,7 +247,9 @@ async def task_save_state(
                 file_or_folder=state_path,
                 r_clone_settings=settings.rclone_settings_for_nodeports,
                 archive_exclude_patterns=mounted_volumes.state_exclude,
-                io_log_redirect_cb=functools.partial(post_sidecar_log_message, app),
+                io_log_redirect_cb=functools.partial(
+                    _progress_cb, app, ProgressType.SERVICE_STATE_PUSHING
+                ),
             )
         )
 
@@ -259,7 +275,9 @@ async def task_ports_inputs_pull(
         nodeports.PortTypeName.INPUTS,
         mounted_volumes.disk_inputs_path,
         port_keys=port_keys,
-        io_log_redirect_cb=functools.partial(post_sidecar_log_message, app),
+        io_log_redirect_cb=functools.partial(
+            _progress_cb, app, ProgressType.SERVICE_INPUTS_PULLING
+        ),
     )
     await post_sidecar_log_message(app, "Finished pulling inputs")
     progress.update(message="finished inputs pulling", percent=0.99)
@@ -280,7 +298,9 @@ async def task_ports_outputs_pull(
         nodeports.PortTypeName.OUTPUTS,
         mounted_volumes.disk_outputs_path,
         port_keys=port_keys,
-        io_log_redirect_cb=functools.partial(post_sidecar_log_message, app),
+        io_log_redirect_cb=functools.partial(
+            _progress_cb, app, ProgressType.SERVICE_OUTPUTS_PULLING
+        ),
     )
     await post_sidecar_log_message(app, "Finished pulling outputs")
     progress.update(message="finished outputs pulling", percent=0.99)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/mounted_fs.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/mounted_fs.py
@@ -7,9 +7,9 @@ from fastapi import FastAPI
 from models_library.projects_nodes import NodeID
 from models_library.services import RunID
 from servicelib.docker_constants import PREFIX_DYNAMIC_SIDECAR_VOLUMES
-from simcore_service_dynamic_sidecar.core.settings import ApplicationSettings
 
 from ..core.docker_utils import get_volume_by_label
+from ..core.settings import ApplicationSettings
 
 
 def _ensure_path(path: Path) -> Path:

--- a/services/web/server/src/simcore_service_webserver/computation_subscribe.py
+++ b/services/web/server/src/simcore_service_webserver/computation_subscribe.py
@@ -94,7 +94,7 @@ async def progress_message_parser(app: web.Application, data: bytes) -> bool:
                     "project_id": rabbit_message.project_id,
                     "node_id": rabbit_message.node_id,
                     "user_id": rabbit_message.user_id,
-                    "progress_type": rabbit_message.progress_type.name,
+                    "progress_type": rabbit_message.progress_type,
                     "progress": rabbit_message.progress,
                 },
             }

--- a/services/web/server/src/simcore_service_webserver/computation_subscribe.py
+++ b/services/web/server/src/simcore_service_webserver/computation_subscribe.py
@@ -8,6 +8,7 @@ from models_library.rabbitmq_messages import (
     InstrumentationRabbitMessage,
     LoggerRabbitMessage,
     ProgressRabbitMessage,
+    ProgressType,
 )
 from servicelib.aiohttp.monitor_services import (
     SERVICE_STARTED_LABELS,
@@ -38,56 +39,60 @@ log = logging.getLogger(__name__)
 async def progress_message_parser(app: web.Application, data: bytes) -> bool:
     # update corresponding project, node, progress value
     rabbit_message = ProgressRabbitMessage.parse_raw(data)
-    await send_messages(
-        app,
-        f"{rabbit_message.user_id}",
-        [
-            {
-                "event_type": SOCKET_IO_NODE_PROGRESS_EVENT,
-                "data": {
-                    "project_id": rabbit_message.project_id,
-                    "node_id": rabbit_message.node_id,
-                    "user_id": rabbit_message.user_id,
-                    "progress_type": rabbit_message.progress_type.name,
-                    "progress": rabbit_message.progress,
-                },
-            }
-        ],
-    )
-    try:
-        project = await projects_api.update_project_node_progress(
+
+    if rabbit_message.progress_type is ProgressType.COMPUTATION_RUNNING:
+        try:
+            project = await projects_api.update_project_node_progress(
+                app,
+                rabbit_message.user_id,
+                f"{rabbit_message.project_id}",
+                f"{rabbit_message.node_id}",
+                progress=rabbit_message.progress,
+            )
+            if project:
+                messages: list[SocketMessageDict] = [
+                    {
+                        "event_type": SOCKET_IO_NODE_UPDATED_EVENT,
+                        "data": {
+                            "project_id": project["uuid"],
+                            "node_id": rabbit_message.node_id,
+                            "data": project["workbench"][f"{rabbit_message.node_id}"],
+                        },
+                    }
+                ]
+                await send_messages(app, f"{rabbit_message.user_id}", messages)
+                return True
+        except ProjectNotFoundError:
+            log.warning(
+                "project related to received rabbitMQ progress message not found: '%s'",
+                json_dumps(rabbit_message, indent=2),
+            )
+            return True
+        except NodeNotFoundError:
+            log.warning(
+                "node related to received rabbitMQ progress message not found: '%s'",
+                json_dumps(rabbit_message, indent=2),
+            )
+            return True
+        return False
+    else:
+        await send_messages(
             app,
-            rabbit_message.user_id,
-            f"{rabbit_message.project_id}",
-            f"{rabbit_message.node_id}",
-            progress=rabbit_message.progress,
-        )
-        if project:
-            messages: list[SocketMessageDict] = [
+            f"{rabbit_message.user_id}",
+            [
                 {
-                    "event_type": SOCKET_IO_NODE_UPDATED_EVENT,
+                    "event_type": SOCKET_IO_NODE_PROGRESS_EVENT,
                     "data": {
-                        "project_id": project["uuid"],
+                        "project_id": rabbit_message.project_id,
                         "node_id": rabbit_message.node_id,
-                        "data": project["workbench"][f"{rabbit_message.node_id}"],
+                        "user_id": rabbit_message.user_id,
+                        "progress_type": rabbit_message.progress_type.name,
+                        "progress": rabbit_message.progress,
                     },
                 }
-            ]
-            await send_messages(app, f"{rabbit_message.user_id}", messages)
-            return True
-    except ProjectNotFoundError:
-        log.warning(
-            "project related to received rabbitMQ progress message not found: '%s'",
-            json_dumps(rabbit_message, indent=2),
+            ],
         )
-        return True
-    except NodeNotFoundError:
-        log.warning(
-            "node related to received rabbitMQ progress message not found: '%s'",
-            json_dumps(rabbit_message, indent=2),
-        )
-        return True
-    return False
+    return True
 
 
 async def log_message_parser(app: web.Application, data: bytes) -> bool:

--- a/services/web/server/src/simcore_service_webserver/socketio/events.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/events.py
@@ -16,11 +16,11 @@ from .server import AsyncServer, get_socket_server
 
 log = logging.getLogger(__name__)
 
-SOCKET_IO_PROJECT_UPDATED_EVENT: str = "projectStateUpdated"
-SOCKET_IO_NODE_UPDATED_EVENT: str = "nodeUpdated"
-SOCKET_IO_LOG_EVENT: str = "logger"
-SOCKET_IO_HEARTBEAT_EVENT: str = "set_heartbeat_emit_interval"
-SOCKET_IO_EVENT: str = "event"
+SOCKET_IO_PROJECT_UPDATED_EVENT: Final[str] = "projectStateUpdated"
+SOCKET_IO_NODE_UPDATED_EVENT: Final[str] = "nodeUpdated"
+SOCKET_IO_LOG_EVENT: Final[str] = "logger"
+SOCKET_IO_HEARTBEAT_EVENT: Final[str] = "set_heartbeat_emit_interval"
+SOCKET_IO_EVENT: Final[str] = "event"
 SOCKET_IO_NODE_PROGRESS_EVENT: Final[str] = "nodeProgress"
 
 

--- a/services/web/server/src/simcore_service_webserver/socketio/events.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/events.py
@@ -4,7 +4,7 @@ This module takes care of sending events to the connected webclient through the 
 
 import logging
 from collections import deque
-from typing import Any, Dict, List, Sequence, TypedDict
+from typing import Any, Final, Sequence, TypedDict
 
 from aiohttp.web import Application
 from servicelib.aiohttp.application_keys import APP_FIRE_AND_FORGET_TASKS_KEY
@@ -21,11 +21,12 @@ SOCKET_IO_NODE_UPDATED_EVENT: str = "nodeUpdated"
 SOCKET_IO_LOG_EVENT: str = "logger"
 SOCKET_IO_HEARTBEAT_EVENT: str = "set_heartbeat_emit_interval"
 SOCKET_IO_EVENT: str = "event"
+SOCKET_IO_NODE_PROGRESS_EVENT: Final[str] = "nodeProgress"
 
 
 class SocketMessageDict(TypedDict):
     event_type: str
-    data: Dict[str, Any]
+    data: dict[str, Any]
 
 
 async def send_messages(
@@ -33,7 +34,7 @@ async def send_messages(
 ) -> None:
     sio: AsyncServer = get_socket_server(app)
 
-    socket_ids: List[str] = []
+    socket_ids: list[str] = []
     with managed_resource(user_id, None, app) as rt:
         socket_ids = await rt.find_socket_ids()
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?
Brings more progress messages to the frontend:

- cluster up-scaling
- ~~sidecar image pulling~~ (might come later)
- state push/pull
- inputs pull
- outputs pull
- service image pulling
- comp. service running


<!-- Explain REVIEWERS what is this PR about -->
This PR enables a new exchange in RabbitMQ for progress information.
This progress are forwarded to the webclient with the ```nodeProgress``` event that contains:
```python
{
  "user_id": int,
  "project_id": uuid,
  "node_id": uuid,
  "progress_type": str,
  "progress": 0-1.0
}
```
progress type can be of the following:
```
"COMPUTATION_RUNNING"

"CLUSTER_UP_SCALING"
"SIDECAR_PULLING"
"SERVICE_INPUTS_PULLING"
"SERVICE_OUTPUTS_PULLING"
"SERVICE_STATE_PULLING"
"SERVICE_IMAGES_PULLING"

"SERVICE_STATE_PUSHING"
"SERVICE_OUTPUTS_PUSHING"
```

NOTE:
for the SERVICE_IMAGES_PULLING as well as for SIDECAR_PULLING it is not possible to know the layer sizes a priori. therefore the progress might "go back in time"

Bonus:
- log messages now contain a log level based on python logging system as an int 
- fix regex for docker generic tags such as envoyproxy/envoy:latest
- 
## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
