### PR TITLE
📝 Maintenance: adds status badges and adds new fields in template forms for bug issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -10,6 +10,21 @@ body:
       options:
         - label: I have searched the existing issues
           required: true
+  - type: dropdown
+    id: deploy
+    attributes:
+      label: Which deploy/s?
+      description: Where did you experience this bug? This will help us identifying the version of the faulty code you used.
+      multiple: true
+      options:
+        - "production aws (e.g. osparc.io)"
+        - "staging aws (e.g. staging.osparc.io)"
+        - "production on-premise (dalco)"
+        - "stating on-premise (dalco)"
+        - "development (master)"
+        - "other (e.g. local)"
+    validations:
+      required: false
   - type: textarea
     attributes:
       label: Current Behavior

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 [![dockerhub_badge]](https://hub.docker.com/u/itisfoundation)
 [![license_badge]](./LICENSE)
 [![sonarcloud_badge]](https://sonarcloud.io/summary/new_code?id=ITISFoundation_osparc-simcore)
+[![osparc_status]](https://status.osparc.io")
+[![s4l_status]](https://s4llite.statuspage.io)
 
 <!-- BADGES: LINKS TO IMAGES. Default to https://shields.io/ ------------------------------>
 [black_badge]:https://img.shields.io/badge/code%20style-black-000000.svg
@@ -22,6 +24,8 @@
 [dockerhub_badge]:https://img.shields.io/website/https/hub.docker.com/u/itisfoundation.svg?down_color=red&label=docker%20images&up_color=blue
 [license_badge]:https://img.shields.io/github/license/ITISFoundation/osparc-simcore
 [sonarcloud_badge]:https://sonarcloud.io/api/project_badges/measure?project=ITISFoundation_osparc-simcore&metric=alert_status
+[s4l_status]:https://img.shields.io/badge/dynamic/json?label=s4l-lite.io&query=%24.status.description&url=https%3A%2F%2Fdfrzcpn4jp96.statuspage.io%2Fapi%2Fv2%2Fstatus.json
+[osparc_status]:https://img.shields.io/badge/dynamic/json?label=osparc.io&query=%24.status.description&url=https%3A%2F%2Fstatus.osparc.io%2Fapi%2Fv2%2Fstatus.json
 <!------------------------------------------------------------------------------------------>
 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![dockerhub_badge]](https://hub.docker.com/u/itisfoundation)
 [![license_badge]](./LICENSE)
 [![sonarcloud_badge]](https://sonarcloud.io/summary/new_code?id=ITISFoundation_osparc-simcore)
-[![osparc_status]](https://status.osparc.io")
+[![osparc_status]](https://status.osparc.io)
 [![s4l_status]](https://s4llite.statuspage.io)
 
 <!-- BADGES: LINKS TO IMAGES. Default to https://shields.io/ ------------------------------>

--- a/scripts/docker/docker-compose-config.bash
+++ b/scripts/docker/docker-compose-config.bash
@@ -49,7 +49,7 @@ fi
 
 
 # check if docker-compose V2 is available
-if docker compose version --short | grep --quiet "^2\." ; then
+if docker compose version --short | grep --quiet "^23\." ; then
   show_info "Running compose V2"
   # V2 does not write the version anymore, so we take it from the first compose file
   first_compose_file="${1}"
@@ -91,7 +91,7 @@ docker-compose \
     do
       docker_command+=" --file=${compose_file_path}"
     done
-    docker_command+="\
+    docker_command+=" \
 config \
 | sed --regexp-extended 's/cpus: ([0-9\\.]+)/cpus: \"\\1\"/'"
     # Execute the command

--- a/scripts/docker/docker-compose-config.bash
+++ b/scripts/docker/docker-compose-config.bash
@@ -49,7 +49,7 @@ fi
 
 
 # check if docker-compose V2 is available
-if docker compose version --short | grep --quiet "^23\." ; then
+if docker compose version --short | grep --quiet "^2\." ; then
   show_info "Running compose V2"
   # V2 does not write the version anymore, so we take it from the first compose file
   first_compose_file="${1}"


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️     Changes in devops configuration
  🗃️    Migration of database

or from https://gitmoji.dev/
-->

## What do these changes do?

- Badges that monitors the status of the status.osparc.io and https://s4llite.statuspage.io and redirect to them upon click.
![image](https://user-images.githubusercontent.com/32402063/225406862-d38d9919-5916-4e83-8a7d-e3b505389c2c.png)
    - @odeimaiz something similar could be added to notify "incidents" in the front-end (see https://status.osparc.io/api for more info )
- add option in bug template form
- 🔨 Patch by @sanderegg that fixes ``make up-prod`` and ``make up-devel``
