### PR TITLE
🐛 Bugfix: Workbench: render Edges after making sure all Nodes were rendered

### DIFF
--- a/services/static-webserver/client/source/class/osparc/theme/ColorDark.js
+++ b/services/static-webserver/client/source/class/osparc/theme/ColorDark.js
@@ -39,7 +39,7 @@ qx.Theme.define("osparc.theme.ColorDark", {
     "text-darker": "c07",
     "contrasted-text-dark": "c01",
     "contrasted-text-light": "c12",
-    "link": "c08",
+    "link": "c11",
 
     // shadows
     "bg-shadow": "c06",

--- a/services/static-webserver/client/source/class/osparc/theme/ColorLight.js
+++ b/services/static-webserver/client/source/class/osparc/theme/ColorLight.js
@@ -39,7 +39,7 @@ qx.Theme.define("osparc.theme.ColorLight", {
     "text-darker": "c07",
     "contrasted-text-dark": "c01",
     "contrasted-text-light": "c12",
-    "link": "c08",
+    "link": "c11",
 
     // shadows
     "bg-shadow": "c06",

--- a/services/static-webserver/client/source/class/osparc/theme/zmt/ColorDark.js
+++ b/services/static-webserver/client/source/class/osparc/theme/zmt/ColorDark.js
@@ -39,7 +39,7 @@ qx.Theme.define("osparc.theme.zmt.ColorDark", {
     "text-darker": "c07",
     "contrasted-text-dark": "c01",
     "contrasted-text-light": "c12",
-    "link": "c08",
+    "link": "c11",
 
     // shadows
     "bg-shadow": "c06",

--- a/services/static-webserver/client/source/class/osparc/theme/zmt/ColorLight.js
+++ b/services/static-webserver/client/source/class/osparc/theme/zmt/ColorLight.js
@@ -39,7 +39,7 @@ qx.Theme.define("osparc.theme.zmt.ColorLight", {
     "text-darker": "c07",
     "contrasted-text-dark": "c01",
     "contrasted-text-light": "c12",
-    "link": "c08",
+    "link": "c11",
 
     // shadows
     "bg-shadow": "c06",

--- a/services/static-webserver/client/source/class/osparc/ui/message/Loading.js
+++ b/services/static-webserver/client/source/class/osparc/ui/message/Loading.js
@@ -115,8 +115,8 @@ qx.Class.define("osparc.ui.message.Loading", {
         alignX: "center",
         alignY: "middle"
       })).set({
-        width: this.self().LOGO_WIDTH*2,
-        maxWidth: this.self().LOGO_WIDTH*2,
+        width: this.self().LOGO_WIDTH*3,
+        maxWidth: this.self().LOGO_WIDTH*3,
         padding: 20
       });
       this._add(new qx.ui.core.Widget(), {


### PR DESCRIPTION
## What do these changes do?

The issue for rendering Edges (node connections) in the Workbench is that the Nodes need to be printed before printing the Edges (these depend on the position of the in/out ports). This PR changes the mechanism for rendering them.

Before, we had a while loop with a 4 seconds timeout that would wait for all Nodes to be visible. We now listen to the ```appear``` event on the Node and once all nodes are printed we proceed to render the Edges.

Reported by Fariba Karimi.

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
