### PR TITLE
✨ public-api: Get and Update jobs metadata

### DIFF
--- a/api/specs/webserver/openapi-projects-metadata.yaml
+++ b/api/specs/webserver/openapi-projects-metadata.yaml
@@ -8,9 +8,9 @@ paths:
       parameters:
       - required: true
         schema:
+          title: Project Id
           type: string
           format: uuid
-          title: Project Id
         name: project_id
         in: path
       responses:
@@ -28,9 +28,9 @@ paths:
       parameters:
       - required: true
         schema:
+          title: Project Id
           type: string
           format: uuid
-          title: Project Id
         name: project_id
         in: path
       requestBody:
@@ -49,45 +49,45 @@ paths:
 components:
   schemas:
     Envelope_ProjectMetadataGet_:
+      title: Envelope[ProjectMetadataGet]
+      type: object
       properties:
         data:
           $ref: '#/components/schemas/ProjectMetadataGet'
         error:
           title: Error
-      type: object
-      title: Envelope[ProjectMetadataGet]
     ProjectMetadataGet:
-      properties:
-        projectUuid:
-          type: string
-          format: uuid
-          title: Projectuuid
-        custom:
-          additionalProperties:
-            anyOf:
-            - type: boolean
-            - type: integer
-            - type: number
-            - type: string
-          type: object
-          title: Custom
-          description: Custom key-value map
-      type: object
+      title: ProjectMetadataGet
       required:
       - projectUuid
-      title: ProjectMetadataGet
-    ProjectMetadataUpdate:
+      type: object
       properties:
+        projectUuid:
+          title: Projectuuid
+          type: string
+          format: uuid
         custom:
+          title: Custom
+          type: object
           additionalProperties:
             anyOf:
             - type: boolean
             - type: integer
             - type: number
             - type: string
-          type: object
-          title: Custom
-      type: object
+          description: Custom key-value map
+    ProjectMetadataUpdate:
+      title: ProjectMetadataUpdate
       required:
       - custom
-      title: ProjectMetadataUpdate
+      type: object
+      properties:
+        custom:
+          title: Custom
+          type: object
+          additionalProperties:
+            anyOf:
+            - type: boolean
+            - type: integer
+            - type: number
+            - type: string

--- a/api/specs/webserver/scripts/_common.py
+++ b/api/specs/webserver/scripts/_common.py
@@ -3,8 +3,9 @@
 
 import inspect
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, NamedTuple
+from typing import Any, ClassVar, NamedTuple
 
 import yaml
 from fastapi import FastAPI
@@ -27,7 +28,7 @@ class Log(BaseModel):
     )
 
     class Config:
-        schema_extra = {
+        schema_extra: ClassVar[dict[str, Any]] = {
             "example": {
                 "message": "Hi there, Mr user",
                 "level": "INFO",
@@ -70,8 +71,8 @@ def create_openapi_specs(
 
     # Removes default response 422
     if drop_fastapi_default_422:
-        for _, method_item in openapi.get("paths", {}).items():
-            for _, param in method_item.items():
+        for method_item in openapi.get("paths", {}).values():
+            for param in method_item.values():
                 # NOTE: If description is like this,
                 # it assumes it is the default HTTPValidationError from fastapi
                 if (e422 := param.get("responses", {}).get("422", None)) and e422.get(

--- a/api/specs/webserver/scripts/openapi_projects_metadata.py
+++ b/api/specs/webserver/scripts/openapi_projects_metadata.py
@@ -19,10 +19,7 @@ from models_library.api_schemas_webserver.projects_metadata import (
     ProjectMetadataUpdate,
 )
 from models_library.generics import Envelope
-from simcore_service_webserver.projects._metadata_handlers import (
-    ProjectMetadataGet,
-    ProjectPathParams,
-)
+from simcore_service_webserver.projects._metadata_handlers import ProjectPathParams
 
 app = FastAPI(redoc_url=None)
 

--- a/packages/postgres-database/src/simcore_postgres_database/utils_aiopg.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_aiopg.py
@@ -39,6 +39,5 @@ async def raise_if_migration_not_ready(engine: Engine):
         version_num = await conn.scalar('SELECT "version_num" FROM "alembic_version"')
         head_version_num = get_current_head()
         if version_num != head_version_num:
-            raise DBMigrationError(
-                f"Migration is incomplete, expected {head_version_num} but got {version_num}"
-            )
+            msg = f"Migration is incomplete, expected {head_version_num} but got {version_num}"
+            raise DBMigrationError(msg)

--- a/packages/postgres-database/src/simcore_postgres_database/utils_aiosqlalchemy.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_aiosqlalchemy.py
@@ -27,6 +27,5 @@ async def raise_if_migration_not_ready(engine: AsyncEngine):
         )
         head_version_num = get_current_head()
         if version_num != head_version_num:
-            raise DBMigrationError(
-                f"Migration is incomplete, expected {head_version_num} but got {version_num}"
-            )
+            msg = f"Migration is incomplete, expected {head_version_num} but got {version_num}"
+            raise DBMigrationError(msg)

--- a/services/api-server/src/simcore_service_api_server/api/dependencies/database.py
+++ b/services/api-server/src/simcore_service_api_server/api/dependencies/database.py
@@ -1,5 +1,5 @@
 import logging
-from typing import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Callable
 
 from aiopg.sa import Engine
 from fastapi import Depends

--- a/services/api-server/src/simcore_service_api_server/api/dependencies/services.py
+++ b/services/api-server/src/simcore_service_api_server/api/dependencies/services.py
@@ -1,7 +1,7 @@
 """ Dependences with any other services (except webserver)
 
 """
-from typing import Callable
+from collections.abc import Callable
 
 from fastapi import HTTPException, Request, status
 

--- a/services/api-server/src/simcore_service_api_server/api/routes/meta.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/meta.py
@@ -1,4 +1,5 @@
-from typing import Annotated, Callable
+from collections.abc import Callable
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 

--- a/services/api-server/src/simcore_service_api_server/api/routes/solvers.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/solvers.py
@@ -197,7 +197,7 @@ async def get_solver_release(
         solver.url = url_for(
             "get_solver_release", solver_key=solver.id, version=solver.version
         )
-        return solver  # noqa: TRY300
+        return solver
 
     except (
         ValueError,

--- a/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
@@ -480,7 +480,7 @@ async def get_job_custom_metadata(
             )
 
 
-@router.put(
+@router.patch(
     "/{solver_key:path}/releases/{version}/jobs/{job_id:uuid}/metadata",
     response_model=JobMetadata,
     responses={**_common_error_responses},

--- a/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
@@ -64,6 +64,13 @@ def _compose_job_resource_name(solver_key, solver_version, job_id) -> str:
 # - Similar to docker container's API design (container = job and image = solver)
 #
 
+_common_error_responses = {
+    status.HTTP_404_NOT_FOUND: {
+        "description": "Job not found",
+        "model": ErrorGet,
+    },
+}
+
 
 @router.get(
     "/{solver_key:path}/releases/{version}/jobs",
@@ -378,6 +385,7 @@ async def get_job_outputs(
 @router.get(
     "/{solver_key:path}/releases/{version}/jobs/{job_id:uuid}/outputs/logfile",
     response_class=RedirectResponse,
+    responses={**_common_error_responses},
     responses=job_output_logfile_responses,
 )
 async def get_job_output_logfile(
@@ -435,28 +443,60 @@ async def get_job_output_logfile(
 @router.get(
     "/{solver_key:path}/releases/{version}/jobs/{job_id:uuid}/metadata",
     response_model=JobMetadata,
+    responses={**_common_error_responses},
     include_in_schema=API_SERVER_DEV_FEATURES_ENABLED,
 )
 async def get_job_custom_metadata(
     solver_key: SolverKeyId,
     version: VersionStr,
     job_id: JobID,
+    webserver_api: Annotated[AuthSession, Depends(get_webserver_session)],
 ):
-    """Gets custom metadata from a job"""
-    msg = f"Getting Job metadata {_compose_job_resource_name(solver_key, version, job_id)!r}. SEE https://github.com/ITISFoundation/osparc-simcore/issues/4313"
-    raise NotImplementedError(msg)
+    """Gets custom metadata from a job
+
+    New in *version 0.5*
+    """
+    job_name = _compose_job_resource_name(solver_key, version, job_id)
+    _logger.debug("Custom metadata for '%s'", job_name)
+
+    try:
+        await webserver_api.get_project_metadata(project_id=job_id)
+
+    except HTTPException as err:
+        if err.status_code == status.HTTP_404_NOT_FOUND:
+            return create_error_json_response(
+                f"Cannot find job={job_name} ",
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
 
 
 @router.put(
     "/{solver_key:path}/releases/{version}/jobs/{job_id:uuid}/metadata",
+    responses={**_common_error_responses},
     include_in_schema=API_SERVER_DEV_FEATURES_ENABLED,
 )
 async def replace_job_custom_metadata(
     solver_key: SolverKeyId,
     version: VersionStr,
     job_id: JobID,
-    replace: JobMetadataUpdate,
+    update: JobMetadataUpdate,
+    webserver_api: Annotated[AuthSession, Depends(get_webserver_session)],
 ):
-    """Changes job's custom metadata"""
-    msg = f"Applies {replace=} to Job {_compose_job_resource_name(solver_key, version, job_id)!r}. SEE https://github.com/ITISFoundation/osparc-simcore/issues/4313"
-    raise NotImplementedError(msg)
+    """Updates custom metadata from a job
+
+    New in *version 0.5*
+    """
+    job_name = _compose_job_resource_name(solver_key, version, job_id)
+    _logger.debug("Custom metadata for '%s'", job_name)
+
+    try:
+        await webserver_api.update_project_metadata(
+            project_id=job_id, metadata=update.metadata
+        )
+
+    except HTTPException as err:
+        if err.status_code == status.HTTP_404_NOT_FOUND:
+            return create_error_json_response(
+                f"Cannot find job={job_name} ",
+                status_code=status.HTTP_404_NOT_FOUND,
+            )

--- a/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
@@ -24,7 +24,7 @@ from ...models.schemas.jobs import (
     JobID,
     JobInputs,
     JobMetadata,
-    JobMetadataReplace,
+    JobMetadataUpdate,
     JobOutputs,
     JobStatus,
 )
@@ -455,7 +455,7 @@ async def replace_job_custom_metadata(
     solver_key: SolverKeyId,
     version: VersionStr,
     job_id: JobID,
-    replace: JobMetadataReplace,
+    replace: JobMetadataUpdate,
 ):
     """Changes job's custom metadata"""
     msg = f"Applies {replace=} to Job {_compose_job_resource_name(solver_key, version, job_id)!r}. SEE https://github.com/ITISFoundation/osparc-simcore/issues/4313"

--- a/services/api-server/src/simcore_service_api_server/api/routes/studies_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/studies_jobs.py
@@ -9,7 +9,7 @@ from ...models.schemas.jobs import (
     Job,
     JobID,
     JobMetadata,
-    JobMetadataReplace,
+    JobMetadataUpdate,
     JobOutputs,
     JobStatus,
 )
@@ -154,7 +154,7 @@ async def get_study_job_custom_metadata(
     include_in_schema=API_SERVER_DEV_FEATURES_ENABLED,
 )
 async def replace_study_job_custom_metadata(
-    study_id: StudyID, job_id: JobID, replace: JobMetadataReplace
+    study_id: StudyID, job_id: JobID, replace: JobMetadataUpdate
 ):
     """Changes job's custom metadata"""
     msg = f"Attaches metadata={replace.metadata!r} to study_id={study_id!r} job_id={job_id!r}. SEE https://github.com/ITISFoundation/osparc-simcore/issues/4313"

--- a/services/api-server/src/simcore_service_api_server/db/tables.py
+++ b/services/api-server/src/simcore_service_api_server/db/tables.py
@@ -7,7 +7,7 @@ from simcore_postgres_database.models.users import UserRole, UserStatus, users
 metadata: TypeAlias = api_keys.metadata
 
 
-# nopycln: file
+# nopycln: file  # noqa: ERA001
 
 __all__: tuple[str, ...] = (
     "api_keys",

--- a/services/api-server/src/simcore_service_api_server/models/schemas/jobs.py
+++ b/services/api-server/src/simcore_service_api_server/models/schemas/jobs.py
@@ -120,7 +120,7 @@ class JobOutputs(BaseModel):
 MetaValueType: TypeAlias = StrictBool | StrictInt | StrictFloat | str
 
 
-class JobMetadataReplace(BaseModel):
+class JobMetadataUpdate(BaseModel):
     metadata: dict[str, MetaValueType] = Field(
         default_factory=dict, description="Custom key-value map"
     )

--- a/services/api-server/src/simcore_service_api_server/models/types.py
+++ b/services/api-server/src/simcore_service_api_server/models/types.py
@@ -1,7 +1,7 @@
-from typing import Any, TypeAlias, Union
+from typing import Any, TypeAlias
 
 AnyDict: TypeAlias = dict[str, Any]
 ListAnyDict: TypeAlias = list[AnyDict]
 
 # Represent the type returned by e.g. json.load
-JSON: TypeAlias = Union[AnyDict, ListAnyDict]
+JSON: TypeAlias = AnyDict | ListAnyDict

--- a/services/api-server/src/simcore_service_api_server/services/webserver.py
+++ b/services/api-server/src/simcore_service_api_server/services/webserver.py
@@ -263,27 +263,29 @@ class AuthSession:
         return data
 
     async def get_project_metadata(self, project_id: ProjectID) -> ProjectMetadataGet:
-        response = await self.client.get(
-            f"/projects/{project_id}/metadata",
-            cookies=self.session_cookies,
-        )
-        response.raise_for_status()
-        data = Envelope[ProjectMetadataGet].parse_raw(response.text).data
-        assert data  # nosec
-        return data
+        with _handle_webserver_api_errors():
+            response = await self.client.get(
+                f"/projects/{project_id}/metadata",
+                cookies=self.session_cookies,
+            )
+            response.raise_for_status()
+            data = Envelope[ProjectMetadataGet].parse_raw(response.text).data
+            assert data  # nosec
+            return data
 
     async def update_project_metadata(
         self, project_id: ProjectID, metadata: dict[str, MetaValueType]
     ) -> ProjectMetadataGet:
-        response = await self.client.patch(
-            f"/projects/{project_id}/metadata",
-            cookies=self.session_cookies,
-            json=jsonable_encoder(ProjectMetadataUpdate(custom=metadata)),
-        )
-        response.raise_for_status()
-        data = Envelope[ProjectMetadataGet].parse_raw(response.text).data
-        assert data  # nosec
-        return data
+        with _handle_webserver_api_errors():
+            response = await self.client.patch(
+                f"/projects/{project_id}/metadata",
+                cookies=self.session_cookies,
+                json=jsonable_encoder(ProjectMetadataUpdate(custom=metadata)),
+            )
+            response.raise_for_status()
+            data = Envelope[ProjectMetadataGet].parse_raw(response.text).data
+            assert data  # nosec
+            return data
 
 
 # MODULES APP SETUP -------------------------------------------------------------

--- a/services/api-server/src/simcore_service_api_server/utils/app_data.py
+++ b/services/api-server/src/simcore_service_api_server/utils/app_data.py
@@ -40,8 +40,7 @@ class AppDataMixin:
             return None
         assert isinstance(cls.state_attr_name, str)  # nosec
 
-        obj = getattr(app.state, cls.state_attr_name, None)
-        return obj
+        return getattr(app.state, cls.state_attr_name, None)
 
     @classmethod
     def pop_instance(cls, app: FastAPI):

--- a/services/api-server/src/simcore_service_api_server/utils/http_calls_capture.py
+++ b/services/api-server/src/simcore_service_api_server/utils/http_calls_capture.py
@@ -48,6 +48,9 @@ class HttpApiCallCaptureModel(BaseModel):
     def request_desc(self) -> str:
         return f"{self.method} {self.path}"
 
+    def as_response(self) -> httpx.Response:
+        return httpx.Response(status_code=self.status_code, json=self.response_body)
+
 
 def get_captured_as_json(name: str, response: httpx.Response) -> str:
     capture_json: str = HttpApiCallCaptureModel.create_from_response(

--- a/services/api-server/tests/conftest.py
+++ b/services/api-server/tests/conftest.py
@@ -25,8 +25,9 @@ pytest_plugins = [
 def project_env_devel_vars(project_slug_dir: Path) -> EnvVarsDict:
     env_devel_file = project_slug_dir / ".env-devel"
     assert env_devel_file.exists()
-    environ = dotenv_values(env_devel_file, verbose=True, interpolate=True)
-    return environ
+    environs = dotenv_values(env_devel_file, verbose=True, interpolate=True)
+    assert not any(value is None for key, value in environs.items())
+    return environs
 
 
 @pytest.fixture(scope="session")

--- a/services/api-server/tests/mocks/cleanup.py
+++ b/services/api-server/tests/mocks/cleanup.py
@@ -1,0 +1,35 @@
+import json
+import re
+from pathlib import Path
+
+from faker import Faker
+
+_fake = Faker()
+
+
+def replace_with_fake(json_key, json_data):
+    if isinstance(json_data, dict):
+        for key, value in json_data.items():
+            json_data[key] = replace_with_fake(key, value)
+    elif isinstance(json_data, list):
+        for i in range(len(json_data)):
+            json_data[i] = replace_with_fake(i, json_data[i])
+    elif isinstance(json_data, str):
+        if "@" in json_data:
+            json_data = _fake.email()
+        elif json_key == "affiliation":
+            json_data = _fake.company()
+        elif json_key == "name" and re.match(r"^[A-Z][a-z]+ [A-Z][a-z]+$", json_data):
+            json_data = f"{_fake.first_name()} {_fake.last_name()}"
+
+    return json_data
+
+
+def main():
+    for path in Path.cwd().glob("*.json"):
+        json_data = replace_with_fake(None, json.loads(path.read_text()))
+        path.write_text(json.dumps(json_data, indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/api-server/tests/mocks/cleanup.py
+++ b/services/api-server/tests/mocks/cleanup.py
@@ -7,19 +7,19 @@ from faker import Faker
 _fake = Faker()
 
 
-def replace_with_fake(json_key, json_data):
+def obfuscate_values(json_key, json_data):
     if isinstance(json_data, dict):
         for key, value in json_data.items():
-            json_data[key] = replace_with_fake(key, value)
+            json_data[key] = obfuscate_values(key, value)
     elif isinstance(json_data, list):
         for i in range(len(json_data)):
-            json_data[i] = replace_with_fake(i, json_data[i])
+            json_data[i] = obfuscate_values(i, json_data[i])
     elif isinstance(json_data, str):
         if "@" in json_data:
             json_data = _fake.email()
         elif json_key == "affiliation":
             json_data = _fake.company()
-        elif json_key == "name" and re.match(r"^[A-Z][a-z]+ [A-Z][a-z]+$", json_data):
+        elif json_key == "name" and re.match(r"^[A-Z][a-z]+ +[A-Z][a-z]+$", json_data):
             json_data = f"{_fake.first_name()} {_fake.last_name()}"
 
     return json_data
@@ -27,7 +27,7 @@ def replace_with_fake(json_key, json_data):
 
 def main():
     for path in Path.cwd().glob("*.json"):
-        json_data = replace_with_fake(None, json.loads(path.read_text()))
+        json_data = obfuscate_values(None, json.loads(path.read_text()))
         path.write_text(json.dumps(json_data, indent=1))
 
 

--- a/services/api-server/tests/mocks/delete_project_not_found.json
+++ b/services/api-server/tests/mocks/delete_project_not_found.json
@@ -1,32 +1,32 @@
 {
-  "name": "DELETE /projects/{{ project_id }}",
-  "description": "<Request('DELETE', 'http://webserver:8080/v0/projects/{{ project_id }}')>",
-  "method": "DELETE",
-  "host": "webserver",
-  "path": "/v0/projects/{{ project_id }}",
-  "query": null,
-  "request_payload": null,
-  "response_body": {
-   "data": null,
-   "error": {
-    "logs": [
-     {
-      "message": "Project {{ project_id }} not found",
-      "level": "ERROR",
-      "logger": "user"
-     }
-    ],
-    "errors": [
-     {
-      "code": "HTTPNotFound",
-      "message": "Project {{ project_id }} not found",
-      "resource": null,
-      "field": null
-     }
-    ],
-    "status": 404,
-    "message": "Project {{ project_id }} not found"
-   }
-  },
-  "status_code": 404
+ "name": "DELETE /projects/{{ project_id }}",
+ "description": "<Request('DELETE', 'http://webserver:8080/v0/projects/{{ project_id }}')>",
+ "method": "DELETE",
+ "host": "webserver",
+ "path": "/v0/projects/{{ project_id }}",
+ "query": null,
+ "request_payload": null,
+ "response_body": {
+  "data": null,
+  "error": {
+   "logs": [
+    {
+     "message": "Project {{ project_id }} not found",
+     "level": "ERROR",
+     "logger": "user"
+    }
+   ],
+   "errors": [
+    {
+     "code": "HTTPNotFound",
+     "message": "Project {{ project_id }} not found",
+     "resource": null,
+     "field": null
+    }
+   ],
+   "status": 404,
+   "message": "Project {{ project_id }} not found"
+  }
+ },
+ "status_code": 404
 }

--- a/services/api-server/tests/mocks/for_test_get_and_update_job_metadata.json
+++ b/services/api-server/tests/mocks/for_test_get_and_update_job_metadata.json
@@ -427,7 +427,7 @@
   "status_code": 204
  },
  {
-  "name": "get_project_metadata_3",
+  "name": "get_project_metadata_2",
   "description": "<Request('GET', 'http://webserver:8080/v0/projects/767a7355-3062-4ceb-b339-ed67d07d2ed2/metadata')>",
   "method": "GET",
   "host": "webserver",

--- a/services/api-server/tests/mocks/for_test_get_and_update_job_metadata.json
+++ b/services/api-server/tests/mocks/for_test_get_and_update_job_metadata.json
@@ -1,0 +1,461 @@
+[
+ {
+  "name": "get_profile",
+  "description": "<Request('GET', 'http://webserver:8080/v0/me')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/me",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": {
+    "first_name": "crespo",
+    "last_name": "",
+    "id": 1,
+    "login": "williamsmartin@example.net",
+    "role": "User",
+    "groups": {
+     "me": {
+      "gid": 3,
+      "label": "crespo",
+      "description": "primary group",
+      "thumbnail": null,
+      "accessRights": {
+       "read": true,
+       "write": false,
+       "delete": false
+      },
+      "inclusionRules": {}
+     },
+     "organizations": [
+      {
+       "gid": 2,
+       "label": "osparc",
+       "description": "osparc product group",
+       "thumbnail": null,
+       "accessRights": {
+        "read": false,
+        "write": false,
+        "delete": false
+       },
+       "inclusionRules": {}
+      }
+     ],
+     "all": {
+      "gid": 1,
+      "label": "Everyone",
+      "description": "all users",
+      "thumbnail": null,
+      "accessRights": {
+       "read": true,
+       "write": false,
+       "delete": false
+      },
+      "inclusionRules": {}
+     }
+    },
+    "gravatar_id": "aa33f6ec77ea434c2ea4fb92d0fd379e"
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "get_service",
+  "description": "<Request('GET', 'http://catalog:8000/v0/services/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/2.0.0?user_id=1')>",
+  "method": "GET",
+  "host": "catalog",
+  "path": "/v0/services/simcore/services/comp/itis/sleeper/2.0.0",
+  "query": "user_id=1",
+  "request_payload": null,
+  "response_body": {
+   "name": "sleeper",
+   "thumbnail": null,
+   "description": "A service which awaits for time to pass.",
+   "deprecated": null,
+   "classifiers": [],
+   "quality": {},
+   "key": "simcore/services/comp/itis/sleeper",
+   "version": "2.0.0",
+   "integration-version": "1.0.0",
+   "type": "computational",
+   "authors": [
+    {
+     "name": "Erin Lee",
+     "email": "sandraramirez@example.org",
+     "affiliation": "Harris PLC"
+    },
+    {
+     "name": "Lynn Lopez",
+     "email": "nreid@example.com",
+     "affiliation": "Gonzalez, Whitney and Lynch"
+    },
+    {
+     "name": "Riley Ray",
+     "email": "christina74@example.com",
+     "affiliation": "Davenport Inc"
+    }
+   ],
+   "contact": "jared54@example.com",
+   "inputs": {
+    "input_1": {
+     "displayOrder": 1.0,
+     "label": "File with int number",
+     "description": "Pick a file containing only one integer",
+     "type": "data:text/plain",
+     "fileToKeyMap": {
+      "single_number.txt": "input_1"
+     }
+    },
+    "input_2": {
+     "displayOrder": 2.0,
+     "label": "Sleep interval",
+     "description": "Choose an amount of time to sleep",
+     "type": "integer",
+     "defaultValue": 2
+    },
+    "input_3": {
+     "displayOrder": 3.0,
+     "label": "Fail after sleep",
+     "description": "If set to true will cause service to fail after it sleeps",
+     "type": "boolean",
+     "defaultValue": false
+    }
+   },
+   "outputs": {
+    "output_1": {
+     "displayOrder": 1.0,
+     "label": "File containing one random integer",
+     "description": "Integer is generated in range [1-9]",
+     "type": "data:text/plain",
+     "fileToKeyMap": {
+      "single_number.txt": "output_1"
+     }
+    },
+    "output_2": {
+     "displayOrder": 2.0,
+     "label": "Random sleep interval",
+     "description": "Interval is generated in range [1-9]",
+     "type": "integer"
+    }
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "create_project",
+  "description": "<Request('POST', 'http://webserver:8080/v0/projects?hidden=true')>",
+  "method": "POST",
+  "host": "webserver",
+  "path": "/v0/projects",
+  "query": "hidden=true",
+  "request_payload": {
+   "uuid": "767a7355-3062-4ceb-b339-ed67d07d2ed2",
+   "name": "solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/767a7355-3062-4ceb-b339-ed67d07d2ed2",
+   "description": "Study associated to solver job:\n{\n  \"id\": \"767a7355-3062-4ceb-b339-ed67d07d2ed2\",\n  \"name\": \"solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/767a7355-3062-4ceb-b339-ed67d07d2ed2\",\n  \"inputs_checksum\": \"f6fce006d0fe7b6168fc20a10ec1fe74d1723ebc935232d3c0707c277db2ef0c\",\n  \"created_at\": \"2023-07-12T12:45:30.757605+00:00\"\n}",
+   "thumbnail": "https://via.placeholder.com/170x120.png",
+   "workbench": {
+    "d49543e7-6e36-57ee-86ff-46b71f63757f": {
+     "key": "simcore/services/comp/itis/sleeper",
+     "version": "2.0.0",
+     "label": "sleeper",
+     "progress": null,
+     "thumbnail": null,
+     "runHash": null,
+     "inputs": {
+      "x": 4.33,
+      "n": 55,
+      "title": "Temperature",
+      "enabled": true
+     },
+     "inputsUnits": {},
+     "inputAccess": null,
+     "inputNodes": [],
+     "outputs": {},
+     "outputNode": null,
+     "outputNodes": null,
+     "parent": null,
+     "position": null,
+     "state": {
+      "modified": true,
+      "dependencies": [],
+      "currentStatus": "NOT_STARTED",
+      "progress": 0
+     },
+     "bootOptions": null
+    }
+   },
+   "accessRights": {},
+   "tags": [],
+   "classifiers": [],
+   "ui": {
+    "workbench": {
+     "d49543e7-6e36-57ee-86ff-46b71f63757f": {
+      "position": {
+       "x": 633,
+       "y": 229
+      },
+      "marker": null
+     }
+    },
+    "slideshow": {},
+    "currentNodeId": "d49543e7-6e36-57ee-86ff-46b71f63757f",
+    "annotations": {}
+   }
+  },
+  "response_body": {
+   "data": {
+    "task_id": "POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b",
+    "task_name": "POST /v0/projects?hidden=true",
+    "status_href": "/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b",
+    "result_href": "/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b/result",
+    "abort_href": "/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b"
+   }
+  },
+  "status_code": 202
+ },
+ {
+  "name": "get_task_status_1",
+  "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": {
+    "task_progress": {
+     "message": "creating new study...",
+     "percent": 0.0
+    },
+    "done": false,
+    "started": "2023-07-12T12:45:30.825756"
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "get_task_status_2",
+  "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": {
+    "task_progress": {
+     "message": "creating new study...",
+     "percent": 0.0
+    },
+    "done": false,
+    "started": "2023-07-12T12:45:30.825756"
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "get_task_status_3",
+  "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": {
+    "task_progress": {
+     "message": "finished",
+     "percent": 1.0
+    },
+    "done": true,
+    "started": "2023-07-12T12:45:30.825756"
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "get_task_result",
+  "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b/result')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.ceb7b7ab-ccef-4ea6-b82f-199d265d4c3b/result",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": {
+    "uuid": "767a7355-3062-4ceb-b339-ed67d07d2ed2",
+    "name": "solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/767a7355-3062-4ceb-b339-ed67d07d2ed2",
+    "description": "Study associated to solver job:\n{\n  \"id\": \"767a7355-3062-4ceb-b339-ed67d07d2ed2\",\n  \"name\": \"solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/767a7355-3062-4ceb-b339-ed67d07d2ed2\",\n  \"inputs_checksum\": \"f6fce006d0fe7b6168fc20a10ec1fe74d1723ebc935232d3c0707c277db2ef0c\",\n  \"created_at\": \"2023-07-12T12:45:30.757605+00:00\"\n}",
+    "thumbnail": "https://via.placeholder.com/170x120.png",
+    "creationDate": "2023-07-12T12:45:30.832Z",
+    "lastChangeDate": "2023-07-12T12:45:30.832Z",
+    "workbench": {
+     "d49543e7-6e36-57ee-86ff-46b71f63757f": {
+      "key": "simcore/services/comp/itis/sleeper",
+      "version": "2.0.0",
+      "label": "sleeper",
+      "progress": 0.0,
+      "inputs": {
+       "x": 4.33,
+       "n": 55,
+       "title": "Temperature",
+       "enabled": true
+      },
+      "inputsUnits": {},
+      "inputNodes": [],
+      "outputs": {},
+      "state": {
+       "modified": true,
+       "dependencies": [],
+       "currentStatus": "NOT_STARTED",
+       "progress": 0.0
+      }
+     }
+    },
+    "prjOwner": "hguerrero@example.com",
+    "accessRights": {
+     "3": {
+      "read": true,
+      "write": true,
+      "delete": true
+     }
+    },
+    "tags": [],
+    "classifiers": [],
+    "state": {
+     "locked": {
+      "value": false,
+      "status": "CLOSED"
+     },
+     "state": {
+      "value": "NOT_STARTED"
+     }
+    },
+    "ui": {
+     "workbench": {
+      "d49543e7-6e36-57ee-86ff-46b71f63757f": {
+       "position": {
+        "x": 633,
+        "y": 229
+       }
+      }
+     },
+     "slideshow": {},
+     "currentNodeId": "d49543e7-6e36-57ee-86ff-46b71f63757f",
+     "annotations": {}
+    },
+    "quality": {},
+    "dev": {}
+   }
+  },
+  "status_code": 201
+ },
+ {
+  "name": "get_project_metadata",
+  "description": "<Request('GET', 'http://webserver:8080/v0/projects/767a7355-3062-4ceb-b339-ed67d07d2ed2/metadata')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/projects/767a7355-3062-4ceb-b339-ed67d07d2ed2/metadata",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": {
+    "projectUuid": "767a7355-3062-4ceb-b339-ed67d07d2ed2",
+    "custom": {}
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "update_project_metadata",
+  "description": "<Request('PATCH', 'http://webserver:8080/v0/projects/767a7355-3062-4ceb-b339-ed67d07d2ed2/metadata')>",
+  "method": "PATCH",
+  "host": "webserver",
+  "path": "/v0/projects/767a7355-3062-4ceb-b339-ed67d07d2ed2/metadata",
+  "query": null,
+  "request_payload": {
+   "custom": {
+    "number": 3.14,
+    "integer": 42,
+    "string": "foo",
+    "boolean": true
+   }
+  },
+  "response_body": {
+   "data": {
+    "projectUuid": "767a7355-3062-4ceb-b339-ed67d07d2ed2",
+    "custom": {
+     "number": 3.14,
+     "string": "foo",
+     "boolean": true,
+     "integer": 42
+    }
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "get_project_metadata_1",
+  "description": "<Request('GET', 'http://webserver:8080/v0/projects/767a7355-3062-4ceb-b339-ed67d07d2ed2/metadata')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/projects/767a7355-3062-4ceb-b339-ed67d07d2ed2/metadata",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": {
+    "projectUuid": "767a7355-3062-4ceb-b339-ed67d07d2ed2",
+    "custom": {
+     "number": 3.14,
+     "string": "foo",
+     "boolean": true,
+     "integer": 42
+    }
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "delete_project",
+  "description": "<Request('DELETE', 'http://webserver:8080/v0/projects/767a7355-3062-4ceb-b339-ed67d07d2ed2')>",
+  "method": "DELETE",
+  "host": "webserver",
+  "path": "/v0/projects/767a7355-3062-4ceb-b339-ed67d07d2ed2",
+  "query": null,
+  "request_payload": null,
+  "response_body": null,
+  "status_code": 204
+ },
+ {
+  "name": "get_project_metadata_3",
+  "description": "<Request('GET', 'http://webserver:8080/v0/projects/767a7355-3062-4ceb-b339-ed67d07d2ed2/metadata')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/projects/767a7355-3062-4ceb-b339-ed67d07d2ed2/metadata",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": null,
+   "error": {
+    "logs": [
+     {
+      "message": "Project with uuid 767a7355-3062-4ceb-b339-ed67d07d2ed2 not found.",
+      "level": "ERROR",
+      "logger": "user"
+     }
+    ],
+    "errors": [
+     {
+      "code": "HTTPNotFound",
+      "message": "Project with uuid 767a7355-3062-4ceb-b339-ed67d07d2ed2 not found.",
+      "resource": null,
+      "field": null
+     }
+    ],
+    "status": 404,
+    "message": "Project with uuid 767a7355-3062-4ceb-b339-ed67d07d2ed2 not found."
+   }
+  },
+  "status_code": 404
+ }
+]

--- a/services/api-server/tests/mocks/on_create_job.json
+++ b/services/api-server/tests/mocks/on_create_job.json
@@ -1,300 +1,300 @@
 [
-  {
-    "name": "GET /services/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/2.0.0",
-    "description": "<Request('GET', 'http://catalog:8000/v0/services/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/2.0.0?user_id=1')>",
-    "method": "GET",
-    "host": "catalog",
-    "path": "/v0/services/simcore/services/comp/itis/sleeper/2.0.0",
-    "query": "user_id=1",
-    "request_payload": null,
-    "response_body": {
-      "name": "sleeper",
-      "thumbnail": null,
-      "description": "A service which awaits for time to pass.",
-      "deprecated": null,
-      "classifiers": [],
-      "quality": {},
+ {
+  "name": "GET /services/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/2.0.0",
+  "description": "<Request('GET', 'http://catalog:8000/v0/services/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/2.0.0?user_id=1')>",
+  "method": "GET",
+  "host": "catalog",
+  "path": "/v0/services/simcore/services/comp/itis/sleeper/2.0.0",
+  "query": "user_id=1",
+  "request_payload": null,
+  "response_body": {
+   "name": "sleeper",
+   "thumbnail": null,
+   "description": "A service which awaits for time to pass.",
+   "deprecated": null,
+   "classifiers": [],
+   "quality": {},
+   "key": "simcore/services/comp/itis/sleeper",
+   "version": "2.0.0",
+   "integration-version": "1.0.0",
+   "type": "computational",
+   "authors": [
+    {
+     "name": "Francisco Higgins",
+     "email": "linda35@example.net",
+     "affiliation": "Grant Ltd"
+    },
+    {
+     "name": "Stacey Lee",
+     "email": "michael80@example.net",
+     "affiliation": "Blevins-Cantrell"
+    }
+   ],
+   "contact": "luis44@example.org",
+   "inputs": {
+    "input_1": {
+     "displayOrder": 1.0,
+     "label": "File with int number",
+     "description": "Pick a file containing only one integer",
+     "type": "data:text/plain",
+     "fileToKeyMap": {
+      "single_number.txt": "input_1"
+     }
+    },
+    "input_2": {
+     "displayOrder": 2.0,
+     "label": "Sleep interval",
+     "description": "Choose an amount of time to sleep",
+     "type": "integer",
+     "defaultValue": 2
+    },
+    "input_3": {
+     "displayOrder": 3.0,
+     "label": "Fail after sleep",
+     "description": "If set to true will cause service to fail after it sleeps",
+     "type": "boolean",
+     "defaultValue": false
+    }
+   },
+   "outputs": {
+    "output_1": {
+     "displayOrder": 1.0,
+     "label": "File containing one random integer",
+     "description": "Integer is generated in range [1-9]",
+     "type": "data:text/plain",
+     "fileToKeyMap": {
+      "single_number.txt": "output_1"
+     }
+    },
+    "output_2": {
+     "displayOrder": 2.0,
+     "label": "Random sleep interval",
+     "description": "Interval is generated in range [1-9]",
+     "type": "integer"
+    }
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "POST /projects",
+  "description": "<Request('POST', 'http://webserver:8080/v0/projects?hidden=true')>",
+  "method": "POST",
+  "host": "webserver",
+  "path": "/v0/projects",
+  "query": "hidden=true",
+  "request_payload": {
+   "uuid": "06325dd9-64af-4243-8011-efdf7fb588a4",
+   "name": "solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/06325dd9-64af-4243-8011-efdf7fb588a4",
+   "description": "Study associated to solver job:\n{\n  \"id\": \"06325dd9-64af-4243-8011-efdf7fb588a4\",\n  \"name\": \"solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/06325dd9-64af-4243-8011-efdf7fb588a4\",\n  \"inputs_checksum\": \"0def0cfbe784a61b4779a5a8cf35a376c6335558f5208958fb13cc24e6851bc6\",\n  \"created_at\": \"2023-06-08T16:15:03.573115\"\n}",
+   "thumbnail": "https://via.placeholder.com/170x120.png",
+   "creationDate": "2023-06-08T16:15:03.587Z",
+   "lastChangeDate": "2023-06-08T16:15:03.587Z",
+   "workbench": {
+    "b5b971ac-86a2-5f31-93ab-d2ac572a201a": {
+     "key": "simcore/services/comp/itis/sleeper",
+     "version": "2.0.0",
+     "label": "sleeper",
+     "progress": null,
+     "thumbnail": null,
+     "runHash": null,
+     "inputs": {
+      "x": 4.33,
+      "n": 55
+     },
+     "inputsUnits": {},
+     "inputAccess": null,
+     "inputNodes": [],
+     "outputs": {},
+     "outputNode": null,
+     "outputNodes": null,
+     "parent": null,
+     "position": null,
+     "state": {
+      "modified": true,
+      "dependencies": [],
+      "currentStatus": "NOT_STARTED",
+      "progress": 0
+     },
+     "bootOptions": null
+    }
+   },
+   "prjOwner": "ginamiller@example.org",
+   "accessRights": {},
+   "tags": [],
+   "classifiers": [],
+   "ui": {
+    "workbench": {
+     "b5b971ac-86a2-5f31-93ab-d2ac572a201a": {
+      "position": {
+       "x": 633,
+       "y": 229
+      },
+      "marker": null
+     }
+    },
+    "slideshow": {},
+    "currentNodeId": "b5b971ac-86a2-5f31-93ab-d2ac572a201a",
+    "annotations": {}
+   },
+   "quality": {},
+   "dev": {}
+  },
+  "response_body": {
+   "data": {
+    "task_id": "POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
+    "task_name": "POST /v0/projects?hidden=true",
+    "status_href": "/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
+    "result_href": "/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59/result",
+    "abort_href": "/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59"
+   }
+  },
+  "status_code": 202
+ },
+ {
+  "name": "GET tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
+  "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": {
+    "task_progress": {
+     "message": "creating new study...",
+     "percent": 0.0
+    },
+    "done": false,
+    "started": "2023-06-08T16:15:03.621835"
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "GET tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
+  "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": {
+    "task_progress": {
+     "message": "creating new study...",
+     "percent": 0.0
+    },
+    "done": false,
+    "started": "2023-06-08T16:15:03.621835"
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "GET tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
+  "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": {
+    "task_progress": {
+     "message": "finished",
+     "percent": 1.0
+    },
+    "done": true,
+    "started": "2023-06-08T16:15:03.621835"
+   }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "GET tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59/result",
+  "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59/result')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59/result",
+  "query": null,
+  "request_payload": null,
+  "response_body": {
+   "data": {
+    "uuid": "06325dd9-64af-4243-8011-efdf7fb588a4",
+    "name": "solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/06325dd9-64af-4243-8011-efdf7fb588a4",
+    "description": "Study associated to solver job:\n{\n  \"id\": \"06325dd9-64af-4243-8011-efdf7fb588a4\",\n  \"name\": \"solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/06325dd9-64af-4243-8011-efdf7fb588a4\",\n  \"inputs_checksum\": \"0def0cfbe784a61b4779a5a8cf35a376c6335558f5208958fb13cc24e6851bc6\",\n  \"created_at\": \"2023-06-08T16:15:03.573115\"\n}",
+    "thumbnail": "https://via.placeholder.com/170x120.png",
+    "creationDate": "2023-06-08T16:15:03.627Z",
+    "lastChangeDate": "2023-06-08T16:15:03.627Z",
+    "workbench": {
+     "b5b971ac-86a2-5f31-93ab-d2ac572a201a": {
       "key": "simcore/services/comp/itis/sleeper",
       "version": "2.0.0",
-      "integration-version": "1.0.0",
-      "type": "computational",
-      "authors": [
-        {
-          "name": "Odei Maiz",
-          "email": "user@bar.com",
-          "affiliation": "Foo Foundation"
-        },
-        {
-          "name": "User Foo",
-          "email": "user@foo.com",
-          "affiliation": "Foo Foundation"
-        }
-      ],
-      "contact": "user@foo.com",
+      "label": "sleeper",
+      "progress": 0.0,
       "inputs": {
-        "input_1": {
-          "displayOrder": 1.0,
-          "label": "File with int number",
-          "description": "Pick a file containing only one integer",
-          "type": "data:text/plain",
-          "fileToKeyMap": {
-            "single_number.txt": "input_1"
-          }
-        },
-        "input_2": {
-          "displayOrder": 2.0,
-          "label": "Sleep interval",
-          "description": "Choose an amount of time to sleep",
-          "type": "integer",
-          "defaultValue": 2
-        },
-        "input_3": {
-          "displayOrder": 3.0,
-          "label": "Fail after sleep",
-          "description": "If set to true will cause service to fail after it sleeps",
-          "type": "boolean",
-          "defaultValue": false
-        }
+       "x": 4.33,
+       "n": 55
       },
-      "outputs": {
-        "output_1": {
-          "displayOrder": 1.0,
-          "label": "File containing one random integer",
-          "description": "Integer is generated in range [1-9]",
-          "type": "data:text/plain",
-          "fileToKeyMap": {
-            "single_number.txt": "output_1"
-          }
-        },
-        "output_2": {
-          "displayOrder": 2.0,
-          "label": "Random sleep interval",
-          "description": "Interval is generated in range [1-9]",
-          "type": "integer"
-        }
+      "inputsUnits": {},
+      "inputNodes": [],
+      "outputs": {},
+      "state": {
+       "modified": true,
+       "dependencies": [],
+       "currentStatus": "NOT_STARTED",
+       "progress": 0.0
       }
+     }
     },
-    "status_code": 200
-  },
-  {
-    "name": "POST /projects",
-    "description": "<Request('POST', 'http://webserver:8080/v0/projects?hidden=true')>",
-    "method": "POST",
-    "host": "webserver",
-    "path": "/v0/projects",
-    "query": "hidden=true",
-    "request_payload": {
-      "uuid": "06325dd9-64af-4243-8011-efdf7fb588a4",
-      "name": "solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/06325dd9-64af-4243-8011-efdf7fb588a4",
-      "description": "Study associated to solver job:\n{\n  \"id\": \"06325dd9-64af-4243-8011-efdf7fb588a4\",\n  \"name\": \"solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/06325dd9-64af-4243-8011-efdf7fb588a4\",\n  \"inputs_checksum\": \"0def0cfbe784a61b4779a5a8cf35a376c6335558f5208958fb13cc24e6851bc6\",\n  \"created_at\": \"2023-06-08T16:15:03.573115\"\n}",
-      "thumbnail": "https://via.placeholder.com/170x120.png",
-      "creationDate": "2023-06-08T16:15:03.587Z",
-      "lastChangeDate": "2023-06-08T16:15:03.587Z",
-      "workbench": {
-        "b5b971ac-86a2-5f31-93ab-d2ac572a201a": {
-          "key": "simcore/services/comp/itis/sleeper",
-          "version": "2.0.0",
-          "label": "sleeper",
-          "progress": null,
-          "thumbnail": null,
-          "runHash": null,
-          "inputs": {
-            "x": 4.33,
-            "n": 55
-          },
-          "inputsUnits": {},
-          "inputAccess": null,
-          "inputNodes": [],
-          "outputs": {},
-          "outputNode": null,
-          "outputNodes": null,
-          "parent": null,
-          "position": null,
-          "state": {
-            "modified": true,
-            "dependencies": [],
-            "currentStatus": "NOT_STARTED",
-            "progress": 0
-          },
-          "bootOptions": null
-        }
-      },
-      "prjOwner": "api-placeholder@osparc.io",
-      "accessRights": {},
-      "tags": [],
-      "classifiers": [],
-      "ui": {
-        "workbench": {
-          "b5b971ac-86a2-5f31-93ab-d2ac572a201a": {
-            "position": {
-              "x": 633,
-              "y": 229
-            },
-            "marker": null
-          }
-        },
-        "slideshow": {},
-        "currentNodeId": "b5b971ac-86a2-5f31-93ab-d2ac572a201a",
-        "annotations": {}
-      },
-      "quality": {},
-      "dev": {}
+    "prjOwner": "sbarnes@example.com",
+    "accessRights": {
+     "3": {
+      "read": true,
+      "write": true,
+      "delete": true
+     }
     },
-    "response_body": {
-      "data": {
-        "task_id": "POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
-        "task_name": "POST /v0/projects?hidden=true",
-        "status_href": "/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
-        "result_href": "/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59/result",
-        "abort_href": "/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59"
+    "tags": [],
+    "classifiers": [],
+    "state": {
+     "locked": {
+      "value": false,
+      "status": "CLOSED"
+     },
+     "state": {
+      "value": "NOT_STARTED"
+     }
+    },
+    "ui": {
+     "workbench": {
+      "b5b971ac-86a2-5f31-93ab-d2ac572a201a": {
+       "position": {
+        "x": 633,
+        "y": 229
+       }
       }
+     },
+     "slideshow": {},
+     "currentNodeId": "b5b971ac-86a2-5f31-93ab-d2ac572a201a",
+     "annotations": {}
     },
-    "status_code": 202
+    "quality": {},
+    "dev": {}
+   }
   },
-  {
-    "name": "GET tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
-    "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59')>",
-    "method": "GET",
-    "host": "webserver",
-    "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
-    "query": null,
-    "request_payload": null,
-    "response_body": {
-      "data": {
-        "task_progress": {
-          "message": "creating new study...",
-          "percent": 0.0
-        },
-        "done": false,
-        "started": "2023-06-08T16:15:03.621835"
-      }
-    },
-    "status_code": 200
-  },
-  {
-    "name": "GET tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
-    "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59')>",
-    "method": "GET",
-    "host": "webserver",
-    "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
-    "query": null,
-    "request_payload": null,
-    "response_body": {
-      "data": {
-        "task_progress": {
-          "message": "creating new study...",
-          "percent": 0.0
-        },
-        "done": false,
-        "started": "2023-06-08T16:15:03.621835"
-      }
-    },
-    "status_code": 200
-  },
-  {
-    "name": "GET tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
-    "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59')>",
-    "method": "GET",
-    "host": "webserver",
-    "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59",
-    "query": null,
-    "request_payload": null,
-    "response_body": {
-      "data": {
-        "task_progress": {
-          "message": "finished",
-          "percent": 1.0
-        },
-        "done": true,
-        "started": "2023-06-08T16:15:03.621835"
-      }
-    },
-    "status_code": 200
-  },
-  {
-    "name": "GET tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59/result",
-    "description": "<Request('GET', 'http://webserver:8080/v0/tasks/POST%2520%252Fv0%252Fprojects%253Fhidden%253Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59/result')>",
-    "method": "GET",
-    "host": "webserver",
-    "path": "/v0/tasks/POST%20%2Fv0%2Fprojects%3Fhidden%3Dtrue.42a04ed5-c581-4a8d-b037-48deda49ef59/result",
-    "query": null,
-    "request_payload": null,
-    "response_body": {
-      "data": {
-        "uuid": "06325dd9-64af-4243-8011-efdf7fb588a4",
-        "name": "solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/06325dd9-64af-4243-8011-efdf7fb588a4",
-        "description": "Study associated to solver job:\n{\n  \"id\": \"06325dd9-64af-4243-8011-efdf7fb588a4\",\n  \"name\": \"solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/06325dd9-64af-4243-8011-efdf7fb588a4\",\n  \"inputs_checksum\": \"0def0cfbe784a61b4779a5a8cf35a376c6335558f5208958fb13cc24e6851bc6\",\n  \"created_at\": \"2023-06-08T16:15:03.573115\"\n}",
-        "thumbnail": "https://via.placeholder.com/170x120.png",
-        "creationDate": "2023-06-08T16:15:03.627Z",
-        "lastChangeDate": "2023-06-08T16:15:03.627Z",
-        "workbench": {
-          "b5b971ac-86a2-5f31-93ab-d2ac572a201a": {
-            "key": "simcore/services/comp/itis/sleeper",
-            "version": "2.0.0",
-            "label": "sleeper",
-            "progress": 0.0,
-            "inputs": {
-              "x": 4.33,
-              "n": 55
-            },
-            "inputsUnits": {},
-            "inputNodes": [],
-            "outputs": {},
-            "state": {
-              "modified": true,
-              "dependencies": [],
-              "currentStatus": "NOT_STARTED",
-              "progress": 0.0
-            }
-          }
-        },
-        "prjOwner": "user@foo.com",
-        "accessRights": {
-          "3": {
-            "read": true,
-            "write": true,
-            "delete": true
-          }
-        },
-        "tags": [],
-        "classifiers": [],
-        "state": {
-          "locked": {
-            "value": false,
-            "status": "CLOSED"
-          },
-          "state": {
-            "value": "NOT_STARTED"
-          }
-        },
-        "ui": {
-          "workbench": {
-            "b5b971ac-86a2-5f31-93ab-d2ac572a201a": {
-              "position": {
-                "x": 633,
-                "y": 229
-              }
-            }
-          },
-          "slideshow": {},
-          "currentNodeId": "b5b971ac-86a2-5f31-93ab-d2ac572a201a",
-          "annotations": {}
-        },
-        "quality": {},
-        "dev": {}
-      }
-    },
-    "status_code": 201
-  },
-  {
-    "name": "DELETE /projects/06325dd9-64af-4243-8011-efdf7fb588a4",
-    "description": "<Request('DELETE', 'http://webserver:8080/v0/projects/06325dd9-64af-4243-8011-efdf7fb588a4')>",
-    "method": "DELETE",
-    "host": "webserver",
-    "path": "/v0/projects/06325dd9-64af-4243-8011-efdf7fb588a4",
-    "query": null,
-    "request_payload": null,
-    "response_body": null,
-    "status_code": 204
-  }
+  "status_code": 201
+ },
+ {
+  "name": "DELETE /projects/06325dd9-64af-4243-8011-efdf7fb588a4",
+  "description": "<Request('DELETE', 'http://webserver:8080/v0/projects/06325dd9-64af-4243-8011-efdf7fb588a4')>",
+  "method": "DELETE",
+  "host": "webserver",
+  "path": "/v0/projects/06325dd9-64af-4243-8011-efdf7fb588a4",
+  "query": null,
+  "request_payload": null,
+  "response_body": null,
+  "status_code": 204
+ }
 ]

--- a/services/api-server/tests/mocks/on_list_jobs.json
+++ b/services/api-server/tests/mocks/on_list_jobs.json
@@ -1,241 +1,241 @@
 [
-  {
-    "name": "get_service",
-    "description": "<Request('GET', 'http://catalog:8000/v0/services/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/2.0.0?user_id=1')>",
-    "method": "GET",
-    "host": "catalog",
-    "path": "/v0/services/simcore/services/comp/itis/sleeper/2.0.0",
-    "query": "user_id=1",
-    "request_payload": null,
-    "response_body": {
-     "name": "sleeper",
-     "thumbnail": null,
-     "description": "A service which awaits for time to pass.",
-     "deprecated": null,
-     "classifiers": [],
-     "quality": {},
-     "key": "simcore/services/comp/itis/sleeper",
-     "version": "2.0.0",
-     "integration-version": "1.0.0",
-     "type": "computational",
-     "authors": [
-      {
-       "name": "Manuel Guidon",
-       "email": "guidon@foo.com",
-       "affiliation": "Foo dot Com"
-      }
-     ],
-     "contact": "neagu@foo.com",
-     "inputs": {
-      "input_1": {
-       "displayOrder": 1.0,
-       "label": "File with int number",
-       "description": "Pick a file containing only one integer",
-       "type": "data:text/plain",
-       "fileToKeyMap": {
-        "single_number.txt": "input_1"
-       }
-      },
-      "input_2": {
-       "displayOrder": 2.0,
-       "label": "Sleep interval",
-       "description": "Choose an amount of time to sleep",
-       "type": "integer",
-       "defaultValue": 2
-      },
-      "input_3": {
-       "displayOrder": 3.0,
-       "label": "Fail after sleep",
-       "description": "If set to true will cause service to fail after it sleeps",
-       "type": "boolean",
-       "defaultValue": false
-      }
-     },
-     "outputs": {
-      "output_1": {
-       "displayOrder": 1.0,
-       "label": "File containing one random integer",
-       "description": "Integer is generated in range [1-9]",
-       "type": "data:text/plain",
-       "fileToKeyMap": {
-        "single_number.txt": "output_1"
-       }
-      },
-      "output_2": {
-       "displayOrder": 2.0,
-       "label": "Random sleep interval",
-       "description": "Interval is generated in range [1-9]",
-       "type": "integer"
-      }
+ {
+  "name": "get_service",
+  "description": "<Request('GET', 'http://catalog:8000/v0/services/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/2.0.0?user_id=1')>",
+  "method": "GET",
+  "host": "catalog",
+  "path": "/v0/services/simcore/services/comp/itis/sleeper/2.0.0",
+  "query": "user_id=1",
+  "request_payload": null,
+  "response_body": {
+   "name": "sleeper",
+   "thumbnail": null,
+   "description": "A service which awaits for time to pass.",
+   "deprecated": null,
+   "classifiers": [],
+   "quality": {},
+   "key": "simcore/services/comp/itis/sleeper",
+   "version": "2.0.0",
+   "integration-version": "1.0.0",
+   "type": "computational",
+   "authors": [
+    {
+     "name": "William Long",
+     "email": "brownkaren@example.net",
+     "affiliation": "Harris-Wright"
+    }
+   ],
+   "contact": "grayrachel@example.com",
+   "inputs": {
+    "input_1": {
+     "displayOrder": 1.0,
+     "label": "File with int number",
+     "description": "Pick a file containing only one integer",
+     "type": "data:text/plain",
+     "fileToKeyMap": {
+      "single_number.txt": "input_1"
      }
     },
-    "status_code": 200
-   },
-  {
-    "name": "list_projects",
-    "description": "<Request('GET', 'http://webserver:8080/v0/projects?type=user&show_hidden=true&limit=2&offset=0&search=solvers%2Fsimcore%252Fservices%252Fcomp%252Fitis%252Fsleeper%2Freleases%2F2.0.0')>",
-    "method": "GET",
-    "host": "webserver",
-    "path": "/v0/projects",
-    "query": "type=user&show_hidden=true&limit=20&offset=0&search=solvers%2Fsimcore%252Fservices%252Fcomp%252Fitis%252Fsleeper%2Freleases%2F2.0.0",
-    "request_payload": null,
-    "response_body": {
-     "_meta": {
-      "limit": 20,
-      "total": 3,
-      "offset": 0,
-      "count": 2
-     },
-     "_links": {
-      "self": "http://webserver:8080/v0/projects?type=user&show_hidden=true&limit=2&offset=0&search=solvers/simcore%252Fservices%252Fcomp%252Fitis%252Fsleeper/releases/2.0.0",
-      "first": "http://webserver:8080/v0/projects?type=user&show_hidden=true&limit=2&offset=0&search=solvers/simcore%252Fservices%252Fcomp%252Fitis%252Fsleeper/releases/2.0.0",
-      "prev": null,
-      "next": "http://webserver:8080/v0/projects?type=user&show_hidden=true&limit=2&offset=2&search=solvers/simcore%252Fservices%252Fcomp%252Fitis%252Fsleeper/releases/2.0.0",
-      "last": "http://webserver:8080/v0/projects?type=user&show_hidden=true&limit=2&offset=2&search=solvers/simcore%252Fservices%252Fcomp%252Fitis%252Fsleeper/releases/2.0.0"
-     },
-     "data": [
-      {
-       "uuid": "1455d63c-4e8f-4ffe-bdd4-e885f991cd87",
-       "name": "solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/1455d63c-4e8f-4ffe-bdd4-e885f991cd87",
-       "description": "Study associated to solver job:\n{\n  \"id\": \"1455d63c-4e8f-4ffe-bdd4-e885f991cd87\",\n  \"name\": \"solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/1455d63c-4e8f-4ffe-bdd4-e885f991cd87\",\n  \"inputs_checksum\": \"4e16c861276db7f69f7fac76dfd9d65308121d767b7cba56c1003ef6ed38ffec\",\n  \"created_at\": \"2023-06-22T18:42:35.489609\"\n}",
-       "thumbnail": "https://via.placeholder.com/170x120.png",
-       "creationDate": "2023-06-22T18:42:35.506Z",
-       "lastChangeDate": "2023-06-22T18:42:35.506Z",
-       "workbench": {
-        "05c7ed3b-0be1-5077-8065-fb55f5e59ff3": {
-         "key": "simcore/services/comp/itis/sleeper",
-         "version": "2.0.0",
-         "label": "sleeper",
-         "progress": 0.0,
-         "inputs": {
-          "x": 4.33,
-          "n": 55,
-          "title": "Temperature",
-          "enabled": true,
-          "input_file": {
-           "store": 0,
-           "path": "api/0a3b2c56-dbcd-4871-b93b-d454b7883f9f/input.txt",
-           "label": "input.txt"
-          }
-         },
-         "inputsUnits": {},
-         "inputNodes": [],
-         "outputs": {},
-         "state": {
-          "modified": true,
-          "dependencies": [],
-          "currentStatus": "NOT_STARTED",
-          "progress": 0.0
-         }
-        }
-       },
-       "prjOwner": "crespo@foo.com",
-       "accessRights": {
-        "3": {
-         "read": true,
-         "write": true,
-         "delete": true
-        }
-       },
-       "tags": [],
-       "classifiers": [],
-       "state": {
-        "locked": {
-         "value": false,
-         "status": "CLOSED"
-        },
-        "state": {
-         "value": "NOT_STARTED"
-        }
-       },
-       "ui": {
-        "workbench": {
-         "05c7ed3b-0be1-5077-8065-fb55f5e59ff3": {
-          "position": {
-           "x": 633,
-           "y": 229
-          }
-         }
-        },
-        "slideshow": {},
-        "currentNodeId": "05c7ed3b-0be1-5077-8065-fb55f5e59ff3",
-        "annotations": {}
-       },
-       "quality": {},
-       "dev": {}
-      },
-      {
-       "uuid": "61d8acda-a560-4d76-ac47-59c56a399d98",
-       "name": "solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/61d8acda-a560-4d76-ac47-59c56a399d98",
-       "description": "Study associated to solver job:\n{\n  \"id\": \"61d8acda-a560-4d76-ac47-59c56a399d98\",\n  \"name\": \"solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/61d8acda-a560-4d76-ac47-59c56a399d98\",\n  \"inputs_checksum\": \"4e16c861276db7f69f7fac76dfd9d65308121d767b7cba56c1003ef6ed38ffec\",\n  \"created_at\": \"2023-06-22T18:42:32.126304\"\n}",
-       "thumbnail": "https://via.placeholder.com/170x120.png",
-       "creationDate": "2023-06-22T18:42:32.201Z",
-       "lastChangeDate": "2023-06-22T18:42:32.201Z",
-       "workbench": {
-        "34805d7e-c2d0-561f-831f-c74a28fc9bd1": {
-         "key": "simcore/services/comp/itis/sleeper",
-         "version": "2.0.0",
-         "label": "sleeper",
-         "progress": 0.0,
-         "inputs": {
-          "x": 4.33,
-          "n": 55,
-          "title": "Temperature",
-          "enabled": true,
-          "input_file": {
-           "store": 0,
-           "path": "api/0a3b2c56-dbcd-4871-b93b-d454b7883f9f/input.txt",
-           "label": "input.txt"
-          }
-         },
-         "inputsUnits": {},
-         "inputNodes": [],
-         "outputs": {},
-         "state": {
-          "modified": true,
-          "dependencies": [],
-          "currentStatus": "NOT_STARTED",
-          "progress": 0.0
-         }
-        }
-       },
-       "prjOwner": "crespo@foo.com",
-       "accessRights": {
-        "3": {
-         "read": true,
-         "write": true,
-         "delete": true
-        }
-       },
-       "tags": [],
-       "classifiers": [],
-       "state": {
-        "locked": {
-         "value": false,
-         "status": "CLOSED"
-        },
-        "state": {
-         "value": "NOT_STARTED"
-        }
-       },
-       "ui": {
-        "workbench": {
-         "34805d7e-c2d0-561f-831f-c74a28fc9bd1": {
-          "position": {
-           "x": 633,
-           "y": 229
-          }
-         }
-        },
-        "slideshow": {},
-        "currentNodeId": "34805d7e-c2d0-561f-831f-c74a28fc9bd1",
-        "annotations": {}
-       },
-       "quality": {},
-       "dev": {}
-      }
-     ]
+    "input_2": {
+     "displayOrder": 2.0,
+     "label": "Sleep interval",
+     "description": "Choose an amount of time to sleep",
+     "type": "integer",
+     "defaultValue": 2
     },
-    "status_code": 200
+    "input_3": {
+     "displayOrder": 3.0,
+     "label": "Fail after sleep",
+     "description": "If set to true will cause service to fail after it sleeps",
+     "type": "boolean",
+     "defaultValue": false
+    }
+   },
+   "outputs": {
+    "output_1": {
+     "displayOrder": 1.0,
+     "label": "File containing one random integer",
+     "description": "Integer is generated in range [1-9]",
+     "type": "data:text/plain",
+     "fileToKeyMap": {
+      "single_number.txt": "output_1"
+     }
+    },
+    "output_2": {
+     "displayOrder": 2.0,
+     "label": "Random sleep interval",
+     "description": "Interval is generated in range [1-9]",
+     "type": "integer"
+    }
    }
+  },
+  "status_code": 200
+ },
+ {
+  "name": "list_projects",
+  "description": "<Request('GET', 'http://webserver:8080/v0/projects?type=user&show_hidden=true&limit=2&offset=0&search=solvers%2Fsimcore%252Fservices%252Fcomp%252Fitis%252Fsleeper%2Freleases%2F2.0.0')>",
+  "method": "GET",
+  "host": "webserver",
+  "path": "/v0/projects",
+  "query": "type=user&show_hidden=true&limit=20&offset=0&search=solvers%2Fsimcore%252Fservices%252Fcomp%252Fitis%252Fsleeper%2Freleases%2F2.0.0",
+  "request_payload": null,
+  "response_body": {
+   "_meta": {
+    "limit": 20,
+    "total": 3,
+    "offset": 0,
+    "count": 2
+   },
+   "_links": {
+    "self": "http://webserver:8080/v0/projects?type=user&show_hidden=true&limit=2&offset=0&search=solvers/simcore%252Fservices%252Fcomp%252Fitis%252Fsleeper/releases/2.0.0",
+    "first": "http://webserver:8080/v0/projects?type=user&show_hidden=true&limit=2&offset=0&search=solvers/simcore%252Fservices%252Fcomp%252Fitis%252Fsleeper/releases/2.0.0",
+    "prev": null,
+    "next": "http://webserver:8080/v0/projects?type=user&show_hidden=true&limit=2&offset=2&search=solvers/simcore%252Fservices%252Fcomp%252Fitis%252Fsleeper/releases/2.0.0",
+    "last": "http://webserver:8080/v0/projects?type=user&show_hidden=true&limit=2&offset=2&search=solvers/simcore%252Fservices%252Fcomp%252Fitis%252Fsleeper/releases/2.0.0"
+   },
+   "data": [
+    {
+     "uuid": "1455d63c-4e8f-4ffe-bdd4-e885f991cd87",
+     "name": "solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/1455d63c-4e8f-4ffe-bdd4-e885f991cd87",
+     "description": "Study associated to solver job:\n{\n  \"id\": \"1455d63c-4e8f-4ffe-bdd4-e885f991cd87\",\n  \"name\": \"solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/1455d63c-4e8f-4ffe-bdd4-e885f991cd87\",\n  \"inputs_checksum\": \"4e16c861276db7f69f7fac76dfd9d65308121d767b7cba56c1003ef6ed38ffec\",\n  \"created_at\": \"2023-06-22T18:42:35.489609\"\n}",
+     "thumbnail": "https://via.placeholder.com/170x120.png",
+     "creationDate": "2023-06-22T18:42:35.506Z",
+     "lastChangeDate": "2023-06-22T18:42:35.506Z",
+     "workbench": {
+      "05c7ed3b-0be1-5077-8065-fb55f5e59ff3": {
+       "key": "simcore/services/comp/itis/sleeper",
+       "version": "2.0.0",
+       "label": "sleeper",
+       "progress": 0.0,
+       "inputs": {
+        "x": 4.33,
+        "n": 55,
+        "title": "Temperature",
+        "enabled": true,
+        "input_file": {
+         "store": 0,
+         "path": "api/0a3b2c56-dbcd-4871-b93b-d454b7883f9f/input.txt",
+         "label": "input.txt"
+        }
+       },
+       "inputsUnits": {},
+       "inputNodes": [],
+       "outputs": {},
+       "state": {
+        "modified": true,
+        "dependencies": [],
+        "currentStatus": "NOT_STARTED",
+        "progress": 0.0
+       }
+      }
+     },
+     "prjOwner": "mark71@example.org",
+     "accessRights": {
+      "3": {
+       "read": true,
+       "write": true,
+       "delete": true
+      }
+     },
+     "tags": [],
+     "classifiers": [],
+     "state": {
+      "locked": {
+       "value": false,
+       "status": "CLOSED"
+      },
+      "state": {
+       "value": "NOT_STARTED"
+      }
+     },
+     "ui": {
+      "workbench": {
+       "05c7ed3b-0be1-5077-8065-fb55f5e59ff3": {
+        "position": {
+         "x": 633,
+         "y": 229
+        }
+       }
+      },
+      "slideshow": {},
+      "currentNodeId": "05c7ed3b-0be1-5077-8065-fb55f5e59ff3",
+      "annotations": {}
+     },
+     "quality": {},
+     "dev": {}
+    },
+    {
+     "uuid": "61d8acda-a560-4d76-ac47-59c56a399d98",
+     "name": "solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/61d8acda-a560-4d76-ac47-59c56a399d98",
+     "description": "Study associated to solver job:\n{\n  \"id\": \"61d8acda-a560-4d76-ac47-59c56a399d98\",\n  \"name\": \"solvers/simcore%2Fservices%2Fcomp%2Fitis%2Fsleeper/releases/2.0.0/jobs/61d8acda-a560-4d76-ac47-59c56a399d98\",\n  \"inputs_checksum\": \"4e16c861276db7f69f7fac76dfd9d65308121d767b7cba56c1003ef6ed38ffec\",\n  \"created_at\": \"2023-06-22T18:42:32.126304\"\n}",
+     "thumbnail": "https://via.placeholder.com/170x120.png",
+     "creationDate": "2023-06-22T18:42:32.201Z",
+     "lastChangeDate": "2023-06-22T18:42:32.201Z",
+     "workbench": {
+      "34805d7e-c2d0-561f-831f-c74a28fc9bd1": {
+       "key": "simcore/services/comp/itis/sleeper",
+       "version": "2.0.0",
+       "label": "sleeper",
+       "progress": 0.0,
+       "inputs": {
+        "x": 4.33,
+        "n": 55,
+        "title": "Temperature",
+        "enabled": true,
+        "input_file": {
+         "store": 0,
+         "path": "api/0a3b2c56-dbcd-4871-b93b-d454b7883f9f/input.txt",
+         "label": "input.txt"
+        }
+       },
+       "inputsUnits": {},
+       "inputNodes": [],
+       "outputs": {},
+       "state": {
+        "modified": true,
+        "dependencies": [],
+        "currentStatus": "NOT_STARTED",
+        "progress": 0.0
+       }
+      }
+     },
+     "prjOwner": "heather83@example.org",
+     "accessRights": {
+      "3": {
+       "read": true,
+       "write": true,
+       "delete": true
+      }
+     },
+     "tags": [],
+     "classifiers": [],
+     "state": {
+      "locked": {
+       "value": false,
+       "status": "CLOSED"
+      },
+      "state": {
+       "value": "NOT_STARTED"
+      }
+     },
+     "ui": {
+      "workbench": {
+       "34805d7e-c2d0-561f-831f-c74a28fc9bd1": {
+        "position": {
+         "x": 633,
+         "y": 229
+        }
+       }
+      },
+      "slideshow": {},
+      "currentNodeId": "34805d7e-c2d0-561f-831f-c74a28fc9bd1",
+      "annotations": {}
+     },
+     "quality": {},
+     "dev": {}
+    }
+   ]
+  },
+  "status_code": 200
+ }
 ]

--- a/services/api-server/tests/unit/api_solvers/conftest.py
+++ b/services/api-server/tests/unit/api_solvers/conftest.py
@@ -19,6 +19,16 @@ from simcore_service_api_server.core.settings import ApplicationSettings
 
 
 @pytest.fixture
+def solver_key() -> str:
+    return "simcore/services/comp/itis/sleeper"
+
+
+@pytest.fixture
+def solver_version() -> str:
+    return "2.0.0"
+
+
+@pytest.fixture
 def mocked_webserver_service_api(
     app: FastAPI, mocked_webserver_service_api_base: MockRouter, faker: Faker
 ) -> MockRouter:

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers.py
@@ -31,7 +31,7 @@ async def test_list_solvers(
     # No warnings for ValidationError with the fixture
     assert (
         not warn.called
-    ), f"No warnings expected in this fixture, got {str(warn.call_args)}"
+    ), f"No warnings expected in this fixture, got {warn.call_args!s}"
 
     data = resp.json()
     assert len(data) == 2

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs.py
@@ -3,9 +3,10 @@
 # pylint: disable=unused-variable
 
 import urllib.parse
+from collections.abc import Iterator
 from pathlib import Path
 from pprint import pprint
-from typing import Any, Iterator
+from typing import Any
 from zipfile import ZipFile
 
 import arrow
@@ -85,7 +86,7 @@ def presigned_download_link(
     print("generated link", presigned_url)
 
     # SEE also https://gist.github.com/amarjandu/77a7d8e33623bae1e4e5ba40dc043cb9
-    yield parse_obj_as(AnyUrl, presigned_url)
+    return parse_obj_as(AnyUrl, presigned_url)
 
 
 @pytest.fixture

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs.py
@@ -203,16 +203,6 @@ async def test_solver_logs(
     pprint(dict(resp.headers))
 
 
-@pytest.fixture
-def solver_key() -> str:
-    return "simcore/services/comp/itis/sleeper"
-
-
-@pytest.fixture
-def solver_version() -> str:
-    return "2.0.0"
-
-
 @pytest.mark.acceptance_test(
     "New feature https://github.com/ITISFoundation/osparc-simcore/issues/3940"
 )

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_delete.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_delete.py
@@ -23,16 +23,6 @@ class MockedBackendApiDict(TypedDict):
 
 
 @pytest.fixture
-def solver_key() -> str:
-    return "simcore/services/comp/itis/sleeper"
-
-
-@pytest.fixture
-def solver_version() -> str:
-    return "2.0.0"
-
-
-@pytest.fixture
 def mocked_backend_services_apis_for_delete_non_existing_project(
     mocked_webserver_service_api: MockRouter,
     project_tests_dir: Path,

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_metadata.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_metadata.py
@@ -1,0 +1,131 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from pathlib import Path
+from typing import TypedDict
+
+import httpx
+import jinja2
+import pytest
+from faker import Faker
+from models_library.basic_regex import UUID_RE_BASE
+from respx import MockRouter
+from simcore_service_api_server.models.schemas.jobs import (
+    Job,
+    JobInputs,
+    JobMetadata,
+    JobMetadataUpdate,
+)
+from simcore_service_api_server.utils.http_calls_capture import HttpApiCallCaptureModel
+from starlette import status
+
+
+class MockedBackendApiDict(TypedDict):
+    catalog: MockRouter | None
+    webserver: MockRouter | None
+
+
+@pytest.fixture
+def mocked_backend(
+    mocked_webserver_service_api: MockRouter,
+    project_tests_dir: Path,
+) -> MockedBackendApiDict:
+    mock_name = "delete_project_not_found.json"
+    environment = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(project_tests_dir / "mocks"), autoescape=True
+    )
+    template = environment.get_template(mock_name)
+
+    def _response(request: httpx.Request, project_id: str):
+        capture = HttpApiCallCaptureModel.parse_raw(
+            template.render(project_id=project_id)
+        )
+        return httpx.Response(
+            status_code=capture.status_code, json=capture.response_body
+        )
+
+    mocked_webserver_service_api.delete(
+        path__regex=rf"/projects/(?P<project_id>{UUID_RE_BASE})$",
+        name="delete_project",
+    ).mock(side_effect=_response)
+
+    return MockedBackendApiDict(webserver=mocked_webserver_service_api, catalog=None)
+
+
+@pytest.mark.acceptance_test(
+    "For https://github.com/ITISFoundation/osparc-simcore/issues/4110"
+)
+async def test_get_and_update_job_metadata(
+    auth: httpx.BasicAuth,
+    client: httpx.AsyncClient,
+    solver_key: str,
+    solver_version: str,
+    faker: Faker,
+    mocked_backend: MockedBackendApiDict,
+):
+    # create Job
+    resp = await client.post(
+        f"/v0/solvers/{solver_key}/releases/{solver_version}/jobs",
+        auth=auth,
+        json=JobInputs(
+            values={
+                "x": 3.14,
+                "n": 42,
+            }
+        ).dict(),
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    job = Job.parse_obj(resp.json())
+
+    # Get metadata
+    resp = await client.get(
+        f"/v0/solvers/{solver_key}/releases/{solver_version}/jobs/{job.id}/metadata",
+        auth=auth,
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    job_meta = JobMetadata.parse_obj(resp.json())
+
+    assert job_meta.metadata == {}
+
+    # Update metadata
+    my_metadata = {"number": 3.14, "integer": 42, "string": "foo", "boolean": True}
+    resp = await client.patch(
+        f"/v0/solvers/{solver_key}/releases/{solver_version}/jobs/{job.id}/metadata",
+        auth=auth,
+        json=JobMetadataUpdate(metadata=my_metadata).dict(),
+    )
+    assert resp.status_code == status.HTTP_200_OK
+
+    job_meta = JobMetadata.parse_obj(resp.json())
+    assert job_meta.metadata == my_metadata
+
+    # Get metadata after update
+    resp = await client.get(
+        f"/v0/solvers/{solver_key}/releases/{solver_version}/jobs/{job.id}/metadata",
+        auth=auth,
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    job_meta = JobMetadata.parse_obj(resp.json())
+
+    assert job_meta.metadata == my_metadata
+
+    # Delete job
+    resp = await client.delete(
+        f"/v0/solvers/{solver_key}/releases/{solver_version}/jobs/{job.id}",
+        auth=auth,
+    )
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+
+    # Get metadata -> job not found!
+    resp = await client.get(
+        f"/v0/solvers/{solver_key}/releases/{solver_version}/jobs/{job.id}/metadata",
+        auth=auth,
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    mock_webserver_router = mocked_backend["webserver"]
+    assert mock_webserver_router
+    assert mock_webserver_router["get_project_metadata"].called
+    assert mock_webserver_router["update_project_metadata"].called
+    assert mock_webserver_router["delete_project"].called

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_read.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_read.py
@@ -21,16 +21,6 @@ class MockBackendRouters(NamedTuple):
 
 
 @pytest.fixture
-def solver_key() -> str:
-    return "simcore/services/comp/itis/sleeper"
-
-
-@pytest.fixture
-def solver_version() -> str:
-    return "2.0.0"
-
-
-@pytest.fixture
 def mocked_backend(
     mocked_webserver_service_api_base: MockRouter,
     mocked_catalog_service_api_base: MockRouter,

--- a/services/api-server/tests/unit/api_studies/conftest.py
+++ b/services/api-server/tests/unit/api_studies/conftest.py
@@ -3,8 +3,9 @@
 # pylint: disable=unused-variable
 
 
+from collections.abc import Iterator
 from copy import deepcopy
-from typing import Any, Iterator
+from typing import Any
 
 import pytest
 import respx
@@ -74,7 +75,7 @@ def mocked_webserver_service_api(
 
         # Mocks /projects/{*}/metadata/ports
         assert oas_paths["/projects/{project_id}/metadata/ports"]
-        assert "get" in oas_paths["/projects/{project_id}/metadata/ports"].keys()
+        assert "get" in oas_paths["/projects/{project_id}/metadata/ports"]
         respx_mock.get(
             path__regex=r"/projects/(?P<project_id>[\w-]+)/metadata/ports$",
             name="list_project_metadata_ports",

--- a/services/api-server/tests/unit/conftest.py
+++ b/services/api-server/tests/unit/conftest.py
@@ -4,9 +4,10 @@
 # pylint: disable=unused-variable
 
 import json
+from collections.abc import AsyncIterator, Iterator
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, AsyncIterator, Iterator
+from typing import Any
 
 import aiohttp.test_utils
 import httpx
@@ -62,8 +63,7 @@ def app_environment(
 @pytest.fixture
 def app(app_environment: EnvVarsDict) -> FastAPI:
     """Inits app on a light environment"""
-    the_app = init_app()
-    return the_app
+    return init_app()
 
 
 @pytest.fixture
@@ -80,7 +80,7 @@ async def client(app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
         ) as client:
             assert isinstance(client._transport, ASGITransport)
             # rewires location test's app to client.app
-            setattr(client, "app", client._transport.app)
+            client.app = client._transport.app
 
             yield client
 

--- a/services/api-server/tests/unit/test_utils_solver_job_models_converters.py
+++ b/services/api-server/tests/unit/test_utils_solver_job_models_converters.py
@@ -75,7 +75,7 @@ def test_job_to_node_inputs_conversion():
             ),
         }
     )
-    for name, value in job_inputs.values.items():
+    for _name, value in job_inputs.values.items():
         assert parse_obj_as(ArgumentTypes, value) == value
 
     node_inputs: InputsDict = {
@@ -92,7 +92,7 @@ def test_job_to_node_inputs_conversion():
         ),
     }
 
-    for name, value in node_inputs.items():
+    for _name, value in node_inputs.items():
         assert parse_obj_as(InputTypes, value) == value
 
     # test transformations in both directions


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

Now a user can attach a key-values map (denoted "custom metadata") to an existing job.

- ✨ Public-api implements `Get` and `Update` jobs metadata.  
- ✨ Enhanced OAS: added error responses
- ♻️ cleanup w/ ruff both code and tests
- ♻️ cleanup test fixtures

## Related issue/s


- resolves https://github.com/ITISFoundation/osparc-simcore/issues/4313


## How to test

- Driving test: services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_metadata.py

## DevOps  

None