### PR TITLE
🐛 Add MIME date field to mails 

### DIFF
--- a/services/web/server/src/simcore_service_webserver/login/utils_email.py
+++ b/services/web/server/src/simcore_service_webserver/login/utils_email.py
@@ -4,6 +4,7 @@ from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.utils import formatdate
 from os.path import join
 from pathlib import Path
 from pprint import pformat
@@ -22,6 +23,9 @@ log = logging.getLogger(__name__)
 
 
 async def _send_mail(*, message: Union[MIMEText, MIMEMultipart], cfg: LoginOptions):
+    # Add DATE header field, it is mandatory
+    message["Date"] = formatdate(localtime=True)
+    #
     log.debug("Email configuration %s", cfg)
     smtp_args = dict(
         hostname=cfg.SMTP_HOST,


### PR DESCRIPTION
After some upgrades and tests with the `osparc.io` mailserver, it showed that the MIMEtext of mails sent by the osparc webserver does not fully conform to the spec. The message needs to contain a valid `DATE` field, otherwise they will not be relayed anymore:

```
The message WAS NOT relayed to:
  [<kaiser@itis.swiss>](mailto:kaiser@itis.swiss):
   554 5.6.0 Bounce, id=00686-13 - BAD HEADER

This nondelivery report was generated by the program amavisd-new at host
smtp.osparc.io. Our internal reference code for your message is
00686-13/XpU25LIw1dSF

INVALID HEADER

  Missing required header field: "Date"

Return-Path: [<s4l-lite@osparc.io>](mailto:s4l-lite@osparc.io)
From: [s4l-lite@osparc.io](mailto:s4l-lite@osparc.io)
Subject: =?utf-8?q?=F0=9F=90=BC_Reset_your_password_on_s4l-lite=2Eio?=
```

Currently, to enable us to send mails, the process asserting that the mails are complaint is disabled on aws-production (`ENABLE_AMAVIS=0`).

This github discussion gives an overview of the problems that spawn when mails do not adhere to the MIME specification: https://github.com/nylas/nylas-mail/issues/1246 . Among other things, `amavis` will flag the mail and spam-filters will apply a penalty, resulting in osparc-mails being flagged as spam more often.


This PR adds a code-line that is used in the e2e-ops mailserver test and works there. For now, due to limited bandwidth and knowhow, I have not added tests or checks. This PR could be tested in master (it might also break things), or can be taken over by a developer.