### PR TITLE
🐛 Fix: Thumbnail width on Large Card

### DIFF
--- a/services/static-webserver/client/source/class/osparc/MaintenanceTracker.js
+++ b/services/static-webserver/client/source/class/osparc/MaintenanceTracker.js
@@ -87,6 +87,7 @@ qx.Class.define("osparc.MaintenanceTracker", {
           text += " - " + osparc.utils.Utils.formatDateAndTime(this.getEnd());
         }
       }
+      text += " (local time)";
       if (this.getReason()) {
         text += ": " + this.getReason();
       }

--- a/services/static-webserver/client/source/class/osparc/component/metadata/ServicesInStudy.js
+++ b/services/static-webserver/client/source/class/osparc/component/metadata/ServicesInStudy.js
@@ -151,8 +151,8 @@ qx.Class.define("osparc.component.metadata.ServicesInStudy", {
             label: node["label"]
           });
           const title = this.tr("Service information");
-          const width = 600;
-          const height = 700;
+          const width = osparc.info.CardLarge.WIDTH;
+          const height = osparc.info.CardLarge.HEIGHT;
           osparc.ui.window.Window.popUpInWindow(serviceDetails, title, width, height);
         }, this);
         this._add(infoButton, {

--- a/services/static-webserver/client/source/class/osparc/component/node/BaseNodeView.js
+++ b/services/static-webserver/client/source/class/osparc/component/node/BaseNodeView.js
@@ -231,8 +231,8 @@ qx.Class.define("osparc.component.node.BaseNodeView", {
         studyId: node.getStudy().getUuid()
       });
       const title = this.tr("Service information");
-      const width = 600;
-      const height = 700;
+      const width = osparc.info.CardLarge.WIDTH;
+      const height = osparc.info.CardLarge.HEIGHT;
       osparc.ui.window.Window.popUpInWindow(serviceDetails, title, width, height);
     },
 

--- a/services/static-webserver/client/source/class/osparc/component/widget/NodesTree.js
+++ b/services/static-webserver/client/source/class/osparc/component/widget/NodesTree.js
@@ -272,11 +272,11 @@ qx.Class.define("osparc.component.widget.NodesTree", {
       }
       if (nodeId) {
         const study = this.getStudy();
+        const width = osparc.info.CardLarge.WIDTH;
+        const height = osparc.info.CardLarge.HEIGHT;
         if (nodeId === study.getUuid()) {
           const studyDetails = new osparc.info.StudyLarge(study);
           const title = this.tr("Study Information");
-          const width = 500;
-          const height = 500;
           osparc.ui.window.Window.popUpInWindow(studyDetails, title, width, height);
         } else {
           const node = study.getWorkbench().getNode(nodeId);
@@ -286,8 +286,6 @@ qx.Class.define("osparc.component.widget.NodesTree", {
             studyId: study.getUuid()
           });
           const title = this.tr("Service information");
-          const width = 600;
-          const height = 700;
           osparc.ui.window.Window.popUpInWindow(serviceDetails, title, width, height);
         }
       }

--- a/services/static-webserver/client/source/class/osparc/component/widget/StudyTitleOnlyTree.js
+++ b/services/static-webserver/client/source/class/osparc/component/widget/StudyTitleOnlyTree.js
@@ -46,8 +46,8 @@ qx.Class.define("osparc.component.widget.StudyTitleOnlyTree", {
     __openStudyInfo: function() {
       const studyDetails = new osparc.info.StudyLarge(this.getStudy());
       const title = this.tr("Study Information");
-      const width = 500;
-      const height = 500;
+      const width = osparc.info.CardLarge.WIDTH;
+      const height = osparc.info.CardLarge.HEIGHT;
       osparc.ui.window.Window.popUpInWindow(studyDetails, title, width, height);
     },
 

--- a/services/static-webserver/client/source/class/osparc/component/workbench/ServiceCatalog.js
+++ b/services/static-webserver/client/source/class/osparc/component/workbench/ServiceCatalog.js
@@ -306,8 +306,8 @@ qx.Class.define("osparc.component.workbench.ServiceCatalog", {
     __showServiceDetails: function() {
       const serviceDetails = new osparc.info.ServiceLarge(this.__getSelectedService());
       const title = this.tr("Service information");
-      const width = 600;
-      const height = 700;
+      const width = osparc.info.CardLarge.WIDTH;
+      const height = osparc.info.CardLarge.HEIGHT;
       osparc.ui.window.Window.popUpInWindow(serviceDetails, title, width, height);
     },
 

--- a/services/static-webserver/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/static-webserver/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -1552,8 +1552,8 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
           studyId: this.getStudy().getUuid()
         });
         const title = this.tr("Service information");
-        const width = 600;
-        const height = 700;
+        const width = osparc.info.CardLarge.WIDTH;
+        const height = osparc.info.CardLarge.HEIGHT;
         osparc.ui.window.Window.popUpInWindow(serviceDetails, title, width, height);
       }
     },

--- a/services/static-webserver/client/source/class/osparc/desktop/SlideshowToolbar.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/SlideshowToolbar.js
@@ -205,8 +205,8 @@ qx.Class.define("osparc.desktop.SlideshowToolbar", {
     __openStudyDetails: function() {
       const studyDetails = new osparc.info.StudyLarge(this.getStudy());
       const title = this.tr("Study Information");
-      const width = 500;
-      const height = 500;
+      const width = osparc.info.CardLarge.WIDTH;
+      const height = osparc.info.CardLarge.HEIGHT;
       osparc.ui.window.Window.popUpInWindow(studyDetails, title, width, height);
     },
 

--- a/services/static-webserver/client/source/class/osparc/info/CardLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/CardLarge.js
@@ -45,6 +45,8 @@ qx.Class.define("osparc.info.CardLarge", {
   },
 
   statics: {
+    WIDTH: 600,
+    HEIGHT: 700,
     PADDING: 5,
     EXTRA_INFO_WIDTH: 250,
     THUMBNAIL_MIN_WIDTH: 150,

--- a/services/static-webserver/client/source/class/osparc/info/CardLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/CardLarge.js
@@ -1,0 +1,64 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2023 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+
+qx.Class.define("osparc.info.CardLarge", {
+  extend: qx.ui.core.Widget,
+  type: "abstract",
+
+  construct: function() {
+    this.base(arguments);
+
+    this.set({
+      minHeight: 350,
+      padding: this.self().PADDING
+    });
+    this._setLayout(new qx.ui.layout.VBox(8));
+  },
+
+  events: {
+    "openAccessRights": "qx.event.type.Event",
+    "openClassifiers": "qx.event.type.Event",
+    "openQuality": "qx.event.type.Event"
+  },
+
+  properties: {
+    openOptions: {
+      check: "Boolean",
+      init: true,
+      nullable: false
+    }
+  },
+
+  statics: {
+    PADDING: 5,
+    EXTRA_INFO_WIDTH: 250,
+    THUMBNAIL_MIN_WIDTH: 150,
+    THUMBNAIL_MAX_WIDTH: 230
+  },
+
+  members: {
+    _attachHandlers: function() {
+      this.addListenerOnce("appear", () => this._rebuildLayout(), this);
+      this.addListener("resize", () => this._rebuildLayout(), this);
+    },
+
+    _rebuildLayout: function() {
+      throw new Error("Abstract method called!");
+    }
+  }
+});

--- a/services/static-webserver/client/source/class/osparc/info/MergedLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/MergedLarge.js
@@ -17,19 +17,13 @@
 
 
 qx.Class.define("osparc.info.MergedLarge", {
-  extend: qx.ui.core.Widget,
+  extend: osparc.info.CardLarge,
 
   /**
     * @param study {osparc.data.model.Study} Study
     */
   construct: function(study) {
     this.base(arguments);
-
-    this.set({
-      minHeight: 350,
-      padding: this.self().PADDING
-    });
-    this._setLayout(new qx.ui.layout.VBox(8));
 
     this.setStudy(study);
     const nodes = study.getWorkbench().getNodes();
@@ -38,7 +32,7 @@ qx.Class.define("osparc.info.MergedLarge", {
       this.setService(nodes[nodeIds[0]]);
     }
 
-    this.addListenerOnce("appear", () => this.__rebuildLayout(), this);
+    this._attachHandlers();
   },
 
   events: {
@@ -59,15 +53,8 @@ qx.Class.define("osparc.info.MergedLarge", {
     }
   },
 
-  statics: {
-    PADDING: 5,
-    EXTRA_INFO_WIDTH: 250,
-    THUMBNAIL_MIN_WIDTH: 150,
-    THUMBNAIL_MAX_WIDTH: 230
-  },
-
   members: {
-    __rebuildLayout: function() {
+    _rebuildLayout: function() {
       this._removeAll();
 
       const title = this.__createTitle();
@@ -81,14 +68,14 @@ qx.Class.define("osparc.info.MergedLarge", {
       const bounds = this.getBounds();
       const offset = 30;
       const widgetWidth = bounds ? bounds.width - offset : 500 - offset;
-      let thumbnailWidth = widgetWidth - 2*this.self().PADDING;
+      let thumbnailWidth = widgetWidth - 2 * osparc.info.CardLarge.PADDING;
       const maxThumbnailHeight = extraInfo.length*20;
       const hBox = new qx.ui.container.Composite(new qx.ui.layout.HBox(3).set({
         alignX: "center"
       }));
       hBox.add(extraInfoLayout);
-      thumbnailWidth -= this.self().EXTRA_INFO_WIDTH;
-      thumbnailWidth = Math.min(thumbnailWidth - 20, this.self().THUMBNAIL_MAX_WIDTH);
+      thumbnailWidth -= osparc.info.CardLarge.EXTRA_INFO_WIDTH;
+      thumbnailWidth = Math.min(thumbnailWidth - 20, osparc.info.CardLarge.THUMBNAIL_MAX_WIDTH);
       const thumbnail = this.__createThumbnail(thumbnailWidth, maxThumbnailHeight);
       const thumbnailLayout = this.__createViewWithEdit(thumbnail, this.__openThumbnailEditor);
       thumbnailLayout.getLayout().set({
@@ -232,7 +219,7 @@ qx.Class.define("osparc.info.MergedLarge", {
 
     __createExtraInfo: function(extraInfo) {
       const moreInfo = osparc.info.StudyUtils.createExtraInfo(extraInfo).set({
-        width: this.self().EXTRA_INFO_WIDTH
+        width: osparc.info.CardLarge.EXTRA_INFO_WIDTH
       });
 
       return moreInfo;

--- a/services/static-webserver/client/source/class/osparc/info/ServiceLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/ServiceLarge.js
@@ -17,7 +17,7 @@
 
 
 qx.Class.define("osparc.info.ServiceLarge", {
-  extend: qx.ui.core.Widget,
+  extend: osparc.info.CardLarge,
 
   /**
     * @param serviceData {Object} Serialized Service Object
@@ -26,12 +26,6 @@ qx.Class.define("osparc.info.ServiceLarge", {
     */
   construct: function(serviceData, instance = null, openOptions = true) {
     this.base(arguments);
-
-    this.set({
-      minHeight: 350,
-      padding: this.self().PADDING
-    });
-    this._setLayout(new qx.ui.layout.VBox(8));
 
     this.setService(serviceData);
 
@@ -51,14 +45,10 @@ qx.Class.define("osparc.info.ServiceLarge", {
       this.setOpenOptions(openOptions);
     }
 
-    this.addListenerOnce("appear", () => this.__rebuildLayout(), this);
-    this.addListener("resize", () => this.__rebuildLayout(), this);
+    this._attachHandlers();
   },
 
   events: {
-    "openAccessRights": "qx.event.type.Event",
-    "openClassifiers": "qx.event.type.Event",
-    "openQuality": "qx.event.type.Event",
     "updateService": "qx.event.type.Data"
   },
 
@@ -67,7 +57,7 @@ qx.Class.define("osparc.info.ServiceLarge", {
       check: "Object",
       init: null,
       nullable: false,
-      apply: "__rebuildLayout"
+      apply: "_rebuildLayout"
     },
 
     nodeId: {
@@ -86,24 +76,11 @@ qx.Class.define("osparc.info.ServiceLarge", {
       check: "String",
       init: null,
       nullable: true
-    },
-
-    openOptions: {
-      check: "Boolean",
-      init: true,
-      nullable: false
     }
   },
 
-  statics: {
-    PADDING: 5,
-    EXTRA_INFO_WIDTH: 300,
-    THUMBNAIL_MIN_WIDTH: 140,
-    THUMBNAIL_MAX_WIDTH: 280
-  },
-
   members: {
-    __rebuildLayout: function() {
+    _rebuildLayout: function() {
       this._removeAll();
 
       const deprecated = this.__createDeprecated();
@@ -122,8 +99,8 @@ qx.Class.define("osparc.info.ServiceLarge", {
       const offset = 30;
       const maxThumbnailHeight = extraInfo.length*20;
       let widgetWidth = bounds ? bounds.width - offset : 500 - offset;
-      let thumbnailWidth = widgetWidth - 2*this.self().PADDING - this.self().EXTRA_INFO_WIDTH;
-      thumbnailWidth = Math.min(thumbnailWidth - 20, this.self().THUMBNAIL_MAX_WIDTH);
+      let thumbnailWidth = widgetWidth - 2 * osparc.info.CardLarge.PADDING - osparc.info.CardLarge.EXTRA_INFO_WIDTH;
+      thumbnailWidth = Math.min(thumbnailWidth - 20, osparc.info.CardLarge.THUMBNAIL_MAX_WIDTH);
       const thumbnail = this.__createThumbnail(thumbnailWidth, maxThumbnailHeight);
       const thumbnailLayout = this.__createViewWithEdit(thumbnail, this.__openThumbnailEditor);
       thumbnailLayout.getLayout().set({
@@ -278,9 +255,8 @@ qx.Class.define("osparc.info.ServiceLarge", {
 
     __createExtraInfo: function(extraInfo) {
       const moreInfo = osparc.info.ServiceUtils.createExtraInfo(extraInfo).set({
-        width: this.self().EXTRA_INFO_WIDTH
+        width: osparc.info.CardLarge.EXTRA_INFO_WIDTH
       });
-
       return moreInfo;
     },
 

--- a/services/static-webserver/client/source/class/osparc/info/StudyLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/StudyLarge.js
@@ -17,7 +17,7 @@
 
 
 qx.Class.define("osparc.info.StudyLarge", {
-  extend: qx.ui.core.Widget,
+  extend: osparc.info.CardLarge,
 
   /**
     * @param study {osparc.data.model.Study|Object} Study or Serialized Study Object
@@ -25,12 +25,6 @@ qx.Class.define("osparc.info.StudyLarge", {
     */
   construct: function(study, openOptions = true) {
     this.base(arguments);
-
-    this.set({
-      minHeight: 350,
-      padding: this.self().PADDING
-    });
-    this._setLayout(new qx.ui.layout.VBox(8));
 
     if (study instanceof osparc.data.model.Study) {
       this.setStudy(study);
@@ -43,18 +37,10 @@ qx.Class.define("osparc.info.StudyLarge", {
       this.setOpenOptions(openOptions);
     }
 
-    this.addListenerOnce("appear", () => {
-      this.__rebuildLayout();
-    }, this);
-    this.addListener("resize", () => {
-      this.__rebuildLayout();
-    }, this);
+    this._attachHandlers();
   },
 
   events: {
-    "openAccessRights": "qx.event.type.Event",
-    "openClassifiers": "qx.event.type.Event",
-    "openQuality": "qx.event.type.Event",
     "updateStudy": "qx.event.type.Data",
     "updateTags": "qx.event.type.Data"
   },
@@ -64,20 +50,7 @@ qx.Class.define("osparc.info.StudyLarge", {
       check: "osparc.data.model.Study",
       init: null,
       nullable: false
-    },
-
-    openOptions: {
-      check: "Boolean",
-      init: true,
-      nullable: false
     }
-  },
-
-  statics: {
-    PADDING: 5,
-    EXTRA_INFO_WIDTH: 250,
-    THUMBNAIL_MIN_WIDTH: 150,
-    THUMBNAIL_MAX_WIDTH: 230
   },
 
   members: {
@@ -85,7 +58,7 @@ qx.Class.define("osparc.info.StudyLarge", {
       return osparc.data.model.Study.canIWrite(this.getStudy().getAccessRights());
     },
 
-    __rebuildLayout: function() {
+    _rebuildLayout: function() {
       this._removeAll();
 
       const title = this.__createTitle();
@@ -99,9 +72,9 @@ qx.Class.define("osparc.info.StudyLarge", {
       const bounds = this.getBounds();
       const offset = 30;
       let widgetWidth = bounds ? bounds.width - offset : 500 - offset;
-      let thumbnailWidth = widgetWidth - 2*this.self().PADDING;
+      let thumbnailWidth = widgetWidth - 2 * osparc.info.CardLarge.PADDING;
       const maxThumbnailHeight = extraInfo.length*20;
-      const slim = widgetWidth < this.self().EXTRA_INFO_WIDTH + this.self().THUMBNAIL_MIN_WIDTH + 2*this.self().PADDING - 20;
+      const slim = widgetWidth < osparc.info.CardLarge.EXTRA_INFO_WIDTH + osparc.info.CardLarge.THUMBNAIL_MIN_WIDTH + 2 * osparc.info.CardLarge.PADDING - 20;
       let hBox = null;
       if (slim) {
         this._add(extraInfoLayout);
@@ -110,9 +83,9 @@ qx.Class.define("osparc.info.StudyLarge", {
           alignX: "center"
         }));
         hBox.add(extraInfoLayout);
-        thumbnailWidth -= this.self().EXTRA_INFO_WIDTH;
+        thumbnailWidth -= osparc.info.CardLarge.EXTRA_INFO_WIDTH;
       }
-      thumbnailWidth = Math.min(thumbnailWidth - 20, this.self().THUMBNAIL_MAX_WIDTH);
+      thumbnailWidth = Math.min(thumbnailWidth - 20, osparc.info.CardLarge.THUMBNAIL_MAX_WIDTH);
       const thumbnail = this.__createThumbnail(thumbnailWidth, maxThumbnailHeight);
       const thumbnailLayout = this.__createViewWithEdit(thumbnail, this.__openThumbnailEditor);
       thumbnailLayout.getLayout().set({
@@ -225,7 +198,7 @@ qx.Class.define("osparc.info.StudyLarge", {
 
     __createExtraInfo: function(extraInfo) {
       const moreInfo = osparc.info.StudyUtils.createExtraInfo(extraInfo).set({
-        width: this.self().EXTRA_INFO_WIDTH
+        width: osparc.info.CardLarge.EXTRA_INFO_WIDTH
       });
 
       return moreInfo;

--- a/services/static-webserver/client/source/class/osparc/info/StudyMedium.js
+++ b/services/static-webserver/client/source/class/osparc/info/StudyMedium.js
@@ -263,8 +263,8 @@ qx.Class.define("osparc.info.StudyMedium", {
     __openStudyDetails: function() {
       const studyDetails = new osparc.info.StudyLarge(this.getStudy());
       const title = this.tr("Study Information");
-      const width = 500;
-      const height = 500;
+      const width = osparc.info.CardLarge.WIDTH;
+      const height = osparc.info.CardLarge.HEIGHT;
       osparc.ui.window.Window.popUpInWindow(studyDetails, title, width, height);
     }
   }

--- a/services/static-webserver/client/source/class/osparc/info/StudyMedium.js
+++ b/services/static-webserver/client/source/class/osparc/info/StudyMedium.js
@@ -35,9 +35,7 @@ qx.Class.define("osparc.info.StudyMedium", {
       this.setStudy(study);
     }
 
-    this.addListenerOnce("appear", () => {
-      this.__rebuildLayout();
-    }, this);
+    this.addListenerOnce("appear", () => this.__rebuildLayout(), this);
   },
 
   properties: {

--- a/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
@@ -204,8 +204,8 @@ qx.Class.define("osparc.navigation.NavigationBar", {
           control.addListener("execute", () => {
             const infoMerged = new osparc.info.MergedLarge(this.getStudy());
             const title = this.tr("Information");
-            const width = 600;
-            const height = 700;
+            const width = osparc.info.CardLarge.WIDTH;
+            const height = osparc.info.CardLarge.HEIGHT;
             osparc.ui.window.Window.popUpInWindow(infoMerged, title, width, height);
           });
           break;

--- a/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
@@ -168,7 +168,9 @@ qx.Class.define("osparc.navigation.NavigationBar", {
           this._addAt(control, 2);
           break;
         case "logo":
-          control = osparc.component.widget.LogoOnOff.getInstance();
+          control = osparc.component.widget.LogoOnOff.getInstance().set({
+            alignY: "middle"
+          });
           this.getChildControl("left-items").add(control);
           break;
         case "logo-powered":


### PR DESCRIPTION
## What do these changes do?

If the the aspect ratio of a thumbnail was too wide, it could trigger an infinite re-render of the entire Large Card (triggering also some unnecessary calls to the backend) and an annoying scrollbar that could hide key buttons.

This zusammenzuführen standardizes all the Large Cards (Study, Service and Merged) and limits the max width of the thumbnail.

Before:
![Before](https://user-images.githubusercontent.com/33152403/225307144-4bb7d5df-6e68-4107-aa96-282e26aa1bee.gif)

After:
![After](https://user-images.githubusercontent.com/33152403/225307421-e9f8ca20-73d0-4588-8f1d-9ce843ef745c.gif)


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
