### PR TITLE
✨Backend messaging: improve progress messages for starting services

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,8 @@ extension-pkg-allow-list=
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code. (This is an alternative name to extension-pkg-allow-list
 # for backward compatibility.)
-extension-pkg-whitelist=pydantic,
+extension-pkg-whitelist=docker,
+                        pydantic,
                         orjson,
                         ujson
 

--- a/packages/service-library/requirements/_test.in
+++ b/packages/service-library/requirements/_test.in
@@ -20,6 +20,7 @@ flaky
 openapi-spec-validator
 pytest
 pytest-aiohttp  # incompatible with pytest-asyncio. See https://github.com/pytest-dev/pytest-asyncio/issues/76
+pytest-benchmark
 pytest-cov
 pytest-docker
 pytest-instafail

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -88,6 +88,8 @@ packaging==21.3
     #   pytest-sugar
 pluggy==1.0.0
     # via pytest
+py-cpuinfo==9.0.0
+    # via pytest-benchmark
 pyparsing==3.0.9
     # via packaging
 pyrsistent==0.19.2
@@ -99,6 +101,7 @@ pytest==7.2.0
     #   -r requirements/_test.in
     #   pytest-aiohttp
     #   pytest-asyncio
+    #   pytest-benchmark
     #   pytest-cov
     #   pytest-docker
     #   pytest-instafail
@@ -109,6 +112,8 @@ pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
 pytest-asyncio==0.20.2
     # via pytest-aiohttp
+pytest-benchmark==4.0.0
+    # via -r requirements/_test.in
 pytest-cov==4.0.0
     # via -r requirements/_test.in
 pytest-docker==1.0.1

--- a/packages/service-library/setup.cfg
+++ b/packages/service-library/setup.cfg
@@ -18,4 +18,4 @@ addopts = --strict-markers
 asyncio_mode = auto
 markers =
 	testit: "marks test to run during development"
-  performance_test: "performance test"
+	performance_test: "performance test"

--- a/packages/service-library/setup.cfg
+++ b/packages/service-library/setup.cfg
@@ -18,3 +18,4 @@ addopts = --strict-markers
 asyncio_mode = auto
 markers =
 	testit: "marks test to run during development"
+  performance_test: "performance test"

--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -392,7 +392,6 @@ async def archive_dir(
             ) from err
 
         except BaseException:
-            # NOTE: Why is this here? a BaseException, really?
             if destination.is_file():
                 destination.unlink(missing_ok=True)
             raise

--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -218,10 +218,9 @@ async def unarchive_dir(
                     for future in asyncio.as_completed(futures):
                         extracted_path = await future
                         extracted_file_size = extracted_path.stat().st_size
-                        if tqdm_progress.update(extracted_file_size):
-                            if log_cb:
-                                with log_catch(log, reraise=False):
-                                    await log_cb(f"{tqdm_progress}")
+                        if tqdm_progress.update(extracted_file_size) and log_cb:
+                            with log_catch(log, reraise=False):
+                                await log_cb(f"{tqdm_progress}")
                         await sub_prog.update(extracted_file_size)
                         extracted_paths.append(extracted_path)
 

--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -8,6 +8,7 @@ from functools import partial
 from pathlib import Path
 from typing import Final, Iterator, Optional
 
+from servicelib.progress_bar import ProgressBarData
 from tqdm import tqdm
 from tqdm.asyncio import tqdm_asyncio
 from tqdm.contrib.logging import logging_redirect_tqdm, tqdm_logging_redirect
@@ -154,6 +155,7 @@ async def unarchive_dir(
     destination_folder: Path,
     *,
     max_workers: int = _MAX_UNARCHIVING_WORKER_COUNT,
+    progress_bar: ProgressBarData,
 ) -> set[Path]:
     """Extracts zipped file archive_to_extract to destination_folder,
     preserving all relative files and folders inside the archive

--- a/packages/service-library/src/servicelib/pools.py
+++ b/packages/service-library/src/servicelib/pools.py
@@ -5,6 +5,7 @@ from typing import Iterator
 # only gets created on use and is guaranteed to be the s
 # ame for the entire lifetime of the application
 __shared_process_pool_executor = {}
+__shared_thread_pool_executor = {}
 
 
 def _get_shared_process_pool_executor(**kwargs) -> ProcessPoolExecutor:
@@ -24,11 +25,11 @@ def _get_shared_thread_pool_executor(**kwargs) -> ThreadPoolExecutor:
     # the key helps to distinguish between them in the same application
     key = "".join(sorted("_".join((k, str(v))) for k, v in kwargs.items()))
 
-    if key not in __shared_process_pool_executor:
+    if key not in __shared_thread_pool_executor:
         # pylint: disable=consider-using-with
-        __shared_process_pool_executor[key] = ThreadPoolExecutor(**kwargs)
+        __shared_thread_pool_executor[key] = ThreadPoolExecutor(**kwargs)
 
-    return __shared_process_pool_executor[key]
+    return __shared_thread_pool_executor[key]
 
 
 @contextmanager

--- a/packages/service-library/src/servicelib/pools.py
+++ b/packages/service-library/src/servicelib/pools.py
@@ -41,11 +41,7 @@ def non_blocking_process_pool_executor(**kwargs) -> Iterator[ProcessPoolExecutor
     try:
         yield executor
     finally:
-        # due to an issue in cpython https://bugs.python.org/issue34073
-        # bypassing shutdown and using a shared pool
-        # remove call to get_shared_process_pool_executor and replace with
-        # a new instance when the issue is fixed
-        # FIXME: uncomment below line when the issue is fixed
+        # NOTE: https://github.com/ITISFoundation/osparc-simcore/issues/3829
         # executor.shutdown(wait=False)
         pass
 
@@ -60,4 +56,6 @@ def non_blocking_thread_pool_executor(**kwargs) -> Iterator[ThreadPoolExecutor]:
     try:
         yield executor
     finally:
-        executor.shutdown(wait=False)
+        # NOTE: https://github.com/ITISFoundation/osparc-simcore/issues/3829
+        # executor.shutdown(wait=False)
+        pass

--- a/packages/service-library/src/servicelib/pools.py
+++ b/packages/service-library/src/servicelib/pools.py
@@ -1,7 +1,6 @@
-import asyncio
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator
+from typing import Iterator
 
 # only gets created on use and is guaranteed to be the s
 # ame for the entire lifetime of the application
@@ -62,10 +61,3 @@ def non_blocking_thread_pool_executor(**kwargs) -> Iterator[ThreadPoolExecutor]:
         yield executor
     finally:
         executor.shutdown(wait=False)
-
-
-async def async_on_threadpool(callable_function: Callable, *args: Any) -> Any:
-    """Ensures blocking operation runs on shared thread pool"""
-    return await asyncio.get_event_loop().run_in_executor(
-        None, callable_function, *args
-    )

--- a/packages/service-library/src/servicelib/pools.py
+++ b/packages/service-library/src/servicelib/pools.py
@@ -1,5 +1,5 @@
 import asyncio
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Any, Callable, Iterator
 
@@ -8,14 +8,26 @@ from typing import Any, Callable, Iterator
 __shared_process_pool_executor = {}
 
 
-def get_shared_process_pool_executor(**kwargs) -> ProcessPoolExecutor:
+def _get_shared_process_pool_executor(**kwargs) -> ProcessPoolExecutor:
     # sometimes a pool requires a specific configuration
     # the key helps to distinguish between them in the same application
-    key = "".join(sorted(["_".join((k, str(v))) for k, v in kwargs.items()]))
+    key = "".join(sorted("_".join((k, str(v))) for k, v in kwargs.items()))
 
     if key not in __shared_process_pool_executor:
         # pylint: disable=consider-using-with
         __shared_process_pool_executor[key] = ProcessPoolExecutor(**kwargs)
+
+    return __shared_process_pool_executor[key]
+
+
+def _get_shared_thread_pool_executor(**kwargs) -> ThreadPoolExecutor:
+    # sometimes a pool requires a specific configuration
+    # the key helps to distinguish between them in the same application
+    key = "".join(sorted("_".join((k, str(v))) for k, v in kwargs.items()))
+
+    if key not in __shared_process_pool_executor:
+        # pylint: disable=consider-using-with
+        __shared_process_pool_executor[key] = ThreadPoolExecutor(**kwargs)
 
     return __shared_process_pool_executor[key]
 
@@ -26,7 +38,7 @@ def non_blocking_process_pool_executor(**kwargs) -> Iterator[ProcessPoolExecutor
     Avoids default context manger behavior which calls
     shutdown with wait=True an blocks.
     """
-    executor = get_shared_process_pool_executor(**kwargs)
+    executor = _get_shared_process_pool_executor(**kwargs)
     try:
         yield executor
     finally:
@@ -37,6 +49,19 @@ def non_blocking_process_pool_executor(**kwargs) -> Iterator[ProcessPoolExecutor
         # FIXME: uncomment below line when the issue is fixed
         # executor.shutdown(wait=False)
         pass
+
+
+@contextmanager
+def non_blocking_thread_pool_executor(**kwargs) -> Iterator[ThreadPoolExecutor]:
+    """
+    Avoids default context manger behavior which calls
+    shutdown with wait=True an blocks.
+    """
+    executor = _get_shared_thread_pool_executor(**kwargs)
+    try:
+        yield executor
+    finally:
+        executor.shutdown(wait=False)
 
 
 async def async_on_threadpool(callable_function: Callable, *args: Any) -> Any:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -16,7 +16,7 @@ class AsyncReportCB(Protocol):
 
 @dataclass
 class ProgressBarData:
-    steps: int
+    steps: int = field(metadata={"description": "Defines the number of steps in the progress bar"})
     progress_report_cb: Optional[AsyncReportCB] = None
     _continuous_progress: float = 0
     _children: list = field(default_factory=list)

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -16,7 +16,40 @@ class AsyncReportCB(Protocol):
 
 @dataclass
 class ProgressBarData:
-    steps: int = field(metadata={"description": "Defines the number of steps in the progress bar"})
+    """A progress bar data allows to keep track of multiple progress(es) even in deeply nested processes.
+
+    - Simple example:
+    async def main_fct():
+        async with ProgressBarData(steps=3) as root_progress_bar:
+            first_step()
+            await root_progress_bar.update()
+            second_step()
+            await root_progress_bar.update()
+            third_step()
+            # Note that the last update is not necessary as the context manager ensures the progress bar is complete
+
+    - nested example:
+
+    async def first_step(progress_bar: ProgressBarData):
+        async with progress_bar.sub_progress(steps=50) as sub_progress_bar:
+            # we create a sub progress bar of 50 steps, that will be stacked into the root progress bar.
+            # i.e. when the sub progress bar reaches 50, it will be equivalent of 1 step in the root progress bar.
+            for n in range(50):
+                await asyncio.sleep(0.01)
+                await sub_progress_bar.update()
+
+
+    async def main_fct():
+        async with ProgressBarData(steps=3) as root_progress_bar:
+            await first_step(root_progress_bar)
+            await second_step()
+            await root_progress_bar.update()
+            await third_step()
+    """
+
+    steps: int = field(
+        metadata={"description": "Defines the number of steps in the progress bar"}
+    )
     progress_report_cb: Optional[AsyncReportCB] = None
     _continuous_progress: float = 0
     _children: list = field(default_factory=list)

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -1,41 +1,48 @@
 import asyncio
-import contextlib
 from dataclasses import dataclass, field
 from typing import Optional
 
 
 @dataclass
-class ProgressBar:
+class ProgressData:
     steps: int
-    progress: float = 0
+    _continuous_progress: float = 0
     _children: list = field(default_factory=list)
-    _parent: Optional["ProgressBar"] = None
+    _parent: Optional["ProgressData"] = None
     _lock: asyncio.Lock = field(init=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._lock = asyncio.Lock()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "ProgressData":
         await self.start()
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback):
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
         await self.finish()
 
-    async def start(self):
+    async def start(self) -> None:
         pass
 
-    async def update(self, value: float = 1):
+    async def update(self, value: float = 1) -> None:
         async with self._lock:
-            self.progress += value
+            new_progress_value = self._continuous_progress + value
+            if round(new_progress_value) > self.steps:
+                raise ValueError(
+                    f"Progress cannot be updated by {value} as it cannot be higher than {self.steps}"
+                )
+            self._continuous_progress += value
             if self._parent:
                 await self._parent.update(value / self.steps)
 
-    async def finish(self):
+    async def finish(self) -> None:
         pass
 
-    @contextlib.asynccontextmanager
-    async def sub_progress(self, steps):
-        child = ProgressBar(steps=steps, _parent=self)
+    def sub_progress(self, steps) -> "ProgressData":
+        if len(self._children) == self.steps:
+            raise RuntimeError(
+                "Too many sub progresses created already. Wrong usage of the progress bar"
+            )
+        child = ProgressData(steps=steps, _parent=self)
         self._children.append(child)
-        yield child
+        return child

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -4,17 +4,17 @@ from typing import Optional
 
 
 @dataclass
-class ProgressData:
+class ProgressBarData:
     steps: int
     _continuous_progress: float = 0
     _children: list = field(default_factory=list)
-    _parent: Optional["ProgressData"] = None
+    _parent: Optional["ProgressBarData"] = None
     _lock: asyncio.Lock = field(init=False)
 
     def __post_init__(self) -> None:
         self._lock = asyncio.Lock()
 
-    async def __aenter__(self) -> "ProgressData":
+    async def __aenter__(self) -> "ProgressBarData":
         await self.start()
         return self
 
@@ -38,11 +38,11 @@ class ProgressData:
     async def finish(self) -> None:
         pass
 
-    def sub_progress(self, steps) -> "ProgressData":
+    def sub_progress(self, steps) -> "ProgressBarData":
         if len(self._children) == self.steps:
             raise RuntimeError(
                 "Too many sub progresses created already. Wrong usage of the progress bar"
             )
-        child = ProgressData(steps=steps, _parent=self)
+        child = ProgressBarData(steps=steps, _parent=self)
         self._children.append(child)
         return child

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -62,7 +62,9 @@ class ProgressBarData:
             if new_progress_value > self.steps:
                 logger.warning(
                     "%s",
-                    f"Progress {self._continuous_progress} is updated by {value} and the current max value {self.steps}",
+                    f"Progress already reached maximum of {self.steps=}, "
+                    f"cause: {self._continuous_progress=} is updated by {value=}"
+                    "TIP: sub progresses are not created correctly please check the stack trace",
                     stack_info=True,
                 )
 

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -1,0 +1,41 @@
+import asyncio
+import contextlib
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class ProgressBar:
+    steps: int
+    progress: float = 0
+    _children: list = field(default_factory=list)
+    _parent: Optional["ProgressBar"] = None
+    _lock: asyncio.Lock = field(init=False)
+
+    def __post_init__(self):
+        self._lock = asyncio.Lock()
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.finish()
+
+    async def start(self):
+        pass
+
+    async def update(self, value: float = 1):
+        async with self._lock:
+            self.progress += value
+            if self._parent:
+                await self._parent.update(value / self.steps)
+
+    async def finish(self):
+        pass
+
+    @contextlib.asynccontextmanager
+    async def sub_progress(self, steps):
+        child = ProgressBar(steps=steps, _parent=self)
+        self._children.append(child)
+        yield child

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -1,15 +1,28 @@
 import asyncio
+import logging
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Protocol, runtime_checkable
+
+from servicelib.logging_utils import log_catch
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class AsyncReportCB(Protocol):
+    async def __call__(self, progress_value: float) -> None:
+        ...
 
 
 @dataclass
 class ProgressBarData:
     steps: int
+    progress_report_cb: Optional[AsyncReportCB] = None
     _continuous_progress: float = 0
     _children: list = field(default_factory=list)
     _parent: Optional["ProgressBarData"] = None
     _lock: asyncio.Lock = field(init=False)
+    _last_report_value: float = 0
 
     def __post_init__(self) -> None:
         self._lock = asyncio.Lock()
@@ -21,22 +34,41 @@ class ProgressBarData:
     async def __aexit__(self, exc_type, exc_value, traceback) -> None:
         await self.finish()
 
+    async def _update_parent(self, value: float) -> None:
+        if self._parent:
+            await self._parent.update(value / self.steps)
+
+    async def _report_external(self, value: float, force: bool = False) -> None:
+        if not self.progress_report_cb:
+            return
+
+        with log_catch(logger, reraise=False):
+            # NOTE: only report if at least a percent was increased
+            if (force and value != self._last_report_value) or (
+                (value - self._last_report_value) / self.steps > 0.01
+            ):
+                await self.progress_report_cb(value / self.steps)
+                self._last_report_value = value
+
     async def start(self) -> None:
-        pass
+        await self._report_external(0, force=True)
 
     async def update(self, value: float = 1) -> None:
         async with self._lock:
             new_progress_value = self._continuous_progress + value
-            if round(new_progress_value) > self.steps:
+            if new_progress_value > self.steps:
+                new_progress_value = round(new_progress_value)
+            if new_progress_value > self.steps:
                 raise ValueError(
                     f"Progress cannot be updated by {value} as it cannot be higher than {self.steps}"
                 )
-            self._continuous_progress += value
-            if self._parent:
-                await self._parent.update(value / self.steps)
+            self._continuous_progress = new_progress_value
+        await self._update_parent(value)
+        await self._report_external(new_progress_value)
 
     async def finish(self) -> None:
-        pass
+        await self.update(self.steps - self._continuous_progress)
+        await self._report_external(self.steps, force=True)
 
     def sub_progress(self, steps) -> "ProgressBarData":
         if len(self._children) == self.steps:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -77,7 +77,7 @@ class ProgressBarData:
         await self.update(self.steps - self._continuous_progress)
         await self._report_external(self.steps, force=True)
 
-    def sub_progress(self, steps) -> "ProgressBarData":
+    def sub_progress(self, steps: int) -> "ProgressBarData":
         if len(self._children) == self.steps:
             raise RuntimeError(
                 "Too many sub progresses created already. Wrong usage of the progress bar"

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -63,7 +63,9 @@ class ProgressBarData:
                 logger.warning(
                     "%s",
                     f"Progress {self._continuous_progress} is updated by {value} and the current max value {self.steps}",
+                    stack_info=True,
                 )
+
                 new_progress_value = self.steps
             self._continuous_progress = new_progress_value
         await self._update_parent(value)

--- a/packages/service-library/src/servicelib/rabbitmq.py
+++ b/packages/service-library/src/servicelib/rabbitmq.py
@@ -97,6 +97,7 @@ class RabbitMQClient:
         self,
         exchange_name: str,
         message_handler: MessageHandler,
+        *,
         exclusive_queue: bool = True,
     ) -> None:
         """subscribe to exchange_name calling message_handler for every incoming message

--- a/packages/service-library/src/servicelib/rabbitmq_utils.py
+++ b/packages/service-library/src/servicelib/rabbitmq_utils.py
@@ -37,4 +37,5 @@ async def wait_till_rabbitmq_responsive(url: str) -> bool:
     with log_context(log, logging.INFO, msg=f"checking RabbitMQ connection at {url=}"):
         connection = await aio_pika.connect(url)
         await connection.close()
+        log.info("rabbitmq connection established")
         return True

--- a/packages/service-library/tests/conftest.py
+++ b/packages/service-library/tests/conftest.py
@@ -14,6 +14,7 @@ from faker import Faker
 pytest_plugins = [
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_swarm",
+    "pytest_simcore.file_extra",
     "pytest_simcore.monkeypatch_extra",
     "pytest_simcore.pytest_global_environs",
     "pytest_simcore.rabbit_service",

--- a/packages/service-library/tests/test_archiving_utils.py
+++ b/packages/service-library/tests/test_archiving_utils.py
@@ -19,6 +19,7 @@ from typing import Callable, Iterable, Iterator, Optional
 import pytest
 from faker import Faker
 from pydantic import ByteSize, parse_obj_as
+from pytest_benchmark.plugin import BenchmarkFixture
 from servicelib import archiving_utils
 from servicelib.archiving_utils import ArchiveError, archive_dir, unarchive_dir
 
@@ -563,7 +564,7 @@ async def _archive_dir_performance(
     "compress, file_size, num_files", [(False, parse_obj_as(ByteSize, "1Mib"), 10000)]
 )
 def test_archive_dir_performance(
-    benchmark,
+    benchmark: BenchmarkFixture,
     create_file_of_size: Callable[[ByteSize, str], Path],
     tmp_path: Path,
     compress: bool,

--- a/packages/service-library/tests/test_archiving_utils.py
+++ b/packages/service-library/tests/test_archiving_utils.py
@@ -559,7 +559,7 @@ async def _archive_dir_performance(
     file_suffix += 1
 
 
-@pytest.mark.performance_test
+@pytest.mark.skip(reason="manual testing")
 @pytest.mark.parametrize(
     "compress, file_size, num_files", [(False, parse_obj_as(ByteSize, "1Mib"), 10000)]
 )

--- a/packages/service-library/tests/test_pools.py
+++ b/packages/service-library/tests/test_pools.py
@@ -2,7 +2,6 @@ from asyncio import BaseEventLoop
 from concurrent.futures import ProcessPoolExecutor
 
 from servicelib.pools import (
-    async_on_threadpool,
     non_blocking_process_pool_executor,
     non_blocking_thread_pool_executor,
 )
@@ -52,7 +51,3 @@ async def test_different_thread_pool_instances() -> None:
         max_workers=1
     ) as first, non_blocking_thread_pool_executor() as second:
         assert first != second
-
-
-async def test_run_on_thread_pool() -> None:
-    assert await async_on_threadpool(return_int_one) == 1

--- a/packages/service-library/tests/test_pools.py
+++ b/packages/service-library/tests/test_pools.py
@@ -1,7 +1,11 @@
 from asyncio import BaseEventLoop
 from concurrent.futures import ProcessPoolExecutor
 
-from servicelib.pools import async_on_threadpool, non_blocking_process_pool_executor
+from servicelib.pools import (
+    async_on_threadpool,
+    non_blocking_process_pool_executor,
+    non_blocking_thread_pool_executor,
+)
 
 
 def return_int_one() -> int:
@@ -30,6 +34,23 @@ async def test_different_pool_instances() -> None:
     with non_blocking_process_pool_executor(
         max_workers=1
     ) as first, non_blocking_process_pool_executor() as second:
+        assert first != second
+
+
+async def test_non_blocking_thread_pool_executor(event_loop: BaseEventLoop) -> None:
+    with non_blocking_thread_pool_executor() as executor:
+        assert await event_loop.run_in_executor(executor, return_int_one) == 1
+
+
+async def test_same_thread_pool_instances() -> None:
+    with non_blocking_thread_pool_executor() as first, non_blocking_thread_pool_executor() as second:
+        assert first == second
+
+
+async def test_different_thread_pool_instances() -> None:
+    with non_blocking_thread_pool_executor(
+        max_workers=1
+    ) as first, non_blocking_thread_pool_executor() as second:
         assert first != second
 
 

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -1,63 +1,66 @@
+# pylint: disable=broad-except
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+# pylint: disable=protected-access
+
 import asyncio
 
 import pytest
-import tqdm
-from servicelib.progress_bar import ProgressBar
-
-
-async def do_something(root: ProgressBar):
-    async with root.sub_progress(steps=50) as sub:
-        for n in range(50):
-            await sub.update()
-
-
-async def do_something_else(root: ProgressBar):
-    async with root.sub_progress(steps=34) as sub:
-        for n in range(17):
-            await sub.update(2)
+from servicelib.progress_bar import ProgressData
 
 
 async def test_progress_bar():
-    async with ProgressBar(steps=2) as root:
-        assert root.progress == 0
+    async with ProgressData(steps=2) as root:
+        assert root._continuous_progress == pytest.approx(0)
         assert root.steps == 2
-        await do_something(root)
-        assert root.progress == pytest.approx(1)
+        async with root.sub_progress(steps=50) as sub:
+            for _ in range(50):
+                await sub.update()
+        assert root._continuous_progress == pytest.approx(1)
         assert root.steps == 2
-        await do_something_else(root)
-        assert root.progress == pytest.approx(2)
+        async with root.sub_progress(steps=50) as sub:
+            for _ in range(50):
+                await sub.update()
+        assert root._continuous_progress == pytest.approx(2)
         assert root.steps == 2
 
 
-async def do_something_tqdm():
-    with tqdm.tqdm(total=100, desc="1st sub loop") as pbar:
-        for n in range(100):
-            await asyncio.sleep(0.01)
-            pbar.update()
+async def test_concurrent_progress_bar():
+    async def do_something(root: ProgressData):
+        async with root.sub_progress(steps=50) as sub:
+            assert sub.steps == 50
+            assert sub._continuous_progress == 0
+            for n in range(50):
+                await sub.update()
+                assert sub._continuous_progress == (n + 1)
+
+    async with ProgressData(steps=12) as root:
+        assert root._continuous_progress == pytest.approx(0)
+        assert root.steps == 12
+        await asyncio.gather(*[do_something(root) for n in range(12)])
+        assert root._continuous_progress == pytest.approx(12)
 
 
-async def do_something_else_tqdm():
-    with tqdm.tqdm(total=100, desc="2nd sub loop") as sub:
-        for n in range(100):
-            await asyncio.sleep(0.01)
-            sub.update(2)
+async def test_too_many_sub_progress_bars_raises():
+    async with ProgressData(steps=2) as root:
+        assert root.steps == 2
+        async with root.sub_progress(steps=50) as sub:
+            for _ in range(50):
+                await sub.update()
+        async with root.sub_progress(steps=50) as sub:
+            for _ in range(50):
+                await sub.update()
+        with pytest.raises(RuntimeError):
+            async with root.sub_progress(steps=50) as sub:
+                for _ in range(50):
+                    await sub.update()
 
 
-async def test_tqdm():
-    # for i in tqdm.trange(4, desc="1st loop"):
-    #     for j in tqdm.trange(5, desc="2nd loop"):
-    #         for k in tqdm.trange(50, desc="3rd loop", leave=False):
-    #             sleep(0.01)
-    with tqdm.tqdm(total=2, desc="1st loop", position=0) as pbar:
-        # await do_something_tqdm()
-        with tqdm.tqdm(total=100, desc="1st sub loop", position=1, leave=False) as sub:
-            for n in range(100):
-                await asyncio.sleep(0.01)
-                sub.update()
-                pbar.update(1 / 100)
-        # await do_something_else_tqdm()
-        with tqdm.tqdm(total=100, desc="2nd sub loop", position=1, leave=False) as sub:
-            for n in range(100):
-                await asyncio.sleep(0.01)
-                sub.update()
-                pbar.update(1 / 100)
+async def test_too_many_updates_raises():
+    async with ProgressData(steps=2) as root:
+        assert root.steps == 2
+        await root.update()
+        await root.update()
+        with pytest.raises(ValueError):
+            await root.update()

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import pytest
+import tqdm
+from servicelib.progress_bar import ProgressBar
+
+
+async def do_something(root: ProgressBar):
+    async with root.sub_progress(steps=50) as sub:
+        for n in range(50):
+            await sub.update()
+
+
+async def do_something_else(root: ProgressBar):
+    async with root.sub_progress(steps=34) as sub:
+        for n in range(17):
+            await sub.update(2)
+
+
+async def test_progress_bar():
+    async with ProgressBar(steps=2) as root:
+        assert root.progress == 0
+        assert root.steps == 2
+        await do_something(root)
+        assert root.progress == pytest.approx(1)
+        assert root.steps == 2
+        await do_something_else(root)
+        assert root.progress == pytest.approx(2)
+        assert root.steps == 2
+
+
+async def do_something_tqdm():
+    with tqdm.tqdm(total=100, desc="1st sub loop") as pbar:
+        for n in range(100):
+            await asyncio.sleep(0.01)
+            pbar.update()
+
+
+async def do_something_else_tqdm():
+    with tqdm.tqdm(total=100, desc="2nd sub loop") as sub:
+        for n in range(100):
+            await asyncio.sleep(0.01)
+            sub.update(2)
+
+
+async def test_tqdm():
+    # for i in tqdm.trange(4, desc="1st loop"):
+    #     for j in tqdm.trange(5, desc="2nd loop"):
+    #         for k in tqdm.trange(50, desc="3rd loop", leave=False):
+    #             sleep(0.01)
+    with tqdm.tqdm(total=2, desc="1st loop", position=0) as pbar:
+        # await do_something_tqdm()
+        with tqdm.tqdm(total=100, desc="1st sub loop", position=1, leave=False) as sub:
+            for n in range(100):
+                await asyncio.sleep(0.01)
+                sub.update()
+                pbar.update(1 / 100)
+        # await do_something_else_tqdm()
+        with tqdm.tqdm(total=100, desc="2nd sub loop", position=1, leave=False) as sub:
+            for n in range(100):
+                await asyncio.sleep(0.01)
+                sub.update()
+                pbar.update(1 / 100)

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -57,10 +57,13 @@ async def test_too_many_sub_progress_bars_raises():
                     await sub.update()
 
 
-async def test_too_many_updates_raises():
+async def test_too_many_updates_does_not_raise_but_show_warning_with_stack(
+    caplog: pytest.LogCaptureFixture,
+):
     async with ProgressBarData(steps=2) as root:
         assert root.steps == 2
         await root.update()
         await root.update()
-        with pytest.raises(ValueError):
-            await root.update()
+        await root.update()
+        assert "already reached maximum" in caplog.messages[0]
+        assert "TIP:" in caplog.messages[0]

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -7,11 +7,11 @@
 import asyncio
 
 import pytest
-from servicelib.progress_bar import ProgressData
+from servicelib.progress_bar import ProgressBarData
 
 
 async def test_progress_bar():
-    async with ProgressData(steps=2) as root:
+    async with ProgressBarData(steps=2) as root:
         assert root._continuous_progress == pytest.approx(0)
         assert root.steps == 2
         async with root.sub_progress(steps=50) as sub:
@@ -27,7 +27,7 @@ async def test_progress_bar():
 
 
 async def test_concurrent_progress_bar():
-    async def do_something(root: ProgressData):
+    async def do_something(root: ProgressBarData):
         async with root.sub_progress(steps=50) as sub:
             assert sub.steps == 50
             assert sub._continuous_progress == 0
@@ -35,7 +35,7 @@ async def test_concurrent_progress_bar():
                 await sub.update()
                 assert sub._continuous_progress == (n + 1)
 
-    async with ProgressData(steps=12) as root:
+    async with ProgressBarData(steps=12) as root:
         assert root._continuous_progress == pytest.approx(0)
         assert root.steps == 12
         await asyncio.gather(*[do_something(root) for n in range(12)])
@@ -43,7 +43,7 @@ async def test_concurrent_progress_bar():
 
 
 async def test_too_many_sub_progress_bars_raises():
-    async with ProgressData(steps=2) as root:
+    async with ProgressBarData(steps=2) as root:
         assert root.steps == 2
         async with root.sub_progress(steps=50) as sub:
             for _ in range(50):
@@ -58,7 +58,7 @@ async def test_too_many_sub_progress_bars_raises():
 
 
 async def test_too_many_updates_raises():
-    async with ProgressData(steps=2) as root:
+    async with ProgressBarData(steps=2) as root:
         assert root.steps == 2
         await root.update()
         await root.update()

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -12,17 +12,17 @@ from servicelib.progress_bar import ProgressBarData
 
 async def test_progress_bar():
     async with ProgressBarData(steps=2) as root:
-        assert root._continuous_progress == pytest.approx(0)
+        assert root._continuous_progress_value == pytest.approx(0)
         assert root.steps == 2
         async with root.sub_progress(steps=50) as sub:
             for _ in range(50):
                 await sub.update()
-        assert root._continuous_progress == pytest.approx(1)
+        assert root._continuous_progress_value == pytest.approx(1)
         assert root.steps == 2
         async with root.sub_progress(steps=50) as sub:
             for _ in range(50):
                 await sub.update()
-        assert root._continuous_progress == pytest.approx(2)
+        assert root._continuous_progress_value == pytest.approx(2)
         assert root.steps == 2
 
 
@@ -30,16 +30,16 @@ async def test_concurrent_progress_bar():
     async def do_something(root: ProgressBarData):
         async with root.sub_progress(steps=50) as sub:
             assert sub.steps == 50
-            assert sub._continuous_progress == 0
+            assert sub._continuous_progress_value == 0
             for n in range(50):
                 await sub.update()
-                assert sub._continuous_progress == (n + 1)
+                assert sub._continuous_progress_value == (n + 1)
 
     async with ProgressBarData(steps=12) as root:
-        assert root._continuous_progress == pytest.approx(0)
+        assert root._continuous_progress_value == pytest.approx(0)
         assert root.steps == 12
         await asyncio.gather(*[do_something(root) for n in range(12)])
-        assert root._continuous_progress == pytest.approx(12)
+        assert root._continuous_progress_value == pytest.approx(12)
 
 
 async def test_too_many_sub_progress_bars_raises():

--- a/packages/service-library/tests/test_rabbitmq.py
+++ b/packages/service-library/tests/test_rabbitmq.py
@@ -253,3 +253,28 @@ async def test_pub_sub_with_non_exclusive_queue(
             for parser in mocked_message_parsers:
                 total_call_count += parser.call_count
             assert total_call_count == 1, "too many messages"
+
+
+def test_rabbit_pub_sub_performance(
+    benchmark,
+    rabbitmq_client: Callable[[str], RabbitMQClient],
+    random_exchange_name: Callable[[], str],
+    mocker: MockerFixture,
+    faker: Faker,
+):
+    async def async_fct_to_test():
+        consumer = rabbitmq_client("consumer")
+        publisher = rabbitmq_client("publisher")
+
+        message = faker.text()
+
+        mocked_message_parser = mocker.AsyncMock(return_value=True)
+        exchange_name = random_exchange_name()
+        await consumer.subscribe(exchange_name, mocked_message_parser)
+        await publisher.publish(exchange_name, message)
+        await _assert_message_received(mocked_message_parser, 1, message)
+
+    def run_test_async():
+        asyncio.get_event_loop().run_until_complete(async_fct_to_test())
+
+    benchmark.pedantic(run_test_async, iterations=1, rounds=10)

--- a/packages/service-library/tests/test_rabbitmq.py
+++ b/packages/service-library/tests/test_rabbitmq.py
@@ -73,8 +73,11 @@ async def rabbitmq_client(
 
 
 @pytest.fixture
-def random_exchange_name(faker: Faker) -> str:
-    return f"pytest_fake_exchange_{faker.pystr()}"
+def random_exchange_name(faker: Faker) -> Callable[[], str]:
+    def _creator() -> str:
+        return f"pytest_fake_exchange_{faker.pystr()}"
+
+    return _creator
 
 
 async def _assert_message_received(
@@ -102,7 +105,7 @@ async def _assert_message_received(
 
 async def test_rabbit_client_pub_sub_message_is_lost_if_no_consumer_present(
     rabbitmq_client: Callable[[str], RabbitMQClient],
-    random_exchange_name: str,
+    random_exchange_name: Callable[[], str],
     mocker: MockerFixture,
     faker: Faker,
 ):
@@ -112,14 +115,16 @@ async def test_rabbit_client_pub_sub_message_is_lost_if_no_consumer_present(
     message = faker.text()
 
     mocked_message_parser = mocker.AsyncMock(return_value=True)
-    await publisher.publish(random_exchange_name, message)
-    await consumer.subscribe(random_exchange_name, mocked_message_parser)
+    exchange_name = random_exchange_name()
+    await publisher.publish(exchange_name, message)
+    await asyncio.sleep(0)  # ensure context switch
+    await consumer.subscribe(exchange_name, mocked_message_parser)
     await _assert_message_received(mocked_message_parser, 0, "")
 
 
 async def test_rabbit_client_pub_sub(
     rabbitmq_client: Callable[[str], RabbitMQClient],
-    random_exchange_name: str,
+    random_exchange_name: Callable[[], str],
     mocker: MockerFixture,
     faker: Faker,
 ):
@@ -129,35 +134,36 @@ async def test_rabbit_client_pub_sub(
     message = faker.text()
 
     mocked_message_parser = mocker.AsyncMock(return_value=True)
-    await consumer.subscribe(random_exchange_name, mocked_message_parser)
-    await publisher.publish(random_exchange_name, message)
+    exchange_name = random_exchange_name()
+    await consumer.subscribe(exchange_name, mocked_message_parser)
+    await publisher.publish(exchange_name, message)
     await _assert_message_received(mocked_message_parser, 1, message)
 
 
 @pytest.mark.parametrize("num_subs", [10])
 async def test_rabbit_client_pub_many_subs(
     rabbitmq_client: Callable[[str], RabbitMQClient],
-    random_exchange_name: str,
+    random_exchange_name: Callable[[], str],
     mocker: MockerFixture,
     faker: Faker,
     num_subs: int,
 ):
     consumers = (rabbitmq_client(f"consumer_{n}") for n in range(num_subs))
-    mocked_message_parsers = (
+    mocked_message_parsers = [
         mocker.AsyncMock(return_value=True) for _ in range(num_subs)
-    )
+    ]
 
     publisher = rabbitmq_client("publisher")
     message = faker.text()
-
+    exchange_name = random_exchange_name()
     await asyncio.gather(
         *(
-            consumer.subscribe(random_exchange_name, parser)
+            consumer.subscribe(exchange_name, parser)
             for consumer, parser in zip(consumers, mocked_message_parsers)
         )
     )
 
-    await publisher.publish(random_exchange_name, message)
+    await publisher.publish(exchange_name, message)
     await asyncio.gather(
         *(
             _assert_message_received(parser, 1, message)
@@ -168,7 +174,7 @@ async def test_rabbit_client_pub_many_subs(
 
 async def test_rabbit_client_pub_sub_republishes_if_exception_raised(
     rabbitmq_client: Callable[[str], RabbitMQClient],
-    random_exchange_name: str,
+    random_exchange_name: Callable[[], str],
     mocker: MockerFixture,
     faker: Faker,
 ):
@@ -186,10 +192,11 @@ async def test_rabbit_client_pub_sub_republishes_if_exception_raised(
             return False
         return True
 
+    exchange_name = random_exchange_name()
     _raise_once_then_true.calls = 0
     mocked_message_parser = mocker.AsyncMock(side_effect=_raise_once_then_true)
-    await consumer.subscribe(random_exchange_name, mocked_message_parser)
-    await publisher.publish(random_exchange_name, message)
+    await consumer.subscribe(exchange_name, mocked_message_parser)
+    await publisher.publish(exchange_name, message)
     await _assert_message_received(mocked_message_parser, 3, message)
 
 
@@ -208,3 +215,41 @@ async def test_rabbit_client_lose_connection(
         rabbit_docker_service.remove()  # type: ignore
     await asyncio.sleep(10)  # wait for the client to disconnect
     assert await rabbit_client.ping() is False
+
+
+@pytest.mark.parametrize("num_subs", [10])
+async def test_pub_sub_with_non_exclusive_queue(
+    rabbitmq_client: Callable[[str], RabbitMQClient],
+    random_exchange_name: Callable[[], str],
+    mocker: MockerFixture,
+    faker: Faker,
+    num_subs: int,
+):
+    consumers = (rabbitmq_client(f"consumer_{n}") for n in range(num_subs))
+    mocked_message_parsers = [
+        mocker.AsyncMock(return_value=True) for _ in range(num_subs)
+    ]
+
+    publisher = rabbitmq_client("publisher")
+    message = faker.text()
+    exchange_name = random_exchange_name()
+    await asyncio.gather(
+        *(
+            consumer.subscribe(exchange_name, parser, exclusive_queue=False)
+            for consumer, parser in zip(consumers, mocked_message_parsers)
+        )
+    )
+
+    await publisher.publish(exchange_name, message)
+    # only one consumer should have gotten the message here and the others not
+    async for attempt in AsyncRetrying(
+        wait=wait_fixed(0.1),
+        stop=stop_after_delay(5),
+        retry=retry_if_exception_type(AssertionError),
+        reraise=True,
+    ):
+        with attempt:
+            total_call_count = 0
+            for parser in mocked_message_parsers:
+                total_call_count += parser.call_count
+            assert total_call_count == 1, "too many messages"

--- a/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
@@ -83,7 +83,9 @@ async def push(
         stack.enter_context(
             log_context(log, logging.INFO, "pushing %s", file_or_folder)
         )
-        tmp_dir_name = stack.enter_context(TemporaryDirectory())
+        tmp_dir_name = stack.enter_context(
+            TemporaryDirectory()  # pylint: disable=consider-using-with
+        )
         sub_progress = await stack.enter_async_context(
             progress_bar.sub_progress(steps=2)
         )

--- a/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
@@ -179,6 +179,7 @@ async def pull(
                 archive_to_extract=archive_file,
                 destination_folder=destination_folder,
                 progress_bar=sub_prog,
+                log_cb=io_log_redirect_cb,
             )
             if io_log_redirect_cb:
                 await io_log_redirect_cb(

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -290,6 +290,7 @@ async def upload_file(
     io_log_redirect_cb: Optional[LogRedirectCB],
     client_session: Optional[ClientSession] = None,
     r_clone_settings: Optional[RCloneSettings] = None,
+    progress_bar: ProgressBarData,
 ) -> tuple[LocationID, ETag]:
     """Uploads a file (potentially in parallel) or a file object (sequential in any case) to S3
 
@@ -350,6 +351,7 @@ async def upload_file(
                     file_to_upload,
                     num_retries=NodePortsSettings.create_from_envs().NODE_PORTS_IO_NUM_RETRY_ATTEMPTS,
                     io_log_redirect_cb=io_log_redirect_cb,
+                    progress_bar=progress_bar,
                 )
 
             # complete the upload

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -347,6 +347,7 @@ async def upload_file(
                     r_clone_settings,
                     upload_links,
                 )
+                await progress_bar.update()
             else:
                 uploaded_parts = await upload_file_to_presigned_links(
                     session,

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -290,7 +290,7 @@ async def upload_file(
     io_log_redirect_cb: Optional[LogRedirectCB],
     client_session: Optional[ClientSession] = None,
     r_clone_settings: Optional[RCloneSettings] = None,
-    progress_bar: ProgressBarData,
+    progress_bar: Optional[ProgressBarData] = None,
 ) -> tuple[LocationID, ETag]:
     """Uploads a file (potentially in parallel) or a file object (sequential in any case) to S3
 
@@ -308,6 +308,9 @@ async def upload_file(
         f"{store_name=}",
         f"{s3_object=}",
     )
+
+    if not progress_bar:
+        progress_bar = ProgressBarData(steps=1)
 
     use_rclone = (
         await r_clone.is_r_clone_available(r_clone_settings)

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -21,6 +21,7 @@ from models_library.projects_nodes_io import StorageFileID
 from models_library.users import UserID
 from models_library.utils.fastapi_encoders import jsonable_encoder
 from pydantic import ByteSize, parse_obj_as
+from servicelib.progress_bar import ProgressBarData
 from settings_library.r_clone import RCloneSettings
 from tenacity._asyncio import AsyncRetrying
 from tenacity.before_sleep import before_sleep_log
@@ -190,6 +191,7 @@ async def download_file_from_s3(
     local_folder: Path,
     io_log_redirect_cb: Optional[LogRedirectCB],
     client_session: Optional[ClientSession] = None,
+    progress_bar: ProgressBarData,
 ) -> Path:
     """Downloads a file from S3
 
@@ -227,15 +229,18 @@ async def download_file_from_s3(
             local_folder,
             client_session=session,
             io_log_redirect_cb=io_log_redirect_cb,
+            progress_bar=progress_bar,
         )
 
 
 async def download_file_from_link(
     download_link: URL,
     destination_folder: Path,
+    *,
     io_log_redirect_cb: Optional[LogRedirectCB],
     file_name: Optional[str] = None,
     client_session: Optional[ClientSession] = None,
+    progress_bar: ProgressBarData,
 ) -> Path:
     # a download link looks something like:
     # http://172.16.9.89:9001/simcore-test/269dec55-6d18-4901-a767-b567db23d425/4ccf4e2e-a6cd-4f77-a255-4c36fa1b1c72/test.test?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=s3access/20190719/us-east-1/s3/aws4_request&X-Amz-Date=20190719T142431Z&X-Amz-Expires=259200&X-Amz-SignedHeaders=host&X-Amz-Signature=90268f3b580b38c1aad128475936c6f5fd335d11d01ec143cca1056d92a724b5
@@ -254,6 +259,7 @@ async def download_file_from_link(
             local_file_path,
             num_retries=NodePortsSettings.create_from_envs().NODE_PORTS_IO_NUM_RETRY_ATTEMPTS,
             io_log_redirect_cb=io_log_redirect_cb,
+            progress_bar=progress_bar,
         )
     if io_log_redirect_cb:
         await io_log_redirect_cb(f"download of {local_file_path} complete.")

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
@@ -345,6 +345,9 @@ class Port(BaseServiceIOModel):
                 )
             else:
                 new_value = converted_value
+                await progress_bar.update()
+        else:
+            await progress_bar.update()
 
         self.value = new_value
         self.value_item = None

--- a/packages/simcore-sdk/tests/integration/test_node_data_data_manager_.py
+++ b/packages/simcore-sdk/tests/integration/test_node_data_data_manager_.py
@@ -144,7 +144,7 @@ async def test_valid_upload_download(
             progress_bar=progress_bar,
         )
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress == pytest.approx(1.0)
+        assert progress_bar._continuous_progress_value == pytest.approx(1.0)
 
         uploaded_hashes = _get_file_hashes_in_path(content_path)
 
@@ -158,7 +158,7 @@ async def test_valid_upload_download(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-        assert progress_bar._continuous_progress == pytest.approx(2.0)
+        assert progress_bar._continuous_progress_value == pytest.approx(2.0)
 
     downloaded_hashes = _get_file_hashes_in_path(content_path)
 
@@ -192,7 +192,7 @@ async def test_valid_upload_download_saved_to(
             progress_bar=progress_bar,
         )
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress == pytest.approx(1)
+        assert progress_bar._continuous_progress_value == pytest.approx(1)
 
         uploaded_hashes = _get_file_hashes_in_path(content_path)
 
@@ -209,7 +209,7 @@ async def test_valid_upload_download_saved_to(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-        assert progress_bar._continuous_progress == pytest.approx(2)
+        assert progress_bar._continuous_progress_value == pytest.approx(2)
 
     downloaded_hashes = _get_file_hashes_in_path(new_destination)
 

--- a/packages/simcore-sdk/tests/integration/test_node_data_data_manager_.py
+++ b/packages/simcore-sdk/tests/integration/test_node_data_data_manager_.py
@@ -144,7 +144,7 @@ async def test_valid_upload_download(
             progress_bar=progress_bar,
         )
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress == pytest.approx(0.5)
+        assert progress_bar._continuous_progress == pytest.approx(1.0)
 
         uploaded_hashes = _get_file_hashes_in_path(content_path)
 
@@ -158,7 +158,7 @@ async def test_valid_upload_download(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-        assert progress_bar._continuous_progress == pytest.approx(1)
+        assert progress_bar._continuous_progress == pytest.approx(2.0)
 
     downloaded_hashes = _get_file_hashes_in_path(content_path)
 
@@ -192,7 +192,7 @@ async def test_valid_upload_download_saved_to(
             progress_bar=progress_bar,
         )
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress == pytest.approx(0.5)
+        assert progress_bar._continuous_progress == pytest.approx(1)
 
         uploaded_hashes = _get_file_hashes_in_path(content_path)
 
@@ -209,7 +209,7 @@ async def test_valid_upload_download_saved_to(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-        assert progress_bar._continuous_progress == pytest.approx(1)
+        assert progress_bar._continuous_progress == pytest.approx(2)
 
     downloaded_hashes = _get_file_hashes_in_path(new_destination)
 

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
@@ -79,7 +79,7 @@ async def test_valid_upload_download(
             progress_bar=progress_bar,
         )
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress == pytest.approx(0.5)
+        assert progress_bar._continuous_progress == pytest.approx(1)
         assert store_id == s3_simcore_location
         assert e_tag
         get_store_id, get_e_tag = await filemanager.get_file_metadata(
@@ -98,7 +98,7 @@ async def test_valid_upload_download(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-        assert progress_bar._continuous_progress == pytest.approx(1)
+        assert progress_bar._continuous_progress == pytest.approx(2)
     assert download_file_path.exists()
     assert download_file_path.name == "test.test"
     assert filecmp.cmp(download_file_path, file_path)

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
@@ -79,7 +79,7 @@ async def test_valid_upload_download(
             progress_bar=progress_bar,
         )
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress == pytest.approx(1)
+        assert progress_bar._continuous_progress_value == pytest.approx(1)
         assert store_id == s3_simcore_location
         assert e_tag
         get_store_id, get_e_tag = await filemanager.get_file_metadata(
@@ -98,7 +98,7 @@ async def test_valid_upload_download(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-        assert progress_bar._continuous_progress == pytest.approx(2)
+        assert progress_bar._continuous_progress_value == pytest.approx(2)
     assert download_file_path.exists()
     assert download_file_path.name == "test.test"
     assert filecmp.cmp(download_file_path, file_path)
@@ -156,7 +156,7 @@ async def test_valid_upload_download_using_file_object(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress == pytest.approx(1)
+    assert progress_bar._continuous_progress_value == pytest.approx(1)
     assert download_file_path.exists()
     assert download_file_path.name == "test.test"
     assert filecmp.cmp(download_file_path, file_path)

--- a/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
@@ -3,6 +3,7 @@
 # pylint: disable=too-many-arguments
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
+# pylint: disable=protected-access
 
 
 import filecmp
@@ -264,7 +265,6 @@ async def test_port_file_accessors(
     e_tag: str,
     option_r_clone_settings: Optional[RCloneSettings],
 ):  # pylint: disable=W0613, W0621
-
     config_value["path"] = f"{project_id}/{node_uuid}/{Path(config_value['path']).name}"
 
     config_dict, _project_id, _node_uuid = create_special_configuration(
@@ -779,3 +779,4 @@ async def test_batch_update_inputs_outputs(
             await PORTS.set_multiple(
                 {"missing_key_in_both": (123132, None)}, progress_bar=progress_bar
             )
+            assert progress_bar._continuous_progress == pytest.approx(0)

--- a/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
@@ -751,7 +751,7 @@ async def test_batch_update_inputs_outputs(
             progress_bar=progress_bar,
         )
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress == pytest.approx(1)
+        assert progress_bar._continuous_progress_value == pytest.approx(1)
         await PORTS.set_multiple(
             {
                 port.key: (k, None)
@@ -759,7 +759,7 @@ async def test_batch_update_inputs_outputs(
             },
             progress_bar=progress_bar,
         )
-        assert progress_bar._continuous_progress == pytest.approx(2)
+        assert progress_bar._continuous_progress_value == pytest.approx(2)
 
     ports_outputs = await PORTS.outputs
     ports_inputs = await PORTS.inputs
@@ -779,4 +779,4 @@ async def test_batch_update_inputs_outputs(
             await PORTS.set_multiple(
                 {"missing_key_in_both": (123132, None)}, progress_bar=progress_bar
             )
-            assert progress_bar._continuous_progress == pytest.approx(0)
+            assert progress_bar._continuous_progress_value == pytest.approx(0)

--- a/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
+++ b/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
@@ -80,7 +80,7 @@ async def test_push_folder(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress == pytest.approx(1)
+    assert progress_bar._continuous_progress_value == pytest.approx(1)
 
     mock_temporary_directory.assert_called_once()
     mock_filemanager.upload_file.assert_called_once_with(
@@ -139,7 +139,7 @@ async def test_push_file(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress == pytest.approx(1)
+    assert progress_bar._continuous_progress_value == pytest.approx(1)
     mock_temporary_directory.assert_not_called()
     mock_filemanager.upload_file.assert_called_once_with(
         r_clone_settings=None,
@@ -210,7 +210,7 @@ async def test_pull_folder(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress == pytest.approx(1)
+    assert progress_bar._continuous_progress_value == pytest.approx(1)
     mock_temporary_directory.assert_called_once()
     mock_filemanager.download_file_from_s3.assert_called_once_with(
         local_folder=test_compression_folder,
@@ -266,7 +266,7 @@ async def test_pull_file(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress == pytest.approx(1)
+    assert progress_bar._continuous_progress_value == pytest.approx(1)
     mock_temporary_directory.assert_not_called()
     mock_filemanager.download_file_from_s3.assert_called_once_with(
         local_folder=file_path.parent,

--- a/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
+++ b/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
@@ -1,6 +1,7 @@
 # pylint:disable=unused-variable
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
+# pylint:disable=protected-access
 
 from filecmp import cmpfiles
 from pathlib import Path
@@ -8,6 +9,7 @@ from shutil import copy, make_archive, unpack_archive
 from typing import Callable, Iterator
 
 import pytest
+from servicelib.progress_bar import ProgressBarData
 from simcore_sdk.node_data import data_manager
 from simcore_sdk.node_ports_common.constants import SIMCORE_LOCATION
 
@@ -69,10 +71,16 @@ async def test_push_folder(
     assert len(list(test_folder.glob("**/*"))) == files_number
     for file_path in test_folder.glob("**/*"):
         assert file_path.exists()
-
-    await data_manager.push(
-        user_id, project_id, node_uuid, test_folder, io_log_redirect_cb=None
-    )
+    async with ProgressBarData(steps=1) as progress_bar:
+        await data_manager.push(
+            user_id,
+            project_id,
+            node_uuid,
+            test_folder,
+            io_log_redirect_cb=None,
+            progress_bar=progress_bar,
+        )
+    assert progress_bar._continuous_progress == pytest.approx(1)
 
     mock_temporary_directory.assert_called_once()
     mock_filemanager.upload_file.assert_called_once_with(
@@ -121,9 +129,16 @@ async def test_push_file(
     assert file_path.exists()
 
     # test push file by file
-    await data_manager.push(
-        user_id, project_id, node_uuid, file_path, io_log_redirect_cb=None
-    )
+    async with ProgressBarData(steps=1) as progress_bar:
+        await data_manager.push(
+            user_id,
+            project_id,
+            node_uuid,
+            file_path,
+            io_log_redirect_cb=None,
+            progress_bar=progress_bar,
+        )
+    assert progress_bar._continuous_progress == pytest.approx(1)
     mock_temporary_directory.assert_not_called()
     mock_filemanager.upload_file.assert_called_once_with(
         r_clone_settings=None,
@@ -184,9 +199,16 @@ async def test_pull_folder(
         test_compression_folder
     )
 
-    await data_manager.pull(
-        user_id, project_id, node_uuid, test_folder, io_log_redirect_cb=None
-    )
+    async with ProgressBarData(steps=1) as progress_bar:
+        await data_manager.pull(
+            user_id,
+            project_id,
+            node_uuid,
+            test_folder,
+            io_log_redirect_cb=None,
+            progress_bar=progress_bar,
+        )
+    assert progress_bar._continuous_progress == pytest.approx(1)
     mock_temporary_directory.assert_called_once()
     mock_filemanager.download_file_from_s3.assert_called_once_with(
         local_folder=test_compression_folder,
@@ -232,9 +254,16 @@ async def test_pull_file(
         "simcore_sdk.node_data.data_manager.TemporaryDirectory"
     )
 
-    await data_manager.pull(
-        user_id, project_id, node_uuid, file_path, io_log_redirect_cb=None
-    )
+    async with ProgressBarData(steps=1) as progress_bar:
+        await data_manager.pull(
+            user_id,
+            project_id,
+            node_uuid,
+            file_path,
+            io_log_redirect_cb=None,
+            progress_bar=progress_bar,
+        )
+    assert progress_bar._continuous_progress == pytest.approx(1)
     mock_temporary_directory.assert_not_called()
     mock_filemanager.download_file_from_s3.assert_called_once_with(
         local_folder=file_path.parent,

--- a/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
+++ b/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
@@ -91,6 +91,7 @@ async def test_push_folder(
         store_id=SIMCORE_LOCATION,
         store_name=None,
         user_id=user_id,
+        progress_bar=progress_bar._children[0],
     )
 
     archive_file = test_compression_folder / f"{test_folder.stem}.zip"
@@ -148,6 +149,7 @@ async def test_push_file(
         store_id=SIMCORE_LOCATION,
         store_name=None,
         user_id=user_id,
+        progress_bar=progress_bar,
     )
     mock_filemanager.reset_mock()
 
@@ -217,6 +219,7 @@ async def test_pull_folder(
         store_name=None,
         user_id=user_id,
         io_log_redirect_cb=None,
+        progress_bar=progress_bar._children[0],
     )
 
     matchs, mismatchs, errors = cmpfiles(
@@ -272,4 +275,5 @@ async def test_pull_file(
         store_name=None,
         user_id=user_id,
         io_log_redirect_cb=None,
+        progress_bar=progress_bar,
     )

--- a/packages/simcore-sdk/tests/unit/test_node_ports_common_file_io_utils.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_common_file_io_utils.py
@@ -228,5 +228,5 @@ async def test_upload_file_to_presigned_links(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress == pytest.approx(1)
+    assert progress_bar._continuous_progress_value == pytest.approx(1)
     assert uploaded_parts

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_nodeports_v2.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_nodeports_v2.py
@@ -137,7 +137,7 @@ async def test_node_ports_accessors(
             },
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress == pytest.approx(1)
+    assert progress_bar._continuous_progress_value == pytest.approx(1)
 
 
 @pytest.fixture(scope="session")

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_nodeports_v2.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_nodeports_v2.py
@@ -1,11 +1,13 @@
 # pylint:disable=unused-variable
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
+# pylint:disable=protected-access
 
 from pathlib import Path
 from typing import Any, Callable
 
 import pytest
+from servicelib.progress_bar import ProgressBarData
 from simcore_sdk.node_ports_v2 import Nodeports, exceptions, ports
 from simcore_sdk.node_ports_v2.ports_mapping import InputsList, OutputsList
 from utils_port_v2 import create_valid_port_mapping
@@ -126,12 +128,16 @@ async def test_node_ports_accessors(
         await node_ports.set(port.key, port.value)
 
     # test batch add
-    await node_ports.set_multiple(
-        {
-            port.key: (port.value, None)
-            for port in list(original_inputs.values()) + list(original_outputs.values())
-        }
-    )
+    async with ProgressBarData(steps=1) as progress_bar:
+        await node_ports.set_multiple(
+            {
+                port.key: (port.value, None)
+                for port in list(original_inputs.values())
+                + list(original_outputs.values())
+            },
+            progress_bar=progress_bar,
+        )
+    assert progress_bar._continuous_progress == pytest.approx(1)
 
 
 @pytest.fixture(scope="session")

--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -78,6 +78,8 @@ class EC2InstancesSettings(BaseCustomSettings):
         "disabled when set to 0. Uses 1st machine defined in EC2_INSTANCES_ALLOWED_TYPES",
     )
 
+    EC2_INSTANCES_MAX_START_TIME: datetime.timedelta = Field(default=datetime.timedelta(minutes=3), description="Usual time taken an EC2 instance with the given AMI takes to be in 'running' mode")
+
     @validator("EC2_INSTANCES_TIME_BEFORE_TERMINATION")
     @classmethod
     def ensure_time_is_in_range(cls, value):

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -5,9 +5,9 @@ from typing import Final
 
 from fastapi import FastAPI
 from models_library.generated_models.docker_rest_api import Node, Task
-from services.autoscaling.src.simcore_service_autoscaling.core.settings import get_application_settings
 
 from ..core.errors import Ec2InvalidDnsNameError
+from ..core.settings import get_application_settings
 from ..models import AssociatedInstance, EC2InstanceData, EC2InstanceType, Resources
 from . import utils_docker
 from .rabbitmq import log_tasks_message, progress_tasks_message
@@ -85,7 +85,6 @@ def try_assigning_task_to_instances(
     return False
 
 
-
 async def try_assigning_task_to_pending_instances(
     app: FastAPI,
     pending_task: Task,
@@ -93,8 +92,10 @@ async def try_assigning_task_to_pending_instances(
     type_to_instance_map: dict[str, EC2InstanceType],
 ) -> bool:
     app_settings = get_application_settings(app)
-    assert app_settings.AUTOSCALING_EC2_INSTANCES # nosec
-    instance_max_time_to_start = app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
+    assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
+    instance_max_time_to_start = (
+        app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
+    )
     for instance, instance_assigned_tasks in list_of_pending_instance_to_tasks:
         instance_type = type_to_instance_map[instance.type]
         instance_total_resources = Resources(

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -94,7 +94,7 @@ async def try_assigning_task_to_pending_instances(
     app_settings = get_application_settings(app)
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
     instance_max_time_to_start = (
-        app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
+        app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MAX_START_TIME
     )
     for instance, instance_assigned_tasks in list_of_pending_instance_to_tasks:
         instance_type = type_to_instance_map[instance.type]

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -5,6 +5,7 @@ from typing import Final
 
 from fastapi import FastAPI
 from models_library.generated_models.docker_rest_api import Node, Task
+from services.autoscaling.src.simcore_service_autoscaling.core.settings import get_application_settings
 
 from ..core.errors import Ec2InvalidDnsNameError
 from ..models import AssociatedInstance, EC2InstanceData, EC2InstanceType, Resources
@@ -84,10 +85,6 @@ def try_assigning_task_to_instances(
     return False
 
 
-_MAX_TIME_TO_START_EC2_INSTANCE: Final[datetime.timedelta] = datetime.timedelta(
-    minutes=3
-)
-
 
 async def try_assigning_task_to_pending_instances(
     app: FastAPI,
@@ -95,6 +92,9 @@ async def try_assigning_task_to_pending_instances(
     list_of_pending_instance_to_tasks: list[tuple[EC2InstanceData, list[Task]]],
     type_to_instance_map: dict[str, EC2InstanceType],
 ) -> bool:
+    app_settings = get_application_settings(app)
+    assert app_settings.AUTOSCALING_EC2_INSTANCES # nosec
+    instance_max_time_to_start = app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
     for instance, instance_assigned_tasks in list_of_pending_instance_to_tasks:
         instance_type = type_to_instance_map[instance.type]
         instance_total_resources = Resources(
@@ -110,7 +110,7 @@ async def try_assigning_task_to_pending_instances(
             now = datetime.datetime.now(datetime.timezone.utc)
             time_since_launch = now - instance.launch_time
             estimated_time_to_completion = (
-                instance.launch_time + _MAX_TIME_TO_START_EC2_INSTANCE - now
+                instance.launch_time + instance_max_time_to_start - now
             )
             await log_tasks_message(
                 app,
@@ -121,7 +121,7 @@ async def try_assigning_task_to_pending_instances(
                 app,
                 [pending_task],
                 time_since_launch.total_seconds()
-                / _MAX_TIME_TO_START_EC2_INSTANCE.total_seconds(),
+                / instance_max_time_to_start.total_seconds(),
             )
             return True
     return False

--- a/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
+++ b/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
@@ -5,6 +5,7 @@
 # pylint: disable=too-many-arguments
 
 
+from datetime import timedelta
 from typing import Callable
 
 import pytest
@@ -141,6 +142,9 @@ async def test_try_assigning_task_to_pending_instances(
     fake_ec2_instance_data: Callable[..., EC2InstanceData],
 ):
     fake_app = mocker.Mock()
+    fake_app.state.settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MAX_START_TIME = (
+        timedelta(minutes=1)
+    )
     pending_task = fake_task(
         Spec={"Resources": {"Reservations": {"NanoCPUs": 2 * 1e9}}}
     )

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events.py
@@ -10,7 +10,11 @@ from models_library.aiodocker_api import AioDockerServiceSpec
 from models_library.projects import ProjectAtDB
 from models_library.projects_nodes import Node
 from models_library.projects_nodes_io import NodeIDStr
-from models_library.rabbitmq_messages import InstrumentationRabbitMessage
+from models_library.rabbitmq_messages import (
+    InstrumentationRabbitMessage,
+    ProgressRabbitMessage,
+    ProgressType,
+)
 from models_library.service_settings_labels import (
     SimcoreServiceLabels,
     SimcoreServiceSettingsLabel,
@@ -215,7 +219,16 @@ class CreateSidecars(DynamicSchedulerEvent):
                 include=DYNAMIC_SIDECAR_SERVICE_EXTENDABLE_SPECS,
             )
         )
-
+        await rabbitmq_client.publish(
+            ProgressRabbitMessage.get_channel_name(),
+            ProgressRabbitMessage(
+                user_id=scheduler_data.user_id,
+                project_id=scheduler_data.project_id,
+                node_id=scheduler_data.node_uuid,
+                progress_type=ProgressType.SIDECARS_PULLING,
+                progress=0,
+            ).json(),
+        )
         dynamic_sidecar_id = await create_service_and_get_id(
             dynamic_sidecar_service_final_spec
         )
@@ -225,6 +238,17 @@ class CreateSidecars(DynamicSchedulerEvent):
                 dynamic_sidecar_id, dynamic_sidecar_settings
             )
         )
+        await rabbitmq_client.publish(
+            ProgressRabbitMessage.get_channel_name(),
+            ProgressRabbitMessage(
+                user_id=scheduler_data.user_id,
+                project_id=scheduler_data.project_id,
+                node_id=scheduler_data.node_uuid,
+                progress_type=ProgressType.SIDECARS_PULLING,
+                progress=1,
+            ).json(),
+        )
+
         await constrain_service_to_node(
             service_name=scheduler_data.service_name,
             docker_node_id=scheduler_data.dynamic_sidecar.docker_node_id,

--- a/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
+++ b/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
@@ -53,6 +53,7 @@ from servicelib.fastapi.long_running_tasks.client import (
     TaskId,
     periodic_task_result,
 )
+from servicelib.progress_bar import ProgressBarData
 from settings_library.rabbit import RabbitSettings
 from settings_library.redis import RedisSettings
 from shared_comp_utils import (
@@ -623,14 +624,16 @@ async def _fetch_data_via_data_manager(
         is True
     )
 
-    await data_manager.pull(
-        user_id=user_id,
-        project_id=project_id,
-        node_uuid=service_uuid,
-        file_or_folder=DY_SERVICES_STATE_PATH,
-        save_to=save_to,
-        io_log_redirect_cb=None,
-    )
+    async with ProgressBarData(steps=1) as progress_bar:
+        await data_manager.pull(
+            user_id=user_id,
+            project_id=project_id,
+            node_uuid=service_uuid,
+            file_or_folder=DY_SERVICES_STATE_PATH,
+            save_to=save_to,
+            io_log_redirect_cb=None,
+            progress_bar=progress_bar,
+        )
 
     return save_to
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
@@ -105,8 +105,8 @@ async def docker_compose_pull(app: FastAPI, compose_spec_yaml: str) -> None:
     async def _progress_cb(current: int, total: int) -> None:
         await post_progress_message(
             app,
-            float(current / (total or 1)),
             ProgressType.SERVICE_IMAGES_PULLING,
+            float(current / (total or 1)),
         )
 
     async def _log_cb(msg: str) -> None:

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
@@ -1,6 +1,6 @@
 import logging
 from functools import lru_cache
-from typing import Optional, cast
+from typing import cast
 
 from fastapi import FastAPI
 from models_library.rabbitmq_messages import (
@@ -15,7 +15,6 @@ from pydantic import NonNegativeFloat
 from servicelib.logging_utils import log_catch, log_context
 from servicelib.rabbitmq import RabbitMQClient
 from servicelib.rabbitmq_utils import wait_till_rabbitmq_responsive
-from simcore_sdk.node_ports_common.file_io_utils import ProgressData
 
 from ..core.settings import ApplicationSettings
 
@@ -27,15 +26,13 @@ async def _post_rabbit_message(app: FastAPI, message: RabbitMessageBase) -> None
         await get_rabbitmq_client(app).publish(message.channel_name, message.json())
 
 
-async def post_log_message(
-    app: FastAPI, msg: str, _: Optional[ProgressData] = None
-) -> None:
+async def post_log_message(app: FastAPI, logs: str) -> None:
     app_settings: ApplicationSettings = app.state.settings
     message = LoggerRabbitMessage(
         node_id=app_settings.DY_SIDECAR_NODE_ID,
         user_id=app_settings.DY_SIDECAR_USER_ID,
         project_id=app_settings.DY_SIDECAR_PROJECT_ID,
-        messages=[msg],
+        messages=[logs],
         log_level=logging.INFO,
     )
 
@@ -43,7 +40,7 @@ async def post_log_message(
 
 
 async def post_progress_message(
-    app: FastAPI, progress_value: NonNegativeFloat, progress_type: ProgressType
+    app: FastAPI, progress_type: ProgressType, progress_value: NonNegativeFloat
 ) -> None:
     app_settings: ApplicationSettings = app.state.settings
     message = ProgressRabbitMessage(

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
@@ -12,7 +12,7 @@ from models_library.rabbitmq_messages import (
     RabbitMessageBase,
 )
 from pydantic import NonNegativeFloat
-from servicelib.logging_utils import log_context
+from servicelib.logging_utils import log_catch, log_context
 from servicelib.rabbitmq import RabbitMQClient
 from servicelib.rabbitmq_utils import wait_till_rabbitmq_responsive
 from simcore_sdk.node_ports_common.file_io_utils import ProgressData
@@ -23,10 +23,7 @@ log = logging.getLogger(__file__)
 
 
 async def _post_rabbit_message(app: FastAPI, message: RabbitMessageBase) -> None:
-    # NOTE: this check is necessary when the dy-sidecar is used on the CLI
-    # where the rabbit is not initialized, it's not optimal but it allows
-    # to run the CLI without rabbit...
-    if _is_rabbitmq_initialized(app):
+    with log_catch(log, reraise=False):
         await get_rabbitmq_client(app).publish(message.channel_name, message.json())
 
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -1,7 +1,7 @@
 import functools
 import logging
-from collections import deque
-from typing import Any, Awaitable, Final, Optional
+from pathlib import Path
+from typing import Final, Optional
 
 from fastapi import FastAPI
 from models_library.rabbitmq_messages import ProgressType
@@ -9,7 +9,6 @@ from servicelib.fastapi.long_running_tasks.server import TaskProgress
 from servicelib.progress_bar import ProgressBarData
 from servicelib.utils import logged_gather
 from simcore_sdk.node_data import data_manager
-from simcore_sdk.node_ports_common.file_io_utils import ProgressData
 from tenacity import retry
 from tenacity.retry import retry_if_result
 from tenacity.stop import stop_after_delay
@@ -131,10 +130,10 @@ async def task_create_service_containers(
 
         progress.update(message="pulling images", percent=0.01)
         await post_sidecar_log_message(app, "pulling service images")
-        await post_progress_message(app, 0, ProgressType.SERVICE_IMAGES_PULLING)
+        await post_progress_message(app, ProgressType.SERVICE_IMAGES_PULLING, 0)
         await docker_compose_pull(app, shared_store.compose_spec)
         await post_sidecar_log_message(app, "service images ready")
-        await post_progress_message(app, 1, ProgressType.SERVICE_IMAGES_PULLING)
+        await post_progress_message(app, ProgressType.SERVICE_IMAGES_PULLING, 1)
 
         progress.update(message="creating and starting containers", percent=0.90)
         await post_sidecar_log_message(app, "starting service containers")
@@ -186,21 +185,6 @@ async def task_runs_docker_compose_down(
     progress.update(message="done", percent=0.99)
 
 
-async def _logs_cb(
-    app: FastAPI,
-    progress_type: ProgressType,
-    msg: str,
-    progress_data: Optional[ProgressData] = None,
-) -> None:
-    await post_sidecar_log_message(app, msg)
-    if progress_data:
-        await post_progress_message(
-            app,
-            float(progress_data.current / (progress_data.total or 1.0)),
-            progress_type,
-        )
-
-
 async def task_restore_state(
     progress: TaskProgress,
     settings: ApplicationSettings,
@@ -208,9 +192,8 @@ async def task_restore_state(
     app: FastAPI,
 ) -> None:
     progress.update(message="checking files", percent=0.0)
-    await post_progress_message(app, 0, ProgressType.SERVICE_STATE_PULLING)
     # first check if there are files (no max concurrency here, these are just quick REST calls)
-    existing_files: list[bool] = await logged_gather(
+    paths_exists: list[bool] = await logged_gather(
         *(
             data_manager.exists(
                 user_id=settings.DY_SIDECAR_USER_ID,
@@ -222,14 +205,22 @@ async def task_restore_state(
         ),
         reraise=True,
     )
+    effective_paths: list[Path] = [
+        path
+        for path, exists in zip(mounted_volumes.disk_state_paths(), paths_exists)
+        if exists
+    ]
 
     progress.update(message="Downloading state", percent=0.05)
     await post_sidecar_log_message(
         app,
-        f"Downloading state files for {existing_files}...",
+        f"Downloading state files for {effective_paths}...",
     )
     async with ProgressBarData(
-        steps=len([exists for exists in existing_files if exists])
+        steps=len(effective_paths),
+        progress_report_cb=functools.partial(
+            post_progress_message, app, ProgressType.SERVICE_STATE_PULLING
+        ),
     ) as root_progress:
         await logged_gather(
             *(
@@ -238,15 +229,10 @@ async def task_restore_state(
                     project_id=str(settings.DY_SIDECAR_PROJECT_ID),
                     node_uuid=str(settings.DY_SIDECAR_NODE_ID),
                     file_or_folder=path,
-                    io_log_redirect_cb=functools.partial(
-                        _logs_cb, app, ProgressType.SERVICE_STATE_PULLING
-                    ),
+                    io_log_redirect_cb=functools.partial(post_sidecar_log_message, app),
                     progress_bar=root_progress,
                 )
-                for path, exists in zip(
-                    mounted_volumes.disk_state_paths(), existing_files
-                )
-                if exists
+                for path in effective_paths
             ),
             max_concurrency=CONCURRENCY_STATE_SAVE_RESTORE,
             reraise=True,  # this should raise if there is an issue
@@ -254,7 +240,6 @@ async def task_restore_state(
 
     await post_sidecar_log_message(app, "Finished state downloading")
     progress.update(message="state restored", percent=0.99)
-    await post_progress_message(app, 1, ProgressType.SERVICE_STATE_PULLING)
 
 
 async def task_save_state(
@@ -263,33 +248,32 @@ async def task_save_state(
     mounted_volumes: MountedVolumes,
     app: FastAPI,
 ) -> None:
-    awaitables: deque[Awaitable[Optional[Any]]] = deque()
-
     progress.update(message="starting state save", percent=0.0)
-    await post_progress_message(app, 0, ProgressType.SERVICE_STATE_PUSHING)
-
-    for state_path in mounted_volumes.disk_state_paths():
-        await post_sidecar_log_message(app, f"Saving state for {state_path}")
-        awaitables.append(
-            data_manager.push(
-                user_id=settings.DY_SIDECAR_USER_ID,
-                project_id=str(settings.DY_SIDECAR_PROJECT_ID),
-                node_uuid=str(settings.DY_SIDECAR_NODE_ID),
-                file_or_folder=state_path,
-                r_clone_settings=settings.rclone_settings_for_nodeports,
-                archive_exclude_patterns=mounted_volumes.state_exclude,
-                io_log_redirect_cb=functools.partial(
-                    _logs_cb, app, ProgressType.SERVICE_STATE_PUSHING
-                ),
-            )
+    async with ProgressBarData(
+        steps=len([mounted_volumes.disk_state_paths()]),
+        progress_report_cb=functools.partial(
+            post_progress_message, app, ProgressType.SERVICE_STATE_PUSHING
+        ),
+    ) as root_progress:
+        await logged_gather(
+            *[
+                data_manager.push(
+                    user_id=settings.DY_SIDECAR_USER_ID,
+                    project_id=str(settings.DY_SIDECAR_PROJECT_ID),
+                    node_uuid=str(settings.DY_SIDECAR_NODE_ID),
+                    file_or_folder=state_path,
+                    r_clone_settings=settings.rclone_settings_for_nodeports,
+                    archive_exclude_patterns=mounted_volumes.state_exclude,
+                    io_log_redirect_cb=functools.partial(post_sidecar_log_message, app),
+                    progress_bar=root_progress,
+                )
+                for state_path in mounted_volumes.disk_state_paths()
+            ],
+            max_concurrency=CONCURRENCY_STATE_SAVE_RESTORE,
         )
-
-    progress.update(message="saving state", percent=0.1)
-    await logged_gather(*awaitables, max_concurrency=CONCURRENCY_STATE_SAVE_RESTORE)
 
     await post_sidecar_log_message(app, "Finished state saving")
     progress.update(message="finished state saving", percent=0.99)
-    await post_progress_message(app, 1, ProgressType.SERVICE_STATE_PUSHING)
 
 
 async def task_ports_inputs_pull(
@@ -300,20 +284,22 @@ async def task_ports_inputs_pull(
 ) -> int:
     progress.update(message="starting inputs pulling", percent=0.0)
     port_keys = [] if port_keys is None else port_keys
-
     await post_sidecar_log_message(app, f"Pulling inputs for {port_keys}")
-    await post_progress_message(app, 0, ProgressType.SERVICE_INPUTS_PULLING)
     progress.update(message="pulling inputs", percent=0.1)
-    transferred_bytes = await nodeports.download_target_ports(
-        nodeports.PortTypeName.INPUTS,
-        mounted_volumes.disk_inputs_path,
-        port_keys=port_keys,
-        io_log_redirect_cb=functools.partial(
-            _logs_cb, app, ProgressType.SERVICE_INPUTS_PULLING
+    async with ProgressBarData(
+        steps=1,
+        progress_report_cb=functools.partial(
+            post_progress_message, app, ProgressType.SERVICE_INPUTS_PULLING
         ),
-    )
+    ) as root_progress:
+        transferred_bytes = await nodeports.download_target_ports(
+            nodeports.PortTypeName.INPUTS,
+            mounted_volumes.disk_inputs_path,
+            port_keys=port_keys,
+            io_log_redirect_cb=functools.partial(post_sidecar_log_message, app),
+            progress_bar=root_progress,
+        )
     await post_sidecar_log_message(app, "Finished pulling inputs")
-    await post_progress_message(app, 1, ProgressType.SERVICE_INPUTS_PULLING)
     progress.update(message="finished inputs pulling", percent=0.99)
     return int(transferred_bytes)
 
@@ -326,19 +312,21 @@ async def task_ports_outputs_pull(
 ) -> int:
     progress.update(message="starting outputs pulling", percent=0.0)
     port_keys = [] if port_keys is None else port_keys
-
     await post_sidecar_log_message(app, f"Pulling output for {port_keys}")
-    await post_progress_message(app, 0, ProgressType.SERVICE_OUTPUTS_PULLING)
-    transferred_bytes = await nodeports.download_target_ports(
-        nodeports.PortTypeName.OUTPUTS,
-        mounted_volumes.disk_outputs_path,
-        port_keys=port_keys,
-        io_log_redirect_cb=functools.partial(
-            _logs_cb, app, ProgressType.SERVICE_OUTPUTS_PULLING
+    async with ProgressBarData(
+        steps=1,
+        progress_report_cb=functools.partial(
+            post_progress_message, app, ProgressType.SERVICE_OUTPUTS_PULLING
         ),
-    )
+    ) as root_progress:
+        transferred_bytes = await nodeports.download_target_ports(
+            nodeports.PortTypeName.OUTPUTS,
+            mounted_volumes.disk_outputs_path,
+            port_keys=port_keys,
+            io_log_redirect_cb=functools.partial(post_sidecar_log_message, app),
+            progress_bar=root_progress,
+        )
     await post_sidecar_log_message(app, "Finished pulling outputs")
-    await post_progress_message(app, 1, ProgressType.SERVICE_OUTPUTS_PULLING)
     progress.update(message="finished outputs pulling", percent=0.99)
     return int(transferred_bytes)
 
@@ -347,7 +335,7 @@ async def task_ports_outputs_push(
     progress: TaskProgress, outputs_manager: OutputsManager, app: FastAPI
 ) -> None:
     progress.update(message="starting outputs pushing", percent=0.0)
-    await post_progress_message(app, 0, ProgressType.SERVICE_OUTPUTS_PUSHING)
+    await post_progress_message(app, ProgressType.SERVICE_OUTPUTS_PUSHING, 0)
 
     await post_sidecar_log_message(
         app,
@@ -357,7 +345,7 @@ async def task_ports_outputs_push(
     await outputs_manager.wait_for_all_uploads_to_finish()
 
     await post_sidecar_log_message(app, "finished outputs pushing")
-    await post_progress_message(app, 1, ProgressType.SERVICE_OUTPUTS_PUSHING)
+    await post_progress_message(app, ProgressType.SERVICE_OUTPUTS_PUSHING, 1)
     progress.update(message="finished outputs pushing", percent=0.99)
 
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -335,8 +335,6 @@ async def task_ports_outputs_push(
     progress: TaskProgress, outputs_manager: OutputsManager, app: FastAPI
 ) -> None:
     progress.update(message="starting outputs pushing", percent=0.0)
-    await post_progress_message(app, ProgressType.SERVICE_OUTPUTS_PUSHING, 0)
-
     await post_sidecar_log_message(
         app,
         f"waiting for outputs {outputs_manager.outputs_context.file_type_port_keys} to be pushed",
@@ -345,7 +343,6 @@ async def task_ports_outputs_push(
     await outputs_manager.wait_for_all_uploads_to_finish()
 
     await post_sidecar_log_message(app, "finished outputs pushing")
-    await post_progress_message(app, ProgressType.SERVICE_OUTPUTS_PUSHING, 1)
     progress.update(message="finished outputs pushing", percent=0.99)
 
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
@@ -10,8 +10,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Coroutine, Optional, cast
 
+import aiofiles.os
 import magic
-from aiofiles.os import wrap as sync_to_async
 from aiofiles.tempfile import TemporaryDirectory as AioTemporaryDirectory
 from models_library.projects import ProjectIDStr
 from models_library.projects_nodes_io import NodeIDStr
@@ -190,7 +190,7 @@ def _is_zip_file(file_path: Path) -> bool:
     return f"{mime_type}" == "application/zip"
 
 
-_shutil_move = sync_to_async(shutil.move)
+_shutil_move = aiofiles.os.wrap(shutil.move)  # type: ignore
 
 
 async def _get_data_from_port(

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
@@ -286,12 +286,12 @@ async def download_target_ports(
                 )
                 for port in ports_to_get
             ],
-            max_concurrency=4,
+            max_concurrency=2,
         )
     # parse results
     data = {
         port.key: {"key": port.key, "value": port_data}
-        for (port, port_data, port_transferred_bytes) in results
+        for (port, port_data, _) in results
     }
     total_transfered_bytes = ByteSize(
         sum(port_transferred_bytes for *_, port_transferred_bytes in results)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
@@ -8,24 +8,26 @@ from collections import deque
 from contextlib import AsyncExitStack
 from enum import Enum
 from pathlib import Path
-from typing import Any, Coroutine, Optional, cast
+from typing import Coroutine, Optional, cast
 
 import magic
 from aiofiles.tempfile import TemporaryDirectory as AioTemporaryDirectory
 from models_library.projects import ProjectIDStr
-from models_library.projects_nodes import OutputsDict
 from models_library.projects_nodes_io import NodeIDStr
 from pydantic import ByteSize
 from servicelib.archiving_utils import PrunableFolder, archive_dir, unarchive_dir
 from servicelib.async_utils import run_sequentially_in_context
 from servicelib.file_utils import remove_directory
+from servicelib.logging_utils import log_context
 from servicelib.pools import async_on_threadpool
+from servicelib.progress_bar import ProgressBarData
 from servicelib.utils import logged_gather
 from simcore_sdk import node_ports_v2
 from simcore_sdk.node_ports_common.file_io_utils import LogRedirectCB
 from simcore_sdk.node_ports_v2 import Nodeports, Port
 from simcore_sdk.node_ports_v2.links import ItemConcreteValue
 from simcore_sdk.node_ports_v2.port import SetKWargs
+from simcore_sdk.node_ports_v2.port_utils import is_file_type
 from simcore_service_dynamic_sidecar.core.settings import (
     ApplicationSettings,
     get_settings,
@@ -72,6 +74,7 @@ async def upload_outputs(
     outputs_path: Path,
     port_keys: list[str],
     io_log_redirect_cb: Optional[LogRedirectCB],
+    progress_bar: ProgressBarData,
 ) -> None:
     # pylint: disable=too-many-branches
     logger.debug("uploading data to simcore...")
@@ -91,14 +94,23 @@ async def upload_outputs(
         str, tuple[Optional[ItemConcreteValue], Optional[SetKWargs]]
     ] = {}
     archiving_tasks: deque[Coroutine[None, None, None]] = deque()
+    ports_to_set = [
+        port_value
+        for port_value in (await PORTS.outputs).values()
+        if (not port_keys) or (port_value.key in port_keys)
+    ]
 
     async with AsyncExitStack() as stack:
-        for port in (await PORTS.outputs).values():
-            logger.debug("Checking port %s", port.key)
-            if port_keys and port.key not in port_keys:
-                continue
-
-            if _FILE_TYPE_PREFIX in port.property_type:
+        sub_progress = await stack.enter_async_context(
+            progress_bar.sub_progress(
+                steps=sum(
+                    2 if is_file_type(port.property_type) else 1
+                    for port in ports_to_set
+                )
+            )
+        )
+        for port in ports_to_set:
+            if is_file_type(port.property_type):
                 src_folder = outputs_path / port.key
                 files_and_folders_list = list(src_folder.rglob("*"))
                 logger.debug("Discovered files to upload %s", files_and_folders_list)
@@ -137,6 +149,7 @@ async def upload_outputs(
                         destination=tmp_file,
                         compress=False,
                         store_relative_path=True,
+                        progress_bar=sub_progress,
                     )
                 )
                 ports_values[port.key] = (
@@ -161,7 +174,7 @@ async def upload_outputs(
         if archiving_tasks:
             await logged_gather(*archiving_tasks)
 
-        await PORTS.set_multiple(ports_values)
+        await PORTS.set_multiple(ports_values, progress_bar=sub_progress)
 
         elapsed_time = time.perf_counter() - start_time
         total_bytes = sum(_get_size_of_value(x) for x in ports_values.values())
@@ -177,102 +190,75 @@ def _is_zip_file(file_path: Path) -> bool:
     return f"{mime_type}" == "application/zip"
 
 
-async def _get_data_from_port(port: Port) -> tuple[Port, Optional[ItemConcreteValue]]:
-    tag = f"[{port.key}] "
-    logger.debug("%s transfer started for %s", tag, port.key)
-    start_time = time.perf_counter()
-    ret = await port.get()
-    elapsed_time = time.perf_counter() - start_time
-    logger.debug("%s transfer completed (=%s) in %3.2fs", tag, ret, elapsed_time)
-    if isinstance(ret, Path):
-        size_mb = ret.stat().st_size / 1024 / 1024
-        logger.debug(
-            "%s %s: data size: %sMB, transfer rate %sMB/s",
-            tag,
-            ret.name,
-            size_mb,
-            size_mb / elapsed_time,
-        )
-    return port, ret
+async def _get_data_from_port(
+    port: Port, *, target_dir: Path, progress_bar: ProgressBarData
+) -> tuple[Port, Optional[ItemConcreteValue], ByteSize]:
+    async with progress_bar.sub_progress(
+        steps=2 if is_file_type(port.property_type) else 1
+    ) as sub_progress:
+        with log_context(logger, logging.DEBUG, f"getting {port.key=}"):
+            port_data = await port.get(sub_progress)
 
-
-async def _download_files(
-    target_path: Path, download_tasks: deque[Coroutine[Any, int, Any]]
-) -> tuple[OutputsDict, ByteSize]:
-    transferred_bytes = 0
-    data: OutputsDict = {}
-
-    if not download_tasks:
-        return data, ByteSize(transferred_bytes)
-
-    # TODO: limit concurrency to avoid saturating storage+db??
-    results: list[tuple[Port, ItemConcreteValue]] = cast(
-        list[tuple[Port, ItemConcreteValue]], await logged_gather(*download_tasks)
-    )
-    logger.debug("completed download %s", results)
-    for port, value in results:
-
-        data[port.key] = {"key": port.key, "value": value}
-
-        if _FILE_TYPE_PREFIX in port.property_type:
-
+        if is_file_type(port.property_type):
             # if there are files, move them to the final destination
-            downloaded_file: Optional[Path] = cast(Optional[Path], value)
-            dest_path: Path = target_path / port.key
+            downloaded_file: Optional[Path] = cast(Optional[Path], port_data)
+            final_path: Path = target_dir / port.key
 
             if not downloaded_file or not downloaded_file.exists():
                 # the link may be empty
                 # remove files all files from disk when disconnecting port
-                logger.debug("removing contents of dir %s", dest_path)
+                logger.debug("removing contents of dir %s", final_path)
                 await remove_directory(
-                    dest_path, only_children=True, ignore_errors=True
+                    final_path, only_children=True, ignore_errors=True
                 )
-                continue
+                return port, None, ByteSize(0)
 
-            transferred_bytes = transferred_bytes + downloaded_file.stat().st_size
+            transferred_bytes = downloaded_file.stat().st_size
 
             # in case of valid file, it is either uncompressed and/or moved to the final directory
-            logger.debug("creating directory %s", dest_path)
-            dest_path.mkdir(exist_ok=True, parents=True)
-            data[port.key] = {"key": port.key, "value": str(dest_path)}
-
-            dest_folder = PrunableFolder(dest_path)
+            with log_context(logger, logging.DEBUG, "creating directory"):
+                final_path.mkdir(exist_ok=True, parents=True)
+            port_data = f"{final_path}"
+            dest_folder = PrunableFolder(final_path)
 
             if _is_zip_file(downloaded_file):
                 # unzip updated data to dest_path
                 logger.debug("unzipping %s", downloaded_file)
                 unarchived: set[Path] = await unarchive_dir(
-                    archive_to_extract=downloaded_file, destination_folder=dest_path
+                    archive_to_extract=downloaded_file,
+                    destination_folder=final_path,
+                    progress_bar=sub_progress,
                 )
 
                 dest_folder.prune(exclude=unarchived)
 
-                logger.debug("all unzipped in %s", dest_path)
+                logger.debug("all unzipped in %s", final_path)
             else:
                 logger.debug("moving %s", downloaded_file)
-                dest_path = dest_path / Path(downloaded_file).name
+                final_path = final_path / Path(downloaded_file).name
                 await async_on_threadpool(
                     # pylint: disable=cell-var-from-loop
-                    lambda: shutil.move(str(downloaded_file), dest_path)
+                    lambda: shutil.move(str(downloaded_file), final_path)
                 )
 
                 # NOTE: after the download the current value of the port
                 # makes sure previously downloaded files are removed
-                dest_folder.prune(exclude={dest_path})
+                dest_folder.prune(exclude={final_path})
 
-                logger.debug("all moved to %s", dest_path)
+                logger.debug("all moved to %s", final_path)
         else:
-            transferred_bytes = transferred_bytes + sys.getsizeof(value)
+            transferred_bytes = sys.getsizeof(port_data)
 
-    return data, ByteSize(transferred_bytes)
+        return port, port_data, ByteSize(transferred_bytes)
 
 
 @run_sequentially_in_context()
 async def download_target_ports(
     port_type_name: PortTypeName,
-    target_path: Path,
+    target_dir: Path,
     port_keys: list[str],
     io_log_redirect_cb: LogRedirectCB,
+    progress_bar: ProgressBarData,
 ) -> ByteSize:
     logger.debug("retrieving data from simcore...")
     start_time = time.perf_counter()
@@ -287,21 +273,33 @@ async def download_target_ports(
     )
 
     # let's gather all the data
-    download_tasks: deque[Coroutine[Any, int, Any]] = deque()
-    for port_value in (await getattr(PORTS, port_type_name.value)).values():
-        # if port_keys contains some keys only download them
-        logger.debug("Checking node %s", port_value.key)
-        if port_keys and port_value.key not in port_keys:
-            continue
-        # collect coroutines
-        download_tasks.append(_get_data_from_port(port_value))
-    logger.debug("retrieving %s data", len(download_tasks))
-
-    data, transferred_bytes = await _download_files(target_path, download_tasks)
+    ports_to_get = [
+        port_value
+        for port_value in (await getattr(PORTS, port_type_name.value)).values()
+        if (not port_keys) or (port_value.key in port_keys)
+    ]
+    async with progress_bar.sub_progress(steps=len(ports_to_get)) as sub_progress:
+        results = await logged_gather(
+            *[
+                _get_data_from_port(
+                    port, target_dir=target_dir, progress_bar=sub_progress
+                )
+                for port in ports_to_get
+            ],
+            max_concurrency=4,
+        )
+    # parse results
+    data = {
+        port.key: {"key": port.key, "value": port_data}
+        for (port, port_data, port_transferred_bytes) in results
+    }
+    total_transfered_bytes = ByteSize(
+        sum(port_transferred_bytes for *_, port_transferred_bytes in results)
+    )
 
     # create/update the json file with the new values
     if data:
-        data_file = target_path / _KEY_VALUE_FILE_NAME
+        data_file = target_dir / _KEY_VALUE_FILE_NAME
         if data_file.exists():
             current_data = json.loads(data_file.read_text())
             # merge data
@@ -311,7 +309,7 @@ async def download_target_ports(
     elapsed_time = time.perf_counter() - start_time
     logger.info(
         "Downloaded %s in %s seconds",
-        transferred_bytes.human_readable(decimal=True),
+        total_transfered_bytes.human_readable(decimal=True),
         elapsed_time,
     )
-    return transferred_bytes
+    return total_transfered_bytes

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
@@ -8,6 +8,7 @@ from functools import partial
 from typing import Optional
 
 from fastapi import FastAPI
+from models_library.rabbitmq_messages import ProgressType
 from pydantic import PositiveFloat
 from pydantic.errors import PydanticErrorMixin
 from servicelib import progress_bar
@@ -15,7 +16,7 @@ from servicelib.background_task import start_periodic_task, stop_periodic_task
 from servicelib.logging_utils import log_catch, log_context
 from simcore_sdk.node_ports_common.file_io_utils import LogRedirectCB
 
-from ...core.rabbitmq import post_log_message
+from ...core.rabbitmq import post_log_message, post_progress_message
 from ...core.settings import ApplicationSettings
 from ..nodeports import upload_outputs
 from ._context import OutputsContext
@@ -100,6 +101,7 @@ class OutputsManager:  # pylint: disable=too-many-instance-attributes
         self,
         outputs_context: OutputsContext,
         io_log_redirect_cb: Optional[LogRedirectCB],
+        progress_cb: Optional[progress_bar.AsyncReportCB],
         *,
         upload_upon_api_request: bool = True,
         task_cancellation_timeout_s: PositiveFloat = 5,
@@ -110,6 +112,7 @@ class OutputsManager:  # pylint: disable=too-many-instance-attributes
         self.upload_upon_api_request = upload_upon_api_request
         self.task_cancellation_timeout_s = task_cancellation_timeout_s
         self.task_monitor_interval_s = task_monitor_interval_s
+        self.task_progress_cb = progress_cb
 
         self._port_key_tracker = _PortKeyTracker()
         self._task_uploading: Optional[Task] = None
@@ -125,7 +128,9 @@ class OutputsManager:  # pylint: disable=too-many-instance-attributes
 
         async def _upload_ports() -> None:
             with log_context(logger, logging.INFO, f"Uploading port keys: {port_keys}"):
-                async with progress_bar.ProgressBarData(steps=1) as root_progress:
+                async with progress_bar.ProgressBarData(
+                    steps=1, progress_report_cb=self.task_progress_cb
+                ) as root_progress:
                     await upload_outputs(
                         outputs_path=self.outputs_context.outputs_path,
                         port_keys=port_keys,
@@ -269,6 +274,9 @@ def setup_outputs_manager(app: FastAPI) -> None:
         outputs_manager = app.state.outputs_manager = OutputsManager(
             outputs_context=outputs_context,
             io_log_redirect_cb=io_log_redirect_cb,
+            progress_cb=partial(
+                post_progress_message, app, ProgressType.SERVICE_OUTPUTS_PUSHING
+            ),
         )
         await outputs_manager.start()
 

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_filter.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_filter.py
@@ -59,7 +59,7 @@ async def outputs_manager(
     outputs_context: OutputsContext,
 ) -> AsyncIterator[OutputsManager]:
     outputs_manager = OutputsManager(
-        outputs_context=outputs_context, io_log_redirect_cb=None
+        outputs_context=outputs_context, io_log_redirect_cb=None, progress_cb=None
     )
     await outputs_manager.start()
     yield outputs_manager

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
@@ -41,7 +41,9 @@ async def outputs_context(
 async def outputs_manager(
     outputs_context: OutputsContext,
 ) -> AsyncIterable[OutputsManager]:
-    outputs_manager = OutputsManager(outputs_context, io_log_redirect_cb=None)
+    outputs_manager = OutputsManager(
+        outputs_context, io_log_redirect_cb=None, progress_cb=None
+    )
     await outputs_manager.start()
 
     outputs_manager.set_all_ports_for_upload = AsyncMock()

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
@@ -171,6 +171,7 @@ async def outputs_manager(
         outputs_context=outputs_context,
         io_log_redirect_cb=None,
         task_monitor_interval_s=0.01,
+        progress_cb=None,
     )
     await outputs_manager.start()
     yield outputs_manager

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
@@ -7,7 +7,7 @@ import inspect
 from dataclasses import dataclass
 from inspect import FullArgSpec
 from pathlib import Path
-from typing import AsyncIterator, Iterator, Optional
+from typing import AsyncIterator, Iterator
 from unittest.mock import AsyncMock
 
 import pytest
@@ -19,7 +19,7 @@ from pytest import FixtureRequest, MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.utils_envs import EnvVarsDict
 from simcore_sdk.node_ports_common.exceptions import S3TransferError
-from simcore_sdk.node_ports_common.file_io_utils import LogRedirectCB, ProgressData
+from simcore_sdk.node_ports_common.file_io_utils import LogRedirectCB
 from simcore_service_dynamic_sidecar.core.settings import ApplicationSettings
 from simcore_service_dynamic_sidecar.modules.mounted_fs import MountedVolumes
 from simcore_service_dynamic_sidecar.modules.outputs._context import (
@@ -397,31 +397,29 @@ async def test_regression_io_log_redirect_cb(
         assert inspect.getfullargspec(
             outputs_manager.io_log_redirect_cb.func
         ) == FullArgSpec(
-            args=["app", "msg", "_"],
+            args=["app", "logs"],
             varargs=None,
             varkw=None,
-            defaults=(None,),
+            defaults=None,
             kwonlyargs=[],
             kwonlydefaults=None,
             annotations={
                 "return": None,
                 "app": FastAPI,
-                "msg": str,
-                "_": Optional[ProgressData],
+                "logs": str,
             },
         )
 
         # ensure logger used in nodeports deos not change
         assert inspect.getfullargspec(LogRedirectCB.__call__) == FullArgSpec(
-            args=["self", "msg", "progress_data"],
+            args=["self", "logs"],
             varargs=None,
             varkw=None,
-            defaults=(None,),
+            defaults=None,
             kwonlyargs=[],
             kwonlydefaults=None,
             annotations={
                 "return": None,
-                "msg": str,
-                "progress_data": Optional[ProgressData],
+                "logs": str,
             },
         )

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_watcher.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_watcher.py
@@ -96,6 +96,7 @@ async def outputs_manager(
         outputs_context=outputs_context,
         io_log_redirect_cb=None,
         task_monitor_interval_s=TICK_INTERVAL,
+        progress_cb=None,
     )
     await outputs_manager.start()
     yield outputs_manager

--- a/services/static-webserver/client/source/class/osparc/data/model/NodeProgressSequence.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/NodeProgressSequence.js
@@ -18,7 +18,7 @@
 /**
  * The progress sequence of a dynamic service is as follows:
  * - CLUSTER_UP_SCALING      (1)
- * - SIDECAR_PULLING         (2)
+ * - SIDECARS_PULLING        (2)
  * - SERVICE_INPUTS_PULLING  (3a)
  * - SERVICE_OUTPUTS_PULLING (3b)
  * - SERVICE_STATE_PULLING   (3c)
@@ -158,7 +158,7 @@ qx.Class.define("osparc.data.model.NodeProgressSequence", {
         case "CLUSTER_UP_SCALING":
           this.setClusterUpScaling(progress);
           break;
-        case "SIDECAR_PULLING":
+        case "SIDECARS_PULLING":
           this.setSidecarPulling(progress);
           break;
         case "SERVICE_INPUTS_PULLING":


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->


https://user-images.githubusercontent.com/35365065/215855621-cf474282-fb7b-4047-90ea-dd092d3df175.mp4

Some details:
- created a progress_bar module that allows to stack progresses in order to have sub, sub-sub-sub-N progresses, very useful for showing progress with deeply nested functions
- this progress_bar can use a hook (such as a method that throws a message in rabbitMQ, that gets forwarded to the frontend)
- fixed a typo in the frontend when looking for SIDECARS_PULLING
Logs now show unarchiving files progress:
![image](https://user-images.githubusercontent.com/35365065/215714366-2492b2b0-b59d-4594-a241-ecc8a042b6ce.png)

Current state of the progresses:
- cluster up scaling uses a 3 minutes time
- sidecars pulling is currently only sending 0 and 1 because it is not possible to know the pulling progress of a service from docker swarm
- inputs pulling, these are actually pulled **AFTER** the service is started and triggered by the frontend via the retrieve call (this should be changed in a later PR)
- outputs pulling, these are giving a quite precise progress bar
- image pulling, these are giving a rather unprecise progress bar, as the total size is not known a priori but at download time

**Important side changes**
- when pulling Inputs/Outputs, the old code was first downloading all ports, and then only sequentially decompressing them. This PR now does the download+decompressing concurrently.
- the compression of data was run in a ```ProcessPoolExecutor``` (1 worker). This is a problem when one wants to have a feedback on the progress. Also performance tests were run on 10000 files of 1MB (10GB in total), and the difference for compressing was measured to be <5%, therefore the ```ProcessPoolExecutor``` was replaced by a ```ThreadPoolExecutor```, see the whole test results in [test_results.md](https://github.com/ITISFoundation/osparc-simcore/files/10559821/test_results.md). These tests may be reproduced using https://github.com/sanderegg/osparc-simcore/blob/ed32d9ff9e4333ce3417777973edfe36a4d6f9d9/packages/service-library/tests/test_archiving_utils.py::test_archive_dir_performance (any comment welcome!)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
