### PR TITLE
✨ Autoscaling: Use EC2 Instance Storage drive (⚠️ devops)

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -96,7 +96,7 @@ class EC2InstancesSettings(BaseCustomSettings):
 
     EC2_INSTANCES_CUSTOM_BOOT_SCRIPTS: list[str] = Field(
         default_factory=list,
-        description="script(s) to run on EC2 instance startup (be careful!)",
+        description="script(s) to run on EC2 instance startup (be careful!), each entry is run one after the other using '&&' operator",
     )
 
     @validator("EC2_INSTANCES_TIME_BEFORE_TERMINATION")

--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -94,6 +94,11 @@ class EC2InstancesSettings(BaseCustomSettings):
         description="time interval between pulls of images (minimum is 1 minute)",
     )
 
+    EC2_INSTANCES_CUSTOM_BOOT_SCRIPTS: list[str] = Field(
+        default_factory=list,
+        description="script(s) to run on EC2 instance startup (be careful!)",
+    )
+
     @validator("EC2_INSTANCES_TIME_BEFORE_TERMINATION")
     @classmethod
     def ensure_time_is_in_range(cls, value):

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -308,13 +308,15 @@ async def _start_instances(
     app_settings: ApplicationSettings = app.state.settings
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
 
+    instance_tags = ec2.get_ec2_tags(app_settings)
+    instance_startup_script = await ec2_startup_script(app_settings)
     results = await asyncio.gather(
         *[
             ec2_client.start_aws_instance(
                 app_settings.AUTOSCALING_EC2_INSTANCES,
                 instance_type=parse_obj_as(InstanceTypeType, instance.name),
-                tags=ec2.get_ec2_tags(app_settings),
-                startup_script=await ec2_startup_script(app_settings),
+                tags=instance_tags,
+                startup_script=instance_startup_script,
                 number_of_instances=instance_num,
             )
             for instance, instance_num in needed_instances.items()

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -130,7 +130,10 @@ async def try_assigning_task_to_pending_instances(
 
 async def ec2_startup_script(app_settings: ApplicationSettings) -> str:
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
-    startup_commands = [await utils_docker.get_docker_swarm_join_bash_command()]
+    startup_commands = [
+        utils_docker.mount_docker_drive_on_ephemeral("/dev/nvme2n1"),
+        await utils_docker.get_docker_swarm_join_bash_command(),
+    ]
     if app_settings.AUTOSCALING_REGISTRY:
         if pull_image_cmd := utils_docker.get_docker_pull_images_on_start_bash_command(
             app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_PRE_PULL_IMAGES

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -130,10 +130,10 @@ async def try_assigning_task_to_pending_instances(
 
 async def ec2_startup_script(app_settings: ApplicationSettings) -> str:
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
-    startup_commands = [
-        utils_docker.mount_docker_drive_on_ephemeral("/dev/nvme2n1"),
-        await utils_docker.get_docker_swarm_join_bash_command(),
-    ]
+    startup_commands = (
+        app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_CUSTOM_BOOT_SCRIPTS
+    )
+    startup_commands.append(await utils_docker.get_docker_swarm_join_bash_command())
     if app_settings.AUTOSCALING_REGISTRY:
         if pull_image_cmd := utils_docker.get_docker_pull_images_on_start_bash_command(
             app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_PRE_PULL_IMAGES

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import re
-from copy import deepcopy
 from typing import Final
 
 from fastapi import FastAPI
@@ -131,8 +130,8 @@ async def try_assigning_task_to_pending_instances(
 
 async def ec2_startup_script(app_settings: ApplicationSettings) -> str:
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
-    startup_commands = deepcopy(
-        app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_CUSTOM_BOOT_SCRIPTS
+    startup_commands = (
+        app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_CUSTOM_BOOT_SCRIPTS.copy()
     )
     startup_commands.append(await utils_docker.get_docker_swarm_join_bash_command())
     if app_settings.AUTOSCALING_REGISTRY:

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import re
+from copy import deepcopy
 from typing import Final
 
 from fastapi import FastAPI
@@ -130,7 +131,7 @@ async def try_assigning_task_to_pending_instances(
 
 async def ec2_startup_script(app_settings: ApplicationSettings) -> str:
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
-    startup_commands = (
+    startup_commands = deepcopy(
         app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_CUSTOM_BOOT_SCRIPTS
     )
     startup_commands.append(await utils_docker.get_docker_swarm_join_bash_command())

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -403,6 +403,61 @@ def get_docker_pull_images_crontab(interval: datetime.timedelta) -> str:
     return " && ".join([crontab_entry])
 
 
+_DOCKER_DAEMON_PATH: Final[Path] = Path("/etc/docker/daemon.json")
+_MOUNTED_DOCKER_PATH: Final[Path] = Path("/mnt/docker")
+_TMP_DAEMON_PATH: Final[Path] = Path("/tmp/daemon.json")
+
+
+def mount_docker_drive_on_ephemeral(device_name: str = "/dev/nvme2n1") -> str:
+    format_drive_cmd = " ".join(
+        ["mkfs", "--type xfs", "-f", "-n ftype=1", f"{device_name}"]
+    )
+    create_drive_mount_path = " ".join(
+        ["mkdir", "--parents", f"{_MOUNTED_DOCKER_PATH}"]
+    )
+    mount_drive_cmd = " ".join(["mount", f"{device_name}", f"{_MOUNTED_DOCKER_PATH}"])
+
+    set_docker_root_path_cmd = " ".join(
+        [
+            "jq",
+            f'\'."data-root"="{_MOUNTED_DOCKER_PATH}/data"\'',
+            f"{_DOCKER_DAEMON_PATH}",
+            ">",
+            f"{_TMP_DAEMON_PATH}",
+            "&&",
+            "mv",
+            f"{_TMP_DAEMON_PATH}",
+            f"{_DOCKER_DAEMON_PATH}",
+        ]
+    )
+
+    set_docker_exec_path_cmd = " ".join(
+        [
+            "jq",
+            f'\'."exec-root"="{_MOUNTED_DOCKER_PATH}/exec"\'',
+            f"{_DOCKER_DAEMON_PATH}",
+            ">",
+            f"{_TMP_DAEMON_PATH}",
+            "&&",
+            "mv",
+            f"{_TMP_DAEMON_PATH}",
+            f"{_DOCKER_DAEMON_PATH}",
+        ]
+    )
+
+    restart_docker_daemon = " ".join(["systemctl", "restart", "docker"])
+    return " && ".join(
+        [
+            format_drive_cmd,
+            create_drive_mount_path,
+            mount_drive_cmd,
+            set_docker_root_path_cmd,
+            set_docker_exec_path_cmd,
+            restart_docker_daemon,
+        ]
+    )
+
+
 async def find_node_with_name(
     docker_client: AutoscalingDocker, name: str
 ) -> Optional[Node]:

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -330,12 +330,14 @@ async def get_docker_swarm_join_bash_command() -> str:
 def get_docker_login_on_start_bash_command(registry_settings: RegistrySettings) -> str:
     return " ".join(
         [
+            "echo",
+            f'"{registry_settings.REGISTRY_PW.get_secret_value()}"',
+            "|",
             "docker",
             "login",
             "--username",
             registry_settings.REGISTRY_USER,
-            "--password",
-            registry_settings.REGISTRY_PW.get_secret_value(),
+            "--password-stdin",
             registry_settings.resolved_registry_url,
         ]
     )
@@ -420,21 +422,7 @@ def mount_docker_drive_on_ephemeral(device_name: str = "/dev/nvme2n1") -> str:
     set_docker_root_path_cmd = " ".join(
         [
             "jq",
-            f'\'."data-root"="{_MOUNTED_DOCKER_PATH}/data"\'',
-            f"{_DOCKER_DAEMON_PATH}",
-            ">",
-            f"{_TMP_DAEMON_PATH}",
-            "&&",
-            "mv",
-            f"{_TMP_DAEMON_PATH}",
-            f"{_DOCKER_DAEMON_PATH}",
-        ]
-    )
-
-    set_docker_exec_path_cmd = " ".join(
-        [
-            "jq",
-            f'\'."exec-root"="{_MOUNTED_DOCKER_PATH}/exec"\'',
+            f'\'."data-root"="{_MOUNTED_DOCKER_PATH}/data", ."exec-root"="{_MOUNTED_DOCKER_PATH}/exec"\'',
             f"{_DOCKER_DAEMON_PATH}",
             ">",
             f"{_TMP_DAEMON_PATH}",
@@ -452,7 +440,6 @@ def mount_docker_drive_on_ephemeral(device_name: str = "/dev/nvme2n1") -> str:
             create_drive_mount_path,
             mount_drive_cmd,
             set_docker_root_path_cmd,
-            set_docker_exec_path_cmd,
             restart_docker_daemon,
         ]
     )

--- a/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
+++ b/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
@@ -232,7 +232,7 @@ def enabled_pre_pull_images(
 def enabled_custom_boot_scripts(
     minimal_configuration: None, monkeypatch: pytest.MonkeyPatch, faker: Faker
 ) -> list[str]:
-    custom_scripts = faker.pylist(allowed_types=(str))
+    custom_scripts = faker.pylist(allowed_types=(str,))
     monkeypatch.setenv(
         "EC2_INSTANCES_CUSTOM_BOOT_SCRIPTS",
         json.dumps(custom_scripts),

--- a/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
+++ b/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
@@ -264,12 +264,13 @@ async def test_ec2_startup_script_with_custom_scripts(
     enabled_custom_boot_scripts: list[str],
     app_settings: ApplicationSettings,
 ):
-    startup_script = await ec2_startup_script(app_settings)
-    assert len(startup_script.split("&&")) == 7 + len(enabled_custom_boot_scripts)
-    assert re.fullmatch(
-        rf"^([^&&]+ &&){{{len(enabled_custom_boot_scripts)}}} (docker swarm join [^&&]+) && (echo [^\s]+ \| docker login [^&&]+) && (echo [^&&]+) && (echo [^&&]+) && (chmod \+x [^&&]+) && (./docker-pull-script.sh) && (echo .+)$",
-        startup_script,
-    ), f"{startup_script=}"
+    for _ in range(3):
+        startup_script = await ec2_startup_script(app_settings)
+        assert len(startup_script.split("&&")) == 7 + len(enabled_custom_boot_scripts)
+        assert re.fullmatch(
+            rf"^([^&&]+ &&){{{len(enabled_custom_boot_scripts)}}} (docker swarm join [^&&]+) && (echo [^\s]+ \| docker login [^&&]+) && (echo [^&&]+) && (echo [^&&]+) && (chmod \+x [^&&]+) && (./docker-pull-script.sh) && (echo .+)$",
+            startup_script,
+        ), f"{startup_script=}"
 
 
 async def test_ec2_startup_script_with_pre_pulling_but_no_registry(

--- a/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
+++ b/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
@@ -229,6 +229,18 @@ def enabled_pre_pull_images(
 
 
 @pytest.fixture
+def enabled_custom_boot_scripts(
+    minimal_configuration: None, monkeypatch: pytest.MonkeyPatch, faker: Faker
+) -> list[str]:
+    custom_scripts = faker.pylist(allowed_types=(str))
+    monkeypatch.setenv(
+        "EC2_INSTANCES_CUSTOM_BOOT_SCRIPTS",
+        json.dumps(custom_scripts),
+    )
+    return custom_scripts
+
+
+@pytest.fixture
 def disabled_registry(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("REGISTRY_AUTH")
 
@@ -241,7 +253,21 @@ async def test_ec2_startup_script_with_pre_pulling(
     startup_script = await ec2_startup_script(app_settings)
     assert len(startup_script.split("&&")) == 7
     assert re.fullmatch(
-        r"^(docker swarm join [^&&]+) && (docker login [^&&]+) && (echo [^&&]+) && (echo [^&&]+) && (chmod \+x [^&&]+) && (./docker-pull-script.sh) && (echo .+)$",
+        r"^(docker swarm join [^&&]+) && (echo [^\s]+ \| docker login [^&&]+) && (echo [^&&]+) && (echo [^&&]+) && (chmod \+x [^&&]+) && (./docker-pull-script.sh) && (echo .+)$",
+        startup_script,
+    ), f"{startup_script=}"
+
+
+async def test_ec2_startup_script_with_custom_scripts(
+    minimal_configuration: None,
+    enabled_pre_pull_images: None,
+    enabled_custom_boot_scripts: list[str],
+    app_settings: ApplicationSettings,
+):
+    startup_script = await ec2_startup_script(app_settings)
+    assert len(startup_script.split("&&")) == 7 + len(enabled_custom_boot_scripts)
+    assert re.fullmatch(
+        rf"^([^&&]+ &&){{{len(enabled_custom_boot_scripts)}}} (docker swarm join [^&&]+) && (echo [^\s]+ \| docker login [^&&]+) && (echo [^&&]+) && (echo [^&&]+) && (chmod \+x [^&&]+) && (./docker-pull-script.sh) && (echo .+)$",
         startup_script,
     ), f"{startup_script=}"
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?
For S4l-lite we do use [g4dn.8xlarge EC2 instance type](https://aws.amazon.com/ec2/instance-types/).
These provide a 900GB SSD with NVME connection that is usable directly and provides with ~16kIOPS. About 5 times more than the usual gp3 EBS backed drive.

This PR brings a new ENV ```EC2_INSTANCES_CUSTOM_BOOT_SCRIPTS``` that allows to pass custom boot scripts to the EC2 instance when booting.
One usage of this is the following:
```
EC2_INSTANCES_CUSTOM_BOOT_SCRIPTS=["mkfs --type xfs -f -n ftype=1 /dev/nvme2n1","mkdir --parents /mnt/docker","mount /dev/nvme2n1 /mnt/docker","jq '.\"data-root\"=\"/mnt/docker/data\", .\"exec-root\"=\"/mnt/docker/exec\"' /etc/docker/daemon.json  > /tmp/daemon.json","mv /tmp/daemon.json /etc/docker/daemon.json","systemctl restart docker"]
```

On each booted EC2 instance created by the Autoscaling service, the Instance Store drive is formatted in XFS, mounted, and the docker data and exec root path are moved to it, providing much higher performances and this also when cold started.

Together with #3876 this brings the option to have "semi-warm" machines in the buffer. E.g. the docker data/exec is warm and the boot drive is almost totally warm. therefore the startup is much faster!
Using as test taging-AWS with 1 machine buffer.. s4l-lite 2.0.106 was up and running in less than 2 minutes.
<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
