### PR TITLE
♻️ director-v2 api client enhancements

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_thin.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_thin.py
@@ -27,12 +27,7 @@ class ThinDynamicSidecarClient(BaseThinClient):
             app.state.settings.DYNAMIC_SERVICES.DYNAMIC_SIDECAR
         )
 
-        self.client = AsyncClient(
-            timeout=Timeout(
-                settings.DYNAMIC_SIDECAR_API_REQUEST_TIMEOUT,
-                connect=settings.DYNAMIC_SIDECAR_API_CONNECT_TIMEOUT,
-            )
-        )
+        self.client = AsyncClient()
 
         # timeouts
         self._health_request_timeout = Timeout(1.0, connect=1.0)
@@ -50,7 +45,11 @@ class ThinDynamicSidecarClient(BaseThinClient):
         )
 
         super().__init__(
-            request_timeout=settings.DYNAMIC_SIDECAR_CLIENT_REQUEST_TIMEOUT_S
+            request_timeout=settings.DYNAMIC_SIDECAR_CLIENT_REQUEST_TIMEOUT_S,
+            timeout=Timeout(
+                settings.DYNAMIC_SIDECAR_API_REQUEST_TIMEOUT,
+                connect=settings.DYNAMIC_SIDECAR_API_CONNECT_TIMEOUT,
+            ),
         )
 
     def _get_url(

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_thin.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_thin.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, Optional
 
 from fastapi import FastAPI, status
-from httpx import AsyncClient, Response, Timeout
+from httpx import Response, Timeout
 from pydantic import AnyHttpUrl
 from servicelib.docker_constants import SUFFIX_EGRESS_PROXY_NAME
 
@@ -26,8 +26,6 @@ class ThinDynamicSidecarClient(BaseThinClient):
         settings: DynamicSidecarSettings = (
             app.state.settings.DYNAMIC_SERVICES.DYNAMIC_SIDECAR
         )
-
-        self.client = AsyncClient()
 
         # timeouts
         self._health_request_timeout = Timeout(1.0, connect=1.0)

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_base.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_base.py
@@ -30,11 +30,11 @@ from simcore_service_director_v2.modules.dynamic_sidecar.api_client._errors impo
 class FakeThickClient(BaseThinClient):
     @retry_on_errors
     async def get_provided_url(self, provided_url: str) -> Response:
-        return await self._client.get(provided_url)
+        return await self.client.get(provided_url)
 
     @retry_on_errors
     async def get_retry_for_status(self) -> Response:
-        return await self._client.get("http://missing-host:1111")
+        return await self.client.get("http://missing-host:1111")
 
 
 def _assert_messages(messages: list[str]) -> None:
@@ -119,7 +119,10 @@ async def test_retry_on_errors_by_error_type(
     if error_class == PoolTimeout:
         _assert_messages(caplog_info_level.messages[:-1])
         connections_message = caplog_info_level.messages[-1]
-        assert connections_message == "Requests while event 'POOL TIMEOUT': []"
+        assert (
+            connections_message
+            == "Pool status @ 'POOL TIMEOUT': requests=[], connections=[]"
+        )
     else:
         _assert_messages(caplog_info_level.messages)
 
@@ -177,11 +180,11 @@ async def test_expect_state_decorator(
     class ATestClient(BaseThinClient):
         @expect_status(codes.OK)
         async def get_200_ok(self) -> Response:
-            return await self._client.get(url_get_200_ok)
+            return await self.client.get(url_get_200_ok)
 
         @expect_status(error_status)
         async def get_wrong_state(self) -> Response:
-            return await self._client.get(get_wrong_state)
+            return await self.client.get(get_wrong_state)
 
     respx_mock.get(url_get_200_ok).mock(return_value=Response(codes.OK))
     respx_mock.get(get_wrong_state).mock(return_value=Response(codes.OK))


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

Apparently the dynamic-schedueler is eating up all connections in the http client used to talk to the dy-sidecars. This causes the director to stop talking to them. 

This tries to add more details about what is happening to the connection pool.
- using correct instance of the client (no longer creating a new one)
- better pool usage details

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist