### PR TITLE
🐛 filetypes in webserver API are case insensitive

### DIFF
--- a/packages/postgres-database/src/simcore_postgres_database/errors.py
+++ b/packages/postgres-database/src/simcore_postgres_database/errors.py
@@ -28,7 +28,12 @@ from psycopg2 import (
     OperationalError,
     ProgrammingError,
 )
-from psycopg2.errors import ForeignKeyViolation, NotNullViolation, UniqueViolation
+from psycopg2.errors import (
+    CheckViolation,
+    ForeignKeyViolation,
+    NotNullViolation,
+    UniqueViolation,
+)
 
 assert issubclass(UniqueViolation, IntegrityError)  # nosec
 
@@ -44,6 +49,7 @@ assert issubclass(UniqueViolation, IntegrityError)  # nosec
 
 
 __all__: tuple[str, ...] = (
+    "CheckViolation",
     "DatabaseError",
     "DataError",
     "DBAPIError",

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/9014ae5fd6e5_checkconstraint_filetype.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/9014ae5fd6e5_checkconstraint_filetype.py
@@ -1,0 +1,29 @@
+"""Checkconstraint filetype
+
+Revision ID: 9014ae5fd6e5
+Revises: 4f9c8738178b
+Create Date: 2023-03-29 13:52:47.611065+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9014ae5fd6e5"
+down_revision = "4f9c8738178b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("UPDATE services_consume_filetypes SET filetype = UPPER(filetype)")
+    op.create_check_constraint(
+        "ck_filetype_is_upper",
+        "services_consume_filetypes",
+        "filetype = upper(filetype)",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "ck_filetype_is_upper", "services_consume_filetypes", type_="check"
+    )

--- a/packages/postgres-database/src/simcore_postgres_database/models/services_consume_filetypes.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/services_consume_filetypes.py
@@ -52,7 +52,7 @@ services_consume_filetypes = sa.Table(
             name="ck_filetype_is_upper",
         ),
         nullable=False,
-        doc="A filetype supported by this service, e.g. CSV, Excel, ect."
+        doc="An extension supported by this service, e.g. CSV, VTK, etc."
         "The filetype identifiers are not well defined, so we avoided using enums"
         "Temptative list in https://en.wikipedia.org/wiki/List_of_file_formats",
     ),

--- a/packages/postgres-database/src/simcore_postgres_database/models/services_consume_filetypes.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/services_consume_filetypes.py
@@ -20,7 +20,6 @@ from .base import metadata
 services_consume_filetypes = sa.Table(
     "services_consume_filetypes",
     metadata,
-    # TODO: add regex to key and version?
     sa.Column(
         "service_key",
         sa.String,
@@ -48,6 +47,10 @@ services_consume_filetypes = sa.Table(
     sa.Column(
         "filetype",
         sa.String,
+        sa.CheckConstraint(
+            "filetype = upper(filetype)",
+            name="ck_filetype_is_upper",
+        ),
         nullable=False,
         doc="A filetype supported by this service, e.g. CSV, Excel, ect."
         "The filetype identifiers are not well defined, so we avoided using enums"

--- a/packages/postgres-database/tests/test_services__meta_data.py
+++ b/packages/postgres-database/tests/test_services__meta_data.py
@@ -116,7 +116,7 @@ def services_fixture(faker: Faker, pg_sa_engine: sa.engine.Engine) -> ServicesFi
                         service_version=version,
                         service_display_name=service_name,
                         service_input_port=f"input_{i}",
-                        filetype=filetype,
+                        filetype=filetype.upper(),
                         is_guest_allowed=is_public,
                     )
 
@@ -134,7 +134,6 @@ def services_fixture(faker: Faker, pg_sa_engine: sa.engine.Engine) -> ServicesFi
 def test_trial_queries_for_service_metadata(
     services_fixture: ServicesFixture, pg_sa_engine: sa.engine.Engine
 ):
-
     # check if service exists and whether is public or not
     with pg_sa_engine.connect() as conn:
         query = sa.select(

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_services.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_services.py
@@ -27,7 +27,7 @@ FAKE_FILE_CONSUMER_SERVICES = [
         "key": "simcore/services/dynamic/sim4life",
         "version": "2.0.0",
         "display_name": "Sim4Life",
-        "consumes": ["DCM", "S4LCacheData"],
+        "consumes": ["DCM", "S4LCACHEDATA"],
     },
     # another service with multiple format support (preferred for CSV)
     {

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/handlers_redirects.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/handlers_redirects.py
@@ -42,6 +42,15 @@ class ViewerQueryParams(BaseModel):
             viewer_version=viewer.version,
         )
 
+    @validator("file_type")
+    @classmethod
+    def ensure_extension_upper_and_dotless(cls, v):
+        # NOTE: see filetype constraint-check
+        if v and isinstance(v, str):
+            w = urllib.parse.unquote(v)
+            return w.upper().lstrip(".")
+        return v
+
 
 class RedirectionQueryParams(ViewerQueryParams):
     file_name: str = "unknown"

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/handlers_redirects.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/handlers_redirects.py
@@ -87,6 +87,20 @@ class RedirectionQueryParams(ViewerQueryParams):
 
         raise ValueError("One or more file parameters missing")
 
+    class Config:
+        schema_extra = {
+            "examples": [
+                {
+                    "viewer_key": "simcore/services/comp/foo",
+                    "viewer_version": "1.2.3",
+                    "file_type": "lowerUPPER",
+                    "file_name": "filename",
+                    "file_size": "12",
+                    "download_link": "https://download.io/file123",
+                }
+            ]
+        }
+
 
 def compose_dispatcher_prefix_url(request: web.Request, viewer: ViewerInfo) -> HttpUrl:
     """This is denoted PREFIX URL because it needs to append extra query


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️     Changes in devops configuration
  🗃️    Migration of database

or from https://gitmoji.dev/
-->

## What do these changes do?

Searching for ``filetype`` values in the API is now case insensitive. To achieve that we enforce the values in the db (currently inserted by hand) to be uppercase and the search/comparison is done that way. Highlights:

- Adds  a check constraint to ``services_consume_filetypes.filetype`` to ensure uppercase
- API parses and formats ``filetype`` as uppercase
- ♻️ Update tests

## Related issue/s

Based on the feedback from @ignapas after testing interaction with nih-portal
 - related to ITISFoundation/osparc-issues#683


## How to test

- add some extension with lower characters  to ``services_consume_filetypes.filetype`` wil raise a "CheckViolation" exception
