### PR TITLE
✨ Personalized resources: Allow override of computational service needed resources (⚠️ devops)

### DIFF
--- a/packages/models-library/src/models_library/services_resources.py
+++ b/packages/models-library/src/models_library/services_resources.py
@@ -143,6 +143,7 @@ class ServiceResourcesDictHelpers:
                                 "reservation": parse_obj_as(ByteSize, "2Gib"),
                             },
                         },
+                        "boot_modes": [BootMode.CPU],
                     },
                 },
                 # service with a compose spec
@@ -153,6 +154,7 @@ class ServiceResourcesDictHelpers:
                             "CPU": {"limit": 0.3, "reservation": 0.3},
                             "RAM": {"limit": 53687091232, "reservation": 53687091232},
                         },
+                        "boot_modes": [BootMode.GPU],
                     },
                     "s4l-core": {
                         "image": "simcore/services/dynamic/s4l-core-dy:3.0.0",
@@ -161,6 +163,7 @@ class ServiceResourcesDictHelpers:
                             "RAM": {"limit": 17179869184, "reservation": 536870912},
                             "VRAM": {"limit": 1, "reservation": 1},
                         },
+                        "boot_modes": [BootMode.GPU],
                     },
                     "sym-server": {
                         "image": "simcore/services/dynamic/sym-server:3.0.0",
@@ -171,6 +174,7 @@ class ServiceResourcesDictHelpers:
                                 "reservation": parse_obj_as(ByteSize, "2Gib"),
                             },
                         },
+                        "boot_modes": [BootMode.GPU],
                     },
                 },
                 # compose spec with image outside the platform
@@ -184,6 +188,7 @@ class ServiceResourcesDictHelpers:
                                 "reservation": parse_obj_as(ByteSize, "2Gib"),
                             },
                         },
+                        "boot_modes": [BootMode.CPU],
                     },
                     "proxy": {
                         "image": "traefik:v2.6.6",
@@ -194,6 +199,7 @@ class ServiceResourcesDictHelpers:
                                 "reservation": parse_obj_as(ByteSize, "2Gib"),
                             },
                         },
+                        "boot_modes": [BootMode.CPU],
                     },
                 },
             ]

--- a/packages/models-library/src/models_library/services_resources.py
+++ b/packages/models-library/src/models_library/services_resources.py
@@ -154,7 +154,7 @@ class ServiceResourcesDictHelpers:
                             "CPU": {"limit": 0.3, "reservation": 0.3},
                             "RAM": {"limit": 53687091232, "reservation": 53687091232},
                         },
-                        "boot_modes": [BootMode.GPU],
+                        "boot_modes": [BootMode.CPU],
                     },
                     "s4l-core": {
                         "image": "simcore/services/dynamic/s4l-core-dy:3.0.0",
@@ -174,7 +174,7 @@ class ServiceResourcesDictHelpers:
                                 "reservation": parse_obj_as(ByteSize, "2Gib"),
                             },
                         },
-                        "boot_modes": [BootMode.GPU],
+                        "boot_modes": [BootMode.CPU],
                     },
                 },
                 # compose spec with image outside the platform

--- a/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
@@ -132,6 +132,7 @@ def env_file_for_testing(
 @pytest.fixture(scope="module")
 def simcore_docker_compose(
     osparc_simcore_root_dir: Path,
+    osparc_simcore_scripts_dir: Path,
     env_file_for_testing: Path,
     temp_folder: Path,
 ) -> dict[str, Any]:
@@ -155,6 +156,7 @@ def simcore_docker_compose(
 
     compose_specs = run_docker_compose_config(
         project_dir=osparc_simcore_root_dir / "services",
+        scripts_dir=osparc_simcore_scripts_dir,
         docker_compose_paths=docker_compose_paths,
         env_file_path=env_file_for_testing,
         destination_path=temp_folder / "simcore_docker_compose.yml",
@@ -205,6 +207,7 @@ def inject_filestash_config_path(
 @pytest.fixture(scope="module")
 def ops_docker_compose(
     osparc_simcore_root_dir: Path,
+    osparc_simcore_scripts_dir: Path,
     env_file_for_testing: Path,
     temp_folder: Path,
     inject_filestash_config_path: None,
@@ -224,6 +227,7 @@ def ops_docker_compose(
 
     compose_specs = run_docker_compose_config(
         project_dir=osparc_simcore_root_dir / "services",
+        scripts_dir=osparc_simcore_scripts_dir,
         docker_compose_paths=docker_compose_path,
         env_file_path=env_file_for_testing,
         destination_path=temp_folder / "ops_docker_compose.yml",

--- a/scripts/docker/docker-compose-config.bash
+++ b/scripts/docker/docker-compose-config.bash
@@ -68,7 +68,7 @@ docker \
 compose \
 --env-file ${env_file}"
 
-  if [ "project_directory" ]; then
+  if [ "$project_directory" ]; then
     docker_command+=" --project-directory ${project_directory}"
   fi
 
@@ -99,7 +99,7 @@ docker-compose \
     do
       docker_command+=" --file=${compose_file_path} "
     done
-    if [ "project_directory" ]; then
+    if [ "$project_directory" ]; then
       docker_command+=" --project-directory ${project_directory}"
     fi
     docker_command+=" \

--- a/scripts/docker/docker-compose-config.bash
+++ b/scripts/docker/docker-compose-config.bash
@@ -17,11 +17,15 @@ show_error() {
 
 
 env_file=".env"
+project_directory=""
 # Parse command line arguments
-while getopts ":e:" opt; do
+while getopts ":e:p:" opt; do
   case $opt in
     e)
       env_file="$OPTARG"
+      ;;
+    p)
+      project_directory="$OPTARG"
       ;;
     \?)
       show_error "Invalid option: -$OPTARG"
@@ -64,6 +68,10 @@ docker \
 compose \
 --env-file ${env_file}"
 
+  if [ "project_directory" ]; then
+    docker_command+=" --project-directory ${project_directory}"
+  fi
+
   for compose_file_path in "$@"
   do
     docker_command+=" --file=${compose_file_path}"
@@ -91,6 +99,9 @@ docker-compose \
     do
       docker_command+=" --file=${compose_file_path} "
     done
+    if [ "project_directory" ]; then
+      docker_command+=" --project-directory ${project_directory}"
+    fi
     docker_command+=" \
 config \
 | sed --regexp-extended 's/cpus: ([0-9\\.]+)/cpus: \"\\1\"/'"

--- a/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
@@ -145,7 +145,9 @@ async def create_job(
 
     # -> director2:   ComputationTaskOut = JobStatus
     # consistency check
-    task: ComputationTaskGet = await director2_api.create_computation(job.id, user_id)
+    task: ComputationTaskGet = await director2_api.create_computation(
+        job.id, user_id, product_name
+    )
     assert task.id == job.id  # nosec
 
     job_status: JobStatus = create_jobstatus_from_task(task)

--- a/services/api-server/src/simcore_service_api_server/modules/director_v2.py
+++ b/services/api-server/src/simcore_service_api_server/modules/director_v2.py
@@ -102,7 +102,10 @@ class DirectorV2Api(BaseServiceClientApi):
     #  ServiceUnabalabe: 503
 
     async def create_computation(
-        self, project_id: UUID, user_id: PositiveInt
+        self,
+        project_id: UUID,
+        user_id: PositiveInt,
+        product_name: str,
     ) -> ComputationTaskGet:
         resp = await self.client.post(
             "/v2/computations",
@@ -110,6 +113,7 @@ class DirectorV2Api(BaseServiceClientApi):
                 "user_id": user_id,
                 "project_id": str(project_id),
                 "start_pipeline": False,
+                "product_name": product_name,
             },
         )
 

--- a/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
@@ -55,7 +55,8 @@ def _compute_service_available_boot_modes(
     currently this uses the simcore.service.settings labels if available for backwards compatiblity.
     if MPI is found, then boot mode is set to MPI, if GPU is found then boot mode is set to GPU, else to CPU.
     In the future a dedicated label might be used, to add openMP for example. and to not abuse the resources of a service.
-    Also these will be used in a project to allow the user to choose among different boot modes"""
+    Also these will be used in a project to allow the user to choose among different boot modes
+    """
 
     resource_entries = filter(lambda entry: entry.name.lower() == "resources", settings)
     generic_resources = {}
@@ -160,7 +161,7 @@ def _get_service_settings(
 ) -> list[SimcoreServiceSettingLabelEntry]:
     service_settings = parse_raw_as(
         list[SimcoreServiceSettingLabelEntry],
-        labels.get(SIMCORE_SERVICE_SETTINGS_LABELS, ""),
+        labels.get(SIMCORE_SERVICE_SETTINGS_LABELS, "[]"),
     )
     logger.debug("received %s", f"{service_settings=}")
     return service_settings

--- a/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
+++ b/services/catalog/src/simcore_service_catalog/api/routes/services_resources.py
@@ -12,6 +12,7 @@ from models_library.service_settings_labels import (
 )
 from models_library.services import ServiceKey, ServiceVersion
 from models_library.services_resources import (
+    BootMode,
     ImageResources,
     ResourcesDict,
     ServiceResourcesDict,
@@ -41,6 +42,49 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 SIMCORE_SERVICE_COMPOSE_SPEC_LABEL: Final[str] = "simcore.service.compose-spec"
+_DEPRECATED_RESOURCES: Final[list[str]] = ["MPI"]
+_BOOT_MODE_TO_RESOURCE_NAME_MAP: Final[dict[str, str]] = {"MPI": "MPI", "GPU": "VRAM"}
+
+
+def _compute_service_available_boot_modes(
+    settings: list[SimcoreServiceSettingLabelEntry],
+    service_key: ServiceKey,
+    service_version: ServiceVersion,
+) -> list[BootMode]:
+    """returns the service boot-modes.
+    currently this uses the simcore.service.settings labels if available for backwards compatiblity.
+    if MPI is found, then boot mode is set to MPI, if GPU is found then boot mode is set to GPU, else to CPU.
+    In the future a dedicated label might be used, to add openMP for example. and to not abuse the resources of a service.
+    Also these will be used in a project to allow the user to choose among different boot modes"""
+
+    resource_entries = filter(lambda entry: entry.name.lower() == "resources", settings)
+    generic_resources = {}
+    for entry in resource_entries:
+        if not isinstance(entry.value, dict):
+            logger.warning(
+                "resource %s for %s got invalid type",
+                f"{entry.dict()!r}",
+                f"{service_key}:{service_version}",
+            )
+            continue
+        generic_resources |= parse_generic_resource(
+            entry.value.get("Reservations", {}).get("GenericResources", []),
+        )
+    # currently these are unique boot modes
+    for mode in BootMode:
+        if (
+            _BOOT_MODE_TO_RESOURCE_NAME_MAP.get(mode.value, mode.value)
+            in generic_resources
+        ):
+            return [mode]
+
+    return [BootMode.CPU]
+
+
+def _remove_deprecated_resources(resources: ResourcesDict) -> ResourcesDict:
+    for res_name in _DEPRECATED_RESOURCES:
+        resources.pop(res_name, None)
+    return resources
 
 
 def _resources_from_settings(
@@ -82,7 +126,7 @@ def _resources_from_settings(
             entry.value.get("Reservations", {}).get("GenericResources", []),
         )
 
-    return service_resources
+    return _remove_deprecated_resources(service_resources)
 
 
 async def _get_service_labels(
@@ -162,6 +206,10 @@ async def get_service_resources(
         service_resources = _resources_from_settings(
             service_settings, default_service_resources, service_key, service_version
         )
+        service_boot_modes = _compute_service_available_boot_modes(
+            service_settings, service_key, service_version
+        )
+
         user_specific_service_specs = await services_repo.get_service_specifications(
             service_key,
             service_version,
@@ -174,7 +222,7 @@ async def get_service_resources(
             )
 
         return ServiceResourcesDictHelpers.create_from_single_service(
-            image_version, service_resources
+            image_version, service_resources, service_boot_modes
         )
 
     # compose specifications available, potentially multiple services
@@ -199,14 +247,18 @@ async def get_service_resources(
         )
 
         if not spec_service_labels:
-            spec_service_resources = default_service_resources
+            spec_service_resources: ResourcesDict = default_service_resources
+            service_boot_modes = [BootMode.CPU]
         else:
             spec_service_settings = _get_service_settings(spec_service_labels)
-            spec_service_resources = _resources_from_settings(
+            spec_service_resources: ResourcesDict = _resources_from_settings(
                 spec_service_settings,
                 default_service_resources,
                 service_key,
                 service_version,
+            )
+            service_boot_modes = _compute_service_available_boot_modes(
+                spec_service_settings, service_key, service_version
             )
             user_specific_service_specs = (
                 await services_repo.get_service_specifications(
@@ -225,6 +277,7 @@ async def get_service_resources(
             {
                 "image": image,
                 "resources": spec_service_resources,
+                "boot_modes": service_boot_modes,
             }
         )
 

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -62,6 +62,7 @@ else
   # CPU: number of CPUs available (= num of processing units - DASK_SIDECAR_NUM_NON_USABLE_CPUS)
   # GPU: number GPUs available (= num of GPUs if a nvidia-smi can be run inside a docker container)
   # RAM: amount of RAM available (= CPU/nproc * total virtual memory given by python psutil - DASK_SIDECAR_NON_USABLE_RAM)
+  # VRAM: amount of VRAM available (in bytes)
 
   # CPUs
   num_cpus=$(($(nproc) - ${DASK_SIDECAR_NUM_NON_USABLE_CPUS:-2}))

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -62,7 +62,6 @@ else
   # CPU: number of CPUs available (= num of processing units - DASK_SIDECAR_NUM_NON_USABLE_CPUS)
   # GPU: number GPUs available (= num of GPUs if a nvidia-smi can be run inside a docker container)
   # RAM: amount of RAM available (= CPU/nproc * total virtual memory given by python psutil - DASK_SIDECAR_NON_USABLE_RAM)
-  # MPI: backwards-compatibility (deprecated if core_number = TARGET_MPI_NODE_CPU_COUNT set to 1)
 
   # CPUs
   num_cpus=$(($(nproc) - ${DASK_SIDECAR_NUM_NON_USABLE_CPUS:-2}))
@@ -87,12 +86,6 @@ else
     resources="$resources,GPU=$num_gpus,VRAM=$total_vram"
   fi
 
-  # add the MPI if possible
-  if [ ${TARGET_MPI_NODE_CPU_COUNT+x} ]; then
-    if [ "$(nproc)" -eq "${TARGET_MPI_NODE_CPU_COUNT}" ]; then
-      resources="$resources,MPI=1"
-    fi
-  fi
 
   #
   # DASK RESOURCES DEFINITION --------------------------------- END

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -83,7 +83,8 @@ else
 
   # add the GPUs if there are any
   if [ "$num_gpus" -gt 0 ]; then
-    resources="$resources,GPU=$num_gpus"
+    total_vram=$(python -c "from simcore_service_dask_sidecar.utils import video_memory; print(video_memory());")
+    resources="$resources,GPU=$num_gpus,VRAM=$total_vram"
   fi
 
   # add the MPI if possible

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/boot_mode.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/boot_mode.py
@@ -1,7 +1,0 @@
-from enum import Enum
-
-
-class BootMode(Enum):
-    CPU = "CPU"
-    GPU = "GPU"
-    MPI = "MPI"

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from pprint import pformat
 from types import TracebackType
-from typing import Any, Coroutine, Dict, List, Optional, Type, cast
+from typing import Any, Coroutine, Optional, cast
 from uuid import uuid4
 
 from aiodocker import Docker
@@ -19,13 +19,13 @@ from dask_task_models_library.container_tasks.io import (
     TaskOutputDataSchema,
 )
 from models_library.projects_state import RunningState
+from models_library.services_resources import BootMode
 from packaging import version
 from pydantic import ValidationError
 from pydantic.networks import AnyUrl
 from settings_library.s3 import S3Settings
 from yarl import URL
 
-from ..boot_mode import BootMode
 from ..dask_utils import TaskPublisher, create_dask_worker_logger, publish_event
 from ..file_utils import pull_file_from_remote, push_file_to_remote
 from ..settings import Settings
@@ -54,7 +54,7 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
     output_data_keys: TaskOutputDataSchema
     log_file_url: AnyUrl
     boot_mode: BootMode
-    task_max_resources: Dict[str, Any]
+    task_max_resources: dict[str, Any]
     task_publishers: TaskPublisher
     s3_settings: Optional[S3Settings]
 
@@ -170,7 +170,7 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
             TaskStateEvent.from_dask_worker(state=state, msg=msg),
         )
 
-    async def run(self, command: List[str]) -> TaskOutputData:
+    async def run(self, command: list[str]) -> TaskOutputData:
         await self._publish_sidecar_state(RunningState.STARTED)
         await self._publish_sidecar_log(
             f"Starting task for {self.service_key}:{self.service_version} on {socket.gethostname()}..."
@@ -262,7 +262,7 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
 
     async def __aexit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         tb: Optional[TracebackType],
     ) -> None:

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from pprint import pformat
 from types import TracebackType
-from typing import Any, Coroutine, Optional, cast
+from typing import Coroutine, Optional, cast
 from uuid import uuid4
 
 from aiodocker import Docker
@@ -54,7 +54,7 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
     output_data_keys: TaskOutputDataSchema
     log_file_url: AnyUrl
     boot_mode: BootMode
-    task_max_resources: dict[str, Any]
+    task_max_resources: dict[str, float]
     task_publishers: TaskPublisher
     s3_settings: Optional[S3Settings]
 

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
@@ -30,7 +30,7 @@ from packaging import version
 from pydantic import ByteSize
 from pydantic.networks import AnyUrl
 from servicelib.docker_utils import to_datetime
-from servicelib.logging_utils import log_context
+from servicelib.logging_utils import log_catch, log_context
 from settings_library.s3 import S3Settings
 
 from ..dask_utils import LogType, create_dask_worker_logger, publish_task_logs
@@ -376,7 +376,7 @@ async def monitor_container_logs(
     Services above are not creating a file and use the usual docker logging. These logs
     are retrieved using the usual cli 'docker logs CONTAINERID'
     """
-    try:
+    with log_catch(logger, reraise=False):
         container_info = await container.show()
         container_name = container_info.get("Name", "undefined")
         logger.info(
@@ -419,14 +419,6 @@ async def monitor_container_logs(
             service_version,
             container.id,
             container_name,
-        )
-    except DockerError as exc:
-        logger.exception(
-            "log monitoring of [%s:%s - %s] stopped with unexpected error:\n%s",
-            service_key,
-            service_version,
-            container.id,
-            exc,
         )
 
 

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
@@ -24,13 +24,13 @@ from aiodocker.containers import DockerContainer
 from aiodocker.volumes import DockerVolume
 from dask_task_models_library.container_tasks.docker import DockerBasicAuth
 from distributed.pubsub import Pub
+from models_library.services_resources import BootMode
 from packaging import version
 from pydantic import ByteSize
 from pydantic.networks import AnyUrl
 from servicelib.docker_utils import to_datetime
 from settings_library.s3 import S3Settings
 
-from ..boot_mode import BootMode
 from ..dask_utils import LogType, create_dask_worker_logger, publish_task_logs
 from ..file_utils import push_file_to_remote
 from ..settings import Settings

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
@@ -131,7 +131,7 @@ _DOCKER_LOG_REGEXP: re.Pattern[str] = re.compile(
     r"^(?P<timestamp>\d+-\d+-\d+T\d+:\d+:\d+\.\d+[^\s]+) (?P<log>.+)$"
 )
 _PROGRESS_REGEXP: re.Pattern[str] = re.compile(
-    r"\[?progress[\]:]?\s*([0-1]?\.\d+|\d+(%)|\d+\s*(percent)|(\d+\/\d+))"
+    r"\[?progress\]?:?\s*([0-1]?\.\d+|\d+(%)|\d+\s*(percent)|(\d+\/\d+))"
 )
 DEFAULT_TIME_STAMP = "2000-01-01T00:00:00.000000000Z"
 

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/dask_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/dask_utils.py
@@ -54,12 +54,11 @@ _DEFAULT_MAX_RESOURCES: Final[dict[str, float]] = {"CPU": 1, "RAM": 1024**3}
 
 
 def get_current_task_resources() -> dict[str, float]:
+    current_task_resources = _DEFAULT_MAX_RESOURCES
     if task := _get_current_task_state():
         if task_resources := task.resource_restrictions:
-            for key, value in _DEFAULT_MAX_RESOURCES.items():
-                task_resources[key] = task_resources.get(key, value)
-            return task_resources
-    return _DEFAULT_MAX_RESOURCES
+            current_task_resources.update(task_resources)
+    return current_task_resources
 
 
 @dataclass()

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/dask_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/dask_utils.py
@@ -17,8 +17,6 @@ from dask_task_models_library.container_tasks.io import TaskCancelEventName
 from distributed.worker import get_worker
 from distributed.worker_state_machine import TaskState
 
-from .boot_mode import BootMode
-
 
 def create_dask_worker_logger(name: str) -> logging.Logger:
     return logging.getLogger(f"distributed.worker.{name}")
@@ -50,16 +48,6 @@ def is_current_task_aborted() -> bool:
         logger.debug("%s shall be aborted", f"{task=}")
         return True
     return False
-
-
-def get_current_task_boot_mode() -> BootMode:
-    task: Optional[TaskState] = _get_current_task_state()
-    if task and task.resource_restrictions:
-        if task.resource_restrictions.get("MPI", 0) > 0:
-            return BootMode.MPI
-        if task.resource_restrictions.get("GPU", 0) > 0:
-            return BootMode.GPU
-    return BootMode.CPU
 
 
 def get_current_task_resources() -> dict[str, Any]:

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/dask_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/dask_utils.py
@@ -3,7 +3,7 @@ import contextlib
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, AsyncIterator, Optional, cast
+from typing import AsyncIterator, Final, Optional
 
 import distributed
 from dask_task_models_library.container_tasks.errors import TaskCancelledError
@@ -50,11 +50,16 @@ def is_current_task_aborted() -> bool:
     return False
 
 
-def get_current_task_resources() -> dict[str, Any]:
+_DEFAULT_MAX_RESOURCES: Final[dict[str, float]] = {"CPU": 1, "RAM": 1024**3}
+
+
+def get_current_task_resources() -> dict[str, float]:
     if task := _get_current_task_state():
         if task_resources := task.resource_restrictions:
-            return cast(dict[str, Any], task_resources)
-    return {}
+            for key, value in _DEFAULT_MAX_RESOURCES.items():
+                task_resources[key] = task_resources.get(key, value)
+            return task_resources
+    return _DEFAULT_MAX_RESOURCES
 
 
 @dataclass()

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/settings.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/settings.py
@@ -22,11 +22,6 @@ class Settings(BaseCustomSettings, MixinLoggingSettings):
 
     SIDECAR_INTERVAL_TO_CHECK_TASK_ABORTED_S: Optional[int] = 5
 
-    TARGET_MPI_NODE_CPU_COUNT: Optional[int] = Field(
-        None,
-        description="If a node has this amount of CPUs it will be a candidate an MPI candidate",
-    )
-
     # dask config ----
 
     DASK_START_AS_SCHEDULER: Optional[bool] = Field(

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
@@ -6,6 +6,7 @@ from typing import Any, Awaitable, Coroutine, Optional, cast
 
 import aiodocker
 from aiodocker.containers import DockerContainer
+from pydantic import ByteSize, parse_obj_as
 
 logger = logging.getLogger(__name__)
 
@@ -75,3 +76,72 @@ def num_available_gpus() -> int:
             return num_gpus
 
     return cast(int, _wrap_async_call(async_num_available_gpus()))
+
+
+def video_memory() -> int:
+    """Returns the number of available GPUs, 0 if not a gpu node"""
+
+    async def async_video_memory() -> int:
+        video_ram: ByteSize = ByteSize(0)
+        container: Optional[DockerContainer] = None
+        async with aiodocker.Docker() as docker:
+            spec_config = {
+                "Cmd": [
+                    "nvidia-smi",
+                    "--query-gpu=memory.total",
+                    "--format=csv,noheader",
+                ],
+                "Image": "nvidia/cuda:10.0-base",
+                "AttachStdin": False,
+                "AttachStdout": False,
+                "AttachStderr": False,
+                "Tty": False,
+                "OpenStdin": False,
+                "HostConfig": {
+                    "Init": True,
+                    "AutoRemove": False,
+                },  # NOTE: The Init parameter shows a weird behavior: no exception thrown when the container fails
+            }
+            try:
+                container = await docker.containers.run(
+                    config=spec_config, name=f"sidecar_{uuid.uuid4()}_test_gpu"
+                )
+                if not container:
+                    return 0
+
+                container_data = await container.wait(timeout=10)
+                container_logs = await cast(
+                    Coroutine,
+                    container.log(stdout=True, stderr=True, follow=False),
+                )
+                video_ram = parse_obj_as(ByteSize, 0)
+                if container_data.setdefault("StatusCode", 127) == 0:
+                    for line in container_logs:
+                        video_ram = parse_obj_as(
+                            ByteSize, video_ram + parse_obj_as(ByteSize, line)
+                        )
+
+                logger.debug(
+                    "testing for GPU VRAM with docker run %s %s completed with status code %s, found %d total vram:\nlogs:\n%s",
+                    spec_config["Image"],
+                    spec_config["Cmd"],
+                    container_data["StatusCode"],
+                    video_ram.human_readable(),
+                    pformat(container_logs),
+                )
+            except asyncio.TimeoutError as err:
+                logger.warning(
+                    "num_gpus timedout while check-run %s: %s", spec_config, err
+                )
+            except aiodocker.exceptions.DockerError as err:
+                logger.warning(
+                    "num_gpus DockerError while check-run %s: %s", spec_config, err
+                )
+            finally:
+                if container is not None:
+                    # ensure container is removed
+                    await container.delete()
+
+            return video_ram
+
+    return cast(int, _wrap_async_call(async_video_memory()))

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
@@ -74,7 +74,7 @@ def num_available_gpus() -> int:
 
 
 def video_memory() -> int:
-    """Returns the number of available GPUs, 0 if not a gpu node"""
+    """Returns the amount of VRAM available in bytes. 0 if no GPU available"""
 
     async def async_video_memory() -> int:
         video_ram: ByteSize = ByteSize(0)

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import uuid
-from pprint import pformat
 from typing import Any, Awaitable, Coroutine, Optional, cast
 
 import aiodocker
@@ -15,6 +14,22 @@ def _wrap_async_call(fct: Awaitable[Any]) -> Any:
     return asyncio.get_event_loop().run_until_complete(fct)
 
 
+def _nvidia_smi_docker_config(cmd: list[str]) -> dict[str, Any]:
+    return {
+        "Cmd": ["nvidia-smi"] + cmd,
+        "Image": "nvidia/cuda:10.0-base",
+        "AttachStdin": False,
+        "AttachStdout": False,
+        "AttachStderr": False,
+        "Tty": False,
+        "OpenStdin": False,
+        "HostConfig": {
+            "Init": True,
+            "AutoRemove": False,
+        },  # NOTE: The Init parameter shows a weird behavior: no exception thrown when the container fails
+    }
+
+
 def num_available_gpus() -> int:
     """Returns the number of available GPUs, 0 if not a gpu node"""
 
@@ -22,19 +37,7 @@ def num_available_gpus() -> int:
         num_gpus = 0
         container: Optional[DockerContainer] = None
         async with aiodocker.Docker() as docker:
-            spec_config = {
-                "Cmd": ["nvidia-smi", "--list-gpus"],
-                "Image": "nvidia/cuda:10.0-base",
-                "AttachStdin": False,
-                "AttachStdout": False,
-                "AttachStderr": False,
-                "Tty": False,
-                "OpenStdin": False,
-                "HostConfig": {
-                    "Init": True,
-                    "AutoRemove": False,
-                },  # NOTE: The Init parameter shows a weird behavior: no exception thrown when the container fails
-            }
+            spec_config = _nvidia_smi_docker_config(["--list-gpus"])
             try:
                 container = await docker.containers.run(
                     config=spec_config, name=f"sidecar_{uuid.uuid4()}_test_gpu"
@@ -51,14 +54,6 @@ def num_available_gpus() -> int:
                     len(container_logs)
                     if container_data.setdefault("StatusCode", 127) == 0
                     else 0
-                )
-                logger.debug(
-                    "testing for GPU presence with docker run %s %s completed with status code %s, found %d gpus:\nlogs:\n%s",
-                    spec_config["Image"],
-                    spec_config["Cmd"],
-                    container_data["StatusCode"],
-                    num_gpus,
-                    pformat(container_logs),
                 )
             except asyncio.TimeoutError as err:
                 logger.warning(
@@ -85,23 +80,13 @@ def video_memory() -> int:
         video_ram: ByteSize = ByteSize(0)
         container: Optional[DockerContainer] = None
         async with aiodocker.Docker() as docker:
-            spec_config = {
-                "Cmd": [
-                    "nvidia-smi",
+            spec_config = _nvidia_smi_docker_config(
+                [
                     "--query-gpu=memory.total",
                     "--format=csv,noheader",
-                ],
-                "Image": "nvidia/cuda:10.0-base",
-                "AttachStdin": False,
-                "AttachStdout": False,
-                "AttachStderr": False,
-                "Tty": False,
-                "OpenStdin": False,
-                "HostConfig": {
-                    "Init": True,
-                    "AutoRemove": False,
-                },  # NOTE: The Init parameter shows a weird behavior: no exception thrown when the container fails
-            }
+                ]
+            )
+
             try:
                 container = await docker.containers.run(
                     config=spec_config, name=f"sidecar_{uuid.uuid4()}_test_gpu"
@@ -121,14 +106,6 @@ def video_memory() -> int:
                             ByteSize, video_ram + parse_obj_as(ByteSize, line)
                         )
 
-                logger.debug(
-                    "testing for GPU VRAM with docker run %s %s completed with status code %s, found %d total vram:\nlogs:\n%s",
-                    spec_config["Image"],
-                    spec_config["Cmd"],
-                    container_data["StatusCode"],
-                    video_ram.human_readable(),
-                    pformat(container_logs),
-                )
             except asyncio.TimeoutError as err:
                 logger.warning(
                     "num_gpus timedout while check-run %s: %s", spec_config, err

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
@@ -89,7 +89,7 @@ def video_memory() -> int:
 
             try:
                 container = await docker.containers.run(
-                    config=spec_config, name=f"sidecar_{uuid.uuid4()}_test_gpu"
+                    config=spec_config, name=f"sidecar_{uuid.uuid4()}_test_gpu_memory"
                 )
                 if not container:
                     return 0

--- a/services/dask-sidecar/tests/unit/conftest.py
+++ b/services/dask-sidecar/tests/unit/conftest.py
@@ -82,7 +82,7 @@ def dask_client(mock_service_envs: None) -> Iterable[distributed.Client]:
     with distributed.LocalCluster(
         worker_class=distributed.Worker,
         **{
-            "resources": {"CPU": 10, "GPU": 10, "MPI": 1},
+            "resources": {"CPU": 10, "GPU": 10},
             "preload": "simcore_service_dask_sidecar.tasks",
         },
     ) as cluster:

--- a/services/dask-sidecar/tests/unit/test_dask_utils.py
+++ b/services/dask-sidecar/tests/unit/test_dask_utils.py
@@ -15,6 +15,7 @@ from dask_task_models_library.container_tasks.errors import TaskCancelledError
 from dask_task_models_library.container_tasks.events import TaskLogEvent
 from dask_task_models_library.container_tasks.io import TaskCancelEventName
 from simcore_service_dask_sidecar.dask_utils import (
+    _DEFAULT_MAX_RESOURCES,
     get_current_task_resources,
     is_current_task_aborted,
     monitor_task_abortion,
@@ -153,4 +154,6 @@ def test_task_resources(
 ):
     future = dask_client.submit(get_current_task_resources, resources=resources)
     received_resources = future.result(timeout=DASK_TESTING_TIMEOUT_S)
-    assert received_resources == resources
+    current_resources = _DEFAULT_MAX_RESOURCES
+    current_resources.update(resources)
+    assert received_resources == current_resources

--- a/services/dask-sidecar/tests/unit/test_dask_utils.py
+++ b/services/dask-sidecar/tests/unit/test_dask_utils.py
@@ -14,9 +14,7 @@ import pytest
 from dask_task_models_library.container_tasks.errors import TaskCancelledError
 from dask_task_models_library.container_tasks.events import TaskLogEvent
 from dask_task_models_library.container_tasks.io import TaskCancelEventName
-from models_library.services_resources import BootMode
 from simcore_service_dask_sidecar.dask_utils import (
-    get_current_task_boot_mode,
     get_current_task_resources,
     is_current_task_aborted,
     monitor_task_abortion,
@@ -143,28 +141,9 @@ def test_monitor_task_abortion(dask_client: distributed.Client):
 
 
 @pytest.mark.parametrize(
-    "resources, expected_boot_mode",
-    [
-        ({"CPU": 2}, BootMode.CPU),
-        ({"MPI": 1.0}, BootMode.MPI),
-        ({"GPU": 5.0}, BootMode.GPU),
-    ],
-)
-def test_task_boot_mode(
-    dask_client: distributed.Client,
-    resources: dict[str, Any],
-    expected_boot_mode: BootMode,
-):
-    future = dask_client.submit(get_current_task_boot_mode, resources=resources)
-    received_boot_mode = future.result(timeout=DASK_TESTING_TIMEOUT_S)
-    assert received_boot_mode == expected_boot_mode
-
-
-@pytest.mark.parametrize(
     "resources",
     [
         ({"CPU": 2}),
-        ({"MPI": 1.0}),
         ({"GPU": 5.0}),
     ],
 )

--- a/services/dask-sidecar/tests/unit/test_dask_utils.py
+++ b/services/dask-sidecar/tests/unit/test_dask_utils.py
@@ -14,7 +14,7 @@ import pytest
 from dask_task_models_library.container_tasks.errors import TaskCancelledError
 from dask_task_models_library.container_tasks.events import TaskLogEvent
 from dask_task_models_library.container_tasks.io import TaskCancelEventName
-from simcore_service_dask_sidecar.boot_mode import BootMode
+from models_library.services_resources import BootMode
 from simcore_service_dask_sidecar.dask_utils import (
     get_current_task_boot_mode,
     get_current_task_resources,

--- a/services/dask-sidecar/tests/unit/test_docker_utils.py
+++ b/services/dask-sidecar/tests/unit/test_docker_utils.py
@@ -9,8 +9,8 @@ from unittest.mock import call
 
 import aiodocker
 import pytest
+from models_library.services_resources import BootMode
 from pytest_mock.plugin import MockerFixture
-from simcore_service_dask_sidecar.boot_mode import BootMode
 from simcore_service_dask_sidecar.computational_sidecar.docker_utils import (
     DEFAULT_TIME_STAMP,
     LogType,
@@ -58,7 +58,6 @@ async def test_create_container_config(
     boot_mode: BootMode,
     task_max_resources: dict[str, Any],
 ):
-
     container_config = await create_container_config(
         docker_registry,
         service_key,

--- a/services/dask-sidecar/tests/unit/test_docker_utils.py
+++ b/services/dask-sidecar/tests/unit/test_docker_utils.py
@@ -186,6 +186,10 @@ async def test_create_container_config(
             "2021-10-05T09:53:48.873236400Z [PROGRESS]1.000000\n",
             (LogType.PROGRESS, "2021-10-05T09:53:48.873236400Z", "1.00"),
         ),
+        (
+            "2021-10-05T09:53:48.873236400Z [PROGRESS]: 1% [ 10 / 624 ] Time Update, estimated remaining time 1 seconds @ 26.43 MCells/s",
+            (LogType.PROGRESS, "2021-10-05T09:53:48.873236400Z", "0.01"),
+        ),
     ],
 )
 async def test_parse_line(log_line: str, expected_parsing: tuple[LogType, str, str]):

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -524,7 +524,7 @@ def test_run_computational_sidecar_dask(
     worker_name = next(iter(dask_client.scheduler_info()["workers"]))
 
     output_data = future.result()
-    assert isinstance(output_data, dict)
+    assert isinstance(output_data, TaskOutputData)
 
     # check that the task produces expected logs
     worker_logs = [log for _, log in dask_client.get_worker_logs()[worker_name]]  # type: ignore

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -50,6 +50,7 @@ from simcore_service_dask_sidecar.computational_sidecar.errors import (
 from simcore_service_dask_sidecar.computational_sidecar.models import (
     LEGACY_INTEGRATION_VERSION,
 )
+from simcore_service_dask_sidecar.dask_utils import _DEFAULT_MAX_RESOURCES
 from simcore_service_dask_sidecar.file_utils import _s3fs_settings_from_s3_settings
 from simcore_service_dask_sidecar.tasks import run_computational_sidecar
 
@@ -208,10 +209,12 @@ def ubuntu_task(
         variable_name="SC_COMP_SERVICES_SCHEDULED_AS", variable_value="CPU"
     )
     list_of_commands += _bash_check_env_exist(
-        variable_name="SIMCORE_NANO_CPUS_LIMIT", variable_value="CPU"
+        variable_name="SIMCORE_NANO_CPUS_LIMIT",
+        variable_value=f"{int(_DEFAULT_MAX_RESOURCES['CPU']*1e9)}",
     )
     list_of_commands += _bash_check_env_exist(
-        variable_name="SIMCORE_MEMORY_BYTES_LIMIT", variable_value="CPU"
+        variable_name="SIMCORE_MEMORY_BYTES_LIMIT",
+        variable_value=f"{_DEFAULT_MAX_RESOURCES['RAM']}",
     )
 
     # check input files

--- a/services/director-v2/openapi.json
+++ b/services/director-v2/openapi.json
@@ -1862,6 +1862,16 @@
           }
         }
       },
+      "BootMode": {
+        "title": "BootMode",
+        "enum": [
+          "CPU",
+          "GPU",
+          "MPI"
+        ],
+        "type": "string",
+        "description": "An enumeration."
+      },
       "BootOption": {
         "title": "BootOption",
         "required": [
@@ -2199,7 +2209,8 @@
         "title": "ComputationCreate",
         "required": [
           "user_id",
-          "project_id"
+          "project_id",
+          "product_name"
         ],
         "type": "object",
         "properties": {
@@ -2222,8 +2233,7 @@
           },
           "product_name": {
             "title": "Product Name",
-            "type": "string",
-            "description": "required if computation is started"
+            "type": "string"
           },
           "subgraph": {
             "title": "Subgraph",
@@ -2462,7 +2472,10 @@
                   "limit": 2147483648,
                   "reservation": 2147483648
                 }
-              }
+              },
+              "boot_modes": [
+                "CPU"
+              ]
             }
           }
         }
@@ -2490,7 +2503,7 @@
         "properties": {
           "image": {
             "title": "Image",
-            "pattern": "[\\w/-]+:[\\w.@]+",
+            "pattern": "^(?P<registry_host>(?:(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(?::\\d+)?)|[a-zA-Z0-9-]+:\\d+))?(?:/)?(?P<docker_image>(?:[a-z0-9][a-z0-9_.-]*/)*[a-z0-9-_]+[a-z0-9])(?::(?P<docker_tag>[\\w][\\w.-]{0,126}[\\w]))?(?P<docker_digest>\\@sha256:[a-fA-F0-9]{64})?$",
             "type": "string",
             "description": "Used by the frontend to provide a context for the users.Services with a docker-compose spec will have multiple entries.Using the `image:version` instead of the docker-compose spec is more helpful for the end user."
           },
@@ -2500,6 +2513,16 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/ResourceValue"
             }
+          },
+          "boot_modes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BootMode"
+            },
+            "description": "describe how a service shall be booted, using CPU, MPI, openMP or GPU",
+            "default": [
+              "CPU"
+            ]
           }
         },
         "example": {
@@ -2640,15 +2663,12 @@
           "RAM": {
             "title": "Ram",
             "type": "integer",
-            "description": "defines the required (maximum) amount of RAM for running the services in bytes"
+            "description": "defines the required (maximum) amount of RAM for running the services"
           },
-          "MPI": {
-            "title": "Mpi",
-            "maximum": 1.0,
-            "minimum": 0.0,
+          "VRAM": {
+            "title": "Vram",
             "type": "integer",
-            "description": "defines whether a MPI node is required for running the services",
-            "deprecated": true
+            "description": "defines the required (maximum) amount of VRAM for running the services"
           }
         }
       },
@@ -3471,6 +3491,27 @@
         },
         "additionalProperties": false
       },
+      "TaskCounts": {
+        "title": "TaskCounts",
+        "type": "object",
+        "properties": {
+          "error": {
+            "title": "Error",
+            "type": "integer",
+            "default": 0
+          },
+          "memory": {
+            "title": "Memory",
+            "type": "integer",
+            "default": 0
+          },
+          "executing": {
+            "title": "Executing",
+            "type": "integer",
+            "default": 0
+          }
+        }
+      },
       "TaskLogFileGet": {
         "title": "TaskLogFileGet",
         "required": [
@@ -3631,10 +3672,7 @@
           "cpu",
           "memory",
           "num_fds",
-          "ready",
-          "executing",
-          "in_flight",
-          "in_memory"
+          "task_counts"
         ],
         "type": "object",
         "properties": {
@@ -3653,29 +3691,14 @@
             "type": "integer",
             "description": "consumed file descriptors"
           },
-          "ready": {
-            "title": "Ready",
-            "minimum": 0.0,
-            "type": "integer",
-            "description": "# tasks ready to run"
-          },
-          "executing": {
-            "title": "Executing",
-            "minimum": 0.0,
-            "type": "integer",
-            "description": "# tasks currently executing"
-          },
-          "in_flight": {
-            "title": "In Flight",
-            "minimum": 0.0,
-            "type": "integer",
-            "description": "# tasks waiting for data"
-          },
-          "in_memory": {
-            "title": "In Memory",
-            "minimum": 0.0,
-            "type": "integer",
-            "description": "# tasks in worker memory"
+          "task_counts": {
+            "title": "Task Counts",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskCounts"
+              }
+            ],
+            "description": "task details"
           }
         }
       },

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -157,12 +157,16 @@ async def create_computation(
             minimal_computational_dag,
             publish=computation.start_pipeline or False,
         )
+        assert computation.product_name  # nosec
         inserted_comp_tasks = await comp_tasks_repo.upsert_tasks_from_project(
             project,
+            catalog_client,
             director_client,
             published_nodes=list(minimal_computational_dag.nodes())
             if computation.start_pipeline
             else [],
+            user_id=computation.user_id,
+            product_name=computation.product_name,
         )
 
         if computation.start_pipeline:

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -73,7 +73,7 @@ SUPPORTED_TRAEFIK_LOG_LEVELS: set[str] = {"info", "debug", "warn", "error"}
 class PlacementConstraintStr(ConstrainedStr):
     strip_whitespace = True
     regex = re.compile(
-        r"^(?!-)(?![.])(?!.*--)(?!.*[.][.])[a-zA-Z0-9.-]*(?<!-)(?<![.])(!=|==){1}[a-zA-Z0-9_. -]*$"
+        r"^(?!-)(?![.])(?!.*--)(?!.*[.][.])[a-zA-Z0-9.-]*(?<!-)(?<![.])(!=|==)[a-zA-Z0-9_. -]*$"
     )
 
 

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -3,6 +3,7 @@
 
 
 import logging
+import re
 from enum import Enum, auto
 from functools import cached_property
 from pathlib import Path
@@ -27,10 +28,10 @@ from models_library.utils.enums import StrAutoEnum
 from pydantic import (
     AnyHttpUrl,
     AnyUrl,
+    ConstrainedStr,
     Field,
     PositiveFloat,
     PositiveInt,
-    constr,
     validator,
 )
 from settings_library.base import BaseCustomSettings
@@ -68,10 +69,12 @@ ORG_LABELS_TO_SCHEMA_LABELS: dict[str, str] = {
 
 SUPPORTED_TRAEFIK_LOG_LEVELS: set[str] = {"info", "debug", "warn", "error"}
 
-PlacementConstraintStr = constr(
-    strip_whitespace=True,
-    regex=r"^(?!-)(?![.])(?!.*--)(?!.*[.][.])[a-zA-Z0-9.-]*(?<!-)(?<![.])(!=|==){1}[a-zA-Z0-9_. -]*$",
-)
+
+class PlacementConstraintStr(ConstrainedStr):
+    strip_whitespace = True
+    regex = re.compile(
+        r"^(?!-)(?![.])(?!.*--)(?!.*[.][.])[a-zA-Z0-9.-]*(?<!-)(?<![.])(!=|==){1}[a-zA-Z0-9_. -]*$"
+    )
 
 
 class VFSCacheMode(str, Enum):

--- a/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
@@ -13,6 +13,7 @@ from models_library.services import (
     ServiceOutput,
     ServicePortKey,
 )
+from models_library.services_resources import BootMode
 from pydantic import BaseModel, ByteSize, Extra, Field, parse_obj_as, validator
 from pydantic.types import PositiveInt
 from simcore_postgres_database.models.comp_tasks import NodeClass, StateType
@@ -34,6 +35,7 @@ class Image(BaseModel):
     node_requirements: Optional[NodeRequirements] = Field(
         None, description="the requirements for the service to run on a node"
     )
+    boot_mode: BootMode = BootMode.CPU
     command: list[str] = Field(
         default=[
             "run",

--- a/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/domains/comp_tasks.py
@@ -13,7 +13,7 @@ from models_library.services import (
     ServiceOutput,
     ServicePortKey,
 )
-from pydantic import BaseModel, Extra, Field, validator
+from pydantic import BaseModel, ByteSize, Extra, Field, parse_obj_as, validator
 from pydantic.types import PositiveInt
 from simcore_postgres_database.models.comp_tasks import NodeClass, StateType
 
@@ -31,7 +31,7 @@ class Image(BaseModel):
     requires_mpi: Optional[bool] = Field(
         None, deprecated=True, description="Use instead node_requirements"
     )
-    node_requirements: NodeRequirements = Field(
+    node_requirements: Optional[NodeRequirements] = Field(
         None, description="the requirements for the service to run on a node"
     )
     command: list[str] = Field(
@@ -52,8 +52,7 @@ class Image(BaseModel):
             v = NodeRequirements(
                 CPU=1.0,
                 GPU=1 if values.get("requires_gpu") else 0,
-                RAM="128 MiB",
-                MPI=1 if values.get("requires_mpi") else 0,
+                RAM=parse_obj_as(ByteSize, "128 MiB"),
             )
         return v
 

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/comp_tasks.py
@@ -24,9 +24,7 @@ class ComputationCreate(BaseModel):
         default=False,
         description="if True the computation pipeline will start right away",
     )
-    product_name: Optional[str] = Field(
-        default=None, description="required if computation is started"
-    )
+    product_name: str
     subgraph: Optional[list[NodeID]] = Field(
         default=None,
         description="An optional set of nodes that must be executed, if empty the whole pipeline is executed",

--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/services.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/services.py
@@ -4,7 +4,7 @@ from models_library.basic_regex import UUID_RE
 from models_library.basic_types import PortInt
 from models_library.service_settings_labels import ContainerSpec
 from models_library.services import KEY_RE, VERSION_RE, ServiceDockerData
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from pydantic.types import ByteSize, NonNegativeInt
 
 from .dynamic_services import ServiceState
@@ -30,17 +30,21 @@ class NodeRequirements(BaseModel):
     )
     ram: ByteSize = Field(
         ...,
-        description="defines the required (maximum) amount of RAM for running the services in bytes",
+        description="defines the required (maximum) amount of RAM for running the services",
         alias="RAM",
     )
-    mpi: Optional[int] = Field(
-        None,
-        deprecated=True,
-        description="defines whether a MPI node is required for running the services",
-        alias="MPI",
-        le=1,
-        ge=0,
+    vram: Optional[ByteSize] = Field(
+        default=None,
+        description="defines the required (maximum) amount of VRAM for running the services",
+        alias="VRAM",
     )
+
+    @validator("vram", "gpu", always=True, pre=True)
+    @classmethod
+    def check_0_is_none(cls, v):
+        if v == 0:
+            v = None
+        return v
 
     class Config:
         schema_extra = {
@@ -50,7 +54,6 @@ class NodeRequirements(BaseModel):
                 {
                     "CPU": 1.0,
                     "RAM": 4194304,
-                    "MPI": 1,
                 },
             ]
         }

--- a/services/director-v2/src/simcore_service_director_v2/modules/catalog.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/catalog.py
@@ -10,7 +10,6 @@ from models_library.users import UserID
 
 from ..core.settings import CatalogSettings
 from ..utils.client_decorators import handle_errors, handle_retry
-from ..utils.logging_utils import log_decorator
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +58,6 @@ class CatalogClient:
     async def request(self, method: str, tail_path: str, **kwargs) -> httpx.Response:
         return await self.client.request(method, tail_path, **kwargs)
 
-    @log_decorator(logger=logger)
     async def get_service(
         self,
         user_id: UserID,
@@ -67,7 +65,6 @@ class CatalogClient:
         service_version: ServiceVersion,
         product_name: str,
     ) -> dict[str, Any]:
-
         resp = await self.request(
             "GET",
             f"/services/{urllib.parse.quote( service_key, safe='')}/{service_version}",
@@ -79,11 +76,22 @@ class CatalogClient:
             return resp.json()
         raise HTTPException(status_code=resp.status_code, detail=resp.content)
 
-    @log_decorator(logger=logger)
+    async def get_service_resources(
+        self, user_id: UserID, service_key: ServiceKey, service_version: ServiceVersion
+    ) -> dict[str, Any]:
+        resp = await self.request(
+            "GET",
+            f"/services/{urllib.parse.quote( service_key, safe='')}/{service_version}/resources",
+            params={"user_id": user_id},
+        )
+        resp.raise_for_status()
+        if resp.status_code == status.HTTP_200_OK:
+            return resp.json()
+        raise HTTPException(status_code=resp.status_code, detail=resp.content)
+
     async def get_service_specifications(
         self, user_id: UserID, service_key: ServiceKey, service_version: ServiceVersion
     ) -> dict[str, Any]:
-
         resp = await self.request(
             "GET",
             f"/services/{urllib.parse.quote( service_key, safe='')}/{service_version}/specifications",

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -48,7 +48,7 @@ from ..core.errors import (
     ComputationalBackendTaskNotFoundError,
     ComputationalBackendTaskResultsNotReadyError,
 )
-from ..core.settings import ComputationalBackendSettings
+from ..core.settings import AppSettings, ComputationalBackendSettings
 from ..models.domains.comp_tasks import Image
 from ..models.schemas.clusters import ClusterDetails, Scheduler
 from ..utils.dask import (
@@ -304,12 +304,15 @@ class DaskClient:
             )
 
             try:
+                assert self.app.state  # nosec
+                assert self.app.state.settings  # nosec
+                settings: AppSettings = self.app.state.settings
                 task_future = self.backend.client.submit(
                     remote_fct,
                     docker_auth=DockerBasicAuth(
-                        server_address=self.app.state.settings.DIRECTOR_V2_DOCKER_REGISTRY.resolved_registry_url,
-                        username=self.app.state.settings.DIRECTOR_V2_DOCKER_REGISTRY.REGISTRY_USER,
-                        password=self.app.state.settings.DIRECTOR_V2_DOCKER_REGISTRY.REGISTRY_PW,
+                        server_address=settings.DIRECTOR_V2_DOCKER_REGISTRY.resolved_registry_url,
+                        username=settings.DIRECTOR_V2_DOCKER_REGISTRY.REGISTRY_USER,
+                        password=settings.DIRECTOR_V2_DOCKER_REGISTRY.REGISTRY_PW,
                     ),
                     service_key=node_image.name,
                     service_version=node_image.tag,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -233,6 +233,7 @@ class DaskClient:
                 project_id=project_id,
                 node_id=node_id,
             )
+            assert node_image.node_requirements  # nosec
             dask_resources = from_node_reqs_to_dask_resources(
                 node_image.node_requirements
             )

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -31,6 +31,7 @@ from models_library.clusters import ClusterAuthentication, ClusterID
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.projects_state import RunningState
+from models_library.services_resources import BootMode
 from models_library.users import UserID
 from pydantic import parse_obj_as
 from pydantic.networks import AnyUrl
@@ -99,6 +100,7 @@ RemoteFct = Callable[
         LogFileUploadURL,
         Commands,
         Optional[S3Settings],
+        BootMode,
     ],
     TaskOutputData,
 ]
@@ -206,6 +208,7 @@ class DaskClient:
             log_file_url: AnyUrl,
             command: list[str],
             s3_settings: Optional[S3Settings],
+            boot_mode: BootMode,
         ) -> TaskOutputData:
             """This function is serialized by the Dask client and sent over to the Dask sidecar(s)
             Therefore, (screaming here) DO NOT MOVE THAT IMPORT ANYWHERE ELSE EVER!!"""
@@ -220,6 +223,7 @@ class DaskClient:
                 log_file_url,
                 command,
                 s3_settings,
+                boot_mode,
             )
 
         if remote_fct is None:
@@ -314,6 +318,7 @@ class DaskClient:
                     log_file_url=log_file_url,
                     command=node_image.command,
                     s3_settings=s3_settings,
+                    boot_mode=node_image.boot_mode,
                     key=job_id,
                     resources=dask_resources,
                     retries=0,

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -9,15 +9,17 @@ from models_library.projects import ProjectAtDB, ProjectID
 from models_library.projects_nodes import Node
 from models_library.projects_nodes_io import NodeID
 from models_library.projects_state import RunningState
-from models_library.services import ServiceDockerData, ServiceKeyVersion
+from models_library.services import ServiceDockerData
+from models_library.users import UserID
 from sqlalchemy import literal_column
 from sqlalchemy.dialects.postgresql import insert
 
 from ....core.errors import ErrorDict
 from ....models.domains.comp_tasks import CompTaskAtDB, Image, NodeSchema
-from ....models.schemas.services import ServiceExtras
+from ....models.schemas.services import NodeRequirements, ServiceExtras
 from ....utils.computations import to_node_class
 from ....utils.db import RUNNING_STATE_TO_DB
+from ...catalog import CatalogClient
 from ...director_v0 import DirectorV0Client
 from ..tables import NodeClass, StateType, comp_tasks
 from ._base import BaseRepository
@@ -38,45 +40,69 @@ _FRONTEND_SERVICES_CATALOG: dict[str, ServiceDockerData] = {
 }
 
 
+async def _get_service_details(
+    catalog_client: CatalogClient, user_id: UserID, product_name: str, node: Node
+) -> ServiceDockerData:
+    service_details = await catalog_client.get_service(
+        user_id,
+        node.key,
+        node.version,
+        product_name,
+    )
+    return ServiceDockerData.construct(**service_details)
+
+
+def _compute_node_requirements(node_resources: dict[str, Any]) -> NodeRequirements:
+    node_defined_resources = {}
+
+    for image_data in node_resources.values():
+        for resource_name, resource_value in image_data.get("resources", {}).items():
+            node_defined_resources[resource_name] = node_defined_resources.get(
+                resource_name, 0
+            ) + min(resource_value["limit"], resource_value["reservation"])
+    return NodeRequirements.parse_obj(node_defined_resources)
+
+
 async def _generate_tasks_list_from_project(
     project: ProjectAtDB,
+    catalog_client: CatalogClient,
     director_client: DirectorV0Client,
     published_nodes: list[NodeID],
+    user_id: UserID,
+    product_name: str,
 ) -> list[CompTaskAtDB]:
-
     list_comp_tasks = []
     for internal_id, node_id in enumerate(project.workbench, 1):
         node: Node = project.workbench[node_id]
 
-        service_key_version = ServiceKeyVersion(
-            key=node.key,
-            version=node.version,
-        )
-        node_class = to_node_class(service_key_version.key)
+        # get node infos
+        node_class = to_node_class(node.key)
         node_details: Optional[ServiceDockerData] = None
+        node_resources: Optional[dict[str, Any]] = None
         node_extras: Optional[ServiceExtras] = None
         if node_class == NodeClass.FRONTEND:
-            node_details = _FRONTEND_SERVICES_CATALOG.get(service_key_version.key, None)
+            node_details = _FRONTEND_SERVICES_CATALOG.get(node.key, None)
         else:
-            node_details, node_extras = await asyncio.gather(
-                director_client.get_service_details(service_key_version),
-                director_client.get_service_extras(service_key_version),
+            node_details, node_resources, node_extras = await asyncio.gather(
+                _get_service_details(catalog_client, user_id, product_name, node),
+                catalog_client.get_service_resources(user_id, node.key, node.version),
+                director_client.get_service_extras(node.key, node.version),
             )
 
         if not node_details:
             continue
 
-        # aggregates node_details amd node_extras into Image
+        # aggregates node_details and node_extras into Image
         data: dict[str, Any] = {
-            "name": service_key_version.key,
-            "tag": service_key_version.version,
+            "name": node.key,
+            "tag": node.version,
         }
-        if node_extras:
-            data.update(node_requirements=node_extras.node_requirements)
-            if node_extras.container_spec:
-                data.update(command=node_extras.container_spec.command)
+
+        if node_resources:
+            data.update(node_requirements=_compute_node_requirements(node_resources))
+        if node_extras and node_extras.container_spec:
+            data.update(command=node_extras.container_spec.command)
         image = Image.parse_obj(data)
-        assert image.command  # nosec
 
         assert node.state is not None  # nosec
         task_state = node.state.current_status
@@ -85,7 +111,7 @@ async def _generate_tasks_list_from_project(
 
         task_db = CompTaskAtDB(
             project_id=project.uuid,
-            node_id=node_id,
+            node_id=NodeID(node_id),
             schema=NodeSchema.parse_obj(
                 node_details.dict(
                     exclude_unset=True, by_alias=True, include={"inputs", "outputs"}
@@ -151,14 +177,22 @@ class CompTasksRepository(BaseRepository):
     async def upsert_tasks_from_project(
         self,
         project: ProjectAtDB,
+        catalog_client: CatalogClient,
         director_client: DirectorV0Client,
         published_nodes: list[NodeID],
+        user_id: UserID,
+        product_name: str,
     ) -> list[CompTaskAtDB]:
         # NOTE: really do an upsert here because of issue https://github.com/ITISFoundation/osparc-simcore/issues/2125
         list_of_comp_tasks_in_project: list[
             CompTaskAtDB
         ] = await _generate_tasks_list_from_project(
-            project, director_client, published_nodes
+            project,
+            catalog_client,
+            director_client,
+            published_nodes,
+            user_id,
+            product_name,
         )
         async with self.db_engine.acquire() as conn:
             # get current tasks
@@ -186,7 +220,6 @@ class CompTasksRepository(BaseRepository):
             # NOTE: an exception to this is when a frontend service changes its output since there is no node_ports, the UPDATE must be done here.
             inserted_comp_tasks_db: list[CompTaskAtDB] = []
             for comp_task_db in list_of_comp_tasks_in_project:
-
                 insert_stmt = insert(comp_tasks).values(**comp_task_db.to_db_model())
 
                 exclusion_rule = (

--- a/services/director-v2/src/simcore_service_director_v2/utils/clients.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/clients.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict
+from typing import Any, Union
 
 import httpx
 from fastapi import HTTPException
@@ -9,7 +9,7 @@ from starlette import status
 logger = logging.getLogger(__name__)
 
 
-def unenvelope_or_raise_error(resp: httpx.Response) -> Dict[str, Any]:
+def unenvelope_or_raise_error(resp: httpx.Response) -> Union[list[Any], dict[str, Any]]:
     """
     Director responses are enveloped
     If successful response, we un-envelop it and return data as a dict

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -284,7 +284,6 @@ async def compute_service_log_file_upload_link(
     node_id: NodeID,
     file_link_type: FileLinkType,
 ) -> AnyUrl:
-
     value_links = await port_utils.get_upload_links_from_storage(
         user_id=user_id,
         project_id=f"{project_id}",
@@ -404,7 +403,9 @@ def from_node_reqs_to_dask_resources(
 ) -> dict[str, Union[int, float]]:
     """Dask resources are set such as {"CPU": X.X, "GPU": Y.Y, "RAM": INT}"""
     dask_resources = node_reqs.dict(
-        exclude_unset=True, by_alias=True, exclude_none=True
+        exclude_unset=True,
+        by_alias=True,
+        exclude_none=True,
     )
     logger.debug("transformed to dask resources: %s", dask_resources)
     return dask_resources

--- a/services/director-v2/tests/unit/conftest.py
+++ b/services/director-v2/tests/unit/conftest.py
@@ -182,24 +182,12 @@ async def dask_spec_local_cluster(
                 },
             },
         },
-        "mpi-worker": {
+        "bigcpu-worker": {
             "cls": Worker,
             "options": {
                 "nthreads": 1,
                 "resources": {
                     "CPU": 8,
-                    "MPI": 1,
-                    "RAM": 768e9,
-                },
-            },
-        },
-        "gpu-mpi-worker": {
-            "cls": Worker,
-            "options": {
-                "nthreads": 1,
-                "resources": {
-                    "GPU": 1,
-                    "MPI": 1,
                     "RAM": 768e9,
                 },
             },
@@ -237,7 +225,7 @@ def local_dask_gateway_server_config(
     c.ClusterConfig.worker_cmd = [  # type: ignore
         "dask-worker",
         "--resources",
-        f"CPU=12,GPU=1,MPI=1,RAM={16e9}",
+        f"CPU=12,GPU=1,RAM={16e9}",
     ]
     # NOTE: This must be set such that the local unsafe backend creates a worker with enough cores/memory
     c.ClusterConfig.worker_cores = 12  # type: ignore

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -38,6 +38,7 @@ from models_library.clusters import ClusterID, NoAuthentication, SimpleAuthentic
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.projects_state import RunningState
+from models_library.services_resources import BootMode
 from models_library.users import UserID
 from pydantic import AnyUrl, ByteSize, SecretStr
 from pydantic.tools import parse_obj_as
@@ -260,7 +261,9 @@ def cpu_image(node_id: NodeID) -> ImageParams:
         name="simcore/services/comp/pytest/cpu_image",
         tag="1.5.5",
         node_requirements=NodeRequirements(
-            CPU=1, RAM=parse_obj_as(ByteSize, "128 MiB"), GPU=None, MPI=None
+            CPU=1,
+            RAM=parse_obj_as(ByteSize, "128 MiB"),
+            GPU=None,
         ),
     )  # type: ignore
     return ImageParams(
@@ -285,7 +288,9 @@ def gpu_image(node_id: NodeID) -> ImageParams:
         name="simcore/services/comp/pytest/gpu_image",
         tag="1.4.7",
         node_requirements=NodeRequirements(
-            CPU=1, GPU=1, RAM=parse_obj_as(ByteSize, "256 MiB"), MPI=None
+            CPU=1,
+            GPU=1,
+            RAM=parse_obj_as(ByteSize, "256 MiB"),
         ),
     )  # type: ignore
     return ImageParams(
@@ -306,41 +311,13 @@ def gpu_image(node_id: NodeID) -> ImageParams:
     )
 
 
-@pytest.fixture
-def mpi_image(node_id: NodeID) -> ImageParams:
-    image = Image(
-        name="simcore/services/comp/pytest/mpi_image",
-        tag="1.4.5123",
-        node_requirements=NodeRequirements(
-            CPU=2, RAM=parse_obj_as(ByteSize, "128 MiB"), MPI=1, GPU=None
-        ),
-    )  # type: ignore
-    return ImageParams(
-        image=image,
-        expected_annotations={
-            "resources": {
-                "CPU": 2.0,
-                "MPI": 1.0,
-                "RAM": 128 * 1024 * 1024,
-            },
-        },
-        expected_used_resources={
-            "CPU": 2.0,
-            "MPI": 1.0,
-            "RAM": 128 * 1024 * 1024.0,
-        },
-        fake_tasks={node_id: image},
-    )
-
-
-@pytest.fixture(params=[cpu_image.__name__, gpu_image.__name__, mpi_image.__name__])
+@pytest.fixture(params=[cpu_image.__name__, gpu_image.__name__])
 def image_params(
-    cpu_image: ImageParams, gpu_image: ImageParams, mpi_image: ImageParams, request
+    cpu_image: ImageParams, gpu_image: ImageParams, request
 ) -> ImageParams:
     return {
         "cpu_image": cpu_image,
         "gpu_image": gpu_image,
-        "mpi_image": mpi_image,
     }[request.param]
 
 
@@ -568,6 +545,7 @@ async def test_computation_task_is_persisted_on_dask_scheduler(
         log_file_url: AnyUrl,
         command: list[str],
         s3_settings: Optional[S3Settings],
+        boot_mode: BootMode = BootMode.CPU,
     ) -> TaskOutputData:
         # get the task data
         worker = get_worker()
@@ -646,6 +624,7 @@ async def test_abort_computation_tasks(
         log_file_url: AnyUrl,
         command: list[str],
         s3_settings: Optional[S3Settings],
+        boot_mode: BootMode = BootMode.CPU,
     ) -> TaskOutputData:
         # get the task data
         worker = get_worker()
@@ -728,6 +707,7 @@ async def test_failed_task_returns_exceptions(
         log_file_url: AnyUrl,
         command: list[str],
         s3_settings: Optional[S3Settings],
+        boot_mode: BootMode = BootMode.CPU,
     ) -> TaskOutputData:
 
         raise ValueError(
@@ -782,20 +762,21 @@ async def test_missing_resource_send_computation_task(
     mocked_storage_service_api: respx.MockRouter,
 ):
 
-    # remove the workers that can handle mpi
+    # remove the workers that can handle gpu
     scheduler_info = dask_client.backend.client.scheduler_info()
     assert scheduler_info
-    # find mpi workers
+    # find gpu workers
     workers_to_remove = [
         worker_key
         for worker_key, worker_info in scheduler_info["workers"].items()
-        if "MPI" in worker_info["resources"]
+        if "GPU" in worker_info["resources"]
     ]
     await dask_client.backend.client.retire_workers(workers=workers_to_remove)  # type: ignore
     await asyncio.sleep(5)  # a bit of time is needed so the cluster adapts
 
-    # now let's adapt the task so it needs mpi
-    image_params.image.node_requirements.mpi = 2
+    # now let's adapt the task so it needs gpu
+    assert image_params.image.node_requirements
+    image_params.image.node_requirements.gpu = 2
 
     with pytest.raises(MissingComputationalResourcesError):
         await dask_client.send_computation_tasks(
@@ -829,7 +810,6 @@ async def test_too_many_resources_send_computation_task(
         node_requirements=NodeRequirements(
             CPU=10000000000000000,
             RAM=parse_obj_as(ByteSize, "128 MiB"),
-            MPI=None,
             GPU=None,
         ),
     )  # type: ignore
@@ -950,6 +930,7 @@ async def test_get_tasks_status(
         log_file_url: AnyUrl,
         command: list[str],
         s3_settings: Optional[S3Settings],
+        boot_mode: BootMode = BootMode.CPU,
     ) -> TaskOutputData:
         # wait here until the client allows us to continue
         start_event = Event(_DASK_EVENT_NAME)
@@ -1029,6 +1010,7 @@ async def test_dask_sub_handlers(
         log_file_url: AnyUrl,
         command: list[str],
         s3_settings: Optional[S3Settings],
+        boot_mode: BootMode = BootMode.CPU,
     ) -> TaskOutputData:
 
         state_pub = distributed.Pub(TaskStateEvent.topic_name())

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -453,6 +453,7 @@ async def test_send_computation_task(
         log_file_url: AnyUrl,
         command: list[str],
         s3_settings: Optional[S3Settings],
+        boot_mode: BootMode,
         expected_annotations,
     ) -> TaskOutputData:
         # get the task data
@@ -1090,6 +1091,7 @@ async def test_get_cluster_details(
         log_file_url: AnyUrl,
         command: list[str],
         s3_settings: Optional[S3Settings],
+        boot_mode: BootMode,
         expected_annotations,
     ) -> TaskOutputData:
         # get the task data

--- a/services/director-v2/tests/unit/test_modules_director_v0.py
+++ b/services/director-v2/tests/unit/test_modules_director_v0.py
@@ -234,7 +234,7 @@ async def test_get_service_extras(
 ):
     director_client: DirectorV0Client = minimal_app.state.director_v0_client
     service_extras: ServiceExtras = await director_client.get_service_extras(
-        mock_service_key_version
+        mock_service_key_version.key, mock_service_key_version.version
     )
     assert mocked_director_service_fcts["get_service_extras"].called
     assert fake_service_extras == service_extras

--- a/services/director-v2/tests/unit/with_dbs/test_api_route_computations.py
+++ b/services/director-v2/tests/unit/with_dbs/test_api_route_computations.py
@@ -190,8 +190,7 @@ async def test_create_computation(
         create_computation_url,
         json=jsonable_encoder(
             ComputationCreate(
-                user_id=user["id"],
-                project_id=proj.uuid,
+                user_id=user["id"], project_id=proj.uuid, product_name=product_name
             )
         ),
     )

--- a/services/osparc-gateway-server/tests/unit/test_utils.py
+++ b/services/osparc-gateway-server/tests/unit/test_utils.py
@@ -51,7 +51,10 @@ async def create_docker_service(
     async def _creator(labels: dict[str, str]) -> dict[str, Any]:
         service = await async_docker_client.services.create(
             task_template={
-                "ContainerSpec": {"Image": "busybox", "Command": ["sleep", "10000"]}
+                "ContainerSpec": {
+                    "Image": "busybox:latest",
+                    "Command": ["sleep", "10000"],
+                }
             },
             name=faker.pystr(),
             labels=labels,

--- a/services/web/server/src/simcore_service_webserver/director_v2_core_computations.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2_core_computations.py
@@ -97,7 +97,7 @@ def set_client(app: web.Application, obj: ComputationsApi):
 
 @log_decorator(logger=log)
 async def create_or_update_pipeline(
-    app: web.Application, user_id: UserID, project_id: ProjectID
+    app: web.Application, user_id: UserID, project_id: ProjectID, product_name: str
 ) -> Optional[DataType]:
     settings: DirectorV2Settings = get_plugin_settings(app)
 
@@ -105,6 +105,7 @@ async def create_or_update_pipeline(
     body = {
         "user_id": user_id,
         "project_id": f"{project_id}",
+        "product_name": product_name,
     }
     # request to director-v2
     try:
@@ -122,7 +123,6 @@ async def create_or_update_pipeline(
 async def is_pipeline_running(
     app: web.Application, user_id: PositiveInt, project_id: UUID
 ) -> Optional[bool]:
-
     # TODO: make it cheaper by /computations/{project_id}/state. First trial shows
     # that the efficiency gain is minimal but should be considered specially if the handler
     # gets heavier with time

--- a/services/web/server/src/simcore_service_webserver/exporter/formatters/formatter_v1.py
+++ b/services/web/server/src/simcore_service_webserver/exporter/formatters/formatter_v1.py
@@ -224,7 +224,7 @@ async def add_new_project(
     if _project_db["uuid"] != str(project.uuid):
         raise ExporterException("Project uuid dose nto match after validation")
 
-    await create_or_update_pipeline(app, user_id, project.uuid)
+    await create_or_update_pipeline(app, user_id, project.uuid, product_name)
 
 
 async def _fix_node_run_hashes_based_on_old_project(

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers_crud.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers_crud.py
@@ -146,6 +146,7 @@ async def create_projects(request: web.Request):
         request_context=req_ctx,
         query_params=query_params,
         predefined_project=predefined_project,
+        product_name=req_ctx.product_name,
         fire_and_forget=True,
     )
 
@@ -249,7 +250,8 @@ async def _create_projects(
     query_params: _ProjectCreateParams,
     request_context: RequestContext,
     predefined_project: Optional[ProjectDict],
-):
+    product_name: str,
+) -> None:
     """
 
     :raises web.HTTPBadRequest
@@ -313,7 +315,7 @@ async def _create_projects(
 
         # This is a new project and every new graph needs to be reflected in the pipeline tables
         await director_v2_api.create_or_update_pipeline(
-            app, request_context.user_id, new_project["uuid"]
+            app, request_context.user_id, new_project["uuid"], product_name
         )
 
         # Appends state
@@ -636,7 +638,10 @@ async def replace_project(request: web.Request):
             request.app, path_params.project_id
         )
         await director_v2_api.create_or_update_pipeline(
-            request.app, req_ctx.user_id, path_params.project_id
+            request.app,
+            req_ctx.user_id,
+            path_params.project_id,
+            product_name=req_ctx.product_name,
         )
         # Appends state
         new_project = await projects_api.add_project_states_for_user(

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_projects.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_projects.py
@@ -179,4 +179,4 @@ async def add_new_project(
     #
     # TODO: Ensure this user has access to these services!
     #
-    await create_or_update_pipeline(app, user.id, project.uuid)
+    await create_or_update_pipeline(app, user.id, project.uuid, product_name)

--- a/services/web/server/tests/unit/with_dbs/01/test_director_v2.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_director_v2.py
@@ -46,10 +46,14 @@ def cluster_id(faker: Faker) -> ClusterID:
 
 
 async def test_create_pipeline(
-    mocked_director_v2, client, user_id: UserID, project_id: ProjectID
+    mocked_director_v2,
+    client,
+    user_id: UserID,
+    project_id: ProjectID,
+    osparc_product_name: str,
 ):
     task_out = await director_v2_api.create_or_update_pipeline(
-        client.app, user_id, project_id
+        client.app, user_id, project_id, osparc_product_name
     )
     assert task_out
     assert isinstance(task_out, dict)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️     Changes in devops configuration
  🗃️    Migration of database

or from https://gitmoji.dev/
-->

## What do these changes do?

This PR will bring the following:
- removes the MPI resource, and uses it instead as a BootMode (fixes https://github.com/ITISFoundation/osparc-simcore/issues/3078)
- adds a VRAM resource
- initial implementation of boot mode concept (https://github.com/ITISFoundation/osparc-simcore/issues/3093)
- deprecates ```TARGET_MPI_NODE_CPU_COUNT``` (⚠️ devops, @mrnicegyu11 @Surfict )
- reads from ```service_specifications``` table to allow resources override
  ![image](https://user-images.githubusercontent.com/35365065/226395216-f066d805-9a2f-480c-9ffd-11bb9a1d26cc.png)




### Details:
replaces https://github.com/ITISFoundation/osparc-simcore/pull/3971
- [x] remove ```mpi``` flag as resource (catalog API /resources endpoint will not return MPI anymore)
- [x] director-v2 does not pass MPI as a task requirements anymore 
- [x] director-v2 uses catalog to get the computational service resources instead of director-v0, thus allowing for resource override through table ```services_specifications```
- [x] dask-sidecar boot mode, remove MPI and MPI advertisement
- [x] dask-sidecar computes VRAM on node using nvidia-smi, and registers
- [x] pass boot-mode from catalog to director-v2
- [x] pass boot-mode from director-v2 to dask-sidecar

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

- ITISFoundation/osparc-issues#428
- #26

-->
related to https://github.com/ITISFoundation/osparc-issues/issues/618

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
