### PR TITLE
🐛 Fix broken output ports

### DIFF
--- a/packages/service-library/src/servicelib/long_running_tasks/_task.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/_task.py
@@ -302,7 +302,7 @@ class TasksManager:
         except Exception as e:  # pylint:disable=broad-except
 
             formatted_traceback = "".join(
-                # pylint: disable=protected-access,no-value-for-parameter
+                # pylint: disable=protected-access,no-value-for-parameter,unexpected-keyword-arg
                 traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
             )
             raise TaskExceptionError(

--- a/packages/service-library/src/servicelib/long_running_tasks/_task.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/_task.py
@@ -300,7 +300,9 @@ class TasksManager:
                 task, task_id, reraise_errors=reraise_errors
             )
         except Exception as e:  # pylint:disable=broad-except
-            formatted_traceback = "\n".join(traceback.format_tb(e.__traceback__))
+            formatted_traceback = "".join(
+                traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
+            )
             raise TaskExceptionError(
                 task_id=task_id, exception=e, traceback=formatted_traceback
             ) from e

--- a/packages/service-library/src/servicelib/long_running_tasks/_task.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/_task.py
@@ -300,7 +300,9 @@ class TasksManager:
                 task, task_id, reraise_errors=reraise_errors
             )
         except Exception as e:  # pylint:disable=broad-except
+
             formatted_traceback = "".join(
+                # pylint: disable=protected-access,no-value-for-parameter
                 traceback.format_exception(etype=type(e), value=e, tb=e.__traceback__)
             )
             raise TaskExceptionError(

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
@@ -134,12 +134,12 @@ class OutputsManager:  # pylint: disable=too-many-instance-attributes
         self._task_uploading = create_task(_upload_ports(), name=task_name)
 
         def _remove_downloads(future: Future) -> None:
+            # pylint: disable=protected-access
             if future._exception is not None:
-                # pylint:disable = unexpected-keyword-arg
                 formatted_traceback = (
                     "\n"
                     + "".join(
-                        # pylint: disable=protected-access,no-value-for-parameter
+                        # pylint:disable = unexpected-keyword-arg, no-value-for-parameter
                         traceback.format_exception(
                             etype=type(future._exception),
                             value=future._exception,

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
@@ -134,12 +134,12 @@ class OutputsManager:  # pylint: disable=too-many-instance-attributes
         self._task_uploading = create_task(_upload_ports(), name=task_name)
 
         def _remove_downloads(future: Future) -> None:
-            # pylint: disable=protected-access
             if future._exception is not None:
                 # pylint:disable = unexpected-keyword-arg
                 formatted_traceback = (
                     "\n"
                     + "".join(
+                        # pylint: disable=protected-access,no-value-for-parameter
                         traceback.format_exception(
                             etype=type(future._exception),
                             value=future._exception,

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import traceback
 from asyncio import CancelledError, Future, Lock, Task, create_task, wait
 from contextlib import suppress
 from datetime import timedelta
@@ -135,11 +136,23 @@ class OutputsManager:  # pylint: disable=too-many-instance-attributes
         def _remove_downloads(future: Future) -> None:
             # pylint: disable=protected-access
             if future._exception is not None:
+                formatted_traceback = (
+                    "\n"
+                    + "".join(
+                        traceback.format_exception(
+                            etype=type(future._exception),
+                            value=future._exception,
+                            tb=future._exception.__traceback__,
+                        )
+                    )
+                    if future._exception.__traceback__
+                    else ""
+                )
                 logger.warning(
-                    "%s ended with exception: %s",
+                    "%s ended with exception: %s%s",
                     task_name,
-                    future._exception
-                    # traceback.format_tb(future._exception),
+                    future._exception,
+                    formatted_traceback,
                 )
 
             # keep track of the last result for each port

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
@@ -136,6 +136,7 @@ class OutputsManager:  # pylint: disable=too-many-instance-attributes
         def _remove_downloads(future: Future) -> None:
             # pylint: disable=protected-access
             if future._exception is not None:
+                # pylint:disable = unexpected-keyword-arg
                 formatted_traceback = (
                     "\n"
                     + "".join(

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_filter.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_filter.py
@@ -118,7 +118,7 @@ async def event_filter(
 
 
 async def _wait_for_event_to_trigger(event_filter: EventFilter) -> None:
-    await asyncio.sleep(event_filter.delay_policy.get_min_interval() * 2)
+    await asyncio.sleep(event_filter.delay_policy.get_min_interval() * 5)
 
 
 async def _wait_for_event_to_trigger_big_directory(event_filter: EventFilter) -> None:

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_filter.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_filter.py
@@ -144,7 +144,6 @@ async def test_event_triggers_once(
     assert mocked_port_key_content_changed.call_count == 2
 
 
-@pytest.mark.flaky(max_runs=3)
 async def test_trigger_once_after_event_chain(
     event_filter: EventFilter,
     port_key_1: str,

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_filter.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_filter.py
@@ -144,6 +144,7 @@ async def test_event_triggers_once(
     assert mocked_port_key_content_changed.call_count == 2
 
 
+@pytest.mark.flaky(max_runs=3)
 async def test_trigger_once_after_event_chain(
     event_filter: EventFilter,
     port_key_1: str,

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
@@ -19,7 +19,7 @@ from pytest import FixtureRequest, MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.utils_envs import EnvVarsDict
 from simcore_sdk.node_ports_common.exceptions import S3TransferError
-from simcore_sdk.node_ports_common.file_io_utils import ProgressData
+from simcore_sdk.node_ports_common.file_io_utils import LogRedirectCB, ProgressData
 from simcore_service_dynamic_sidecar.core.settings import ApplicationSettings
 from simcore_service_dynamic_sidecar.modules.mounted_fs import MountedVolumes
 from simcore_service_dynamic_sidecar.modules.outputs._context import (
@@ -392,6 +392,7 @@ async def test_regression_io_log_redirect_cb(
         outputs_manager: OutputsManager = app.state.outputs_manager
         assert outputs_manager.io_log_redirect_cb is not None
 
+        # ensure callback signature passed to nodeports does not change
         assert inspect.getfullargspec(
             outputs_manager.io_log_redirect_cb.func
         ) == FullArgSpec(
@@ -406,5 +407,20 @@ async def test_regression_io_log_redirect_cb(
                 "app": FastAPI,
                 "msg": str,
                 "_": Optional[ProgressData],
+            },
+        )
+
+        # ensure logger used in nodeports deos not change
+        assert inspect.getfullargspec(LogRedirectCB.__call__) == FullArgSpec(
+            args=["self", "msg", "progress_data"],
+            varargs=None,
+            varkw=None,
+            defaults=(None,),
+            kwonlyargs=[],
+            kwonlydefaults=None,
+            annotations={
+                "return": None,
+                "msg": str,
+                "progress_data": Optional[ProgressData],
             },
         )

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
@@ -3,21 +3,34 @@
 # pylint: disable=unused-argument
 
 import asyncio
+import inspect
 from dataclasses import dataclass
+from inspect import FullArgSpec
 from pathlib import Path
-from typing import AsyncIterator, Iterator
+from typing import AsyncIterator, Iterator, Optional
 from unittest.mock import AsyncMock
 
 import pytest
+from async_asgi_testclient import TestClient
+from faker import Faker
+from fastapi import FastAPI
 from pydantic import PositiveFloat
-from pytest import FixtureRequest
+from pytest import FixtureRequest, MonkeyPatch
 from pytest_mock.plugin import MockerFixture
+from pytest_simcore.helpers.utils_envs import EnvVarsDict
 from simcore_sdk.node_ports_common.exceptions import S3TransferError
-from simcore_service_dynamic_sidecar.modules.outputs._context import OutputsContext
+from simcore_sdk.node_ports_common.file_io_utils import ProgressData
+from simcore_service_dynamic_sidecar.core.settings import ApplicationSettings
+from simcore_service_dynamic_sidecar.modules.mounted_fs import MountedVolumes
+from simcore_service_dynamic_sidecar.modules.outputs._context import (
+    OutputsContext,
+    setup_outputs_context,
+)
 from simcore_service_dynamic_sidecar.modules.outputs._manager import (
     OutputsManager,
     UploadPortsFailed,
     _PortKeyTracker,
+    setup_outputs_manager,
 )
 
 # UTILS
@@ -336,3 +349,62 @@ async def test_port_key_tracker_workflow(
     assert await port_key_tracker.can_schedule_ports_to_upload() is False
 
     assert set(await port_key_tracker.get_uploading()) == expected_uploading
+
+
+async def test_regression_io_log_redirect_cb(
+    mock_environment: EnvVarsDict, monkeypatch: MonkeyPatch, faker: Faker
+):
+    for mock_empty_str in {
+        "RABBIT_HOST",
+        "RABBIT_USER",
+        "RABBIT_PASSWORD",
+        "POSTGRES_HOST",
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_DB",
+    }:
+        monkeypatch.setenv(mock_empty_str, "")
+
+    mounted_volumes = MountedVolumes(
+        run_id=faker.uuid4(cast_to=None),
+        node_id=faker.uuid4(cast_to=None),
+        inputs_path=Path("/"),
+        outputs_path=Path("/"),
+        state_paths=[],
+        state_exclude=set(),
+        compose_namespace="",
+        dy_volumes=Path("/"),
+    )
+
+    app = FastAPI()
+
+    # setup settings
+    app.state.settings = ApplicationSettings.create_from_envs()
+
+    # mocked_volumes
+    app.state.mounted_volumes = mounted_volumes
+
+    setup_outputs_context(app)
+    setup_outputs_manager(app)
+
+    async with TestClient(app):  # runs setup handlers
+
+        outputs_manager: OutputsManager = app.state.outputs_manager
+        assert outputs_manager.io_log_redirect_cb is not None
+
+        assert inspect.getfullargspec(
+            outputs_manager.io_log_redirect_cb.func
+        ) == FullArgSpec(
+            args=["app", "msg", "_"],
+            varargs=None,
+            varkw=None,
+            defaults=(None,),
+            kwonlyargs=[],
+            kwonlydefaults=None,
+            annotations={
+                "return": None,
+                "app": FastAPI,
+                "msg": str,
+                "_": Optional[ProgressData],
+            },
+        )


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Out ports are currently not working. An interface changed that was not tested.
- ♻️ better error formatting for simpler tracking of issues
- ✨ added regression test to avoid changes to logging callback breaking the outputs again

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/3794
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/3800
- https://github.com/ITISFoundation/osparc-issues/issues/638


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist