### PR TITLE
Maintenance/upgrade aio pika

### DIFF
--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==9.0.7
+aio-pika==9.1.2
     # via -r requirements/_base.in
 aiodebug==2.3.0
     # via -r requirements/_base.in

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -4,18 +4,22 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==9.0.7
+aio-pika==9.1.2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.12.1
     # via -r requirements/_base.in
 aiodebug==2.3.0
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+aiodocker==0.21.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiofiles==23.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
 aiohttp==3.8.4
-    # via -r requirements/_base.in
+    # via
+    #   -r requirements/_base.in
+    #   aiodocker
 aiopg==1.4.0
     # via -r requirements/_base.in
 aiormq==6.7.6
@@ -119,6 +123,7 @@ typer==0.9.0
 typing-extensions==4.5.0
     # via
     #   aiodebug
+    #   aiodocker
     #   alembic
     #   pydantic
     #   typer

--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -4,19 +4,21 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==8.2.5
+aio-pika==9.1.2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiodebug==2.3.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiodocker==0.21.0
-    # via -r requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
 aiofiles==22.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiohttp==3.8.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
     #   aiodocker
-aiormq==6.4.2
+aiormq==6.7.6
     # via aio-pika
 aiosignal==1.2.0
     # via aiohttp
@@ -108,7 +110,7 @@ typing-extensions==4.4.0
     #   pydantic
 uvicorn==0.19.0
     # via -r requirements/_base.in
-yarl==1.8.1
+yarl==1.9.2
     # via
     #   aio-pika
     #   aiohttp

--- a/services/agent/requirements/_test.txt
+++ b/services/agent/requirements/_test.txt
@@ -275,7 +275,7 @@ wrapt==1.15.0
     #   aws-xray-sdk
 xmltodict==0.13.0
     # via moto
-yarl==1.8.1
+yarl==1.9.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -4,13 +4,15 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==8.2.5
-    # via
-    #   -c requirements/../../../packages/service-library/requirements/./_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+aio-pika==9.1.2
+    # via -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.11.1
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 aiodebug==2.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+aiodocker==0.21.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -22,11 +24,12 @@ aiohttp==3.8.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
+    #   aiodocker
 aiopg==1.4.0
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-aiormq==6.4.2
+aiormq==6.7.6
     # via aio-pika
 aiosignal==1.2.0
     # via aiohttp
@@ -213,6 +216,7 @@ typer==0.4.1
 typing-extensions==4.3.0
     # via
     #   aiodebug
+    #   aiodocker
     #   pydantic
 ujson==5.5.0
     # via
@@ -232,7 +236,7 @@ watchgod==0.8.2
     # via uvicorn
 websockets==10.2
     # via uvicorn
-yarl==1.7.2
+yarl==1.9.2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -4,10 +4,8 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==9.0.4
-    # via
-    #   -c requirements/../../../packages/service-library/requirements/./_base.in
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aio-pika==9.1.2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 aioboto3==10.4.0
     # via -r requirements/_base.in
 aiobotocore==2.4.2
@@ -17,7 +15,9 @@ aiodebug==2.3.0
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 aiodocker==0.21.0
-    # via -r requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
 aiofiles==23.1.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
@@ -29,7 +29,7 @@ aiohttp==3.8.4
     #   aiodocker
 aioitertools==0.11.0
     # via aiobotocore
-aiormq==6.7.2
+aiormq==6.7.6
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
@@ -178,7 +178,7 @@ uvicorn==0.20.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 wrapt==1.14.1
     # via aiobotocore
-yarl==1.8.2
+yarl==1.9.2
     # via
     #   aio-pika
     #   aiohttp

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -4,13 +4,15 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==8.2.5
-    # via
-    #   -c requirements/../../../packages/service-library/requirements/./_base.in
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aio-pika==9.1.2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.11.1
     # via -r requirements/_base.in
 aiodebug==2.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aiodocker==0.21.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -18,10 +20,16 @@ aiofiles==0.8.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
+aiohttp==3.8.4
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   aiodocker
 aioredis==2.0.1
     # via aiocache
-aiormq==6.4.2
+aiormq==6.7.6
     # via aio-pika
+aiosignal==1.3.1
+    # via aiohttp
 alembic==1.8.1
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
 anyio==3.6.2
@@ -37,6 +45,7 @@ asgiref==3.5.2
     # via uvicorn
 async-timeout==4.0.2
     # via
+    #   aiohttp
     #   aioredis
     #   redis
 asyncpg==0.27.0
@@ -44,6 +53,7 @@ asyncpg==0.27.0
 attrs==21.4.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
+    #   aiohttp
     #   jsonschema
 certifi==2022.12.7
     # via
@@ -51,7 +61,9 @@ certifi==2022.12.7
     #   httpx
     #   requests
 charset-normalizer==2.0.12
-    # via requests
+    # via
+    #   aiohttp
+    #   requests
 click==8.1.3
     # via
     #   typer
@@ -66,6 +78,10 @@ fastapi==0.85.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
+frozenlist==1.3.3
+    # via
+    #   aiohttp
+    #   aiosignal
 greenlet==2.0.2
     # via sqlalchemy
 h11==0.12.0
@@ -108,7 +124,9 @@ markupsafe==2.1.1
 msgpack==1.0.3
     # via aiocache
 multidict==6.0.2
-    # via yarl
+    # via
+    #   aiohttp
+    #   yarl
 orjson==3.7.2
     # via fastapi
 packaging==21.3
@@ -180,6 +198,7 @@ typer==0.4.1
 typing-extensions==4.3.0
     # via
     #   aiodebug
+    #   aiodocker
     #   aioredis
     #   pydantic
 ujson==5.5.0
@@ -200,10 +219,11 @@ watchgod==0.8.2
     # via uvicorn
 websockets==10.1
     # via uvicorn
-yarl==1.7.2
+yarl==1.9.2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   aio-pika
+    #   aiohttp
     #   aiormq
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -6,10 +6,12 @@
 #
 aiohttp==3.8.4
     # via
-    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   pytest-aiohttp
 aiosignal==1.3.1
-    # via aiohttp
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 alembic==1.8.1
     # via -r requirements/_test.in
 anyio==3.6.2
@@ -49,6 +51,7 @@ faker==18.7.0
     # via -r requirements/_test.in
 frozenlist==1.3.3
     # via
+    #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
 greenlet==2.0.2
@@ -181,7 +184,7 @@ urllib3==1.26.9
     #   requests
 websocket-client==1.5.1
     # via docker
-yarl==1.7.2
+yarl==1.9.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -4,14 +4,16 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==9.0.7
+aio-pika==9.1.2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiobotocore==2.5.0
     # via s3fs
 aiodebug==2.3.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiodocker==0.21.0
-    # via -r requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
 aiofiles==23.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -4,13 +4,15 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==8.2.5
-    # via
-    #   -c requirements/../../../packages/service-library/requirements/./_base.in
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aio-pika==9.1.2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.11.1
     # via -r requirements/_base.in
 aiodebug==2.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aiodocker==0.21.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -18,8 +20,14 @@ aiofiles==22.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiormq==6.4.2
+aiohttp==3.8.4
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   aiodocker
+aiormq==6.7.6
     # via aio-pika
+aiosignal==1.3.1
+    # via aiohttp
 anyio==3.6.2
     # via
     #   httpcore
@@ -30,10 +38,13 @@ arrow==1.2.3
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
 async-timeout==4.0.2
-    # via redis
+    # via
+    #   aiohttp
+    #   redis
 attrs==21.4.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
+    #   aiohttp
     #   jsonschema
 boto3==1.24.96
     # via -r requirements/_base.in
@@ -45,6 +56,8 @@ certifi==2022.12.7
     # via
     #   httpcore
     #   httpx
+charset-normalizer==3.1.0
+    # via aiohttp
 click==8.1.3
     # via
     #   typer
@@ -60,6 +73,10 @@ fastapi==0.85.1
     #   fastapi-pagination
 fastapi-pagination==0.10.0
     # via -r requirements/_base.in
+frozenlist==1.3.3
+    # via
+    #   aiohttp
+    #   aiosignal
 h11==0.12.0
     # via
     #   httpcore
@@ -93,7 +110,9 @@ jsonschema==3.2.0
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
 multidict==6.0.3
-    # via yarl
+    # via
+    #   aiohttp
+    #   yarl
 pamqp==3.2.1
     # via aiormq
 pydantic==1.10.2
@@ -152,6 +171,7 @@ typer==0.6.1
 typing-extensions==4.4.0
     # via
     #   aiodebug
+    #   aiodocker
     #   pydantic
 urllib3==1.26.12
     # via
@@ -167,9 +187,10 @@ watchfiles==0.18.0
     # via uvicorn
 websockets==10.3
     # via uvicorn
-yarl==1.8.2
+yarl==1.9.2
     # via
     #   aio-pika
+    #   aiohttp
     #   aiormq
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/datcore-adapter/requirements/_test.txt
+++ b/services/datcore-adapter/requirements/_test.txt
@@ -17,7 +17,9 @@ certifi==2022.12.7
     #   httpx
     #   requests
 charset-normalizer==3.1.0
-    # via requests
+    # via
+    #   -c requirements/_base.txt
+    #   requests
 coverage==7.2.5
     # via
     #   -r requirements/_test.in

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -4,10 +4,8 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==8.2.4
-    # via
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/_base.in
+aio-pika==9.1.2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.11.1
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
@@ -17,7 +15,9 @@ aiodebug==2.3.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 aiodocker==0.19.1
-    # via -r requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
 aiofiles==0.8.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -33,7 +33,7 @@ aiopg==1.4.0
     #   -r requirements/_base.in
 aioredis==2.0.1
     # via aiocache
-aiormq==6.4.2
+aiormq==6.7.6
     # via aio-pika
 aiosignal==1.2.0
     # via aiohttp
@@ -91,6 +91,7 @@ commonmark==0.9.1
     # via rich
 dask==2023.3.2
     # via
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask-gateway
     #   distributed
@@ -324,7 +325,7 @@ watchgod==0.8.2
     # via uvicorn
 websockets==10.1
     # via uvicorn
-yarl==1.7.2
+yarl==1.9.2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --resolver=backtracking --strip-extras requirements/_test.in
 #
-aio-pika==8.2.4
+aio-pika==9.1.2
     # via -r requirements/_test.in
 aioboto3==11.2.0
     # via -r requirements/_test.in
@@ -18,7 +18,7 @@ aiohttp==3.8.3
     #   pytest-aiohttp
 aioitertools==0.11.0
     # via aiobotocore
-aiormq==6.4.2
+aiormq==6.7.6
     # via
     #   -c requirements/_base.txt
     #   aio-pika
@@ -344,7 +344,7 @@ wrapt==1.15.0
     # via
     #   aiobotocore
     #   astroid
-yarl==1.7.2
+yarl==1.9.2
     # via
     #   -c requirements/_base.txt
     #   aio-pika

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -4,10 +4,8 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==8.2.4
-    # via
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/_base.in
+aio-pika==9.1.2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.11.1
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 aiodebug==2.3.0
@@ -15,7 +13,9 @@ aiodebug==2.3.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 aiodocker==0.19.1
-    # via -r requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
 aiofiles==0.8.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -28,7 +28,7 @@ aiopg==1.4.0
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 aioprocessing==2.0.1
     # via -r requirements/_base.in
-aiormq==6.4.2
+aiormq==6.7.6
     # via aio-pika
 aiosignal==1.2.0
     # via aiohttp
@@ -41,7 +41,9 @@ anyio==3.6.2
     #   httpcore
     #   starlette
 arrow==1.2.3
-    # via -r requirements/../../../packages/models-library/requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/_base.in
 asgiref==3.5.2
     # via uvicorn
 async-timeout==4.0.2
@@ -244,7 +246,7 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-yarl==1.7.2
+yarl==1.9.2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -4,11 +4,13 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==8.3.0
+aio-pika==9.1.2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+aiodebug==2.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiodebug==2.3.0
+aiodocker==0.21.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -16,8 +18,14 @@ aiofiles==22.1.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiormq==6.6.4
+aiohttp==3.8.4
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   aiodocker
+aiormq==6.7.6
     # via aio-pika
+aiosignal==1.3.1
+    # via aiohttp
 anyio==3.6.2
     # via
     #   httpcore
@@ -28,10 +36,13 @@ arrow==1.2.3
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
 async-timeout==4.0.2
-    # via redis
+    # via
+    #   aiohttp
+    #   redis
 attrs==21.4.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
+    #   aiohttp
     #   jsonschema
 certifi==2022.12.7
     # via
@@ -39,6 +50,8 @@ certifi==2022.12.7
     #   httpx
 cffi==1.15.1
     # via cryptography
+charset-normalizer==3.1.0
+    # via aiohttp
 click==8.1.3
     # via
     #   typer
@@ -57,6 +70,10 @@ fastapi==0.89.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
+frozenlist==1.3.3
+    # via
+    #   aiohttp
+    #   aiosignal
 h11==0.14.0
     # via
     #   httpcore
@@ -78,7 +95,9 @@ jsonschema==3.2.0
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
 multidict==6.0.4
-    # via yarl
+    # via
+    #   aiohttp
+    #   yarl
 packaging==23.0
     # via -r requirements/_base.in
 pamqp==3.2.1
@@ -141,6 +160,7 @@ typer==0.7.0
 typing-extensions==4.4.0
     # via
     #   aiodebug
+    #   aiodocker
     #   pydantic
 uvicorn==0.20.0
     # via
@@ -152,9 +172,10 @@ watchfiles==0.18.1
     # via uvicorn
 websockets==10.4
     # via uvicorn
-yarl==1.8.2
+yarl==1.9.2
     # via
     #   aio-pika
+    #   aiohttp
     #   aiormq
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -4,11 +4,13 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==9.0.7
+aio-pika==9.1.2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+aiodebug==2.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiodebug==2.3.0
+aiodocker==0.21.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -16,8 +18,14 @@ aiofiles==23.1.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
+aiohttp==3.8.4
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   aiodocker
 aiormq==6.7.6
     # via aio-pika
+aiosignal==1.3.1
+    # via aiohttp
 anyio==3.6.2
     # via
     #   httpcore
@@ -26,12 +34,15 @@ anyio==3.6.2
 arrow==1.2.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
 async-timeout==4.0.2
-    # via redis
+    # via
+    #   aiohttp
+    #   redis
 attrs==21.4.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
+    #   aiohttp
     #   jsonschema
 certifi==2023.5.7
     # via
@@ -39,7 +50,9 @@ certifi==2023.5.7
     #   httpx
     #   requests
 charset-normalizer==3.1.0
-    # via requests
+    # via
+    #   aiohttp
+    #   requests
 click==8.1.3
     # via
     #   typer
@@ -62,6 +75,10 @@ fastapi==0.95.2
     #   -r requirements/_base.in
 fonttools==4.39.4
     # via matplotlib
+frozenlist==1.3.3
+    # via
+    #   aiohttp
+    #   aiosignal
 h11==0.14.0
     # via
     #   httpcore
@@ -94,7 +111,9 @@ matplotlib==3.7.1
 mdurl==0.1.2
     # via markdown-it-py
 multidict==6.0.4
-    # via yarl
+    # via
+    #   aiohttp
+    #   yarl
 numpy==1.24.3
     # via
     #   contourpy
@@ -185,6 +204,7 @@ typer==0.9.0
 typing-extensions==4.5.0
     # via
     #   aiodebug
+    #   aiodocker
     #   pydantic
     #   typer
 tzdata==2023.3
@@ -208,6 +228,7 @@ websockets==11.0.3
 yarl==1.9.2
     # via
     #   aio-pika
+    #   aiohttp
     #   aiormq
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -4,10 +4,8 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==8.2.5
-    # via
-    #   -c requirements/../../../packages/service-library/requirements/./_base.in
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aio-pika==9.1.2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 aioboto3==9.6.0
     # via -r requirements/_base.in
 aiobotocore==2.3.0
@@ -15,6 +13,10 @@ aiobotocore==2.3.0
     #   aioboto3
     #   types-aiobotocore
 aiodebug==2.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aiodocker==0.21.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -27,6 +29,7 @@ aiohttp==3.8.3
     #   -r requirements/../../../packages/service-library/requirements/_aiohttp.in
     #   -r requirements/_base.in
     #   aiobotocore
+    #   aiodocker
     #   aiohttp-swagger
     #   aiozipkin
 aiohttp-swagger==1.0.16
@@ -37,7 +40,7 @@ aiopg==1.4.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_aiohttp.in
     #   -r requirements/_base.in
-aiormq==6.4.2
+aiormq==6.7.6
     # via aio-pika
 aiosignal==1.2.0
     # via aiohttp
@@ -195,6 +198,7 @@ types-aiobotocore-s3==2.3.3
 typing-extensions==4.3.0
     # via
     #   aiodebug
+    #   aiodocker
     #   botocore-stubs
     #   pydantic
     #   types-aiobotocore
@@ -211,7 +215,7 @@ werkzeug==2.2.2
     # via -r requirements/../../../packages/service-library/requirements/_aiohttp.in
 wrapt==1.14.1
     # via aiobotocore
-yarl==1.7.2
+yarl==1.9.2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   aio-pika

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -315,7 +315,7 @@ wrapt==1.14.1
     #   aws-xray-sdk
 xmltodict==0.13.0
     # via moto
-yarl==1.7.2
+yarl==1.9.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -4,16 +4,18 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --resolver=backtracking --strip-extras requirements/_base.in
 #
-aio-pika==8.2.4
-    # via
-    #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/_base.in
+aio-pika==9.1.2
+    # via -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.11.1
     # via -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
 aiodebug==2.3.0
     # via
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
+aiodocker==0.21.0
+    # via
+    #   -c requirements/../../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 aiofiles==0.8.0
     # via
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -22,6 +24,7 @@ aiohttp==3.8.3
     # via
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
+    #   aiodocker
     #   aiohttp-jinja2
     #   aiohttp-security
     #   aiohttp-session
@@ -39,7 +42,7 @@ aiopg==1.4.0
     # via
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-aiormq==6.4.2
+aiormq==6.7.6
     # via aio-pika
 aiosignal==1.2.0
     # via aiohttp
@@ -241,6 +244,7 @@ typer==0.4.1
 typing-extensions==4.3.0
     # via
     #   aiodebug
+    #   aiodocker
     #   pydantic
 ujson==5.5.0
     # via

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -4,10 +4,8 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --resolver=backtracking --strip-extras requirements/_test.in
 #
-aio-pika==9.0.7
-    # via
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/_test.in
+aio-pika==9.1.2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.12.1
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 aiodebug==2.3.0
@@ -15,7 +13,9 @@ aiodebug==2.3.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 aiodocker==0.21.0
-    # via -r requirements/_test.in
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_test.in
 aiofiles==23.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 4
- #packages after : 9

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 8.2.4, 8.3.0, 9.0.7, 8.2.5, 9.0.4 | 9.1.2      | *minor*    | 11 | agent⬆️</br>autoscaling⬆️</br>catalog⬆️</br>dask-sidecar⬆️</br>director-v2⬆️🧪</br>invitations⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>web⬆️ |
|   2 | aiodebug                  | 2.3.0           | 2.3.0      |            | 2 | invitations⬆️</br>resource-usage-tracker⬆️ |
|   3 | aiormq                    | 6.6.4, 6.4.2, 6.7.2 | 6.7.6      |            | 7 | agent⬆️</br>autoscaling⬆️</br>catalog⬆️</br>director-v2⬆️🧪</br>invitations⬆️</br>web⬆️ |
|   4 | yarl                      | 1.8.2, 1.7.2, 1.8.1 | 1.9.2      | *minor*    | 8 | agent⬆️🧪</br>autoscaling⬆️</br>catalog⬆️🧪</br>director-v2⬆️🧪</br>invitations⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 76

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.1.2                     | 9.1.2                     |                           |
|   2 | aioboto3                  | 9.6.0, 10.4.0             | 9.6.0, 11.2.0             |                           |
|   3 | aiobotocore               | 2.3.0, 2.4.2, 2.5.0       | 2.3.0, 2.5.0              |                           |
|   4 | aiocache                  | 0.11.1, 0.12.1            | 0.12.1                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.19.1, 0.21.0            | 0.21.0                    |                           |
|   7 | aiofiles                  | 0.8.0, 22.1.0, 23.1.0     | 23.1.0                    |                           |
|   8 | aiohttp                   | 3.8.3, 3.8.4              | 3.8.3, 3.8.4              |                           |
|   9 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  10 | aiohttp-security          | 0.4.0                     |                           |                           |
|  11 | aiohttp-session           | 2.11.0                    |                           |                           |
|  12 | aiohttp-swagger           | 1.0.16                    |                           |                           |
|  13 | aioitertools              | 0.10.0, 0.11.0            | 0.11.0                    |                           |
|  14 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  15 | aioprocessing             | 2.0.1                     |                           |                           |
|  16 | aioredis                  | 2.0.1                     |                           |                           |
|  17 | aioresponses              |                           | 0.7.4                     |                           |
|  18 | aiormq                    | 6.7.6                     | 6.7.6                     |                           |
|  19 | aiosignal                 | 1.2.0, 1.3.1              | 1.2.0, 1.3.1              |                           |
|  20 | aiosmtplib                | 1.1.6                     |                           |                           |
|  21 | aiozipkin                 | 1.1.1                     |                           |                           |
|  22 | alembic                   | 1.8.1, 1.10.4             | 1.8.1, 1.10.4             |                           |
|  23 | anyio                     | 3.6.2                     | 3.6.2                     |                           |
|  24 | arrow                     | 1.2.3                     | 1.2.3                     |                           |
|  25 | asgi-lifespan             |                           | 2.1.0                     |                           |
|  26 | asgiref                   | 3.5.2                     |                           |                           |
|  27 | astroid                   |                           | 2.15.5                    | 2.15.5                    |
|  28 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  29 | async-timeout             | 4.0.2                     | 4.0.2                     |                           |
|  30 | asyncpg                   | 0.27.0                    |                           |                           |
|  31 | attrs                     | 21.4.0, 23.1.0            | 21.4.0, 23.1.0            |                           |
|  32 | aws-sam-translator        |                           | 1.55.0, 1.66.0, 1.67.0    |                           |
|  33 | aws-xray-sdk              |                           | 2.12.0                    |                           |
|  34 | bcrypt                    | 3.2.0                     |                           |                           |
|  35 | bidict                    | 0.22.0                    |                           |                           |
|  36 | black                     |                           |                           | 22.12.0, 23.3.0           |
|  37 | blinker                   |                           | 1.6.2                     |                           |
|  38 | blosc                     | 1.11.1                    |                           |                           |
|  39 | bokeh                     | 2.4.3                     | 2.4.3                     |                           |
|  40 | boto3                     | 1.21.21, 1.24.59, 1.24.96 | 1.21.21, 1.24.59, 1.26.76, 1.26.133 |                           |
|  41 | boto3-stubs               |                           | 1.26.133                  |                           |
|  42 | botocore                  | 1.24.21, 1.27.59, 1.27.96, 1.29.76 | 1.24.21, 1.27.59, 1.29.76, 1.29.133 |                           |
|  43 | botocore-stubs            | 1.27.17, 1.29.78          | 1.29.130                  |                           |
|  44 | build                     |                           |                           | 0.10.0                    |
|  45 | bump2version              |                           |                           | 1.0.1                     |
|  46 | certifi                   | 2022.12.7, 2023.5.7       | 2022.12.7, 2023.5.7       |                           |
|  47 | cffi                      | 1.15.0, 1.15.1            | 1.15.0, 1.15.1            |                           |
|  48 | cfgv                      |                           |                           | 3.3.1                     |
|  49 | cfn-lint                  |                           | 0.72.0, 0.72.6, 0.77.5    |                           |
|  50 | change-case               |                           |                           | 0.5.2                     |
|  51 | charset-normalizer        | 2.0.12, 2.1.1, 3.0.1, 3.1.0 | 2.0.12, 2.1.1, 3.0.1, 3.1.0 |                           |
|  52 | click                     | 8.1.3                     | 8.1.3                     | 8.1.3                     |
|  53 | cloudpickle               | 2.2.1                     | 2.2.1                     |                           |
|  54 | colorama                  | 0.4.6                     |                           |                           |
|  55 | colorlog                  | 6.7.0                     | 6.7.0                     |                           |
|  56 | commonmark                | 0.9.1                     |                           |                           |
|  57 | contourpy                 | 1.0.7                     |                           |                           |
|  58 | coverage                  |                           | 7.2.5, 7.2.6              |                           |
|  59 | cryptography              | 39.0.1, 40.0.2            | 39.0.1, 40.0.2            |                           |
|  60 | cycler                    | 0.11.0                    |                           |                           |
|  61 | dask                      | 2023.3.2, 2023.5.0        | 2023.3.2                  |                           |
|  62 | dask-gateway              | 2023.1.1                  | 2023.1.1                  |                           |
|  63 | dask-gateway-server       | 2023.1.1                  | 2023.1.1                  |                           |
|  64 | dateparser                | 1.1.8                     |                           |                           |
|  65 | debugpy                   |                           | 1.6.7                     |                           |
|  66 | decorator                 | 4.4.2                     |                           |                           |
|  67 | deepdiff                  |                           | 6.3.0                     |                           |
|  68 | dill                      |                           | 0.3.6                     | 0.3.6                     |
|  69 | distlib                   |                           |                           | 0.3.6                     |
|  70 | distributed               | 2023.3.2, 2023.5.0        | 2023.3.2                  |                           |
|  71 | distro                    | 1.5.0                     |                           |                           |
|  72 | dnspython                 | 2.1.0, 2.2.1, 2.3.0       | 2.3.0                     |                           |
|  73 | docker                    | 6.0.0, 6.1.2              | 6.1.2                     |                           |
|  74 | docker-compose            | 1.29.1                    |                           |                           |
|  75 | dockerpty                 | 0.4.1                     |                           |                           |
|  76 | docopt                    | 0.6.2                     |                           |                           |
|  77 | ecdsa                     |                           | 0.18.0                    |                           |
|  78 | email-validator           | 1.2.1, 1.3.0, 1.3.1, 2.0.0.post2 | 2.0.0.post2               |                           |
|  79 | et-xmlfile                | 1.1.0                     |                           |                           |
|  80 | exceptiongroup            | 1.1.1                     | 1.1.1                     |                           |
|  81 | execnet                   |                           | 1.9.0                     |                           |
|  82 | expiringdict              | 1.2.1                     |                           |                           |
|  83 | faker                     |                           | 18.7.0, 18.9.0            |                           |
|  84 | fakeredis                 |                           | 2.12.1                    |                           |
|  85 | fastapi                   | 0.85.0, 0.85.1, 0.85.2, 0.89.1, 0.90.1, 0.95.2 |                           |                           |
|  86 | fastapi-pagination        | 0.10.0                    |                           |                           |
|  87 | filelock                  |                           |                           | 3.12.0                    |
|  88 | flaky                     |                           | 3.7.0                     |                           |
|  89 | flask                     |                           | 2.1.3, 2.2.5, 2.3.2       |                           |
|  90 | flask-cors                |                           | 3.0.10                    |                           |
|  91 | fonttools                 | 4.39.4                    |                           |                           |
|  92 | frozenlist                | 1.3.0, 1.3.1, 1.3.3       | 1.3.0, 1.3.1, 1.3.3       |                           |
|  93 | fsspec                    | 2023.5.0                  | 2023.5.0                  |                           |
|  94 | graphql-core              |                           | 3.2.3                     |                           |
|  95 | greenlet                  | 2.0.2                     | 2.0.2                     |                           |
|  96 | gunicorn                  | 20.1.0                    |                           |                           |
|  97 | h11                       | 0.12.0, 0.14.0            | 0.12.0, 0.14.0            |                           |
|  98 | h2                        | 4.1.0                     |                           |                           |
|  99 | hpack                     | 4.0.0                     |                           |                           |
| 100 | httmock                   | 1.4.0                     |                           |                           |
| 101 | httpcore                  | 0.15.0, 0.16.3, 0.17.1    | 0.15.0, 0.16.3, 0.17.0, 0.17.1 |                           |
| 102 | httptools                 | 0.2.0, 0.5.0              |                           |                           |
| 103 | httpx                     | 0.24.0, 0.24.1            | 0.24.0, 0.24.1            |                           |
| 104 | hyperframe                | 6.0.1                     |                           |                           |
| 105 | hypothesis                |                           | 6.75.3                    |                           |
| 106 | icdiff                    |                           | 2.0.6                     |                           |
| 107 | identify                  |                           |                           | 2.5.24                    |
| 108 | idna                      | 2.10, 3.3, 3.4            | 2.10, 3.3, 3.4            |                           |
| 109 | importlib-metadata        | 6.6.0                     | 6.6.0                     |                           |
| 110 | iniconfig                 | 2.0.0                     | 2.0.0                     |                           |
| 111 | inotify                   |                           |                           | 0.2.10                    |
| 112 | isodate                   | 0.6.1                     |                           |                           |
| 113 | isort                     |                           | 5.12.0                    | 5.12.0                    |
| 114 | itsdangerous              | 1.1.0, 2.1.2              | 2.1.2                     |                           |
| 115 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 116 | jinja2                    | 3.1.2                     | 3.1.2                     | 3.1.2                     |
| 117 | jmespath                  | 1.0.0, 1.0.1              | 1.0.0, 1.0.1              |                           |
| 118 | jschema-to-python         |                           | 1.2.3                     |                           |
| 119 | json2html                 | 1.3.0                     |                           |                           |
| 120 | jsondiff                  | 2.0.0                     | 2.0.0                     |                           |
| 121 | jsonpatch                 |                           | 1.32                      |                           |
| 122 | jsonpickle                |                           | 3.0.1                     |                           |
| 123 | jsonpointer               |                           | 2.3                       |                           |
| 124 | jsonschema                | 3.2.0, 4.17.3             | 3.2.0, 4.17.3             |                           |
| 125 | junit-xml                 |                           | 1.9                       |                           |
| 126 | kiwisolver                | 1.4.4                     |                           |                           |
| 127 | lazy-object-proxy         | 1.7.1                     | 1.9.0                     | 1.7.1, 1.9.0              |
| 128 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 129 | lupa                      |                           | 1.14.1                    |                           |
| 130 | lz4                       | 4.3.2                     | 4.3.2                     |                           |
| 131 | mako                      | 1.2.2, 1.2.4              | 1.2.2, 1.2.4              |                           |
| 132 | markdown-it-py            | 2.2.0                     |                           |                           |
| 133 | markupsafe                | 2.1.1, 2.1.2              | 2.1.1, 2.1.2              | 2.1.1                     |
| 134 | matplotlib                | 3.7.1                     |                           |                           |
| 135 | mccabe                    |                           | 0.7.0                     | 0.7.0                     |
| 136 | mdurl                     | 0.1.2                     |                           |                           |
| 137 | minio                     |                           | 7.0.4                     |                           |
| 138 | moto                      |                           | 4.0.1, 4.1.9, 4.1.10      |                           |
| 139 | mpmath                    |                           | 1.3.0                     |                           |
| 140 | msgpack                   | 1.0.3, 1.0.5              | 1.0.5                     |                           |
| 141 | multidict                 | 6.0.2, 6.0.3, 6.0.4       | 6.0.2, 6.0.4              |                           |
| 142 | mypy                      |                           | 1.3.0                     |                           |
| 143 | mypy-extensions           |                           | 1.0.0                     | 1.0.0                     |
| 144 | networkx                  | 2.5.1                     | 2.8.8, 3.1                |                           |
| 145 | nodeenv                   |                           |                           | 1.8.0                     |
| 146 | nose                      |                           |                           | 1.3.7                     |
| 147 | numpy                     | 1.24.3                    | 1.24.3                    |                           |
| 148 | openapi-core              | 0.12.0                    |                           |                           |
| 149 | openapi-schema-validator  | 0.2.3                     | 0.2.3                     |                           |
| 150 | openapi-spec-validator    | 0.4.0                     | 0.4.0                     |                           |
| 151 | openpyxl                  | 3.0.9                     |                           |                           |
| 152 | ordered-set               | 4.1.0                     | 4.1.0                     |                           |
| 153 | orjson                    | 3.7.2                     |                           |                           |
| 154 | packaging                 | 21.3, 23.0, 23.1          | 21.3, 23.0, 23.1          | 21.3, 23.0, 23.1          |
| 155 | pamqp                     | 3.2.1                     | 3.2.1                     |                           |
| 156 | pandas                    | 2.0.1                     | 2.0.1                     |                           |
| 157 | paramiko                  | 2.11.0                    |                           |                           |
| 158 | partd                     | 1.4.0                     | 1.4.0                     |                           |
| 159 | passlib                   | 1.7.4                     |                           |                           |
| 160 | pathspec                  |                           |                           | 0.11.1                    |
| 161 | pbr                       |                           | 5.11.1                    |                           |
| 162 | pillow                    | 9.5.0                     | 9.5.0                     |                           |
| 163 | pint                      | 0.19.2, 0.21              | 0.21                      |                           |
| 164 | pip-tools                 |                           |                           | 6.13.0                    |
| 165 | platformdirs              |                           | 3.5.1                     | 3.5.1                     |
| 166 | pluggy                    | 1.0.0                     | 1.0.0                     |                           |
| 167 | pprintpp                  |                           | 0.4.0                     |                           |
| 168 | pre-commit                |                           |                           | 3.3.1, 3.3.2              |
| 169 | prometheus-api-client     | 0.5.3                     |                           |                           |
| 170 | prometheus-client         | 0.14.1                    |                           |                           |
| 171 | psutil                    | 5.9.1, 5.9.5              | 5.9.5                     |                           |
| 172 | psycopg2-binary           | 2.9.6                     | 2.9.6                     |                           |
| 173 | ptvsd                     |                           | 4.3.2                     |                           |
| 174 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 175 | py-partiql-parser         |                           | 0.3.0                     |                           |
| 176 | pyasn1                    |                           | 0.5.0                     |                           |
| 177 | pycparser                 | 2.20, 2.21                | 2.21                      |                           |
| 178 | pydantic                  | 1.9.0, 1.10.2, 1.10.7, 1.10.8 | 1.10.2, 1.10.7, 1.10.8    |                           |
| 179 | pyftpdlib                 |                           | 1.5.7                     |                           |
| 180 | pygments                  | 2.13.0, 2.14.0, 2.15.1    |                           |                           |
| 181 | pyinstrument              | 3.4.2, 4.1.1, 4.3.0, 4.4.0 | 4.4.0                     |                           |
| 182 | pyinstrument-cext         | 0.2.4                     |                           |                           |
| 183 | pyjwt                     | 2.4.0                     |                           |                           |
| 184 | pylint                    |                           | 2.17.4                    | 2.17.4                    |
| 185 | pynacl                    | 1.4.0                     |                           |                           |
| 186 | pyopenssl                 |                           | 23.1.1                    |                           |
| 187 | pyparsing                 | 3.0.9                     | 3.0.9                     | 3.0.9                     |
| 188 | pyproject-hooks           |                           |                           | 1.0.0                     |
| 189 | pyrsistent                | 0.18.1, 0.19.2, 0.19.3    | 0.18.1, 0.19.2, 0.19.3    |                           |
| 190 | pytest                    | 7.3.1                     | 7.3.1                     |                           |
| 191 | pytest-aiohttp            |                           | 1.0.4                     |                           |
| 192 | pytest-asyncio            |                           | 0.21.0                    |                           |
| 193 | pytest-benchmark          |                           | 4.0.0                     |                           |
| 194 | pytest-cov                |                           | 4.0.0, 4.1.0              |                           |
| 195 | pytest-docker             |                           | 1.0.1                     |                           |
| 196 | pytest-icdiff             |                           | 0.6                       |                           |
| 197 | pytest-instafail          |                           | 0.5.0                     |                           |
| 198 | pytest-lazy-fixture       |                           | 0.6.3                     |                           |
| 199 | pytest-localftpserver     |                           | 1.1.4                     |                           |
| 200 | pytest-mock               |                           | 3.10.0                    |                           |
| 201 | pytest-runner             |                           | 6.0.0                     |                           |
| 202 | pytest-sugar              |                           | 0.9.7                     |                           |
| 203 | pytest-xdist              |                           | 3.3.0                     |                           |
| 204 | python-dateutil           | 2.8.2                     | 2.8.2                     |                           |
| 205 | python-dotenv             | 0.20.0, 0.21.0, 1.0.0     | 0.21.0, 1.0.0             |                           |
| 206 | python-engineio           | 4.3.4                     |                           |                           |
| 207 | python-jose               |                           | 3.3.0                     |                           |
| 208 | python-magic              | 0.4.25                    |                           |                           |
| 209 | python-multipart          | 0.0.5                     |                           |                           |
| 210 | python-socketio           | 5.8.0                     |                           |                           |
| 211 | pytz                      | 2022.1, 2023.3            | 2023.3                    |                           |
| 212 | pyyaml                    | 5.4.1, 6.0                | 5.4.1, 6.0                | 5.4.1, 6.0                |
| 213 | redis                     | 4.5.4, 4.5.5              | 4.5.4, 4.5.5              |                           |
| 214 | regex                     | 2023.5.5                  | 2023.5.5                  |                           |
| 215 | requests                  | 2.30.0, 2.31.0            | 2.30.0, 2.31.0            |                           |
| 216 | requests-mock             |                           | 1.10.0                    |                           |
| 217 | responses                 |                           | 0.23.1                    |                           |
| 218 | respx                     |                           | 0.20.1                    |                           |
| 219 | rich                      | 12.5.1, 12.6.0, 13.3.5    |                           |                           |
| 220 | rsa                       |                           | 4.9                       |                           |
| 221 | s3fs                      | 2023.5.0                  |                           |                           |
| 222 | s3transfer                | 0.5.2, 0.6.0              | 0.5.2, 0.6.0, 0.6.1       |                           |
| 223 | sarif-om                  |                           | 1.0.4                     |                           |
| 224 | semantic-version          | 2.9.0                     |                           |                           |
| 225 | setproctitle              | 1.2.3                     |                           |                           |
| 226 | shellingham               | 1.5.0.post1               |                           |                           |
| 227 | six                       | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            |                           |
| 228 | sniffio                   | 1.2.0, 1.3.0              | 1.2.0, 1.3.0              |                           |
| 229 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 230 | sqlalchemy                | 1.4.47, 1.4.48            | 1.4.47, 1.4.48            |                           |
| 231 | sqlalchemy2-stubs         |                           | 0.0.2a34                  |                           |
| 232 | sshpubkeys                |                           | 3.3.1                     |                           |
| 233 | starlette                 | 0.20.4, 0.22.0, 0.23.1, 0.27.0 |                           |                           |
| 234 | strict-rfc3339            | 0.7                       |                           |                           |
| 235 | sympy                     |                           | 1.12                      |                           |
| 236 | tblib                     | 1.7.0                     | 1.7.0                     |                           |
| 237 | tenacity                  | 8.0.1, 8.1.0, 8.2.1, 8.2.2 | 8.0.1, 8.2.2              |                           |
| 238 | termcolor                 |                           | 2.3.0                     |                           |
| 239 | texttable                 | 1.6.3                     |                           |                           |
| 240 | tomli                     | 2.0.1                     | 2.0.1                     | 2.0.1                     |
| 241 | tomlkit                   |                           | 0.11.8                    | 0.11.8                    |
| 242 | toolz                     | 0.12.0                    | 0.12.0                    |                           |
| 243 | tornado                   | 6.3.2                     | 6.3.2                     |                           |
| 244 | tqdm                      | 4.64.0, 4.64.1, 4.65.0    | 4.65.0                    |                           |
| 245 | traitlets                 | 5.9.0                     | 5.9.0                     |                           |
| 246 | twilio                    | 7.12.0                    |                           |                           |
| 247 | typer                     | 0.4.1, 0.6.1, 0.7.0, 0.9.0 | 0.9.0                     | 0.9.0                     |
| 248 | types-aiobotocore         | 2.3.3, 2.4.2.post1        |                           |                           |
| 249 | types-aiobotocore-ec2     | 2.4.2                     |                           |                           |
| 250 | types-aiobotocore-s3      | 2.3.3                     |                           |                           |
| 251 | types-aiofiles            |                           | 23.1.0.2                  |                           |
| 252 | types-awscrt              | 0.16.10                   | 0.16.17                   |                           |
| 253 | types-boto3               |                           | 1.0.2                     |                           |
| 254 | types-pkg-resources       |                           | 0.1.3                     |                           |
| 255 | types-pyyaml              |                           | 6.0.12.9, 6.0.12.10       |                           |
| 256 | types-s3transfer          |                           | 0.6.1                     |                           |
| 257 | typing-extensions         | 4.3.0, 4.4.0, 4.5.0, 4.6.0, 4.6.1 | 4.3.0, 4.4.0, 4.5.0, 4.6.0, 4.6.1 | 4.3.0, 4.4.0, 4.5.0, 4.6.0, 4.6.1 |
| 258 | tzdata                    | 2023.3                    | 2023.3                    |                           |
| 259 | tzlocal                   | 5.0.1                     |                           |                           |
| 260 | ujson                     | 5.5.0                     |                           |                           |
| 261 | urllib3                   | 1.26.9, 1.26.11, 1.26.12, 1.26.14, 1.26.16, 2.0.2 | 1.26.9, 1.26.11, 1.26.12, 1.26.14, 1.26.15, 1.26.16, 2.0.2 |                           |
| 262 | uvicorn                   | 0.15.0, 0.17.0, 0.19.0, 0.20.0, 0.22.0 |                           |                           |
| 263 | uvloop                    | 0.16.0, 0.17.0            |                           |                           |
| 264 | virtualenv                |                           |                           | 20.23.0                   |
| 265 | watchdog                  | 2.1.5                     |                           | 3.0.0                     |
| 266 | watchfiles                | 0.18.0, 0.18.1, 0.19.0    |                           |                           |
| 267 | watchgod                  | 0.8.2                     |                           |                           |
| 268 | websocket-client          | 0.59.0, 1.5.1             | 0.59.0, 1.5.1, 1.5.2      |                           |
| 269 | websockets                | 10.1, 10.2, 10.3, 10.4, 11.0.3 | 11.0.3                    |                           |
| 270 | werkzeug                  | 2.1.2, 2.2.2              | 2.1.2, 2.2.2, 2.3.4       |                           |
| 271 | wheel                     |                           |                           | 0.40.0                    |
| 272 | wrapt                     | 1.14.1, 1.15.0            | 1.14.1, 1.15.0            | 1.14.1, 1.15.0            |
| 273 | xmltodict                 |                           | 0.13.0                    |                           |
| 274 | yarl                      | 1.5.1, 1.9.2              | 1.5.1, 1.9.2              |                           |
| 275 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 276 | zipp                      | 3.15.0                    | 3.15.0                    |                           |

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
