### PR TITLE
♻️Autoscaling: set default termination time of EC2 instance to 1 minute

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -69,7 +69,7 @@ class EC2InstancesSettings(BaseCustomSettings):
     )
 
     EC2_INSTANCES_TIME_BEFORE_TERMINATION: datetime.timedelta = Field(
-        default=datetime.timedelta(minutes=55),
+        default=datetime.timedelta(minutes=1),
         description="Time after which an EC2 instance may be terminated (repeat every hour, min 0, max 59 minutes)",
     )
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️     Changes in devops configuration
  🗃️    Migration of database

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
as explained there:
https://aws.amazon.com/ec2/pricing/on-demand/

The price of EC2 instances is billed by the second. therefore the default for terminating a node is changed from 55 minutes to 1 minute. 

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
