### PR TITLE
Rabbitmq/only listens to logs if needed

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
@@ -142,6 +142,3 @@ async def rabbitmq_client(
     yield _creator
     # cleanup, properly close the clients
     await asyncio.gather(*(client.close() for client in created_clients))
-    for client in created_clients:
-        assert client._channel_pool  # pylint: disable=protected-access
-        assert client._channel_pool.is_closed  # pylint: disable=protected-access

--- a/packages/service-library/src/servicelib/rabbitmq.py
+++ b/packages/service-library/src/servicelib/rabbitmq.py
@@ -107,9 +107,11 @@ class RabbitMQClient:
         await self._rpc.initialize()
 
     async def close(self) -> None:
-        with log_context(_logger, logging.INFO, msg="Closing connection to RabbitMQ"):
-            assert self._channel_pool  # nosec
-            await self._channel_pool.close()
+        with log_context(
+            _logger,
+            logging.INFO,
+            msg=f"{self.client_name} closing connection to RabbitMQ",
+        ):
             assert self._connection_pool  # nosec
             await self._connection_pool.close()
 

--- a/packages/service-library/tests/test_rabbitmq.py
+++ b/packages/service-library/tests/test_rabbitmq.py
@@ -44,8 +44,6 @@ async def test_rabbit_client(rabbit_client_name: str, rabbit_service: RabbitSett
     await client.close()
     assert client._connection_pool
     assert client._connection_pool.is_closed
-    assert client._channel_pool
-    assert client._channel_pool.is_closed
 
 
 @pytest.fixture

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -266,6 +266,8 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.path=/v0/
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.interval=2000ms
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.healthcheck.timeout=1000ms
+        # NOTE: stickyness must remain until the long running tasks in the webserver are removed
+        # and also https://github.com/ITISFoundation/osparc-simcore/pull/4180 is resolved.
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.sticky.cookie=true
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.sticky.cookie.samesite=lax
         - traefik.http.services.${SWARM_STACK_NAME}_webserver.loadbalancer.sticky.cookie.httponly=true

--- a/services/web/server/src/simcore_service_webserver/groups_api.py
+++ b/services/web/server/src/simcore_service_webserver/groups_api.py
@@ -329,7 +329,7 @@ async def _get_user_in_group_permissions(
         .select_from(users.join(user_to_groups, users.c.id == user_to_groups.c.uid))
         .where(and_(user_to_groups.c.gid == gid, users.c.id == the_user_id_in_group))
     )
-    the_user: RowProxy = await result.fetchone()
+    the_user: RowProxy | None = await result.fetchone()
     if not the_user:
         raise UserInGroupNotFoundError(the_user_id_in_group, gid)
     return the_user

--- a/services/web/server/src/simcore_service_webserver/groups_api.py
+++ b/services/web/server/src/simcore_service_webserver/groups_api.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Any, Optional
+from typing import Any
 
 import sqlalchemy as sa
 from aiohttp import web
@@ -139,7 +139,7 @@ async def get_product_group_for_user(
 
 async def create_user_group(
     app: web.Application, user_id: int, new_group: dict
-) -> dict[str, str]:
+) -> dict[str, Any]:
     engine = app[APP_DB_ENGINE_KEY]
     async with engine.acquire() as conn:
         result = await conn.execute(
@@ -281,9 +281,9 @@ async def add_user_in_group(
     user_id: int,
     gid: int,
     *,
-    new_user_id: Optional[int] = None,
-    new_user_email: Optional[str] = None,
-    access_rights: Optional[AccessRightsDict] = None,
+    new_user_id: int | None = None,
+    new_user_email: str | None = None,
+    access_rights: AccessRightsDict | None = None,
 ) -> None:
     """
     adds new_user (either by id or email) in group (with gid) owned by user_id
@@ -323,7 +323,6 @@ async def add_user_in_group(
 async def _get_user_in_group_permissions(
     conn: SAConnection, gid: int, the_user_id_in_group: int
 ) -> RowProxy:
-
     # now get the user
     result = await conn.execute(
         sa.select([users, user_to_groups.c.access_rights])
@@ -410,7 +409,7 @@ async def delete_user_in_group(
         )
 
 
-async def get_group_from_gid(app: web.Application, gid: int) -> Optional[RowProxy]:
+async def get_group_from_gid(app: web.Application, gid: int) -> RowProxy | None:
     engine: Engine = app[APP_DB_ENGINE_KEY]
 
     async with engine.acquire() as conn:

--- a/services/web/server/src/simcore_service_webserver/notifications/_constants.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_constants.py
@@ -1,0 +1,3 @@
+from typing import Final
+
+APP_RABBITMQ_CONSUMERS_KEY: Final[str] = f"{__name__}.rabbit_consumers"

--- a/services/web/server/src/simcore_service_webserver/notifications/project_logs.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/project_logs.py
@@ -1,0 +1,31 @@
+from aiohttp import web
+from models_library.projects import ProjectID
+from models_library.rabbitmq_messages import LoggerRabbitMessage
+from servicelib.rabbitmq import RabbitMQClient
+
+from ..rabbitmq import get_rabbitmq_client
+from ._constants import APP_RABBITMQ_CONSUMERS_KEY
+
+
+def _get_queue_name_from_exchange_name(app: web.Application, exchange_name: str) -> str:
+    exchange_to_queues = app[APP_RABBITMQ_CONSUMERS_KEY]
+    queue_name = exchange_to_queues[exchange_name]
+    return queue_name
+
+
+async def subscribe(app: web.Application, project_id: ProjectID) -> None:
+    rabbit_client: RabbitMQClient = get_rabbitmq_client(app)
+    exchange_name = LoggerRabbitMessage.get_channel_name()
+    queue_name = _get_queue_name_from_exchange_name(app, exchange_name)
+    await rabbit_client.add_topics(
+        exchange_name, queue_name, topics=[f"{project_id}.*"]
+    )
+
+
+async def unsubscribe(app: web.Application, project_id: ProjectID) -> None:
+    rabbit_client: RabbitMQClient = get_rabbitmq_client(app)
+    exchange_name = LoggerRabbitMessage.get_channel_name()
+    queue_name = _get_queue_name_from_exchange_name(app, exchange_name)
+    await rabbit_client.remove_topics(
+        exchange_name, queue_name, topics=[f"{project_id}.*"]
+    )

--- a/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
+++ b/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
@@ -75,20 +75,23 @@ pytest_simcore_core_services_selection = [
 
 pytest_simcore_ops_services_selection = []
 
+_STABLE_DELAY_S = 3
+
 
 async def _assert_no_handler_not_called(handler: mock.Mock) -> None:
     with pytest.raises(RetryError):
         async for attempt in AsyncRetrying(
             retry=retry_always,
-            stop=stop_after_delay(5),
+            stop=stop_after_delay(_STABLE_DELAY_S),
             reraise=True,
             wait=wait_fixed(1),
         ):
             with attempt:
                 print(
-                    f"--> checking no mesage reached webclient... {attempt.retry_state.attempt_number} attempt"
+                    f"--> checking no message reached webclient for {attempt.retry_state.attempt_number}/{_STABLE_DELAY_S}s..."
                 )
                 handler.assert_not_called()
+    print(f"no calls received for {_STABLE_DELAY_S}s. very good.")
 
 
 async def _assert_handler_called(handler: mock.Mock, expected_call: mock._Call) -> None:

--- a/services/web/server/tests/unit/with_dbs/02/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/02/conftest.py
@@ -375,17 +375,3 @@ def mock_get_total_project_dynamic_nodes_creation_interval(
         ".get_total_project_dynamic_nodes_creation_interval",
         return_value=_VERY_LONG_LOCK_TIMEOUT_S,
     )
-
-
-@pytest.fixture
-def mock_notifications_plugin(mocker: MockerFixture) -> dict[str, mock.Mock]:
-    mocked_subscribe = mocker.patch(
-        "simcore_service_webserver.notifications.project_logs.subscribe",
-        autospec=True,
-    )
-    mocked_unsubscribe = mocker.patch(
-        "simcore_service_webserver.notifications.project_logs.unsubscribe",
-        autospec=True,
-    )
-
-    return {"subscribe": mocked_subscribe, "unsubscribe": mocked_unsubscribe}

--- a/services/web/server/tests/unit/with_dbs/02/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/02/conftest.py
@@ -375,3 +375,17 @@ def mock_get_total_project_dynamic_nodes_creation_interval(
         ".get_total_project_dynamic_nodes_creation_interval",
         return_value=_VERY_LONG_LOCK_TIMEOUT_S,
     )
+
+
+@pytest.fixture
+def mock_notifications_plugin(mocker: MockerFixture) -> dict[str, mock.Mock]:
+    mocked_subscribe = mocker.patch(
+        "simcore_service_webserver.notifications.project_logs.subscribe",
+        autospec=True,
+    )
+    mocked_unsubscribe = mocker.patch(
+        "simcore_service_webserver.notifications.project_logs.unsubscribe",
+        autospec=True,
+    )
+
+    return {"subscribe": mocked_subscribe, "unsubscribe": mocked_unsubscribe}

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__delete.py
@@ -140,10 +140,13 @@ async def test_delete_multiple_opened_project_forbidden(
 
     url = client.app.router["open_project"].url_for(project_id=user_project["uuid"])
     resp = await client.post(url, json=client_session_id1)
-    await assert_status(resp, expected_ok)
-    mocked_notifications_plugin["subscribe"].assert_called_once_with(
-        client.app, ProjectID(user_project["uuid"])
-    )
+    data, error = await assert_status(resp, expected_ok)
+    if data:
+        mocked_notifications_plugin["subscribe"].assert_called_once_with(
+            client.app, ProjectID(user_project["uuid"])
+        )
+    else:
+        mocked_notifications_plugin["subscribe"].assert_not_called()
 
     # delete project in tab2
     client_session_id2 = client_session_id_factory()

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__delete.py
@@ -13,6 +13,7 @@ import sqlalchemy as sa
 from aiohttp import web
 from aiohttp.test_utils import TestClient
 from faker import Faker
+from models_library.projects import ProjectID
 from models_library.projects_state import ProjectStatus
 from pytest_simcore.helpers.utils_assert import assert_status
 from pytest_simcore.helpers.utils_webserver_unit_with_db import (
@@ -113,6 +114,7 @@ async def test_delete_project(
     ],
 )
 async def test_delete_multiple_opened_project_forbidden(
+    mock_notifications_plugin: dict[str, mock.Mock],
     mock_catalog_api: dict[str, mock.Mock],
     client,
     logged_user,
@@ -128,7 +130,6 @@ async def test_delete_multiple_opened_project_forbidden(
 ):
     # service in project
     service = await create_dynamic_service_mock(logged_user["id"], user_project["uuid"])
-
     # open project in tab1
     client_session_id1 = client_session_id_factory()
     try:
@@ -140,6 +141,9 @@ async def test_delete_multiple_opened_project_forbidden(
     url = client.app.router["open_project"].url_for(project_id=user_project["uuid"])
     resp = await client.post(url, json=client_session_id1)
     await assert_status(resp, expected_ok)
+    mock_notifications_plugin["subscribe"].assert_called_once_with(
+        client.app, ProjectID(user_project["uuid"])
+    )
 
     # delete project in tab2
     client_session_id2 = client_session_id_factory()

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__delete.py
@@ -114,7 +114,7 @@ async def test_delete_project(
     ],
 )
 async def test_delete_multiple_opened_project_forbidden(
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
     mock_catalog_api: dict[str, mock.Mock],
     client,
     logged_user,
@@ -141,7 +141,7 @@ async def test_delete_multiple_opened_project_forbidden(
     url = client.app.router["open_project"].url_for(project_id=user_project["uuid"])
     resp = await client.post(url, json=client_session_id1)
     await assert_status(resp, expected_ok)
-    mock_notifications_plugin["subscribe"].assert_called_once_with(
+    mocked_notifications_plugin["subscribe"].assert_called_once_with(
         client.app, ProjectID(user_project["uuid"])
     )
 

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
@@ -625,7 +625,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_starts_them_if
             client.app, ProjectID(project["uuid"])
         )
         mocked_notifications_plugin["subscribe"].reset_mock()
-        mocked_director_v2_api["director_v2_api.run_dynamic_service"].assert_called()
+        mocked_director_v2_api["director_v2.api.run_dynamic_service"].assert_called()
 
 
 @pytest.mark.parametrize(*standard_user_role())
@@ -650,7 +650,7 @@ async def test_open_project_with_deprecated_services_ok_but_does_not_start_dynam
     mocked_notifications_plugin["subscribe"].assert_called_once_with(
         client.app, ProjectID(user_project["uuid"])
     )
-    mocked_director_v2_api["director_v2_api.run_dynamic_service"].assert_not_called()
+    mocked_director_v2_api["director_v2.api.run_dynamic_service"].assert_not_called()
 
 
 @pytest.fixture
@@ -739,12 +739,10 @@ async def test_close_project(
         mocked_notifications_plugin["subscribe"].assert_called_once_with(
             client.app, ProjectID(user_project["uuid"])
         )
-        mocked_director_v2_api["director_v2_api.list_dynamic_services"].assert_any_call(
+        mocked_director_v2_api["director_v2.api.list_dynamic_services"].assert_any_call(
             client.server.app, logged_user["id"], user_project["uuid"]
         )
-        mocked_director_v2_api[
-            "director_v2._core_dynamic_services.list_dynamic_services"
-        ].reset_mock()
+        mocked_director_v2_api["director_v2.api.list_dynamic_services"].reset_mock()
     else:
         mocked_notifications_plugin["subscribe"].assert_not_called()
 
@@ -768,7 +766,7 @@ async def test_close_project(
             ),
         ]
         mocked_director_v2_api[
-            "director_v2._core_dynamic_services.list_dynamic_services"
+            "director_v2.api.list_dynamic_services"
         ].assert_has_calls(calls)
 
         calls = [
@@ -781,9 +779,9 @@ async def test_close_project(
             )
             for service in fake_dynamic_services
         ]
-        mocked_director_v2_api[
-            "director_v2._core_dynamic_services.stop_dynamic_service"
-        ].assert_has_calls(calls)
+        mocked_director_v2_api["director_v2.api.stop_dynamic_service"].assert_has_calls(
+            calls
+        )
 
         # should not be callsed request_retrieve_dyn_service
 

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
@@ -356,9 +356,7 @@ async def test_open_project(
                     ),
                 )
             )
-        mocked_director_v2_api["director_v2.api.run_dynamic_service"].assert_has_calls(
-            calls
-        )
+        mocked_director_v2_api["run_dynamic_service"].assert_has_calls(calls)
     else:
         mocked_notifications_plugin["subscribe"].assert_not_called()
 
@@ -427,9 +425,7 @@ async def test_open_template_project_for_edition(
                     product_name=osparc_product_name,
                 )
             )
-        mocked_director_v2_api["director_v2.api.run_dynamic_service"].assert_has_calls(
-            calls
-        )
+        mocked_director_v2_api["run_dynamic_service"].assert_has_calls(calls)
     else:
         mocked_notifications_plugin["subscribe"].assert_not_called()
 
@@ -494,7 +490,7 @@ async def test_open_project_with_small_amount_of_dynamic_services_starts_them_au
     project = await user_project_with_num_dynamic_services(num_of_dyn_services)
     all_service_uuids = list(project["workbench"])
     for num_service_already_running in range(num_of_dyn_services):
-        mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
+        mocked_director_v2_api["list_dynamic_services"].return_value = [
             {"service_uuid": all_service_uuids[service_id]}
             for service_id in range(num_service_already_running)
         ]
@@ -506,10 +502,10 @@ async def test_open_project_with_small_amount_of_dynamic_services_starts_them_au
             client.app, ProjectID(project["uuid"])
         )
         mocked_notifications_plugin["subscribe"].reset_mock()
-        assert mocked_director_v2_api[
-            "director_v2.api.run_dynamic_service"
-        ].call_count == (num_of_dyn_services - num_service_already_running)
-        mocked_director_v2_api["director_v2.api.run_dynamic_service"].reset_mock()
+        assert mocked_director_v2_api["run_dynamic_service"].call_count == (
+            num_of_dyn_services - num_service_already_running
+        )
+        mocked_director_v2_api["run_dynamic_service"].reset_mock()
 
 
 @pytest.mark.parametrize(*standard_user_role())
@@ -532,7 +528,7 @@ async def test_open_project_with_disable_service_auto_start_set_overrides_behavi
     project = await user_project_with_num_dynamic_services(num_of_dyn_services)
     all_service_uuids = list(project["workbench"])
     for num_service_already_running in range(num_of_dyn_services):
-        mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
+        mocked_director_v2_api["list_dynamic_services"].return_value = [
             {"service_uuid": all_service_uuids[service_id]}
             for service_id in range(num_service_already_running)
         ]
@@ -549,9 +545,7 @@ async def test_open_project_with_disable_service_auto_start_set_overrides_behavi
             client.app, ProjectID(project["uuid"])
         )
         mocked_notifications_plugin["subscribe"].reset_mock()
-        mocked_director_v2_api[
-            "director_v2.api.run_dynamic_service"
-        ].assert_not_called()
+        mocked_director_v2_api["run_dynamic_service"].assert_not_called()
 
 
 @pytest.mark.parametrize(*standard_user_role())
@@ -573,7 +567,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_does_not_start
     )
     all_service_uuids = list(project["workbench"])
     for num_service_already_running in range(max_amount_of_auto_started_dyn_services):
-        mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
+        mocked_director_v2_api["list_dynamic_services"].return_value = [
             {"service_uuid": all_service_uuids[service_id]}
             for service_id in range(num_service_already_running)
         ]
@@ -584,9 +578,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_does_not_start
             client.app, ProjectID(project["uuid"])
         )
         mocked_notifications_plugin["subscribe"].reset_mock()
-        mocked_director_v2_api[
-            "director_v2.api.run_dynamic_service"
-        ].assert_not_called()
+        mocked_director_v2_api["run_dynamic_service"].assert_not_called()
 
 
 @pytest.mark.parametrize(*standard_user_role())
@@ -614,7 +606,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_starts_them_if
     project = await user_project_with_num_dynamic_services(num_of_dyn_services + 1)
     all_service_uuids = list(project["workbench"])
     for num_service_already_running in range(num_of_dyn_services):
-        mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
+        mocked_director_v2_api["list_dynamic_services"].return_value = [
             {"service_uuid": all_service_uuids[service_id]}
             for service_id in range(num_service_already_running)
         ]
@@ -917,18 +909,14 @@ async def test_project_node_lifetime(
     data, errors = await assert_status(resp, expected_response_on_Create)
     node_id = None
     if resp.status == web.HTTPCreated.status_code:
-        mocked_director_v2_api[
-            "director_v2.api.run_dynamic_service"
-        ].assert_called_once()
+        mocked_director_v2_api["run_dynamic_service"].assert_called_once()
         assert "node_id" in data
         node_id = data["node_id"]
     else:
-        mocked_director_v2_api[
-            "director_v2.api.run_dynamic_service"
-        ].assert_not_called()
+        mocked_director_v2_api["run_dynamic_service"].assert_not_called()
 
     # create a new NOT dynamic node...
-    mocked_director_v2_api["director_v2.api.run_dynamic_service"].reset_mock()
+    mocked_director_v2_api["run_dynamic_service"].reset_mock()
     url = client.app.router["create_node"].url_for(project_id=user_project["uuid"])
     body = {
         "service_key": "simcore/services/comp/key",
@@ -938,18 +926,14 @@ async def test_project_node_lifetime(
     data, errors = await assert_status(resp, expected_response_on_Create)
     node_id_2 = None
     if resp.status == web.HTTPCreated.status_code:
-        mocked_director_v2_api[
-            "director_v2.api.run_dynamic_service"
-        ].assert_not_called()
+        mocked_director_v2_api["run_dynamic_service"].assert_not_called()
         assert "node_id" in data
         node_id_2 = data["node_id"]
     else:
-        mocked_director_v2_api[
-            "director_v2.api.run_dynamic_service"
-        ].assert_not_called()
+        mocked_director_v2_api["run_dynamic_service"].assert_not_called()
 
     # get the node state
-    mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
+    mocked_director_v2_api["list_dynamic_services"].return_value = [
         {"service_uuid": node_id, "service_state": "running"}
     ]
     url = client.app.router["get_node"].url_for(
@@ -965,7 +949,7 @@ async def test_project_node_lifetime(
         assert data["service_state"] == "running"
 
     # get the NOT dynamic node state
-    mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = []
+    mocked_director_v2_api["list_dynamic_services"].return_value = []
 
     url = client.app.router["get_node"].url_for(
         project_id=user_project["uuid"], node_id=node_id_2
@@ -980,7 +964,7 @@ async def test_project_node_lifetime(
         assert data["service_state"] == "idle"
 
     # delete the node
-    mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
+    mocked_director_v2_api["list_dynamic_services"].return_value = [
         {"service_uuid": node_id}
     ]
     url = client.app.router["delete_node"].url_for(

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
@@ -356,7 +356,9 @@ async def test_open_project(
                     ),
                 )
             )
-        mocked_director_v2_api["run_dynamic_service"].assert_has_calls(calls)
+        mocked_director_v2_api["director_v2.api.run_dynamic_service"].assert_has_calls(
+            calls
+        )
     else:
         mocked_notifications_plugin["subscribe"].assert_not_called()
 
@@ -425,7 +427,9 @@ async def test_open_template_project_for_edition(
                     product_name=osparc_product_name,
                 )
             )
-        mocked_director_v2_api["run_dynamic_service"].assert_has_calls(calls)
+        mocked_director_v2_api["director_v2.api.run_dynamic_service"].assert_has_calls(
+            calls
+        )
     else:
         mocked_notifications_plugin["subscribe"].assert_not_called()
 
@@ -490,7 +494,7 @@ async def test_open_project_with_small_amount_of_dynamic_services_starts_them_au
     project = await user_project_with_num_dynamic_services(num_of_dyn_services)
     all_service_uuids = list(project["workbench"])
     for num_service_already_running in range(num_of_dyn_services):
-        mocked_director_v2_api["list_dynamic_services"].return_value = [
+        mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
             {"service_uuid": all_service_uuids[service_id]}
             for service_id in range(num_service_already_running)
         ]
@@ -502,10 +506,10 @@ async def test_open_project_with_small_amount_of_dynamic_services_starts_them_au
             client.app, ProjectID(project["uuid"])
         )
         mocked_notifications_plugin["subscribe"].reset_mock()
-        assert mocked_director_v2_api["run_dynamic_service"].call_count == (
-            num_of_dyn_services - num_service_already_running
-        )
-        mocked_director_v2_api["run_dynamic_service"].reset_mock()
+        assert mocked_director_v2_api[
+            "director_v2.api.run_dynamic_service"
+        ].call_count == (num_of_dyn_services - num_service_already_running)
+        mocked_director_v2_api["director_v2.api.run_dynamic_service"].reset_mock()
 
 
 @pytest.mark.parametrize(*standard_user_role())
@@ -528,7 +532,7 @@ async def test_open_project_with_disable_service_auto_start_set_overrides_behavi
     project = await user_project_with_num_dynamic_services(num_of_dyn_services)
     all_service_uuids = list(project["workbench"])
     for num_service_already_running in range(num_of_dyn_services):
-        mocked_director_v2_api["list_dynamic_services"].return_value = [
+        mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
             {"service_uuid": all_service_uuids[service_id]}
             for service_id in range(num_service_already_running)
         ]
@@ -545,7 +549,9 @@ async def test_open_project_with_disable_service_auto_start_set_overrides_behavi
             client.app, ProjectID(project["uuid"])
         )
         mocked_notifications_plugin["subscribe"].reset_mock()
-        mocked_director_v2_api["run_dynamic_service"].assert_not_called()
+        mocked_director_v2_api[
+            "director_v2.api.run_dynamic_service"
+        ].assert_not_called()
 
 
 @pytest.mark.parametrize(*standard_user_role())
@@ -567,7 +573,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_does_not_start
     )
     all_service_uuids = list(project["workbench"])
     for num_service_already_running in range(max_amount_of_auto_started_dyn_services):
-        mocked_director_v2_api["list_dynamic_services"].return_value = [
+        mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
             {"service_uuid": all_service_uuids[service_id]}
             for service_id in range(num_service_already_running)
         ]
@@ -578,7 +584,9 @@ async def test_open_project_with_large_amount_of_dynamic_services_does_not_start
             client.app, ProjectID(project["uuid"])
         )
         mocked_notifications_plugin["subscribe"].reset_mock()
-        mocked_director_v2_api["run_dynamic_service"].assert_not_called()
+        mocked_director_v2_api[
+            "director_v2.api.run_dynamic_service"
+        ].assert_not_called()
 
 
 @pytest.mark.parametrize(*standard_user_role())
@@ -606,7 +614,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_starts_them_if
     project = await user_project_with_num_dynamic_services(num_of_dyn_services + 1)
     all_service_uuids = list(project["workbench"])
     for num_service_already_running in range(num_of_dyn_services):
-        mocked_director_v2_api["list_dynamic_services"].return_value = [
+        mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
             {"service_uuid": all_service_uuids[service_id]}
             for service_id in range(num_service_already_running)
         ]

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
@@ -766,7 +766,7 @@ async def test_close_project(
             ),
         ]
         mocked_director_v2_api[
-            "director_v2.api.list_dynamic_services"
+            "director_v2._core_dynamic_services.list_dynamic_services"
         ].assert_has_calls(calls)
 
         calls = [
@@ -779,9 +779,9 @@ async def test_close_project(
             )
             for service in fake_dynamic_services
         ]
-        mocked_director_v2_api["director_v2.api.stop_dynamic_service"].assert_has_calls(
-            calls
-        )
+        mocked_director_v2_api[
+            "director_v2._core_dynamic_services.stop_dynamic_service"
+        ].assert_has_calls(calls)
 
         # should not be callsed request_retrieve_dyn_service
 
@@ -915,14 +915,18 @@ async def test_project_node_lifetime(
     data, errors = await assert_status(resp, expected_response_on_Create)
     node_id = None
     if resp.status == web.HTTPCreated.status_code:
-        mocked_director_v2_api["run_dynamic_service"].assert_called_once()
+        mocked_director_v2_api[
+            "director_v2.api.run_dynamic_service"
+        ].assert_called_once()
         assert "node_id" in data
         node_id = data["node_id"]
     else:
-        mocked_director_v2_api["run_dynamic_service"].assert_not_called()
+        mocked_director_v2_api[
+            "director_v2.api.run_dynamic_service"
+        ].assert_not_called()
 
     # create a new NOT dynamic node...
-    mocked_director_v2_api["run_dynamic_service"].reset_mock()
+    mocked_director_v2_api["director_v2.api.run_dynamic_service"].reset_mock()
     url = client.app.router["create_node"].url_for(project_id=user_project["uuid"])
     body = {
         "service_key": "simcore/services/comp/key",
@@ -932,14 +936,18 @@ async def test_project_node_lifetime(
     data, errors = await assert_status(resp, expected_response_on_Create)
     node_id_2 = None
     if resp.status == web.HTTPCreated.status_code:
-        mocked_director_v2_api["run_dynamic_service"].assert_not_called()
+        mocked_director_v2_api[
+            "director_v2.api.run_dynamic_service"
+        ].assert_not_called()
         assert "node_id" in data
         node_id_2 = data["node_id"]
     else:
-        mocked_director_v2_api["run_dynamic_service"].assert_not_called()
+        mocked_director_v2_api[
+            "director_v2.api.run_dynamic_service"
+        ].assert_not_called()
 
     # get the node state
-    mocked_director_v2_api["list_dynamic_services"].return_value = [
+    mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
         {"service_uuid": node_id, "service_state": "running"}
     ]
     url = client.app.router["get_node"].url_for(
@@ -955,7 +963,7 @@ async def test_project_node_lifetime(
         assert data["service_state"] == "running"
 
     # get the NOT dynamic node state
-    mocked_director_v2_api["list_dynamic_services"].return_value = []
+    mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = []
 
     url = client.app.router["get_node"].url_for(
         project_id=user_project["uuid"], node_id=node_id_2
@@ -970,7 +978,7 @@ async def test_project_node_lifetime(
         assert data["service_state"] == "idle"
 
     # delete the node
-    mocked_director_v2_api["list_dynamic_services"].return_value = [
+    mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
         {"service_uuid": node_id}
     ]
     url = client.app.router["delete_node"].url_for(

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
@@ -316,7 +316,7 @@ async def test_open_project(
     mock_orphaned_services: mock.Mock,
     mock_catalog_api: dict[str, mock.Mock],
     osparc_product_name: str,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # POST /v0/projects/{project_id}:open
     # open project
@@ -327,7 +327,7 @@ async def test_open_project(
     await assert_status(resp, expected)
 
     if resp.status == web.HTTPOk.status_code:
-        mock_notifications_plugin["subscribe"].assert_called_once_with(
+        mocked_notifications_plugin["subscribe"].assert_called_once_with(
             client.app, ProjectID(user_project["uuid"])
         )
         dynamic_services = {
@@ -360,7 +360,7 @@ async def test_open_project(
             calls
         )
     else:
-        mock_notifications_plugin["subscribe"].assert_not_called()
+        mocked_notifications_plugin["subscribe"].assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -383,7 +383,7 @@ async def test_open_template_project_for_edition(
     mock_orphaned_services: mock.Mock,
     mock_catalog_api: dict[str, mock.Mock],
     osparc_product_name: str,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # POST /v0/projects/{project_id}:open
     # open project
@@ -398,7 +398,7 @@ async def test_open_template_project_for_edition(
     resp = await client.post(f"{url}", json=client_session_id_factory())
     await assert_status(resp, expected)
     if resp.status == web.HTTPOk.status_code:
-        mock_notifications_plugin["subscribe"].assert_called_once_with(
+        mocked_notifications_plugin["subscribe"].assert_called_once_with(
             client.app, ProjectID(template_project["uuid"])
         )
         dynamic_services = {
@@ -431,7 +431,7 @@ async def test_open_template_project_for_edition(
             calls
         )
     else:
-        mock_notifications_plugin["subscribe"].assert_not_called()
+        mocked_notifications_plugin["subscribe"].assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -485,7 +485,7 @@ async def test_open_project_with_small_amount_of_dynamic_services_starts_them_au
     mock_catalog_api: dict[str, mock.Mock],
     max_amount_of_auto_started_dyn_services: int,
     faker: Faker,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     assert client.app
     num_of_dyn_services = max_amount_of_auto_started_dyn_services or faker.pyint(
@@ -502,10 +502,10 @@ async def test_open_project_with_small_amount_of_dynamic_services_starts_them_au
         url = client.app.router["open_project"].url_for(project_id=project["uuid"])
         resp = await client.post(f"{url}", json=client_session_id_factory())
         await assert_status(resp, expected.ok)
-        mock_notifications_plugin["subscribe"].assert_called_once_with(
+        mocked_notifications_plugin["subscribe"].assert_called_once_with(
             client.app, ProjectID(project["uuid"])
         )
-        mock_notifications_plugin["subscribe"].reset_mock()
+        mocked_notifications_plugin["subscribe"].reset_mock()
         assert mocked_director_v2_api[
             "director_v2.api.run_dynamic_service"
         ].call_count == (num_of_dyn_services - num_service_already_running)
@@ -523,7 +523,7 @@ async def test_open_project_with_disable_service_auto_start_set_overrides_behavi
     mock_catalog_api: dict[str, mock.Mock],
     max_amount_of_auto_started_dyn_services: int,
     faker: Faker,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     assert client.app
     num_of_dyn_services = max_amount_of_auto_started_dyn_services or faker.pyint(
@@ -545,10 +545,10 @@ async def test_open_project_with_disable_service_auto_start_set_overrides_behavi
 
         resp = await client.post(f"{url}", json=client_session_id_factory())
         await assert_status(resp, expected.ok)
-        mock_notifications_plugin["subscribe"].assert_called_once_with(
+        mocked_notifications_plugin["subscribe"].assert_called_once_with(
             client.app, ProjectID(project["uuid"])
         )
-        mock_notifications_plugin["subscribe"].reset_mock()
+        mocked_notifications_plugin["subscribe"].reset_mock()
         mocked_director_v2_api[
             "director_v2.api.run_dynamic_service"
         ].assert_not_called()
@@ -564,7 +564,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_does_not_start
     mocked_director_v2_api: dict[str, mock.Mock],
     mock_catalog_api: dict[str, mock.Mock],
     max_amount_of_auto_started_dyn_services: int,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     assert client.app
 
@@ -580,10 +580,10 @@ async def test_open_project_with_large_amount_of_dynamic_services_does_not_start
         url = client.app.router["open_project"].url_for(project_id=project["uuid"])
         resp = await client.post(f"{url}", json=client_session_id_factory())
         await assert_status(resp, expected.ok)
-        mock_notifications_plugin["subscribe"].assert_called_once_with(
+        mocked_notifications_plugin["subscribe"].assert_called_once_with(
             client.app, ProjectID(project["uuid"])
         )
-        mock_notifications_plugin["subscribe"].reset_mock()
+        mocked_notifications_plugin["subscribe"].reset_mock()
         mocked_director_v2_api[
             "director_v2.api.run_dynamic_service"
         ].assert_not_called()
@@ -602,7 +602,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_starts_them_if
     mock_catalog_api: dict[str, mock.Mock],
     max_amount_of_auto_started_dyn_services: int,
     faker: Faker,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     assert client.app
     assert max_amount_of_auto_started_dyn_services == 0, "setting not disabled!"
@@ -621,10 +621,10 @@ async def test_open_project_with_large_amount_of_dynamic_services_starts_them_if
         url = client.app.router["open_project"].url_for(project_id=project["uuid"])
         resp = await client.post(f"{url}", json=client_session_id_factory())
         await assert_status(resp, expected.ok)
-        mock_notifications_plugin["subscribe"].assert_called_once_with(
+        mocked_notifications_plugin["subscribe"].assert_called_once_with(
             client.app, ProjectID(project["uuid"])
         )
-        mock_notifications_plugin["subscribe"].reset_mock()
+        mocked_notifications_plugin["subscribe"].reset_mock()
         mocked_director_v2_api["director_v2_api.run_dynamic_service"].assert_called()
 
 
@@ -639,7 +639,7 @@ async def test_open_project_with_deprecated_services_ok_but_does_not_start_dynam
     mock_service_resources: ServiceResourcesDict,
     mock_orphaned_services,
     mock_catalog_api: dict[str, mock.Mock],
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     mock_catalog_api["get_service"].return_value["deprecated"] = (
         datetime.utcnow() - timedelta(days=1)
@@ -647,7 +647,7 @@ async def test_open_project_with_deprecated_services_ok_but_does_not_start_dynam
     url = client.app.router["open_project"].url_for(project_id=user_project["uuid"])
     resp = await client.post(url, json=client_session_id_factory())
     await assert_status(resp, expected.ok)
-    mock_notifications_plugin["subscribe"].assert_called_once_with(
+    mocked_notifications_plugin["subscribe"].assert_called_once_with(
         client.app, ProjectID(user_project["uuid"])
     )
     mocked_director_v2_api["director_v2_api.run_dynamic_service"].assert_not_called()
@@ -690,7 +690,7 @@ async def test_open_project_more_than_limitation_of_max_studies_open_per_user(
     mocked_director_v2_api: dict[str, mock.Mock],
     mock_catalog_api: dict[str, mock.Mock],
     user_role: UserRole,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     client_id_1 = client_session_id_factory()
     await _open_project(
@@ -721,7 +721,7 @@ async def test_close_project(
     fake_services,
     mock_rabbitmq: None,
     mock_progress_bar: Any,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # POST /v0/projects/{project_id}:close
     fake_dynamic_services = fake_services(number_services=5)
@@ -736,7 +736,7 @@ async def test_close_project(
     resp = await client.post(url, json=client_id)
 
     if resp.status == web.HTTPOk.status_code:
-        mock_notifications_plugin["subscribe"].assert_called_once_with(
+        mocked_notifications_plugin["subscribe"].assert_called_once_with(
             client.app, ProjectID(user_project["uuid"])
         )
         mocked_director_v2_api["director_v2_api.list_dynamic_services"].assert_any_call(
@@ -746,7 +746,7 @@ async def test_close_project(
             "director_v2._core_dynamic_services.list_dynamic_services"
         ].reset_mock()
     else:
-        mock_notifications_plugin["subscribe"].assert_not_called()
+        mocked_notifications_plugin["subscribe"].assert_not_called()
 
     # close project
     url = client.app.router["close_project"].url_for(project_id=user_project["uuid"])
@@ -754,7 +754,7 @@ async def test_close_project(
     await assert_status(resp, expected.no_content)
 
     if resp.status == web.HTTPNoContent.status_code:
-        mock_notifications_plugin["unsubscribe"].assert_called_once_with(
+        mocked_notifications_plugin["unsubscribe"].assert_called_once_with(
             client.app, ProjectID(user_project["uuid"])
         )
         # These checks are after a fire&forget, so we wait a moment
@@ -806,7 +806,7 @@ async def test_get_active_project(
     socketio_client_factory: Callable,
     mocked_director_v2_api: dict[str, mock.Mock],
     mock_catalog_api: dict[str, mock.Mock],
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # login with socket using client session id
     client_id1 = client_session_id_factory()
@@ -840,7 +840,7 @@ async def test_get_active_project(
     resp = await client.get(get_active_projects_url)
     data, error = await assert_status(resp, expected)
     if resp.status == web.HTTPOk.status_code:
-        mock_notifications_plugin["subscribe"].assert_called_once_with(
+        mocked_notifications_plugin["subscribe"].assert_called_once_with(
             client.app, ProjectID(user_project["uuid"])
         )
         assert not error
@@ -852,7 +852,7 @@ async def test_get_active_project(
 
         assert data == user_project
     else:
-        mock_notifications_plugin["subscribe"].assert_not_called()
+        mocked_notifications_plugin["subscribe"].assert_not_called()
 
     # login with socket using client session id2
     client_id2 = client_session_id_factory()
@@ -1080,7 +1080,7 @@ async def test_open_shared_project_2_users_locked(
     mock_catalog_api: dict[str, mock.Mock],
     clean_redis_table: None,
     mock_rabbitmq: None,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # Use-case: user 1 opens a shared project, user 2 tries to open it as well
     mock_project_state_updated_handler = mocker.Mock()
@@ -1262,7 +1262,7 @@ async def test_open_shared_project_at_same_time(
     mock_catalog_api: dict[str, mock.Mock],
     clean_redis_table,
     mock_rabbitmq: None,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     NUMBER_OF_ADDITIONAL_CLIENTS = 20
     # log client 1
@@ -1346,7 +1346,7 @@ async def test_opened_project_can_still_be_opened_after_refreshing_tab(
     mock_orphaned_services,
     mock_catalog_api: dict[str, mock.Mock],
     clean_redis_table,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     """Simulating a refresh goes as follows:
     The user opens a project, then hit the F5 refresh page.

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
@@ -610,7 +610,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_starts_them_if
     # - services start in a sequence with  a lock
     # - lock is a bit slower to acquire and release then without the non locking version
     # 20 services ~ 55 second runtime
-    num_of_dyn_services = faker.pyint(min_value=10, max_value=20)
+    num_of_dyn_services = 7
     project = await user_project_with_num_dynamic_services(num_of_dyn_services + 1)
     all_service_uuids = list(project["workbench"])
     for num_service_already_running in range(num_of_dyn_services):

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_handlers__open_close.py
@@ -1262,7 +1262,7 @@ async def test_open_shared_project_at_same_time(
     mock_rabbitmq: None,
     mocked_notifications_plugin: dict[str, mock.Mock],
 ):
-    NUMBER_OF_ADDITIONAL_CLIENTS = 20
+    NUMBER_OF_ADDITIONAL_CLIENTS = 10
     # log client 1
     client_1 = client
     client_id1 = client_session_id_factory()

--- a/services/web/server/tests/unit/with_dbs/03/garbage_collector/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/03/garbage_collector/test_resource_manager.py
@@ -462,7 +462,7 @@ async def test_interactive_services_removed_after_logout(
     expected_save_state: bool,
     open_project: Callable,
     mock_progress_bar: Any,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     assert client.app
 
@@ -527,7 +527,7 @@ async def test_interactive_services_remain_after_websocket_reconnection_from_2_t
     mocker: MockerFixture,
     open_project: Callable,
     mock_progress_bar: Any,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # login - logged_user fixture
     # create empty study - empty_user_project fixture
@@ -658,7 +658,7 @@ async def test_interactive_services_removed_per_project(
     expected_save_state: bool,
     open_project: Callable,
     mock_progress_bar: Any,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # create server with delay set to DELAY
     # login - logged_user fixture
@@ -822,7 +822,7 @@ async def test_websocket_disconnected_remove_or_maintain_files_based_on_role(
     expected_save_state: bool,
     open_project: Callable,
     mock_progress_bar: Any,
-    mock_notifications_plugin: dict[str, mock.Mock],
+    mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # login - logged_user fixture
     # create empty study - empty_user_project fixture

--- a/services/web/server/tests/unit/with_dbs/03/garbage_collector/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/03/garbage_collector/test_resource_manager.py
@@ -462,6 +462,7 @@ async def test_interactive_services_removed_after_logout(
     expected_save_state: bool,
     open_project: Callable,
     mock_progress_bar: Any,
+    mock_notifications_plugin: dict[str, mock.Mock],
 ):
     assert client.app
 
@@ -526,6 +527,7 @@ async def test_interactive_services_remain_after_websocket_reconnection_from_2_t
     mocker: MockerFixture,
     open_project: Callable,
     mock_progress_bar: Any,
+    mock_notifications_plugin: dict[str, mock.Mock],
 ):
     # login - logged_user fixture
     # create empty study - empty_user_project fixture
@@ -656,6 +658,7 @@ async def test_interactive_services_removed_per_project(
     expected_save_state: bool,
     open_project: Callable,
     mock_progress_bar: Any,
+    mock_notifications_plugin: dict[str, mock.Mock],
 ):
     # create server with delay set to DELAY
     # login - logged_user fixture
@@ -819,6 +822,7 @@ async def test_websocket_disconnected_remove_or_maintain_files_based_on_role(
     expected_save_state: bool,
     open_project: Callable,
     mock_progress_bar: Any,
+    mock_notifications_plugin: dict[str, mock.Mock],
 ):
     # login - logged_user fixture
     # create empty study - empty_user_project fixture

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -16,6 +16,7 @@ import textwrap
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, AsyncIterator, Callable, Iterator
+from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, Mock
 from uuid import uuid4
 
@@ -533,6 +534,7 @@ async def primary_group(
     client: TestClient,
     logged_user: UserInfoDict,
 ) -> dict[str, Any]:
+    assert client.app
     primary_group, _, _ = await list_user_groups(client.app, logged_user["id"])
     return primary_group
 
@@ -542,6 +544,7 @@ async def standard_groups(
     client: TestClient,
     logged_user: UserInfoDict,
 ) -> AsyncIterator[list[dict[str, Any]]]:
+    assert client.app
     sparc_group = {
         "gid": "5",  # this will be replaced
         "label": "SPARC",
@@ -601,6 +604,7 @@ async def all_group(
     client: TestClient,
     logged_user: UserInfoDict,
 ) -> dict[str, str]:
+    assert client.app
     _, _, all_group = await list_user_groups(client.app, logged_user["id"])
     return all_group
 
@@ -612,6 +616,20 @@ def mock_rabbitmq(mocker: MockerFixture) -> None:
         autospec=True,
         return_value=AsyncMock(),
     )
+
+
+@pytest.fixture
+def mock_notifications_plugin(mocker: MockerFixture) -> dict[str, mock.Mock]:
+    mocked_subscribe = mocker.patch(
+        "simcore_service_webserver.notifications.project_logs.subscribe",
+        autospec=True,
+    )
+    mocked_unsubscribe = mocker.patch(
+        "simcore_service_webserver.notifications.project_logs.unsubscribe",
+        autospec=True,
+    )
+
+    return {"subscribe": mocked_subscribe, "unsubscribe": mocked_unsubscribe}
 
 
 @pytest.fixture

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -619,7 +619,7 @@ def mock_rabbitmq(mocker: MockerFixture) -> None:
 
 
 @pytest.fixture
-def mock_notifications_plugin(mocker: MockerFixture) -> dict[str, mock.Mock]:
+def mocked_notifications_plugin(mocker: MockerFixture) -> dict[str, mock.Mock]:
     mocked_subscribe = mocker.patch(
         "simcore_service_webserver.notifications.project_logs.subscribe",
         autospec=True,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?
- [x] when a project is opened by the frontend through a webserver instance, only that instance will start listening to the logs of that project vs all webserver instances listen to all logs of every projects/users
- [x] when a project is closed the webserver instance stops listening to the project logs
- [x] when a user disconnects (websocket connection lost), the webserver instance will also stop listening to the project logs

Bonuses:
- [x] fix closing of webserver's rabbitmq client by closing the connection (this auto-closes the channels without error)
- [x] add client name in close message of rabbitmq client
- [x] fixed some tests missing mocks

**IMPORTANT NOTE: currently this will work because we use sticky connections!!**
**NOTE2:** The studies running through the oSparc API will not generate load on the webserver(s) anymore.
**NOTE3:** The studies running through one specific instance of the webserver will not load the other for nothing anymore.
**NOTE4:** Expected reduction of CPU load on the webservers.

## Related issue/s
- requires https://github.com/ITISFoundation/osparc-simcore/pull/4166
- https://github.com/ITISFoundation/osparc-simcore/issues/3991
- https://github.com/ITISFoundation/osparc-issues/issues/675
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
