### PR TITLE
⬆️ Bump Postgres minor version

### DIFF
--- a/packages/postgres-database/tests/docker-compose.yml
+++ b/packages/postgres-database/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   postgres:
-    image: "postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce"
+    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
     init: true
     environment:
       POSTGRES_USER: test

--- a/packages/service-library/tests/aiohttp/with_postgres/docker-compose.yml
+++ b/packages/service-library/tests/aiohttp/with_postgres/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   postgres:
-    image: "postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce"
+    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
     restart: always
     environment:
       POSTGRES_DB: db

--- a/scripts/maintenance/consistency/docker-compose.yml
+++ b/scripts/maintenance/consistency/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   postgres:
-    image: "postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce"
+    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     init: true

--- a/services/director/tests/test_producer.py
+++ b/services/director/tests/test_producer.py
@@ -343,9 +343,9 @@ async def test_get_service_key_version_from_docker_service(
 @pytest.mark.parametrize(
     "fake_service_str",
     [
-        "postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce",
-        "/simcore/postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce",
-        "itisfoundation/postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce",
+        "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc",
+        "/simcore/postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc",
+        "itisfoundation/postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc",
         "/simcore/services/stuff/postgres:10.11",
     ],
 )

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -486,7 +486,7 @@ services:
       - default # actually needed for the postgres service only
 
   postgres:
-    image: "postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce"
+    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
     init: true
     hostname: "{{.Node.Hostname}}-{{.Service.Name}}-{{.Task.Slot}}"
     environment:

--- a/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   postgres:
-    image: "postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce"
+    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
     restart: always
     init: true
     environment:

--- a/services/web/server/tests/unit/with_dbs/docker-compose.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   postgres:
-    image: "postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce"
+    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
     restart: always
     init: true
     environment:


### PR DESCRIPTION
Bumps PostgresSQL Minor Version from 14.5 to 14.8

There are no DB migrations necessary, postgres claims that the update can be done on-the-fly.

See: https://www.postgresql.org/docs/release/14.8/