### PR TITLE
🐛 Saving data when closing a service is done only after checking

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
@@ -3,6 +3,7 @@ import logging
 import sqlalchemy as sa
 from aiopg.sa.result import RowProxy
 from models_library.projects import ProjectAtDB, ProjectID
+from models_library.projects_nodes_io import NodeID
 
 from ....core.errors import ProjectNotFoundError
 from ..tables import projects
@@ -22,3 +23,12 @@ class ProjectsRepository(BaseRepository):
         if not row:
             raise ProjectNotFoundError(project_id)
         return ProjectAtDB.from_orm(row)
+
+    async def is_node_present_in_workbench(
+        self, project_id: ProjectID, node_uuid: NodeID
+    ) -> bool:
+        try:
+            project = await self.get_project(project_id)
+            return f"{node_uuid}" in project.workbench
+        except ProjectNotFoundError:
+            return False

--- a/services/director-v2/tests/unit/with_dbs/test_modules_db_repositories_projects.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_db_repositories_projects.py
@@ -1,0 +1,98 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+
+from typing import Any, Callable, cast
+
+import pytest
+import sqlalchemy as sa
+from faker import Faker
+from fastapi import FastAPI
+from models_library.projects import ProjectAtDB
+from pytest import MonkeyPatch
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from pytest_simcore.helpers.utils_envs import setenvs_from_dict
+from simcore_service_director_v2.modules.db.repositories.projects import (
+    ProjectsRepository,
+)
+from simcore_service_director_v2.utils.db import get_repository
+
+pytest_simcore_core_services_selection = [
+    "postgres",
+]
+pytest_simcore_ops_services_selection = [
+    "adminer",
+]
+
+
+@pytest.fixture
+def mock_env(
+    monkeypatch: MonkeyPatch,
+    postgres_host_config: dict[str, str],
+    mock_env: EnvVarsDict,
+    postgres_db: sa.engine.Engine,
+) -> EnvVarsDict:
+    """overrides unit/conftest:mock_env fixture"""
+    env_vars = mock_env.copy()
+    env_vars.update(
+        {
+            "DIRECTOR_V2_POSTGRES_ENABLED": "true",
+            "S3_ACCESS_KEY": "12345678",
+            "S3_BUCKET_NAME": "simcore",
+            "S3_ENDPOINT": "http://172.17.0.1:9001",
+            "S3_SECRET_KEY": "12345678",
+            "S3_SECURE": "False",
+        }
+    )
+    setenvs_from_dict(monkeypatch, env_vars)
+    return env_vars
+
+
+@pytest.fixture
+def workbench() -> dict[str, Any]:
+    return {
+        "13220a1d-a569-49de-b375-904301af9295": {
+            "key": "simcore/services/dynamic/a-nice-one",
+            "version": "2.1.4",
+            "label": "sleeper",
+            "inputsUnits": {},
+            "inputNodes": ["38a0d401-af4b-4ea7-ab4c-5005c712a546"],
+            "parent": None,
+            "thumbnail": "",
+        }
+    }
+
+
+@pytest.fixture()
+async def project(
+    mock_env: EnvVarsDict,
+    registered_user: Callable[..., dict],
+    project: Callable[..., ProjectAtDB],
+    workbench: dict[str, Any],
+) -> ProjectAtDB:
+    return project(registered_user(), workbench=workbench)
+
+
+async def test_is_node_present_in_workbench(
+    initialized_app: FastAPI, project: ProjectAtDB, faker: Faker
+):
+    project_repository = cast(
+        ProjectsRepository,
+        get_repository(initialized_app, ProjectsRepository),
+    )
+
+    for node_uuid in project.workbench:
+        assert (
+            await project_repository.is_node_present_in_workbench(
+                project_id=project.uuid, node_uuid=node_uuid
+            )
+            is True
+        )
+
+    not_existing_node = faker.uuid4(cast_to=None)
+    assert not_existing_node not in project.workbench
+    assert (
+        await project_repository.is_node_present_in_workbench(
+            project_id=project.uuid, node_uuid=not_existing_node
+        )
+        is False
+    )


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

When a node is no longer present in the database, the device state will no longer be saved.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

- fixes https://github.com/ITISFoundation/osparc-simcore/issues/3567

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
