### PR TITLE
🐛 Fix: Service Catalog filters parameters

### DIFF
--- a/api/specs/webserver/openapi-user.yaml
+++ b/api/specs/webserver/openapi-user.yaml
@@ -140,7 +140,7 @@ paths:
         in: path
         required: true
         schema:
-          type: integer
+          type: string
     patch:
       tags:
         - user

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -339,17 +339,19 @@ qx.Class.define("osparc.store.Store", {
           })
           .catch(err => console.error("getServices failed", err))
           .finally(() => {
+            let servicesObj = {};
             if (includeRetired) {
-              const servicesObj = osparc.utils.Services.convertArrayToObject(allServices);
-              osparc.utils.Services.addTSRInfo(servicesObj);
-              osparc.utils.Services.servicesCached = servicesObj;
-              resolve(servicesObj);
+              servicesObj = osparc.utils.Services.convertArrayToObject(allServices);
             } else {
               const nonDepServices = allServices.filter(service => !(osparc.utils.Services.isRetired(service) || osparc.utils.Services.isDeprecated(service)));
-              const servicesObj = osparc.utils.Services.convertArrayToObject(nonDepServices);
-              osparc.utils.Services.addTSRInfo(servicesObj);
-              resolve(servicesObj);
+              servicesObj = osparc.utils.Services.convertArrayToObject(nonDepServices);
             }
+            osparc.utils.Services.addTSRInfo(servicesObj);
+            osparc.utils.Services.addExtraTypeInfo(servicesObj);
+            if (includeRetired) {
+              osparc.utils.Services.servicesCached = servicesObj;
+            }
+            resolve(servicesObj);
           });
       });
     },

--- a/services/static-webserver/client/source/class/osparc/utils/Services.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Services.js
@@ -343,6 +343,14 @@ qx.Class.define("osparc.utils.Services", {
       });
     },
 
+    addExtraTypeInfo: function(services) {
+      Object.values(services).forEach(serviceWVersion => {
+        Object.values(serviceWVersion).forEach(service => {
+          service["x-type"] = service["tpye"];
+        });
+      });
+    },
+
     removeFileToKeyMap: function(service) {
       [
         "inputs",

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -1313,7 +1313,7 @@ paths:
         in: path
         required: true
         schema:
-          type: integer
+          type: string
     patch:
       tags:
         - user


### PR DESCRIPTION
## What do these changes do?

In the Service Catalog, services can be filtered by type. This service type is given by the backend, but while the backend provides the following list:
- COMPUTATIONAL
- DYNAMIC
- FRONTEND
- BACKEND
the frontend expects:
- computational
- dynamic
- parameter
- file
- iterator
- probe

This PR maps the FRONTEND and BACKEND types to parameter, file, iterator and probe.

Bonus:
- [x] Patch user notifications expects a (notification_id) string in the path instead of an int.

## Related issue/s

closes https://github.com/ITISFoundation/osparc-simcore/issues/3676

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
