### PR TITLE
✨ Feature: Maintenance Notification on ribbon

### DIFF
--- a/services/static-webserver/client/source/class/osparc/component/node/BaseNodeView.js
+++ b/services/static-webserver/client/source/class/osparc/component/node/BaseNodeView.js
@@ -369,7 +369,7 @@ qx.Class.define("osparc.component.node.BaseNodeView", {
       } else {
         this.__inputsButton.setIcon("@FontAwesome5Solid/sign-in-alt/14");
       }
-      osparc.utils.StatusUI.updateIconAnimation(buttonsIcon);
+      osparc.utils.StatusUI.updateCircleAnimation(buttonsIcon);
       this.__enableIframeContent(!waiting);
     },
 

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
@@ -49,7 +49,7 @@ qx.Class.define("osparc.component.notification.Notification", {
       let fullText = "";
       switch (this.getType()) {
         case "maintenance": {
-          fullText += qx.locale.Manager.tr("Maintenance scheduled.");
+          fullText += "<b>" + qx.locale.Manager.tr("Maintenance scheduled.") + "</b>";
           fullText += wLineBreak ? "<br>" : " ";
           fullText += this.getText() + ".";
           fullText += wLineBreak ? "<br>" : " ";

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
@@ -1,0 +1,70 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2023 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+qx.Class.define("osparc.component.notification.Notification", {
+  extend: qx.core.Object,
+
+  construct: function(text, type = "maintenance") {
+    this.base(arguments);
+
+    if (type) {
+      this.setType(type);
+    }
+
+    if (text) {
+      this.setText(text);
+    }
+  },
+
+  properties: {
+    type: {
+      check: ["maintenance"],
+      init: null,
+      nullable: false
+    },
+
+    text: {
+      check: "String",
+      init: "",
+      nullable: false
+    },
+
+    read: {
+      check: "Boolean",
+      init: false,
+      nullable: false,
+      event: "changeRead"
+    }
+  },
+
+  members: {
+    getFullText: function(wLineBreak = false) {
+      let fullText = "";
+      switch (this.getType()) {
+        case "maintenance": {
+          fullText += qx.locale.Manager.tr("Maintenance scheduled.");
+          fullText += wLineBreak ? "<br>" : " ";
+          fullText += this.getText() + ".";
+          fullText += wLineBreak ? "<br>" : " ";
+          fullText += qx.locale.Manager.tr("Please save your work and logout.");
+          break;
+        }
+      }
+      return fullText;
+    }
+  }
+});

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
@@ -41,13 +41,6 @@ qx.Class.define("osparc.component.notification.Notification", {
       check: "String",
       init: "",
       nullable: false
-    },
-
-    read: {
-      check: "Boolean",
-      init: false,
-      nullable: false,
-      event: "changeRead"
     }
   },
 

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
@@ -18,7 +18,7 @@
 qx.Class.define("osparc.component.notification.Notification", {
   extend: qx.core.Object,
 
-  construct: function(text, type = "maintenance") {
+  construct: function(text, type = "maintenance", closable = false) {
     this.base(arguments);
 
     if (text) {
@@ -27,6 +27,10 @@ qx.Class.define("osparc.component.notification.Notification", {
 
     if (type) {
       this.setType(type);
+    }
+
+    if (closable) {
+      this.setClosable(closable);
     }
   },
 
@@ -40,6 +44,12 @@ qx.Class.define("osparc.component.notification.Notification", {
     text: {
       check: "String",
       init: "",
+      nullable: false
+    },
+
+    closable: {
+      check: "Boolean",
+      init: true,
       nullable: false
     }
   },

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
@@ -49,7 +49,7 @@ qx.Class.define("osparc.component.notification.Notification", {
       let fullText = "";
       switch (this.getType()) {
         case "maintenance": {
-          fullText += "<b>" + qx.locale.Manager.tr("Maintenance scheduled.") + "</b>";
+          fullText += qx.locale.Manager.tr("Maintenance scheduled.");
           fullText += wLineBreak ? "<br>" : " ";
           fullText += this.getText() + ".";
           fullText += wLineBreak ? "<br>" : " ";

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
@@ -25,13 +25,8 @@ qx.Class.define("osparc.component.notification.Notification", {
       this.setText(text);
     }
 
-    if (type) {
-      this.setType(type);
-    }
-
-    if (closable) {
-      this.setClosable(closable);
-    }
+    this.setType(type);
+    this.setClosable(closable);
   },
 
   properties: {

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
@@ -21,12 +21,12 @@ qx.Class.define("osparc.component.notification.Notification", {
   construct: function(text, type = "maintenance") {
     this.base(arguments);
 
-    if (type) {
-      this.setType(type);
-    }
-
     if (text) {
       this.setText(text);
+    }
+
+    if (type) {
+      this.setType(type);
     }
   },
 

--- a/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
@@ -47,8 +47,13 @@ qx.Class.define("osparc.component.notification.NotificationsRibbon", {
       this.__updateRibbon();
     },
 
+    /**
+     * @param {osparc.component.notification.Notification} notification
+     */
     removeNotification: function(notification) {
-      this.__notifications.push(notification);
+      if (this.__notifications.indexOf(notification) > -1) {
+        this.__notifications.remove(notification);
+      }
       this.__updateRibbon();
     },
 

--- a/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
@@ -62,9 +62,9 @@ qx.Class.define("osparc.component.notification.NotificationsRibbon", {
       const notifications = this.__notifications;
       if (notifications.length) {
         this.show();
-        notifications.forEach(notificationUI => {
-          const text = notificationUI.getFullText();
-          const notification = new qx.ui.basic.Atom().set({
+        notifications.forEach(notification => {
+          const text = notification.getFullText();
+          const notificationAtom = new qx.ui.basic.Atom().set({
             label: text,
             icon: "@FontAwesome5Solid/exclamation-triangle/14",
             center: true,
@@ -72,17 +72,17 @@ qx.Class.define("osparc.component.notification.NotificationsRibbon", {
             gap: 10,
             height: 20
           });
-          notification.getChildControl("label").set({
+          notificationAtom.getChildControl("label").set({
             textColor: "black",
             font: "text-14",
             rich: true,
             wrap: true,
             selectable: true
           });
-          notification.getChildControl("icon").set({
+          notificationAtom.getChildControl("icon").set({
             textColor: "black"
           });
-          this._add(notification);
+          this._add(notificationAtom);
         });
       } else {
         this.exclude();

--- a/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
@@ -1,0 +1,71 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2023 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+qx.Class.define("osparc.component.notification.NotificationsRibbon", {
+  extend: qx.ui.core.Widget,
+
+  construct: function() {
+    this.base(arguments);
+
+    this._setLayout(new qx.ui.layout.VBox());
+
+    this.set({
+      backgroundColor: "warning-yellow",
+      alignX: "center",
+      alignY: "middle",
+      visibility: "excluded"
+    });
+
+    const notifications = osparc.component.notification.Notifications.getInstance();
+    notifications.getNotifications().addListener("change", () => this.__updateNotificationsButton(), this);
+    this.__updateNotificationsButton();
+  },
+
+  members: {
+    __updateNotificationsButton: function() {
+      const notifications = osparc.component.notification.Notifications.getInstance().getNotifications();
+      if (notifications.length) {
+        this.show();
+        this._removeAll();
+        notifications.forEach(notificationUI => {
+          let text = notificationUI.getText();
+          text = text.replaceAll("<br>", ". ");
+          const notification = new qx.ui.basic.Atom().set({
+            label: text,
+            icon: "@FontAwesome5Solid/exclamation-triangle/16",
+            center: true,
+            padding: 2,
+            gap: 15,
+            height: 20
+          });
+          notification.getChildControl("label").set({
+            textColor: "black",
+            font: "text-14",
+            rich: true,
+            wrap: true
+          });
+          notification.getChildControl("icon").set({
+            textColor: "black"
+          });
+          this._add(notification);
+        });
+      } else {
+        this.exclude();
+      }
+    }
+  }
+});

--- a/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
@@ -82,7 +82,19 @@ qx.Class.define("osparc.component.notification.NotificationsRibbon", {
           notificationAtom.getChildControl("icon").set({
             textColor: "black"
           });
-          this._add(notificationAtom);
+          if (notification.getClosable()) {
+            const closableLayout = new qx.ui.container.Composite(new qx.ui.layout.HBox(5, "center"));
+            closableLayout.add(notificationAtom);
+            const closeButton = new qx.ui.form.Button(null, "@FontAwesome5Solid/times/12").set({
+              backgroundColor: "transparent",
+              textColor: "black"
+            });
+            closeButton.addListener("tap", () => this.removeNotification(notification), this);
+            closableLayout.add(closeButton);
+            this._add(closableLayout);
+          } else {
+            this._add(notificationAtom);
+          }
         });
       } else {
         this.exclude();

--- a/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
@@ -17,11 +17,14 @@
 
 qx.Class.define("osparc.component.notification.NotificationsRibbon", {
   extend: qx.ui.core.Widget,
+  type: "singleton",
 
   construct: function() {
     this.base(arguments);
 
     this._setLayout(new qx.ui.layout.VBox());
+
+    this.__notifications = new qx.data.Array();
 
     this.set({
       backgroundColor: "warning-yellow",
@@ -30,20 +33,33 @@ qx.Class.define("osparc.component.notification.NotificationsRibbon", {
       visibility: "excluded"
     });
 
-    const notifications = osparc.component.notification.Notifications.getInstance();
-    notifications.getNotifications().addListener("change", () => this.__updateNotificationsButton(), this);
-    this.__updateNotificationsButton();
+    this.__updateRibbon();
   },
 
   members: {
-    __updateNotificationsButton: function() {
-      const notifications = osparc.component.notification.Notifications.getInstance().getNotifications();
+    __notifications: null,
+
+    /**
+     * @param {osparc.component.notification.Notification} notification
+     */
+    addNotification: function(notification) {
+      this.__notifications.push(notification);
+      this.__updateRibbon();
+    },
+
+    removeNotification: function(notification) {
+      this.__notifications.push(notification);
+      this.__updateRibbon();
+    },
+
+    __updateRibbon: function() {
+      const notifications = this.__notifications;
+      console.log("notifications", notifications);
       if (notifications.length) {
         this.show();
         this._removeAll();
         notifications.forEach(notificationUI => {
-          let text = notificationUI.getText();
-          text = text.replaceAll("<br>", ". ");
+          const text = notificationUI.getFullText();
           const notification = new qx.ui.basic.Atom().set({
             label: text,
             icon: "@FontAwesome5Solid/exclamation-triangle/16",

--- a/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
@@ -54,7 +54,6 @@ qx.Class.define("osparc.component.notification.NotificationsRibbon", {
 
     __updateRibbon: function() {
       const notifications = this.__notifications;
-      console.log("notifications", notifications);
       if (notifications.length) {
         this.show();
         this._removeAll();

--- a/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
@@ -58,10 +58,10 @@ qx.Class.define("osparc.component.notification.NotificationsRibbon", {
     },
 
     __updateRibbon: function() {
+      this._removeAll();
       const notifications = this.__notifications;
       if (notifications.length) {
         this.show();
-        this._removeAll();
         notifications.forEach(notificationUI => {
           const text = notificationUI.getFullText();
           const notification = new qx.ui.basic.Atom().set({

--- a/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
@@ -66,7 +66,7 @@ qx.Class.define("osparc.component.notification.NotificationsRibbon", {
           const text = notificationUI.getFullText();
           const notification = new qx.ui.basic.Atom().set({
             label: text,
-            icon: "@FontAwesome5Solid/exclamation-triangle/16",
+            icon: "@FontAwesome5Solid/exclamation-triangle/14",
             center: true,
             padding: 2,
             gap: 10,

--- a/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
@@ -65,14 +65,15 @@ qx.Class.define("osparc.component.notification.NotificationsRibbon", {
             icon: "@FontAwesome5Solid/exclamation-triangle/16",
             center: true,
             padding: 2,
-            gap: 15,
+            gap: 10,
             height: 20
           });
           notification.getChildControl("label").set({
             textColor: "black",
             font: "text-14",
             rich: true,
-            wrap: true
+            wrap: true,
+            selectable: true
           });
           notification.getChildControl("icon").set({
             textColor: "black"

--- a/services/static-webserver/client/source/class/osparc/component/permissions/PublishTemplateWith.js
+++ b/services/static-webserver/client/source/class/osparc/component/permissions/PublishTemplateWith.js
@@ -85,7 +85,7 @@ qx.Class.define("osparc.component.permissions.PublishTemplateWith", {
       },
       "productAll": {
         contextId: 2,
-        label: "Public for product users"
+        label: "Public for Product users"
       },
       "all": {
         contextId: 3,

--- a/services/static-webserver/client/source/class/osparc/component/permissions/PublishTemplateWith.js
+++ b/services/static-webserver/client/source/class/osparc/component/permissions/PublishTemplateWith.js
@@ -85,11 +85,11 @@ qx.Class.define("osparc.component.permissions.PublishTemplateWith", {
       },
       "productAll": {
         contextId: 2,
-        label: "Product Everyone"
+        label: "Public for product users"
       },
       "all": {
         contextId: 3,
-        label: "Everyone"
+        label: "Public"
       }
     }
   },

--- a/services/static-webserver/client/source/class/osparc/component/permissions/Service.js
+++ b/services/static-webserver/client/source/class/osparc/component/permissions/Service.js
@@ -72,7 +72,7 @@ qx.Class.define("osparc.component.permissions.Service", {
     getEveryoneObj: function() {
       return {
         "gid": 1,
-        "label": "Everyone",
+        "label": "Public",
         "description": "",
         "thumbnail": null,
         "accessRights": this.getCollaboratorAccessRight(),

--- a/services/static-webserver/client/source/class/osparc/component/permissions/Study.js
+++ b/services/static-webserver/client/source/class/osparc/component/permissions/Study.js
@@ -96,7 +96,7 @@ qx.Class.define("osparc.component.permissions.Study", {
     getEveryoneObj: function(isResourceStudy) {
       return {
         "gid": 1,
-        "label": "Everyone",
+        "label": "Public",
         "description": "",
         "thumbnail": null,
         "accessRights": isResourceStudy ? this.getCollaboratorAccessRight() : this.getViewerAccessRight(),

--- a/services/static-webserver/client/source/class/osparc/component/task/TasksButton.js
+++ b/services/static-webserver/client/source/class/osparc/component/task/TasksButton.js
@@ -41,6 +41,7 @@ qx.Class.define("osparc.component.task.TasksButton", {
       switch (id) {
         case "icon": {
           control = new qx.ui.basic.Image("@FontAwesome5Solid/cog/24");
+          osparc.utils.Utils.addClass(control.getContentElement(), "rotate");
 
           const logoContainer = new qx.ui.container.Composite(new qx.ui.layout.HBox().set({
             alignY: "middle"

--- a/services/static-webserver/client/source/class/osparc/component/widget/SlideBar.js
+++ b/services/static-webserver/client/source/class/osparc/component/widget/SlideBar.js
@@ -85,7 +85,7 @@ qx.Class.define("osparc.component.widget.SlideBar", {
       const size = this.getInnerSize();
       if (size) {
         this.set({
-          scrollStep: parseInt(size.width/0.9)
+          scrollStep: size.width
         });
       }
       const buttonBackward = this.getChildControl("button-backward");

--- a/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
@@ -78,7 +78,7 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
         return null;
       }
 
-      let text = qx.locale.Manager.tr("Maintenance scheduled");
+      let text = qx.locale.Manager.tr("Maintenance scheduled.");
       if (this.getStart()) {
         text += "<br>";
         text += osparc.utils.Utils.formatDateAndTime(this.getStart());
@@ -91,7 +91,7 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
         text += ": " + this.getReason();
       }
       text += "<br>";
-      text += qx.locale.Manager.tr("Please save your work and logout");
+      text += qx.locale.Manager.tr("Please save your work and logout.");
       return text;
     },
 

--- a/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
@@ -144,7 +144,8 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
       const messageToRibbon = () => {
         const text = this.__getText();
         const notification = new osparc.component.notification.Notification(text);
-        this.__lastRibbonMessage = osparc.component.notification.NotificationsRibbon.getInstance().addNotification(notification);
+        osparc.component.notification.NotificationsRibbon.getInstance().addNotification(notification);
+        this.__lastRibbonMessage = notification;
       };
       const now = new Date();
       const diff = this.getStart().getTime() - now.getTime() - this.self().WARN_IN_ADVANCE;
@@ -157,7 +158,7 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
 
     __removeRibbonMessage: function() {
       if (this.__lastRibbonMessage) {
-        osparc.component.message.FlashMessenger.getInstance().removeMessage(this.__lastRibbonMessage);
+        osparc.component.notification.NotificationsRibbon.getInstance().removeNotification(this.__lastRibbonMessage);
         this.__lastRibbonMessage = null;
       }
     },

--- a/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
@@ -73,23 +73,18 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
       }
     },
 
-    __getText: function(wDecoration = true) {
+    __getText: function() {
       if (this.getStart() === null) {
         return null;
       }
 
-      let text = wDecoration ? qx.locale.Manager.tr("Maintenance scheduled.") : "";
-      if (this.getStart()) {
-        text += wDecoration ? "<br>" : "";
-        text += osparc.utils.Utils.formatDateAndTime(this.getStart());
-      }
+      let text = osparc.utils.Utils.formatDateAndTime(this.getStart());
       if (this.getEnd()) {
         text += " - " + osparc.utils.Utils.formatDateAndTime(this.getEnd());
       }
       if (this.getReason()) {
         text += ": " + this.getReason();
       }
-      text += wDecoration ? "<br>" + qx.locale.Manager.tr("Please save your work and logout.") : "";
       return text;
     },
 
@@ -131,8 +126,9 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
       this.__removeNotification();
 
       const text = this.__getText();
-      const notification = this.__lastNotification = new osparc.component.notification.NotificationUI(text);
-      osparc.component.notification.Notifications.getInstance().addNotification(notification);
+      const notification = new osparc.component.notification.Notification(text);
+      const notificationUI = this.__lastNotification = new osparc.component.notification.NotificationUI(notification.getFullText(true));
+      osparc.component.notification.Notifications.getInstance().addNotification(notificationUI);
     },
 
     __removeNotification: function() {
@@ -146,7 +142,7 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
       this.__removeRibbonMessage();
 
       const messageToRibbon = () => {
-        const text = this.__getText(false);
+        const text = this.__getText();
         const notification = new osparc.component.notification.Notification(text);
         this.__lastRibbonMessage = osparc.component.notification.NotificationsRibbon.getInstance().addNotification(notification);
       };

--- a/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/data/MaintenanceTracker.js
@@ -40,7 +40,7 @@ qx.Class.define("osparc.data.MaintenanceTracker", {
   },
 
   statics: {
-    CHECK_INTERVAL: 15*1000, // Check every 15'
+    CHECK_INTERVAL: 15*60*1000, // Check every 15'
     WARN_IN_ADVANCE: 20*60*1000 // Show Ribbon Message 20' in advance
   },
 

--- a/services/static-webserver/client/source/class/osparc/data/model/NodeProgressSequence.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/NodeProgressSequence.js
@@ -91,7 +91,7 @@ qx.Class.define("osparc.data.model.NodeProgressSequence", {
         gap: 15
       });
       const icon = atom.getChildControl("icon");
-      osparc.utils.StatusUI.updateIconAnimation(icon);
+      osparc.utils.StatusUI.updateCircleAnimation(icon);
       return atom;
     },
 
@@ -119,7 +119,7 @@ qx.Class.define("osparc.data.model.NodeProgressSequence", {
           atom.setIcon("@FontAwesome5Solid/circle-notch/16");
         }
         const icon = atom.getChildControl("icon");
-        osparc.utils.StatusUI.updateIconAnimation(icon);
+        osparc.utils.StatusUI.updateCircleAnimation(icon);
       }
 
       if (pBar) {

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -45,6 +45,9 @@ qx.Class.define("osparc.desktop.MainPage", {
 
     this._setLayout(new qx.ui.layout.VBox(null, null, "separator-vertical"));
 
+    const notificationsRibbon = this.__createNotificationsRibbon();
+    this._add(notificationsRibbon);
+
     const navBar = this.__navBar = this.__createNavigationBar();
     this._add(navBar);
 
@@ -72,6 +75,11 @@ qx.Class.define("osparc.desktop.MainPage", {
     __dashboardLayout: null,
     __loadingPage: null,
     __studyEditor: null,
+
+    __createNotificationsRibbon: function() {
+      const notificationsRibbon = new osparc.component.notification.NotificationsRibbon();
+      return notificationsRibbon;
+    },
 
     __createNavigationBar: function() {
       const navBar = new osparc.navigation.NavigationBar();

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -45,8 +45,7 @@ qx.Class.define("osparc.desktop.MainPage", {
 
     this._setLayout(new qx.ui.layout.VBox(null, null, "separator-vertical"));
 
-    const notificationsRibbon = this.__createNotificationsRibbon();
-    this._add(notificationsRibbon);
+    this._add(osparc.component.notification.NotificationsRibbon.getInstance());
 
     const navBar = this.__navBar = this.__createNavigationBar();
     this._add(navBar);
@@ -75,11 +74,6 @@ qx.Class.define("osparc.desktop.MainPage", {
     __dashboardLayout: null,
     __loadingPage: null,
     __studyEditor: null,
-
-    __createNotificationsRibbon: function() {
-      const notificationsRibbon = new osparc.component.notification.NotificationsRibbon();
-      return notificationsRibbon;
-    },
 
     __createNavigationBar: function() {
       const navBar = new osparc.navigation.NavigationBar();

--- a/services/static-webserver/client/source/class/osparc/navigation/BreadcrumbsSlideshow.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/BreadcrumbsSlideshow.js
@@ -94,7 +94,7 @@ qx.Class.define("osparc.navigation.BreadcrumbsSlideshow", {
           const check = node.isDynamic() ? "interactive" : "output";
           node.getStatus().bind(check, statusIcon, "source", {
             converter: output => osparc.utils.StatusUI.getIconSource(output),
-            onUpdate: (_, target) => osparc.utils.StatusUI.updateIconAnimation(target)
+            onUpdate: (_, target) => osparc.utils.StatusUI.updateCircleAnimation(target)
           });
           node.getStatus().bind(check, statusIcon, "textColor", {
             converter: output => osparc.utils.StatusUI.getColor(output)

--- a/services/static-webserver/client/source/class/osparc/ui/basic/NodeStatusUI.js
+++ b/services/static-webserver/client/source/class/osparc/ui/basic/NodeStatusUI.js
@@ -119,7 +119,7 @@ qx.Class.define("osparc.ui.basic.NodeStatusUI", {
       this.getNode().getStatus().bind("interactive", this.__icon, "source", {
         converter: state => osparc.utils.StatusUI.getIconSource(state),
         onUpdate: (source, target) => {
-          osparc.utils.StatusUI.updateIconAnimation(this.__icon);
+          osparc.utils.StatusUI.updateCircleAnimation(this.__icon);
           const props = qx.util.PropertyUtil.getProperties(osparc.data.model.NodeStatus);
           const state = source.getInteractive();
           if (props["interactive"]["check"].includes(state)) {

--- a/services/static-webserver/client/source/class/osparc/ui/message/Loading.js
+++ b/services/static-webserver/client/source/class/osparc/ui/message/Loading.js
@@ -115,7 +115,7 @@ qx.Class.define("osparc.ui.message.Loading", {
         wrap: true
       });
       const icon = atom.getChildControl("icon");
-      osparc.utils.StatusUI.updateIconAnimation(icon);
+      osparc.utils.StatusUI.updateCircleAnimation(icon);
 
       const messages = this.__messages = new qx.ui.container.Composite(new qx.ui.layout.VBox(10).set({
         alignX: "center"
@@ -182,7 +182,7 @@ qx.Class.define("osparc.ui.message.Loading", {
         const iconSource = osparc.utils.StatusUI.getIconSource(state.toLowerCase(), this.self().STATUS_ICON_SIZE);
         if (iconSource) {
           this.__header.setIcon(iconSource);
-          osparc.utils.StatusUI.updateIconAnimation(this.__header.getChildControl("icon"));
+          osparc.utils.StatusUI.updateCircleAnimation(this.__header.getChildControl("icon"));
         }
       }
     },

--- a/services/static-webserver/client/source/class/osparc/utils/StatusUI.js
+++ b/services/static-webserver/client/source/class/osparc/utils/StatusUI.js
@@ -99,7 +99,7 @@ qx.Class.define("osparc.utils.StatusUI", {
       }
     },
 
-    updateIconAnimation: function(target) {
+    updateCircleAnimation: function(target) {
       const elem = target.getContentElement();
       if (target.getSource() && target.getSource().includes("circle-notch")) {
         osparc.utils.Utils.addClass(elem, "rotate");

--- a/services/static-webserver/client/source/class/osparc/viewer/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/viewer/MainPage.js
@@ -21,10 +21,16 @@ qx.Class.define("osparc.viewer.MainPage", {
   construct: function(studyId, viewerNodeId) {
     this.base();
 
-    this._setLayout(new qx.ui.layout.VBox());
+    this._setLayout(new qx.ui.layout.VBox(null, null, "separator-vertical"));
+
+    const notificationsRibbon = this.__createNotificationsRibbon();
+    this._add(notificationsRibbon);
 
     const navBar = this.__createNavigationBar();
     this._add(navBar);
+
+    // Some resources request before building the main stack
+    osparc.data.MaintenanceTracker.getInstance().startTracker();
 
     const nodeViewer = this.__createNodeViewer(studyId, viewerNodeId);
     this._add(nodeViewer, {
@@ -34,6 +40,11 @@ qx.Class.define("osparc.viewer.MainPage", {
 
   members: {
     __iframeLayout: null,
+
+    __createNotificationsRibbon: function() {
+      const notificationsRibbon = new osparc.component.notification.NotificationsRibbon();
+      return notificationsRibbon;
+    },
 
     __createNavigationBar: function() {
       const navBar = new osparc.viewer.NavigationBar();

--- a/services/static-webserver/client/source/class/osparc/viewer/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/viewer/MainPage.js
@@ -23,8 +23,7 @@ qx.Class.define("osparc.viewer.MainPage", {
 
     this._setLayout(new qx.ui.layout.VBox(null, null, "separator-vertical"));
 
-    const notificationsRibbon = this.__createNotificationsRibbon();
-    this._add(notificationsRibbon);
+    this._add(osparc.component.notification.NotificationsRibbon.getInstance());
 
     const navBar = this.__createNavigationBar();
     this._add(navBar);
@@ -40,11 +39,6 @@ qx.Class.define("osparc.viewer.MainPage", {
 
   members: {
     __iframeLayout: null,
-
-    __createNotificationsRibbon: function() {
-      const notificationsRibbon = new osparc.component.notification.NotificationsRibbon();
-      return notificationsRibbon;
-    },
 
     __createNavigationBar: function() {
       const navBar = new osparc.viewer.NavigationBar();


### PR DESCRIPTION
## What do these changes do?

Maintenance Notifications, instead of being shown as Flash Messages, they now go to the Ribbon.

A closable Notification is added 12h in advance and a permanent one will replace it/will be shown 30' in advance.

![MaintenanceBanner](https://user-images.githubusercontent.com/33152403/215457117-ccd342ce-16d2-4690-9df6-72121b7fd472.gif)


#### Bonus:
- [x] Scroll Step: Set to container width


## Related issue/s

ITISFoundation/osparc-issues#765


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
