### PR TITLE
✨ Frontend: Window too small message to ribbon

### DIFF
--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -95,9 +95,6 @@ qx.Class.define("osparc.Application", {
       this.__updateFavicon();
       this.__updateSocial();
 
-      // Some resources request before building the main stack
-      osparc.WindowSizeTracker.getInstance().startTracker();
-
       this.__startupChecks();
     },
 

--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -479,7 +479,7 @@ qx.Class.define("osparc.Application", {
       osparc.component.message.FlashMessenger.getInstance().logAs(this.tr("You are logged out"));
 
       osparc.data.PollTasks.getInstance().removeTasks();
-      osparc.data.MaintenanceTracker.getInstance().stopTracker();
+      osparc.MaintenanceTracker.getInstance().stopTracker();
       osparc.auth.Manager.getInstance().logout();
       if (this.__mainPage) {
         this.__mainPage.closeEditor();

--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -30,11 +30,6 @@ qx.Class.define("osparc.Application", {
     qx.locale.MTranslation
   ],
 
-  statics: {
-    MIN_WIDTH: 1240,
-    MIN_HEIGHT: 700
-  },
-
   members: {
     __current: null,
     __themeSwitcher: null,
@@ -100,66 +95,10 @@ qx.Class.define("osparc.Application", {
       this.__updateFavicon();
       this.__updateSocial();
 
+      // Some resources request before building the main stack
+      osparc.WindowSizeTracker.getInstance().startTracker();
+
       this.__startupChecks();
-
-      // onload, load, DOMContentLoaded, appear... didn't work
-      // bit of a hack
-      setTimeout(() => this.__checkScreenSize(), 100);
-      window.addEventListener("resize", () => this.__checkScreenSize());
-    },
-
-    __checkScreenSize: function() {
-      osparc.store.StaticInfo.getInstance().getPlatformName()
-        .then(platformName => {
-          const preferencesSettings = osparc.desktop.preferences.Preferences.getInstance();
-          if (platformName !== "master" && preferencesSettings.getConfirmWindowSize()) {
-            const title = this.tr("Oops, your window size is a bit small!");
-            const tooSmallWindow = new osparc.ui.window.SingletonWindow("tooSmallScreen", title).set({
-              height: 100,
-              width: 400,
-              layout: new qx.ui.layout.VBox(),
-              appearance: "service-window",
-              showMinimize: false,
-              showMaximize: false,
-              showClose: false,
-              resizable: false,
-              modal: true,
-              contentPadding: 10
-            });
-            const w = document.documentElement.clientWidth;
-            const h = document.documentElement.clientHeight;
-            if (this.self().MIN_WIDTH > w || this.self().MIN_HEIGHT > h) {
-              const product = this.tr("This app");
-              const baseTextMsg = this.tr(`
-                performs better for larger window size. A minimum window size \
-               of ${this.self().MIN_WIDTH}x${this.self().MIN_HEIGHT} is recommended.<br>\
-               Touchscreen devices are not supported yet.
-              `);
-              const label = new qx.ui.basic.Label().set({
-                value: product + baseTextMsg,
-                rich: true
-              });
-              osparc.store.StaticInfo.getInstance().getDisplayName()
-                .then(displayName => {
-                  label.setValue(displayName + baseTextMsg);
-                });
-              tooSmallWindow.add(label, {
-                flex: 1
-              });
-              const okBtn = new qx.ui.form.Button(this.tr("Got it")).set({
-                allowGrowX: false,
-                allowGrowY: false,
-                alignX: "right"
-              });
-              okBtn.addListener("execute", () => tooSmallWindow.close());
-              tooSmallWindow.add(okBtn);
-              tooSmallWindow.center();
-              tooSmallWindow.open();
-            } else {
-              tooSmallWindow.close();
-            }
-          }
-        });
     },
 
     __initRouting: function() {

--- a/services/static-webserver/client/source/class/osparc/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/MaintenanceTracker.js
@@ -81,7 +81,7 @@ qx.Class.define("osparc.MaintenanceTracker", {
 
       let text = osparc.utils.Utils.formatDateAndTime(this.getStart());
       if (this.getEnd()) {
-        if (osparc.utils.Utils.formatDate(this.getStart()) === osparc.utils.Utils.formatDate(this.getEnd())) {
+        if (this.getStart().getDate() === this.getEnd().getDate()) {
           // do not print the same day twice
           text += " - " + osparc.utils.Utils.formatTime(this.getEnd());
         } else {

--- a/services/static-webserver/client/source/class/osparc/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/MaintenanceTracker.js
@@ -15,7 +15,7 @@
 
 ************************************************************************ */
 
-qx.Class.define("osparc.data.MaintenanceTracker", {
+qx.Class.define("osparc.MaintenanceTracker", {
   extend: qx.core.Object,
   type: "singleton",
 

--- a/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
+++ b/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
@@ -21,9 +21,9 @@ qx.Class.define("osparc.WindowSizeTracker", {
 
   properties: {
     tooSmall: {
-      check: "Boolean",
-      init: false,
-      nullable: false,
+      check: [null, "shortText", "longText"], // display short message, long one or none
+      init: null,
+      nullable: true,
       apply: "__applyTooSmall"
     }
   },
@@ -47,31 +47,34 @@ qx.Class.define("osparc.WindowSizeTracker", {
       const width = document.documentElement.clientWidth;
       const height = document.documentElement.clientHeight;
       if (width < this.self().MIN_WIDTH || height < this.self().MIN_HEIGHT) {
-        this.setTooSmall(true);
+        this.setTooSmall(width < 1000 ? "shortText" : "longText");
       } else {
-        this.setTooSmall(false);
+        this.setTooSmall(null);
       }
     },
 
     __applyTooSmall: function(tooSmall) {
       this.__removeRibbonMessage();
 
-      if (tooSmall) {
-        const width = document.documentElement.clientWidth;
-        const text = this.__getText(width > 400);
-        const notification = new osparc.component.notification.Notification(text, "smallWindow", true);
-        osparc.component.notification.NotificationsRibbon.getInstance().addNotification(notification);
-        this.__lastRibbonMessage = notification;
+      if (tooSmall === null) {
+        return;
       }
+
+      let notification = null;
+      if (tooSmall === "shortText") {
+        notification = new osparc.component.notification.Notification(null, "smallWindow", true);
+      } else if (tooSmall === "longText") {
+        const text = this.__getLongText(true);
+        notification = new osparc.component.notification.Notification(text, "smallWindow", true);
+      }
+      osparc.component.notification.NotificationsRibbon.getInstance().addNotification(notification);
+      this.__lastRibbonMessage = notification;
     },
 
-    __getText: function(longVersion = true) {
-      let text = "";
-      if (longVersion) {
-        text += qx.locale.Manager.tr("This app performs better for at least ");
-        text += this.self().MIN_WIDTH + "x" + this.self().MIN_HEIGHT;
-        text += qx.locale.Manager.tr(" window size. Touchscreen devices are not supported yet.");
-      }
+    __getLongText: function() {
+      let text = qx.locale.Manager.tr("This app performs better for at least ");
+      text += this.self().MIN_WIDTH + "x" + this.self().MIN_HEIGHT;
+      text += qx.locale.Manager.tr(" window size. Touchscreen devices are not supported yet.");
       return text;
     },
 

--- a/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
+++ b/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
@@ -68,10 +68,9 @@ qx.Class.define("osparc.WindowSizeTracker", {
     __getText: function(longVersion = true) {
       let text = "";
       if (longVersion) {
-        text += qx.locale.Manager.tr(" This app performs better for at least ");
+        text += qx.locale.Manager.tr("This app performs better for at least ");
         text += this.self().MIN_WIDTH + "x" + this.self().MIN_HEIGHT;
-        text += qx.locale.Manager.tr(" window size.");
-        text += qx.locale.Manager.tr(" Touchscreen devices are not supported yet.");
+        text += qx.locale.Manager.tr(" window size. Touchscreen devices are not supported yet.");
       }
       return text;
     },

--- a/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
+++ b/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
@@ -66,7 +66,7 @@ qx.Class.define("osparc.WindowSizeTracker", {
     },
 
     __getText: function(longVersion = true) {
-      let text = qx.locale.Manager.tr("Oops, your window is a bit small!");
+      let text = "";
       if (longVersion) {
         text += qx.locale.Manager.tr(" This app performs better for at least ");
         text += this.self().MIN_WIDTH + "x" + this.self().MIN_HEIGHT;

--- a/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
+++ b/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
@@ -72,9 +72,9 @@ qx.Class.define("osparc.WindowSizeTracker", {
     },
 
     __getLongText: function() {
-      let text = qx.locale.Manager.tr("This app performs better for at least ");
-      text += this.self().MIN_WIDTH + "x" + this.self().MIN_HEIGHT;
-      text += qx.locale.Manager.tr(" window size. Touchscreen devices are not supported yet.");
+      let text = qx.locale.Manager.tr("This app performs better for larger window size, min ");
+      text += " " + this.self().MIN_WIDTH + "x" + this.self().MIN_HEIGHT + (".");
+      text += " " + qx.locale.Manager.tr("Touchscreen devices are not supported yet.");
       return text;
     },
 

--- a/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
+++ b/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
@@ -1,0 +1,110 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2023 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+qx.Class.define("osparc.WindowSizeTracker", {
+  extend: qx.core.Object,
+  type: "singleton",
+
+  properties: {
+    tooSmall: {
+      check: "Boolean",
+      init: false,
+      nullable: false,
+      apply: "__applyTooSmall"
+    }
+  },
+
+  statics: {
+    MIN_WIDTH: 1240,
+    MIN_HEIGHT: 700
+  },
+
+  members: {
+    __lastRibbonMessage: null,
+
+    startTracker: function() {
+      // onload, load, DOMContentLoaded, appear... didn't work
+      // bit of a hack
+      setTimeout(() => this.__checkScreenSize(), 100);
+      window.addEventListener("resize", () => this.__checkScreenSize());
+    },
+
+    __checkScreenSize: function() {
+      const width = document.documentElement.clientWidth;
+      const height = document.documentElement.clientHeight;
+      if (width < this.self().MIN_WIDTH || height < this.self().MIN_HEIGHT) {
+        this.setTooSmall(true);
+      } else {
+        this.setTooSmall(false);
+      }
+    },
+
+    __applyTooSmall: function(tooSmall) {
+      if (tooSmall) {
+        const width = document.documentElement.clientWidth;
+        const text = this.__getText(width > 400);
+        this.setText(text);
+      } else {
+        this.setText();
+      }
+    },
+
+    __getText: function(longVersion = true) {
+      let text = this.tr("Oops, your window is a bit small!");
+      if (longVersion) {
+        text += this.tr(" This app performs better for minimum ");
+        text += this.self().MIN_WIDTH + "x" + this.self().MIN_HEIGHT;
+        text += this.tr(" window size.");
+        text += this.tr(" Touchscreen devices are not supported yet.");
+      }
+      return text;
+    },
+
+    __scheduleRibbonMessage: function() {
+      this.__removeRibbonMessage();
+
+      const now = new Date();
+      const diffClosable = this.getStart().getTime() - now.getTime() - this.self().CLOSABLE_WARN_IN_ADVANCE;
+      const diffPermanent = this.getStart().getTime() - now.getTime() - this.self().PERMANENT_WARN_IN_ADVANCE;
+
+      const messageToRibbon = closable => {
+        this.__removeRibbonMessage();
+        const text = this.__getText();
+        const notification = new osparc.component.notification.Notification(text, "maintenance", closable);
+        osparc.component.notification.NotificationsRibbon.getInstance().addNotification(notification);
+        this.__lastRibbonMessage = notification;
+      };
+      if (diffClosable < 0) {
+        messageToRibbon(true);
+      } else {
+        setTimeout(() => messageToRibbon(true), diffClosable);
+      }
+      if (diffPermanent < 0) {
+        messageToRibbon(false);
+      } else {
+        setTimeout(() => messageToRibbon(false), diffPermanent);
+      }
+    },
+
+    __removeRibbonMessage: function() {
+      if (this.__lastRibbonMessage) {
+        osparc.component.notification.NotificationsRibbon.getInstance().removeNotification(this.__lastRibbonMessage);
+        this.__lastRibbonMessage = null;
+      }
+    }
+  }
+});

--- a/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
+++ b/services/static-webserver/client/source/class/osparc/WindowSizeTracker.js
@@ -54,50 +54,26 @@ qx.Class.define("osparc.WindowSizeTracker", {
     },
 
     __applyTooSmall: function(tooSmall) {
+      this.__removeRibbonMessage();
+
       if (tooSmall) {
         const width = document.documentElement.clientWidth;
         const text = this.__getText(width > 400);
-        this.setText(text);
-      } else {
-        this.setText();
+        const notification = new osparc.component.notification.Notification(text, "smallWindow", true);
+        osparc.component.notification.NotificationsRibbon.getInstance().addNotification(notification);
+        this.__lastRibbonMessage = notification;
       }
     },
 
     __getText: function(longVersion = true) {
-      let text = this.tr("Oops, your window is a bit small!");
+      let text = qx.locale.Manager.tr("Oops, your window is a bit small!");
       if (longVersion) {
-        text += this.tr(" This app performs better for minimum ");
+        text += qx.locale.Manager.tr(" This app performs better for at least ");
         text += this.self().MIN_WIDTH + "x" + this.self().MIN_HEIGHT;
-        text += this.tr(" window size.");
-        text += this.tr(" Touchscreen devices are not supported yet.");
+        text += qx.locale.Manager.tr(" window size.");
+        text += qx.locale.Manager.tr(" Touchscreen devices are not supported yet.");
       }
       return text;
-    },
-
-    __scheduleRibbonMessage: function() {
-      this.__removeRibbonMessage();
-
-      const now = new Date();
-      const diffClosable = this.getStart().getTime() - now.getTime() - this.self().CLOSABLE_WARN_IN_ADVANCE;
-      const diffPermanent = this.getStart().getTime() - now.getTime() - this.self().PERMANENT_WARN_IN_ADVANCE;
-
-      const messageToRibbon = closable => {
-        this.__removeRibbonMessage();
-        const text = this.__getText();
-        const notification = new osparc.component.notification.Notification(text, "maintenance", closable);
-        osparc.component.notification.NotificationsRibbon.getInstance().addNotification(notification);
-        this.__lastRibbonMessage = notification;
-      };
-      if (diffClosable < 0) {
-        messageToRibbon(true);
-      } else {
-        setTimeout(() => messageToRibbon(true), diffClosable);
-      }
-      if (diffPermanent < 0) {
-        messageToRibbon(false);
-      } else {
-        setTimeout(() => messageToRibbon(false), diffPermanent);
-      }
     },
 
     __removeRibbonMessage: function() {

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
@@ -51,29 +51,26 @@ qx.Class.define("osparc.component.notification.Notification", {
 
   members: {
     getFullText: function(wLineBreak = false) {
-      let text = "";
+      let fullText = "";
       switch (this.getType()) {
         case "maintenance": {
-          text += qx.locale.Manager.tr("Maintenance scheduled.");
-          text += wLineBreak ? "<br>" : " ";
-          text += this.getText() + ".";
-          text += wLineBreak ? "<br>" : " ";
-          text += qx.locale.Manager.tr("Please save your work and logout.");
+          fullText += qx.locale.Manager.tr("Maintenance scheduled.");
+          fullText += wLineBreak ? "<br>" : " ";
+          fullText += this.getText() + ".";
+          fullText += wLineBreak ? "<br>" : " ";
+          fullText += qx.locale.Manager.tr("Please save your work and logout.");
           break;
         }
         case "smallWindow": {
-          text += qx.locale.Manager.tr("Oops, your window is a bit small!");
-          const width = document.documentElement.clientWidth;
-          if (width > 400) {
-            text += qx.locale.Manager.tr(" This app performs better for minimum ");
-            text += osparc.WindowSizeTracker.MIN_WIDTH + "x" + osparc.WindowSizeTracker.MIN_HEIGHT;
-            text += qx.locale.Manager.tr(" window size.");
-            text += qx.locale.Manager.tr(" Touchscreen devices are not supported yet.");
+          fullText += qx.locale.Manager.tr("Oops, your window is a bit small!");
+          const orginalText = this.getText();
+          if (orginalText) {
+            fullText += orginalText;
           }
           break;
         }
       }
-      return text;
+      return fullText;
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
@@ -31,7 +31,7 @@ qx.Class.define("osparc.component.notification.Notification", {
 
   properties: {
     type: {
-      check: ["maintenance"],
+      check: ["maintenance", "smallWindow"],
       init: null,
       nullable: false
     },
@@ -51,18 +51,29 @@ qx.Class.define("osparc.component.notification.Notification", {
 
   members: {
     getFullText: function(wLineBreak = false) {
-      let fullText = "";
+      let text = "";
       switch (this.getType()) {
         case "maintenance": {
-          fullText += qx.locale.Manager.tr("Maintenance scheduled.");
-          fullText += wLineBreak ? "<br>" : " ";
-          fullText += this.getText() + ".";
-          fullText += wLineBreak ? "<br>" : " ";
-          fullText += qx.locale.Manager.tr("Please save your work and logout.");
+          text += qx.locale.Manager.tr("Maintenance scheduled.");
+          text += wLineBreak ? "<br>" : " ";
+          text += this.getText() + ".";
+          text += wLineBreak ? "<br>" : " ";
+          text += qx.locale.Manager.tr("Please save your work and logout.");
+          break;
+        }
+        case "smallWindow": {
+          text += qx.locale.Manager.tr("Oops, your window is a bit small!");
+          const width = document.documentElement.clientWidth;
+          if (width > 400) {
+            text += qx.locale.Manager.tr(" This app performs better for minimum ");
+            text += osparc.WindowSizeTracker.MIN_WIDTH + "x" + osparc.WindowSizeTracker.MIN_HEIGHT;
+            text += qx.locale.Manager.tr(" window size.");
+            text += qx.locale.Manager.tr(" Touchscreen devices are not supported yet.");
+          }
           break;
         }
       }
-      return fullText;
+      return text;
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
@@ -62,7 +62,7 @@ qx.Class.define("osparc.component.notification.Notification", {
           break;
         }
         case "smallWindow": {
-          fullText += qx.locale.Manager.tr("Oops, your window is a bit small!");
+          fullText += qx.locale.Manager.tr("Oops, your window size is a bit small!");
           const longText = this.getText();
           if (longText) {
             fullText += " " + longText;

--- a/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/Notification.js
@@ -63,9 +63,9 @@ qx.Class.define("osparc.component.notification.Notification", {
         }
         case "smallWindow": {
           fullText += qx.locale.Manager.tr("Oops, your window is a bit small!");
-          const orginalText = this.getText();
-          if (orginalText) {
-            fullText += orginalText;
+          const longText = this.getText();
+          if (longText) {
+            fullText += " " + longText;
           }
           break;
         }

--- a/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
+++ b/services/static-webserver/client/source/class/osparc/component/notification/NotificationsRibbon.js
@@ -22,7 +22,7 @@ qx.Class.define("osparc.component.notification.NotificationsRibbon", {
   construct: function() {
     this.base(arguments);
 
-    this._setLayout(new qx.ui.layout.VBox());
+    this._setLayout(new qx.ui.layout.VBox(null, null, "separator-vertical"));
 
     this.__notifications = new qx.data.Array();
 

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -51,6 +51,7 @@ qx.Class.define("osparc.desktop.MainPage", {
     this._add(navBar);
 
     // Some resources request before building the main stack
+    osparc.WindowSizeTracker.getInstance().startTracker();
     osparc.MaintenanceTracker.getInstance().startTracker();
 
     const store = osparc.store.Store.getInstance();

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -51,7 +51,7 @@ qx.Class.define("osparc.desktop.MainPage", {
     this._add(navBar);
 
     // Some resources request before building the main stack
-    osparc.data.MaintenanceTracker.getInstance().startTracker();
+    osparc.MaintenanceTracker.getInstance().startTracker();
 
     const store = osparc.store.Store.getInstance();
     Promise.all([

--- a/services/static-webserver/client/source/class/osparc/desktop/preferences/Preferences.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/preferences/Preferences.js
@@ -61,13 +61,6 @@ qx.Class.define("osparc.desktop.preferences.Preferences", {
       init: true,
       check: "Boolean",
       event: "changeConfirmStopNode"
-    },
-
-    confirmWindowSize: {
-      nullable: false,
-      init: true,
-      check: "Boolean",
-      event: "changeConfirmWindowSize"
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/ConfirmationsPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/ConfirmationsPage.js
@@ -100,11 +100,6 @@ qx.Class.define("osparc.desktop.preferences.pages.ConfirmationsPage", {
         box.add(cbConfirmStopNode);
       }
 
-      const cbConfirmWindowSize = new qx.ui.form.CheckBox(this.tr("Window size check"));
-      preferencesSettings.bind("confirmWindowSize", cbConfirmWindowSize, "value");
-      cbConfirmWindowSize.bind("value", preferencesSettings, "confirmWindowSize");
-      box.add(cbConfirmWindowSize);
-
       return box;
     }
   }

--- a/services/static-webserver/client/source/class/osparc/navigation/UserMenuButton.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/UserMenuButton.js
@@ -128,6 +128,7 @@ qx.Class.define("osparc.navigation.UserMenuButton", {
           control = new qx.ui.menu.Button(this.tr("About Product"));
           osparc.store.StaticInfo.getInstance().getDisplayName()
             .then(displayName => {
+              control.getChildControl("label").setRich(true);
               control.setLabel(this.tr("About ") + displayName);
             });
           control.addListener("execute", () => osparc.AboutProduct.getInstance().open());

--- a/services/static-webserver/client/source/class/osparc/viewer/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/viewer/MainPage.js
@@ -29,7 +29,7 @@ qx.Class.define("osparc.viewer.MainPage", {
     this._add(navBar);
 
     // Some resources request before building the main stack
-    osparc.data.MaintenanceTracker.getInstance().startTracker();
+    osparc.MaintenanceTracker.getInstance().startTracker();
 
     const nodeViewer = this.__createNodeViewer(studyId, viewerNodeId);
     this._add(nodeViewer, {

--- a/services/static-webserver/client/source/class/osparc/viewer/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/viewer/MainPage.js
@@ -29,6 +29,7 @@ qx.Class.define("osparc.viewer.MainPage", {
     this._add(navBar);
 
     // Some resources request before building the main stack
+    osparc.WindowSizeTracker.getInstance().startTracker();
     osparc.MaintenanceTracker.getInstance().startTracker();
 
     const nodeViewer = this.__createNodeViewer(studyId, viewerNodeId);

--- a/tests/e2e/tutorials/ti-plan.js
+++ b/tests/e2e/tutorials/ti-plan.js
@@ -117,6 +117,8 @@ async function runTutorial() {
     await tutorial.waitFor(5000, "Export Report");
     await tutorial.takeScreenshot("postpro_export_report");
 
+    await tutorial.waitFor(15000, "Export Report: waiting even longer");
+
     const outFiles = [
       "output_1.zip",
       "TIP_report.pdf",


### PR DESCRIPTION
## What do these changes do?

This PR changes the notification system for small screens.

We used to have a (too annoying) pop up message in the center of the window. This PR will replace it with a message on the ribbon.

![tooSmall](https://user-images.githubusercontent.com/33152403/216988549-24cf73d6-d2da-4bc6-9de2-00d801063b76.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
