### PR TITLE
♻️ removing code that is no longer required

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/models/schemas/dynamic_services/scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/schemas/dynamic_services/scheduler.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import re
-import warnings
 from enum import Enum
 from functools import cached_property
 from typing import Any, Mapping, TypeAlias
@@ -17,15 +16,7 @@ from models_library.service_settings_labels import (
 )
 from models_library.services import RunID
 from models_library.services_resources import ServiceResourcesDict
-from pydantic import (
-    AnyHttpUrl,
-    BaseModel,
-    ConstrainedStr,
-    Extra,
-    Field,
-    parse_obj_as,
-    root_validator,
-)
+from pydantic import AnyHttpUrl, BaseModel, ConstrainedStr, Extra, Field, parse_obj_as
 from servicelib.error_codes import ErrorCodeStr
 from servicelib.exception_utils import DelayedExceptionHandler
 
@@ -161,24 +152,6 @@ class ServiceRemovalState(BaseModel):
     def mark_removed(self) -> None:
         self.can_remove = False
         self.was_removed = True
-
-    @root_validator(pre=True)
-    @classmethod
-    def _can_save_is_no_longer_none(cls, values):
-        warnings.warn(
-            (
-                "Once https://github.com/ITISFoundation/osparc-simcore/issues/4202 "
-                "reaches production this entire root_validator function "
-                "can be safely removed. Please check "
-                "https://github.com/ITISFoundation/osparc-simcore/issues/4204"
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        can_save: bool | None = values.get("can_save", None)
-        if can_save is None:
-            values["can_save"] = False
-        return values
 
 
 class DynamicSidecar(BaseModel):

--- a/services/director-v2/tests/mocks/fake_scheduler_data.json
+++ b/services/director-v2/tests/mocks/fake_scheduler_data.json
@@ -39,7 +39,7 @@
     "is_service_environment_ready": true,
     "service_removal_state": {
       "can_remove": false,
-      "can_save": null,
+      "can_save": false,
       "was_removed": false
     },
     "dynamic_sidecar_id": "sbig36r7lmciw0qvmbyjq8l87",

--- a/services/director-v2/tests/mocks/fake_scheduler_data_compose_spec.json
+++ b/services/director-v2/tests/mocks/fake_scheduler_data_compose_spec.json
@@ -39,7 +39,7 @@
     "is_service_environment_ready": false,
     "service_removal_state": {
       "can_remove": false,
-      "can_save": null,
+      "can_save": false,
       "was_removed": false
     },
     "dynamic_sidecar_id": "mz4vljrbwcnj6ffoiu7rozkqb",

--- a/services/director-v2/tests/mocks/legacy_scheduler_data_format.json
+++ b/services/director-v2/tests/mocks/legacy_scheduler_data_format.json
@@ -186,7 +186,7 @@
       "is_service_environment_ready": true,
       "service_removal_state": {
         "can_remove": false,
-        "can_save": null,
+        "can_save": false,
         "was_removed": false
       },
       "wait_for_manual_intervention_after_error": false,

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_observer.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_observer.py
@@ -119,7 +119,7 @@ def _is_observation_task_present(
     )
 
 
-@pytest.mark.parametrize("can_save", [None, False, True])
+@pytest.mark.parametrize("can_save", [False, True])
 async def test_regression_break_endless_loop_cancellation_edge_case(
     disable_observation: None,
     mock_are_sidecar_and_proxy_services_present: None,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

Field `can_save`, can no longer be `None`, removing all relative tests and validation code.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->

- closes https://github.com/ITISFoundation/osparc-simcore/issues/4204


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
