### PR TITLE
🐛 Fixes replace operation in projects and uninitialized variable in health-check 

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/incidents.py
+++ b/packages/service-library/src/servicelib/aiohttp/incidents.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Generic, List, Optional, TypeVar
+from typing import Any, Callable, Generic, TypeVar
 
 import attr
 
@@ -20,9 +20,9 @@ class LimitedOrderedStack(Generic[ItemT]):
     """
 
     max_size: int = 100
-    order_by: Optional[Callable[[ItemT], Any]] = None
+    order_by: Callable[[ItemT], Any] | None = None
 
-    _items: List[ItemT] = attr.ib(init=False, default=attr.Factory(list))
+    _items: list[ItemT] = attr.ib(init=False, default=attr.Factory(list))
     _hits: int = attr.ib(init=False, default=0)
 
     def __len__(self) -> int:
@@ -38,13 +38,13 @@ class LimitedOrderedStack(Generic[ItemT]):
         return self._hits
 
     @property
-    def max_item(self) -> Optional[ItemT]:
+    def max_item(self) -> ItemT | None:
         if self._items:
             return self._items[0]
         return None
 
     @property
-    def min_item(self) -> Optional[ItemT]:
+    def min_item(self) -> ItemT | None:
         if self._items:
             return self._items[-1]
         return None

--- a/services/web/server/src/simcore_service_webserver/diagnostics/_healthcheck.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics/_healthcheck.py
@@ -25,7 +25,9 @@ kSTART_SENSING_DELAY_SECS = f"{__name__}.start_sensing_delay"
 
 class IncidentsRegistry(LimitedOrderedStack[SlowCallback]):
     def max_delay(self) -> float:
-        delay: float = self.max_item.delay_secs or 0.0
+        delay: float = 0.0
+        if self.max_item:
+            delay = self.max_item.delay_secs
         return delay
 
 

--- a/services/web/server/src/simcore_service_webserver/projects/_handlers_crud.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_handlers_crud.py
@@ -442,8 +442,10 @@ async def replace_project(request: web.Request):
 
     try:
         new_project = await request.json()
+        # NOTE: this is a temporary fix until proper Model is introduced in ProjectReplace
         # Prune state field (just in case)
         new_project.pop("state", None)
+        new_project.pop("permalink", None)
 
     except json.JSONDecodeError as exc:
         raise web.HTTPBadRequest(reason="Invalid request body") from exc


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

Various errors detected in master

- Temporary fix of `PUT projects` error (until proper validation of body is in place)
```log
  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_webserver/projects/_handlers_crud.py", line 463, in replace_project
    Project.parse_obj(new_project)  # validate
  File "pydantic/main.py", line 511, in pydantic.main.BaseModel.parse_obj
  File "pydantic/main.py", line 331, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for Project
permalink
  extra fields not permitted (type=value_error.extra)
```
- Fixes healthcheck 
```log
  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_webserver/diagnostics/plugin.py", line 51, in _on_healthcheck_async_adapter
    assert_healthy_app(app)
  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_webserver/diagnostics/_healthcheck.py", line 98, in assert_healthy_app
    max_delay: float = incidents.max_delay()
  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_webserver/diagnostics/_healthcheck.py", line 28, in max_delay
    delay: float = self.max_item.delay_secs or 0.0
AttributeError: 'NoneType' object has no attribute 'delay_secs'
```

## Related issue/s



## How to test


## DevOps

None