### PR TITLE
✨Comp backend: disconnect progress update in webserver

### DIFF
--- a/packages/models-library/src/models_library/projects_nodes.py
+++ b/packages/models-library/src/models_library/projects_nodes.py
@@ -142,7 +142,7 @@ class Node(BaseModel):
         default=None,
         ge=0,
         le=100,
-        description="the node progress value",
+        description="the node progress value (deprecated in DB, still used for API only)",
         deprecated=True,
     )
     thumbnail: HttpUrlWithCustomMinLength | None = Field(

--- a/packages/models-library/src/models_library/rabbitmq_messages.py
+++ b/packages/models-library/src/models_library/rabbitmq_messages.py
@@ -82,7 +82,9 @@ class ProgressType(StrAutoEnum):
 
 
 class ProgressMessageMixin(RabbitMessageBase):
-    channel_name: Literal["simcore.services.progress"] = "simcore.services.progress"
+    channel_name: Literal[
+        "simcore.services.progress.v2"
+    ] = "simcore.services.progress.v2"
     progress_type: ProgressType = (
         ProgressType.COMPUTATION_RUNNING
     )  # NOTE: backwards compatible
@@ -93,11 +95,13 @@ class ProgressMessageMixin(RabbitMessageBase):
 
 
 class ProgressRabbitMessageNode(ProgressMessageMixin, NodeMessageBase):
-    ...
+    def routing_key(self) -> str | None:
+        return f"{self.project_id}.{self.node_id}"
 
 
 class ProgressRabbitMessageProject(ProgressMessageMixin, ProjectMessageBase):
-    ...
+    def routing_key(self) -> str | None:
+        return f"{self.project_id}.all_nodes"
 
 
 class InstrumentationRabbitMessage(RabbitMessageBase, NodeMessageBase):

--- a/services/autoscaling/tests/unit/test_utils_rabbitmq.py
+++ b/services/autoscaling/tests/unit/test_utils_rabbitmq.py
@@ -150,7 +150,7 @@ async def test_post_task_progress_message(
     await client.subscribe(
         ProgressRabbitMessageNode.get_channel_name(),
         mocked_message_handler,
-        topics=None,
+        topics=[BIND_TO_ALL_TOPICS],
     )
 
     service_with_labels = await create_service(

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -35,9 +35,6 @@ fi
 
 if [ ${DASK_START_AS_SCHEDULER+x} ]; then
   scheduler_version=$(dask scheduler --version)
-  mkdir --parents /home/scu/.config/dask
-  dask_logging=$(printf "logging:\n  distributed: %s\n  distributed.scheduler: %s" "${LOG_LEVEL:-warning}" "${LOG_LEVEL:-warning}")
-  echo "$dask_logging" >> /home/scu/.config/dask/distributed.yaml
 
   echo "$INFO" "Starting as dask scheduler:${scheduler_version}..."
   if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_consumers.py
@@ -64,7 +64,7 @@ async def _handle_computation_running_progress(
                     },
                 }
             ]
-            await send_messages(app, f"{message.user_id}", messages)
+            await send_messages(app, message.user_id, messages)
             return True
     except ProjectNotFoundError:
         _logger.warning(
@@ -111,7 +111,7 @@ async def _progress_message_parser(app: web.Application, data: bytes) -> bool:
     }
     if is_type_message_node:
         socket_message["data"]["node_id"] = rabbit_message.node_id
-    await send_messages(app, f"{rabbit_message.user_id}", [socket_message])
+    await send_messages(app, rabbit_message.user_id, [socket_message])
     return True
 
 
@@ -125,7 +125,7 @@ async def _log_message_parser(app: web.Application, data: bytes) -> bool:
                 "data": rabbit_message.dict(exclude={"user_id", "channel_name"}),
             }
         ]
-        await send_messages(app, f"{rabbit_message.user_id}", socket_messages)
+        await send_messages(app, rabbit_message.user_id, socket_messages)
     return True
 
 
@@ -154,7 +154,7 @@ async def _events_message_parser(app: web.Application, data: bytes) -> bool:
             },
         }
     ]
-    await send_messages(app, f"{rabbit_message.user_id}", socket_messages)
+    await send_messages(app, rabbit_message.user_id, socket_messages)
     return True
 
 

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_consumers.py
@@ -174,7 +174,7 @@ EXCHANGE_TO_PARSER_CONFIG: Final[
     (
         ProgressRabbitMessageNode.get_channel_name(),
         _progress_message_parser,
-        {},
+        dict(topics=[]),
     ),
     (
         InstrumentationRabbitMessage.get_channel_name(),

--- a/services/web/server/src/simcore_service_webserver/notifications/project_logs.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/project_logs.py
@@ -1,6 +1,10 @@
 from aiohttp import web
 from models_library.projects import ProjectID
-from models_library.rabbitmq_messages import LoggerRabbitMessage
+from models_library.rabbitmq_messages import (
+    LoggerRabbitMessage,
+    ProgressRabbitMessageNode,
+    ProgressRabbitMessageProject,
+)
 from servicelib.rabbitmq import RabbitMQClient
 
 from ..rabbitmq import get_rabbitmq_client
@@ -13,19 +17,29 @@ def _get_queue_name_from_exchange_name(app: web.Application, exchange_name: str)
     return queue_name
 
 
+_SUBSCRIBABLE_EXCHANGES = [
+    LoggerRabbitMessage,
+    ProgressRabbitMessageNode,
+    ProgressRabbitMessageProject,
+]
+
+
 async def subscribe(app: web.Application, project_id: ProjectID) -> None:
     rabbit_client: RabbitMQClient = get_rabbitmq_client(app)
-    exchange_name = LoggerRabbitMessage.get_channel_name()
-    queue_name = _get_queue_name_from_exchange_name(app, exchange_name)
-    await rabbit_client.add_topics(
-        exchange_name, queue_name, topics=[f"{project_id}.*"]
-    )
+
+    for exchange in _SUBSCRIBABLE_EXCHANGES:
+        exchange_name = exchange.get_channel_name()
+        queue_name = _get_queue_name_from_exchange_name(app, exchange_name)
+        await rabbit_client.add_topics(
+            exchange_name, queue_name, topics=[f"{project_id}.*"]
+        )
 
 
 async def unsubscribe(app: web.Application, project_id: ProjectID) -> None:
     rabbit_client: RabbitMQClient = get_rabbitmq_client(app)
-    exchange_name = LoggerRabbitMessage.get_channel_name()
-    queue_name = _get_queue_name_from_exchange_name(app, exchange_name)
-    await rabbit_client.remove_topics(
-        exchange_name, queue_name, topics=[f"{project_id}.*"]
-    )
+    for exchange in _SUBSCRIBABLE_EXCHANGES:
+        exchange_name = exchange.get_channel_name()
+        queue_name = _get_queue_name_from_exchange_name(app, exchange_name)
+        await rabbit_client.remove_topics(
+            exchange_name, queue_name, topics=[f"{project_id}.*"]
+        )

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -419,40 +419,7 @@ async def update_project_node_state(
     partial_workbench_data: dict[str, Any] = {
         node_id: {"state": {"currentStatus": new_state}},
     }
-    if RunningState(new_state) in [
-        RunningState.PUBLISHED,
-        RunningState.PENDING,
-        RunningState.STARTED,
-    ]:
-        partial_workbench_data[node_id]["progress"] = 0
-    elif RunningState(new_state) in [RunningState.SUCCESS, RunningState.FAILED]:
-        partial_workbench_data[node_id]["progress"] = 100
 
-    db: ProjectDBAPI = app[APP_PROJECT_DBAPI]
-    updated_project, _ = await db.update_project_workbench(
-        partial_workbench_data=partial_workbench_data,
-        user_id=user_id,
-        project_uuid=project_id,
-    )
-    updated_project = await add_project_states_for_user(
-        user_id=user_id, project=updated_project, is_template=False, app=app
-    )
-    return updated_project
-
-
-async def update_project_node_progress(
-    app: web.Application, user_id: int, project_id: str, node_id: str, progress: float
-) -> dict | None:
-    log.debug(
-        "updating node %s progress in project %s for user %s with %s",
-        node_id,
-        project_id,
-        user_id,
-        progress,
-    )
-    partial_workbench_data = {
-        node_id: {"progress": int(100.0 * float(progress) + 0.5)},
-    }
     db: ProjectDBAPI = app[APP_PROJECT_DBAPI]
     updated_project, _ = await db.update_project_workbench(
         partial_workbench_data=partial_workbench_data,
@@ -880,6 +847,9 @@ async def add_project_states_for_user(
                     node_state.json(by_alias=True, exclude_unset=True)
                 )
                 prj_node.setdefault("state", {}).update(node_state_dict)
+                prj_node.update(
+                    {"progress": round(node_state_dict.get("progress", 0) * 100.0)}
+                )
 
     project["state"] = ProjectState(
         locked=lock_state, state=ProjectRunningState(value=running_state)

--- a/services/web/server/tests/integration/01/test_exporter.py
+++ b/services/web/server/tests/integration/01/test_exporter.py
@@ -105,6 +105,7 @@ KEYS_TO_IGNORE_FROM_COMPARISON = {
     "last_change_date",
     "runHash",  # this changes after import, but the runnable states should remain the same
     "eTag",  # this must change
+    "progress",  # this key is deprecated and removed
     REMAPPING_KEY,
 }
 
@@ -335,7 +336,6 @@ def dict_with_keys(dict_data: dict[str, Any], kept_keys: set[str]) -> dict[str, 
 def dict_without_keys(
     dict_data: dict[str, Any], skipped_keys: set[str]
 ) -> dict[str, Any]:
-
     modified_dict = {}
     for key, value in dict_data.items():
         if key not in skipped_keys:

--- a/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
+++ b/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
@@ -75,10 +75,10 @@ pytest_simcore_core_services_selection = [
 
 pytest_simcore_ops_services_selection = []
 
-_STABLE_DELAY_S = 3
+_STABLE_DELAY_S = 2
 
 
-async def _assert_no_handler_not_called(handler: mock.Mock) -> None:
+async def _assert_handler_not_called(handler: mock.Mock) -> None:
     with pytest.raises(RetryError):
         async for attempt in AsyncRetrying(
             retry=retry_always,
@@ -177,9 +177,6 @@ async def rabbitmq_publisher(
 
 @pytest.mark.parametrize("user_role", [UserRole.GUEST], ids=str)
 @pytest.mark.parametrize(
-    "project_hidden", [False, True], ids=lambda id: f"ProjectHidden={id}"
-)
-@pytest.mark.parametrize(
     "sender_same_user_id", [True, False], ids=lambda id: f"same_sender_id={id}"
 )
 @pytest.mark.parametrize(
@@ -195,8 +192,6 @@ async def test_log_workflow(
         [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
     ],
     mocker: MockerFixture,
-    project_hidden: bool,
-    aiopg_engine: aiopg.sa.Engine,
     sender_same_user_id: bool,
     subscribe_to_logs: bool,
 ):
@@ -205,14 +200,6 @@ async def test_log_workflow(
 
     """
     socket_io_conn = await socketio_client_factory(None, client)
-
-    if project_hidden:
-        async with aiopg_engine.acquire() as conn:
-            await conn.execute(
-                sa.update(projects)
-                .values(hidden=True)
-                .where(projects.c.uuid == user_project["uuid"])
-            )
 
     mock_log_handler = mocker.MagicMock()
     socket_io_conn.on(SOCKET_IO_LOG_EVENT, handler=mock_log_handler)
@@ -235,14 +222,14 @@ async def test_log_workflow(
     )
     await rabbitmq_publisher.publish(log_message.channel_name, log_message)
 
-    call_expected = not project_hidden and sender_same_user_id and subscribe_to_logs
+    call_expected = sender_same_user_id and subscribe_to_logs
     if call_expected:
         expected_call = jsonable_encoder(
             log_message, exclude={"user_id", "channel_name"}
         )
         await _assert_handler_called_with_json(mock_log_handler, expected_call)
     else:
-        await _assert_no_handler_not_called(mock_log_handler)
+        await _assert_handler_not_called(mock_log_handler)
 
 
 @pytest.mark.parametrize("user_role", [UserRole.GUEST], ids=str)
@@ -281,7 +268,7 @@ async def test_log_workflow_only_receives_messages_if_subscribed(
         mocked_send_messages,
         mock.call(
             client.app,
-            f"{log_message.user_id}",
+            log_message.user_id,
             [
                 {
                     "event_type": SOCKET_IO_LOG_EVENT,
@@ -294,13 +281,11 @@ async def test_log_workflow_only_receives_messages_if_subscribed(
 
     # when unsubscribed, we do not receive the messages anymore
     await project_logs.unsubscribe(client.app, project_id)
-    await _assert_no_handler_not_called(mocked_send_messages)
+    await rabbitmq_publisher.publish(log_message.channel_name, log_message)
+    await _assert_handler_not_called(mocked_send_messages)
 
 
 @pytest.mark.parametrize("user_role", [UserRole.GUEST], ids=str)
-@pytest.mark.parametrize(
-    "project_hidden", [False, True], ids=lambda id: f"ProjectHidden={id}"
-)
 @pytest.mark.parametrize(
     "progress_type",
     [p for p in ProgressType if p is not ProgressType.COMPUTATION_RUNNING],
@@ -322,7 +307,6 @@ async def test_progress_non_computational_workflow(
         [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
     ],
     mocker: MockerFixture,
-    project_hidden: bool,
     progress_type: ProgressType,
     sender_same_user_id: bool,
     subscribe_to_logs: bool,
@@ -338,8 +322,12 @@ async def test_progress_non_computational_workflow(
 
     random_node_id_in_project = NodeID(choice(list(user_project["workbench"])))
     sender_user_id = UserID(logged_user["id"])
+    project_id = ProjectID(user_project["uuid"])
     if sender_same_user_id is False:
         sender_user_id = UserID(faker.pyint(min_value=logged_user["id"] + 1))
+    if subscribe_to_logs:
+        assert client.app
+        await project_logs.subscribe(client.app, project_id)
     progress_message = ProgressRabbitMessageNode(
         user_id=sender_user_id,
         project_id=ProjectID(user_project["uuid"]),
@@ -349,20 +337,20 @@ async def test_progress_non_computational_workflow(
     )
     await rabbitmq_publisher.publish(progress_message.channel_name, progress_message)
 
-    call_expected = sender_same_user_id
+    call_expected = sender_same_user_id and subscribe_to_logs
     if call_expected:
         expected_call = jsonable_encoder(progress_message, exclude={"channel_name"})
         await _assert_handler_called_with_json(mock_progress_handler, expected_call)
     else:
-        await _assert_no_handler_not_called(mock_progress_handler)
+        await _assert_handler_not_called(mock_progress_handler)
 
 
 @pytest.mark.parametrize("user_role", [UserRole.GUEST], ids=str)
 @pytest.mark.parametrize(
-    "project_hidden", [False, True], ids=lambda id: f"ProjectHidden={id}"
+    "sender_same_user_id", [True, False], ids=lambda id: f"same_sender_id={id}"
 )
 @pytest.mark.parametrize(
-    "sender_same_user_id", [True, False], ids=lambda id: f"same_sender_id={id}"
+    "subscribe_to_logs", [True, False], ids=lambda id: f"subscribed={id}"
 )
 async def test_progress_computational_workflow(
     client: TestClient,
@@ -373,33 +361,28 @@ async def test_progress_computational_workflow(
         [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
     ],
     mocker: MockerFixture,
-    project_hidden: bool,
     aiopg_engine: aiopg.sa.Engine,
     sender_same_user_id: bool,
     faker: Faker,
+    subscribe_to_logs: bool,
 ):
     """
-    RabbitMQ --> Webserver -->  DB (progress update in Projects table)
-                                Redis --> webclient (socketio)
+    RabbitMQ (TOPIC) --> Webserver -->  DB (get project)
+                                        Redis --> webclient (socketio)
 
     """
     socket_io_conn = await socketio_client_factory(None, client)
 
     mock_progress_handler = mocker.MagicMock()
     socket_io_conn.on(SOCKET_IO_NODE_UPDATED_EVENT, handler=mock_progress_handler)
-
-    if project_hidden:
-        async with aiopg_engine.acquire() as conn:
-            await conn.execute(
-                sa.update(projects)
-                .values(hidden=True)
-                .where(projects.c.uuid == user_project["uuid"])
-            )
-
     random_node_id_in_project = NodeID(choice(list(user_project["workbench"])))
     sender_user_id = UserID(logged_user["id"])
+    project_id = ProjectID(user_project["uuid"])
     if sender_same_user_id is False:
         sender_user_id = UserID(faker.pyint(min_value=logged_user["id"] + 1))
+    if subscribe_to_logs:
+        assert client.app
+        await project_logs.subscribe(client.app, project_id)
     progress_message = ProgressRabbitMessageNode(
         user_id=sender_user_id,
         project_id=ProjectID(user_project["uuid"]),
@@ -409,7 +392,7 @@ async def test_progress_computational_workflow(
     )
     await rabbitmq_publisher.publish(progress_message.channel_name, progress_message)
 
-    call_expected = not project_hidden and sender_same_user_id
+    call_expected = sender_same_user_id and subscribe_to_logs
     if call_expected:
         expected_call = jsonable_encoder(
             progress_message, include={"node_id", "project_id"}
@@ -420,30 +403,23 @@ async def test_progress_computational_workflow(
         expected_call["data"]["progress"] = int(progress_message.progress * 100)
         await _assert_handler_called_with_json(mock_progress_handler, expected_call)
     else:
-        await _assert_no_handler_not_called(mock_progress_handler)
+        await _assert_handler_not_called(mock_progress_handler)
 
     # check the database. doing it after the waiting calls above is safe
     async with aiopg_engine.acquire() as conn:
         result = await conn.execute(
-            sa.select([projects.c.workbench]).where(
+            sa.select(projects.c.workbench).where(
                 projects.c.uuid == user_project["uuid"]
             )
         )
         row = await result.fetchone()
         assert row
         project_workbench = dict(row[projects.c.workbench])
-    if sender_same_user_id:
-        assert project_workbench[f"{random_node_id_in_project}"]["progress"] == int(
-            progress_message.progress * 100
-        )
-    else:
-        assert project_workbench[f"{random_node_id_in_project}"]["progress"] == 0
+        # NOTE: the progress might still be present but is not used anymore
+        assert project_workbench[f"{random_node_id_in_project}"].get("progress", 0) == 0
 
 
 @pytest.mark.parametrize("user_role", [UserRole.GUEST], ids=str)
-@pytest.mark.parametrize(
-    "project_hidden", [False, True], ids=lambda id: f"ProjectHidden={id}"
-)
 @pytest.mark.parametrize("metrics_name", ["service_started", "service_stopped"])
 async def test_instrumentation_workflow(
     client: TestClient,
@@ -451,8 +427,6 @@ async def test_instrumentation_workflow(
     logged_user: UserInfoDict,
     user_project: ProjectDict,
     mocker: MockerFixture,
-    project_hidden: bool,
-    aiopg_engine: aiopg.sa.Engine,
     faker: Faker,
     metrics_name: str,
 ):
@@ -464,13 +438,6 @@ async def test_instrumentation_workflow(
     mocked_metrics_method = mocker.patch(
         f"simcore_service_webserver.notifications._rabbitmq_consumers.{metrics_name}"
     )
-    if project_hidden:
-        async with aiopg_engine.acquire() as conn:
-            await conn.execute(
-                sa.update(projects)
-                .values(hidden=True)
-                .where(projects.c.uuid == user_project["uuid"])
-            )
 
     random_node_id_in_project = NodeID(choice(list(user_project["workbench"])))
     rabbit_message = InstrumentationRabbitMessage(
@@ -501,9 +468,6 @@ async def test_instrumentation_workflow(
 
 @pytest.mark.parametrize("user_role", [UserRole.GUEST], ids=str)
 @pytest.mark.parametrize(
-    "project_hidden", [False, True], ids=lambda id: f"ProjectHidden={id}"
-)
-@pytest.mark.parametrize(
     "sender_same_user_id", [True, False], ids=lambda id: f"same_sender_id={id}"
 )
 async def test_event_workflow(
@@ -515,8 +479,6 @@ async def test_event_workflow(
         [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
     ],
     mocker: MockerFixture,
-    project_hidden: bool,
-    aiopg_engine: aiopg.sa.Engine,
     sender_same_user_id: bool,
     faker: Faker,
 ):
@@ -525,15 +487,6 @@ async def test_event_workflow(
 
     """
     socket_io_conn = await socketio_client_factory(None, client)
-
-    if project_hidden:
-        async with aiopg_engine.acquire() as conn:
-            await conn.execute(
-                sa.update(projects)
-                .values(hidden=True)
-                .where(projects.c.uuid == user_project["uuid"])
-            )
-
     mock_event_handler = mocker.MagicMock()
     socket_io_conn.on(SOCKET_IO_EVENT, handler=mock_event_handler)
 
@@ -555,4 +508,4 @@ async def test_event_workflow(
         expected_call = jsonable_encoder(rabbit_message, include={"action", "node_id"})
         await _assert_handler_called_with_json(mock_event_handler, expected_call)
     else:
-        await _assert_no_handler_not_called(mock_event_handler)
+        await _assert_handler_not_called(mock_event_handler)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?
- [x] webserver does not anymore update the progress in the projects table
- [x] webserver only transfer the progress update to the connected client if needed


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
