### PR TITLE
WIP: ✨ Frontend: ReleaseData comes from /statics

### DIFF
--- a/services/static-webserver/client/source/class/osparc/store/StaticInfo.js
+++ b/services/static-webserver/client/source/class/osparc/store/StaticInfo.js
@@ -65,6 +65,25 @@ qx.Class.define("osparc.store.StaticInfo", {
       return this.getValue(staticKey);
     },
 
+    getReleaseData: function() {
+      return new Promise(resolve => {
+        Promise.all([
+          this.getValue("vcsReleaseTag"),
+          this.getValue("vcsReleaseDate"),
+          this.getValue("vcsReleaseUrl")
+        ]).then(values => {
+          const rTag = values[0];
+          const rDate = values[1];
+          const rUrl = values[2];
+          resolve({
+            "tag": rTag,
+            "date": rDate,
+            "url": rUrl
+          });
+        }).catch(() => resolve(null));
+      });
+    },
+
     getMaxNumberDyNodes: function() {
       return new Promise(resolve => {
         const staticKey = "webserverProjects";

--- a/services/static-webserver/client/source/class/osparc/utils/LibVersions.js
+++ b/services/static-webserver/client/source/class/osparc/utils/LibVersions.js
@@ -60,18 +60,6 @@ qx.Class.define("osparc.utils.LibVersions", {
       return url;
     },
 
-    getVcsReleaseDate: function() {
-      return qx.core.Environment.get("osparc.vcsReleaseDate");
-    },
-
-    getVcsReleaseTag: function() {
-      return qx.core.Environment.get("osparc.vcsReleaseTag");
-    },
-
-    getVcsReleaseUrl: function() {
-      return qx.core.Environment.get("osparc.vcsReleaseUrl");
-    },
-
     getPlatformVersion: function() {
       const name = "osparc-simcore";
       const commitId = this.getVcsRef();


### PR DESCRIPTION
## What do these changes do?

- Get it from /statics instead of the qx.environment


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
