### PR TITLE
♻️ Maintenance: Enhanced logs on sms service errors and tests image labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/4_pre_release.yml
+++ b/.github/ISSUE_TEMPLATE/4_pre_release.yml
@@ -106,6 +106,7 @@ body:
         - Fill up
       value: |
         - [ ] `` make release-staging name=<sprint_name> version=<version> git_sha=<commit_sha>``
+           - `https://github.com/ITISFoundation/osparc-simcore/releases/new?prerelease=1&target=<commit_sha>&tag=staging_<sprint_name><version>&title=Staging%20<sprint_name><version>`
         - [ ] Draft [pre-release](https://github.com/ITISFoundation/osparc-simcore/releases)
         - [ ] Announce
           ```json

--- a/services/web/server/src/simcore_service_webserver/login/_2fa.py
+++ b/services/web/server/src/simcore_service_webserver/login/_2fa.py
@@ -169,10 +169,11 @@ async def send_email_code(
 #
 
 _FROM, _TO = 3, -1
+_MIN_NUM_DIGITS = 5
 
 
-def mask_phone_number(phn: str) -> str:
-    assert len(phn) > 5  # nosec
+def mask_phone_number(phone: str) -> str:
+    assert len(phone) > _MIN_NUM_DIGITS  # nosec
     # SEE https://github.com/pydantic/pydantic/issues/1551
     # SEE https://en.wikipedia.org/wiki/E.164
-    return phn[:_FROM] + len(phn[_FROM:_TO]) * "X" + phn[_TO:]
+    return phone[:_FROM] + len(phone[_FROM:_TO]) * "X" + phone[_TO:]

--- a/services/web/server/src/simcore_service_webserver/login/_constants.py
+++ b/services/web/server/src/simcore_service_webserver/login/_constants.py
@@ -1,6 +1,9 @@
 from typing import Final
 
 MSG_2FA_CODE_SENT: Final[str] = "Code sent by SMS to {phone_number}"
+MSG_2FA_UNAVAILABLE_OEC: Final[
+    str
+] = "Currently we cannot use 2FA, please try again later ({error_code})"
 MSG_ACTIVATED: Final[str] = "Your account is activated"
 MSG_ACTIVATION_REQUIRED: Final[
     str

--- a/services/web/server/src/simcore_service_webserver/login/handlers_auth.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_auth.py
@@ -125,7 +125,7 @@ async def login(request: web.Request):
 
     # no phone
     if not user["phone"]:
-        response = envelope_response(
+        return envelope_response(
             # LoginNextPage
             {
                 "name": CODE_PHONE_NUMBER_REQUIRED,
@@ -139,7 +139,6 @@ async def login(request: web.Request):
             },
             status=web.HTTPAccepted.status_code,
         )
-        return response
 
     # create 2FA
     assert user["phone"]  # nosec
@@ -268,5 +267,4 @@ async def logout(request: web.Request) -> web.Response:
         await notify_user_logout(request.app, user_id, logout_.client_session_id)
         await forget(request, response)
 
-        return response
         return response

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_2fa.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_2fa.py
@@ -3,6 +3,7 @@
 # pylint: disable=unused-variable
 
 import asyncio
+import logging
 from contextlib import AsyncExitStack
 from unittest.mock import Mock
 
@@ -12,6 +13,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, make_mocked_request
 from faker import Faker
 from pytest import CaptureFixture, MonkeyPatch
+from pytest_mock import MockerFixture
 from pytest_simcore.helpers.utils_assert import assert_status
 from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_dict
 from pytest_simcore.helpers.utils_login import NewUser, parse_link, parse_test_marks
@@ -27,8 +29,10 @@ from simcore_service_webserver.login._2fa import (
     get_redis_validation_code_client,
     send_email_code,
 )
+from simcore_service_webserver.login._constants import MSG_2FA_UNAVAILABLE_OEC
 from simcore_service_webserver.login.storage import AsyncpgStorage
 from simcore_service_webserver.products.plugin import get_current_product
+from twilio.base.exceptions import TwilioRestException
 
 
 @pytest.fixture
@@ -65,7 +69,7 @@ def postgres_db(postgres_db: sa.engine.Engine):
 
 
 @pytest.fixture
-def mocked_twilio_service(mocker) -> dict[str, Mock]:
+def mocked_twilio_service(mocker: MockerFixture) -> dict[str, Mock]:
     return {
         "send_sms_code_for_registration": mocker.patch(
             "simcore_service_webserver.login.handlers_registration.send_sms_code",
@@ -322,3 +326,56 @@ async def test_send_email_code(
     assert parsed_context["code"] == f"{code}"
     assert parsed_context["name"] == user_name.capitalize()
     assert parsed_context["support_email"] == support_email
+
+
+async def test_2fa_sms_failure_during_login(
+    client: TestClient,
+    fake_user_email: str,
+    fake_user_password: str,
+    fake_user_phone_number: str,
+    caplog: pytest.LogCaptureFixture,
+    mocker: MockerFixture,
+):
+    assert client.app
+
+    # Mocks error in graylog https://monitoring.osparc.io/graylog/search/649e7619ce6e0838a96e9bf1?q=%222FA%22&rangetype=relative&from=172800
+    mocker.patch(
+        "simcore_service_webserver.login.handlers_auth.send_sms_code",
+        autospec=True,
+        side_effect=TwilioRestException(
+            status=400,
+            uri="https://www.twilio.com/doc",
+            msg="Unable to create record: A 'From' phone number is required",
+        ),
+    )
+
+    # A registered user ...
+    async with NewUser(
+        params={
+            "email": fake_user_email,
+            "password": fake_user_password,
+            "phone": fake_user_phone_number,
+        },
+        app=client.app,
+    ):
+        # ... logs in, but fails to send SMS !
+        with caplog.at_level(logging.ERROR):
+            url = client.app.router["auth_login"].url_for()
+            response = await client.post(
+                f"{url}",
+                json={
+                    "email": fake_user_email,
+                    "password": fake_user_password,
+                },
+            )
+
+            # Expects failure:
+            #    HTTPServiceUnavailable: Currently we cannot use 2FA, please try again later (OEC:140558738809344)
+            data, error = await assert_status(response, web.HTTPServiceUnavailable)
+            assert not data
+            assert error["errors"][0]["message"].startswith(
+                MSG_2FA_UNAVAILABLE_OEC[:10]
+            )
+
+            # Expects logs like 'Failed while setting up 2FA code and sending SMS to 157XXXXXXXX3 [OEC:140392495277888]'
+            assert f"{fake_user_phone_number[:3]}" in caplog.text

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_2fa.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_2fa.py
@@ -101,7 +101,7 @@ async def test_2fa_code_operations(client: TestClient):
     assert await get_2fa_code(client.app, email) is None
 
 
-@pytest.mark.acceptance_test
+@pytest.mark.acceptance_test()
 async def test_workflow_register_and_login_with_2fa(
     client: TestClient,
     db: AsyncpgStorage,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

Various improvements:
- ♻️ Adds user_id (in extras) and masked phone number for sms failures @odeimaiz @sanderegg 
   - addresses the issue with failing sms in US 
- ♻️ Adds more validation checks for image-labels in registry, e.g. version in metadata vs image tag @mguidon 
   - addresses issue with wrong version of s4l
- 🔨 Minor improvement in release form


## Related issue/s

- maintenance

## How to test

- test_2fa_sms_failure_during_login
```cmd
cd services/web/server
make install-dev
pytest -vv tests/unit/**/test_*_login.py
```

## DevOps 

None