### PR TITLE
✨ Autoscaling: buffer machines Episode II (⚠️ devops)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ popd;
 endef
 
 rebuild: build-nc # alias
-build build-nc: .env ## Builds production images and tags them as 'local/{service-name}:production'. For single target e.g. 'make target=webserver build'. To export to a folder: `make local-dst=/tmp/build`
+build build-nc: .env ## Builds production images and tags them as 'local/{service-name}:production'. For single target e.g. 'make target=webserver build'. To export to a folder: `make local-dest=/tmp/build`
 	# Building service$(if $(target),,s) $(target)
 	@$(_docker_compose_build)
 

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ popd;
 endef
 
 rebuild: build-nc # alias
-build build-nc: .env ## Builds production images and tags them as 'local/{service-name}:production'. For single target e.g. 'make target=webserver build'
+build build-nc: .env ## Builds production images and tags them as 'local/{service-name}:production'. For single target e.g. 'make target=webserver build'. To export to a folder: `make local-dst=/tmp/build`
 	# Building service$(if $(target),,s) $(target)
 	@$(_docker_compose_build)
 

--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -177,4 +177,4 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
 
 
 def get_application_settings(app: FastAPI) -> ApplicationSettings:
-    return app.state.settings
+    return cast(ApplicationSettings, app.state.settings)

--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -2,6 +2,7 @@ import datetime
 from functools import cached_property
 from typing import Optional, cast
 
+from fastapi import FastAPI
 from models_library.basic_types import (
     BootModeEnum,
     BuildTargetEnum,
@@ -173,3 +174,7 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
     def valid_log_level(cls, value: str) -> str:
         # NOTE: mypy is not happy without the cast
         return cast(str, cls.validate_log_level(value))
+
+
+def get_application_settings(app: FastAPI) -> ApplicationSettings:
+    return app.state.settings

--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -74,7 +74,8 @@ class EC2InstancesSettings(BaseCustomSettings):
 
     EC2_INSTANCES_MACHINES_BUFFER: NonNegativeInt = Field(
         default=0,
-        description="Buffer of readily available machines for fast usage (always on)",
+        description="Constant reserve of drained ready machines for fast(er) usage,"
+        "disabled when set to 0. Uses 1st machine defined in EC2_INSTANCES_ALLOWED_TYPES",
     )
 
     @validator("EC2_INSTANCES_TIME_BEFORE_TERMINATION")

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -321,8 +321,10 @@ async def _start_instances(
         elif isinstance(r, Exception):
             logger.error("Unexpected error happened when starting EC2 instance: %s", r)
             last_issue = f"{r}"
-        else:
+        elif isinstance(r, list):
             new_pending_instances.extend(r)
+        else:
+            new_pending_instances.append(r)
 
     log_message = f"{sum(n for n in needed_instances.values())} new machines launched, it might take up to 3 minutes to start, Please wait..."
     if last_issue:

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -277,8 +277,7 @@ async def _find_needed_instances(
             app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
             - len(cluster.reserve_drained_nodes)
         )
-        > 0
-    ):
+    ) > 0:
         default_instance_type = available_ec2_types[0]
         num_instances_per_type[default_instance_type] += num_missing_nodes
 

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -400,14 +400,14 @@ async def _scale_up_cluster(
 
 
 async def _try_attach_pending_ec2s(app: FastAPI, cluster: Cluster) -> Cluster:
-    """label the instances that connected to the swarm that are missing the monitoring labels"""
+    """label the drained instances that connected to the swarm which are missing the monitoring labels"""
     newly_attached_nodes: list[AssociatedInstance] = []
     still_pending_ec2: list[EC2InstanceData] = []
     app_settings: ApplicationSettings = app.state.settings
     for instance_data in cluster.pending_ec2s:
         try:
             node_host_name = node_host_name_from_ec2_private_dns(instance_data)
-            if new_node := await utils_docker.try_get_node_with_name(
+            if new_node := await utils_docker.find_node_with_name(
                 get_docker_client(app), node_host_name
             ):
                 # it is attached, let's label it, but keep it as drained
@@ -538,5 +538,5 @@ async def cluster_scaling_from_labelled_services(app: FastAPI) -> None:
     cluster = await _try_attach_pending_ec2s(app, cluster)
     cluster = await _scale_cluster(app, cluster)
 
-    # informa status
+    # inform on rabbit about status
     await post_autoscaling_status_message(app, cluster)

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -354,6 +354,14 @@ async def _scale_up_cluster(
         )
     )
 
+    def _sort_according_to_allowed_types(instance_type: EC2Instance) -> int:
+        assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
+        return app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES.index(
+            instance_type.name
+        )
+
+    allowed_instance_types.sort(key=_sort_according_to_allowed_types)
+
     # let's start these
     if needed_ec2_instances := await _find_needed_instances(
         app,

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -37,7 +37,7 @@ class Resources(BaseModel):
         )
 
 
-class EC2Instance(BaseModel, frozen=True):
+class EC2InstanceType(BaseModel, frozen=True):
     name: str
     cpus: PositiveInt
     ram: ByteSize

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -9,6 +9,31 @@ from pydantic import BaseModel, ByteSize, Field, NonNegativeFloat, PositiveInt
 from types_aiobotocore_ec2.literals import InstanceStateNameType, InstanceTypeType
 
 
+class SimcoreServiceDockerLabelKeys(BaseModel):
+    # NOTE: in a next PR, this should be moved to packages models-library and used
+    # all over, and aliases should use io.simcore.service.*
+    # https://github.com/ITISFoundation/osparc-simcore/issues/3638
+
+    user_id: UserID = Field(..., alias="user_id")
+    project_id: ProjectID = Field(..., alias="study_id")
+    node_id: NodeID = Field(..., alias="uuid")
+
+    def to_docker_labels(self) -> dict[str, str]:
+        """returns a dictionary of strings as required by docker"""
+        std_export = self.dict(by_alias=True)
+        return {k: f"{v}" for k, v in std_export.items()}
+
+    @classmethod
+    def from_docker_task(cls, docker_task: Task) -> "SimcoreServiceDockerLabelKeys":
+        assert docker_task.Spec  # nosec
+        assert docker_task.Spec.ContainerSpec  # nosec
+        task_labels = docker_task.Spec.ContainerSpec.Labels or {}
+        return cls.parse_obj(task_labels)
+
+    class Config:
+        allow_population_by_field_name = True
+
+
 class Resources(BaseModel):
     cpus: NonNegativeFloat
     ram: ByteSize
@@ -37,35 +62,11 @@ class Resources(BaseModel):
         )
 
 
-class EC2InstanceType(BaseModel, frozen=True):
+@dataclass(frozen=True)
+class EC2InstanceType:
     name: str
     cpus: PositiveInt
     ram: ByteSize
-
-
-class SimcoreServiceDockerLabelKeys(BaseModel):
-    # NOTE: in a next PR, this should be moved to packages models-library and used
-    # all over, and aliases should use io.simcore.service.*
-    # https://github.com/ITISFoundation/osparc-simcore/issues/3638
-
-    user_id: UserID = Field(..., alias="user_id")
-    project_id: ProjectID = Field(..., alias="study_id")
-    node_id: NodeID = Field(..., alias="uuid")
-
-    def to_docker_labels(self) -> dict[str, str]:
-        """returns a dictionary of strings as required by docker"""
-        std_export = self.dict(by_alias=True)
-        return {k: f"{v}" for k, v in std_export.items()}
-
-    @classmethod
-    def from_docker_task(cls, docker_task: Task) -> "SimcoreServiceDockerLabelKeys":
-        assert docker_task.Spec  # nosec
-        assert docker_task.Spec.ContainerSpec  # nosec
-        task_labels = docker_task.Spec.ContainerSpec.Labels or {}
-        return cls.parse_obj(task_labels)
-
-    class Config:
-        allow_population_by_field_name = True
 
 
 InstancePrivateDNSName = str

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -1,5 +1,5 @@
 import datetime
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from models_library.generated_models.docker_rest_api import Node, Task
 from models_library.projects import ProjectID
@@ -84,3 +84,33 @@ class EC2InstanceData:
 class AssociatedInstance:
     node: Node
     ec2_instance: EC2InstanceData
+
+
+@dataclass(frozen=True)
+class Cluster:
+    active_nodes: list[AssociatedInstance] = field(
+        metadata={
+            "description": "This is a EC2 backed docker node which is active (with running tasks)"
+        }
+    )
+    drained_nodes: list[AssociatedInstance] = field(
+        metadata={
+            "description": "This is a EC2 backed docker node which is drained (with no tasks)"
+        }
+    )
+    reserve_drained_nodes: list[AssociatedInstance] = field(
+        metadata={
+            "description": "This is a EC2 backed docker node which is drained in the reserve if this is enabled (with no tasks)"
+        }
+    )
+    pending_ec2s: list[EC2InstanceData] = field(
+        metadata={
+            "description": "This is an EC2 instance that is not yet associated to a docker node"
+        }
+    )
+    disconnected_nodes: list[Node] = field(
+        metadata={
+            "description": "This is a docker node which is not backed by a running EC2 instance"
+        }
+    )
+    terminated_instances: list[EC2InstanceData]

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -23,7 +23,7 @@ from ..core.errors import (
     Ec2TooManyInstancesError,
 )
 from ..core.settings import EC2InstancesSettings, EC2Settings
-from ..models import EC2Instance, EC2InstanceData
+from ..models import EC2InstanceData, EC2InstanceType
 from ..utils.ec2 import compose_user_data
 
 logger = logging.getLogger(__name__)
@@ -65,16 +65,16 @@ class AutoscalingEC2:
     async def get_ec2_instance_capabilities(
         self,
         instance_type_names: set[InstanceTypeType],
-    ) -> list[EC2Instance]:
+    ) -> list[EC2InstanceType]:
         """instance_type_names must be a set of unique values"""
         instance_types = await self.client.describe_instance_types(
             InstanceTypes=list(instance_type_names)
         )
-        list_instances: list[EC2Instance] = []
+        list_instances: list[EC2InstanceType] = []
         for instance in instance_types.get("InstanceTypes", []):
             with contextlib.suppress(KeyError):
                 list_instances.append(
-                    EC2Instance(
+                    EC2InstanceType(
                         name=instance["InstanceType"],
                         cpus=instance["VCpuInfo"]["DefaultVCpus"],
                         ram=parse_obj_as(

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from models_library.generated_models.docker_rest_api import Node, Task
 
 from ..core.errors import Ec2InvalidDnsNameError
-from ..models import AssociatedInstance, EC2Instance, EC2InstanceData, Resources
+from ..models import AssociatedInstance, EC2InstanceData, EC2InstanceType, Resources
 from . import utils_docker
 from .rabbitmq import log_tasks_message, progress_tasks_message
 
@@ -68,7 +68,8 @@ def try_assigning_task_to_node(
 
 
 def try_assigning_task_to_instances(
-    pending_task: Task, list_of_instance_to_tasks: list[tuple[EC2Instance, list[Task]]]
+    pending_task: Task,
+    list_of_instance_to_tasks: list[tuple[EC2InstanceType, list[Task]]],
 ) -> bool:
     for instance, instance_assigned_tasks in list_of_instance_to_tasks:
         instance_total_resource = Resources(cpus=instance.cpus, ram=instance.ram)
@@ -91,7 +92,7 @@ async def try_assigning_task_to_pending_instances(
     app: FastAPI,
     pending_task: Task,
     list_of_pending_instance_to_tasks: list[tuple[EC2InstanceData, list[Task]]],
-    type_to_instance_map: dict[str, EC2Instance],
+    type_to_instance_map: dict[str, EC2InstanceType],
 ) -> bool:
     for instance, instance_assigned_tasks in list_of_pending_instance_to_tasks:
         instance_type = type_to_instance_map[instance.type]

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -52,10 +52,10 @@ async def associate_ec2_instances_with_nodes(
 
 
 def try_assigning_task_to_node(
-    pending_task: Task, node_to_tasks: list[tuple[Node, list[Task]]]
+    pending_task: Task, instance_to_tasks: list[tuple[AssociatedInstance, list[Task]]]
 ) -> bool:
-    for node, node_assigned_tasks in node_to_tasks:
-        instance_total_resource = utils_docker.get_node_total_resources(node)
+    for instance, node_assigned_tasks in instance_to_tasks:
+        instance_total_resource = utils_docker.get_node_total_resources(instance.node)
         tasks_needed_resources = utils_docker.compute_tasks_needed_resources(
             node_assigned_tasks
         )

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/ec2.py
@@ -11,7 +11,7 @@ from typing import Callable
 from .._meta import VERSION
 from ..core.errors import ConfigurationError, Ec2InstanceNotFoundError
 from ..core.settings import ApplicationSettings
-from ..models import EC2Instance, Resources
+from ..models import EC2InstanceType, Resources
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def compose_user_data(docker_join_bash_command: str) -> str:
 
 
 def closest_instance_policy(
-    ec2_instance: EC2Instance,
+    ec2_instance: EC2InstanceType,
     resources: Resources,
 ) -> float:
     if ec2_instance.cpus < resources.cpus or ec2_instance.ram < resources.ram:
@@ -55,13 +55,13 @@ def closest_instance_policy(
 
 
 def find_best_fitting_ec2_instance(
-    allowed_ec2_instances: list[EC2Instance],
+    allowed_ec2_instances: list[EC2InstanceType],
     resources: Resources,
-    score_type: Callable[[EC2Instance, Resources], float] = closest_instance_policy,
-) -> EC2Instance:
+    score_type: Callable[[EC2InstanceType, Resources], float] = closest_instance_policy,
+) -> EC2InstanceType:
     if not allowed_ec2_instances:
         raise ConfigurationError(msg="allowed ec2 instances is missing!")
-    score_to_ec2_candidate: dict[float, EC2Instance] = OrderedDict(
+    score_to_ec2_candidate: dict[float, EC2InstanceType] = OrderedDict(
         sorted(
             {
                 score_type(instance, resources): instance

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
@@ -91,7 +91,7 @@ async def create_autoscaling_status_message(
         + len(cluster.drained_nodes)
         + len(cluster.reserve_drained_nodes),
         nodes_active=len(cluster.active_nodes),
-        nodes_drained=len(cluster.drained_nodes),
+        nodes_drained=len(cluster.drained_nodes) + len(cluster.reserve_drained_nodes),
         cluster_total_resources=total_resources.dict(),
         cluster_used_resources=used_resources.dict(),
         instances_pending=len(cluster.pending_ec2s),

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -328,7 +328,7 @@ async def get_docker_swarm_join_bash_command() -> str:
     )
 
 
-async def try_get_node_with_name(
+async def find_node_with_name(
     docker_client: AutoscalingDocker, name: str
 ) -> Optional[Node]:
     list_of_nodes = await docker_client.nodes.list(filters={"name": name})

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -11,7 +11,6 @@ from typing import Final, Optional, cast
 
 from models_library.docker import DockerLabelKey
 from models_library.generated_models.docker_rest_api import (
-    Availability,
     Node,
     NodeState,
     Service,
@@ -24,7 +23,7 @@ from servicelib.logging_utils import log_context
 from servicelib.utils import logged_gather
 
 from ..core.settings import ApplicationSettings
-from ..models import AssociatedInstance, Resources
+from ..models import Resources
 from ..modules.docker import AutoscalingDocker
 
 logger = logging.getLogger(__name__)
@@ -37,8 +36,15 @@ _TASK_STATUS_WITH_ASSIGNED_RESOURCES: Final[tuple[TaskState, ...]] = (
     TaskState.starting,
     TaskState.running,
 )
-_MINUTE: Final[int] = 60
-_TIMEOUT_WAITING_FOR_NODES_S: Final[int] = 5 * _MINUTE
+
+_DISALLOWED_DOCKER_PLACEMENT_CONSTRAINTS: Final[list[str]] = [
+    "node.id",
+    "node.hostname",
+    "node.role",
+]
+
+_PENDING_DOCKER_TASK_MESSAGE: Final[str] = "pending task scheduling"
+_INSUFFICIENT_RESOURCES_DOCKER_TASK_ERR: Final[str] = "insufficient resources on"
 
 
 async def get_monitored_nodes(
@@ -80,16 +86,6 @@ async def remove_nodes(
         with log_context(logger, logging.INFO, msg=f"remove {node.ID=}"):
             await docker_client.nodes.remove(node_id=node.ID, force=force)
     return nodes_that_need_removal
-
-
-_DISALLOWED_DOCKER_PLACEMENT_CONSTRAINTS: Final[list[str]] = [
-    "node.id",
-    "node.hostname",
-    "node.role",
-]
-
-_PENDING_DOCKER_TASK_MESSAGE: Final[str] = "pending task scheduling"
-_INSUFFICIENT_RESOURCES_DOCKER_TASK_ERR: Final[str] = "insufficient resources on"
 
 
 def _is_task_waiting_for_resources(task: Task) -> bool:
@@ -385,25 +381,3 @@ def get_docker_tags(app_settings: ApplicationSettings) -> dict[DockerLabelKey, s
         tag_key: "true"
         for tag_key in app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NEW_NODES_LABELS
     }
-
-
-async def get_drained_empty_nodes(
-    docker_client: AutoscalingDocker,
-    app_settings: ApplicationSettings,
-    associated_instances: list[AssociatedInstance],
-) -> list[AssociatedInstance]:
-    assert app_settings.AUTOSCALING_NODES_MONITORING  # nosec
-    return [
-        instance
-        for instance in associated_instances
-        if (
-            await compute_node_used_resources(
-                docker_client,
-                instance.node,
-                service_labels=app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_SERVICE_LABELS,
-            )
-            == Resources.create_as_empty()
-        )
-        and (instance.node.Spec is not None)
-        and (instance.node.Spec.Availability == Availability.drain)
-    ]

--- a/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
@@ -457,7 +457,6 @@ async def test_cluster_scaling_up(
     mock_tag_node.assert_not_called()
     mock_set_node_availability.assert_not_called()
     mock_compute_node_used_resources.assert_not_called()
-    # mock_cluster_used_resources.assert_called_once()
     # check rabbit messages were sent
     _assert_rabbit_autoscaling_message_sent(
         mock_rabbitmq_post_message,

--- a/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
@@ -88,11 +88,9 @@ def mock_rabbitmq_post_message(mocker: MockerFixture) -> Iterator[mock.Mock]:
 
 
 @pytest.fixture
-def mock_try_get_node_with_name(
-    mocker: MockerFixture, fake_node: Node
-) -> Iterator[mock.Mock]:
+def find_node_with_name(mocker: MockerFixture, fake_node: Node) -> Iterator[mock.Mock]:
     mocked_wait_for_node = mocker.patch(
-        "simcore_service_autoscaling.dynamic_scaling_core.utils_docker.try_get_node_with_name",
+        "simcore_service_autoscaling.dynamic_scaling_core.utils_docker.find_node_with_name",
         autospec=True,
         return_value=fake_node,
     )
@@ -383,7 +381,7 @@ async def test_cluster_scaling_up(
     mock_tag_node: mock.Mock,
     fake_node: Node,
     mock_rabbitmq_post_message: mock.Mock,
-    mock_try_get_node_with_name: mock.Mock,
+    find_node_with_name: mock.Mock,
     mock_set_node_availability: mock.Mock,
     # mock_cluster_used_resources: mock.Mock,
     mock_compute_node_used_resources: mock.Mock,
@@ -413,7 +411,7 @@ async def test_cluster_scaling_up(
     )
 
     # as the new node is already running, but is not yet connected, hence not tagged and drained
-    mock_try_get_node_with_name.assert_not_called()
+    find_node_with_name.assert_not_called()
     mock_tag_node.assert_not_called()
     mock_set_node_availability.assert_not_called()
     mock_compute_node_used_resources.assert_not_called()
@@ -446,7 +444,7 @@ async def test_cluster_scaling_up(
         instance_state="running",
     )
     # the node is tagged and made active right away since we still have the pending task
-    mock_try_get_node_with_name.assert_called_once()
+    find_node_with_name.assert_called_once()
     assert app_settings.AUTOSCALING_NODES_MONITORING
     expected_docker_node_tags = {
         tag_key: "true"
@@ -527,7 +525,7 @@ async def test_cluster_scaling_up_starts_multiple_instances(
     fake_node: Node,
     scale_up_params: _ScaleUpParams,
     mock_rabbitmq_post_message: mock.Mock,
-    mock_try_get_node_with_name: mock.Mock,
+    find_node_with_name: mock.Mock,
     mock_set_node_availability: mock.Mock,
     mocker: MockerFixture,
 ):
@@ -585,7 +583,7 @@ async def test_cluster_scaling_up_starts_multiple_instances(
         all_private_dns_names.append(instance_private_dns_name)
 
     # as the new node is already running, but is not yet connected, hence not tagged and drained
-    mock_try_get_node_with_name.assert_not_called()
+    find_node_with_name.assert_not_called()
     mock_tag_node.assert_not_called()
     mock_set_node_availability.assert_not_called()
     # check rabbit messages were sent

--- a/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
@@ -266,8 +266,6 @@ async def test_cluster_scaling_from_labelled_services_with_no_services_and_machi
     app_settings: ApplicationSettings,
     initialized_app: FastAPI,
     aws_allowed_ec2_instance_type_names: list[str],
-    # mock_start_aws_instance: mock.Mock,
-    # mock_terminate_instances: mock.Mock,
     mock_rabbitmq_post_message: mock.Mock,
     ec2_client: EC2Client,
 ):

--- a/services/autoscaling/tests/unit/test_utils_docker.py
+++ b/services/autoscaling/tests/unit/test_utils_docker.py
@@ -31,6 +31,7 @@ from simcore_service_autoscaling.utils.utils_docker import (
     compute_cluster_used_resources,
     compute_node_used_resources,
     compute_tasks_needed_resources,
+    find_node_with_name,
     get_docker_swarm_join_bash_command,
     get_max_resources_from_docker_task,
     get_monitored_nodes,
@@ -38,7 +39,6 @@ from simcore_service_autoscaling.utils.utils_docker import (
     pending_service_tasks_with_insufficient_resources,
     remove_nodes,
     tag_node,
-    try_get_node_with_name,
 )
 
 
@@ -748,7 +748,7 @@ async def test_try_get_node_with_name(
     assert host_node.Description
     assert host_node.Description.Hostname
 
-    received_node = await try_get_node_with_name(
+    received_node = await find_node_with_name(
         autoscaling_docker, host_node.Description.Hostname
     )
     assert received_node == host_node
@@ -760,7 +760,7 @@ async def test_try_get_node_with_name_fake(
     assert fake_node.Description
     assert fake_node.Description.Hostname
 
-    received_node = await try_get_node_with_name(
+    received_node = await find_node_with_name(
         autoscaling_docker, fake_node.Description.Hostname
     )
     assert received_node is None
@@ -773,7 +773,7 @@ async def test_tag_node(
     assert host_node.Description.Hostname
     tags = faker.pydict(allowed_types=(str,))
     await tag_node(autoscaling_docker, host_node, tags=tags, available=False)
-    updated_node = await try_get_node_with_name(
+    updated_node = await find_node_with_name(
         autoscaling_docker, host_node.Description.Hostname
     )
     assert updated_node
@@ -782,7 +782,7 @@ async def test_tag_node(
     assert updated_node.Spec.Labels == tags
 
     await tag_node(autoscaling_docker, updated_node, tags={}, available=True)
-    updated_node = await try_get_node_with_name(
+    updated_node = await find_node_with_name(
         autoscaling_docker, host_node.Description.Hostname
     )
     assert updated_node

--- a/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
+++ b/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
@@ -13,7 +13,7 @@ from models_library.generated_models.docker_rest_api import Node, Task
 from pydantic import ByteSize
 from pytest_mock import MockerFixture
 from simcore_service_autoscaling.core.errors import Ec2InvalidDnsNameError
-from simcore_service_autoscaling.models import EC2Instance
+from simcore_service_autoscaling.models import EC2InstanceType
 from simcore_service_autoscaling.modules.ec2 import EC2InstanceData
 from simcore_service_autoscaling.utils.dynamic_scaling import (
     associate_ec2_instances_with_nodes,
@@ -149,7 +149,7 @@ async def test_try_assigning_task_to_pending_instances(
         (fake_instance, [])
     ]
     type_to_instance_map = {
-        fake_instance.type: EC2Instance(
+        fake_instance.type: EC2InstanceType(
             name=fake_instance.type, cpus=4, ram=ByteSize(1024 * 1024)
         )
     }

--- a/services/autoscaling/tests/unit/test_utils_ec2.py
+++ b/services/autoscaling/tests/unit/test_utils_ec2.py
@@ -76,9 +76,10 @@ async def test_find_best_fitting_ec2_instance_closest_instance_policy(
         score_type=closest_instance_policy,
     )
 
-    assert found_instance.dict(exclude={"name"}) == expected_ec2_instance.dict(
-        exclude={"name"}
-    )
+    SKIPPED_KEYS = ["name"]
+    for k in found_instance.__dict__.keys():
+        if k not in SKIPPED_KEYS:
+            assert getattr(found_instance, k) == getattr(expected_ec2_instance, k)
 
 
 def test_compose_user_data(faker: Faker):

--- a/services/autoscaling/tests/unit/test_utils_ec2.py
+++ b/services/autoscaling/tests/unit/test_utils_ec2.py
@@ -14,7 +14,7 @@ from simcore_service_autoscaling.core.errors import (
 )
 from simcore_service_autoscaling.models import Resources
 from simcore_service_autoscaling.utils.ec2 import (
-    EC2Instance,
+    EC2InstanceType,
     closest_instance_policy,
     compose_user_data,
     find_best_fitting_ec2_instance,
@@ -31,9 +31,9 @@ async def test_find_best_fitting_ec2_instance_with_no_instances_raises():
 
 
 @pytest.fixture
-def random_fake_available_instances(faker: Faker) -> list[EC2Instance]:
+def random_fake_available_instances(faker: Faker) -> list[EC2InstanceType]:
     list_of_instances = [
-        EC2Instance(
+        EC2InstanceType(
             name=faker.pystr(),
             cpus=n,
             ram=ByteSize(n),
@@ -45,7 +45,7 @@ def random_fake_available_instances(faker: Faker) -> list[EC2Instance]:
 
 
 async def test_find_best_fitting_ec2_instance_closest_instance_policy_with_resource_0_raises(
-    random_fake_available_instances: list[EC2Instance],
+    random_fake_available_instances: list[EC2InstanceType],
 ):
     with pytest.raises(Ec2InstanceNotFoundError):
         find_best_fitting_ec2_instance(
@@ -60,17 +60,17 @@ async def test_find_best_fitting_ec2_instance_closest_instance_policy_with_resou
     [
         (
             Resources(cpus=n, ram=ByteSize(n)),
-            EC2Instance(name="fake", cpus=n, ram=ByteSize(n)),
+            EC2InstanceType(name="fake", cpus=n, ram=ByteSize(n)),
         )
         for n in range(1, 30)
     ],
 )
 async def test_find_best_fitting_ec2_instance_closest_instance_policy(
     needed_resources: Resources,
-    expected_ec2_instance: EC2Instance,
-    random_fake_available_instances: list[EC2Instance],
+    expected_ec2_instance: EC2InstanceType,
+    random_fake_available_instances: list[EC2InstanceType],
 ):
-    found_instance: EC2Instance = find_best_fitting_ec2_instance(
+    found_instance: EC2InstanceType = find_best_fitting_ec2_instance(
         allowed_ec2_instances=random_fake_available_instances,
         resources=needed_resources,
         score_type=closest_instance_policy,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?
continues from #3790 
<!-- Explain REVIEWERS what is this PR about -->

This PR reworked the machine buffering enhancement. After this PR the autoscaling service can keep a constant number of so-called "reserve machines" that are in docker swarm *drain* mode. Therefore these machines are ready for running services in a few seconds (max 20 seconds which is the time the autoscaling background task interval + possibly starting other instances).

#### Use-cases:
1. no load: the reserved drain machines are kept forever
2. under load: when machines in the reserve are used for services, then new machines are pre-created and added to the reserve again


#### Next steps:
- implement some heuristic to have *smart reserve*. Why keep unneeded resources forever if there is a long time of innactivity?
-  (⚠️ devops) ```EC2_INSTANCES_MACHINES_BUFFER``` is now usable and shall be defined as ```0``` to disable machine buffering, or any number to enable it. 
- NOTE: The type of machine used for buffering is the first one defined in ```EC2_INSTANCES_ALLOWED_TYPES```


More details:
- a new model that objectify the concept of a cluster enables much easier handling 
## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
