### PR TITLE
✨Frontend UX: Enhance registration/login process

### DIFF
--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -107,7 +107,7 @@ qx.Class.define("osparc.Application", {
     },
 
     __checkScreenSize: function() {
-      osparc.utils.LibVersions.getPlatformName()
+      osparc.store.StaticInfo.getInstance().getPlatformName()
         .then(platformName => {
           const preferencesSettings = osparc.desktop.preferences.Preferences.getInstance();
           if (platformName !== "master" && preferencesSettings.getConfirmWindowSize()) {
@@ -254,7 +254,7 @@ qx.Class.define("osparc.Application", {
     },
 
     __updateTabName: function() {
-      osparc.utils.LibVersions.getPlatformName()
+      osparc.store.StaticInfo.getInstance().getPlatformName()
         .then(platformName => {
           if (osparc.utils.Utils.isInZ43()) {
             document.title += " Z43";
@@ -276,7 +276,7 @@ qx.Class.define("osparc.Application", {
     },
 
     __checkCookiesAccepted: function() {
-      osparc.utils.LibVersions.getPlatformName()
+      osparc.store.StaticInfo.getInstance().getPlatformName()
         .then(platformName => {
           if (platformName !== "master") {
             if (!osparc.CookiePolicy.areCookiesAccepted()) {

--- a/services/static-webserver/client/source/class/osparc/auth/LoginPage.js
+++ b/services/static-webserver/client/source/class/osparc/auth/LoginPage.js
@@ -199,7 +199,7 @@ qx.Class.define("osparc.auth.LoginPage", {
       const separator = new qx.ui.basic.Label("::");
       versionLinkLayout.add(separator);
 
-      osparc.utils.LibVersions.getPlatformName()
+      osparc.store.StaticInfo.getInstance().getPlatformName()
         .then(platformName => {
           text += platformName.length ? ` (${platformName})` : " (production)";
         })

--- a/services/static-webserver/client/source/class/osparc/auth/ui/Login2FAValidationCodeView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/Login2FAValidationCodeView.js
@@ -63,9 +63,8 @@ qx.Class.define("osparc.auth.ui.Login2FAValidationCodeView", {
         center: true,
         appearance: "strong-button"
       });
-      validateCodeTF.bind("value", validateCodeBtn, "enabled", {
-        converter: val => Boolean(val)
-      });
+      validateCodeBtn.setEnabled(false);
+      validateCodeTF.addListener("input", e => validateCodeBtn.setEnabled(Boolean(e.getData())));
       validateCodeBtn.addListener("execute", () => this.__validateCodeLogin(), this);
       this.add(validateCodeBtn);
 

--- a/services/static-webserver/client/source/class/osparc/auth/ui/Login2FAValidationCodeView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/Login2FAValidationCodeView.js
@@ -63,6 +63,9 @@ qx.Class.define("osparc.auth.ui.Login2FAValidationCodeView", {
         center: true,
         appearance: "strong-button"
       });
+      validateCodeTF.bind("value", validateCodeBtn, "enabled", {
+        converter: val => Boolean(val)
+      });
       validateCodeBtn.addListener("execute", () => this.__validateCodeLogin(), this);
       this.add(validateCodeBtn);
 

--- a/services/static-webserver/client/source/class/osparc/auth/ui/Login2FAValidationCodeView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/Login2FAValidationCodeView.js
@@ -81,7 +81,7 @@ qx.Class.define("osparc.auth.ui.Login2FAValidationCodeView", {
       }));
       resendLayout.add(resendBtnsLayout);
 
-      const resendCodeSMSBtn = this.__resendCodeSMSBtn = new qx.ui.form.Button().set({
+      const resendCodeSMSBtn = this.__resendCodeSMSBtn = new osparc.ui.form.FetchButton().set({
         label: this.tr("Via SMS") + ` (60)`,
         enabled: false
       });
@@ -92,16 +92,21 @@ qx.Class.define("osparc.auth.ui.Login2FAValidationCodeView", {
         flex: 1
       });
       resendCodeSMSBtn.addListener("execute", () => {
+        resendCodeSMSBtn.setFetching(true);
         osparc.auth.Manager.getInstance().resendCodeViaSMS(this.getUserEmail())
           .then(data => {
+            resendCodeSMSBtn.setFetching(false);
             osparc.component.message.FlashMessenger.logAs(data.reason, "INFO");
             introText.setValue(justSentText + this.getUserPhoneNumber());
             this.__restartTimers();
           })
-          .catch(err => osparc.component.message.FlashMessenger.logAs(err.message, "ERROR"));
+          .catch(err => {
+            resendCodeSMSBtn.setFetching(false);
+            osparc.component.message.FlashMessenger.logAs(err.message, "ERROR");
+          });
       }, this);
 
-      const resendCodeEmailBtn = this.__resendCodeEmailBtn = new qx.ui.form.Button().set({
+      const resendCodeEmailBtn = this.__resendCodeEmailBtn = new osparc.ui.form.FetchButton().set({
         label: this.tr("Via email") + ` (60)`,
         enabled: false
       });
@@ -109,13 +114,18 @@ qx.Class.define("osparc.auth.ui.Login2FAValidationCodeView", {
         flex: 1
       });
       resendCodeEmailBtn.addListener("execute", () => {
+        resendCodeEmailBtn.setFetching(true);
         osparc.auth.Manager.getInstance().resendCodeViaEmail(this.getUserEmail())
           .then(data => {
+            resendCodeEmailBtn.setFetching(false);
             osparc.component.message.FlashMessenger.logAs(data.reason, "INFO");
             introText.setValue(justSentText + this.getUserEmail());
             this.__restartTimers();
           })
-          .catch(err => osparc.component.message.FlashMessenger.logAs(err.message, "ERROR"));
+          .catch(err => {
+            resendCodeEmailBtn.setFetching(false);
+            osparc.component.message.FlashMessenger.logAs(err.message, "ERROR");
+          });
       }, this);
       this.add(resendLayout);
     },

--- a/services/static-webserver/client/source/class/osparc/auth/ui/VerifyPhoneNumberView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/VerifyPhoneNumberView.js
@@ -105,16 +105,19 @@ qx.Class.define("osparc.auth.ui.VerifyPhoneNumberView", {
 
     __createValidationLayout: function() {
       const smsValidationLayout = new qx.ui.container.Composite(new qx.ui.layout.HBox(5));
-      const validationCode = this.__validateCodeTF = new qx.ui.form.TextField().set({
+      const validateCodeTF = this.__validateCodeTF = new qx.ui.form.TextField().set({
         placeholder: this.tr("Type the SMS code"),
         enabled: false
       });
-      smsValidationLayout.add(validationCode, {
+      smsValidationLayout.add(validateCodeTF, {
         flex: 1
       });
       const validateCodeBtn = this.__validateCodeBtn = new osparc.ui.form.FetchButton(this.tr("Validate")).set({
         minWidth: 80,
-        enabled: false
+        appearance: "strong-button"
+      });
+      validateCodeTF.bind("value", validateCodeBtn, "enabled", {
+        converter: val => Boolean(val)
       });
       smsValidationLayout.add(validateCodeBtn);
       return smsValidationLayout;

--- a/services/static-webserver/client/source/class/osparc/auth/ui/VerifyPhoneNumberView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/VerifyPhoneNumberView.js
@@ -96,6 +96,8 @@ qx.Class.define("osparc.auth.ui.VerifyPhoneNumberView", {
       });
 
       const verifyPhoneNumberBtn = this.__verifyPhoneNumberBtn = new osparc.ui.form.FetchButton(this.tr("Send SMS")).set({
+        appearance: "strong-button",
+        center: true,
         maxHeight: 23,
         minWidth: 80
       });
@@ -113,8 +115,9 @@ qx.Class.define("osparc.auth.ui.VerifyPhoneNumberView", {
         flex: 1
       });
       const validateCodeBtn = this.__validateCodeBtn = new osparc.ui.form.FetchButton(this.tr("Validate")).set({
-        minWidth: 80,
-        appearance: "strong-button"
+        appearance: "strong-button",
+        center: true,
+        minWidth: 80
       });
       validateCodeTF.bind("value", validateCodeBtn, "enabled", {
         converter: val => Boolean(val)

--- a/services/static-webserver/client/source/class/osparc/auth/ui/VerifyPhoneNumberView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/VerifyPhoneNumberView.js
@@ -153,7 +153,6 @@ qx.Class.define("osparc.auth.ui.VerifyPhoneNumberView", {
             this.__verifyPhoneNumberBtn.setFetching(false);
             osparc.auth.core.Utils.restartResendTimer(this.__verifyPhoneNumberBtn, this.tr("Send SMS"));
             this.__validateCodeTF.setEnabled(true);
-            this.__validateCodeBtn.setEnabled(true);
           })
           .catch(err => {
             osparc.component.message.FlashMessenger.logAs(err.message, "ERROR");

--- a/services/static-webserver/client/source/class/osparc/auth/ui/VerifyPhoneNumberView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/VerifyPhoneNumberView.js
@@ -119,9 +119,8 @@ qx.Class.define("osparc.auth.ui.VerifyPhoneNumberView", {
         center: true,
         minWidth: 80
       });
-      validateCodeTF.bind("value", validateCodeBtn, "enabled", {
-        converter: val => Boolean(val)
-      });
+      validateCodeBtn.setEnabled(false);
+      validateCodeTF.addListener("input", e => validateCodeBtn.setEnabled(Boolean(e.getData())));
       smsValidationLayout.add(validateCodeBtn);
       return smsValidationLayout;
     },

--- a/services/static-webserver/client/source/class/osparc/auth/ui/VerifyPhoneNumberView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/VerifyPhoneNumberView.js
@@ -129,6 +129,7 @@ qx.Class.define("osparc.auth.ui.VerifyPhoneNumberView", {
     __createSendViaEmailButton: function() {
       const txt = this.tr("Skip phone registration and send code via email");
       const sendViaEmail = this.__sendViaEmail = new osparc.ui.form.LinkButton(txt).set({
+        iconPosition: "left",
         zIndex: 1, // the contries list that goes on top has a z-index of 2
         appearance: "link-button"
       });

--- a/services/static-webserver/client/source/class/osparc/component/task/TaskUI.js
+++ b/services/static-webserver/client/source/class/osparc/component/task/TaskUI.js
@@ -111,6 +111,7 @@ qx.Class.define("osparc.component.task.TaskUI", {
           confirmText: this.tr("Cancel"),
           confirmAction: "delete"
         });
+        win.getChildControl("cancel-button").setLabel(this.tr("Ignore"));
         win.center();
         win.open();
         win.addListener("close", () => {

--- a/services/static-webserver/client/source/class/osparc/component/task/TasksButton.js
+++ b/services/static-webserver/client/source/class/osparc/component/task/TasksButton.js
@@ -66,6 +66,7 @@ qx.Class.define("osparc.component.task.TasksButton", {
     },
 
     __updateTasksButton: function() {
+      this._createChildControlImpl("icon");
       const number = this.getChildControl("number");
 
       const tasks = osparc.component.task.Tasks.getInstance();

--- a/services/static-webserver/client/source/class/osparc/dashboard/ServiceBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ServiceBrowser.js
@@ -159,7 +159,7 @@ qx.Class.define("osparc.dashboard.ServiceBrowser", {
     },
 
     __addNewServiceButtons: function() {
-      osparc.utils.LibVersions.getPlatformName()
+      osparc.store.StaticInfo.getInstance().getPlatformName()
         .then(platformName => {
           if (platformName === "dev") {
             const testDataButton = new qx.ui.form.Button(this.tr("Test with data"), "@FontAwesome5Solid/plus-circle/14");

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -974,7 +974,12 @@ qx.Class.define("osparc.data.model.Node", {
       }
       this.addListener("changeLabel", () => loadingPage.setHeader(this.__getLoadingPageHeader()), this);
 
-      loadingPage.addExtraWidget(this.getStatus().getProgressSequence().getWidgetForLoadingPage());
+      const nodeStatus = this.getStatus();
+      const sequenceWidget = nodeStatus.getProgressSequence().getWidgetForLoadingPage();
+      nodeStatus.bind("interactive", sequenceWidget, "visiblity", {
+        converter: state => ["starting", "pulling", "pending", "connecting"].includes(state) ? "visible" : "excluded"
+      });
+      loadingPage.addExtraWidget(sequenceWidget);
 
       this.getStatus().addListener("changeInteractive", () => {
         loadingPage.setHeader(this.__getLoadingPageHeader());

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -92,9 +92,11 @@ qx.Class.define("osparc.desktop.MainPage", {
           if (osparc.utils.Utils.isProduct("s4llite")) {
             msg = this.tr("Do you really want to close the project?");
             msg += "<br>";
-            msg += this.tr("Make sure you saved the changes to the current <b>smash file</b> and <b>open notebooks</b>.");
+            msg += this.tr("Make sure you saved the changes to:");
             msg += "<br>";
-            msg += this.tr("Running <b>simulations</b> will be killed.");
+            msg += this.tr("- your current <b>smash file</b> (Running <b>simulations</b> will be killed)");
+            msg += "<br>";
+            msg += this.tr("- the current <b>open notebooks</b> (<b>jupyterlab</b> will be killed)");
             confirmText = this.tr("Close");
           }
           const win = new osparc.ui.window.Confirmation(msg).set({

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -94,7 +94,7 @@ qx.Class.define("osparc.desktop.MainPage", {
             msg += "<br>";
             msg += this.tr("Make sure you saved the changes to:");
             msg += "<br>";
-            msg += this.tr("- your current <b>smash file</b> (Running <b>simulations</b> will be killed)");
+            msg += this.tr("- your current <b>smash file</b> (running <b>simulations</b> will be killed)");
             msg += "<br>";
             msg += this.tr("- the current <b>open notebooks</b> (<b>jupyterlab</b> will be killed)");
             confirmText = this.tr("Close");

--- a/services/static-webserver/client/source/class/osparc/store/StaticInfo.js
+++ b/services/static-webserver/client/source/class/osparc/store/StaticInfo.js
@@ -42,6 +42,24 @@ qx.Class.define("osparc.store.StaticInfo", {
       });
     },
 
+    getPlatformName: function() {
+      return new Promise(resolve => {
+        const staticKey = "stackName";
+        this.getValue(staticKey)
+          .then(stackName => {
+            let platformName = "dev";
+            if (stackName.includes("master")) {
+              platformName = "master";
+            } else if (stackName.includes("staging")) {
+              platformName = "staging";
+            } else if (stackName.includes("production")) {
+              platformName = "";
+            }
+            resolve(platformName);
+          });
+      });
+    },
+
     getDisplayName: function() {
       const staticKey = "displayName";
       return this.getValue(staticKey);

--- a/services/static-webserver/client/source/class/osparc/ui/basic/LogoWPlatform.js
+++ b/services/static-webserver/client/source/class/osparc/ui/basic/LogoWPlatform.js
@@ -57,7 +57,7 @@ qx.Class.define("osparc.ui.basic.LogoWPlatform", {
             font: "text-9"
           });
 
-          osparc.utils.LibVersions.getPlatformName()
+          osparc.store.StaticInfo.getInstance().getPlatformName()
             .then(platformName => {
               platformName = platformName.toUpperCase();
               if (osparc.utils.Utils.isInZ43()) {

--- a/services/static-webserver/client/source/class/osparc/utils/LibVersions.js
+++ b/services/static-webserver/client/source/class/osparc/utils/LibVersions.js
@@ -38,7 +38,7 @@ qx.Class.define("osparc.utils.LibVersions", {
 
       let url = remoteUrl;
       if (commitId) {
-        url = remoteUrl + "/tree/" + String(commitId) + "/";
+        url = remoteUrl + "/commits/" + String(commitId) + "/";
       }
 
       return {
@@ -55,7 +55,7 @@ qx.Class.define("osparc.utils.LibVersions", {
 
       let url = remoteUrl;
       if (commitId) {
-        url = remoteUrl + "/tree/" + String(commitId) + "/services/static-webserver/client/";
+        url = remoteUrl + "/commits/" + String(commitId) + "/services/static-webserver/client/";
       }
       let status = qx.core.Environment.get("osparc.vcsStatusClient");
       if (status) {

--- a/services/static-webserver/client/source/class/osparc/utils/LibVersions.js
+++ b/services/static-webserver/client/source/class/osparc/utils/LibVersions.js
@@ -31,6 +31,7 @@ qx.Class.define("osparc.utils.LibVersions", {
 
       return remoteUrl;
     },
+
     getPlatformVersion: function() {
       const name = "osparc-simcore";
       const commitId = qx.core.Environment.get("osparc.vcsRef");
@@ -128,22 +129,6 @@ qx.Class.define("osparc.utils.LibVersions", {
             return statics["thirdPartyReferences"];
           }
           return [];
-        });
-    },
-
-    getPlatformName: function() {
-      return osparc.data.Resources.get("statics")
-        .then(statics => statics.stackName)
-        .then(stackName => {
-          let platformName = "dev";
-          if (stackName.includes("master")) {
-            platformName = "master";
-          } else if (stackName.includes("staging")) {
-            platformName = "staging";
-          } else if (stackName.includes("production")) {
-            platformName = "";
-          }
-          return platformName;
         });
     }
   }

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -192,7 +192,7 @@ qx.Class.define("osparc.utils.Utils", {
 
     isDevelopmentPlatform: function() {
       return new Promise(resolve => {
-        osparc.utils.LibVersions.getPlatformName()
+        osparc.store.StaticInfo.getInstance().getPlatformName()
           .then(platformName => resolve(["dev", "master"].includes(platformName)));
       });
     },


### PR DESCRIPTION
## What do these changes do?

Thanks to the feedback coming from @pcrespov 

In order to give a better feedback to the user:
- [x] "Skip phone registration" is a fetch button (make clear when the backend is done sending the email)
- [x] "via SMS" and "via email" are fetch buttons (make clear when the backend is done sending the SMS/email)
- [x] Enable "Validate" button if the field is not empty

### Bonus:
- [x] Show Dynamic loading Sequence only if "starting", "pulling", "pending" or "connecting"

![LoginUX](https://user-images.githubusercontent.com/33152403/214848382-9acd670d-74e4-4737-b7d1-ee3e413d2646.gif)


## Related issue/s

related to https://github.com/ITISFoundation/osparc-issues/issues/765

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
