### PR TITLE
✨ Reset Node's start up sequence

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -1134,8 +1134,9 @@ qx.Class.define("osparc.data.model.Node", {
 
     startDynamicService: function() {
       if (this.isDynamic()) {
-        const metaData = this.getMetaData();
+        this.getStatus().getProgressSequence().resetSequence();
 
+        const metaData = this.getMetaData();
         const msg = "Starting " + metaData.key + ":" + metaData.version + "...";
         const msgData = {
           nodeId: this.getNodeId(),
@@ -1150,8 +1151,9 @@ qx.Class.define("osparc.data.model.Node", {
 
     stopDynamicService: function() {
       if (this.isDynamic()) {
-        const metaData = this.getMetaData();
+        this.getStatus().getProgressSequence().resetSequence();
 
+        const metaData = this.getMetaData();
         const msg = "Stopping " + metaData.key + ":" + metaData.version + "...";
         const msgData = {
           nodeId: this.getNodeId(),

--- a/services/static-webserver/client/source/class/osparc/data/model/NodeProgressSequence.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/NodeProgressSequence.js
@@ -151,6 +151,16 @@ qx.Class.define("osparc.data.model.NodeProgressSequence", {
       return this.__sequenceLoadingPage;
     },
 
+    resetSequence: function() {
+      // reverted setting
+      this.setImagesPulling(0);
+      this.setStatePulling(0);
+      this.setOutputsPulling(0);
+      this.setInputsPulling(0);
+      this.setSidecarPulling(0);
+      this.setClusterUpScaling(0);
+    },
+
     addProgressMessage: function(progressType, progress) {
       console.log(progressType, progress);
 

--- a/services/static-webserver/client/source/class/osparc/data/model/NodeStatus.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/NodeStatus.js
@@ -161,7 +161,7 @@ qx.Class.define("osparc.data.model.NodeStatus", {
 
     __applyInteractive: function(value) {
       if (value === "failed") {
-        // ask why it failed
+        this.getProgressSequence().resetSequence();
       }
     },
 


### PR DESCRIPTION
## What do these changes do?

Reset Node's start up sequence when:
- it fails
- it gets restarted
- it gets stopped

![ResetSequence](https://user-images.githubusercontent.com/33152403/216628210-078b33c7-7784-4d0f-ba2f-de1daa6780c5.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
