### PR TITLE
✨Adding an RPC client/server working via rabbitmq

### DIFF
--- a/packages/service-library/src/servicelib/rabbitmq.py
+++ b/packages/service-library/src/servicelib/rabbitmq.py
@@ -118,11 +118,11 @@ class RabbitMQClient:
             # consumer/publisher must set the same configuration for same queue
             # exclusive means that the queue is only available for THIS very client
             # and will be deleted when the client disconnects
-            queue_parameters = dict(
-                durable=True,
-                exclusive=exclusive_queue,
-                arguments={"x-message-ttl": _RABBIT_QUEUE_MESSAGE_DEFAULT_TTL_S},
-            )
+            queue_parameters = {
+                "durable": True,
+                "exclusive": exclusive_queue,
+                "arguments": {"x-message-ttl": _RABBIT_QUEUE_MESSAGE_DEFAULT_TTL_S},
+            }
             if not exclusive_queue:
                 # NOTE: setting a name will ensure multiple instance will take their data here
                 queue_parameters |= {"name": exchange_name}

--- a/packages/service-library/src/servicelib/rabbitmq_robust_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq_robust_rpc.py
@@ -1,0 +1,103 @@
+import asyncio
+from typing import Any, Awaitable, Final, Optional
+from uuid import uuid4
+
+from aio_pika import (
+    MessageProcessError,
+    RobustChannel,
+    RobustConnection,
+    connect_robust,
+)
+from aio_pika.patterns import RPC
+from pydantic import PositiveFloat
+from pydantic.errors import PydanticErrorMixin
+from settings_library.rabbit import RabbitSettings
+
+_ERROR_PREFIX: Final[str] = "rabbitmq.robust_rpc."
+
+
+class BaseRPCError(PydanticErrorMixin, RuntimeError):
+    ...
+
+
+class NotStartedError(BaseRPCError):
+    code = f"{_ERROR_PREFIX}.not_started"
+    msg_template = (
+        "{class_name} was not fully initialized, check that start() was called."
+    )
+
+
+class RemoteMethodNotRegisteredError(BaseRPCError):
+    code = f"{_ERROR_PREFIX}.remote_not_registered"
+    msg_template = (
+        "Could not find a remote method named: '{method_name}'. "
+        "Message from remote server was returned: {incoming_message}. "
+    )
+
+
+class RPCBase:
+    def __init__(self, rabbit_settings: RabbitSettings, channel_name: str) -> None:
+        self.channel_name = channel_name
+        self.rabbit_settings = rabbit_settings
+
+        self._connection: Optional[RobustConnection] = None
+        self._channel: Optional[RobustChannel] = None
+        self._rpc: Optional[RPC] = None
+
+    async def start(self) -> None:
+        self._connection = await connect_robust(
+            self.rabbit_settings.dsn,
+            client_properties={"connection_name": self.channel_name},
+        )
+
+        self._channel = await self._connection.channel()
+        self._rpc = await RPC.create(self._channel)
+
+    async def stop(self) -> None:
+        if self._rpc is not None:
+            await self._rpc.close()
+        if self._channel is not None:
+            await self._channel.close()
+        if self._connection is not None:
+            await self._connection.close()
+
+
+class RobustRPCClient(RPCBase):
+    def __init__(self, rabbit_settings: RabbitSettings) -> None:
+        channel_name = f"{RobustRPCClient.__name__}{uuid4()}"
+        super().__init__(rabbit_settings, channel_name)
+
+    async def request(
+        self, method_name, *, timeout: Optional[PositiveFloat] = 5, **kwargs
+    ) -> Any:
+        """
+        Calls into an already existing handler which was defined refined remotely
+        """
+
+        if not self._rpc:
+            raise NotStartedError(class_name=self.__class__.__name__)
+
+        try:
+            return await asyncio.wait_for(
+                self._rpc.call(method_name, kwargs=kwargs), timeout=timeout
+            )
+        except MessageProcessError as e:
+            if e.args[0] == "Message has been returned":
+                raise RemoteMethodNotRegisteredError(
+                    method_name=method_name, incoming_message=e.args[1]
+                ) from e
+            raise e
+
+
+class RobustRPCServer(RPCBase):
+    def __init__(self, rabbit_settings: RabbitSettings) -> None:
+        channel_name = f"{RobustRPCServer.__name__}{uuid4()}"
+        super().__init__(rabbit_settings, channel_name)
+
+    async def register(self, handler: Awaitable) -> None:
+        """register an awaitable handler that can be invoked remotely"""
+
+        if self._rpc is None:
+            raise NotStartedError(class_name=self.__class__.__name__)
+
+        await self._rpc.register(handler.__name__, handler, auto_delete=True)

--- a/packages/service-library/src/servicelib/rabbitmq_utils.py
+++ b/packages/service-library/src/servicelib/rabbitmq_utils.py
@@ -23,12 +23,12 @@ class RabbitMQRetryPolicyUponInitialization:
     def __init__(self, logger: Optional[logging.Logger] = None):
         logger = logger or log
 
-        self.kwargs = dict(
-            wait=wait_fixed(2),
-            stop=stop_after_delay(3 * _MINUTE),
-            before_sleep=before_sleep_log(logger, logging.WARNING),
-            reraise=True,
-        )
+        self.kwargs = {
+            "wait": wait_fixed(2),
+            "stop": stop_after_delay(3 * _MINUTE),
+            "before_sleep": before_sleep_log(logger, logging.WARNING),
+            "reraise": True,
+        }
 
 
 @retry(**RabbitMQRetryPolicyUponInitialization().kwargs)

--- a/packages/service-library/tests/test_rabbitmq_robust_rpc.py
+++ b/packages/service-library/tests/test_rabbitmq_robust_rpc.py
@@ -1,0 +1,229 @@
+# pylint:disable=redefined-outer-name
+# pylint:disable=unused-argument
+
+import asyncio
+from typing import Any, Awaitable, Final
+
+import pytest
+from pydantic import NonNegativeInt
+from servicelib.rabbitmq_robust_rpc import (
+    NotStartedError,
+    RemoteMethodNotRegisteredError,
+    RobustRPCClient,
+    RobustRPCServer,
+)
+from settings_library.rabbit import RabbitSettings
+
+pytest_simcore_core_services_selection = [
+    "rabbit",
+]
+
+MULTIPLE_REQUESTS_COUNT: Final[NonNegativeInt] = 100
+
+
+@pytest.fixture
+async def rpc_client(rabbit_service: RabbitSettings) -> RobustRPCClient:
+    client = RobustRPCClient(rabbit_settings=rabbit_service)
+    await client.start()
+    yield client
+    await client.stop()
+
+
+@pytest.fixture
+async def rpc_server(rabbit_service: RabbitSettings) -> RobustRPCServer:
+    server = RobustRPCServer(rabbit_settings=rabbit_service)
+    await server.start()
+    yield server
+    await server.stop()
+
+
+async def add_me(*, x: Any, y: Any) -> Any:
+    result = x + y
+    # NOTE: types are not enforced
+    # result's type will on the caller side will be the one it has here
+    return result
+
+
+class CustomClass:
+    def __init__(self, x: Any, y: Any) -> None:
+        self.x = x
+        self.y = y
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} x={self.x}, y={self.y}>"
+
+    def __eq__(self, other: "CustomClass") -> bool:
+        return self.x == other.x and self.y == other.y
+
+    def __add__(self, other: "CustomClass") -> "CustomClass":
+        return CustomClass(x=self.x + other.x, y=self.y + other.y)
+
+
+@pytest.mark.parametrize(
+    "x,y,expected_result,expected_type",
+    [
+        pytest.param(12, 20, 32, int, id="expect_int"),
+        pytest.param(12, 20.0, 32.0, float, id="expect_float"),
+        pytest.param(b"123b", b"xyz0", b"123bxyz0", bytes, id="expect_bytes"),
+        pytest.param([1, 2], [2, 3], [1, 2, 2, 3], list, id="list_addition"),
+        pytest.param(
+            CustomClass(2, 1),
+            CustomClass(1, 2),
+            CustomClass(3, 3),
+            CustomClass,
+            id="custom_class",
+        ),
+        pytest.param(
+            CustomClass([{"p", "1"}], [{"h": 1}]),
+            CustomClass([{3, b"bytes"}], [{"b": 2}]),
+            CustomClass([{"p", "1"}, {3, b"bytes"}], [{"h": 1}, {"b": 2}]),
+            CustomClass,
+            id="custom_class_complex_objects",
+        ),
+    ],
+)
+async def test_base_rpc_pattern(
+    rpc_client: RobustRPCClient,
+    rpc_server: RobustRPCServer,
+    x: Any,
+    y: Any,
+    expected_result: Any,
+    expected_type: type,
+):
+    await rpc_server.register(add_me)
+
+    request_result = await rpc_client.request(add_me.__name__, x=x, y=y)
+    assert request_result == expected_result
+    assert type(request_result) == expected_type
+
+
+async def test_multiple_requests_sequence_same_server_and_client(
+    rpc_client: RobustRPCClient, rpc_server: RobustRPCServer
+):
+    await rpc_server.register(add_me)
+
+    for i in range(MULTIPLE_REQUESTS_COUNT):
+        assert await rpc_client.request(add_me.__name__, x=1 + i, y=2 + i) == 3 + i * 2
+
+
+async def test_multiple_requests_parallel_same_server_and_client(
+    rpc_client: RobustRPCClient, rpc_server: RobustRPCServer
+):
+    await rpc_server.register(add_me)
+
+    expected_result: list[int] = []
+    requests: list[Awaitable] = []
+    for i in range(MULTIPLE_REQUESTS_COUNT):
+        requests.append(rpc_client.request(add_me.__name__, x=1 + i, y=2 + i))
+        expected_result.append(3 + i * 2)
+
+    assert await asyncio.gather(*requests) == expected_result
+
+
+async def test_multiple_requests_parallel_same_server_different_clients(
+    rabbit_service: RabbitSettings, rpc_server: RobustRPCServer
+):
+    await rpc_server.register(add_me)
+
+    clients: list[RobustRPCClient] = []
+    for _ in range(MULTIPLE_REQUESTS_COUNT):
+        client = RobustRPCClient(rabbit_service)
+        clients.append(client)
+
+    # worst case scenario
+    await asyncio.gather(*[c.start() for c in clients])
+
+    requests: list[Awaitable] = []
+    expected_result: list[int] = []
+    for i in range(MULTIPLE_REQUESTS_COUNT):
+        client = clients[i]
+        requests.append(client.request(add_me.__name__, x=1 + i, y=2 + i))
+        expected_result.append(3 + i * 2)
+
+    assert await asyncio.gather(*requests) == expected_result
+
+    # worst case scenario
+    await asyncio.gather(*[c.stop() for c in clients])
+
+
+async def test_raise_error_if_not_started(rabbit_service: RabbitSettings):
+    client = RobustRPCClient(rabbit_settings=rabbit_service)
+    with pytest.raises(NotStartedError):
+        await client.request(add_me, x=1, y=2)
+
+    # expect not to raise error
+    await client.stop()
+
+    server = RobustRPCServer(rabbit_settings=rabbit_service)
+    with pytest.raises(NotStartedError):
+        await server.register(add_me)
+
+    # expect not to raise error
+    await server.stop()
+
+
+async def _assert_event_not_registered(rpc_client: RobustRPCClient):
+    with pytest.raises(RemoteMethodNotRegisteredError) as exec_info:
+        assert await rpc_client.request(add_me.__name__, x=1, y=3) == 3
+    assert (
+        f"Could not find a remote method named: '{add_me.__name__}'"
+        in f"{exec_info.value}"
+    )
+
+
+async def test_server_not_started(rpc_client: RobustRPCClient):
+    await _assert_event_not_registered(rpc_client)
+
+
+async def test_server_handler_not_registered(
+    rpc_client: RobustRPCClient, rpc_server: RobustRPCServer
+):
+    await _assert_event_not_registered(rpc_client)
+
+
+async def test_request_is_missing_arguments(
+    rpc_client: RobustRPCClient, rpc_server: RobustRPCServer
+):
+    await rpc_server.register(add_me)
+
+    # missing 1 argument
+    with pytest.raises(TypeError) as exec_info:
+        await rpc_client.request(add_me.__name__, x=1)
+    assert (
+        f"{add_me.__name__}() missing 1 required keyword-only argument: 'y'"
+        in f"{exec_info.value}"
+    )
+
+    # missing all arguments
+    with pytest.raises(TypeError) as exec_info:
+        await rpc_client.request(add_me.__name__)
+    assert (
+        f"{add_me.__name__}() missing 2 required keyword-only arguments: 'x' and 'y'"
+        in f"{exec_info.value}"
+    )
+
+
+async def test_client_cancels_long_running_request_or_client_takes_too_much_to_respond(
+    rpc_client: RobustRPCClient, rpc_server: RobustRPCServer
+):
+    async def _long_running(*, time_to_sleep: float) -> None:
+        await asyncio.sleep(time_to_sleep)
+
+    await rpc_server.register(_long_running)
+
+    # this task will be cancelled
+    with pytest.raises(asyncio.TimeoutError):
+        await rpc_client.request(_long_running.__name__, time_to_sleep=10, timeout=0.5)
+
+
+async def test_server_handler_raises_error(
+    rpc_client: RobustRPCClient, rpc_server: RobustRPCServer
+):
+    async def _raising_error() -> None:
+        raise RuntimeError("failed as requested")
+
+    await rpc_server.register(_raising_error)
+
+    with pytest.raises(RuntimeError) as exec_info:
+        await rpc_client.request(_raising_error.__name__)
+    assert "failed as requested" == f"{exec_info.value}"


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

This adds an RPC via rabbitmq, it will decoupling code much more simpler.

From the first tests added it is looking nice
```
test_base_rpc_pattern[expect_int]
test_base_rpc_pattern[expect_float] 
test_base_rpc_pattern[expect_bytes] 
test_base_rpc_pattern[list_addition]
test_base_rpc_pattern[custom_class]
test_base_rpc_pattern[custom_class_complex_objects] 
test_multiple_requests_sequence_same_server_and_client 
test_multiple_requests_parallel_same_server_and_client 
test_multiple_requests_parallel_same_server_different_clients
test_raise_error_if_not_started
test_server_not_started 
test_server_handler_not_registered
test_request_is_missing_arguments 
test_client_cancels_long_running_request_or_client_takes_too_much_to_respond 
test_server_handler_raises_error
```



## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
