### PR TITLE
🎨 Frontend: auto-start service when double clicking in service

### DIFF
--- a/services/static-webserver/client/source/class/osparc/component/workbench/WorkbenchUI.js
+++ b/services/static-webserver/client/source/class/osparc/component/workbench/WorkbenchUI.js
@@ -478,6 +478,9 @@ qx.Class.define("osparc.component.workbench.WorkbenchUI", {
 
       nodeUI.addListener("dbltap", e => {
         this.fireDataEvent("nodeSelected", nodeUI.getNodeId());
+        if (nodeUI.getNode().canNodeStart()) {
+          nodeUI.getNode().requestStartNode();
+        }
         e.stopPropagation();
       }, this);
     },

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -894,7 +894,14 @@ qx.Class.define("osparc.data.model.Node", {
     },
     // !---- Output Nodes -----
 
+    canNodeStart: function() {
+      return this.isDynamic() && ["idle", "failed"].includes(this.getStatus());
+    },
+
     requestStartNode: function() {
+      if (!this.canNodeStart()) {
+        return;
+      }
       const params = {
         url: {
           studyId: this.getStudy().getUuid(),
@@ -1391,6 +1398,7 @@ qx.Class.define("osparc.data.model.Node", {
         converter: state => (state === "ready") ? "excluded" : "visible"
       });
       this.getStatus().bind("interactive", startButton, "enabled", {
+        // OM
         converter: state => ["idle", "failed"].includes(state)
       });
       const executeListenerId = startButton.addListener("execute", this.requestStartNode, this);

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -895,12 +895,12 @@ qx.Class.define("osparc.data.model.Node", {
     // !---- Output Nodes -----
 
     canNodeStart: function() {
-      return this.isDynamic() && ["idle", "failed"].includes(this.getStatus());
+      return this.isDynamic() && ["idle", "failed"].includes(this.getStatus().getInteractive());
     },
 
     requestStartNode: function() {
       if (!this.canNodeStart()) {
-        return;
+        return false;
       }
       const params = {
         url: {


### PR DESCRIPTION
## What do these changes do?

4000! 🥳 

Request start service when double clicking on it if it's idle or failed.

4 different ways to start a service:
![AutoStart](https://user-images.githubusercontent.com/33152403/226403183-e3bc11c6-66d9-40fd-936a-dea4ed258967.gif)


## Related issue/s
closes https://github.com/ITISFoundation/osparc-simcore/issues/3521


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] ``make version-*``
- [ ] ``make openapi.json``
- [ ] ``cd packages/postgres-database``, ``make setup-commit``, ``sc-pg review -m "my changes"``
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
