### PR TITLE
✨Webserver: Allow to disable auto-start of dynamic services

### DIFF
--- a/api/specs/webserver/openapi-projects.yaml
+++ b/api/specs/webserver/openapi-projects.yaml
@@ -177,12 +177,12 @@ paths:
         required: true
         schema:
           type: string
-      - name: num_auto_start_services
+      - name: disable_service_auto_start
         in: query
         required: false
         schema:
-          type: integer
-          minimum: 0
+          type: boolean
+          default: false
     post:
       tags:
         - project

--- a/api/specs/webserver/openapi-projects.yaml
+++ b/api/specs/webserver/openapi-projects.yaml
@@ -177,6 +177,12 @@ paths:
         required: true
         schema:
           type: string
+      - name: num_auto_start_services
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
     post:
       tags:
         - project

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -4257,12 +4257,12 @@ paths:
             CreationStatus:
               operationId: get_task_status
               parameters:
-                task_id: '$response.body#/data/task_id'
+                task_id: $response.body#/data/task_id
             CreationResult:
               operationId: get_task_result
               description: Returns 201 if creation succeeded
               parameters:
-                task_id: '$response.body#/data/task_id'
+                task_id: $response.body#/data/task_id
         default:
           $ref: "#/components/responses/DefaultErrorResponse"
   /projects/active:
@@ -4354,12 +4354,12 @@ paths:
         required: true
         schema:
           type: string
-      - name: num_auto_start_services
+      - name: disable_service_auto_start
         in: query
         required: false
         schema:
-          type: integer
-          minimum: 0
+          type: boolean
+          default: false
     post:
       tags:
         - project

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -4257,12 +4257,12 @@ paths:
             CreationStatus:
               operationId: get_task_status
               parameters:
-                task_id: $response.body#/data/task_id
+                task_id: '$response.body#/data/task_id'
             CreationResult:
               operationId: get_task_result
               description: Returns 201 if creation succeeded
               parameters:
-                task_id: $response.body#/data/task_id
+                task_id: '$response.body#/data/task_id'
         default:
           $ref: "#/components/responses/DefaultErrorResponse"
   /projects/active:
@@ -4354,6 +4354,12 @@ paths:
         required: true
         schema:
           type: string
+      - name: num_auto_start_services
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
     post:
       tags:
         - project

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -933,7 +933,12 @@ async def set_project_node_resources(
 
 
 async def run_project_dynamic_services(
-    request: web.Request, project: dict, user_id: UserID, product_name: str
+    request: web.Request,
+    project: dict,
+    user_id: UserID,
+    product_name: str,
+    *,
+    num_auto_start_services: int | None,
 ) -> None:
     # first get the services if they already exist
     project_settings = get_settings(request.app).WEBSERVER_PROJECTS

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -937,8 +937,6 @@ async def run_project_dynamic_services(
     project: dict,
     user_id: UserID,
     product_name: str,
-    *,
-    num_auto_start_services: int | None,
 ) -> None:
     # first get the services if they already exist
     project_settings = get_settings(request.app).WEBSERVER_PROJECTS

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -102,17 +102,21 @@ async def open_project(request: web.Request) -> web.Response:
         )
 
         # user id opened project uuid
-        with contextlib.suppress(ProjectStartsTooManyDynamicNodes):
-            # NOTE: this method raises that exception when the number of dynamic
-            # services in the project is highter than the maximum allowed per project
-            # the project shall still open though.
-            await projects_api.run_project_dynamic_services(
-                request,
-                project,
-                req_ctx.user_id,
-                req_ctx.product_name,
-                num_auto_start_services=query_params.num_auto_start_services,
-            )
+        if (
+            query_params.num_auto_start_services is not None
+            and query_params.num_auto_start_services > 0
+        ):
+            with contextlib.suppress(ProjectStartsTooManyDynamicNodes):
+                # NOTE: this method raises that exception when the number of dynamic
+                # services in the project is highter than the maximum allowed per project
+                # the project shall still open though.
+                await projects_api.run_project_dynamic_services(
+                    request,
+                    project,
+                    req_ctx.user_id,
+                    req_ctx.product_name,
+                    num_auto_start_services=query_params.num_auto_start_services,
+                )
 
         # and let's update the project last change timestamp
         await projects_api.update_project_last_change_timestamp(

--- a/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_handlers.py
@@ -47,7 +47,7 @@ routes = web.RouteTableDef()
 
 
 class _OpenProjectQuery(BaseModel):
-    num_auto_start_services: int | None = None
+    disable_service_auto_start: bool = False
 
 
 @routes.post(f"/{VTAG}/projects/{{project_id}}:open", name="open_project")
@@ -102,20 +102,13 @@ async def open_project(request: web.Request) -> web.Response:
         )
 
         # user id opened project uuid
-        if (
-            query_params.num_auto_start_services is not None
-            and query_params.num_auto_start_services > 0
-        ):
+        if not query_params.disable_service_auto_start:
             with contextlib.suppress(ProjectStartsTooManyDynamicNodes):
                 # NOTE: this method raises that exception when the number of dynamic
                 # services in the project is highter than the maximum allowed per project
                 # the project shall still open though.
                 await projects_api.run_project_dynamic_services(
-                    request,
-                    project,
-                    req_ctx.user_id,
-                    req_ctx.product_name,
-                    num_auto_start_services=query_params.num_auto_start_services,
+                    request, project, req_ctx.user_id, req_ctx.product_name
                 )
 
         # and let's update the project last change timestamp

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
@@ -494,6 +494,7 @@ async def test_open_project_with_small_amount_of_dynamic_services_starts_them_au
         mocked_director_v2_api["director_v2_api.run_dynamic_service"].reset_mock()
 
 
+@pytest.mark.parametrize("num_auto_start_services", list(range(6)))
 @pytest.mark.parametrize(*standard_user_role())
 async def test_open_project_with_num_auto_start_services_query_overrides_behavior(
     client: TestClient,
@@ -505,6 +506,7 @@ async def test_open_project_with_num_auto_start_services_query_overrides_behavio
     mock_catalog_api: dict[str, mock.Mock],
     max_amount_of_auto_started_dyn_services: int,
     faker: Faker,
+    num_auto_start_services: int,
 ):
     assert client.app
     num_of_dyn_services = max_amount_of_auto_started_dyn_services or faker.pyint(
@@ -512,7 +514,6 @@ async def test_open_project_with_num_auto_start_services_query_overrides_behavio
     )
     project = await user_project_with_num_dynamic_services(num_of_dyn_services)
     all_service_uuids = list(project["workbench"])
-    NUM_AUTO_START_SERVICE = 0
     for num_service_already_running in range(num_of_dyn_services):
         mocked_director_v2_api["director_v2_api.list_dynamic_services"].return_value = [
             {"service_uuid": all_service_uuids[service_id]}
@@ -522,14 +523,14 @@ async def test_open_project_with_num_auto_start_services_query_overrides_behavio
         url = (
             client.app.router["open_project"]
             .url_for(project_id=project["uuid"])
-            .with_query(num_auto_start_services=NUM_AUTO_START_SERVICE)
+            .with_query(num_auto_start_services=num_auto_start_services)
         )
 
         resp = await client.post(f"{url}", json=client_session_id_factory())
         await assert_status(resp, expected.ok)
         assert (
             mocked_director_v2_api["director_v2_api.run_dynamic_service"].call_count
-            == NUM_AUTO_START_SERVICE
+            == num_auto_start_services
         )
         mocked_director_v2_api["director_v2_api.run_dynamic_service"].reset_mock()
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?
- [x] add query parameter in the /open entrypoint to tell the backend how many dynamic services shall auto-start (between 0 and ENV variable)
```/projects/{project_id}:open?disable_service_auto_start=true``` will prevent any dynamic service to start
@odeimaiz 


## Related issue/s
fixes https://github.com/ITISFoundation/osparc-simcore/issues/4074
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
