### PR TITLE
♻️  `webserver`: fixes mypy issues in `tags` plugin

### DIFF
--- a/api/specs/webserver/scripts/openapi_tags.py
+++ b/api/specs/webserver/scripts/openapi_tags.py
@@ -8,15 +8,14 @@
 
 
 from enum import Enum
-from typing import Union
 
 from fastapi import FastAPI, status
 from models_library.generics import Envelope
-from simcore_service_webserver.tags_handlers import TagCreate, TagGet, TagUpdate
+from simcore_service_webserver.tags._handlers import TagCreate, TagGet, TagUpdate
 
 app = FastAPI(redoc_url=None)
 
-TAGS: list[Union[str, Enum]] = [
+TAGS: list[str | Enum] = [
     "tag",
 ]
 

--- a/packages/service-library/src/servicelib/request_keys.py
+++ b/packages/service-library/src/servicelib/request_keys.py
@@ -1,6 +1,7 @@
-""" Storage keys in requests 
+""" Storage keys in requests
 
 """
+from typing import Final
 
 # RQT=request
-RQT_USERID_KEY = __name__ + ".userid"
+RQT_USERID_KEY: Final[str] = f"{__name__}.userid"

--- a/services/web/server/src/simcore_service_webserver/application.py
+++ b/services/web/server/src/simcore_service_webserver/application.py
@@ -41,7 +41,7 @@ from .socketio.plugin import setup_socketio
 from .statics.plugin import setup_statics
 from .storage.plugin import setup_storage
 from .studies_dispatcher.plugin import setup_studies_dispatcher
-from .tags import setup_tags
+from .tags.plugin import setup_tags
 from .tracing import setup_app_tracing
 from .users import setup_users
 from .version_control.plugin import setup_version_control

--- a/services/web/server/src/simcore_service_webserver/projects/projects_tags_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_tags_handlers.py
@@ -5,9 +5,10 @@
 import logging
 
 from aiohttp import web
+from servicelib.request_keys import RQT_USERID_KEY
 
 from .._meta import api_version_prefix as VTAG
-from ..login.decorators import RQT_USERID_KEY, login_required
+from ..login.decorators import login_required
 from ..security.decorators import permission_required
 from .projects_db import APP_PROJECT_DBAPI, ProjectDBAPI
 

--- a/services/web/server/src/simcore_service_webserver/tags/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/tags/_handlers.py
@@ -22,6 +22,7 @@ from simcore_postgres_database.utils_tags import (
 from .._meta import api_version_prefix as VTAG
 from ..login.decorators import RQT_USERID_KEY, login_required
 from ..security.decorators import permission_required
+from ..utils_aiohttp import envelope_json_response
 
 
 def _handle_tags_exceptions(handler: Handler):
@@ -140,7 +141,7 @@ async def create_tag(request: web.Request):
             **tag_data.dict(exclude_unset=True),
         )
         model = TagGet.from_db(tag)
-        return model.dict(by_alias=True)
+        return envelope_json_response(model)
 
 
 @routes.get(f"/{VTAG}/tags", name="list_tags")
@@ -154,7 +155,9 @@ async def list_tags(request: web.Request):
     repo = TagsRepo(user_id=req_ctx.user_id)
     async with engine.acquire() as conn:
         tags = await repo.list(conn)
-        return [TagGet.from_db(t).dict(by_alias=True) for t in tags]
+        return envelope_json_response(
+            [TagGet.from_db(t).dict(by_alias=True) for t in tags]
+        )
 
 
 @routes.patch(f"/{VTAG}/tags/{{tag_id}}", name="update_tag")
@@ -173,7 +176,7 @@ async def update_tag(request: web.Request):
             conn, query_params.tag_id, **tag_data.dict(exclude_unset=True)
         )
         model = TagGet.from_db(tag)
-        return model.dict(by_alias=True)
+        return envelope_json_response(model)
 
 
 @routes.delete(f"/{VTAG}/tags/{{tag_id}}", name="delete_tag")

--- a/services/web/server/src/simcore_service_webserver/tags/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/tags/_handlers.py
@@ -1,9 +1,10 @@
 import functools
+import re
 
 from aiohttp import web
 from aiopg.sa.engine import Engine
 from models_library.users import UserID
-from pydantic import BaseModel, Extra, Field, PositiveInt, constr
+from pydantic import BaseModel, ConstrainedStr, Extra, Field, PositiveInt
 from servicelib.aiohttp.application_keys import APP_DB_ENGINE_KEY
 from servicelib.aiohttp.requests_validation import (
     parse_request_body_as,
@@ -25,7 +26,7 @@ from ..security.decorators import permission_required
 
 def _handle_tags_exceptions(handler: Handler):
     @functools.wraps(handler)
-    async def wrapper(request: web.Request) -> web.Response:
+    async def wrapper(request: web.Request) -> web.StreamResponse:
         try:
             return await handler(request)
 
@@ -54,7 +55,8 @@ class _InputSchema(BaseModel):
         allow_mutations = False
 
 
-ColorStr = constr(regex=r"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")
+class ColorStr(ConstrainedStr):
+    regex = re.compile(r"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")
 
 
 class TagPathParams(_InputSchema):

--- a/services/web/server/src/simcore_service_webserver/tags/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/tags/_handlers.py
@@ -18,9 +18,9 @@ from simcore_postgres_database.utils_tags import (
     TagsRepo,
 )
 
-from ._meta import api_version_prefix as VTAG
-from .login.decorators import RQT_USERID_KEY, login_required
-from .security.decorators import permission_required
+from .._meta import api_version_prefix as VTAG
+from ..login.decorators import RQT_USERID_KEY, login_required
+from ..security.decorators import permission_required
 
 
 def _handle_tags_exceptions(handler: Handler):

--- a/services/web/server/src/simcore_service_webserver/tags/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/tags/_handlers.py
@@ -47,7 +47,7 @@ def _handle_tags_exceptions(handler: Handler):
 
 
 class _RequestContext(BaseModel):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)
+    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore
 
 
 class _InputSchema(BaseModel):

--- a/services/web/server/src/simcore_service_webserver/tags/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/tags/plugin.py
@@ -9,7 +9,7 @@ from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setu
 
 from . import _handlers
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 @app_module_setup(
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
     ModuleCategory.ADDON,
     settings_name="WEBSERVER_TAGS",
     depends=["simcore_service_webserver.rest"],
-    logger=logger,
+    logger=_logger,
 )
 def setup_tags(app: web.Application):
     assert app[APP_SETTINGS_KEY].WEBSERVER_TAGS  # nosec

--- a/services/web/server/src/simcore_service_webserver/tags/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/tags/plugin.py
@@ -7,7 +7,7 @@ from aiohttp import web
 from servicelib.aiohttp.application_keys import APP_SETTINGS_KEY
 from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
 
-from . import tags_handlers
+from . import _handlers
 
 logger = logging.getLogger(__name__)
 
@@ -21,4 +21,4 @@ logger = logging.getLogger(__name__)
 )
 def setup_tags(app: web.Application):
     assert app[APP_SETTINGS_KEY].WEBSERVER_TAGS  # nosec
-    app.router.add_routes(tags_handlers.routes)
+    app.router.add_routes(_handlers.routes)

--- a/services/web/server/tests/unit/with_dbs/03/tags/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/03/tags/conftest.py
@@ -22,7 +22,7 @@ from simcore_service_webserver.rest import setup_rest
 from simcore_service_webserver.security.plugin import setup_security
 from simcore_service_webserver.session import setup_session
 from simcore_service_webserver.socketio.plugin import setup_socketio
-from simcore_service_webserver.tags import setup_tags
+from simcore_service_webserver.tags.plugin import setup_tags
 
 API_VERSION = "v0"
 RESOURCE_NAME = "projects"

--- a/services/web/server/tests/unit/with_dbs/03/tags/test_tags.py
+++ b/services/web/server/tests/unit/with_dbs/03/tags/test_tags.py
@@ -25,11 +25,11 @@ from pytest_simcore.helpers.utils_login import UserInfoDict
 from pytest_simcore.helpers.utils_projects import assert_get_same_project
 from pytest_simcore.helpers.utils_tags import create_tag, delete_tag
 from simcore_postgres_database.models.tags import tags
-from simcore_service_webserver import tags_handlers
 from simcore_service_webserver._meta import api_version_prefix
 from simcore_service_webserver.db import get_database_engine
 from simcore_service_webserver.db_models import UserRole
 from simcore_service_webserver.projects.project_models import ProjectDict
+from simcore_service_webserver.tags import _handlers
 
 
 @pytest.fixture
@@ -41,7 +41,7 @@ def _clean_tags_table(postgres_db: sa.engine.Engine) -> Iterator[None]:
 
 @pytest.mark.parametrize(
     "route",
-    tags_handlers.routes,
+    _handlers.routes,
     ids=lambda r: f"{r.method.upper()} {r.path}",
 )
 def test_tags_route_against_openapi_specs(route, openapi_specs: OpenApiSpecs):


### PR DESCRIPTION
## What do these changes do?

- ♻️ refactors ``tags`` plugin in webserver
   - plugin under ``tags `` folder
   - protected internal modules
   - uses envelpe reposnses
   - general code cleanup (e.g. `_logger`,  TODO, ...)


## Related issue/s

- part of https://github.com/ITISFoundation/osparc-simcore/issues/4071

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```cmd
cd services/web/server
make mypy | grep tags
```