### PR TITLE
✨Autoscaling: allow multiple autoscaling services

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -457,12 +457,12 @@ async def _analyze_current_cluster(app: FastAPI) -> Cluster:
     # get the EC2 instances we have
     existing_ec2_instances = await get_ec2_client(app).get_instances(
         app_settings.AUTOSCALING_EC2_INSTANCES,
-        list(ec2.get_ec2_tags(app_settings).keys()),
+        ec2.get_ec2_tags(app_settings),
     )
 
     terminated_ec2_instances = await get_ec2_client(app).get_instances(
         app_settings.AUTOSCALING_EC2_INSTANCES,
-        list(ec2.get_ec2_tags(app_settings).keys()),
+        ec2.get_ec2_tags(app_settings),
         state_names=["terminated"],
     )
 

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -454,7 +454,7 @@ async def _analyze_current_cluster(app: FastAPI) -> Cluster:
         node_labels=app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NODE_LABELS,
     )
 
-    # get the whatever EC2 instances we have
+    # get the EC2 instances we have
     existing_ec2_instances = await get_ec2_client(app).get_instances(
         app_settings.AUTOSCALING_EC2_INSTANCES,
         list(ec2.get_ec2_tags(app_settings).keys()),

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -3,7 +3,6 @@ import collections
 import dataclasses
 import itertools
 import logging
-from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import cast
 
@@ -272,7 +271,7 @@ async def _find_needed_instances(
                 f"{task.Name or 'unknown task name'}:{task.ServiceID or 'unknown service ID'}",
             )
 
-    num_instances_per_type = defaultdict(
+    num_instances_per_type = collections.defaultdict(
         int, collections.Counter(t for t, _ in needed_new_instance_to_tasks)
     )
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -203,46 +203,6 @@ class AutoscalingEC2:
         logger.debug("received: %s", f"{all_instances=}")
         return all_instances
 
-    async def get_running_instance(
-        self,
-        instance_settings: EC2InstancesSettings,
-        tag_keys: list[str],
-        instance_host_name: str,
-    ) -> EC2InstanceData:
-        filters = [
-            {
-                "Name": "key-name",
-                "Values": [instance_settings.EC2_INSTANCES_KEY_NAME],
-            },
-            {"Name": "instance-state-name", "Values": ["running"]},
-            {
-                "Name": "network-interface.private-dns-name",
-                "Values": [f"{instance_host_name}.ec2.internal"],
-            },
-        ]
-        filters.extend([{"Name": "tag-key", "Values": [t]} for t in tag_keys])
-        instances = await self.client.describe_instances(Filters=filters)
-        if not instances["Reservations"]:
-            # NOTE: wrong hostname, or not running, or wrong usage
-            raise Ec2InstanceNotFoundError()
-
-        # NOTE: since the hostname is unique, there is only one instance here
-        assert "Instances" in instances["Reservations"][0]  # nosec
-        instance = instances["Reservations"][0]["Instances"][0]
-        assert "LaunchTime" in instance  # nosec
-        assert "InstanceId" in instance  # nosec
-        assert "PrivateDnsName" in instance  # nosec
-        assert "InstanceType" in instance  # nosec
-        assert "State" in instance  # nosec
-        assert "Name" in instance["State"]  # nosec
-        return EC2InstanceData(
-            launch_time=instance["LaunchTime"],
-            id=instance["InstanceId"],
-            aws_private_dns=instance["PrivateDnsName"],
-            type=instance["InstanceType"],
-            state=instance["State"]["Name"],
-        )
-
     async def terminate_instances(self, instance_datas: list[EC2InstanceData]) -> None:
         try:
             await self.client.terminate_instances(

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -15,6 +15,7 @@ from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_random_exponential
 from types_aiobotocore_ec2 import EC2Client
 from types_aiobotocore_ec2.literals import InstanceStateNameType, InstanceTypeType
+from types_aiobotocore_ec2.type_defs import FilterTypeDef
 
 from ..core.errors import (
     ConfigurationError,
@@ -169,7 +170,7 @@ class AutoscalingEC2:
         if state_names is None:
             state_names = ["pending", "running"]
 
-        filters = [
+        filters: list[FilterTypeDef] = [
             {
                 "Name": "key-name",
                 "Values": [instance_settings.EC2_INSTANCES_KEY_NAME],

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -85,6 +85,13 @@ def try_assigning_task_to_instances(
     return False
 
 
+_TIME_FORMAT = "{:02d}:{:02d}"  # format for minutes:seconds
+
+
+def _format_delta(delta: datetime.timedelta) -> str:
+    return _TIME_FORMAT.format(delta.seconds // 60, delta.seconds % 60)
+
+
 async def try_assigning_task_to_pending_instances(
     app: FastAPI,
     pending_task: Task,
@@ -113,10 +120,11 @@ async def try_assigning_task_to_pending_instances(
             estimated_time_to_completion = (
                 instance.launch_time + instance_max_time_to_start - now
             )
+
             await log_tasks_message(
                 app,
                 [pending_task],
-                f"adding machines to the cluster (time waiting: {time_since_launch}, est. remaining time: {estimated_time_to_completion})...please wait...",
+                f"adding machines to the cluster (time waiting: {_format_delta(time_since_launch)}, est. remaining time: {_format_delta(estimated_time_to_completion)})...please wait...",
             )
             await progress_tasks_message(
                 app,

--- a/services/autoscaling/tests/unit/test_modules_ec2.py
+++ b/services/autoscaling/tests/unit/test_modules_ec2.py
@@ -239,7 +239,7 @@ async def test_get_instances(
     all_instances = await ec2_client.describe_instances()
     assert not all_instances["Reservations"]
     assert (
-        await autoscaling_ec2.get_instances(app_settings.AUTOSCALING_EC2_INSTANCES, [])
+        await autoscaling_ec2.get_instances(app_settings.AUTOSCALING_EC2_INSTANCES, {})
         == []
     )
 
@@ -258,7 +258,7 @@ async def test_get_instances(
 
     instance_received = await autoscaling_ec2.get_instances(
         app_settings.AUTOSCALING_EC2_INSTANCES,
-        tag_keys=list(tags.keys()),
+        tags=tags,
     )
     assert created_instances == instance_received
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:
PREFIX:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.


or from https://gitmoji.dev/

SUFFIX:
 (⚠️ devops)  changes in devops configuration required before deploying
 (🗃️ DB change)  changes in the DB tables
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
This PR allows to run several Autoscaling services with different purposes:
- 1 Autoscaling that takes care for example of scaling EC2 instances for a specific service (i.e. jupyter-math)
- 1 Autoscaling that takes care for example of scaling EC2 instances for another service (i.e. s4l)

The PR allows both Autoscaling application to not trample each other feet by stealing each other machines.

 Each Autoscaling is made unique through the ENV ```NODES_MONITORING_NODE_LABELS``` and ```NODES_MONITORING_SERVICE_LABELS```


## Related issue/s
NOTE: the moto library has an issue, see https://github.com/getmoto/moto/issues/5966. This implied that a patch had to be applied in the unit tests. Real testing with AWS showed that the system is functional.
<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->
bonus:
fixes https://github.com/ITISFoundation/osparc-simcore/issues/3842


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
