### PR TITLE
✨ Maintenance Tracker II

### DIFF
--- a/services/static-webserver/client/source/class/osparc/component/message/FlashMessenger.js
+++ b/services/static-webserver/client/source/class/osparc/component/message/FlashMessenger.js
@@ -74,7 +74,7 @@ qx.Class.define("osparc.component.message.FlashMessenger", {
      * @param {Number} duration
      */
     logAs: function(message, level="INFO", logger=null, duration=null) {
-      this.log({
+      return this.log({
         message,
         level: level.toUpperCase(),
         logger,
@@ -93,46 +93,48 @@ qx.Class.define("osparc.component.message.FlashMessenger", {
       }
       const level = logMessage.level.toUpperCase(); // "DEBUG", "INFO", "WARNING", "ERROR"
 
-      const flash = new osparc.ui.message.FlashMessage(message, level, logMessage.duration);
-      flash.addListener("closeMessage", () => this.__removeMessage(flash), this);
-      this.__messages.push(flash);
+      const flashMessage = new osparc.ui.message.FlashMessage(message, level, logMessage.duration);
+      flashMessage.addListener("closeMessage", () => this.removeMessage(flashMessage), this);
+      this.__messages.push(flashMessage);
+
+      return flashMessage;
     },
 
     /**
      * Private method to show a message to the user. It will stack it on the previous ones.
      *
-     * @param {osparc.ui.message.FlashMessage} message FlassMessage element to show.
+     * @param {osparc.ui.message.FlashMessage} flashMessage FlassMessage element to show.
      */
-    __showMessage: function(message) {
-      this.__messages.remove(message);
+    __showMessage: function(flashMessage) {
+      this.__messages.remove(flashMessage);
       this.__messageContainer.resetDecorator();
-      this.__messageContainer.add(message);
+      this.__messageContainer.add(flashMessage);
       const {
         width
-      } = message.getSizeHint();
+      } = flashMessage.getSizeHint();
       if (this.__displayedMessagesCount === 0 || width > this.__messageContainer.getWidth()) {
         this.__updateContainerPosition(width);
       }
       this.__displayedMessagesCount++;
 
-      let duration = message.getDuration();
+      let duration = flashMessage.getDuration();
       if (duration === null) {
-        const wordCount = message.getMessage().split(" ").length;
+        const wordCount = flashMessage.getMessage().split(" ").length;
         duration = Math.max(5500, wordCount*400); // An average reader takes 300ms to read a word
       }
-      qx.event.Timer.once(() => this.__removeMessage(message), this, duration);
+      qx.event.Timer.once(() => this.removeMessage(flashMessage), this, duration);
     },
 
     /**
      * Private method to remove a message. If there are still messages in the queue, it will show the next available one.
      *
-     * @param {osparc.ui.message.FlashMessage} message FlassMessage element to remove.
+     * @param {osparc.ui.message.FlashMessage} flashMessage FlassMessage element to remove.
      */
-    __removeMessage: function(message) {
-      if (this.__messageContainer.indexOf(message) > -1) {
+    removeMessage: function(flashMessage) {
+      if (this.__messageContainer.indexOf(flashMessage) > -1) {
         this.__displayedMessagesCount--;
         this.__messageContainer.setDecorator("flash-container-transitioned");
-        this.__messageContainer.remove(message);
+        this.__messageContainer.remove(flashMessage);
         qx.event.Timer.once(() => {
           if (this.__messages.length) {
             // There are still messages to show

--- a/services/static-webserver/client/source/class/osparc/component/notification/NotificationUI.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/NotificationUI.js
@@ -72,7 +72,9 @@ qx.Class.define("osparc.component.notification.NotificationUI", {
             wrap: true
           });
           this.bind("text", control, "value");
-          this._add(control);
+          this._add(control, {
+            flex: 1
+          });
           break;
       }
       return control || this.base(arguments, id);

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notifications.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notifications.js
@@ -44,6 +44,11 @@ qx.Class.define("osparc.component.notification.Notifications", {
       this.__notificationsContainer.addAt(notification, 0);
     },
 
+    removeNotification: function(notification) {
+      this.__notifications.remove(notification);
+      this.__notificationsContainer.remove(notification);
+    },
+
     getNotifications: function() {
       return this.__notifications;
     },

--- a/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
@@ -116,7 +116,6 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
 
     __scheduleMaintenance: function() {
       this.__scheduleStart();
-      this.__scheduleEnd();
     },
 
     __scheduleStart: function() {
@@ -178,19 +177,18 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
         qx.core.Init.getApplication().logout();
       };
       const now = new Date();
-      const diff = this.getStart().getTime() - now.getTime();
-      console.log("logout scheduled: ", this.getStart());
-      this.__logoutTimer = setTimeout(() => logoutUser(), diff);
+      if (this.getStart().getTime() > now.getTime()) {
+        const diff = this.getStart().getTime() - now.getTime();
+        this.__logoutTimer = setTimeout(() => logoutUser(), diff);
+      } else if (this.getEnd().getTime() > now.getTime()) {
+        logoutUser();
+      }
     },
 
     __removeScheduledLogout: function() {
       if (this.__logoutTimer) {
         clearTimeout(this.__logoutTimer);
       }
-    },
-
-    __scheduleEnd: function() {
-
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
@@ -40,8 +40,7 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
   },
 
   statics: {
-    // CHECK_INTERVAL: 15*60*1000, // Check every 15'
-    CHECK_INTERVAL: 5*1000, // testing
+    CHECK_INTERVAL: 15*60*1000, // Check every 15'
     WARN_IN_ADVANCE: 20*60*1000 // Show Flash Message 20' in advance
   },
 
@@ -180,7 +179,7 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
       if (this.getStart().getTime() > now.getTime()) {
         const diff = this.getStart().getTime() - now.getTime();
         this.__logoutTimer = setTimeout(() => logoutUser(), diff);
-      } else if (this.getEnd().getTime() > now.getTime()) {
+      } else if (this.getStart().getTime() < now.getTime() && this.getEnd().getTime() > now.getTime()) {
         logoutUser();
       }
     },

--- a/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
@@ -110,7 +110,11 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
         this.setReason(reason);
       }
 
-      if (oldStart !== this.getStart() || oldEnd !== this.getEnd() || oldReason !== this.getReason()) {
+      if (
+        (oldStart === null || oldStart.getTime() !== this.getStart().getTime()) ||
+        (oldEnd === null || oldEnd.getTime() !== this.getEnd().getTime()) ||
+        oldReason !== this.getReason()
+      ) {
         this.__scheduleMaintenance();
       }
     },

--- a/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
@@ -173,6 +173,15 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
       this.__removeScheduledLogout();
 
       const logoutUser = () => {
+        this.set({
+          start: null,
+          end: null,
+          reason: null
+        });
+        let text = qx.locale.Manager.tr("We are under maintenance.");
+        text += "<br>";
+        text += qx.locale.Manager.tr("Please, check back later");
+        osparc.component.message.FlashMessenger.getInstance().logAs(text, "WARNING");
         qx.core.Init.getApplication().logout();
       };
       const now = new Date();

--- a/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
@@ -97,18 +97,10 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
       const oldStart = this.getStart();
       const oldEnd = this.getEnd();
       const oldReason = this.getReason();
-      if ("start" in maintenanceData) {
-        const startDate = new Date(maintenanceData.start);
-        this.setStart(startDate);
-      }
-      if ("end" in maintenanceData) {
-        const endDate = new Date(maintenanceData.end);
-        this.setEnd(new Date(endDate));
-      }
-      if ("reason" in maintenanceData) {
-        const reason = maintenanceData.reason;
-        this.setReason(reason);
-      }
+
+      this.setStart("start" in maintenanceData ? new Date(maintenanceData.start) : null);
+      this.setEnd("end" in maintenanceData ? new Date(maintenanceData.end) : null);
+      this.setReason("reason" in maintenanceData ? maintenanceData.reason : null);
 
       if (
         (oldStart === null || oldStart.getTime() !== this.getStart().getTime()) ||


### PR DESCRIPTION
## What do these changes do?

Keep asking every 20' in case there are updates:
- [x] React to Redis' maintenance entry changes
  - [x] Update notification/logout if maintenance is updated
  - [x] Remove it if maintenance is removed

![maintenance](https://user-images.githubusercontent.com/33152403/213701678-b8f6ddc0-82f6-413f-b48c-e7bdfb6f21b9.gif)

## Related issue/s
related to https://github.com/ITISFoundation/osparc-simcore/issues/3784: UI: force logout users only between the time span (begin, end] of maintenance


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
