### PR TITLE
🚑️ Fix GC error while trying to close service

### DIFF
--- a/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
@@ -304,7 +304,7 @@ async def _remove_single_service_if_orphan(
     currently_opened_projects_node_ids: dict[str, str],
 ) -> None:
     """
-    Only removes the service if it is an orphan.
+    Removes the service if it is an orphan. Otherwise the service is left running.
     """
 
     service_host = interactive_service["service_host"]

--- a/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
@@ -366,7 +366,7 @@ async def _remove_single_service_if_orphan(
             except (UserNotFoundError, ValueError):
                 user_role = None
 
-            project_uuid = interactive_service.get("project_id", "")
+            project_uuid = interactive_service["project_id"]
 
             save_state = await ProjectDBAPI.get_from_app_context(app).has_permission(
                 user_id, project_uuid, "write"

--- a/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_core.py
@@ -298,11 +298,15 @@ async def remove_users_manually_marked_as_guests(
 
 
 @log_decorator(logger, log_traceback=True)
-async def _remove_single_orphaned_service(
+async def _remove_single_service_if_orphan(
     app: web.Application,
     interactive_service: dict[str, Any],
     currently_opened_projects_node_ids: dict[str, str],
 ) -> None:
+    """
+    Only removes the service if it is an orphan.
+    """
+
     service_host = interactive_service["service_host"]
     # if not present in DB or not part of currently opened projects, can be removed
     service_uuid = interactive_service["service_uuid"]
@@ -362,7 +366,7 @@ async def _remove_single_orphaned_service(
             except (UserNotFoundError, ValueError):
                 user_role = None
 
-            project_uuid = currently_opened_projects_node_ids[service_uuid]
+            project_uuid = interactive_service.get("project_id", "")
 
             save_state = await ProjectDBAPI.get_from_app_context(app).has_permission(
                 user_id, project_uuid, "write"
@@ -425,7 +429,7 @@ async def remove_orphaned_services(
     # a big study with logs of heavy projects, this will
     # ensure it gets done in parallel
     tasks = [
-        _remove_single_orphaned_service(
+        _remove_single_service_if_orphan(
             app, interactive_service, currently_opened_projects_node_ids
         )
         for interactive_service in running_interactive_services

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -52,9 +52,11 @@ async def test_regression_remove_orphaned_services_node_ids_unhashable_type_set(
     await remove_orphaned_services(mock_registry, mock_app)
 
 
-async def test_regression_project_id_recovered_from_the_wrong_place(
+async def test_regression_project_id_recovered_from_the_wrong_data_structure(
     faker: Faker, mocker: MockerFixture
 ):
+    # tests that KeyError is not raised
+
     base_module = "simcore_service_webserver.garbage_collector_core"
     mocker.patch(
         f"{base_module}.is_node_id_present_in_any_project_workbench",

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock
 import pytest
 from faker import Faker
 from pytest_mock import MockerFixture
-from simcore_service_webserver.garbage_collector_core import remove_orphaned_services
+from simcore_service_webserver.garbage_collector_core import (
+    _remove_single_service_if_orphan,
+    remove_orphaned_services,
+)
 
 
 @pytest.fixture
@@ -47,3 +50,31 @@ async def test_regression_remove_orphaned_services_node_ids_unhashable_type_set(
     mock_app: AsyncMock,
 ):
     await remove_orphaned_services(mock_registry, mock_app)
+
+
+async def test_regression_project_id_recovered_from_the_wrong_place(
+    faker: Faker, mocker: MockerFixture
+):
+    base_module = "simcore_service_webserver.garbage_collector_core"
+    mocker.patch(
+        f"{base_module}.is_node_id_present_in_any_project_workbench",
+        autospec=True,
+        return_value=True,
+    )
+    mocker.patch(
+        f"{base_module}.ProjectDBAPI.get_from_app_context",
+        autospec=True,
+        return_value=AsyncMock(),
+    )
+    mocker.patch(f"{base_module}.director_v2_api.stop_dynamic_service", autospec=True)
+
+    await _remove_single_service_if_orphan(
+        app=AsyncMock(),
+        interactive_service={
+            "service_host": "host",
+            "service_uuid": faker.uuid4(),
+            "user_id": 1,
+            "project_id": faker.uuid4(),
+        },
+        currently_opened_projects_node_ids={},
+    )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️     Changes in devops configuration
  🗃️    Migration of database

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->

GC was wrongly fetching the `project_id`, it is now recovered from the intended data structure. I have no idea why I did that 🤷‍♂️

```
ERROR: [2023-03-17 08:34:35,601/MainProcess] [simcore_service_webserver.garbage_collector_core:_remove_single_orphaned_service(166)]  -  Exception: '6c2bca80-75f6-56bd-b169-7386e6e0ce21'
Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.9/site-packages/servicelib/logging_utils.py", line 160, in log_decorator_wrapper
    value = await func(*args, **kwargs)
  File "/home/scu/.venv/lib/python3.9/site-packages/simcore_service_webserver/garbage_collector_core.py", line 365, in _remove_single_orphaned_service
    project_uuid = currently_opened_projects_node_ids[service_uuid]
KeyError: '6c2bca80-75f6-56bd-b169-7386e6e0ce21'
```

## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26

-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/3975



## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
- [X] Unit tests for the changes exist