### PR TITLE
✨ Frontend: Navigate through login forms

### DIFF
--- a/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/ProfilePage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/ProfilePage.js
@@ -47,14 +47,17 @@ qx.Class.define("osparc.desktop.preferences.pages.ProfilePage", {
       const box = this._createSectionBox(this.tr("User"));
 
       const email = new qx.ui.form.TextField().set({
+        tabIndex: 1,
         placeholder: this.tr("Email")
       });
 
       const firstName = new qx.ui.form.TextField().set({
+        tabIndex: 2,
         placeholder: this.tr("First Name")
       });
 
       const lastName = new qx.ui.form.TextField().set({
+        tabIndex: 3,
         placeholder: this.tr("Last Name")
       });
 
@@ -78,13 +81,15 @@ qx.Class.define("osparc.desktop.preferences.pages.ProfilePage", {
           readOnly: true
         });
       }
+      role.set({
+        tabIndex: 4
+      });
 
       const form = new qx.ui.form.Form();
       form.add(email, "Email", null, "email");
       form.add(firstName, "First Name", null, "firstName");
       form.add(lastName, "Last Name", null, "lastName");
       form.add(role, "Role", null, "role");
-
       box.add(new qx.ui.form.renderer.Single(form));
 
       const expirationLayout = new qx.ui.container.Composite(new qx.ui.layout.HBox(5)).set({

--- a/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/SecurityPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/SecurityPage.js
@@ -39,22 +39,28 @@ qx.Class.define("osparc.desktop.preferences.pages.SecurityPage", {
       const box = this._createSectionBox(this.tr("Password"));
 
       const currentPassword = new osparc.ui.form.PasswordField().set({
+        tabIndex: 1,
         required: true,
         placeholder: this.tr("Your current password")
       });
-      box.add(currentPassword);
 
       const newPassword = new osparc.ui.form.PasswordField().set({
+        tabIndex: 2,
         required: true,
         placeholder: this.tr("Your new password")
       });
-      box.add(newPassword);
 
       const confirm = new osparc.ui.form.PasswordField().set({
+        tabIndex: 3,
         required: true,
         placeholder: this.tr("Retype your new password")
       });
-      box.add(confirm);
+
+      const form = new qx.ui.form.Form();
+      form.add(currentPassword, "Current Password", null, "curPassword");
+      form.add(newPassword, "New Password", null, "newPassword");
+      form.add(confirm, "Confirm New Password", null, "newPassword2");
+      box.add(new qx.ui.form.renderer.Single(form));
 
       const manager = new qx.ui.form.validation.Manager();
       manager.add(newPassword, osparc.auth.core.Utils.passwordLengthValidator);

--- a/services/static-webserver/client/source/class/osparc/theme/Appearance.js
+++ b/services/static-webserver/client/source/class/osparc/theme/Appearance.js
@@ -452,7 +452,7 @@ qx.Theme.define("osparc.theme.Appearance", {
     "strong-button": {
       include: "material-button",
       style: state => ({
-        decorator: state.hovered ? "strong-bordered-button" : "no-border",
+        decorator: state.hovered || state.focused ? "strong-bordered-button" : "no-border",
         backgroundColor: "strong-main",
         textColor: "#d2d8dc" // dark theme's text color
       })
@@ -462,8 +462,8 @@ qx.Theme.define("osparc.theme.Appearance", {
       include: "material-button",
       style: state => ({
         decorator: "bordered-button",
-        backgroundColor: state.hovered ? "danger-red" : null,
-        textColor: state.hovered ? "#d2d8dc" : "danger-red" // dark theme's text color
+        backgroundColor: state.hovered || state.focused ? "danger-red" : null,
+        textColor: state.hovered || state.focused ? "#d2d8dc" : "danger-red" // dark theme's text color
       })
     },
 

--- a/services/static-webserver/client/source/class/osparc/theme/products/osparc/Appearance.js
+++ b/services/static-webserver/client/source/class/osparc/theme/products/osparc/Appearance.js
@@ -22,7 +22,7 @@ qx.Theme.define("osparc.theme.products.osparc.Appearance", {
     "strong-button": {
       include: "material-button",
       style: state => ({
-        decorator: state.hovered ? "strong-bordered-button" : "no-border",
+        decorator: state.hovered || state.focused ? "strong-bordered-button" : "no-border",
         backgroundColor: "strong-main",
         textColor: "strong-text"
       })

--- a/services/static-webserver/client/source/class/osparc/theme/products/s4l/Appearance.js
+++ b/services/static-webserver/client/source/class/osparc/theme/products/s4l/Appearance.js
@@ -22,7 +22,7 @@ qx.Theme.define("osparc.theme.products.s4l.Appearance", {
     "strong-button": {
       include: "material-button",
       style: state => ({
-        decorator: state.hovered ? "strong-bordered-button" : "no-border",
+        decorator: state.hovered || state.focused ? "strong-bordered-button" : "no-border",
         backgroundColor: "strong-main",
         textColor: "strong-text"
       })

--- a/services/static-webserver/client/source/class/osparc/theme/products/tis/Appearance.js
+++ b/services/static-webserver/client/source/class/osparc/theme/products/tis/Appearance.js
@@ -22,7 +22,7 @@ qx.Theme.define("osparc.theme.products.tis.Appearance", {
     "strong-button": {
       include: "material-button",
       style: state => ({
-        decorator: state.hovered ? "strong-bordered-button" : "no-border",
+        decorator: state.hovered || state.focused ? "strong-bordered-button" : "no-border",
         backgroundColor: "strong-main",
         textColor: "strong-text"
       })

--- a/services/static-webserver/client/source/class/osparc/ui/form/PasswordField.js
+++ b/services/static-webserver/client/source/class/osparc/ui/form/PasswordField.js
@@ -125,6 +125,7 @@ qx.Class.define("osparc.ui.form.PasswordField", {
           break;
         case "eyeButton":
           control = new qx.ui.form.ToggleButton().set({
+            focusable: false,
             maxHeight: 18,
             width: 22,
             padding: 0,


### PR DESCRIPTION
## What do these changes do?

As requested by @GitHK, this PR makes it easier to navigate through the login/registration forms (the tab sequence was broken when the show-password-eye was introduced).

- [x] Make them ```tab``` compatible
- [x] Make it clear when the ```strong-button``` is focused

![Tabs](https://user-images.githubusercontent.com/33152403/221614758-52249ebe-1af3-427a-aa9e-6ce079519295.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
