### PR TITLE
🔨♻️ Fixes mypy  issue after upgrade

### DIFF
--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -84,6 +84,7 @@ jobs:
               - 'packages/dask-task-models-library/**'
               - 'packages/pytest-simcore/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
             models-library:
               - 'packages/models-library/**'
               - 'packages/postgres-database/**'

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -85,6 +85,7 @@ jobs:
               - 'packages/pytest-simcore/**'
               - 'services/docker-compose*'
               - 'scripts/mypy/*'
+              - 'mypy.ini'
             models-library:
               - 'packages/models-library/**'
               - 'packages/postgres-database/**'
@@ -94,6 +95,8 @@ jobs:
               - 'packages/postgres-database/**'
               - 'packages/pytest-simcore/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
+              - 'mypy.ini'
             service-integration:
               - 'packages/models-library/**'
               - 'packages/pytest-simcore/**'
@@ -114,28 +117,40 @@ jobs:
               - 'packages/**'
               - 'services/agent/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
+              - 'mypy.ini'
             api:
               - 'api/**'
             api-server:
               - 'packages/**'
               - 'services/api-server/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
+              - 'mypy.ini'
             autoscaling:
               - 'packages/**'
               - 'services/autoscaling/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
+              - 'mypy.ini'
             catalog:
               - 'packages/**'
               - 'services/catalog/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
+              - 'mypy.ini'
             dask-sidecar:
               - 'packages/**'
               - 'services/dask-sidecar/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
+              - 'mypy.ini'
             datcore-adapter:
               - 'packages/**'
               - 'services/datcore-adapter/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
+              - 'mypy.ini'
             director:
               - 'packages/**'
               - 'services/director/**'
@@ -148,10 +163,14 @@ jobs:
               - 'packages/**'
               - 'services/dynamic-sidecar/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
+              - 'mypy.ini'
             invitations:
               - 'packages/**'
               - 'services/invitations/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
+              - 'mypy.ini'
             migration:
               - 'packages/**'
               - 'services/migration/**'
@@ -160,6 +179,8 @@ jobs:
               - 'packages/**'
               - 'services/osparc-gateway-server/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
+              - 'mypy.ini'
             static-webserver:
               - 'services/static-webserver/**'
               - 'services/docker-compose*'
@@ -167,6 +188,8 @@ jobs:
               - 'packages/**'
               - 'services/storage/**'
               - 'services/docker-compose*'
+              - 'scripts/mypy/*'
+              - 'mypy.ini'
             webserver:
               - 'packages/**'
               - 'services/web/**'

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,7 +25,7 @@ disallow_untyped_defs = False
 # removes all the missing imports stuff from external libraries which is annoying to the least
 ignore_missing_imports = True
 
-plugins = pydantic.mypy, sqlmypy
+plugins = pydantic.mypy, sqlalchemy.ext.mypy.plugin
 
 [pydantic-mypy]
 # SEE https://docs.pydantic.dev/mypy_plugin/#plugin-settings

--- a/mypy.ini
+++ b/mypy.ini
@@ -28,6 +28,7 @@ ignore_missing_imports = True
 plugins = pydantic.mypy, sqlmypy
 
 [pydantic-mypy]
+# SEE https://docs.pydantic.dev/mypy_plugin/#plugin-settings
 init_forbid_extra = True
 init_typed = True
 warn_required_dynamic_aliases = True

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/53e095260441_add_projects_access_rights_and_.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/53e095260441_add_projects_access_rights_and_.py
@@ -7,6 +7,7 @@ Create Date: 2020-04-24 06:30:31.689985+00:00
 """
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
 
 # revision identifiers, used by Alembic.
 revision = "53e095260441"
@@ -21,7 +22,7 @@ def upgrade():
         "projects",
         sa.Column(
             "access_rights",
-            sa.dialects.postgresql.JSONB(),
+            JSONB,
             nullable=False,
             server_default=sa.text("'{}'::jsonb"),
         ),

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/da8abd0d8e42_add_comp_runs_table.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/da8abd0d8e42_add_comp_runs_table.py
@@ -7,6 +7,7 @@ Create Date: 2021-05-12 13:46:36.676255+00:00
 """
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects.postgresql import ENUM
 
 # revision identifiers, used by Alembic.
 revision = "da8abd0d8e42"
@@ -31,7 +32,7 @@ def upgrade():
         sa.Column("iteration", sa.BigInteger(), autoincrement=False, nullable=False),
         sa.Column(
             "result",
-            sa.dialects.postgresql.ENUM(
+            ENUM(
                 "NOT_STARTED",
                 "PUBLISHED",
                 "PENDING",

--- a/packages/postgres-database/src/simcore_postgres_database/utils_aiopg_orm.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_aiopg_orm.py
@@ -6,6 +6,8 @@
         - the new async sqlalchemy ORM https://docs.sqlalchemy.org/en/14/orm/
         - https://piccolo-orm.readthedocs.io/en/latest/index.html
 """
+# pylint: disable=no-value-for-parameter
+
 import functools
 import operator
 from typing import Any, Generic, TypeVar
@@ -16,8 +18,6 @@ from aiopg.sa.result import ResultProxy, RowProxy
 from sqlalchemy import func
 from sqlalchemy.sql.base import ImmutableColumnCollection
 from sqlalchemy.sql.dml import Insert, Update, UpdateBase
-
-# pylint: disable=no-value-for-parameter
 from sqlalchemy.sql.elements import literal_column
 from sqlalchemy.sql.schema import Column
 from sqlalchemy.sql.selectable import Select

--- a/packages/postgres-database/src/simcore_postgres_database/utils_aiopg_orm.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_aiopg_orm.py
@@ -6,11 +6,9 @@
         - the new async sqlalchemy ORM https://docs.sqlalchemy.org/en/14/orm/
         - https://piccolo-orm.readthedocs.io/en/latest/index.html
 """
-# pylint: disable=no-value-for-parameter
-
 import functools
 import operator
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 import sqlalchemy as sa
 from aiopg.sa.connection import SAConnection
@@ -18,6 +16,8 @@ from aiopg.sa.result import ResultProxy, RowProxy
 from sqlalchemy import func
 from sqlalchemy.sql.base import ImmutableColumnCollection
 from sqlalchemy.sql.dml import Insert, Update, UpdateBase
+
+# pylint: disable=no-value-for-parameter
 from sqlalchemy.sql.elements import literal_column
 from sqlalchemy.sql.schema import Column
 from sqlalchemy.sql.selectable import Select
@@ -59,7 +59,7 @@ class BaseOrm(Generic[RowUId]):
         self._writeonce: set = writeonce or set()
 
         # row selection logic
-        self._where_clause = None
+        self._where_clause: Any = None
         try:
             self._primary_key: Column = next(c for c in table.columns if c.primary_key)
             # FIXME: how can I compare a concrete with a generic type??
@@ -126,7 +126,7 @@ class BaseOrm(Generic[RowUId]):
         if unique_id and rowid:
             raise ValueError("Either identifier or unique condition but not both")
 
-        if rowid:
+        if rowid is not None:
             self._where_clause = self._primary_key == rowid
         elif unique_id:
             self._where_clause = functools.reduce(

--- a/packages/postgres-database/src/simcore_postgres_database/utils_aiosqlalchemy.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_aiosqlalchemy.py
@@ -8,7 +8,7 @@ from .utils_migration import get_current_head
 
 async def get_pg_engine_stateinfo(engine: AsyncEngine) -> dict[str, Any]:
     return {
-        "current pool connections": f"{engine.pool.checkedin()=},{engine.pool.checkedout()=}",
+        "current pool connections": f"{engine.pool.checkedin()=},{engine.pool.checkedout()=}",  # type: ignore
     }
 
 

--- a/packages/postgres-database/src/simcore_postgres_database/utils_aiosqlalchemy.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_aiosqlalchemy.py
@@ -1,14 +1,14 @@
-from typing import Any
-
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from .utils_migration import get_current_head
 
 
-async def get_pg_engine_stateinfo(engine: AsyncEngine) -> dict[str, Any]:
+async def get_pg_engine_stateinfo(engine: AsyncEngine) -> dict[str, str]:
+    checkedin = engine.pool.checkedin()  # type: ignore
+    checkedout = engine.pool.checkedout()  # type: ignore
     return {
-        "current pool connections": f"{engine.pool.checkedin()=},{engine.pool.checkedout()=}",  # type: ignore
+        "current pool connections": f"{checkedin=},{checkedout=}",
     }
 
 

--- a/scripts/mypy.bash
+++ b/scripts/mypy.bash
@@ -26,7 +26,6 @@ echo_requirements() {
   echo "Installed :"
   docker run \
     --interactive \
-    --tty \
     --rm \
     --user="$(id --user "$USER")":"$(id --group "$USER")" \
     --entrypoint="pip" \

--- a/scripts/mypy.bash
+++ b/scripts/mypy.bash
@@ -22,6 +22,20 @@ build() {
     "$SCRIPT_DIR/mypy"
 }
 
+echo_requirements() {
+  echo "Installed :"
+  docker run \
+    --interactive \
+    --tty \
+    --rm \
+    --user="$(id --user "$USER")":"$(id --group "$USER")" \
+    --entrypoint="pip" \
+    "$IMAGE_NAME" \
+     --no-cache-dir freeze
+}
+
+
+
 run() {
   echo Using "$(docker run --rm "$IMAGE_NAME" --version)"
   echo Mypy config "${MYPY_CONFIG}"
@@ -45,6 +59,7 @@ run() {
 # USAGE
 #    ./scripts/mypy.bash --help
 build
+echo_requirements
 run "$@"
 echo "DONE"
 # ----------------------------------------------------------------------

--- a/scripts/mypy/Dockerfile
+++ b/scripts/mypy/Dockerfile
@@ -4,7 +4,8 @@ FROM python:${PYTHON_VERSION}-slim-buster as base
 
 COPY requirements.txt /requirements.txt
 
-RUN pip install --upgrade pip \
-  && pip install -r requirements.txt
+RUN pip --no-cache-dir install --upgrade pip \
+  && pip --no-cache-dir install -r requirements.txt \
+  && pip --no-cache-dir freeze
 
 ENTRYPOINT ["mypy", "--config-file", "/config/mypy.ini", "--warn-unused-configs"]

--- a/scripts/mypy/requirements.txt
+++ b/scripts/mypy/requirements.txt
@@ -1,6 +1,6 @@
 mypy~=1.2.0
-pydantic[email]
-sqlalchemy-stubs
+pydantic[email]~=1.10  # plugin for primary lib: keep in sync. SEE https://docs.pydantic.dev/mypy_plugin/#plugin-settings
+sqlalchemy[mypy]~=1.4  # plugin for primary lib: keep in sync. SEE https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html#installation
 types-aiofiles
 types-attrs
 types-PyYAML

--- a/services/api-server/src/simcore_service_api_server/models/schemas/jobs.py
+++ b/services/api-server/src/simcore_service_api_server/models/schemas/jobs.py
@@ -232,7 +232,7 @@ class JobStatus(BaseModel):
 
     job_id: UUID
     state: TaskStates
-    progress: PercentageInt = Field(default=0)  # type: ignore
+    progress: PercentageInt = Field(default=PercentageInt(0))
 
     # Timestamps on states
     # TODO: sync state events and timestamps

--- a/services/api-server/src/simcore_service_api_server/models/schemas/jobs.py
+++ b/services/api-server/src/simcore_service_api_server/models/schemas/jobs.py
@@ -232,7 +232,7 @@ class JobStatus(BaseModel):
 
     job_id: UUID
     state: TaskStates
-    progress: PercentageInt = Field(default=0)
+    progress: PercentageInt = Field(default=0)  # type: ignore
 
     # Timestamps on states
     # TODO: sync state events and timestamps

--- a/services/api-server/src/simcore_service_api_server/models/schemas/meta.py
+++ b/services/api-server/src/simcore_service_api_server/models/schemas/meta.py
@@ -9,8 +9,8 @@ class Meta(BaseModel):
     released: dict[str, VersionStr] | None = Field(
         None, description="Maps every route's path tag with a released version"
     )
-    docs_url: AnyHttpUrl = Field(default="https://docs.osparc.io")
-    docs_dev_url: AnyHttpUrl = Field(default="https://api.osparc.io/dev/docs")
+    docs_url: AnyHttpUrl
+    docs_dev_url: AnyHttpUrl
 
     class Config:
         schema_extra = {
@@ -18,7 +18,7 @@ class Meta(BaseModel):
                 "name": "simcore_service_foo",
                 "version": "2.4.45",
                 "released": {"v1": "1.3.4", "v2": "2.4.45"},
-                "doc_url": "https://api.osparc.io/doc",
-                "doc_dev_url": "https://api.osparc.io/dev/doc",
+                "docs_url": "https://api.osparc.io/doc",
+                "docs_dev_url": "https://api.osparc.io/dev/doc",
             }
         }

--- a/services/catalog/src/simcore_service_catalog/api/dependencies/database.py
+++ b/services/catalog/src/simcore_service_catalog/api/dependencies/database.py
@@ -11,7 +11,9 @@ logger = logging.getLogger(__name__)
 
 
 def _get_db_engine(request: Request) -> AsyncEngine:
-    return request.app.state.engine
+    engine: AsyncEngine = request.app.state.engine
+    assert engine  # nosec
+    return engine
 
 
 def get_repository(repo_type: type[BaseRepository]) -> Callable:

--- a/services/catalog/src/simcore_service_catalog/models/domain/dag.py
+++ b/services/catalog/src/simcore_service_catalog/models/domain/dag.py
@@ -20,11 +20,11 @@ class DAGBase(BaseModel):
 class DAGAtDB(DAGBase):
     id: int
     # pylint: disable=unsubscriptable-object
-    workbench: Json[dict[str, Node]]  # type: ignore
+    workbench: Json[dict[str, Node]]
 
     class Config:
         orm_mode = True
 
 
 class DAGData(DAGAtDB):
-    workbench: dict[str, Node] | None  # type: ignore
+    workbench: dict[str, Node] | None


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

After the upgrade of ``mypy`` in PR https://github.com/ITISFoundation/osparc-simcore/pull/4108 I noticed that many of the packages started to fail the ``mypy`` type-check step. 

- [x] 🔨 constraint requirements in ``mypy`` config
   - ``sqlalchemy-stub`` does not seem sufficient to support ``mypy``. Extended to ``sqlalchemy[mypy]``. See [details here](https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html#installation).
- [x] fix new mypy issues in ``api-server``
- [x] fix new mypy issues in ``catalog``
- [x] fix new mypy issues in ``postgres-database``
- [x] 🔨 change CI to trigger  **all** packages with type-check step when ``scripts/mypy`` changes 

## Related issue/s

- Follows up from https://github.com/ITISFoundation/osparc-simcore/pull/4108
- Related to https://github.com/ITISFoundation/osparc-simcore/issues/4071

## How to test

- all ``typecheck`` steps in CI pass
- locally: ``make mypy``
