### PR TITLE
🐛 Bug/autoscaling datetime failure

### DIFF
--- a/packages/service-library/tests/test_docker_utils.py
+++ b/packages/service-library/tests/test_docker_utils.py
@@ -1,12 +1,60 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from servicelib.docker_utils import to_datetime
 
+NOW = datetime.now(timezone.utc)
+
 
 @pytest.mark.parametrize(
     "docker_time, expected_datetime",
-    [("2020-10-09T12:28:14.771034099Z", datetime(2020, 10, 9, 12, 28, 14, 771034))],
+    [
+        (
+            "2020-10-09T12:28:14.771034099Z",
+            datetime(2020, 10, 9, 12, 28, 14, 771034),
+        ),
+        (NOW.strftime("%Y-%m-%dT%H:%M:%S.%f"), NOW),
+    ],
 )
 def test_to_datetime(docker_time: str, expected_datetime: datetime):
-    assert to_datetime(docker_time) == expected_datetime
+    got_dt = to_datetime(docker_time)
+
+    assert got_dt.replace(tzinfo=timezone.utc) == expected_datetime.replace(
+        tzinfo=timezone.utc
+    )
+
+
+def test_to_datetime_conversion_known_errors():
+    """
+    Keeps an overview of formatting errors produced by 'to_datetime'
+    """
+    # this works
+    to_datetime("2020-10-09T12:28:14.123456099Z")
+
+    # When “Z” (Zulu) is tacked on the end of a time, it indicates that that time is UTC,
+    # so really the literal Z is part of the time. What is T between date and time?
+    # The T is just a literal to separate the date from the time,
+    # and the Z means “zero hour offset” also known as “Zulu time” (UTC)
+    with pytest.raises(ValueError) as err_info:
+        # ValueError: unconverted data remains: Z
+        # Z at the end (represnting ZULU = UTC) should be removed
+        datetime.strptime("2020-10-09T12:28:14.123456Z", "%Y-%m-%dT%H:%M:%S.%f")
+
+    assert err_info.value.args == ("unconverted data remains: Z",)
+
+    # %f (milliseconds) has here 5 digits (can have at most 6) but to_datetime truncates after 6!
+    # therefore it cannot understand Z
+    with pytest.raises(ValueError) as err_info:
+        # ValueError: unconverted data remains: Z
+        to_datetime("2020-10-09T12:28:14.12345Z")
+
+    assert err_info.value.args == ("unconverted data remains: Z",)
+
+    # This was the error in pending_service_tasks_with_insufficient_resources
+    # The 'T' is missing between the date and the time stamp
+    with pytest.raises(ValueError) as err_info:
+        # "time data '2023-03-15 13:01:21.774501' does not match format '%Y-%m-%dT%H:%M:%S.%f'"
+        to_datetime(f"{datetime.now(timezone.utc)}")
+
+    assert "time data" in err_info.value.args
+    assert "does not match" in err_info.value.args

--- a/packages/service-library/tests/test_docker_utils.py
+++ b/packages/service-library/tests/test_docker_utils.py
@@ -24,13 +24,7 @@ def test_to_datetime(docker_time: str, expected_datetime: datetime):
     )
 
 
-def test_to_datetime_conversion_known_errors():
-    """
-    Keeps an overview of formatting errors produced by 'to_datetime'
-    """
-    # this works
-    to_datetime("2020-10-09T12:28:14.123456099Z")
-
+def test_to_strptime_errors():
     # When “Z” (Zulu) is tacked on the end of a time, it indicates that that time is UTC,
     # so really the literal Z is part of the time. What is T between date and time?
     # The T is just a literal to separate the date from the time,
@@ -40,7 +34,16 @@ def test_to_datetime_conversion_known_errors():
         # Z at the end (represnting ZULU = UTC) should be removed
         datetime.strptime("2020-10-09T12:28:14.123456Z", "%Y-%m-%dT%H:%M:%S.%f")
 
-    assert err_info.value.args == ("unconverted data remains: Z",)
+    error_msg = err_info.value.args[0]
+    assert error_msg == "unconverted data remains: Z"
+
+
+def test_to_datetime_known_errors():
+    """
+    Keeps an overview of formatting errors produced by 'to_datetime'
+    """
+    # this works
+    to_datetime("2020-10-09T12:28:14.123456099Z")
 
     # %f (milliseconds) has here 5 digits (can have at most 6) but to_datetime truncates after 6!
     # therefore it cannot understand Z
@@ -48,7 +51,8 @@ def test_to_datetime_conversion_known_errors():
         # ValueError: unconverted data remains: Z
         to_datetime("2020-10-09T12:28:14.12345Z")
 
-    assert err_info.value.args == ("unconverted data remains: Z",)
+    error_msg = err_info.value.args[0]
+    assert error_msg == "unconverted data remains: Z"
 
     # This was the error in pending_service_tasks_with_insufficient_resources
     # The 'T' is missing between the date and the time stamp
@@ -56,5 +60,6 @@ def test_to_datetime_conversion_known_errors():
         # "time data '2023-03-15 13:01:21.774501' does not match format '%Y-%m-%dT%H:%M:%S.%f'"
         to_datetime(f"{datetime.now(timezone.utc)}")
 
-    assert "time data" in err_info.value.args
-    assert "does not match" in err_info.value.args
+    error_msg = err_info.value.args[0]
+    assert "time data" in error_msg
+    assert "does not match" in error_msg

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -140,7 +140,11 @@ def _by_created_dt(task: Task) -> datetime.datetime:
     # NOTE: SAFE implementation to extract task.CreatedAt as datetime for comparison
     if task.CreatedAt:
         with suppress(ValueError):
-            return to_datetime(task.CreatedAt).replace(tzinfo=datetime.timezone.utc)
+            created_at = to_datetime(task.CreatedAt)
+            created_at_utc: datetime.datetime = created_at.replace(
+                tzinfo=datetime.timezone.utc
+            )
+            return created_at_utc
     return datetime.datetime.now(datetime.timezone.utc)
 
 

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -7,6 +7,7 @@ import collections
 import datetime
 import logging
 import re
+from contextlib import suppress
 from pathlib import Path
 from typing import Final, Optional, cast
 
@@ -135,6 +136,14 @@ async def _associated_service_has_no_node_placement_contraints(
     return True
 
 
+def _by_created_dt(task: Task) -> datetime.datetime:
+    # NOTE: SAFE implementation to extract task.CreatedAt as datetime for comparison
+    if task.CreatedAt:
+        with suppress(ValueError):
+            return to_datetime(task.CreatedAt).replace(tzinfo=datetime.timezone.utc)
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
 async def pending_service_tasks_with_insufficient_resources(
     docker_client: AutoscalingDocker,
     service_labels: list[DockerLabelKey],
@@ -157,17 +166,7 @@ async def pending_service_tasks_with_insufficient_resources(
         ),
     )
 
-    sorted_tasks = sorted(
-        tasks,
-        key=lambda task: cast(  # NOTE: some mypy fun here
-            datetime.datetime,
-            (
-                to_datetime(
-                    task.CreatedAt or f"{datetime.datetime.now(datetime.timezone.utc)}"
-                )
-            ),
-        ),
-    )
+    sorted_tasks = sorted(tasks, key=_by_created_dt)
 
     pending_tasks = [
         task


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️     Changes in devops configuration
  🗃️    Migration of database

or from https://gitmoji.dev/
-->

## What do these changes do?

Fixes unhandled exception in the sort predicate when autoscaling services is sorting tasks. This issue was found in production AWS [logs](https://monitoring.osparc.io/graylog/search?rangetype=absolute&from=2023-03-15T10%3A52%3A04.734Z&to=2023-03-15T10%3A52%3A06.734Z&q=source%3A%22manager1%22+AND+gl2_source_input%3A%2261b8724b5311605a9cb391d3%22&highlightMessage=6ceedf7f-c31f-11ed-bcdd-0242ac120009)

```logs

  File "/home/scu/.venv/lib/python3.9/site-packages/servicelib/background_task.py", line 33, in _periodic_scheduled_task
    await task(**task_kwargs)
  File "/home/scu/.venv/lib/python3.9/site-packages/servicelib/redis_utils.py", line 30, in wrapper
    return await func(*args, **kwargs)
  File "/home/scu/.venv/lib/python3.9/site-packages/simcore_service_autoscaling/dynamic_scaling_core.py", line 552, in cluster_scaling_from_labelled_services
    cluster = await _scale_cluster(app, cluster)
  File "/home/scu/.venv/lib/python3.9/site-packages/simcore_service_autoscaling/dynamic_scaling_core.py", line 515, in _scale_cluster
    pending_tasks = await utils_docker.pending_service_tasks_with_insufficient_resources(
  File "/home/scu/.venv/lib/python3.9/site-packages/simcore_service_autoscaling/utils/utils_docker.py", line 160, in pending_service_tasks_with_insufficient_resources
    sorted_tasks = sorted(
  File "/home/scu/.venv/lib/python3.9/site-packages/simcore_service_autoscaling/utils/utils_docker.py", line 165, in <lambda>
    to_datetime(
  File "/home/scu/.venv/lib/python3.9/site-packages/servicelib/docker_utils.py", line 12, in to_datetime
    return datetime.strptime(
  File "/usr/local/lib/python3.9/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/local/lib/python3.9/_strptime.py", line 352, in _strptime
    raise ValueError("unconverted data remains: %s" %
ValueError: unconverted data remains: Z
ERROR:servicelib.background_task:Unhandled exception: unconverted data remains: Z
```

Once merged, i will prepare a hotfix to production ASAP

## Related issue/s

- Addresses incident https://s4llite.statuspage.io/incidents/r810b51d1l88 
   - Issue detected in AWS production (not in staging) in the autoscaling service and reported by @mrnicegyu11 

## How to test

- Includes tests that reproduce the error in the log 
