### PR TITLE
🐛✨ Frontend: Make labels html compatible

### DIFF
--- a/services/static-webserver/client/source/class/osparc/auth/LoginPage.js
+++ b/services/static-webserver/client/source/class/osparc/auth/LoginPage.js
@@ -205,12 +205,8 @@ qx.Class.define("osparc.auth.LoginPage", {
             const releaseUrl = rData["url"];
             if (releaseDate && releaseTag && releaseUrl) {
               const date = osparc.utils.Utils.formatDate(new Date(releaseDate));
-              const dateLabel = new qx.ui.basic.Label(date).set({
-                textColor: "text-darker"
-              });
-              versionLinkLayout.add(dateLabel);
               versionLink.set({
-                value: "(" + releaseTag + ")&nbsp",
+                value: date + " (" + releaseTag + ")&nbsp",
                 url: releaseUrl
               });
             }

--- a/services/static-webserver/client/source/class/osparc/component/metadata/ServicesInStudy.js
+++ b/services/static-webserver/client/source/class/osparc/component/metadata/ServicesInStudy.js
@@ -174,6 +174,7 @@ qx.Class.define("osparc.component.metadata.ServicesInStudy", {
           break;
         }
         const nameLabel = new qx.ui.basic.Label(nodeMetaData["name"]).set({
+          rich: true,
           toolTipText: node["key"],
           font: "text-14"
         });

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -53,7 +53,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     },
     EXPECTED_S4L_LITE_SERVICE_KEYS: {
       "simcore/services/dynamic/sim4life-lite": {
-        title: "Start <i>S4L lite</i>",
+        title: "Start <i>S4L<sup>lite</sup></i>",
         description: "New project",
         newStudyLabel: "New project",
         idToWidget: "startS4LButton"

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -53,7 +53,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     },
     EXPECTED_S4L_LITE_SERVICE_KEYS: {
       "simcore/services/dynamic/sim4life-lite": {
-        title: "Start S4L lite",
+        title: "Start <i>S4L lite</i>",
         description: "New project",
         newStudyLabel: "New project",
         idToWidget: "startS4LButton"

--- a/services/static-webserver/client/source/class/osparc/product/AboutProduct.js
+++ b/services/static-webserver/client/source/class/osparc/product/AboutProduct.js
@@ -73,14 +73,14 @@ qx.Class.define("osparc.product.AboutProduct", {
       const color = qx.theme.manager.Color.getInstance().resolve("text");
 
       // https://zurichmedtech.github.io/s4l-lite-manual/#/docs/what_is_s4l_lite
-      const introText = "<b>S4L lite</b> is a powerful web-based simulation platform that allows you to model and analyze real-world phenomena and to design complex technical devices in a validated environment. With its intuitive interface and advanced tools, <b>S4L lite</b> makes it easy to develop your simulation project, wherever you are.";
+      const introText = "<b><i>S4L<sup>lite</sup></i></b> is a powerful web-based simulation platform that allows you to model and analyze real-world phenomena and to design complex technical devices in a validated environment. With its intuitive interface and advanced tools, <b><i>S4L<sup>lite</sup></i></b> makes it easy to develop your simulation project, wherever you are.";
 
       const licenseUrl = "https://zurichmedtech.github.io/s4l-lite-manual/#/docs/licensing/copyright_Sim4Life";
       const licenseText = `Click <a href=${licenseUrl} style='color: ${color}' target='_blank'>here</a> to read the license agreements.`;
 
       // more info ZMT website
       const moreInfoUrl = "https://zmt.swiss/";
-      const moreInfoText = `For more information about <b>S4L lite</b>, visit <a href=${moreInfoUrl} style='color: ${color}' target='_blank'>our website</a>.`;
+      const moreInfoText = `For more information about <b><i>S4L<sup>lite</sup></i></b>, visit <a href=${moreInfoUrl} style='color: ${color}' target='_blank'>our website</a>.`;
 
       [
         introText,

--- a/services/static-webserver/client/source/class/osparc/product/tutorial/s4llite/Dashboard.js
+++ b/services/static-webserver/client/source/class/osparc/product/tutorial/s4llite/Dashboard.js
@@ -45,7 +45,7 @@ qx.Class.define("osparc.product.tutorial.s4llite.Dashboard", {
 
       const newProject = new qx.ui.basic.Label().set({
         value: this.tr("\
-        1) Start S4L lite: Click the <b>+ Start S4L lite</b> button to create a new project. This will start the user interface of S4L lite.\
+        1) Start <i>S4L<sup>lite</sup></i>: Click the <b>+ Start <i>S4L<sup>lite</sup></i></b> button to create a new project. This will start the user interface of <i>S4L<sup>lite</sup></i>.\
         "),
         rich: true,
         wrap: true,
@@ -66,7 +66,7 @@ qx.Class.define("osparc.product.tutorial.s4llite.Dashboard", {
 
       const otherProjects2 = new qx.ui.basic.Label().set({
         value: this.tr("\
-        3) TUTORIALS: A set of pre-built read-only tutorial projects with results is available to all S4L lite users. When a tutorial is selected, a \
+        3) TUTORIALS: A set of pre-built read-only tutorial projects with results is available to all <i>S4L<sup>lite</sup></i> users. When a tutorial is selected, a \
         copy is automatically created and added to the user’s Projects tab. This new copy is editable and can be shared.\
         "),
         rich: true,
@@ -85,8 +85,8 @@ qx.Class.define("osparc.product.tutorial.s4llite.Dashboard", {
 
       const importProjects = new qx.ui.basic.Label().set({
         value: this.tr("\
-        4) To open an existing desktop project in S4L lite: \
-        - Click the + Start S4L lite button to create a new project.<br>\
+        4) To open an existing desktop project in <i>S4L<sup>lite</sup></i>: \
+        - Click the + Start <i>S4L<sup>lite</sup></i> button to create a new project.<br>\
         - Click the menu and select “File Browser…”.<br>\
         - Click “Upload File” for the .smash project and select the file from your desktop. Repeat the same step, but this \
         time select “Upload Folder” and then select the result folder from your desktop. Close the window<br>\

--- a/services/static-webserver/client/source/class/osparc/product/tutorial/s4llite/S4LLiteSpecs.js
+++ b/services/static-webserver/client/source/class/osparc/product/tutorial/s4llite/S4LLiteSpecs.js
@@ -19,23 +19,23 @@ qx.Class.define("osparc.product.tutorial.s4llite.S4LLiteSpecs", {
   extend: osparc.product.tutorial.SlideBase,
 
   construct: function() {
-    const title = this.tr("S4L lite: Features and Limitations");
+    const title = this.tr("<i>S4L<sup>lite</sup></i>: Features and Limitations");
     this.base(arguments, title);
   },
 
   members: {
     _populateCard: function() {
       const introText = this.tr("\
-      S4L lite is a powerful web-based simulation platform that allows you to model and analyze real-world phenomena and to \
-      design complex technical devices in a validated environment. S4L lite has been created specifically for students to \
+      <i>S4L<sup>lite</sup></i> is a powerful web-based simulation platform that allows you to model and analyze real-world phenomena and to \
+      design complex technical devices in a validated environment. <i>S4L<sup>lite</sup></i> has been created specifically for students to \
       facilitate their understanding of computational modeling and simulations for various topics, ranging from wireless communication \
-      to medical applications. The access to S4L lite is available free of charge to students enrolled at registered universities.\
+      to medical applications. The access to <i>S4L<sup>lite</sup></i> is available free of charge to students enrolled at registered universities.\
       ");
       const intro = osparc.product.tutorial.Utils.createLabel(introText);
       this._add(intro);
 
       const featuresText = this.tr("\
-      <b>S4L lite offers</b><br>\
+      <b><i>S4L<sup>lite</sup></i> offers</b><br>\
       - Framework (GUI, Modeling, Postprocessing)<br>\
       - 3D modeling environment (based on the ACIS toolkit) and CAD translators<br>\
       - Postprocessing and visualization of the simulation results (2D and 3D viewers, 2D planar slice, volume rendering, streamlines, surface fields on arbitrary 3D structures, radiation and far-field data)<br>\

--- a/services/static-webserver/client/source/class/osparc/product/tutorial/s4llite/S4LLiteUI.js
+++ b/services/static-webserver/client/source/class/osparc/product/tutorial/s4llite/S4LLiteUI.js
@@ -19,14 +19,14 @@ qx.Class.define("osparc.product.tutorial.s4llite.S4LLiteUI", {
   extend: osparc.product.tutorial.SlideBase,
 
   construct: function() {
-    const title = this.tr("S4L lite");
+    const title = this.tr("<i>S4L<sup>lite</sup></i>");
     this.base(arguments, title);
   },
 
   members: {
     _populateCard: function() {
       const introText = this.tr("\
-      To check the S4L lite manual, please open a project and access the documentation via Help in the menu as shown below. Enjoy!\
+      To check the <i>S4L<sup>lite</sup></i> manual, please open a project and access the documentation via Help in the menu as shown below. Enjoy!\
       ");
       const intro = osparc.product.tutorial.Utils.createLabel(introText);
       this._add(intro);

--- a/services/static-webserver/client/source/class/osparc/product/tutorial/s4llite/Welcome.js
+++ b/services/static-webserver/client/source/class/osparc/product/tutorial/s4llite/Welcome.js
@@ -35,13 +35,13 @@ qx.Class.define("osparc.product.tutorial.s4llite.Welcome", {
 
       const intro = new qx.ui.basic.Label().set({
         value: this.tr("\
-        This quick user’s guide gives a short introduction to S4L lite. We will show:<br>\
+        This quick user’s guide gives a short introduction to <i>S4L<sup>lite</sup></i>. We will show:<br>\
           - how to get started with a new project,<br>\
           - how to get started from an existing tutorial project<br>\
-          - how to open Sim4Life lite desktop simulation projects in S4L lite,<br>\
-          - S4L lite features, limitations and user interface<br>\
+          - how to open Sim4Life lite desktop simulation projects in <i>S4L<sup>lite</sup></i>,<br>\
+          - <i>S4L<sup>lite</sup></i> features, limitations and user interface<br>\
           <br>\
-          For more specific technical information, please refer to the Dashboard Manual and the S4L lite Manual.\
+          For more specific technical information, please refer to the Dashboard Manual and the <i>S4L<sup>lite</sup></i> Manual.\
         "),
         rich: true,
         wrap: true,

--- a/services/static-webserver/client/source/class/osparc/store/Support.js
+++ b/services/static-webserver/client/source/class/osparc/store/Support.js
@@ -28,17 +28,18 @@ qx.Class.define("osparc.store.Support", {
     },
 
     addManualButtonsToMenu: function(menu, menuButton) {
-      const control = new qx.ui.menu.Button(qx.locale.Manager.tr("Quick Start")).set({
+      const qsButton = new qx.ui.menu.Button(qx.locale.Manager.tr("Quick Start"));
+      qsButton.getChildControl("label").set({
         rich: true
       });
       const tutorial = osparc.product.tutorial.Utils.getTutorial();
       if (tutorial) {
-        control.addListener("execute", () => {
+        qsButton.addListener("execute", () => {
           const tutorialWindow = tutorial.tutorial();
           tutorialWindow.center();
           tutorialWindow.open();
         });
-        menu.add(control);
+        menu.add(qsButton);
       }
       osparc.store.Support.getManuals()
         .then(manuals => {
@@ -46,7 +47,8 @@ qx.Class.define("osparc.store.Support", {
             menuButton.setVisibility(manuals.length ? "visible" : "excluded");
           }
           manuals.forEach(manual => {
-            const manualBtn = new qx.ui.menu.Button(manual.label).set({
+            const manualBtn = new qx.ui.menu.Button(manual.label);
+            manualBtn.getChildControl("label").set({
               rich: true
             });
             manualBtn.addListener("execute", () => window.open(manual.url), this);
@@ -68,7 +70,8 @@ qx.Class.define("osparc.store.Support", {
           }
           issues.forEach(issueInfo => {
             const label = issueInfo["label"];
-            const issueButton = new qx.ui.menu.Button(label).set({
+            const issueButton = new qx.ui.menu.Button(label);
+            issueButton.getChildControl("label").set({
               rich: true
             });
             issueButton.addListener("execute", () => {
@@ -95,7 +98,8 @@ qx.Class.define("osparc.store.Support", {
           }
 
           supports.forEach(suportInfo => {
-            const supportBtn = new qx.ui.menu.Button(suportInfo["label"]).set({
+            const supportBtn = new qx.ui.menu.Button(suportInfo["label"]);
+            supportBtn.getChildControl("label").set({
               rich: true
             });
             let icon = null;

--- a/services/static-webserver/client/source/class/osparc/store/Support.js
+++ b/services/static-webserver/client/source/class/osparc/store/Support.js
@@ -28,7 +28,9 @@ qx.Class.define("osparc.store.Support", {
     },
 
     addManualButtonsToMenu: function(menu, menuButton) {
-      const control = new qx.ui.menu.Button(qx.locale.Manager.tr("Quick Start"));
+      const control = new qx.ui.menu.Button(qx.locale.Manager.tr("Quick Start")).set({
+        rich: true
+      });
       const tutorial = osparc.product.tutorial.Utils.getTutorial();
       if (tutorial) {
         control.addListener("execute", () => {
@@ -44,7 +46,9 @@ qx.Class.define("osparc.store.Support", {
             menuButton.setVisibility(manuals.length ? "visible" : "excluded");
           }
           manuals.forEach(manual => {
-            const manualBtn = new qx.ui.menu.Button(manual.label);
+            const manualBtn = new qx.ui.menu.Button(manual.label).set({
+              rich: true
+            });
             manualBtn.addListener("execute", () => window.open(manual.url), this);
             menu.add(manualBtn);
           });
@@ -64,7 +68,9 @@ qx.Class.define("osparc.store.Support", {
           }
           issues.forEach(issueInfo => {
             const label = issueInfo["label"];
-            const issueButton = new qx.ui.menu.Button(label);
+            const issueButton = new qx.ui.menu.Button(label).set({
+              rich: true
+            });
             issueButton.addListener("execute", () => {
               const issueConfirmationWindow = new osparc.ui.window.Dialog(label + " " + qx.locale.Manager.tr("Information"), null,
                 qx.locale.Manager.tr("To create an issue, you must have an account and be already logged-in.")
@@ -89,7 +95,9 @@ qx.Class.define("osparc.store.Support", {
           }
 
           supports.forEach(suportInfo => {
-            const supportBtn = new qx.ui.menu.Button(suportInfo["label"]);
+            const supportBtn = new qx.ui.menu.Button(suportInfo["label"]).set({
+              rich: true
+            });
             let icon = null;
             let cb = null;
             switch (suportInfo["kind"]) {


### PR DESCRIPTION
## What do these changes do?

The last re-rebranding implies that S4L lite is now written as <i>S4L<sup>lite</sup></i>.

Some labels in the frontend couldn't support html text. This PR brings that feature.

- [x] HTML compatible labels
- [x] Quick Starts updated
- [x] Bugfix: Release date out of place

## Related issue/s

closes https://github.com/ITISFoundation/osparc-issues/issues/864


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
