### PR TITLE
🐛 fix e2e: ti-plan test

### DIFF
--- a/tests/e2e/tutorials/tutorialBase.js
+++ b/tests/e2e/tutorials/tutorialBase.js
@@ -675,7 +675,7 @@ class TutorialBase {
     await this.waitAndClick('mode-button-postro', s4lIframe);
     await this.takeScreenshot("Postpro");
     const algorithmTrees = await utils.getChildrenElementsBySelector(s4lIframe, '[osparc-test-id="tree-algorithm');
-    if (algorithmTrees.length !== 1) {
+    if (algorithmTrees.length < 1) {
       throw("Post Pro tree missing");
     }
 


### PR DESCRIPTION
## What do these changes do?

Fixes ti-plan e2e test:

The PostPro step (s4l-lite-postpro) must have the smash file preloaded. We used to have only one pipeline in the algorithm tree (TI Field + Surface viewer) and one week ago we added a second pipeline (HF Field + Surface viewer), that's why the test started failing. With this change we make sure that there is at least one pipeline in the algorithm tree.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
