### PR TITLE
🐛 Avoid project_networks_attach failing

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_public.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_public.py
@@ -183,8 +183,8 @@ class DynamicSidecarClient:
                 dynamic_sidecar_network_name=dynamic_sidecar_network_name,
             )
         except EntrypointContainerNotFoundError:
-            # sometimes arrives before the sidecar started the user services
-            # operation can be skipped
+            # project_network changes are propagated form the workbench before
+            # the user services are started. It is safe to skip
             return
 
         network_names_to_ids: dict[str, str] = await get_or_create_networks_ids(

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_public.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_public.py
@@ -177,10 +177,15 @@ class DynamicSidecarClient:
 
         sorted_container_names = sorted(containers_status.keys())
 
-        entrypoint_container_name = await self.get_entrypoint_container_name(
-            dynamic_sidecar_endpoint=dynamic_sidecar_endpoint,
-            dynamic_sidecar_network_name=dynamic_sidecar_network_name,
-        )
+        try:
+            entrypoint_container_name = await self.get_entrypoint_container_name(
+                dynamic_sidecar_endpoint=dynamic_sidecar_endpoint,
+                dynamic_sidecar_network_name=dynamic_sidecar_network_name,
+            )
+        except EntrypointContainerNotFoundError:
+            # sometimes arrives before the sidecar started the user services
+            # operation can be skipped
+            return
 
         network_names_to_ids: dict[str, str] = await get_or_create_networks_ids(
             [project_network], project_id


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

If the user services were not started already, the project_network attach fails. It should be interrupted without an error.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

- fixes https://github.com/ITISFoundation/osparc-simcore/issues/3866
- https://github.com/ITISFoundation/osparc-issues/issues/638

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
