### PR TITLE
🐛 Frontend: cleanup shared-with grouping

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
@@ -313,7 +313,7 @@ qx.Class.define("osparc.dashboard.ResourceContainerManager", {
             groupContainer = this.__createGroupContainer(orgId, "loading-label");
             osparc.store.Store.getInstance().getOrganizationOrUser(orgId)
               .then(org => {
-                if (org) {
+                if (org && org["collabType"] !== 2) {
                   let icon = "";
                   if (org.thumbnail) {
                     icon = org.thumbnail;
@@ -321,19 +321,13 @@ qx.Class.define("osparc.dashboard.ResourceContainerManager", {
                     icon = "@FontAwesome5Solid/globe/24";
                   } else if (org["collabType"] === 1) {
                     icon = "@FontAwesome5Solid/users/24";
-                  } else if (org["collabType"] === 2) {
-                    icon = "@FontAwesome5Solid/user/24";
                   }
                   groupContainer.set({
                     headerIcon: icon,
                     headerLabel: org.label
                   });
                 } else {
-                  // unknown org/user: show email address instead
-                  groupContainer.set({
-                    headerIcon: "@FontAwesome5Solid/user/24",
-                    headerLabel: resourceData["prjOwner"]
-                  });
+                  groupContainer.exclude();
                 }
               })
               .finally(() => {


### PR DESCRIPTION
## What do these changes do?

This PR excludes from the shared-with grouping the organizations that are actually single users.

Before:
![Before](https://user-images.githubusercontent.com/33152403/218477035-de9251b0-1f3f-459f-8fb8-b7e1d3e0ffd5.gif)


After:
![After](https://user-images.githubusercontent.com/33152403/218476212-c53fb0b0-8775-4ecd-a354-9a7cb1ba4ace.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
