### PR TITLE
✨Frontend User registration: Check Invitation email from token

### DIFF
--- a/services/static-webserver/client/source/class/osparc/auth/Manager.js
+++ b/services/static-webserver/client/source/class/osparc/auth/Manager.js
@@ -51,6 +51,15 @@ qx.Class.define("osparc.auth.Manager", {
       return osparc.data.Resources.fetch("auth", "postRegister", params);
     },
 
+    checkInvitation: function(invitation) {
+      const params = {
+        data: {
+          invitation
+        }
+      };
+      return osparc.data.Resources.fetch("auth", "checkInvitation", params);
+    },
+
     verifyPhoneNumber: function(email, phoneNumber) {
       const params = {
         data: {

--- a/services/static-webserver/client/source/class/osparc/auth/ui/RegistrationView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/RegistrationView.js
@@ -67,12 +67,18 @@ qx.Class.define("osparc.auth.ui.RegistrationView", {
       this.add(pass2);
 
       const urlFragment = osparc.utils.Utils.parseURLFragment();
-      const token = urlFragment.params ? urlFragment.params.invitation || null : null;
-      const invitation = new qx.ui.form.TextField().set({
-        visibility: "excluded",
-        value: token
-      });
-      this.add(invitation);
+      const invitationToken = urlFragment.params ? urlFragment.params.invitation || null : null;
+      if (invitationToken) {
+        osparc.auth.Manager.getInstance().checkInvitation(invitationToken)
+          .then(data => {
+            if (data && data.email) {
+              email.set({
+                value: data.email,
+                enabled: false
+              });
+            }
+          });
+      }
 
       // validation
       validator.add(email, qx.util.Validate.email());
@@ -105,7 +111,7 @@ qx.Class.define("osparc.auth.ui.RegistrationView", {
             email: email.getValue(),
             password: pass1.getValue(),
             confirm: pass2.getValue(),
-            invitation: invitation.getValue() ? invitation.getValue() : ""
+            invitation: invitationToken ? invitationToken : ""
           });
         }
       }, this);

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -583,6 +583,10 @@ qx.Class.define("osparc.data.Resources", {
             method: "POST",
             url: statics.API + "/auth/register"
           },
+          checkInvitation: {
+            method: "POST",
+            url: statics.API + "/auth/register/invitations:check"
+          },
           verifyPhoneNumber: {
             method: "POST",
             url: statics.API + "/auth/verify-phone-number"


### PR DESCRIPTION
## What do these changes do?

This PR implements the frontend part of https://github.com/ITISFoundation/osparc-simcore/pull/3856

During the registration process, if the user made it to the registration view using an invitation token, this invitation, that can contain the user's email address encrypted, is checked with the backend. If the backend responds with an associated email to that token, the frontend will fill up and disable the email textfield.


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
