### PR TITLE
🎨 Frontend: Improve UX for "Download of Study Data"

### DIFF
--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -73,6 +73,8 @@ qx.Class.define("osparc.Application", {
       // to provide our own message here
       window.addEventListener("beforeunload", e => {
         const downloadLinkTracker = osparc.DownloadLinkTracker.getInstance();
+        // The downloadLinkTracker uses an external link for downloading files.
+        // When it starts (click), triggers an unload event. This condition avoids the false positive
         if (!downloadLinkTracker.isDownloading() && webSocket.isConnected()) {
           // Cancel the event as stated by the standard.
           e.preventDefault();

--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -72,7 +72,8 @@ qx.Class.define("osparc.Application", {
       // from osparc. unfortunately it is not possible
       // to provide our own message here
       window.addEventListener("beforeunload", e => {
-        if (webSocket.isConnected()) {
+        const downloadLinkTracker = osparc.DownloadLinkTracker.getInstance();
+        if (!downloadLinkTracker.isDownloading() && webSocket.isConnected()) {
           // Cancel the event as stated by the standard.
           e.preventDefault();
           // Chrome requires returnValue to be set.

--- a/services/static-webserver/client/source/class/osparc/DownloadLinkTracker.js
+++ b/services/static-webserver/client/source/class/osparc/DownloadLinkTracker.js
@@ -1,0 +1,42 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2023 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+qx.Class.define("osparc.DownloadLinkTracker", {
+  extend: qx.core.Object,
+  type: "singleton",
+
+  properties: {
+    downloading: {
+      check: "Boolean",
+      init: false,
+      nullable: true
+    }
+  },
+
+  members: {
+    downloadLinkUnattended: function(url, fileName) {
+      const downloadAnchorNode = document.createElement("a");
+      downloadAnchorNode.setAttribute("href", url);
+      downloadAnchorNode.setAttribute("download", fileName);
+      downloadAnchorNode.setAttribute("osparc", "downloadFile");
+      this.setDownloading(true);
+      downloadAnchorNode.click();
+      this.setDownloading(false);
+      downloadAnchorNode.remove();
+    }
+  }
+});

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -877,11 +877,11 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       osparc.component.message.FlashMessenger.getInstance().logAs(text, "INFO");
 
       const url = window.location.href + "v0/projects/" + studyData["uuid"] + ":xport";
-      const downloadStartedCB = () => {
+      const progressCB = () => {
         const textSuccess = this.tr("Download started");
         exportTask.setSubtitle(textSuccess);
       };
-      osparc.utils.Utils.downloadLink(url, "POST", null, downloadStartedCB)
+      osparc.utils.Utils.downloadLink(url, "POST", null, progressCB)
         .catch(e => {
           const msg = osparc.data.Resources.getErrorMsg(JSON.parse(e.response)) || this.tr("Something went wrong Exporting the study");
           osparc.component.message.FlashMessenger.logAs(msg, "ERROR");

--- a/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
+++ b/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
@@ -76,9 +76,13 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
           this._add(control);
           break;
         case "download-progress":
-          control = new qx.ui.indicator.ProgressBar(0, 1).set({
+          control = new qx.ui.indicator.ProgressBar().set({
+            alignY: "middle",
             maxHeight: 15,
             width: 100
+          });
+          control.getChildControl("progress").set({
+            backgroundColor: "strong-main"
           });
           this._add(control);
           break;

--- a/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
+++ b/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
@@ -76,7 +76,7 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
           this._add(control);
           break;
         case "download-progress":
-          control = new qx.ui.indicator.ProgressBar().set({
+          control = new qx.ui.indicator.ProgressBar(0, 1).set({
             alignY: "middle",
             maxHeight: 15,
             width: 100
@@ -138,10 +138,11 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
         osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId)
           .then(data => {
             if (data) {
-              osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName);
-              this.getChildControl("download-button").exclude();
               const pBar = this.getChildControl("download-progress");
               pBar.show();
+              const progressCB = p => pBar.setValue(p);
+              osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName, progressCB);
+              this.getChildControl("download-button").exclude();
             }
           });
       }

--- a/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
+++ b/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
@@ -141,7 +141,12 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
               const pBar = this.getChildControl("download-progress");
               pBar.show();
               const progressCB = p => pBar.setValue(p);
-              osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName, progressCB);
+              const loadCB = () => {
+                this.getChildControl("download-button").show();
+                pBar.exclude();
+                pBar.setValue(0);
+              };
+              osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName, progressCB, loadCB);
               this.getChildControl("download-button").exclude();
             }
           });

--- a/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
+++ b/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
@@ -135,10 +135,14 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
       if (selection) {
         const fileId = selection.getFileId();
         const locationId = selection.getLocation();
-        osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId);
-        this.getChildControl("download-button").exclude();
-        const pBar = this.getChildControl("download-progress");
-        pBar.show();
+        osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId)
+          .then(data => {
+            if (data) {
+              this.downloadLink(data.link, "GET", data.fileName);
+              this.getChildControl("download-button").exclude();
+              const pBar = this.getChildControl("download-progress");
+              pBar.show();
+          });
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
+++ b/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
@@ -47,8 +47,6 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
     const downloadBtn = this.getChildControl("download-button");
     downloadBtn.addListener("execute", () => this.__retrieveURLAndDownload(), this);
 
-    this.getChildControl("download-progress").exclude();
-
     const deleteBtn = this.getChildControl("delete-button");
     deleteBtn.addListener("execute", () => this.__deleteFile(), this);
   },
@@ -72,17 +70,6 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
         case "selected-label":
           control = new qx.ui.basic.Label().set({
             alignY: "middle"
-          });
-          this._add(control);
-          break;
-        case "download-progress":
-          control = new qx.ui.indicator.ProgressBar(0, 1).set({
-            alignY: "middle",
-            maxHeight: 15,
-            width: 100
-          });
-          control.getChildControl("progress").set({
-            backgroundColor: "strong-main"
           });
           this._add(control);
           break;
@@ -138,21 +125,7 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
         osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId)
           .then(data => {
             if (data) {
-              const downloadButton = this.getChildControl("download-button");
-              const pBar = this.getChildControl("download-progress");
-              pBar.show();
-              const progressCB = p => pBar.setValue(p);
-              const loadedCb = () => {
-                pBar.set({
-                  value: 0,
-                  visibility: "excluded"
-                });
-                downloadButton.set({
-                  visibility: "visible"
-                });
-              };
-              osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName, progressCB, loadedCb);
-              downloadButton.exclude();
+              osparc.DownloadLinkTracker.getInstance().downloadLinkUnattended(data.link, data.fileName);
             }
           });
       }

--- a/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
+++ b/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
@@ -142,6 +142,7 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
               this.getChildControl("download-button").exclude();
               const pBar = this.getChildControl("download-progress");
               pBar.show();
+            }
           });
       }
     },

--- a/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
+++ b/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
@@ -138,7 +138,7 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
         osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId)
           .then(data => {
             if (data) {
-              this.downloadLink(data.link, "GET", data.fileName);
+              osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName);
               this.getChildControl("download-button").exclude();
               const pBar = this.getChildControl("download-progress");
               pBar.show();

--- a/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
+++ b/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
@@ -47,6 +47,8 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
     const downloadBtn = this.getChildControl("download-button");
     downloadBtn.addListener("execute", () => this.__retrieveURLAndDownload(), this);
 
+    this.getChildControl("download-progress").exclude();
+
     const deleteBtn = this.getChildControl("delete-button");
     deleteBtn.addListener("execute", () => this.__deleteFile(), this);
   },
@@ -70,6 +72,13 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
         case "selected-label":
           control = new qx.ui.basic.Label().set({
             alignY: "middle"
+          });
+          this._add(control);
+          break;
+        case "download-progress":
+          control = new qx.ui.indicator.ProgressBar(0, 1).set({
+            maxHeight: 15,
+            width: 100
           });
           this._add(control);
           break;
@@ -123,6 +132,9 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
         const fileId = selection.getFileId();
         const locationId = selection.getLocation();
         osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId);
+        this.getChildControl("download-button").exclude();
+        const pBar = this.getChildControl("download-progress");
+        pBar.show();
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
+++ b/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
@@ -87,7 +87,7 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
           this._add(control);
           break;
         case "download-button":
-          control = new qx.ui.form.Button(this.tr("Download"), "@FontAwesome5Solid/cloud-download-alt/16");
+          control = new osparc.ui.form.FetchButton(this.tr("Download"), "@FontAwesome5Solid/cloud-download-alt/16");
           osparc.utils.Utils.setIdToWidget(control, "filesTreeDownloadBtn");
           this._add(control);
           break;
@@ -138,16 +138,27 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
         osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId)
           .then(data => {
             if (data) {
+              const downloadButton = this.getChildControl("download-button");
               const pBar = this.getChildControl("download-progress");
               pBar.show();
               const progressCB = p => pBar.setValue(p);
-              const loadCB = () => {
-                this.getChildControl("download-button").show();
-                pBar.exclude();
-                pBar.setValue(0);
+              const loadingCb = () => {
+                pBar.set({
+                  value: 0,
+                  visibility: "excluded"
+                });
+                downloadButton.set({
+                  fetching: true,
+                  visibility: "visible"
+                });
               };
-              osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName, progressCB, loadCB);
-              this.getChildControl("download-button").exclude();
+              const loadedCb = () => {
+                downloadButton.set({
+                  fetching: false
+                });
+              };
+              osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName, progressCB, loadingCb, loadedCb);
+              downloadButton.exclude();
             }
           });
       }

--- a/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
+++ b/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
@@ -87,7 +87,7 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
           this._add(control);
           break;
         case "download-button":
-          control = new osparc.ui.form.FetchButton(this.tr("Download"), "@FontAwesome5Solid/cloud-download-alt/16");
+          control = new qx.ui.form.Button(this.tr("Download"), "@FontAwesome5Solid/cloud-download-alt/16");
           osparc.utils.Utils.setIdToWidget(control, "filesTreeDownloadBtn");
           this._add(control);
           break;
@@ -142,22 +142,16 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
               const pBar = this.getChildControl("download-progress");
               pBar.show();
               const progressCB = p => pBar.setValue(p);
-              const loadingCb = () => {
+              const loadedCb = () => {
                 pBar.set({
                   value: 0,
                   visibility: "excluded"
                 });
                 downloadButton.set({
-                  fetching: true,
                   visibility: "visible"
                 });
               };
-              const loadedCb = () => {
-                downloadButton.set({
-                  fetching: false
-                });
-              };
-              osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName, progressCB, loadingCb, loadedCb);
+              osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName, progressCB, loadedCb);
               downloadButton.exclude();
             }
           });

--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -224,7 +224,12 @@ qx.Class.define("osparc.file.FilePicker", {
             if ("location_id" in fileMetadata && "file_id" in fileMetadata) {
               const locationId = fileMetadata["location_id"];
               const fileId = fileMetadata["file_id"];
-              osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId);
+              osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId)
+                .then(data => {
+                  if (data) {
+                    this.downloadLink(data.link, "GET", data.fileName);
+                  }
+                });
             }
           });
       } else if (osparc.file.FilePicker.isOutputDownloadLink(node.getOutputs())) {

--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -227,7 +227,7 @@ qx.Class.define("osparc.file.FilePicker", {
               osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId)
                 .then(data => {
                   if (data) {
-                    this.downloadLink(data.link, "GET", data.fileName);
+                    osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName);
                   }
                 });
             }

--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -217,7 +217,9 @@ qx.Class.define("osparc.file.FilePicker", {
       }
     },
 
-    downloadOutput: function(node) {
+    downloadOutput: function(node, downloadFileBtn) {
+      const progressCb = () => downloadFileBtn.setFetching(true);
+      const loadedCb = () => downloadFileBtn.setFetching(false);
       if (osparc.file.FilePicker.isOutputFromStore(node.getOutputs())) {
         this.self().getOutputFileMetadata(node)
           .then(fileMetadata => {
@@ -227,7 +229,7 @@ qx.Class.define("osparc.file.FilePicker", {
               osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId)
                 .then(data => {
                   if (data) {
-                    osparc.DownloadLinkTracker.getInstance().downloadLinkUnattended(data.link, data.fileName);
+                    osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName, progressCb, loadedCb);
                   }
                 });
             }
@@ -235,7 +237,7 @@ qx.Class.define("osparc.file.FilePicker", {
       } else if (osparc.file.FilePicker.isOutputDownloadLink(node.getOutputs())) {
         const outFileValue = osparc.file.FilePicker.getOutput(node.getOutputs());
         if (osparc.utils.Utils.isObject(outFileValue) && "downloadLink" in outFileValue) {
-          osparc.DownloadLinkTracker.getInstance().downloadLinkUnattended(outFileValue["downloadLink"]);
+          osparc.utils.Utils.downloadLink(outFileValue["downloadLink"], "GET", null, progressCb, loadedCb);
         }
       }
     },
@@ -352,10 +354,10 @@ qx.Class.define("osparc.file.FilePicker", {
 
     __getDownloadFileButton: function() {
       const node = this.getNode();
-      const downloadFileBtn = new qx.ui.form.Button(this.tr("Download"), "@FontAwesome5Solid/cloud-download-alt/14").set({
+      const downloadFileBtn = new osparc.ui.form.FetchButton(this.tr("Download"), "@FontAwesome5Solid/cloud-download-alt/14").set({
         allowGrowX: false
       });
-      downloadFileBtn.addListener("execute", () => osparc.file.FilePicker.downloadOutput(node));
+      downloadFileBtn.addListener("execute", () => osparc.file.FilePicker.downloadOutput(node, downloadFileBtn));
       return downloadFileBtn;
     },
 

--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -227,7 +227,7 @@ qx.Class.define("osparc.file.FilePicker", {
               osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId)
                 .then(data => {
                   if (data) {
-                    osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName);
+                    osparc.DownloadLinkTracker.getInstance().downloadLinkUnattended(data.link, data.fileName);
                   }
                 });
             }
@@ -235,7 +235,7 @@ qx.Class.define("osparc.file.FilePicker", {
       } else if (osparc.file.FilePicker.isOutputDownloadLink(node.getOutputs())) {
         const outFileValue = osparc.file.FilePicker.getOutput(node.getOutputs());
         if (osparc.utils.Utils.isObject(outFileValue) && "downloadLink" in outFileValue) {
-          osparc.utils.Utils.downloadLink(outFileValue["downloadLink"], "GET");
+          osparc.DownloadLinkTracker.getInstance().downloadLinkUnattended(outFileValue["downloadLink"]);
         }
       }
     },

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -456,7 +456,7 @@ qx.Class.define("osparc.utils.Utils", {
       });
     },
 
-    downloadLink: function(url, method, fileName, downloadStartedCB) {
+    downloadLink: function(url, method, fileName, progressCb, loadCb) {
       return new Promise((resolve, reject) => {
         let xhr = new XMLHttpRequest();
         xhr.open(method, url, true);
@@ -476,9 +476,9 @@ qx.Class.define("osparc.utils.Utils", {
         xhr.addEventListener("progress", e => {
           if (xhr.readyState === XMLHttpRequest.LOADING) {
             if (xhr.status === 0 || (xhr.status >= 200 && xhr.status < 400)) {
-              console.log("Progress", e.getData());
-              if (downloadStartedCB) {
-                downloadStartedCB();
+              if (e["type"] === "progress" && progressCb) {
+                console.log("Progress", e);
+                progressCb(e.loaded / e.total);
               }
             }
           }
@@ -492,6 +492,9 @@ qx.Class.define("osparc.utils.Utils", {
             }
             this.self().downloadContent(urlBlob, fileName);
             resolve();
+            if (loadCb) {
+              loadCb();
+            }
           } else {
             reject(xhr);
           }

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -456,7 +456,7 @@ qx.Class.define("osparc.utils.Utils", {
       });
     },
 
-    downloadLink: function(url, method, fileName, progressCb, loadingCb, loadedCb) {
+    downloadLink: function(url, method, fileName, progressCb, loadedCb) {
       return new Promise((resolve, reject) => {
         let xhr = new XMLHttpRequest();
         xhr.open(method, url, true);
@@ -484,8 +484,8 @@ qx.Class.define("osparc.utils.Utils", {
         });
         xhr.addEventListener("load", () => {
           if (xhr.status == 200) {
-            if (loadingCb) {
-              loadingCb();
+            if (loadedCb) {
+              loadedCb();
             }
             const blob = new Blob([xhr.response]);
             const urlBlob = window.URL.createObjectURL(blob);
@@ -493,9 +493,6 @@ qx.Class.define("osparc.utils.Utils", {
               fileName = this.self().filenameFromContentDisposition(xhr);
             }
             this.self().downloadContent(urlBlob, fileName);
-            if (loadedCb) {
-              loadedCb();
-            }
             resolve();
           } else {
             reject(xhr);

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -477,7 +477,6 @@ qx.Class.define("osparc.utils.Utils", {
           if (xhr.readyState === XMLHttpRequest.LOADING) {
             if (xhr.status === 0 || (xhr.status >= 200 && xhr.status < 400)) {
               if (e["type"] === "progress" && progressCb) {
-                console.log("Progress", e);
                 progressCb(e.loaded / e.total);
               }
             }

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -456,7 +456,7 @@ qx.Class.define("osparc.utils.Utils", {
       });
     },
 
-    downloadLink: function(url, method, fileName, progressCb, loadCb) {
+    downloadLink: function(url, method, fileName, progressCb, loadingCb, loadedCb) {
       return new Promise((resolve, reject) => {
         let xhr = new XMLHttpRequest();
         xhr.open(method, url, true);
@@ -484,16 +484,19 @@ qx.Class.define("osparc.utils.Utils", {
         });
         xhr.addEventListener("load", () => {
           if (xhr.status == 200) {
-            let blob = new Blob([xhr.response]);
-            let urlBlob = window.URL.createObjectURL(blob);
+            if (loadingCb) {
+              loadingCb();
+            }
+            const blob = new Blob([xhr.response]);
+            const urlBlob = window.URL.createObjectURL(blob);
             if (!fileName) {
               fileName = this.self().filenameFromContentDisposition(xhr);
             }
             this.self().downloadContent(urlBlob, fileName);
-            resolve();
-            if (loadCb) {
-              loadCb();
+            if (loadedCb) {
+              loadedCb();
             }
+            resolve();
           } else {
             reject(xhr);
           }

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -454,7 +454,6 @@ qx.Class.define("osparc.utils.Utils", {
         xhr.open(method, url, true);
         xhr.responseType = "blob";
         xhr.addEventListener("readystatechange", () => {
-        // xhr.onreadystatechange = () => {
           if (xhr.readyState === XMLHttpRequest.HEADERS_RECEIVED) {
             // The responseType value can be changed at any time before the readyState reaches 3.
             // When the readyState reaches 2, we have access to the response headers to make that decision with.

--- a/tests/e2e/utils/auto.js
+++ b/tests/e2e/utils/auto.js
@@ -291,7 +291,6 @@ async function deleteFirstStudy(page, studyName) {
   const firstChildId = '[osparc-test-id="' + studyCardId + '"]';
   const studyCardStyle = await utils.getStyle(page, firstChildId);
   if (studyCardStyle.cursor === "not-allowed") {
-    console.log("Andrei you were wrong");
     return false;
   }
   await utils.waitAndClick(page, firstChildId + ' > [osparc-test-id="studyItemMenuButton"]');


### PR DESCRIPTION
## What do these changes do?

This PR changes the way files are downloaded in the File Browser window.

Until now, we were downloading files using XMLHttpRequest and the given (presigned) URL. This meant that first the response had to be loaded, then convert it into the file blob and finally download it.

Now, we simply create a virtual HTML ```<a>``` tag, make it point to the given (presigned) URL and virtually click it, which directly starts the download process.

![DownloadFile](https://user-images.githubusercontent.com/33152403/224783249-643e7240-e616-4cf5-a363-7feb8715bf17.gif)


## Related issue/s
closes https://github.com/ITISFoundation/osparc-issues/issues/899


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
