### PR TITLE
🐛upgrade dask-sidecar cuda version to properly detect GPU nodes

### DIFF
--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
 import uuid
-from typing import Any, Awaitable, Coroutine, cast
+from collections.abc import Awaitable, Coroutine
+from typing import Any, cast
 
 import aiodocker
 from aiodocker.containers import DockerContainer
@@ -16,8 +17,8 @@ def _wrap_async_call(fct: Awaitable[Any]) -> Any:
 
 def _nvidia_smi_docker_config(cmd: list[str]) -> dict[str, Any]:
     return {
-        "Cmd": ["nvidia-smi"] + cmd,
-        "Image": "nvidia/cuda:10.0-base",
+        "Cmd": ["nvidia-smi", *cmd],
+        "Image": "nvidia/cuda:12.2.0-base-ubuntu22.04",
         "AttachStdin": False,
         "AttachStdout": False,
         "AttachStderr": False,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

nvidia/cuda:10.0-base has been removed from Dockerhub.

upgraded to latest version which is ```nvidia/cuda:12.2.0-base-ubuntu22.04```

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
