### PR TITLE
✨ Frontend: show password

### DIFF
--- a/services/static-webserver/client/source/class/osparc/AboutProduct.js
+++ b/services/static-webserver/client/source/class/osparc/AboutProduct.js
@@ -101,7 +101,7 @@ qx.Class.define("osparc.AboutProduct", {
         .then(vendor => {
           if (vendor) {
             copyrightLink.set({
-              value: vendor.copyright + " " + new Date().getFullYear(),
+              value: vendor.copyright,
               url: vendor.url
             });
           }

--- a/services/static-webserver/client/source/class/osparc/auth/ui/LoginView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/LoginView.js
@@ -73,8 +73,8 @@ qx.Class.define("osparc.auth.ui.LoginView", {
         placeholder: this.tr(" Your password"),
         required: true
       });
-      pass.getContentElement().setAttribute("autocomplete", "current-password");
-      osparc.utils.Utils.setIdToWidget(pass, "loginPasswordFld");
+      pass.getChildControl("passwordField").getContentElement().setAttribute("autocomplete", "current-password");
+      osparc.utils.Utils.setIdToWidget(pass.getChildControl("passwordField"), "loginPasswordFld");
       this.add(pass);
       this.__form.add(pass, "", null, "password", null);
 

--- a/services/static-webserver/client/source/class/osparc/auth/ui/LoginView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/LoginView.js
@@ -69,7 +69,7 @@ qx.Class.define("osparc.auth.ui.LoginView", {
         email.focus();
         email.activate();
       });
-      const pass = new qx.ui.form.PasswordField().set({
+      const pass = new osparc.ui.form.PasswordField().set({
         placeholder: this.tr(" Your password"),
         required: true
       });

--- a/services/static-webserver/client/source/class/osparc/auth/ui/RegistrationView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/RegistrationView.js
@@ -52,14 +52,14 @@ qx.Class.define("osparc.auth.ui.RegistrationView", {
         email.activate();
       });
 
-      const pass1 = new qx.ui.form.PasswordField().set({
+      const pass1 = new osparc.ui.form.PasswordField().set({
         required: true,
         placeholder: this.tr("Type a password")
       });
       osparc.utils.Utils.setIdToWidget(pass1, "registrationPass1Fld");
       this.add(pass1);
 
-      const pass2 = new qx.ui.form.PasswordField().set({
+      const pass2 = new osparc.ui.form.PasswordField().set({
         required: true,
         placeholder: this.tr("Retype the password")
       });

--- a/services/static-webserver/client/source/class/osparc/auth/ui/RegistrationView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/RegistrationView.js
@@ -56,14 +56,14 @@ qx.Class.define("osparc.auth.ui.RegistrationView", {
         required: true,
         placeholder: this.tr("Type a password")
       });
-      osparc.utils.Utils.setIdToWidget(pass1, "registrationPass1Fld");
+      osparc.utils.Utils.setIdToWidget(pass1.getChildControl("passwordField"), "registrationPass1Fld");
       this.add(pass1);
 
       const pass2 = new osparc.ui.form.PasswordField().set({
         required: true,
         placeholder: this.tr("Retype the password")
       });
-      osparc.utils.Utils.setIdToWidget(pass2, "registrationPass2Fld");
+      osparc.utils.Utils.setIdToWidget(pass2.getChildControl("passwordField"), "registrationPass2Fld");
       this.add(pass2);
 
       const urlFragment = osparc.utils.Utils.parseURLFragment();

--- a/services/static-webserver/client/source/class/osparc/auth/ui/ResetPassView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/ResetPassView.js
@@ -36,13 +36,13 @@ qx.Class.define("osparc.auth.ui.ResetPassView", {
 
       this._addTitleHeader(this.tr("Reset Password"));
 
-      let password = new qx.ui.form.PasswordField().set({
+      let password = new osparc.ui.form.PasswordField().set({
         required: true,
         placeholder: this.tr("Your new password")
       });
       this.add(password);
 
-      let confirm = new qx.ui.form.PasswordField().set({
+      let confirm = new osparc.ui.form.PasswordField().set({
         required: true,
         placeholder: this.tr("Retype your new password")
       });

--- a/services/static-webserver/client/source/class/osparc/component/editor/ClusterEditor.js
+++ b/services/static-webserver/client/source/class/osparc/component/editor/ClusterEditor.js
@@ -144,7 +144,7 @@ qx.Class.define("osparc.component.editor.ClusterEditor", {
         }
         case "simpleAuthenticationPassword": {
           const endpointLayout = this.getChildControl("endpointLayout");
-          control = new qx.ui.form.PasswordField().set({
+          control = new osparc.ui.form.PasswordField().set({
             font: "text-14",
             backgroundColor: "background-main",
             placeholder: this.tr("Password")

--- a/services/static-webserver/client/source/class/osparc/component/form/Auto.js
+++ b/services/static-webserver/client/source/class/osparc/component/form/Auto.js
@@ -504,7 +504,7 @@ qx.Class.define("osparc.component.form.Auto", {
           setup = this.__setupSpinner;
           break;
         case "Password":
-          control = new qx.ui.form.PasswordField();
+          control = new osparc.ui.form.PasswordField();
           setup = this.__setupTextField;
           break;
         case "TextArea":

--- a/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/SecurityPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/SecurityPage.js
@@ -38,19 +38,19 @@ qx.Class.define("osparc.desktop.preferences.pages.SecurityPage", {
       // layout
       const box = this._createSectionBox(this.tr("Password"));
 
-      const currentPassword = new qx.ui.form.PasswordField().set({
+      const currentPassword = new osparc.ui.form.PasswordField().set({
         required: true,
         placeholder: this.tr("Your current password")
       });
       box.add(currentPassword);
 
-      const newPassword = new qx.ui.form.PasswordField().set({
+      const newPassword = new osparc.ui.form.PasswordField().set({
         required: true,
         placeholder: this.tr("Your new password")
       });
       box.add(newPassword);
 
-      const confirm = new qx.ui.form.PasswordField().set({
+      const confirm = new osparc.ui.form.PasswordField().set({
         required: true,
         placeholder: this.tr("Retype your new password")
       });

--- a/services/static-webserver/client/source/class/osparc/ui/form/PasswordField.js
+++ b/services/static-webserver/client/source/class/osparc/ui/form/PasswordField.js
@@ -104,7 +104,7 @@ qx.Class.define("osparc.ui.form.PasswordField", {
     },
 
     // overridden
-    _createChildControlImpl : function(id, hash) {
+    _createChildControlImpl : function(id) {
       let control;
       switch (id) {
         case "passwordField":
@@ -117,6 +117,7 @@ qx.Class.define("osparc.ui.form.PasswordField", {
         case "eyeButton":
           control = new qx.ui.form.ToggleButton().set({
             maxHeight: 18,
+            width: 22,
             padding: 0,
             paddingRight: 4,
             icon: "@FontAwesome5Solid/eye/10",
@@ -147,19 +148,19 @@ qx.Class.define("osparc.ui.form.PasswordField", {
     },
 
     isEmpty: function() {
-      const value = this.getChildControl("textfield").getValue();
+      const value = this.getChildControl("passwordField").getValue();
       return value == null || value == "";
     },
 
     // overridden
     focus: function() {
       this.base(arguments);
-      this.getChildControl("textfield").getFocusElement().focus();
+      this.getChildControl("passwordField").getFocusElement().focus();
     },
 
     // overridden
     tabFocus : function() {
-      const field = this.getChildControl("textfield");
+      const field = this.getChildControl("passwordField");
       field.getFocusElement().focus();
       field.selectAllText();
     }

--- a/services/static-webserver/client/source/class/osparc/ui/form/PasswordField.js
+++ b/services/static-webserver/client/source/class/osparc/ui/form/PasswordField.js
@@ -41,10 +41,15 @@ qx.Class.define("osparc.ui.form.PasswordField", {
     const passwordField = this._createChildControl("passwordField");
     this._createChildControl("eyeButton");
 
+    this.__focusedBorder(false);
+
     // forward the focusin and focusout events to the passwordField. The passwordField
     // is not focusable so the events need to be forwarded manually.
     this.addListener("focusin", () => passwordField.fireNonBubblingEvent("focusin", qx.event.type.Focus), this);
-    this.addListener("focusout", () => passwordField.fireNonBubblingEvent("focusout", qx.event.type.Focus), this);
+    this.addListener("focusout", () => {
+      this.__focusedBorder(false);
+      passwordField.fireNonBubblingEvent("focusout", qx.event.type.Focus);
+    }, this);
   },
 
   events: {
@@ -109,6 +114,9 @@ qx.Class.define("osparc.ui.form.PasswordField", {
       switch (id) {
         case "passwordField":
           control = new qx.ui.form.PasswordField();
+          control.getContentElement().setStyles({
+            "border-bottom-width": "0px"
+          });
           control.addListener("changeValue", () => this.fireDataEvent("changeValue", control.getValue()), this);
           this._add(control, {
             flex: 1
@@ -156,13 +164,22 @@ qx.Class.define("osparc.ui.form.PasswordField", {
     focus: function() {
       this.base(arguments);
       this.getChildControl("passwordField").getFocusElement().focus();
+      this.__focusedBorder(true);
     },
 
     // overridden
-    tabFocus : function() {
+    tabFocus: function() {
       const field = this.getChildControl("passwordField");
       field.getFocusElement().focus();
       field.selectAllText();
+      this.__focusedBorder(true);
+    },
+
+    __focusedBorder: function(focused = false) {
+      this.getContentElement().setStyles({
+        "border-bottom-width": focused ? "2px" : "1px",
+        "border-color": "text"
+      });
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/ui/form/PasswordField.js
+++ b/services/static-webserver/client/source/class/osparc/ui/form/PasswordField.js
@@ -114,6 +114,7 @@ qx.Class.define("osparc.ui.form.PasswordField", {
       switch (id) {
         case "passwordField":
           control = new qx.ui.form.PasswordField();
+          // remove border, it'0's handled by this widget
           control.getContentElement().setStyles({
             "border-bottom-width": "0px"
           });

--- a/services/static-webserver/client/source/class/osparc/ui/form/PasswordField.js
+++ b/services/static-webserver/client/source/class/osparc/ui/form/PasswordField.js
@@ -1,0 +1,167 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2023 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+qx.Class.define("osparc.ui.form.PasswordField", {
+  extend : qx.ui.core.Widget,
+  include : [
+    qx.ui.form.MForm
+  ],
+  implement : [
+    qx.ui.form.IStringForm,
+    qx.ui.form.IForm
+  ],
+
+  construct: function() {
+    this.base(arguments);
+
+    this.set({
+      padding: 0
+    });
+
+    // set the layout
+    const layout = new qx.ui.layout.HBox();
+    this._setLayout(layout);
+    layout.setAlignY("middle");
+
+    // password field
+    const passwordField = this._createChildControl("passwordField");
+    this._createChildControl("eyeButton");
+
+    // forward the focusin and focusout events to the passwordField. The passwordField
+    // is not focusable so the events need to be forwarded manually.
+    this.addListener("focusin", () => passwordField.fireNonBubblingEvent("focusin", qx.event.type.Focus), this);
+    this.addListener("focusout", () => passwordField.fireNonBubblingEvent("focusout", qx.event.type.Focus), this);
+  },
+
+  events: {
+    "changeValue" : "qx.event.type.Data"
+  },
+
+  properties: {
+    placeholder: {
+      check: "String",
+      nullable: true,
+      apply: "_applyPlaceholder"
+    },
+
+    // overridden
+    appearance: {
+      refine: true,
+      init: "textfield"
+    },
+
+    // overridden
+    focusable: {
+      refine: true,
+      init: true
+    },
+
+    // overridden
+    width: {
+      refine: true,
+      init: 120
+    }
+  },
+
+  // eslint-disable-next-line qx-rules/no-refs-in-members
+  members: {
+    /**
+     * @lint ignoreReferenceField(_forwardStates)
+     */
+    _forwardStates: {
+      focused : true,
+      invalid : true
+    },
+
+    setValue: function(value) {
+      this.getChildControl("passwordField").setValue(value);
+    },
+
+    resetValue: function() {
+      this.getChildControl("passwordField").resetValue();
+    },
+
+    getValue: function() {
+      return this.getChildControl("passwordField").getValue();
+    },
+
+    _applyPlaceholder : function(value) {
+      this.getChildControl("passwordField").setPlaceholder(value);
+    },
+
+    // overridden
+    _createChildControlImpl : function(id, hash) {
+      let control;
+      switch (id) {
+        case "passwordField":
+          control = new qx.ui.form.PasswordField();
+          control.addListener("changeValue", () => this.fireDataEvent("changeValue", control.getValue()), this);
+          this._add(control, {
+            flex: 1
+          });
+          break;
+        case "eyeButton":
+          control = new qx.ui.form.ToggleButton().set({
+            maxHeight: 18,
+            padding: 0,
+            paddingRight: 4,
+            icon: "@FontAwesome5Solid/eye/10",
+            backgroundColor: "transparent"
+          });
+          control.addListener("tap", this.__toggleEye, this);
+          this._add(control);
+          break;
+      }
+      return control || this.base(arguments, id);
+    },
+
+    __toggleEye: function() {
+      const passwordField = this.getChildControl("passwordField");
+      if (passwordField.getContentElement() && passwordField.getContentElement().getDomElement()) {
+        const domEl = passwordField.getContentElement().getDomElement();
+        const eyeButton = this.getChildControl("eyeButton");
+        if (eyeButton.getValue()) {
+          // show
+          domEl.setAttribute("type", "text");
+          eyeButton.setIcon("@FontAwesome5Solid/eye-slash/10");
+        } else {
+          // hide
+          domEl.setAttribute("type", "password");
+          eyeButton.setIcon("@FontAwesome5Solid/eye/10");
+        }
+      }
+    },
+
+    isEmpty: function() {
+      const value = this.getChildControl("textfield").getValue();
+      return value == null || value == "";
+    },
+
+    // overridden
+    focus: function() {
+      this.base(arguments);
+      this.getChildControl("textfield").getFocusElement().focus();
+    },
+
+    // overridden
+    tabFocus : function() {
+      const field = this.getChildControl("textfield");
+      field.getFocusElement().focus();
+      field.selectAllText();
+    }
+  }
+});

--- a/services/static-webserver/client/source/class/osparc/utils/LibVersions.js
+++ b/services/static-webserver/client/source/class/osparc/utils/LibVersions.js
@@ -60,6 +60,18 @@ qx.Class.define("osparc.utils.LibVersions", {
       return url;
     },
 
+    getVcsReleaseDate: function() {
+      return qx.core.Environment.get("osparc.vcsReleaseDate");
+    },
+
+    getVcsReleaseTag: function() {
+      return qx.core.Environment.get("osparc.vcsReleaseTag");
+    },
+
+    getVcsReleaseUrl: function() {
+      return qx.core.Environment.get("osparc.vcsReleaseUrl");
+    },
+
     getPlatformVersion: function() {
       const name = "osparc-simcore";
       const commitId = this.getVcsRef();


### PR DESCRIPTION
## What do these changes do?

This PR implements a new passwordField widget that is able to show/hide the password

requested by @sfarcito

![asdf](https://user-images.githubusercontent.com/33152403/217868467-41d27f04-2006-4a82-b2ed-87f9c3f83353.gif)

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
