### PR TITLE
✨ Dask gateway: add traefik proxy for http(s) access

### DIFF
--- a/services/osparc-gateway-server/docker-compose.yml
+++ b/services/osparc-gateway-server/docker-compose.yml
@@ -1,7 +1,31 @@
 version: '3.9'
 services:
+  traefik:
+    image: "traefik:v2.9"
+    init: true
+    command:
+      # - "--log.level=DEBUG"
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.swarmMode=true"
+      - "--entrypoints.web.address=:80"
+    ports:
+      - "80:80"
+      - "8080:8080"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    networks:
+      - public
+      - dask_net
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager
+
   osparc-gateway-server:
     image: ${DOCKER_REGISTRY:-itisfoundation}/osparc-gateway-server:${DOCKER_IMAGE_TAG:-latest}
+    init: true
     ports:
       - "8000:8000"
     volumes:
@@ -25,7 +49,15 @@ services:
       placement:
         constraints:
           - node.role == manager
+      labels:
+        - traefik.enable=true
+        - traefik.http.routers.gateway.rule=hostregexp(`{host:.+}`)
+        - traefik.http.routers.gateway.entrypoints=web
+        - traefik.http.routers.gateway.service=gateway
+        - traefik.http.services.gateway.loadbalancer.server.port=8000
 networks:
+  public:
+    name: ${SWARM_STACK_NAME:?swarm_stack_name_required}_dask_public
   dask_net:
     name: ${SWARM_STACK_NAME:?swarm_stack_name_required}_dask_net
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️     Changes in devops configuration
  🗃️    Migration of database

or from https://gitmoji.dev/
-->

## What do these changes do?
- add a traefik proxy in the dask-gateway docker-compose
- the idea is to provide https access


## Related issue/s
- related to https://github.com/ITISFoundation/osparc-issues/issues/885
- related to https://github.com/ITISFoundation/osparc-issues/issues/675
- related to https://github.com/ITISFoundation/osparc-simcore/issues/2945
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
