### PR TITLE
✨ Frontend Dashboard: Convert tab labels into icons for small screens

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
@@ -40,7 +40,8 @@ qx.Class.define("osparc.dashboard.CardBase", {
     "updateTemplate": "qx.event.type.Data",
     "updateService": "qx.event.type.Data",
     "publishTemplate": "qx.event.type.Data",
-    "tagClicked": "qx.event.type.Data"
+    "tagClicked": "qx.event.type.Data",
+    "emptyStudyClicked": "qx.event.type.Data"
   },
 
   statics: {

--- a/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
@@ -716,6 +716,26 @@ qx.Class.define("osparc.dashboard.CardBase", {
       shareIcon.addListener("mouseout", () => hint.exclude(), this);
     },
 
+    _getEmptyWorkbenchIcon: function() {
+      let toolTipText = this.tr("Empty") + " ";
+      if (this.isResourceType("study")) {
+        toolTipText += osparc.product.Utils.getStudyAlias();
+      } else if (this.isResourceType("template")) {
+        toolTipText += osparc.product.Utils.getTemplateAlias();
+      }
+      const control = new qx.ui.basic.Image().set({
+        source: "@FontAwesome5Solid/times-circle/14",
+        alignY: "bottom",
+        toolTipText
+      });
+      control.addListener("tap", e => {
+        e.stopPropagation();
+        this.setValue(false);
+        this.fireDataEvent("emptyStudyClicked", this.getUuid());
+      }, this);
+      return control;
+    },
+
     /**
      * Event handler for the pointer over event.
      */

--- a/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
@@ -87,13 +87,14 @@ qx.Class.define("osparc.dashboard.Dashboard", {
 
     __createMainViewLayout: function() {
       const permissions = osparc.data.Permissions.getInstance();
+      const tabIconSize = 20;
       const tabs = [{
         id: "studiesTabBtn",
         label: osparc.product.Utils.getStudyAlias({
           plural: true,
           allUpperCase: true
         }),
-        icon: "@FontAwesome5Solid/file/24",
+        icon: "@FontAwesome5Solid/file/"+tabIconSize,
         buildLayout: this.__createStudyBrowser
       }];
       if (permissions.canDo("dashboard.templates.read")) {
@@ -103,7 +104,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
             plural: true,
             allUpperCase: true
           }),
-          icon: "@FontAwesome5Solid/copy/24",
+          icon: "@FontAwesome5Solid/copy/"+tabIconSize,
           buildLayout: this.__createTemplateBrowser
         };
         tabs.push(templatesTab);
@@ -112,7 +113,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
         tabs.push({
           id: "servicesTabBtn",
           label: this.tr("SERVICES"),
-          icon: "@FontAwesome5Solid/cogs/24",
+          icon: "@FontAwesome5Solid/cogs/"+tabIconSize,
           buildLayout: this.__createServiceBrowser
         });
       }
@@ -120,7 +121,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
         tabs.push({
           id: "dataTabBtn",
           label: this.tr("DATA"),
-          icon: "@FontAwesome5Solid/folder/24",
+          icon: "@FontAwesome5Solid/folder/"+tabIconSize,
           buildLayout: this.__createDataBrowser}
         );
       }
@@ -188,8 +189,8 @@ qx.Class.define("osparc.dashboard.Dashboard", {
       tabs.forEach(tab => {
         const tabButton = tab.getChildControl("button");
         if (newSize.width < smallBrakpoint) {
-          tabButton.getChildControl("label").exclude();
           tabButton.getChildControl("icon").show();
+          tabButton.getChildControl("label").exclude();
         } else {
           tabButton.getChildControl("label").show();
           tabButton.getChildControl("icon").exclude();

--- a/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
@@ -93,6 +93,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
           plural: true,
           allUpperCase: true
         }),
+        icon: "@FontAwesome5Solid/paw/24",
         buildLayout: this.__createStudyBrowser
       }];
       if (permissions.canDo("dashboard.templates.read")) {
@@ -102,6 +103,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
             plural: true,
             allUpperCase: true
           }),
+          icon: "@FontAwesome5Solid/paw/24",
           buildLayout: this.__createTemplateBrowser
         };
         tabs.push(templatesTab);
@@ -110,6 +112,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
         tabs.push({
           id: "servicesTabBtn",
           label: this.tr("SERVICES"),
+          icon: "@FontAwesome5Solid/paw/24",
           buildLayout: this.__createServiceBrowser
         });
       }
@@ -117,17 +120,21 @@ qx.Class.define("osparc.dashboard.Dashboard", {
         tabs.push({
           id: "dataTabBtn",
           label: this.tr("DATA"),
+          icon: "@FontAwesome5Solid/paw/24",
           buildLayout: this.__createDataBrowser}
         );
       }
-      tabs.forEach(({id, label, buildLayout}) => {
-        const tabPage = new qx.ui.tabview.Page(label).set({
+      tabs.forEach(({id, label, icon, buildLayout}) => {
+        const tabPage = new qx.ui.tabview.Page(label, icon).set({
           appearance: "dashboard-page"
         });
         const tabButton = tabPage.getChildControl("button");
         tabButton.set({
           font: "text-16",
           minWidth: 70
+        });
+        tabButton.getChildControl("icon").set({
+          toolTipText: label
         });
         osparc.utils.Utils.setIdToWidget(tabButton, id);
         tabPage.setLayout(new qx.ui.layout.Grow());
@@ -166,6 +173,22 @@ qx.Class.define("osparc.dashboard.Dashboard", {
           });
         })
         .catch(err => console.error(err));
+    },
+
+    topBarResized: function(newSize) {
+      const tabs = this.getChildren();
+      const nTabs = tabs.length;
+      const smallBrakpoint = nTabs*110;
+      tabs.forEach(tab => {
+        const tabButton = tab.getChildControl("button");
+        if (newSize.width < smallBrakpoint) {
+          tabButton.getChildControl("label").exclude();
+          tabButton.getChildControl("icon").show();
+        } else {
+          tabButton.getChildControl("label").show();
+          tabButton.getChildControl("icon").exclude();
+        }
+      });
     },
 
     __createStudyBrowser: function() {

--- a/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
@@ -112,7 +112,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
         tabs.push({
           id: "servicesTabBtn",
           label: this.tr("SERVICES"),
-          icon: "@FontAwesome5Solid/paw/24",
+          icon: "@FontAwesome5Solid/cogs/24",
           buildLayout: this.__createServiceBrowser
         });
       }
@@ -139,7 +139,8 @@ qx.Class.define("osparc.dashboard.Dashboard", {
           alignX: "center"
         });
         tabButton.getChildControl("icon").set({
-          alignX: "center"
+          alignX: "center",
+          visibility: "excluded"
         });
         osparc.utils.Utils.setIdToWidget(tabButton, id);
         tabPage.setLayout(new qx.ui.layout.Grow());

--- a/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
@@ -93,7 +93,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
           plural: true,
           allUpperCase: true
         }),
-        icon: "@FontAwesome5Solid/paw/24",
+        icon: "@FontAwesome5Solid/file/24",
         buildLayout: this.__createStudyBrowser
       }];
       if (permissions.canDo("dashboard.templates.read")) {
@@ -103,7 +103,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
             plural: true,
             allUpperCase: true
           }),
-          icon: "@FontAwesome5Solid/paw/24",
+          icon: "@FontAwesome5Solid/copy/24",
           buildLayout: this.__createTemplateBrowser
         };
         tabs.push(templatesTab);
@@ -120,7 +120,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
         tabs.push({
           id: "dataTabBtn",
           label: this.tr("DATA"),
-          icon: "@FontAwesome5Solid/paw/24",
+          icon: "@FontAwesome5Solid/folder/24",
           buildLayout: this.__createDataBrowser}
         );
       }
@@ -130,11 +130,16 @@ qx.Class.define("osparc.dashboard.Dashboard", {
         });
         const tabButton = tabPage.getChildControl("button");
         tabButton.set({
+          alignX: "center",
+          toolTipText: label,
+          minWidth: 50
+        });
+        tabButton.getChildControl("label").set({
           font: "text-16",
-          minWidth: 70
+          alignX: "center"
         });
         tabButton.getChildControl("icon").set({
-          toolTipText: label
+          alignX: "center"
         });
         osparc.utils.Utils.setIdToWidget(tabButton, id);
         tabPage.setLayout(new qx.ui.layout.Grow());

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonBase.js
@@ -82,11 +82,11 @@ qx.Class.define("osparc.dashboard.GridButtonBase", {
         rowSpan: 1,
         colSpan: 3
       },
-      TSR: {
+      TAGS: {
         row: 3,
         column: 0
       },
-      TAGS: {
+      TSR: {
         row: 4,
         column: 0
       },

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
@@ -60,6 +60,7 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
             alignY: "middle",
             toolTipText: this.tr("Empty")
           });
+          control.addListener("tap", () => this.fireDataEvent("emptyStudyClicked", this.getUuid()));
           this._mainLayout.add(control, osparc.dashboard.GridButtonBase.POS.UPDATES);
           break;
         case "update-study":

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
@@ -54,11 +54,17 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
           });
           this._mainLayout.add(control, osparc.dashboard.GridButtonBase.POS.VIEWER_MODE);
           break;
-        case "empty-workbench":
+        case "empty-workbench": {
+          let toolTipText = this.tr("Empty") + " ";
+          if (this.isResourceType("study")) {
+            toolTipText += osparc.product.Utils.getStudyAlias();
+          } else if (this.isResourceType("template")) {
+            toolTipText += osparc.product.Utils.getTemplateAlias();
+          }
           control = new qx.ui.basic.Image().set({
             source: "@FontAwesome5Solid/times-circle/14",
             alignY: "bottom",
-            toolTipText: this.tr("Empty")
+            toolTipText
           });
           control.addListener("tap", e => {
             e.stopPropagation();
@@ -67,6 +73,8 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
           }, this);
           this._mainLayout.add(control, osparc.dashboard.GridButtonBase.POS.UPDATES);
           break;
+
+        }
         case "update-study":
           control = new qx.ui.basic.Image().set({
             source: "@MaterialIcons/update/16",

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
@@ -50,14 +50,14 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
           break;
         case "workbench-mode":
           control = new qx.ui.basic.Image().set({
-            alignY: "middle"
+            alignY: "bottom"
           });
           this._mainLayout.add(control, osparc.dashboard.GridButtonBase.POS.VIEWER_MODE);
           break;
         case "empty-workbench":
           control = new qx.ui.basic.Image().set({
             source: "@FontAwesome5Solid/times-circle/14",
-            alignY: "middle",
+            alignY: "bottom",
             toolTipText: this.tr("Empty")
           });
           control.addListener("tap", e => {
@@ -71,14 +71,14 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
           control = new qx.ui.basic.Image().set({
             source: "@MaterialIcons/update/16",
             visibility: "excluded",
-            alignY: "middle"
+            alignY: "bottom"
           });
           this._mainLayout.add(control, osparc.dashboard.GridButtonBase.POS.UPDATES);
           break;
         case "hits-service":
           control = new qx.ui.basic.Label().set({
             toolTipText: this.tr("Number of times you instantiated it"),
-            alignY: "middle"
+            alignY: "bottom"
           });
           this._mainLayout.add(control, osparc.dashboard.GridButtonBase.POS.UPDATES);
           break;

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
@@ -60,7 +60,11 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
             alignY: "middle",
             toolTipText: this.tr("Empty")
           });
-          control.addListener("tap", () => this.fireDataEvent("emptyStudyClicked", this.getUuid()));
+          control.addListener("tap", e => {
+            e.stopPropagation();
+            this.setValue(false);
+            this.fireDataEvent("emptyStudyClicked", this.getUuid());
+          }, this);
           this._mainLayout.add(control, osparc.dashboard.GridButtonBase.POS.UPDATES);
           break;
         case "update-study":

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
@@ -55,25 +55,9 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
           this._mainLayout.add(control, osparc.dashboard.GridButtonBase.POS.VIEWER_MODE);
           break;
         case "empty-workbench": {
-          let toolTipText = this.tr("Empty") + " ";
-          if (this.isResourceType("study")) {
-            toolTipText += osparc.product.Utils.getStudyAlias();
-          } else if (this.isResourceType("template")) {
-            toolTipText += osparc.product.Utils.getTemplateAlias();
-          }
-          control = new qx.ui.basic.Image().set({
-            source: "@FontAwesome5Solid/times-circle/14",
-            alignY: "bottom",
-            toolTipText
-          });
-          control.addListener("tap", e => {
-            e.stopPropagation();
-            this.setValue(false);
-            this.fireDataEvent("emptyStudyClicked", this.getUuid());
-          }, this);
+          control = this._getEmptyWorkbenchIcon();
           this._mainLayout.add(control, osparc.dashboard.GridButtonBase.POS.UPDATES);
           break;
-
         }
         case "update-study":
           control = new qx.ui.basic.Image().set({

--- a/services/static-webserver/client/source/class/osparc/dashboard/ListButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ListButtonItem.js
@@ -121,16 +121,7 @@ qx.Class.define("osparc.dashboard.ListButtonItem", {
           });
           break;
         case "empty-workbench":
-          control = new qx.ui.basic.Image().set({
-            alignY: "middle",
-            source: "@FontAwesome5Solid/times-circle/14",
-            toolTipText: this.tr("Empty")
-          });
-          control.addListener("tap", e => {
-            e.stopPropagation();
-            this.setValue(false);
-            this.fireDataEvent("emptyStudyClicked", this.getUuid());
-          }, this);
+          control = this._getEmptyWorkbenchIcon();
           this._add(control, {
             row: 0,
             column: osparc.dashboard.ListButtonBase.POS.UPDATES

--- a/services/static-webserver/client/source/class/osparc/dashboard/ListButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ListButtonItem.js
@@ -126,7 +126,11 @@ qx.Class.define("osparc.dashboard.ListButtonItem", {
             source: "@FontAwesome5Solid/times-circle/14",
             toolTipText: this.tr("Empty")
           });
-          control.addListener("tap", () => this.fireDataEvent("emptyStudyClicked", this.getUuid()));
+          control.addListener("tap", e => {
+            e.stopPropagation();
+            this.setValue(false);
+            this.fireDataEvent("emptyStudyClicked", this.getUuid());
+          }, this);
           this._add(control, {
             row: 0,
             column: osparc.dashboard.ListButtonBase.POS.UPDATES

--- a/services/static-webserver/client/source/class/osparc/dashboard/ListButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ListButtonItem.js
@@ -126,6 +126,7 @@ qx.Class.define("osparc.dashboard.ListButtonItem", {
             source: "@FontAwesome5Solid/times-circle/14",
             toolTipText: this.tr("Empty")
           });
+          control.addListener("tap", () => this.fireDataEvent("emptyStudyClicked", this.getUuid()));
           this._add(control, {
             row: 0,
             column: osparc.dashboard.ListButtonBase.POS.UPDATES

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
@@ -135,6 +135,7 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
       resourcesContainer.addListener("updateService", e => this._updateServiceData(e.getData()));
       resourcesContainer.addListener("publishTemplate", e => this.fireDataEvent("publishTemplate", e.getData()));
       resourcesContainer.addListener("tagClicked", e => this.__searchBarFilter.addTagActiveFilter(e.getData()));
+      resourcesContainer.addListener("emptyStudyClicked", e => console.log("delete", e.getData()));
 
       this._add(resourcesContainer);
     },

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceBrowserBase.js
@@ -129,14 +129,12 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
       this.__viewMenuButton = new qx.ui.form.MenuButton(this.tr("View"), "@FontAwesome5Solid/chevron-down/10", viewByMenu);
 
       const resourcesContainer = this._resourcesContainer = new osparc.dashboard.ResourceContainerManager();
-
       resourcesContainer.addListener("updateStudy", e => this._updateStudyData(e.getData()));
       resourcesContainer.addListener("updateTemplate", e => this._updateTemplateData(e.getData()));
       resourcesContainer.addListener("updateService", e => this._updateServiceData(e.getData()));
       resourcesContainer.addListener("publishTemplate", e => this.fireDataEvent("publishTemplate", e.getData()));
       resourcesContainer.addListener("tagClicked", e => this.__searchBarFilter.addTagActiveFilter(e.getData()));
-      resourcesContainer.addListener("emptyStudyClicked", e => console.log("delete", e.getData()));
-
+      resourcesContainer.addListener("emptyStudyClicked", e => this._deleteResourceRequested(e.getData()));
       this._add(resourcesContainer);
     },
 
@@ -282,6 +280,10 @@ qx.Class.define("osparc.dashboard.ResourceBrowserBase", {
     },
 
     _createStudyFromService: function() {
+      throw new Error("Abstract method called!");
+    },
+
+    _deleteResourceRequested: function(resourceId) {
       throw new Error("Abstract method called!");
     },
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
@@ -59,6 +59,7 @@ qx.Class.define("osparc.dashboard.ResourceContainerManager", {
     "updateService": "qx.event.type.Data",
     "publishTemplate": "qx.event.type.Data",
     "tagClicked": "qx.event.type.Data",
+    "emptyStudyClicked": "qx.event.type.Data",
     "changeSelection": "qx.event.type.Data",
     "changeVisibility": "qx.event.type.Data"
   },
@@ -206,8 +207,9 @@ qx.Class.define("osparc.dashboard.ResourceContainerManager", {
         "updateTemplate",
         "updateService",
         "publishTemplate",
-        "tagClicked"
-      ].forEach(ev => card.addListener(ev, e => this.fireDataEvent(ev, e.getData())));
+        "tagClicked",
+        "emptyStudyClicked"
+      ].forEach(eName => card.addListener(eName, e => this.fireDataEvent(eName, e.getData())));
 
       return card;
     },

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -802,10 +802,10 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     },
 
     _deleteResourceRequested: function(studyId) {
-      this.__deleteResourceRequested(this.__getStudyData(studyId));
+      this.__deleteStudyRequested(this.__getStudyData(studyId));
     },
 
-    __deleteResourceRequested: function(studyData) {
+    __deleteStudyRequested: function(studyData) {
       const preferencesSettings = osparc.desktop.preferences.Preferences.getInstance();
       if (preferencesSettings.getConfirmDeleteStudy()) {
         const win = this.__createConfirmWindow([studyData.name]);
@@ -824,7 +824,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     __getDeleteStudyMenuButton: function(studyData) {
       const deleteButton = new qx.ui.menu.Button(this.tr("Delete"));
       osparc.utils.Utils.setIdToWidget(deleteButton, "studyItemMenuDelete");
-      deleteButton.addListener("execute", () => this.__deleteResourceRequested(studyData), this);
+      deleteButton.addListener("execute", () => this.__deleteStudyRequested(studyData), this);
       return deleteButton;
     },
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -566,11 +566,11 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
           win.open();
           win.addListener("close", () => {
             if (win.getConfirmed()) {
-              this.__deleteStudies(selection.map(button => this.__getStudyData(button.getUuid(), false)), false);
+              this.__doDeleteStudies(selection.map(button => this.__getStudyData(button.getUuid(), false)), false);
             }
           }, this);
         } else {
-          this.__deleteStudies(selection.map(button => this.__getStudyData(button.getUuid(), false)), false);
+          this.__doDeleteStudies(selection.map(button => this.__getStudyData(button.getUuid(), false)), false);
         }
       }, this);
       return deleteButton;
@@ -801,24 +801,26 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       return exportButton;
     },
 
+    deleteStudyRequested: function(studyData) {
+      const preferencesSettings = osparc.desktop.preferences.Preferences.getInstance();
+      if (preferencesSettings.getConfirmDeleteStudy()) {
+        const win = this.__createConfirmWindow([studyData.name]);
+        win.center();
+        win.open();
+        win.addListener("close", () => {
+          if (win.getConfirmed()) {
+            this.__doDeleteStudy(studyData);
+          }
+        }, this);
+      } else {
+        this.__doDeleteStudy(studyData);
+      }
+    },
+
     __getDeleteStudyMenuButton: function(studyData) {
       const deleteButton = new qx.ui.menu.Button(this.tr("Delete"));
       osparc.utils.Utils.setIdToWidget(deleteButton, "studyItemMenuDelete");
-      deleteButton.addListener("execute", () => {
-        const preferencesSettings = osparc.desktop.preferences.Preferences.getInstance();
-        if (preferencesSettings.getConfirmDeleteStudy()) {
-          const win = this.__createConfirmWindow([studyData.name]);
-          win.center();
-          win.open();
-          win.addListener("close", () => {
-            if (win.getConfirmed()) {
-              this.__deleteStudy(studyData);
-            }
-          }, this);
-        } else {
-          this.__deleteStudy(studyData);
-        }
-      }, this);
+      deleteButton.addListener("execute", () => this.deleteStudyRequested(studyData), this);
       return deleteButton;
     },
 
@@ -968,7 +970,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       req.send(body);
     },
 
-    __deleteStudy: function(studyData) {
+    __doDeleteStudy: function(studyData) {
       const myGid = osparc.auth.Data.getInstance().getGroupId();
       const collabGids = Object.keys(studyData["accessRights"]);
       const amICollaborator = collabGids.indexOf(myGid) > -1;
@@ -999,10 +1001,8 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         });
     },
 
-    __deleteStudies: function(studiesData) {
-      studiesData.forEach(studyData => {
-        this.__deleteStudy(studyData);
-      });
+    __doDeleteStudies: function(studiesData) {
+      studiesData.forEach(studyData => this.__doDeleteStudy(studyData));
     },
 
     __createConfirmWindow: function(studyNames) {

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -801,7 +801,11 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       return exportButton;
     },
 
-    deleteStudyRequested: function(studyData) {
+    _deleteResourceRequested: function(studyId) {
+      this.__deleteResourceRequested(this.__getStudyData(studyId));
+    },
+
+    __deleteResourceRequested: function(studyData) {
       const preferencesSettings = osparc.desktop.preferences.Preferences.getInstance();
       if (preferencesSettings.getConfirmDeleteStudy()) {
         const win = this.__createConfirmWindow([studyData.name]);
@@ -820,7 +824,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     __getDeleteStudyMenuButton: function(studyData) {
       const deleteButton = new qx.ui.menu.Button(this.tr("Delete"));
       osparc.utils.Utils.setIdToWidget(deleteButton, "studyItemMenuDelete");
-      deleteButton.addListener("execute", () => this.deleteStudyRequested(studyData), this);
+      deleteButton.addListener("execute", () => this.__deleteResourceRequested(studyData), this);
       return deleteButton;
     },
 

--- a/services/static-webserver/client/source/class/osparc/data/Permissions.js
+++ b/services/static-webserver/client/source/class/osparc/data/Permissions.js
@@ -137,21 +137,21 @@ qx.Class.define("osparc.data.Permissions", {
         ],
         "admin": []
       };
-      let productOnlyTesters = [];
+      let fromUserToTester = [];
       if (osparc.product.Utils.isProduct("tis")) {
-        productOnlyTesters = [
+        fromUserToTester = [
           "dashboard.templates.read",
           "dashboard.services.read",
           "study.slides.edit",
           "study.slides.stop"
         ];
       } else if (osparc.product.Utils.isProduct("s4llite")) {
-        productOnlyTesters = [
+        fromUserToTester = [
           "dashboard.services.read",
           "dashboard.data.read"
         ];
       }
-      productOnlyTesters.forEach(onlyTester => {
+      fromUserToTester.forEach(onlyTester => {
         initPermissions.user.remove(onlyTester);
         initPermissions.tester.push(onlyTester);
       });

--- a/services/static-webserver/client/source/class/osparc/data/Permissions.js
+++ b/services/static-webserver/client/source/class/osparc/data/Permissions.js
@@ -36,11 +36,10 @@
 
 qx.Class.define("osparc.data.Permissions", {
   extend: qx.core.Object,
-
-  type : "singleton",
+  type: "singleton",
 
   construct() {
-    const initPermissions = osparc.data.Permissions.getInitPermissions();
+    const initPermissions = this.self().getInitPermissions();
     for (const role in initPermissions) {
       if (Object.prototype.hasOwnProperty.call(initPermissions, role)) {
         initPermissions[role].forEach(action => {
@@ -152,7 +151,10 @@ qx.Class.define("osparc.data.Permissions", {
         ];
       }
       fromUserToTester.forEach(onlyTester => {
-        initPermissions.user.remove(onlyTester);
+        const idx = initPermissions.user.indexOf(onlyTester);
+        if (idx > -1) {
+          initPermissions.user.splice(idx, 1);
+        }
         initPermissions.tester.push(onlyTester);
       });
       return initPermissions;

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -186,6 +186,7 @@ qx.Class.define("osparc.desktop.MainPage", {
       tabsBar.set({
         paddingBottom: 8
       });
+      this.__navBar.getChildControl("center-items").addListener("resize", e => dashboard.topBarResized(e.getData()));
       this.__navBar.addDashboardTabButtons(tabsBar);
       const itemWidth = osparc.dashboard.GridButtonBase.ITEM_WIDTH + osparc.dashboard.GridButtonBase.SPACING;
       dashboard.setMinWidth(this.self().MIN_STUDIES_PER_ROW * itemWidth + 8);

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -184,11 +184,10 @@ qx.Class.define("osparc.desktop.MainPage", {
       const dashboard = this.__dashboard = new osparc.dashboard.Dashboard();
       const tabsBar = dashboard.getChildControl("bar");
       tabsBar.set({
-        paddingBottom: 8
+        paddingBottom: 6
       });
       this.__navBar.getChildControl("center-items").addListener("resize", e => {
         dashboard.topBarResized(e.getData());
-        tabsBar.setPaddingBottom(8);
       });
       this.__navBar.addDashboardTabButtons(tabsBar);
       const itemWidth = osparc.dashboard.GridButtonBase.ITEM_WIDTH + osparc.dashboard.GridButtonBase.SPACING;

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -186,7 +186,10 @@ qx.Class.define("osparc.desktop.MainPage", {
       tabsBar.set({
         paddingBottom: 8
       });
-      this.__navBar.getChildControl("center-items").addListener("resize", e => dashboard.topBarResized(e.getData()));
+      this.__navBar.getChildControl("center-items").addListener("resize", e => {
+        dashboard.topBarResized(e.getData());
+        tabsBar.setPaddingBottom(8);
+      });
       this.__navBar.addDashboardTabButtons(tabsBar);
       const itemWidth = osparc.dashboard.GridButtonBase.ITEM_WIDTH + osparc.dashboard.GridButtonBase.SPACING;
       dashboard.setMinWidth(this.self().MIN_STUDIES_PER_ROW * itemWidth + 8);

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -188,7 +188,6 @@ qx.Class.define("osparc.desktop.StudyEditor", {
           // If it is larger than PROJECTS_MAX_NUM_RUNNING_DYNAMIC_NODES, dynamics won't start -> Flash Message
           osparc.store.StaticInfo.getInstance().getMaxNumberDyNodes()
             .then(maxNumber => {
-              console.log(maxNumber);
               if (maxNumber) {
                 const nodes = study.getWorkbench().getNodes();
                 const nDynamics = Object.values(nodes).filter(node => node.isDynamic()).length;

--- a/services/static-webserver/client/source/class/osparc/ui/window/Dialog.js
+++ b/services/static-webserver/client/source/class/osparc/ui/window/Dialog.js
@@ -19,7 +19,7 @@ qx.Class.define("osparc.ui.window.Dialog", {
    */
   construct: function(caption, icon, message) {
     this.base(arguments, caption, icon);
-    this.getChildControl("captionbar").setPadding(10);
+
     this.set({
       autoDestroy: true,
       layout: new qx.ui.layout.VBox(15),

--- a/services/static-webserver/client/source/class/osparc/ui/window/Window.js
+++ b/services/static-webserver/client/source/class/osparc/ui/window/Window.js
@@ -10,6 +10,10 @@ qx.Class.define("osparc.ui.window.Window", {
   construct: function(caption, icon) {
     this.base(arguments, caption, icon);
 
+    this.getChildControl("captionbar").set({
+      padding: 8
+    });
+
     this.getChildControl("title").set({
       font: "text-14",
       rich: true


### PR DESCRIPTION
## What do these changes do?
- [x] When the window is too small the Dashboard tab labels turn into icons.

#### Bonus
- [x] tapping on ```empty-study``` icon triggers a study/template delete request
- [x] qx.Window: Less padded captionbars

Small screens:
![LabelsToIcons](https://user-images.githubusercontent.com/33152403/221585622-d9f07552-f533-4200-8866-b0068b97b993.gif)


Empty Study:
![EmptyStudy](https://user-images.githubusercontent.com/33152403/221582139-7c17ed0d-1593-4556-96ff-6e2cf2da5bc4.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
