### PR TITLE
🐛 Fix GC taking too much time to stop services

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_abc.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_abc.py
@@ -107,6 +107,10 @@ class SchedulerPublicInterface(ABC):
         """The service will be removed as soon as possible"""
 
     @abstractmethod
+    async def services_awaits_manual_interventions(self, node_uuid: NodeID) -> bool:
+        """returns True if services is waiting for manual intervention"""
+
+    @abstractmethod
     async def get_stack_status(self, node_uuid: NodeID) -> RunningDynamicServiceDetails:
         """Polled by the frontend for the status of the service"""
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
@@ -292,6 +292,16 @@ class Scheduler(SchedulerInternalsMixin, SchedulerPublicInterface):
 
         logger.debug("Service '%s' marked for removal from scheduler", service_name)
 
+    async def services_awaits_manual_interventions(self, node_uuid: NodeID) -> bool:
+        """returns True if services is waiting for manual intervention"""
+        scheduler_data: SchedulerData = self.get_scheduler_data(node_uuid)
+        return (
+            scheduler_data.dynamic_sidecar.status.current
+            == DynamicSidecarStatus.FAILING
+            and scheduler_data.dynamic_sidecar.wait_for_manual_intervention_after_error
+            is True
+        )
+
     async def remove_service_from_observation(self, node_uuid: NodeID) -> None:
         # TODO: this is used internally no need to be here exposed in the interface
         """

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_task.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_task.py
@@ -102,6 +102,9 @@ class DynamicSidecarsScheduler(SchedulerInternalsInterface, SchedulerPublicInter
             node_uuid, can_save, skip_observation_recreation
         )
 
+    async def services_awaits_manual_interventions(self, node_uuid: NodeID) -> bool:
+        return await self._scheduler.services_awaits_manual_interventions(node_uuid)
+
     async def get_stack_status(self, node_uuid: NodeID) -> RunningDynamicServiceDetails:
         return await self._scheduler.get_stack_status(node_uuid)
 

--- a/services/web/server/src/simcore_service_webserver/garbage_collector_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector_utils.py
@@ -187,7 +187,7 @@ def log_context(log: Callable, message: str):
 
         yield
 
-        log("%s [DONE w/ SUCCESS]", message)
+        log("%s [DONE]", message)
 
     except Exception as e:  # pylint: disable=broad-except
         log("%s [DONE w/ ERROR %s]", message, type(e))

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -1,15 +1,19 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 
+import re
 from unittest.mock import AsyncMock
 
 import pytest
+from aiohttp import ClientSession, web
+from aioresponses import aioresponses as AioResponsesMock
 from faker import Faker
 from pytest_mock import MockerFixture
 from simcore_service_webserver.garbage_collector_core import (
     _remove_single_service_if_orphan,
     remove_orphaned_services,
 )
+from yarl import URL
 
 
 @pytest.fixture
@@ -69,6 +73,59 @@ async def test_regression_project_id_recovered_from_the_wrong_data_structure(
         return_value=AsyncMock(),
     )
     mocker.patch(f"{base_module}.director_v2_api.stop_dynamic_service", autospec=True)
+
+    await _remove_single_service_if_orphan(
+        app=AsyncMock(),
+        interactive_service={
+            "service_host": "host",
+            "service_uuid": faker.uuid4(),
+            "user_id": 1,
+            "project_id": faker.uuid4(),
+        },
+        currently_opened_projects_node_ids={},
+    )
+
+
+async def test_remove_single_service_if_orphan_service_is_waiting_manual_intervention(
+    faker: Faker,
+    mocker: MockerFixture,
+    aioresponses_mocker: AioResponsesMock,
+):
+
+    base_module = "simcore_service_webserver.garbage_collector_core"
+    mocker.patch(
+        f"{base_module}.is_node_id_present_in_any_project_workbench",
+        autospec=True,
+        return_value=True,
+    )
+    mocker.patch(
+        f"{base_module}.ProjectDBAPI.get_from_app_context",
+        autospec=True,
+        return_value=AsyncMock(),
+    )
+
+    # mock settings
+    mocked_settings = AsyncMock()
+    mocked_settings.base_url = URL("http://director-v2:8000/v2")
+    mocked_settings.DIRECTOR_V2_STOP_SERVICE_TIMEOUT = 10
+    mocker.patch(
+        "simcore_service_webserver.director_v2_core_dynamic_services.get_plugin_settings",
+        autospec=True,
+        return_value=mocked_settings,
+    )
+
+    mocker.patch(
+        "simcore_service_webserver.director_v2_core_base.get_client_session",
+        autospec=True,
+        return_value=ClientSession(),
+    )
+
+    aioresponses_mocker.delete(
+        re.compile(r"^http://[a-z\-_]*director-v2:[0-9]+/v2/dynamic_services.*$"),
+        status=web.HTTPBadRequest.status_code,
+        payload={"code": "waiting_for_intervention"},
+        repeat=True,
+    )
 
     await _remove_single_service_if_orphan(
         app=AsyncMock(),


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️     Changes in devops configuration
  🗃️    Migration of database

or from https://gitmoji.dev/
-->

## What do these changes do?

Due to the fact that the director-v2 did not provide any hints that a service was awaiting for manual intervention the GC, would hang for a very long time before removing services.

- 🐛 `director-v2` removes raises 400 BadRequest when a service requires manual intervention
- 🐛 `GC` knows about services which require manual intervention



## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->

- fixes https://github.com/ITISFoundation/osparc-simcore/issues/4035


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
