### PR TITLE
🐛 Adds message-id and date to email headers

### DIFF
--- a/services/web/server/src/simcore_service_webserver/email_core.py
+++ b/services/web/server/src/simcore_service_webserver/email_core.py
@@ -87,7 +87,7 @@ def _compose_mime(
     message["From"] = sender
     message["To"] = recipient
     message["Subject"] = subject
-    message["Date"] = formatdate(localtime=True)
+    message["Date"] = formatdate()
     message["Message-ID"] = make_msgid(domain=settings.SMTP_HOST)
 
 

--- a/services/web/server/src/simcore_service_webserver/email_core.py
+++ b/services/web/server/src/simcore_service_webserver/email_core.py
@@ -36,7 +36,7 @@ async def _do_send_mail(
     # WARNING: _do_send_mail is mocked so be careful when changing the signature or name !!
 
     logger.debug("Email configuration %s", settings.json(indent=1))
-    logger.debug("%s", f"{message=}")
+    logger.debug("message=%s", f"{message._headers}")
 
     if settings.SMTP_PORT == 587:
         # NOTE: aiosmtplib does not handle port 587 correctly this is a workaround
@@ -77,6 +77,7 @@ async def _do_send_mail(
 
 def _compose_mime(
     message: Union[MIMEText, MIMEMultipart],
+    settings: SMTPSettings,
     *,
     sender: str,
     recipient: str,
@@ -86,8 +87,8 @@ def _compose_mime(
     message["From"] = sender
     message["To"] = recipient
     message["Subject"] = subject
-    message["Date"] = formatdate()
-    message["Message-ID"] = make_msgid()
+    message["Date"] = formatdate(localtime=True)
+    message["Message-ID"] = make_msgid(domain=settings.SMTP_HOST)
 
 
 class SMTPServerInfo(TypedDict):
@@ -122,6 +123,7 @@ async def send_email(
     message = MIMEText(body, "html")
     _compose_mime(
         message,
+        settings=settings,
         sender=sender,
         recipient=recipient,
         subject=subject,
@@ -151,6 +153,7 @@ async def send_email_with_attachements(
     message = MIMEMultipart()
     _compose_mime(
         message,
+        settings=settings,
         sender=sender,
         recipient=recipient,
         subject=subject,

--- a/services/web/server/src/simcore_service_webserver/email_core.py
+++ b/services/web/server/src/simcore_service_webserver/email_core.py
@@ -4,7 +4,7 @@ from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from email.utils import formatdate
+from email.utils import formatdate, make_msgid
 from pathlib import Path
 from pprint import pformat
 from typing import Any, Mapping, NamedTuple, Optional, TypedDict, Union
@@ -35,7 +35,8 @@ async def _do_send_mail(
 ) -> None:
     # WARNING: _do_send_mail is mocked so be careful when changing the signature or name !!
 
-    logger.debug("Email configuration %s", settings)
+    logger.debug("Email configuration %s", settings.json(indent=1))
+    logger.debug("%s", f"{message=}")
 
     if settings.SMTP_PORT == 587:
         # NOTE: aiosmtplib does not handle port 587 correctly this is a workaround
@@ -85,7 +86,8 @@ def _compose_mime(
     message["From"] = sender
     message["To"] = recipient
     message["Subject"] = subject
-    message["Date"] = formatdate(localtime=True)
+    message["Date"] = formatdate()
+    message["Message-ID"] = make_msgid()
 
 
 class SMTPServerInfo(TypedDict):

--- a/services/web/server/src/simcore_service_webserver/email_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/email_handlers.py
@@ -91,7 +91,7 @@ async def test_email(request: web.Request):
     try:
         info = await check_email_server_responsiveness(settings)
 
-        await send_email_from_template(
+        message = await send_email_from_template(
             request,
             from_=body.from_ or product.support_email,
             to=body.to,
@@ -102,7 +102,10 @@ async def test_email(request: web.Request):
         return envelope_json_response(
             TestPassed(
                 fixtures=body.dict(),
-                info={"email-server": info},
+                info={
+                    "email-server": info,
+                    "message": message.items(),
+                },
             )
         )
 

--- a/services/web/server/src/simcore_service_webserver/email_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/email_handlers.py
@@ -104,7 +104,7 @@ async def test_email(request: web.Request):
                 fixtures=body.dict(),
                 info={
                     "email-server": info,
-                    "message": message.items(),
+                    "email-headers": message.items(),
                 },
             )
         )

--- a/services/web/server/src/simcore_service_webserver/email_settings.py
+++ b/services/web/server/src/simcore_service_webserver/email_settings.py
@@ -6,6 +6,6 @@ from ._constants import APP_SETTINGS_KEY
 
 def get_plugin_settings(app: web.Application) -> SMTPSettings:
     settings = app[APP_SETTINGS_KEY].WEBSERVER_EMAIL
-    assert settings, "setup_settings not called?"  # nosec
+    assert settings, "setup_settings not called or WEBSERVER_EMAIL=null?"  # nosec
     assert isinstance(settings, SMTPSettings)  # nosec
     return settings

--- a/services/web/server/src/simcore_service_webserver/login/_2fa.py
+++ b/services/web/server/src/simcore_service_webserver/login/_2fa.py
@@ -20,7 +20,7 @@ from simcore_postgres_database.models.users import UserNameConverter
 from twilio.rest import Client
 
 from ..redis import get_redis_validation_code_client
-from .utils_email import get_template_path, render_and_send_mail
+from .utils_email import get_template_path, send_email_from_template
 
 log = logging.getLogger(__name__)
 
@@ -149,7 +149,7 @@ async def send_email_code(
 ):
     email_template_path = await get_template_path(request, "new_2fa_code.jinja2")
     first_name = _get_human_readable_first_name(user_name)
-    await render_and_send_mail(
+    await send_email_from_template(
         request,
         from_=support_email,
         to=user_email,

--- a/services/web/server/src/simcore_service_webserver/login/handlers_change.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_change.py
@@ -31,7 +31,7 @@ from .utils import (
     flash_response,
     validate_user_status,
 )
-from .utils_email import get_template_path, render_and_send_mail
+from .utils_email import get_template_path, send_email_from_template
 
 log = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ async def submit_request_to_reset_password(request: web.Request):
 
     except web.HTTPError as err:
         try:
-            await render_and_send_mail(
+            await send_email_from_template(
                 request,
                 from_=product.support_email,
                 to=request_body.email,
@@ -105,7 +105,7 @@ async def submit_request_to_reset_password(request: web.Request):
         link = make_confirmation_link(request, confirmation)
         try:
             # primary reset email with a URL and the normal instructions.
-            await render_and_send_mail(
+            await send_email_from_template(
                 request,
                 from_=product.support_email,
                 to=request_body.email,
@@ -159,7 +159,7 @@ async def submit_request_to_change_email(request: web.Request):
     )
     link = make_confirmation_link(request, confirmation)
     try:
-        await render_and_send_mail(
+        await send_email_from_template(
             request,
             from_=product.support_email,
             to=request_body.email,

--- a/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
@@ -43,7 +43,7 @@ from .utils import (
     flash_response,
     get_client_ip,
 )
-from .utils_email import get_template_path, render_and_send_mail
+from .utils_email import get_template_path, send_email_from_template
 
 log = logging.getLogger(__name__)
 
@@ -153,7 +153,7 @@ async def register(request: web.Request):
             email_template_path = await get_template_path(
                 request, "registration_email.jinja2"
             )
-            await render_and_send_mail(
+            await send_email_from_template(
                 request,
                 from_=product.support_email,
                 to=registration.email,

--- a/services/web/server/src/simcore_service_webserver/login/utils_email.py
+++ b/services/web/server/src/simcore_service_webserver/login/utils_email.py
@@ -11,7 +11,7 @@ from ..email_core import AttachmentTuple, send_email_from_template
 log = logging.getLogger(__name__)
 
 
-def themed(dirname, template) -> Path:
+def themed(dirname: str, template: str) -> Path:
     return resources.get_path(join(dirname, template))
 
 
@@ -19,14 +19,12 @@ async def get_template_path(request: web.Request, filename: str) -> Path:
     return await get_product_template_path(request, filename)
 
 
-# legacy alias
-render_and_send_mail = send_email_from_template
-
 # prevents auto-removal by pycln
 assert AttachmentTuple  # nosec
+assert send_email_from_template  # nosec
 
 
 __all__: tuple[str, ...] = (
     "AttachmentTuple",
-    "render_and_send_mail",
+    "send_email_from_template",
 )

--- a/services/web/server/src/simcore_service_webserver/publication_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/publication_handlers.py
@@ -58,7 +58,7 @@ async def service_submission(request: web.Request):
     try:
         # NOTE: temporarily internal import to avoid render_and_send_mail to be interpreted as handler
         # TODO: Move outside when get_handlers_from_namespace is fixed
-        from .login.utils_email import AttachmentTuple, render_and_send_mail
+        from .login.utils_email import AttachmentTuple, send_email_from_template
 
         attachments = [
             AttachmentTuple(
@@ -74,7 +74,7 @@ async def service_submission(request: web.Request):
                 )
             )
         # send email
-        await render_and_send_mail(
+        await send_email_from_template(
             request,
             from_=user_email,
             to=support_email_address,

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_utils_emails.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_utils_emails.py
@@ -22,7 +22,7 @@ from simcore_service_webserver.login.plugin import setup_login
 from simcore_service_webserver.login.utils_email import (
     AttachmentTuple,
     get_template_path,
-    render_and_send_mail,
+    send_email_from_template,
     themed,
 )
 from simcore_service_webserver.statics_constants import FRONTEND_APPS_AVAILABLE
@@ -82,7 +82,7 @@ async def test_render_and_send_mail_for_registration(
 ):
     link = faker.url()  # some url link
 
-    await render_and_send_mail(
+    await send_email_from_template(
         http_request,
         from_=f"no-reply@{product_name}.test",
         to=destination_email,
@@ -110,7 +110,7 @@ async def test_render_and_send_mail_for_password(
 ):
     link = faker.url()  # some url link
 
-    await render_and_send_mail(
+    await send_email_from_template(
         http_request,
         from_=f"no-reply@{product_name}.test",
         to=destination_email,
@@ -123,7 +123,7 @@ async def test_render_and_send_mail_for_password(
         },
     )
 
-    await render_and_send_mail(
+    await send_email_from_template(
         http_request,
         from_=f"no-reply@{product_name}.test",
         to=destination_email,
@@ -145,7 +145,7 @@ async def test_render_and_send_mail_to_change_email(
 ):
     link = faker.url()  # some url link
 
-    await render_and_send_mail(
+    await send_email_from_template(
         http_request,
         from_=f"no-reply@{product_name}.test",
         to=destination_email,
@@ -167,7 +167,7 @@ async def test_render_and_send_mail_for_submission(
 ):
     data = {"name": faker.first_name(), "surname": faker.last_name()}  # some form
 
-    await render_and_send_mail(
+    await send_email_from_template(
         http_request,
         from_=f"no-reply@{product_name}.test",
         to=destination_email,


### PR DESCRIPTION
## What do these changes do?

- 🐛 Sets more fields in header reducing the changes that get rejected or marked as spam
- ♻️ returns email-headers in  ``POST /emails:test`` entrypoint
- ♻️ cleanup naming

## Related issue/s

- some registration emails got into spam folder

## How to test

- Manual test using ``POST /emails:test``

