### PR TITLE
🐛 Removing overlay from docker-compose spec

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_compose_egress_config.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_compose_egress_config.py
@@ -164,10 +164,7 @@ def _add_egress_proxy_network(
     service_spec: ComposeSpecLabel, egress_proxy_name: str
 ) -> None:
     networks = service_spec.get("networks")
-    networks[_get_egress_proxy_network_name(egress_proxy_name)] = {
-        "driver": "overlay",
-        "internal": True,
-    }
+    networks[_get_egress_proxy_network_name(egress_proxy_name)] = {"internal": True}
     service_spec["networks"] = networks
 
 
@@ -280,8 +277,7 @@ def add_egress_configuration(
         # placing containers with internet access in an isolated network
         service_networks = service_spec.setdefault("networks", {})
         service_networks[_DEFAULT_USER_SERVICES_NETWORK_WITH_INTERNET_NAME] = {
-            "driver": "overlay",
-            "internal": False,
+            "internal": False
         }
         # attach to network
         for (

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/validation.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/validation.py
@@ -143,7 +143,6 @@ def _connect_user_services(
     networks = parsed_compose_spec["networks"]
 
     networks[DEFAULT_USER_SERVICES_NETWORK_NAME] = {
-        "driver": "overlay",
         "internal": not allow_internet_access,
     }
 

--- a/services/dynamic-sidecar/tests/unit/test_api_containers.py
+++ b/services/dynamic-sidecar/tests/unit/test_api_containers.py
@@ -350,7 +350,6 @@ async def test_start_same_space_twice(compose_spec: str, test_client: TestClient
 
 
 async def test_containers_get(
-    docker_swarm: None,
     test_client: TestClient,
     started_containers: list[str],
     ensure_external_volumes: None,
@@ -366,7 +365,6 @@ async def test_containers_get(
 
 
 async def test_containers_get_status(
-    docker_swarm: None,
     test_client: TestClient,
     started_containers: list[str],
     ensure_external_volumes: None,
@@ -389,7 +387,6 @@ async def test_containers_get_status(
 
 
 async def test_containers_docker_status_docker_error(
-    docker_swarm: None,
     test_client: TestClient,
     started_containers: list[str],
     mock_aiodocker_containers_get: int,
@@ -399,7 +396,7 @@ async def test_containers_docker_status_docker_error(
 
 
 async def test_container_inspect_logs_remove(
-    docker_swarm: None, test_client: TestClient, started_containers: list[str]
+    test_client: TestClient, started_containers: list[str]
 ):
     for container in started_containers:
         # get container logs
@@ -415,7 +412,7 @@ async def test_container_inspect_logs_remove(
 
 
 async def test_container_logs_with_timestamps(
-    docker_swarm: None, test_client: TestClient, started_containers: list[str]
+    test_client: TestClient, started_containers: list[str]
 ):
     for container in started_containers:
         print("getting logs of container", container, "...")
@@ -448,7 +445,6 @@ async def test_container_missing_container(
 
 
 async def test_container_docker_error(
-    docker_swarm: None,
     test_client: TestClient,
     started_containers: list[str],
     mock_aiodocker_containers_get: int,
@@ -603,7 +599,6 @@ def _get_entrypoint_container_name(test_client: TestClient) -> str:
 
 @pytest.mark.parametrize("include_exclude_filter_option", [True, False])
 async def test_containers_entrypoint_name_ok(
-    docker_swarm: None,
     test_client: TestClient,
     dynamic_sidecar_network_name: str,
     started_containers: list[str],
@@ -623,7 +618,6 @@ async def test_containers_entrypoint_name_ok(
 
 @pytest.mark.parametrize("include_exclude_filter_option", [True, False])
 async def test_containers_entrypoint_name_containers_not_started(
-    docker_swarm: None,
     test_client: TestClient,
     dynamic_sidecar_network_name: str,
     started_containers: list[str],

--- a/services/dynamic-sidecar/tests/unit/test_api_containers_long_running_tasks.py
+++ b/services/dynamic-sidecar/tests/unit/test_api_containers_long_running_tasks.py
@@ -349,7 +349,6 @@ async def _debug_progress(message: str, percent: float, task_id: TaskId) -> None
 
 
 async def test_create_containers_task(
-    docker_swarm: None,
     httpx_async_client: AsyncClient,
     client: Client,
     compose_spec: str,


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

_The art of copy and pasting is something very few manage to master. I am really bad at it.🤦_ 

PR https://github.com/ITISFoundation/osparc-simcore/pull/3606 broke the sidecars not running on manager nodes.
Removed `overlay` driver from the service docker-compose spec. The node needs to be a swarm manager in order to use it. It is also not necessary in this case.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->
- fixes issue introduced by https://github.com/ITISFoundation/osparc-simcore/pull/3606

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist
