### PR TITLE
✨ S4L e2e: wait for S4L Splash Screen to disappear

### DIFF
--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -624,8 +624,25 @@ class TutorialBase {
     await this.takeScreenshot('waitFor_finished')
   }
 
+  async __s4lSplashScreenOff(s4lNodeId) {
+    await this.waitFor(10000, 'Wait for the s4l iframe to appear');
+    await this.takeScreenshot("s4l");
+
+    const s4lIframe = await this.getIframe(s4lNodeId);
+    return new Promise(resolve => {
+      s4lIframe.waitForSelector("[osparc-test-id=splash-screen-off]", {
+        timeout: 60000
+      })
+        .then(() => resolve(true))
+        .catch(() => resolve(false));
+    });
+  }
+
   async testS4L(s4lNodeId) {
-    await this.waitFor(20000, 'Wait for the splash screen to disappear');
+    const slpashScreenGone = await this.__s4lSplashScreenOff(s4lNodeId);
+    if (!slpashScreenGone) {
+      throw("S4L Splash Screen Timeout");
+    }
 
     const s4lIframe = await this.getIframe(s4lNodeId);
     await this.waitAndClick('mode-button-modeling', s4lIframe);
@@ -648,8 +665,10 @@ class TutorialBase {
   }
 
   async testS4LTIPostPro(s4lNodeId) {
-    await this.waitFor(20000, 'Wait for the splash screen to disappear');
-    await this.takeScreenshot("s4l");
+    const slpashScreenGone = await this.__s4lSplashScreenOff(s4lNodeId);
+    if (!slpashScreenGone) {
+      throw("S4L Splash screen Timeout");
+    }
 
     const s4lIframe = await this.getIframe(s4lNodeId);
     await this.waitAndClick('mode-button-postro', s4lIframe);
@@ -675,7 +694,10 @@ class TutorialBase {
   }
 
   async testS4LDipole(s4lNodeId) {
-    await this.waitFor(20000, 'Wait for the splash screen to disappear');
+    const slpashScreenGone = await this.__s4lSplashScreenOff(s4lNodeId);
+    if (!slpashScreenGone) {
+      throw("S4L Splash screen Timeout");
+    }
 
     const s4lIframe = await this.getIframe(s4lNodeId);
     await this.waitAndClick('mode-button-modeling', s4lIframe);

--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -639,8 +639,8 @@ class TutorialBase {
   }
 
   async testS4L(s4lNodeId) {
-    const slpashScreenGone = await this.__s4lSplashScreenOff(s4lNodeId);
-    if (!slpashScreenGone) {
+    const splashScreenGone = await this.__s4lSplashScreenOff(s4lNodeId);
+    if (!splashScreenGone) {
       throw("S4L Splash Screen Timeout");
     }
 
@@ -665,8 +665,8 @@ class TutorialBase {
   }
 
   async testS4LTIPostPro(s4lNodeId) {
-    const slpashScreenGone = await this.__s4lSplashScreenOff(s4lNodeId);
-    if (!slpashScreenGone) {
+    const splashScreenGone = await this.__s4lSplashScreenOff(s4lNodeId);
+    if (!splashScreenGone) {
       throw("S4L Splash screen Timeout");
     }
 
@@ -694,8 +694,8 @@ class TutorialBase {
   }
 
   async testS4LDipole(s4lNodeId) {
-    const slpashScreenGone = await this.__s4lSplashScreenOff(s4lNodeId);
-    if (!slpashScreenGone) {
+    const splashScreenGone = await this.__s4lSplashScreenOff(s4lNodeId);
+    if (!splashScreenGone) {
       throw("S4L Splash screen Timeout");
     }
 


### PR DESCRIPTION
## What do these changes do?

Instead of waiting fixed 20" for the s4l iframe to appear and the splash screen to disappear, we now wait fixed 10" for the s4l iframe to appear and a maximum of 60" for the splash screen to disappear.


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
