### PR TITLE
🐛 Fix edge case when cancelling observation

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_base.py
@@ -27,7 +27,7 @@ def _log_pool_status(client: AsyncClient, event_name: str) -> None:
             (r.request.method, r.request.url, r.request.headers)
             for r in client._transport._pool._requests
         ],
-        client._transport._pool.connections,
+        [(id(c), c.__dict__) for c in client._transport._pool.connections],
     )
 
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_base.py
@@ -21,12 +21,14 @@ logger = logging.getLogger(__name__)
 def _log_pool_status(client: AsyncClient, event_name: str) -> None:
     # pylint: disable=protected-access
     logger.warning(
-        "Pool status @ '%s': requests=%s, connections=%s",
+        "Pool status @ '%s': requests(%s)=%s, connections(%s)=%s",
         event_name.upper(),
+        len(client._transport._pool._requests),
         [
             (r.request.method, r.request.url, r.request.headers)
             for r in client._transport._pool._requests
         ],
+        len(client._transport._pool.connections),
         [(id(c), c.__dict__) for c in client._transport._pool.connections],
     )
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_base.py
@@ -25,7 +25,7 @@ def _log_pool_status(client: AsyncClient, event_name: str) -> None:
         event_name.upper(),
         len(client._transport._pool._requests),
         [
-            (r.request.method, r.request.url, r.request.headers)
+            (id(r), r.request.method, r.request.url, r.request.headers)
             for r in client._transport._pool._requests
         ],
         len(client._transport._pool.connections),

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_abc.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_abc.py
@@ -98,7 +98,10 @@ class SchedulerPublicInterface(ABC):
 
     @abstractmethod
     async def mark_service_for_removal(
-        self, node_uuid: NodeID, can_save: Optional[bool]
+        self,
+        node_uuid: NodeID,
+        can_save: Optional[bool],
+        skip_observation_recreation: bool = False,
     ) -> None:
         """The service will be removed as soon as possible"""
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_observer.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_observer.py
@@ -59,6 +59,7 @@ async def _apply_observation_cycle(
         await scheduler.mark_service_for_removal(
             node_uuid=scheduler_data.node_uuid,
             can_save=scheduler_data.dynamic_sidecar.were_containers_created,
+            skip_observation_recreation=True,
         )
 
     for dynamic_scheduler_event in REGISTERED_EVENTS:

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_task.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_task.py
@@ -87,9 +87,14 @@ class DynamicSidecarsScheduler(SchedulerInternalsInterface, SchedulerPublicInter
         return self._scheduler.list_services(user_id=user_id, project_id=project_id)
 
     async def mark_service_for_removal(
-        self, node_uuid: NodeID, can_save: Optional[bool]
+        self,
+        node_uuid: NodeID,
+        can_save: Optional[bool],
+        skip_observation_recreation: bool = False,
     ) -> None:
-        return await self._scheduler.mark_service_for_removal(node_uuid, can_save)
+        return await self._scheduler.mark_service_for_removal(
+            node_uuid, can_save, skip_observation_recreation
+        )
 
     async def get_stack_status(self, node_uuid: NodeID) -> RunningDynamicServiceDetails:
         return await self._scheduler.get_stack_status(node_uuid)

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_base.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_base.py
@@ -121,7 +121,7 @@ async def test_retry_on_errors_by_error_type(
         connections_message = caplog_info_level.messages[-1]
         assert (
             connections_message
-            == "Pool status @ 'POOL TIMEOUT': requests=[], connections=[]"
+            == "Pool status @ 'POOL TIMEOUT': requests(0)=[], connections(0)=[]"
         )
     else:
         _assert_messages(caplog_info_level.messages)

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_observer.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_observer.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi import FastAPI
 from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
-from pytest_simcore.helpers.typing_env import EnvVarsDict
+from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_dict
 from simcore_service_director_v2.core.settings import AppSettings
 from simcore_service_director_v2.models.schemas.dynamic_services import SchedulerData
 from simcore_service_director_v2.modules.dynamic_sidecar.api_client import (
@@ -68,19 +68,24 @@ def mock_env(
     mock_env: EnvVarsDict,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("SIMCORE_SERVICES_NETWORK_NAME", "test_network")
-    monkeypatch.setenv("DIRECTOR_HOST", "mocked_out")
-    monkeypatch.setenv("DIRECTOR_V2_DYNAMIC_SCHEDULER_ENABLED", "true")
-    monkeypatch.setenv("S3_ENDPOINT", "endpoint")
-    monkeypatch.setenv("S3_ACCESS_KEY", "access_key")
-    monkeypatch.setenv("S3_SECRET_KEY", "secret_key")
-    monkeypatch.setenv("S3_BUCKET_NAME", "bucket_name")
-    monkeypatch.setenv("S3_SECURE", "false")
-    monkeypatch.setenv("DIRECTOR_V2_POSTGRES_ENABLED", "false")
-    monkeypatch.setenv("POSTGRES_HOST", "test")
-    monkeypatch.setenv("POSTGRES_USER", "test")
-    monkeypatch.setenv("POSTGRES_PASSWORD", "test")
-    monkeypatch.setenv("POSTGRES_DB", "test")
+    setenvs_from_dict(
+        monkeypatch,
+        {
+            "SIMCORE_SERVICES_NETWORK_NAME": "test_network",
+            "DIRECTOR_HOST": "mocked_out",
+            "DIRECTOR_V2_DYNAMIC_SCHEDULER_ENABLED": "true",
+            "S3_ENDPOINT": "endpoint",
+            "S3_ACCESS_KEY": "access_key",
+            "S3_SECRET_KEY": "secret_key",
+            "S3_BUCKET_NAME": "bucket_name",
+            "S3_SECURE": "false",
+            "DIRECTOR_V2_POSTGRES_ENABLED": "false",
+            "POSTGRES_HOST": "test",
+            "POSTGRES_USER": "test",
+            "POSTGRES_PASSWORD": "test",
+            "POSTGRES_DB": "test",
+        },
+    )
 
 
 @pytest.fixture

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_observer.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_observer.py
@@ -1,0 +1,161 @@
+# pylint:disable=protected-access
+# pylint:disable=redefined-outer-name
+# pylint:disable=unused-argument
+
+from typing import Optional
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from pytest import MonkeyPatch
+from pytest_mock.plugin import MockerFixture
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from simcore_service_director_v2.core.settings import AppSettings
+from simcore_service_director_v2.models.schemas.dynamic_services import SchedulerData
+from simcore_service_director_v2.modules.dynamic_sidecar.api_client import (
+    setup,
+    shutdown,
+)
+from simcore_service_director_v2.modules.dynamic_sidecar.scheduler import (
+    DynamicSidecarsScheduler,
+    setup_scheduler,
+    shutdown_scheduler,
+)
+from simcore_service_director_v2.modules.dynamic_sidecar.scheduler._core._observer import (
+    _apply_observation_cycle,
+)
+
+
+@pytest.fixture
+def disable_observation(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "simcore_service_director_v2.modules.dynamic_sidecar.scheduler._task.DynamicSidecarsScheduler.start",
+        autospec=True,
+    )
+
+
+@pytest.fixture
+def mock_are_sidecar_and_proxy_services_present(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "simcore_service_director_v2.modules.dynamic_sidecar.scheduler._core._observer.are_sidecar_and_proxy_services_present",
+        autospec=True,
+        return_value=False,
+    )
+
+
+@pytest.fixture
+def mock_events(mocker: MockerFixture) -> None:
+    for event_to_mock in (
+        "CreateSidecars",
+        "WaitForSidecarAPI",
+        "UpdateHealth",
+        "GetStatus",
+        "PrepareServicesEnvironment",
+        "CreateUserServices",
+        "AttachProjectsNetworks",
+        "RemoveUserCreatedServices",
+    ):
+        mocker.patch(
+            f"simcore_service_director_v2.modules.dynamic_sidecar.scheduler._core._events.{event_to_mock}.action",
+            autospec=True,
+            return_value=True,
+        )
+
+
+@pytest.fixture
+def mock_env(
+    docker_swarm: None,
+    mock_env: EnvVarsDict,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SIMCORE_SERVICES_NETWORK_NAME", "test_network")
+    monkeypatch.setenv("DIRECTOR_HOST", "mocked_out")
+    monkeypatch.setenv("DIRECTOR_V2_DYNAMIC_SCHEDULER_ENABLED", "true")
+    monkeypatch.setenv("S3_ENDPOINT", "endpoint")
+    monkeypatch.setenv("S3_ACCESS_KEY", "access_key")
+    monkeypatch.setenv("S3_SECRET_KEY", "secret_key")
+    monkeypatch.setenv("S3_BUCKET_NAME", "bucket_name")
+    monkeypatch.setenv("S3_SECURE", "false")
+    monkeypatch.setenv("DIRECTOR_V2_POSTGRES_ENABLED", "false")
+    monkeypatch.setenv("POSTGRES_HOST", "test")
+    monkeypatch.setenv("POSTGRES_USER", "test")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "test")
+    monkeypatch.setenv("POSTGRES_DB", "test")
+
+
+@pytest.fixture
+def mocked_app(mock_env: None) -> FastAPI:
+    app = FastAPI()
+    app.state.settings = AppSettings()
+    app.state.rabbitmq_client = AsyncMock()
+    return app
+
+
+@pytest.fixture
+async def dynamic_sidecar_scheduler(mocked_app: FastAPI) -> DynamicSidecarsScheduler:
+    await setup_scheduler(mocked_app)
+    await setup(mocked_app)
+
+    yield mocked_app.state.dynamic_sidecar_scheduler
+
+    await shutdown_scheduler(mocked_app)
+    await shutdown(mocked_app)
+
+
+def _is_observation_task_present(
+    dynamic_sidecar_scheduler,
+    scheduler_data_from_http_request,
+) -> bool:
+    return (
+        scheduler_data_from_http_request.service_name
+        in dynamic_sidecar_scheduler._scheduler._service_observation_task
+    )
+
+
+@pytest.mark.parametrize("can_save", [None, False, False])
+async def test_regression_break_endless_loop_cancellation_edge_case(
+    disable_observation: None,
+    mock_are_sidecar_and_proxy_services_present: None,
+    mock_events: None,
+    dynamic_sidecar_scheduler: DynamicSidecarsScheduler,
+    scheduler_data_from_http_request: SchedulerData,
+    can_save: Optional[bool],
+):
+    # in this situation the scheduler would never end loops forever
+    await dynamic_sidecar_scheduler._scheduler._add_service(
+        scheduler_data_from_http_request
+    )
+
+    # simulate edge case
+    scheduler_data_from_http_request.dynamic_sidecar.were_containers_created = True
+
+    assert (
+        _is_observation_task_present(
+            dynamic_sidecar_scheduler, scheduler_data_from_http_request
+        )
+        is False
+    )
+
+    # NOTE: this will create the observation task as well!
+    # Simulates user action like going back to the dashboard.
+    await dynamic_sidecar_scheduler.mark_service_for_removal(
+        scheduler_data_from_http_request.node_uuid, can_save=can_save
+    )
+
+    assert (
+        _is_observation_task_present(
+            dynamic_sidecar_scheduler, scheduler_data_from_http_request
+        )
+        is True
+    )
+
+    await _apply_observation_cycle(
+        dynamic_sidecar_scheduler, scheduler_data_from_http_request
+    )
+
+    assert (
+        _is_observation_task_present(
+            dynamic_sidecar_scheduler, scheduler_data_from_http_request
+        )
+        is False
+    )


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

- ♻️ adds extra logs for the connection pool in the dynamic_sidecar_client
- 🐛 fixes an edge case where dynamic sidecars scheduler would end up in a loop calling `_apply_observation_cycle` and `mark_service_for_removal`. This was introduced when https://github.com/ITISFoundation/osparc-simcore/pull/3771 was added


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

- https://github.com/ITISFoundation/osparc-issues/issues/638


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [x] Unit tests for the changes exist