### PR TITLE
🐛 Fixes is3793: error while pulling images 

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,9 @@
 {
   "recommendations": [
     "eamodio.gitlens",
+    "exiasr.hadolint",
     "ms-python.python",
     "samuelcolvin.jinjahtml",
-    "timonwong.shellcheck",
-    "exiasr.hadolint"
+    "timonwong.shellcheck"
   ]
 }

--- a/packages/service-library/src/servicelib/long_running_tasks/_errors.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/_errors.py
@@ -30,7 +30,7 @@ class TaskCancelledError(BaseLongRunningError):
 class TaskExceptionError(BaseLongRunningError):
     code: str = "long_running_task.task_exception_error"
     msg_template: str = (
-        "Task {task_id} finished with exception: '{exception!r}'\n{traceback}"
+        "Task {task_id} finished with exception: '{exception}'\n{traceback}"
     )
 
 

--- a/packages/service-library/src/servicelib/long_running_tasks/_errors.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/_errors.py
@@ -30,7 +30,7 @@ class TaskCancelledError(BaseLongRunningError):
 class TaskExceptionError(BaseLongRunningError):
     code: str = "long_running_task.task_exception_error"
     msg_template: str = (
-        "Task {task_id} finished with exception: '{exception}'\n{traceback}"
+        "Task {task_id} finished with exception: '{exception!r}'\n{traceback}"
     )
 
 

--- a/services/dynamic-sidecar/setup.cfg
+++ b/services/dynamic-sidecar/setup.cfg
@@ -9,3 +9,5 @@ commit_args = --no-verify
 
 [tool:pytest]
 asyncio_mode = auto
+markers =
+	testit: "marks test to run during development"

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
@@ -121,7 +121,7 @@ def _parse_docker_pull_progress(
     if status in list(_PullProgressStates):
         layer_id: LayerId = docker_pull_progress["id"]
         # inits in case states are not in order
-        image_pulling_data[layer_id].setdefault((0, 0))
+        image_pulling_data.setdefault(layer_id, (0, 0))
 
         if status == _PullProgressStates.DOWNLOADING:
             # writes

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
@@ -217,7 +217,7 @@ async def _pull_image_with_progress(
             f"{image_name=}",
         )
 
-    simplified_image_name = image_name.rsplit("/", maxsplit=1)[-1]
+    shorter_image_name: Final[str] = image_name.rsplit("/", maxsplit=1)[-1]
     all_image_pulling_data[image_name] = {}
     async for pull_progress in client.images.pull(
         image_name,
@@ -235,4 +235,4 @@ async def _pull_image_with_progress(
             total_current, total_total = _compute_sizes(all_image_pulling_data)
             await progress_cb(total_current, total_total)
 
-        await log_cb(f"pulling {simplified_image_name}: {pull_progress}...")
+        await log_cb(f"pulling {shorter_image_name}: {pull_progress}...")

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
@@ -169,26 +169,3 @@ async def test_issue_3793_pulling_images_raises_error():
             progress_cb=_print_progress,
             log_cb=_print_log,
         )
-
-    # This is how
-
-    # {'status': 'Pulling fs layer', 'progressDetail': {}, 'id': '6e3729cf69e0'}
-    # {'status': 'Downloading', 'progressDetail': {'current': 309633, 'total': 30428708}, 'progress': '[>                                                  ]  309.6kB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Downloading', 'progressDetail': {'current': 4663681, 'total': 30428708}, 'progress': '[=======>                                           ]  4.664MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Downloading', 'progressDetail': {'current': 5912961, 'total': 30428708}, 'progress': '[=========>                                         ]  5.913MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Downloading', 'progressDetail': {'current': 8718721, 'total': 30428708}, 'progress': '[==============>                                    ]  8.719MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Downloading', 'progressDetail': {'current': 11204993, 'total': 30428708}, 'progress': '[==================>                                ]   11.2MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Downloading', 'progressDetail': {'current': 15563137, 'total': 30428708}, 'progress': '[=========================>                         ]  15.56MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Downloading', 'progressDetail': {'current': 23361921, 'total': 30428708}, 'progress': '[======================================>            ]  23.36MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Verifying Checksum', 'progressDetail': {}, 'id': '6e3729cf69e0'}
-    # {'status': 'Download complete', 'progressDetail': {}, 'id': '6e3729cf69e0'}
-    # {'status': 'Extracting', 'progressDetail': {'current': 327680, 'total': 30428708}, 'progress': '[>                                                  ]  327.7kB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Extracting', 'progressDetail': {'current': 7864320, 'total': 30428708}, 'progress': '[============>                                      ]  7.864MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Extracting', 'progressDetail': {'current': 13434880, 'total': 30428708}, 'progress': '[======================>                            ]  13.43MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Extracting', 'progressDetail': {'current': 21626880, 'total': 30428708}, 'progress': '[===================================>               ]  21.63MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Extracting', 'progressDetail': {'current': 26542080, 'total': 30428708}, 'progress': '[===========================================>       ]  26.54MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Extracting', 'progressDetail': {'current': 30146560, 'total': 30428708}, 'progress': '[=================================================> ]  30.15MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Extracting', 'progressDetail': {'current': 30428708, 'total': 30428708}, 'progress': '[==================================================>]  30.43MB/30.43MB', 'id': '6e3729cf69e0'}
-    # {'status': 'Pull complete', 'progressDetail': {}, 'id': '6e3729cf69e0'}
-    # {'status': 'Digest: sha256:27cb6e6ccef575a4698b66f5de06c7ecd61589132d5a91d098f7f3f9285415a9'}
-    # {'status': 'Status: Downloaded newer image for ubuntu:latest'}

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
@@ -133,7 +133,6 @@ def test_get_docker_service_images(compose_spec_yaml: str):
     }
 
 
-@pytest.mark.testit
 @pytest.mark.skip(
     reason="Only for manual testing."
     "Avoid this test in CI since it consumes disk and time"
@@ -169,3 +168,27 @@ async def test_issue_3793_pulling_images_raises_error():
             progress_cb=_print_progress,
             log_cb=_print_log,
         )
+
+
+@pytest.mark.parametrize("repeat", ["first-pull", "repeat-pull"])
+async def test_pull_image(repeat: str):
+    async def _print_progress(current: int, total: int):
+        print("progress ->", f"{current=}", f"{total=}")
+
+    async def _print_log(msg):
+        assert "alpine" in msg
+        print("log -> ", msg)
+
+    await pull_images(
+        images={
+            "alpine:latest",
+        },
+        registry_settings=RegistrySettings(
+            REGISTRY_AUTH=False,
+            REGISTRY_USER="",
+            REGISTRY_PW="",
+            REGISTRY_SSL=False,
+        ),
+        progress_cb=_print_progress,
+        log_cb=_print_log,
+    )

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
@@ -169,3 +169,26 @@ async def test_issue_3793_pulling_images_raises_error():
             progress_cb=_print_progress,
             log_cb=_print_log,
         )
+
+    # This is how
+
+    # {'status': 'Pulling fs layer', 'progressDetail': {}, 'id': '6e3729cf69e0'}
+    # {'status': 'Downloading', 'progressDetail': {'current': 309633, 'total': 30428708}, 'progress': '[>                                                  ]  309.6kB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Downloading', 'progressDetail': {'current': 4663681, 'total': 30428708}, 'progress': '[=======>                                           ]  4.664MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Downloading', 'progressDetail': {'current': 5912961, 'total': 30428708}, 'progress': '[=========>                                         ]  5.913MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Downloading', 'progressDetail': {'current': 8718721, 'total': 30428708}, 'progress': '[==============>                                    ]  8.719MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Downloading', 'progressDetail': {'current': 11204993, 'total': 30428708}, 'progress': '[==================>                                ]   11.2MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Downloading', 'progressDetail': {'current': 15563137, 'total': 30428708}, 'progress': '[=========================>                         ]  15.56MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Downloading', 'progressDetail': {'current': 23361921, 'total': 30428708}, 'progress': '[======================================>            ]  23.36MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Verifying Checksum', 'progressDetail': {}, 'id': '6e3729cf69e0'}
+    # {'status': 'Download complete', 'progressDetail': {}, 'id': '6e3729cf69e0'}
+    # {'status': 'Extracting', 'progressDetail': {'current': 327680, 'total': 30428708}, 'progress': '[>                                                  ]  327.7kB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Extracting', 'progressDetail': {'current': 7864320, 'total': 30428708}, 'progress': '[============>                                      ]  7.864MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Extracting', 'progressDetail': {'current': 13434880, 'total': 30428708}, 'progress': '[======================>                            ]  13.43MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Extracting', 'progressDetail': {'current': 21626880, 'total': 30428708}, 'progress': '[===================================>               ]  21.63MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Extracting', 'progressDetail': {'current': 26542080, 'total': 30428708}, 'progress': '[===========================================>       ]  26.54MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Extracting', 'progressDetail': {'current': 30146560, 'total': 30428708}, 'progress': '[=================================================> ]  30.15MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Extracting', 'progressDetail': {'current': 30428708, 'total': 30428708}, 'progress': '[==================================================>]  30.43MB/30.43MB', 'id': '6e3729cf69e0'}
+    # {'status': 'Pull complete', 'progressDetail': {}, 'id': '6e3729cf69e0'}
+    # {'status': 'Digest: sha256:27cb6e6ccef575a4698b66f5de06c7ecd61589132d5a91d098f7f3f9285415a9'}
+    # {'status': 'Status: Downloaded newer image for ubuntu:latest'}

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
@@ -10,10 +10,12 @@ from faker import Faker
 from models_library.services import RunID
 from pydantic import PositiveInt
 from pytest import FixtureRequest
+from settings_library.docker_registry import RegistrySettings
 from simcore_service_dynamic_sidecar.core.docker_utils import (
     get_docker_service_images,
     get_running_containers_count_from_names,
     get_volume_by_label,
+    pull_images,
 )
 from simcore_service_dynamic_sidecar.core.errors import VolumeNotFoundError
 
@@ -129,3 +131,41 @@ def test_get_docker_service_images(compose_spec_yaml: str):
         "nginx:latest",
         "simcore/services/dynamic/jupyter-math:2.1.3",
     }
+
+
+@pytest.mark.testit
+@pytest.mark.skip(
+    reason="Only for manual testing."
+    "Avoid this test in CI since it consumes disk and time"
+)
+async def test_issue_3793_pulling_images_raises_error():
+    """
+    Reproduces (sometimes) https://github.com/ITISFoundation/osparc-simcore/issues/3793
+    """
+
+    async def _print_progress(*args, **kwargs):
+        print("progress -> ", args, kwargs)
+
+    async def _print_log(*args, **kwargs):
+        print("log -> ", args, kwargs)
+
+    for n in range(2):
+        await pull_images(
+            images={
+                "ubuntu:latest",
+                "ubuntu:18.04",
+                "ubuntu:22.04",
+                "ubuntu:22.10",
+                "ubuntu:23.04",
+                "ubuntu:14.04",
+                "itisfoundation/mattward-viewer:latest",  # 6.1 GB
+            },
+            registry_settings=RegistrySettings(
+                REGISTRY_AUTH=False,
+                REGISTRY_USER="",
+                REGISTRY_PW="",
+                REGISTRY_SSL=False,
+            ),
+            progress_cb=_print_progress,
+            log_cb=_print_log,
+        )

--- a/services/web/server/src/simcore_service_webserver/session_access.py
+++ b/services/web/server/src/simcore_service_webserver/session_access.py
@@ -34,6 +34,7 @@ def access_tokens_cleanup_ctx(session: Session) -> Iterator[dict[str, AccessToke
     # Note that these access_tokens correspond to the values BEFORE that call
     # and all the tokens added/removed in the decorators nested on the handler
     # are not updated on ``access_tokens`` returned.
+    access_tokens = {}
     try:
         access_tokens = session.setdefault(SESSION_GRANTED_ACCESS_TOKENS_KEY, {})
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?


#### What cause the exception and why such a strange error message?
The error message reported in #3793: ``[...] 784 finished with exception: ''93dac263047b''``  is due to a ``KeyError``. And the trace shows the location:
```log
[... ]
 /simcore_service_dynamic_sidecar/core/docker_utils.py", line 129, in _parse_docker_pull_progress
    _, layer_total_size = all_image_pulling_data[image_name][layer_id]
[... ]
```
Since a ``KeyError `` converted to a string is directly the erroneous key 
```python
x = {}
try:
   y = x["93dac263047b"]
except KeyError as err:
  print(f"The error is {err}")
```
will print
```cmd
The error is 93dac263047b
```

#### How was it solved?

- 🐛Essentially initializing the item as ``all_image_pulling_data[image_name].setdefault(layer_id, (0,0))``. The former version of the algorithm expected a particular sequence of states that write and read from that container and **occasionally** that sequence was broken. 
- ♻️  On top this PR does a bit of refactoring of ``_pull_image_with_progress`` simplifying the code and documenting/annotating all parts more.

#### Extra 
- ♻️ improves error handling of deserialized session tokens (we experience some old tokens caused problems during login)


## Related issue/s

- Fixes ITISFoundation/osparc-simcore#3793


## How to test

- ``test_issue_3793_pulling_images_raises_error`` could **sometimes** reproduce  locally the error. It consumes a lot of time and disk so it has been excluded from CI and remains only for local manual test

## Checklist


- [x] Unit tests for the changes exist
- [x] Runs in the swarm
- [x] Documentation reflects the changes
