### PR TITLE
✨ Personalized resources: Allow override of computational service needed resources

### DIFF
--- a/packages/models-library/src/models_library/docker.py
+++ b/packages/models-library/src/models_library/docker.py
@@ -7,20 +7,7 @@ from models_library.projects_nodes import NodeID
 from models_library.users import UserID
 from pydantic import BaseModel, ConstrainedStr, Field
 
-from .basic_regex import (
-    DOCKER_GENERIC_TAG_KEY_RE,
-    DOCKER_IMAGE_KEY_RE,
-    DOCKER_IMAGE_VERSION_RE,
-    DOCKER_LABEL_KEY_REGEX,
-)
-
-
-class DockerImageKey(ConstrainedStr):
-    regex = re.compile(DOCKER_IMAGE_KEY_RE)
-
-
-class DockerImageVersion(ConstrainedStr):
-    regex = re.compile(DOCKER_IMAGE_VERSION_RE)
+from .basic_regex import DOCKER_GENERIC_TAG_KEY_RE, DOCKER_LABEL_KEY_REGEX
 
 
 class DockerLabelKey(ConstrainedStr):

--- a/packages/models-library/src/models_library/docker.py
+++ b/packages/models-library/src/models_library/docker.py
@@ -5,7 +5,7 @@ from models_library.generated_models.docker_rest_api import Task
 from models_library.projects import ProjectID
 from models_library.projects_nodes import NodeID
 from models_library.users import UserID
-from pydantic import BaseModel, ConstrainedStr, Field, constr
+from pydantic import BaseModel, ConstrainedStr, Field
 
 from .basic_regex import (
     DOCKER_GENERIC_TAG_KEY_RE,
@@ -14,8 +14,13 @@ from .basic_regex import (
     DOCKER_LABEL_KEY_REGEX,
 )
 
-DockerImageKey = constr(regex=DOCKER_IMAGE_KEY_RE)
-DockerImageVersion = constr(regex=DOCKER_IMAGE_VERSION_RE)
+
+class DockerImageKey(ConstrainedStr):
+    regex = re.compile(DOCKER_IMAGE_KEY_RE)
+
+
+class DockerImageVersion(ConstrainedStr):
+    regex = re.compile(DOCKER_IMAGE_VERSION_RE)
 
 
 class DockerLabelKey(ConstrainedStr):

--- a/packages/models-library/src/models_library/projects_nodes.py
+++ b/packages/models-library/src/models_library/projects_nodes.py
@@ -18,7 +18,6 @@ from pydantic import (
     validator,
 )
 
-from .basic_regex import VERSION_RE
 from .basic_types import EnvVarKey
 from .projects_access import AccessEnum
 from .projects_nodes_io import (
@@ -30,7 +29,7 @@ from .projects_nodes_io import (
 )
 from .projects_nodes_ui import Position
 from .projects_state import RunningState
-from .services import PROPERTY_KEY_RE, SERVICE_KEY_RE
+from .services import PROPERTY_KEY_RE, ServiceKey, ServiceVersion
 
 # NOTE: WARNING the order here matters
 
@@ -100,20 +99,18 @@ class NodeState(BaseModel):
 
 
 class Node(BaseModel):
-    key: str = Field(
+    key: ServiceKey = Field(
         ...,
         description="distinctive name for the node based on the docker registry path",
-        regex=SERVICE_KEY_RE,
         examples=[
             "simcore/services/comp/itis/sleeper",
             "simcore/services/dynamic/3dviewer",
             "simcore/services/frontend/file-picker",
         ],
     )
-    version: str = Field(
+    version: ServiceVersion = Field(
         ...,
         description="semantic version number of the node",
-        regex=VERSION_RE,
         examples=["1.0.0", "0.0.1"],
     )
     label: str = Field(

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -4,6 +4,7 @@ NOTE: to dump json-schema from CLI use
     python -c "from models_library.services import ServiceDockerData as cls; print(cls.schema_json(indent=2))" > services-schema.json
 """
 
+import re
 from datetime import datetime
 from enum import Enum
 from typing import Any, Optional, Union
@@ -11,6 +12,7 @@ from uuid import UUID
 
 from pydantic import (
     BaseModel,
+    ConstrainedStr,
     EmailStr,
     Extra,
     Field,
@@ -54,8 +56,14 @@ LATEST_INTEGRATION_VERSION = "1.0.0"
 ServicePortKey = constr(regex=PROPERTY_KEY_RE)
 FileName = constr(regex=FILENAME_RE)
 
-ServiceKey = constr(regex=KEY_RE)
-ServiceVersion = constr(regex=VERSION_RE)
+
+class ServiceKey(ConstrainedStr):
+    regex = re.compile(KEY_RE)
+
+
+class ServiceVersion(ConstrainedStr):
+    regex = re.compile(VERSION_RE)
+
 
 RunID = UUID
 

--- a/packages/models-library/src/models_library/services.py
+++ b/packages/models-library/src/models_library/services.py
@@ -58,7 +58,7 @@ FileName = constr(regex=FILENAME_RE)
 
 
 class ServiceKey(ConstrainedStr):
-    regex = re.compile(KEY_RE)
+    regex = re.compile(SERVICE_KEY_RE)
 
 
 class ServiceVersion(ConstrainedStr):

--- a/packages/models-library/src/models_library/services_resources.py
+++ b/packages/models-library/src/models_library/services_resources.py
@@ -1,7 +1,10 @@
 import logging
 import re
+from enum import auto
 from typing import Any, Final, Union
 
+from models_library.docker import DockerGenericTag
+from models_library.utils.enums import StrAutoEnum
 from pydantic import (
     BaseModel,
     ByteSize,
@@ -16,10 +19,6 @@ from pydantic import (
 from .utils.fastapi_encoders import jsonable_encoder
 
 logger = logging.getLogger(__name__)
-
-
-class DockerImage(ConstrainedStr):
-    regex = re.compile(r"[\w/-]+:[\w.@]+")
 
 
 class DockerComposeServiceName(ConstrainedStr):
@@ -65,8 +64,14 @@ class ResourceValue(BaseModel):
 ResourcesDict = dict[ResourceName, ResourceValue]
 
 
+class BootMode(StrAutoEnum):
+    CPU = auto()
+    GPU = auto()
+    MPI = auto()
+
+
 class ImageResources(BaseModel):
-    image: DockerImage = Field(
+    image: DockerGenericTag = Field(
         ...,
         description=(
             "Used by the frontend to provide a context for the users."
@@ -76,6 +81,10 @@ class ImageResources(BaseModel):
         ),
     )
     resources: ResourcesDict
+    boot_modes: list[BootMode] = Field(
+        default=[BootMode.CPU],
+        description="describe how a service shall be booted, using CPU, MPI, openMP or GPU",
+    )
 
     class Config:
         schema_extra = {

--- a/packages/models-library/src/models_library/services_resources.py
+++ b/packages/models-library/src/models_library/services_resources.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from enum import auto
 from typing import Any, Final, Optional, Union
 
@@ -8,7 +7,6 @@ from models_library.utils.enums import StrAutoEnum
 from pydantic import (
     BaseModel,
     ByteSize,
-    ConstrainedStr,
     Field,
     StrictFloat,
     StrictInt,
@@ -21,16 +19,12 @@ from .utils.fastapi_encoders import jsonable_encoder
 logger = logging.getLogger(__name__)
 
 
-class DockerComposeServiceName(ConstrainedStr):
-    regex = re.compile(r"^[a-zA-Z0-9._-]+$")
-
-
 ResourceName = str
 
 # NOTE: replace hard coded `container` with function which can
 # extract the name from the `service_key` or `registry_address/service_key`
-DEFAULT_SINGLE_SERVICE_NAME: Final[DockerComposeServiceName] = parse_obj_as(
-    DockerComposeServiceName, "container"
+DEFAULT_SINGLE_SERVICE_NAME: Final[DockerGenericTag] = parse_obj_as(
+    DockerGenericTag, "container"
 )
 
 MEMORY_50MB: Final[int] = parse_obj_as(ByteSize, "50mib")
@@ -106,13 +100,13 @@ class ImageResources(BaseModel):
         }
 
 
-ServiceResourcesDict = dict[DockerComposeServiceName, ImageResources]
+ServiceResourcesDict = dict[DockerGenericTag, ImageResources]
 
 
 class ServiceResourcesDictHelpers:
     @staticmethod
     def create_from_single_service(
-        image: DockerComposeServiceName,
+        image: DockerGenericTag,
         resources: ResourcesDict,
         boot_modes: Optional[list[BootMode]] = None,
     ) -> ServiceResourcesDict:
@@ -132,7 +126,7 @@ class ServiceResourcesDictHelpers:
     @staticmethod
     def create_jsonable(
         service_resources: ServiceResourcesDict,
-    ) -> dict[DockerComposeServiceName, Any]:
+    ) -> dict[DockerGenericTag, Any]:
         return jsonable_encoder(service_resources)
 
     class Config:

--- a/packages/models-library/src/models_library/services_resources.py
+++ b/packages/models-library/src/models_library/services_resources.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from enum import auto
-from typing import Any, Final, Union
+from typing import Any, Final, Optional, Union
 
 from models_library.docker import DockerGenericTag
 from models_library.utils.enums import StrAutoEnum
@@ -112,11 +112,21 @@ ServiceResourcesDict = dict[DockerComposeServiceName, ImageResources]
 class ServiceResourcesDictHelpers:
     @staticmethod
     def create_from_single_service(
-        image: DockerComposeServiceName, resources: ResourcesDict
+        image: DockerComposeServiceName,
+        resources: ResourcesDict,
+        boot_modes: Optional[list[BootMode]] = None,
     ) -> ServiceResourcesDict:
+        if boot_modes is None:
+            boot_modes = [BootMode.CPU]
         return parse_obj_as(
             ServiceResourcesDict,
-            {DEFAULT_SINGLE_SERVICE_NAME: {"image": image, "resources": resources}},
+            {
+                DEFAULT_SINGLE_SERVICE_NAME: {
+                    "image": image,
+                    "resources": resources,
+                    "boot_modes": boot_modes,
+                }
+            },
         )
 
     @staticmethod

--- a/packages/models-library/src/models_library/services_resources.py
+++ b/packages/models-library/src/models_library/services_resources.py
@@ -1,13 +1,14 @@
 import logging
+import re
 from typing import Any, Final, Union
 
 from pydantic import (
     BaseModel,
     ByteSize,
+    ConstrainedStr,
     Field,
     StrictFloat,
     StrictInt,
-    constr,
     parse_obj_as,
     root_validator,
 )
@@ -16,8 +17,15 @@ from .utils.fastapi_encoders import jsonable_encoder
 
 logger = logging.getLogger(__name__)
 
-DockerImage = constr(regex=r"[\w/-]+:[\w.@]+")
-DockerComposeServiceName = constr(regex=r"^[a-zA-Z0-9._-]+$")
+
+class DockerImage(ConstrainedStr):
+    regex = re.compile(r"[\w/-]+:[\w.@]+")
+
+
+class DockerComposeServiceName(ConstrainedStr):
+    regex = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+
 ResourceName = str
 
 # NOTE: replace hard coded `container` with function which can

--- a/packages/models-library/src/models_library/services_resources.py
+++ b/packages/models-library/src/models_library/services_resources.py
@@ -29,7 +29,9 @@ ResourceName = str
 
 # NOTE: replace hard coded `container` with function which can
 # extract the name from the `service_key` or `registry_address/service_key`
-DEFAULT_SINGLE_SERVICE_NAME: Final[DockerComposeServiceName] = "container"
+DEFAULT_SINGLE_SERVICE_NAME: Final[DockerComposeServiceName] = parse_obj_as(
+    DockerComposeServiceName, "container"
+)
 
 MEMORY_50MB: Final[int] = parse_obj_as(ByteSize, "50mib")
 MEMORY_250MB: Final[int] = parse_obj_as(ByteSize, "250mib")

--- a/packages/models-library/tests/test_service_resources.py
+++ b/packages/models-library/tests/test_service_resources.py
@@ -7,7 +7,6 @@ from typing import Any
 import pytest
 from models_library.docker import DockerGenericTag
 from models_library.services_resources import (
-    DockerComposeServiceName,
     ImageResources,
     ResourcesDict,
     ResourceValue,
@@ -74,7 +73,7 @@ def test_image_resources_parsed_as_expected() -> None:
     "example", ServiceResourcesDictHelpers.Config.schema_extra["examples"]
 )
 def test_service_resource_parsed_as_expected(
-    example: dict[DockerComposeServiceName, Any], compose_image: DockerGenericTag
+    example: dict[DockerGenericTag, Any], compose_image: DockerGenericTag
 ) -> None:
     def _assert_service_resources_dict(
         service_resources_dict: ServiceResourcesDict,
@@ -103,7 +102,7 @@ def test_service_resource_parsed_as_expected(
 @pytest.mark.parametrize(
     "example", ServiceResourcesDictHelpers.Config.schema_extra["examples"]
 )
-def test_create_jsonable_dict(example: dict[DockerComposeServiceName, Any]) -> None:
+def test_create_jsonable_dict(example: dict[DockerGenericTag, Any]) -> None:
     service_resources_dict: ServiceResourcesDict = parse_obj_as(
         ServiceResourcesDict, example
     )

--- a/packages/models-library/tests/test_service_resources.py
+++ b/packages/models-library/tests/test_service_resources.py
@@ -5,9 +5,9 @@
 from typing import Any
 
 import pytest
+from models_library.docker import DockerGenericTag
 from models_library.services_resources import (
     DockerComposeServiceName,
-    DockerImage,
     ImageResources,
     ResourcesDict,
     ResourceValue,
@@ -28,7 +28,7 @@ from pydantic import parse_obj_as
     ),
 )
 def test_compose_image(example: str) -> None:
-    parse_obj_as(DockerImage, example)
+    parse_obj_as(DockerGenericTag, example)
 
 
 @pytest.fixture
@@ -39,8 +39,8 @@ def resources_dict() -> ResourcesDict:
 
 
 @pytest.fixture
-def compose_image() -> DockerImage:
-    return parse_obj_as(DockerImage, "image:latest")
+def compose_image() -> DockerGenericTag:
+    return parse_obj_as(DockerGenericTag, "image:latest")
 
 
 def _ensure_resource_value_is_an_object(data: ResourcesDict) -> None:
@@ -74,7 +74,7 @@ def test_image_resources_parsed_as_expected() -> None:
     "example", ServiceResourcesDictHelpers.Config.schema_extra["examples"]
 )
 def test_service_resource_parsed_as_expected(
-    example: dict[DockerComposeServiceName, Any], compose_image: DockerImage
+    example: dict[DockerComposeServiceName, Any], compose_image: DockerGenericTag
 ) -> None:
     def _assert_service_resources_dict(
         service_resources_dict: ServiceResourcesDict,

--- a/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
@@ -6,11 +6,11 @@ from typing import Any, Final, Optional, cast
 import yaml
 from aiocache import cached
 from fastapi import APIRouter, Depends, HTTPException, status
-from models_library.docker import DockerImageKey, DockerImageVersion
 from models_library.service_settings_labels import (
     ComposeSpecLabel,
     SimcoreServiceSettingLabelEntry,
 )
+from models_library.services import ServiceKey, ServiceVersion
 from models_library.services_resources import (
     ImageResources,
     ResourcesDict,
@@ -54,8 +54,8 @@ def _remove_deprecated_resources(resources: ResourcesDict) -> ResourcesDict:
 def _from_service_settings(
     settings: list[SimcoreServiceSettingLabelEntry],
     default_service_resources: ResourcesDict,
-    service_key: DockerImageKey,
-    service_version: DockerImageVersion,
+    service_key: ServiceKey,
+    service_version: ServiceVersion,
 ) -> ResourcesDict:
     # filter resource entries
     resource_entries = filter(lambda entry: entry.name.lower() == "resources", settings)
@@ -94,7 +94,7 @@ def _from_service_settings(
 
 
 async def _get_service_labels(
-    director_client: DirectorApi, key: DockerImageKey, version: DockerImageVersion
+    director_client: DirectorApi, key: ServiceKey, version: ServiceVersion
 ) -> Optional[dict[str, Any]]:
     try:
         service_labels = cast(
@@ -140,8 +140,8 @@ def _get_service_settings(
     key_builder=lambda f, *args, **kwargs: f"{f.__name__}_{kwargs.get('user_id', 'default')}_{kwargs['service_key']}_{kwargs['service_version']}",
 )
 async def get_service_resources(
-    service_key: DockerImageKey,
-    service_version: DockerImageVersion,
+    service_key: ServiceKey,
+    service_version: ServiceVersion,
     director_client: DirectorApi = Depends(get_director_api),
     default_service_resources: ResourcesDict = Depends(get_default_service_resources),
     services_repo: ServicesRepository = Depends(get_repository(ServicesRepository)),

--- a/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
@@ -42,6 +42,13 @@ logger = logging.getLogger(__name__)
 
 SIMCORE_SERVICE_SETTINGS_LABELS: Final[str] = "simcore.service.settings"
 SIMCORE_SERVICE_COMPOSE_SPEC_LABEL: Final[str] = "simcore.service.compose-spec"
+_DEPRECATED_RESOURCES: Final[list[str]] = ["MPI"]
+
+
+def _remove_deprecated_resources(resources: ResourcesDict) -> ResourcesDict:
+    for res_name in _DEPRECATED_RESOURCES:
+        resources.pop(res_name, None)
+    return resources
 
 
 def _from_service_settings(
@@ -83,7 +90,7 @@ def _from_service_settings(
             entry.value.get("Reservations", {}).get("GenericResources", []),
         )
 
-    return service_resources
+    return _remove_deprecated_resources(service_resources)
 
 
 async def _get_service_labels(

--- a/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 from typing import Any, Final, Optional, cast
 
 import yaml
-from aiocache import cached
 from fastapi import APIRouter, Depends, HTTPException, status
 from models_library.service_settings_labels import (
     ComposeSpecLabel,
@@ -23,7 +22,6 @@ from pydantic import parse_obj_as, parse_raw_as
 from ...db.repositories.services import ServicesRepository
 from ...models.domain.group import GroupAtDB
 from ...models.schemas.constants import (
-    DIRECTOR_CACHING_TTL,
     RESPONSE_MODEL_POLICY,
     SIMCORE_SERVICE_SETTINGS_LABELS,
 )
@@ -134,10 +132,6 @@ def _get_service_settings(
     "/{service_key:path}/{service_version}/resources",
     response_model=ServiceResourcesDict,
     **RESPONSE_MODEL_POLICY,
-)
-@cached(
-    ttl=DIRECTOR_CACHING_TTL,
-    key_builder=lambda f, *args, **kwargs: f"{f.__name__}_{kwargs.get('user_id', 'default')}_{kwargs['service_key']}_{kwargs['service_version']}",
 )
 async def get_service_resources(
     service_key: ServiceKey,

--- a/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
@@ -5,6 +5,7 @@ from typing import Any, Final, Optional, cast
 
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, status
+from models_library.docker import DockerGenericTag
 from models_library.service_settings_labels import (
     ComposeSpecLabel,
     SimcoreServiceSettingLabelEntry,
@@ -178,7 +179,7 @@ async def get_service_resources(
     services_repo: ServicesRepository = Depends(get_repository(ServicesRepository)),
     user_groups: list[GroupAtDB] = Depends(list_user_groups),
 ) -> ServiceResourcesDict:
-    image_version = f"{service_key}:{service_version}"
+    image_version = parse_obj_as(DockerGenericTag, f"{service_key}:{service_version}")
     if is_function_service(service_key):
         return ServiceResourcesDictHelpers.create_from_single_service(
             image_version, default_service_resources

--- a/services/catalog/src/simcore_service_catalog/services/director.py
+++ b/services/catalog/src/simcore_service_catalog/services/director.py
@@ -1,7 +1,7 @@
 import asyncio
 import functools
 import logging
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
+from typing import Any, Awaitable, Callable, Optional, Union
 
 import httpx
 from fastapi import FastAPI, HTTPException
@@ -66,7 +66,9 @@ async def close_director(app: FastAPI) -> None:
 # DIRECTOR API CLASS ---------------------------------------------
 
 
-def safe_request(request_func: Callable[..., Awaitable[httpx.Response]]):
+def safe_request(
+    request_func: Callable[..., Awaitable[httpx.Response]]
+) -> httpx.Response:
     """
     Creates a context for safe inter-process communication (IPC)
     """
@@ -74,7 +76,7 @@ def safe_request(request_func: Callable[..., Awaitable[httpx.Response]]):
 
     def _unenvelope_or_raise_error(
         resp: httpx.Response,
-    ) -> Union[List[Any], Dict[str, Any]]:
+    ) -> Union[list[Any], dict[str, Any]]:
         """
         Director responses are enveloped
         If successful response, we un-envelop it and return data as a dict
@@ -153,7 +155,7 @@ class DirectorApi:
         return await self.client.get(path, timeout=20.0)
 
     @safe_request
-    async def put(self, path: str, body: Dict) -> httpx.Response:
+    async def put(self, path: str, body: dict) -> httpx.Response:
         return await self.client.put(path, json=body)
 
     async def is_responsive(self) -> bool:

--- a/services/catalog/src/simcore_service_catalog/services/director.py
+++ b/services/catalog/src/simcore_service_catalog/services/director.py
@@ -68,7 +68,7 @@ async def close_director(app: FastAPI) -> None:
 
 def safe_request(
     request_func: Callable[..., Awaitable[httpx.Response]]
-) -> httpx.Response:
+) -> Callable[..., Awaitable[Union[list[Any], dict[str, Any]]]]:
     """
     Creates a context for safe inter-process communication (IPC)
     """
@@ -107,7 +107,9 @@ def safe_request(
         return data or {}
 
     @functools.wraps(request_func)
-    async def request_wrapper(zelf: "DirectorApi", path: str, *args, **kwargs):
+    async def request_wrapper(
+        zelf: "DirectorApi", path: str, *args, **kwargs
+    ) -> Union[list[Any], dict[str, Any]]:
         normalized_path = path.lstrip("/")
         try:
             resp = await request_func(zelf, path=normalized_path, *args, **kwargs)

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -83,7 +83,8 @@ else
 
   # add the GPUs if there are any
   if [ "$num_gpus" -gt 0 ]; then
-    resources="$resources,GPU=$num_gpus"
+    total_vram=$(python -c "from simcore_service_dask_sidecar.utils import video_memory; print(video_memory());")
+    resources="$resources,GPU=$num_gpus,VRAM=$total_vram"
   fi
 
   # add the MPI if possible

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
@@ -6,6 +6,7 @@ from typing import Any, Awaitable, Coroutine, Optional, cast
 
 import aiodocker
 from aiodocker.containers import DockerContainer
+from pydantic import ByteSize, parse_obj_as
 
 logger = logging.getLogger(__name__)
 
@@ -75,3 +76,72 @@ def num_available_gpus() -> int:
             return num_gpus
 
     return cast(int, _wrap_async_call(async_num_available_gpus()))
+
+
+def video_memory() -> int:
+    """Returns the number of available GPUs, 0 if not a gpu node"""
+
+    async def async_video_memory() -> int:
+        video_ram: ByteSize = ByteSize(0)
+        container: Optional[DockerContainer] = None
+        async with aiodocker.Docker() as docker:
+            spec_config = {
+                "Cmd": [
+                    "nvidia-smi",
+                    "--query-gpu=memory.total",
+                    "--format=csv,noheader",
+                ],
+                "Image": "nvidia/cuda:10.0-base",
+                "AttachStdin": False,
+                "AttachStdout": False,
+                "AttachStderr": False,
+                "Tty": False,
+                "OpenStdin": False,
+                "HostConfig": {
+                    "Init": True,
+                    "AutoRemove": False,
+                },  # NOTE: The Init parameter shows a weird behavior: no exception thrown when the container fails
+            }
+            try:
+                container = await docker.containers.run(
+                    config=spec_config, name=f"sidecar_{uuid.uuid4()}_test_gpu"
+                )
+                if not container:
+                    return 0
+
+                container_data = await container.wait(timeout=10)
+                container_logs = await cast(
+                    Coroutine,
+                    container.log(stdout=True, stderr=True, follow=False),
+                )
+                video_ram = parse_obj_as(ByteSize, 0)
+                if container_data.setdefault("StatusCode", 127) == 0:
+                    for line in container_logs:
+                        video_ram = parse_obj_as(
+                            ByteSize, video_ram + parse_obj_as(ByteSize, line)
+                        )
+
+                logger.debug(
+                    "testing for GPU VRAM with docker run %s %s completed with status code %s, found %d total vram:\nlogs:\n%s",
+                    spec_config["Image"],
+                    spec_config["Cmd"],
+                    container_data["StatusCode"],
+                    video_ram.human_readable(),
+                    pformat(container_logs),
+                )
+            except asyncio.TimeoutError as err:
+                logger.warning(
+                    "num_gpus timedout while check-run %s: %s", spec_config, err
+                )
+            except aiodocker.exceptions.DockerError as err:
+                logger.warning(
+                    "num_gpus DockerError while check-run %s: %s", spec_config, err
+                )
+            finally:
+                if container is not None:
+                    # ensure container is removed
+                    await container.delete()
+
+            return video_ram
+
+    return cast(int, _wrap_async_call(async_video_memory()))

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -157,12 +157,16 @@ async def create_computation(
             minimal_computational_dag,
             publish=computation.start_pipeline or False,
         )
+        assert computation.product_name  # nosec
         inserted_comp_tasks = await comp_tasks_repo.upsert_tasks_from_project(
             project,
+            catalog_client,
             director_client,
             published_nodes=list(minimal_computational_dag.nodes())
             if computation.start_pipeline
             else [],
+            user_id=computation.user_id,
+            product_name=computation.product_name,
         )
 
         if computation.start_pipeline:

--- a/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
@@ -13,7 +13,7 @@ from models_library.services import (
     ServiceOutput,
     ServicePortKey,
 )
-from pydantic import BaseModel, Extra, Field, validator
+from pydantic import BaseModel, ByteSize, Extra, Field, parse_obj_as, validator
 from pydantic.types import PositiveInt
 from simcore_postgres_database.models.comp_tasks import NodeClass, StateType
 
@@ -52,7 +52,7 @@ class Image(BaseModel):
             v = NodeRequirements(
                 CPU=1.0,
                 GPU=1 if values.get("requires_gpu") else 0,
-                RAM="128 MiB",
+                RAM=parse_obj_as(ByteSize, "128 MiB"),
                 MPI=1 if values.get("requires_mpi") else 0,
             )
         return v

--- a/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
@@ -53,7 +53,6 @@ class Image(BaseModel):
                 CPU=1.0,
                 GPU=1 if values.get("requires_gpu") else 0,
                 RAM=parse_obj_as(ByteSize, "128 MiB"),
-                MPI=1 if values.get("requires_mpi") else 0,
             )
         return v
 

--- a/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
@@ -31,7 +31,7 @@ class Image(BaseModel):
     requires_mpi: Optional[bool] = Field(
         None, deprecated=True, description="Use instead node_requirements"
     )
-    node_requirements: NodeRequirements = Field(
+    node_requirements: Optional[NodeRequirements] = Field(
         None, description="the requirements for the service to run on a node"
     )
     command: list[str] = Field(

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/comp_tasks.py
@@ -24,9 +24,7 @@ class ComputationCreate(BaseModel):
         default=False,
         description="if True the computation pipeline will start right away",
     )
-    product_name: Optional[str] = Field(
-        default=None, description="required if computation is started"
-    )
+    product_name: str
     subgraph: Optional[list[NodeID]] = Field(
         default=None,
         description="An optional set of nodes that must be executed, if empty the whole pipeline is executed",

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/services.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/services.py
@@ -4,7 +4,7 @@ from models_library.basic_regex import UUID_RE
 from models_library.basic_types import PortInt
 from models_library.service_settings_labels import ContainerSpec
 from models_library.services import KEY_RE, VERSION_RE, ServiceDockerData
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from pydantic.types import ByteSize, NonNegativeInt
 
 from .dynamic_services import ServiceState
@@ -30,7 +30,7 @@ class NodeRequirements(BaseModel):
     )
     ram: ByteSize = Field(
         ...,
-        description="defines the required (maximum) amount of RAM for running the services in bytes",
+        description="defines the required (maximum) amount of RAM for running the services",
         alias="RAM",
     )
     mpi: Optional[int] = Field(
@@ -41,6 +41,18 @@ class NodeRequirements(BaseModel):
         le=1,
         ge=0,
     )
+    vram: Optional[ByteSize] = Field(
+        default=None,
+        description="defines the required (maximum) amount of VRAM for running the services",
+        alias="VRAM",
+    )
+
+    @validator("mpi", "vram", "gpu", always=True, pre=True)
+    @classmethod
+    def check_0_is_none(cls, v):
+        if v == 0:
+            v = None
+        return v
 
     class Config:
         schema_extra = {

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/services.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/services.py
@@ -54,7 +54,6 @@ class NodeRequirements(BaseModel):
                 {
                     "CPU": 1.0,
                     "RAM": 4194304,
-                    "MPI": 1,
                 },
             ]
         }

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/services.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/services.py
@@ -33,21 +33,13 @@ class NodeRequirements(BaseModel):
         description="defines the required (maximum) amount of RAM for running the services",
         alias="RAM",
     )
-    mpi: Optional[int] = Field(
-        None,
-        deprecated=True,
-        description="defines whether a MPI node is required for running the services",
-        alias="MPI",
-        le=1,
-        ge=0,
-    )
     vram: Optional[ByteSize] = Field(
         default=None,
         description="defines the required (maximum) amount of VRAM for running the services",
         alias="VRAM",
     )
 
-    @validator("mpi", "vram", "gpu", always=True, pre=True)
+    @validator("vram", "gpu", always=True, pre=True)
     @classmethod
     def check_0_is_none(cls, v):
         if v == 0:

--- a/services/director-v2/src/simcore_service_director_v2/modules/catalog.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/catalog.py
@@ -10,7 +10,6 @@ from models_library.users import UserID
 
 from ..core.settings import CatalogSettings
 from ..utils.client_decorators import handle_errors, handle_retry
-from ..utils.logging_utils import log_decorator
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +58,6 @@ class CatalogClient:
     async def request(self, method: str, tail_path: str, **kwargs) -> httpx.Response:
         return await self.client.request(method, tail_path, **kwargs)
 
-    @log_decorator(logger=logger)
     async def get_service(
         self,
         user_id: UserID,
@@ -67,7 +65,6 @@ class CatalogClient:
         service_version: ServiceVersion,
         product_name: str,
     ) -> dict[str, Any]:
-
         resp = await self.request(
             "GET",
             f"/services/{urllib.parse.quote( service_key, safe='')}/{service_version}",
@@ -79,11 +76,22 @@ class CatalogClient:
             return resp.json()
         raise HTTPException(status_code=resp.status_code, detail=resp.content)
 
-    @log_decorator(logger=logger)
+    async def get_service_resources(
+        self, user_id: UserID, service_key: ServiceKey, service_version: ServiceVersion
+    ) -> dict[str, Any]:
+        resp = await self.request(
+            "GET",
+            f"/services/{urllib.parse.quote( service_key, safe='')}/{service_version}/resources",
+            params={"user_id": user_id},
+        )
+        resp.raise_for_status()
+        if resp.status_code == status.HTTP_200_OK:
+            return resp.json()
+        raise HTTPException(status_code=resp.status_code, detail=resp.content)
+
     async def get_service_specifications(
         self, user_id: UserID, service_key: ServiceKey, service_version: ServiceVersion
     ) -> dict[str, Any]:
-
         resp = await self.request(
             "GET",
             f"/services/{urllib.parse.quote( service_key, safe='')}/{service_version}/specifications",

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -43,7 +43,6 @@ async def _generate_tasks_list_from_project(
     director_client: DirectorV0Client,
     published_nodes: list[NodeID],
 ) -> list[CompTaskAtDB]:
-
     list_comp_tasks = []
     for internal_id, node_id in enumerate(project.workbench, 1):
         node: Node = project.workbench[node_id]
@@ -85,7 +84,7 @@ async def _generate_tasks_list_from_project(
 
         task_db = CompTaskAtDB(
             project_id=project.uuid,
-            node_id=node_id,
+            node_id=NodeID(node_id),
             schema=NodeSchema.parse_obj(
                 node_details.dict(
                     exclude_unset=True, by_alias=True, include={"inputs", "outputs"}
@@ -186,7 +185,6 @@ class CompTasksRepository(BaseRepository):
             # NOTE: an exception to this is when a frontend service changes its output since there is no node_ports, the UPDATE must be done here.
             inserted_comp_tasks_db: list[CompTaskAtDB] = []
             for comp_task_db in list_of_comp_tasks_in_project:
-
                 insert_stmt = insert(comp_tasks).values(**comp_task_db.to_db_model())
 
                 exclusion_rule = (

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -9,7 +9,7 @@ from models_library.projects import ProjectAtDB, ProjectID
 from models_library.projects_nodes import Node
 from models_library.projects_nodes_io import NodeID
 from models_library.projects_state import RunningState
-from models_library.services import ServiceDockerData, ServiceKeyVersion
+from models_library.services import ServiceDockerData
 from models_library.users import UserID
 from sqlalchemy import literal_column
 from sqlalchemy.dialects.postgresql import insert
@@ -64,10 +64,7 @@ async def _generate_tasks_list_from_project(
     for internal_id, node_id in enumerate(project.workbench, 1):
         node: Node = project.workbench[node_id]
 
-        service_key_version = ServiceKeyVersion(
-            key=node.key,
-            version=node.version,
-        )
+        # get node infos
         node_class = to_node_class(node.key)
         node_details: Optional[ServiceDockerData] = None
         node_resources: Optional[dict[str, Any]] = None
@@ -78,7 +75,7 @@ async def _generate_tasks_list_from_project(
             node_details, node_resources, node_extras = await asyncio.gather(
                 _get_service_details(catalog_client, user_id, product_name, node),
                 catalog_client.get_service_resources(user_id, node.key, node.version),
-                director_client.get_service_extras(service_key_version),
+                director_client.get_service_extras(node.key, node.version),
             )
 
         if not node_details:

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -68,12 +68,12 @@ async def _generate_tasks_list_from_project(
             key=node.key,
             version=node.version,
         )
-        node_class = to_node_class(service_key_version.key)
+        node_class = to_node_class(node.key)
         node_details: Optional[ServiceDockerData] = None
         node_resources: Optional[dict[str, Any]] = None
         node_extras: Optional[ServiceExtras] = None
         if node_class == NodeClass.FRONTEND:
-            node_details = _FRONTEND_SERVICES_CATALOG.get(service_key_version.key, None)
+            node_details = _FRONTEND_SERVICES_CATALOG.get(node.key, None)
         else:
             node_details, node_resources, node_extras = await asyncio.gather(
                 _get_service_details(catalog_client, user_id, product_name, node),
@@ -86,8 +86,8 @@ async def _generate_tasks_list_from_project(
 
         # aggregates node_details and node_extras into Image
         data: dict[str, Any] = {
-            "name": service_key_version.key,
-            "tag": service_key_version.version,
+            "name": node.key,
+            "tag": node.version,
         }
         if node_resources:
             # TODO: this works only for single containers

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -101,9 +101,8 @@ async def _generate_tasks_list_from_project(
             data.update(
                 node_requirements=NodeRequirements.parse_obj(node_defined_resources)
             )
-        if node_extras:
-            if node_extras.container_spec:
-                data.update(command=node_extras.container_spec.command)
+        if node_extras and node_extras.container_spec:
+            data.update(command=node_extras.container_spec.command)
         image = Image.parse_obj(data)
         assert image.command  # nosec
 

--- a/services/director-v2/src/simcore_service_director_v2/utils/clients.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/clients.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict
+from typing import Any, Union
 
 import httpx
 from fastapi import HTTPException
@@ -9,7 +9,7 @@ from starlette import status
 logger = logging.getLogger(__name__)
 
 
-def unenvelope_or_raise_error(resp: httpx.Response) -> Dict[str, Any]:
+def unenvelope_or_raise_error(resp: httpx.Response) -> Union[list[Any], dict[str, Any]]:
     """
     Director responses are enveloped
     If successful response, we un-envelop it and return data as a dict

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -284,7 +284,6 @@ async def compute_service_log_file_upload_link(
     node_id: NodeID,
     file_link_type: FileLinkType,
 ) -> AnyUrl:
-
     value_links = await port_utils.get_upload_links_from_storage(
         user_id=user_id,
         project_id=f"{project_id}",
@@ -404,7 +403,9 @@ def from_node_reqs_to_dask_resources(
 ) -> dict[str, Union[int, float]]:
     """Dask resources are set such as {"CPU": X.X, "GPU": Y.Y, "RAM": INT}"""
     dask_resources = node_reqs.dict(
-        exclude_unset=True, by_alias=True, exclude_none=True
+        exclude_unset=True,
+        by_alias=True,
+        exclude_none=True,
     )
     logger.debug("transformed to dask resources: %s", dask_resources)
     return dask_resources

--- a/services/director-v2/tests/unit/test_modules_director_v0.py
+++ b/services/director-v2/tests/unit/test_modules_director_v0.py
@@ -234,7 +234,7 @@ async def test_get_service_extras(
 ):
     director_client: DirectorV0Client = minimal_app.state.director_v0_client
     service_extras: ServiceExtras = await director_client.get_service_extras(
-        mock_service_key_version
+        mock_service_key_version.key, mock_service_key_version.version
     )
     assert mocked_director_service_fcts["get_service_extras"].called
     assert fake_service_extras == service_extras

--- a/services/director-v2/tests/unit/with_dbs/test_api_route_computations.py
+++ b/services/director-v2/tests/unit/with_dbs/test_api_route_computations.py
@@ -190,8 +190,7 @@ async def test_create_computation(
         create_computation_url,
         json=jsonable_encoder(
             ComputationCreate(
-                user_id=user["id"],
-                project_id=proj.uuid,
+                user_id=user["id"], project_id=proj.uuid, product_name=product_name
             )
         ),
     )

--- a/services/web/server/src/simcore_service_webserver/director_v2_core_computations.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_core_computations.py
@@ -97,7 +97,7 @@ def set_client(app: web.Application, obj: ComputationsApi):
 
 @log_decorator(logger=log)
 async def create_or_update_pipeline(
-    app: web.Application, user_id: UserID, project_id: ProjectID
+    app: web.Application, user_id: UserID, project_id: ProjectID, product_name: str
 ) -> Optional[DataType]:
     settings: DirectorV2Settings = get_plugin_settings(app)
 
@@ -105,6 +105,7 @@ async def create_or_update_pipeline(
     body = {
         "user_id": user_id,
         "project_id": f"{project_id}",
+        "product_name": product_name,
     }
     # request to director-v2
     try:
@@ -122,7 +123,6 @@ async def create_or_update_pipeline(
 async def is_pipeline_running(
     app: web.Application, user_id: PositiveInt, project_id: UUID
 ) -> Optional[bool]:
-
     # TODO: make it cheaper by /computations/{project_id}/state. First trial shows
     # that the efficiency gain is minimal but should be considered specially if the handler
     # gets heavier with time

--- a/services/web/server/src/simcore_service_webserver/exporter/formatters/formatter_v1.py
+++ b/services/web/server/src/simcore_service_webserver/exporter/formatters/formatter_v1.py
@@ -224,7 +224,7 @@ async def add_new_project(
     if _project_db["uuid"] != str(project.uuid):
         raise ExporterException("Project uuid dose nto match after validation")
 
-    await create_or_update_pipeline(app, user_id, project.uuid)
+    await create_or_update_pipeline(app, user_id, project.uuid, product_name)
 
 
 async def _fix_node_run_hashes_based_on_old_project(

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers_crud.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers_crud.py
@@ -146,6 +146,7 @@ async def create_projects(request: web.Request):
         request_context=req_ctx,
         query_params=query_params,
         predefined_project=predefined_project,
+        product_name=req_ctx.product_name,
         fire_and_forget=True,
     )
 
@@ -249,7 +250,8 @@ async def _create_projects(
     query_params: _ProjectCreateParams,
     request_context: RequestContext,
     predefined_project: Optional[ProjectDict],
-):
+    product_name: str,
+) -> None:
     """
 
     :raises web.HTTPBadRequest
@@ -313,7 +315,7 @@ async def _create_projects(
 
         # This is a new project and every new graph needs to be reflected in the pipeline tables
         await director_v2_api.create_or_update_pipeline(
-            app, request_context.user_id, new_project["uuid"]
+            app, request_context.user_id, new_project["uuid"], product_name
         )
 
         # Appends state
@@ -636,7 +638,10 @@ async def replace_project(request: web.Request):
             request.app, path_params.project_id
         )
         await director_v2_api.create_or_update_pipeline(
-            request.app, req_ctx.user_id, path_params.project_id
+            request.app,
+            req_ctx.user_id,
+            path_params.project_id,
+            product_name=req_ctx.product_name,
         )
         # Appends state
         new_project = await projects_api.add_project_states_for_user(

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_projects.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_projects.py
@@ -179,4 +179,4 @@ async def add_new_project(
     #
     # TODO: Ensure this user has access to these services!
     #
-    await create_or_update_pipeline(app, user.id, project.uuid)
+    await create_or_update_pipeline(app, user.id, project.uuid, product_name)

--- a/services/web/server/tests/unit/with_dbs/01/test_director_v2.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_director_v2.py
@@ -46,10 +46,14 @@ def cluster_id(faker: Faker) -> ClusterID:
 
 
 async def test_create_pipeline(
-    mocked_director_v2, client, user_id: UserID, project_id: ProjectID
+    mocked_director_v2,
+    client,
+    user_id: UserID,
+    project_id: ProjectID,
+    osparc_product_name: str,
 ):
     task_out = await director_v2_api.create_or_update_pipeline(
-        client.app, user_id, project_id
+        client.app, user_id, project_id, osparc_product_name
     )
     assert task_out
     assert isinstance(task_out, dict)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️     Changes in devops configuration
  🗃️    Migration of database

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

- [x] remove ```mpi``` flag as resource (catalog API /resources endpoint will not return MPI anymore)
- [x] director-v2 does not pass MPI as a task requirements anymore 
- [x] director-v2 uses catalog to get the computational service resources instead of director-v0, thus allowing for resource override through table ```services_specifications```
- [ ] dask-sidecar boot mode, remove MPI and MPI advertisement
- [x] pass boot-mode from catalog to director-v2
- [ ] pass boot-mode from director-v2 to dask-sidecar

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
