### PR TITLE
🐛Personalized-resource-limits: return default value when no product is defined

### DIFF
--- a/services/web/server/src/simcore_service_webserver/users/_db.py
+++ b/services/web/server/src/simcore_service_webserver/users/_db.py
@@ -10,7 +10,6 @@ from simcore_postgres_database.utils_groups_extra_properties import (
     GroupExtraPropertiesNotFound,
     GroupExtraPropertiesRepo,
 )
-from sqlalchemy.sql import func
 
 from ..db.models import user_to_groups
 from ..db.plugin import get_database_engine
@@ -24,13 +23,12 @@ async def do_update_expired_users(conn: SAConnection) -> list[UserID]:
         .where(
             (users.c.expires_at.is_not(None))
             & (users.c.status == UserStatus.ACTIVE)
-            & (users.c.expires_at < func.now())
+            & (users.c.expires_at < sa.sql.func.now())
         )
         .returning(users.c.id)
     )
     if rows := await result.fetchall():
-        expired = [r.id for r in rows]
-        return expired
+        return [r.id for r in rows]
     return []
 
 

--- a/services/web/server/src/simcore_service_webserver/users/_db.py
+++ b/services/web/server/src/simcore_service_webserver/users/_db.py
@@ -47,21 +47,19 @@ async def get_users_ids_in_group(conn: SAConnection, gid: GroupID) -> set[UserID
 async def list_user_permissions(
     app: web.Application, *, user_id: UserID, product_name: str
 ) -> list[Permission]:
-    engine = get_database_engine(app)
-    permissions = [
-        Permission(
-            name="override_services_specifications",
-            allowed=False,
-        )
-    ]
+    override_services_specifications = Permission(
+        name="override_services_specifications",
+        allowed=False,
+    )
     with contextlib.suppress(GroupExtraPropertiesNotFound):
-        async with engine.acquire() as conn:
+        async with get_database_engine(app).acquire() as conn:
             user_group_extra_properties = (
                 await GroupExtraPropertiesRepo.get_aggregated_properties_for_user(
                     conn, user_id=user_id, product_name=product_name
                 )
             )
-        permissions[
-            0
-        ].allowed = user_group_extra_properties.override_services_specifications
-    return permissions
+        override_services_specifications.allowed = (
+            user_group_extra_properties.override_services_specifications
+        )
+
+    return [override_services_specifications]


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?
Fixes the exception raised when there is no product defined for a user. Instead of 500 error, a default permission (in this case a False) is returned.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
