### PR TITLE
✨ Frontend: Increase light theme's contrast

### DIFF
--- a/services/static-webserver/client/source/class/osparc/component/form/tag/TagItem.js
+++ b/services/static-webserver/client/source/class/osparc/component/form/tag/TagItem.js
@@ -176,7 +176,7 @@ qx.Class.define("osparc.component.form.tag.TagItem", {
             });
             this.__colorInput.bind("value", this.getChildControl("colorbutton"), "backgroundColor");
             this.__colorInput.bind("value", this.getChildControl("colorbutton"), "textColor", {
-              converter: value => qx.theme.manager.Color.getInstance().resolve(osparc.utils.Utils.getContrastedTextColor(value))
+              converter: value => osparc.utils.Utils.getContrastedBinaryColor(value)
             });
             this.__validationManager.add(this.__colorInput, osparc.utils.Validators.hexColor);
           }

--- a/services/static-webserver/client/source/class/osparc/theme/Appearance.js
+++ b/services/static-webserver/client/source/class/osparc/theme/Appearance.js
@@ -453,7 +453,8 @@ qx.Theme.define("osparc.theme.Appearance", {
       include: "material-button",
       style: state => ({
         decorator: state.hovered ? "strong-bordered-button" : "no-border",
-        backgroundColor: "strong-main"
+        backgroundColor: "strong-main",
+        textColor: "#d2d8dc" // dark theme's text color
       })
     },
 
@@ -462,7 +463,7 @@ qx.Theme.define("osparc.theme.Appearance", {
       style: state => ({
         decorator: "bordered-button",
         backgroundColor: state.hovered ? "danger-red" : null,
-        textColor: state.hovered ? "text" : "danger-red"
+        textColor: state.hovered ? "#d2d8dc" : "danger-red" // dark theme's text color
       })
     },
 

--- a/services/static-webserver/client/source/class/osparc/theme/zmt/ColorLight.js
+++ b/services/static-webserver/client/source/class/osparc/theme/zmt/ColorLight.js
@@ -5,12 +5,12 @@ qx.Theme.define("osparc.theme.zmt.ColorLight", {
     "c00": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 0),
     "c01": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 8),
     "c02": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 15),
-    "c03": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 20),
-    "c04": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 25),
-    "c05": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 30),
-    "c06": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 35),
-    "c07": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 45),
-    "c08": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 55),
+    "c03": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 25),
+    "c04": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 35),
+    "c05": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 45),
+    "c06": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 55),
+    "c07": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 60),
+    "c08": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 65),
     "c09": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 70),
     "c10": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 80),
     "c11": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 85),
@@ -18,7 +18,8 @@ qx.Theme.define("osparc.theme.zmt.ColorLight", {
     "c13": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 100),
     "c14": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.static.base", 105),
 
-    "strong-main": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.zmt", 65),
+    // "strong-main": osparc.theme.colorProvider.ColorProvider.getColor("color.scales.zmt", 65),
+    "strong-main": "rgba(0, 144, 208, 1)",
     "a-bit-transparent": "rgba(255, 255, 255, 0.4)",
 
 
@@ -51,8 +52,8 @@ qx.Theme.define("osparc.theme.zmt.ColorLight", {
     "window-caption-text-active": "c12",
 
     // material-button
-    "material-button-background": "c03",
-    "material-button-background-disabled": "c02",
+    "material-button-background": "c04",
+    "material-button-background-disabled": "c03",
     "material-button-background-hovered": "c05",
     "material-button-background-pressed": "c05",
     "material-button-text-disabled": "c07",
@@ -93,8 +94,8 @@ qx.Theme.define("osparc.theme.zmt.ColorLight", {
     "border-lead": "c07",
 
     // window
-    "window-border": "c04",
-    "window-border-inner": "c01",
+    "window-border": "c03",
+    "window-border-inner": "c02",
 
     // group box
     "white-box-border": "c03",

--- a/services/static-webserver/client/source/class/osparc/ui/basic/Tag.js
+++ b/services/static-webserver/client/source/class/osparc/ui/basic/Tag.js
@@ -48,7 +48,7 @@ qx.Class.define("osparc.ui.basic.Tag", {
     _applyColor: function(color) {
       this.setBackgroundColor(color);
       // Set the right color for the font
-      const textColor = qx.theme.manager.Color.getInstance().resolve(osparc.utils.Utils.getContrastedTextColor(color));
+      const textColor = osparc.utils.Utils.getContrastedBinaryColor(color);
       this.setTextColor(textColor);
     }
   }

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -467,6 +467,11 @@ qx.Class.define("osparc.utils.Utils", {
       return L > 0.35 ? "contrasted-text-dark" : "contrasted-text-light";
     },
 
+    getContrastedBinaryColor: function(color) {
+      const L = this.getColorLuminance(color);
+      return L > 0.35 ? "#202020" : "#D0D0D0";
+    },
+
     getRoundedBinaryColor: function(color) {
       const L = this.getColorLuminance(color);
       return L > 0.35 ? "#FFF" : "#000";


### PR DESCRIPTION
## What do these changes do?

As reported by @eofli, the light theme needs some love and also contrast in its basic color palette. This PR only brings the contrast thing.

Notice the buttons and strong button's text color.

### Bonus:
- [x] Tag's text color theme independent

Before:
![Before](https://user-images.githubusercontent.com/33152403/215532697-03575700-abbc-41cf-8eb2-6646ba6f48c4.gif)

After:
![After](https://user-images.githubusercontent.com/33152403/215532061-a3ca3ffe-046d-40c7-ad16-b4704c8b2995.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
