### PR TITLE
♻️ Ensure log level is passed to the frontend

### DIFF
--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/events.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/events.py
@@ -1,5 +1,6 @@
+import logging
 from abc import ABC, abstractmethod
-from typing import Optional, Union
+from typing import Union
 
 from distributed.worker import get_worker
 from models_library.projects_state import RunningState
@@ -8,7 +9,7 @@ from pydantic import BaseModel, Extra, NonNegativeFloat
 
 class BaseTaskEvent(BaseModel, ABC):
     job_id: str
-    msg: Optional[str] = None
+    msg: str | None = None
 
     @staticmethod
     @abstractmethod
@@ -28,7 +29,7 @@ class TaskStateEvent(BaseTaskEvent):
 
     @classmethod
     def from_dask_worker(
-        cls, state: RunningState, msg: Optional[str] = None
+        cls, state: RunningState, msg: str | None = None
     ) -> "TaskStateEvent":
         return cls(job_id=get_worker().get_current_task(), state=state, msg=msg)
 
@@ -76,6 +77,7 @@ class TaskProgressEvent(BaseTaskEvent):
 
 class TaskLogEvent(BaseTaskEvent):
     log: str
+    log_level: int = logging.INFO
 
     @staticmethod
     def topic_name() -> str:
@@ -91,6 +93,7 @@ class TaskLogEvent(BaseTaskEvent):
                 {
                     "job_id": "simcore/services/comp/sleeper:1.1.0:projectid_ec7e595a-63ee-46a1-a04a-901b11b649f8:nodeid_39467d89-b659-4914-9359-c40b1b6d1d6d:uuid_5ee5c655-450d-4711-a3ec-32ffe16bc580",
                     "log": "some logs",
+                    "log_level": logging.INFO,
                 },
             ]
         }

--- a/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/dynamic_scaling_core.py
@@ -342,9 +342,15 @@ async def _start_instances(
             new_pending_instances.append(r)
 
     log_message = f"{sum(n for n in needed_instances.values())} new machines launched, it might take up to 3 minutes to start, Please wait..."
-    if last_issue:
-        log_message += "\nUnexpected issues detected, probably due to high load, please contact support"
     await log_tasks_message(app, tasks, log_message)
+    if last_issue:
+        await log_tasks_message(
+            app,
+            tasks,
+            "Unexpected issues detected, probably due to high load, please contact support",
+            level=logging.ERROR,
+        )
+
     return new_pending_instances
 
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
@@ -253,7 +253,7 @@ class DaskScheduler(BaseCompScheduler):
             project_id=project_id,
             node_id=node_id,
             messages=[task_log_event.log],
-            log_level=logging.INFO,
+            log_level=task_log_event.log_level,
         )
 
         await self.rabbitmq_client.publish(message.channel_name, message.json())

--- a/services/director-v2/src/simcore_service_director_v2/modules/projects_networks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/projects_networks.py
@@ -187,7 +187,6 @@ async def _get_networks_with_aliases_for_default_network(
     new_networks_with_aliases[default_network] = ContainerAliases.parse_obj({})
 
     for node_uuid, node_content in new_workbench.items():
-
         # only add dynamic-sidecar nodes
         if not await requires_dynamic_sidecar(
             service_key=node_content.key,
@@ -215,7 +214,7 @@ async def _get_networks_with_aliases_for_default_network(
                         f"Network name is {default_network}"
                     )
                 ],
-                log_level=logging.INFO,
+                log_level=logging.WARNING,
             )
             await rabbitmq_client.publish(message.channel_name, message.json())
             continue

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
@@ -7,7 +7,6 @@ run sequentially by this service
 """
 import logging
 from copy import deepcopy
-from typing import Optional
 
 from fastapi import FastAPI
 from models_library.rabbitmq_messages import ProgressType
@@ -32,7 +31,7 @@ def _docker_compose_options_from_settings(settings: ApplicationSettings) -> str:
     return " ".join(options)
 
 
-def _increase_timeout(docker_command_timeout: Optional[int]) -> Optional[int]:
+def _increase_timeout(docker_command_timeout: int | None) -> int | None:
     if docker_command_timeout is None:
         return None
     # NOTE: ensuring process has enough time to end
@@ -44,7 +43,7 @@ async def _write_file_and_spawn_process(
     yaml_content: str,
     *,
     command: str,
-    process_termination_timeout: Optional[int],
+    process_termination_timeout: int | None,
 ) -> CommandResult:
     """The command which accepts {file_path} as an argument for string formatting
 
@@ -111,7 +110,7 @@ async def docker_compose_pull(app: FastAPI, compose_spec_yaml: str) -> None:
         )
 
     async def _log_cb(msg: str) -> None:
-        await post_sidecar_log_message(app, msg)
+        await post_sidecar_log_message(app, msg, log_level=logging.INFO)
 
     await pull_images(list_of_images, registry_settings, _progress_cb, _log_cb)
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/rabbitmq.py
@@ -26,14 +26,14 @@ async def _post_rabbit_message(app: FastAPI, message: RabbitMessageBase) -> None
         await get_rabbitmq_client(app).publish(message.channel_name, message.json())
 
 
-async def post_log_message(app: FastAPI, logs: str) -> None:
+async def post_log_message(app: FastAPI, logs: str, *, log_level: int) -> None:
     app_settings: ApplicationSettings = app.state.settings
     message = LoggerRabbitMessage(
         node_id=app_settings.DY_SIDECAR_NODE_ID,
         user_id=app_settings.DY_SIDECAR_USER_ID,
         project_id=app_settings.DY_SIDECAR_PROJECT_ID,
         messages=[logs],
-        log_level=logging.INFO,
+        log_level=log_level,
     )
 
     await _post_rabbit_message(app, message)
@@ -53,8 +53,8 @@ async def post_progress_message(
     await _post_rabbit_message(app, message)
 
 
-async def post_sidecar_log_message(app: FastAPI, logs: str) -> None:
-    await post_log_message(app, f"[sidecar] {logs}")
+async def post_sidecar_log_message(app: FastAPI, logs: str, *, log_level: int) -> None:
+    await post_log_message(app, f"[sidecar] {logs}", log_level=log_level)
 
 
 async def post_event_reload_iframe(app: FastAPI) -> None:

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
@@ -256,7 +256,7 @@ def setup_outputs_manager(app: FastAPI) -> None:
 
         io_log_redirect_cb: LogRedirectCB | None = None
         if settings.RABBIT_SETTINGS:
-            io_log_redirect_cb = partial(post_log_message, app)
+            io_log_redirect_cb = partial(post_log_message, app, log_level=logging.INFO)
         logger.debug(
             "setting up outputs manager %s",
             "with redirection of logs..." if io_log_redirect_cb else "...",

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
@@ -401,12 +401,13 @@ async def test_regression_io_log_redirect_cb(
             varargs=None,
             varkw=None,
             defaults=None,
-            kwonlyargs=[],
+            kwonlyargs=["log_level"],
             kwonlydefaults=None,
             annotations={
                 "return": None,
                 "app": FastAPI,
                 "logs": str,
+                "log_level": int,
             },
         )
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  ♻️     Refactor code.
  🚑️    Critical hotfix.
  ⚗️     Perform experiments.
  ⬆️     Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️     Changes in devops configuration
  🗃️    Migration of database

or from https://gitmoji.dev/
-->

## What do these changes do?

The log level is already properly passed to the frontend with a default of INFO message (python log level of 20).
new: ensure the log level is passed all the way from the computational backend.

For now, not many changes.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->
relates to https://github.com/ITISFoundation/osparc-simcore/issues/4075

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
