### PR TITLE
🐛Computational backend: correct parsing of log lines

### DIFF
--- a/packages/service-library/src/servicelib/docker_utils.py
+++ b/packages/service-library/src/servicelib/docker_utils.py
@@ -6,7 +6,7 @@ import arrow
 def to_datetime(docker_timestamp: str) -> datetime:
     # docker follows RFC3339Nano timestamp which is based on ISO 8601
     # https://medium.easyread.co/understanding-about-rfc-3339-for-datetime-formatting-in-software-engineering-940aa5d5f68a
-    ## This is acceptable in ISO 8601 and RFC 3339 (with T)
+    # This is acceptable in ISO 8601 and RFC 3339 (with T)
     # 2019-10-12T07:20:50.52Z
     # This is only accepted in RFC 3339 (without T)
     # 2019-10-12 07:20:50.52Z


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?
- [x] fixed some issues with parsing progress logs output by old computational services
- [x] improved reliability


## Related issue/s
- relates to https://github.com/ITISFoundation/osparc-issues/issues/675
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
