### PR TITLE
🎨 Guest users warning message

### DIFF
--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -362,7 +362,10 @@ qx.Class.define("osparc.Application", {
         .then(profile => {
           this.__connectWebSocket();
 
-          if ("expirationDate" in profile) {
+          if (osparc.auth.Data.getInstance().isGuest()) {
+            osparc.utils.Utils.createAccountMessage()
+              .then(msg => osparc.component.message.FlashMessenger.getInstance().logAs(msg, "WARNING"));
+          } else if ("expirationDate" in profile) {
             const now = new Date();
             const today = new Date(now.toISOString().slice(0, 10));
             const expirationDay = new Date(profile["expirationDate"]);

--- a/services/static-webserver/client/source/class/osparc/store/Support.js
+++ b/services/static-webserver/client/source/class/osparc/store/Support.js
@@ -149,12 +149,12 @@ qx.Class.define("osparc.store.Support", {
 
     mailToText: function(email, subject) {
       const color = qx.theme.manager.Color.getInstance().resolve("text");
-      const textLink = `&nbsp&nbsp<a href="mailto:${email}?subject=${subject}" style='color: ${color}' target='_blank'>${email}</a>&nbsp&nbsp`;
+      const textLink = `<a href="mailto:${email}?subject=${subject}" style='color: ${color}' target='_blank'>${email}</a>`;
       return textLink;
     },
 
     getMailToLabel: function(email, subject) {
-      const textLink = this.mailToText(email, subject);
+      const textLink = `&nbsp&nbsp${this.mailToText(email, subject)}&nbsp&nbsp`;
       const mailto = new qx.ui.basic.Label(textLink).set({
         alignX: "center",
         font: "text-14",

--- a/services/static-webserver/client/source/class/osparc/store/Support.js
+++ b/services/static-webserver/client/source/class/osparc/store/Support.js
@@ -149,13 +149,12 @@ qx.Class.define("osparc.store.Support", {
 
     mailToText: function(email, subject) {
       const color = qx.theme.manager.Color.getInstance().resolve("text");
-      const textLink = `<a href="mailto:${email}?subject=${subject}" style='color: ${color}' target='_blank'>${email}</a>`;
+      const textLink = `<center>&nbsp&nbsp<a href="mailto:${email}?subject=${subject}" style='color: ${color}' target='_blank'>${email}</a>&nbsp&nbsp<center>`;
       return textLink;
     },
 
     getMailToLabel: function(email, subject) {
-      const textLink = `&nbsp&nbsp${this.mailToText(email, subject)}&nbsp&nbsp`;
-      const mailto = new qx.ui.basic.Label(textLink).set({
+      const mailto = new qx.ui.basic.Label(this.mailToText(email, subject)).set({
         alignX: "center",
         font: "text-14",
         selectable: true,
@@ -176,8 +175,6 @@ qx.Class.define("osparc.store.Support", {
       const createAccountWindow = new osparc.ui.window.Dialog("Create Account").set({
         maxWidth: 380
       });
-      let message = qx.locale.Manager.tr("Registration is currently only available with an invitation.");
-      message += "<br>";
       Promise.all([
         osparc.store.VendorInfo.getInstance().getVendor(),
         osparc.store.StaticInfo.getInstance().getDisplayName()
@@ -186,18 +183,17 @@ qx.Class.define("osparc.store.Support", {
           const vendor = values[0];
           const displayName = values[1];
           if ("invitation_url" in vendor) {
+            let message = qx.locale.Manager.tr("Registration is currently only available with an invitation.");
+            message += "<br>";
             message += qx.locale.Manager.tr("Please request access to ") + displayName + ":";
             message += "<br>";
             createAccountWindow.setMessage(message);
             const linkLabel = new osparc.ui.basic.LinkLabel(vendor["invitation_url"], vendor["invitation_url"]);
             createAccountWindow.addWidget(linkLabel);
           } else {
-            message += qx.locale.Manager.tr("Please contact:");
-            createAccountWindow.setMessage(message);
-            osparc.store.VendorInfo.getInstance().getSupportEmail()
-              .then(supportEmail => {
-                const mailto = this.getMailToLabel(supportEmail, "Request Account " + displayName);
-                createAccountWindow.addWidget(mailto);
+            osparc.utils.Utils.createAccountMessage()
+              .then(message => {
+                createAccountWindow.setMessage(message);
               });
           }
         });

--- a/services/static-webserver/client/source/class/osparc/store/Support.js
+++ b/services/static-webserver/client/source/class/osparc/store/Support.js
@@ -147,14 +147,19 @@ qx.Class.define("osparc.store.Support", {
       });
     },
 
-    getMailToLabel: function(email, subject) {
+    mailToText: function(email, subject) {
       const color = qx.theme.manager.Color.getInstance().resolve("text");
       const textLink = `&nbsp&nbsp<a href="mailto:${email}?subject=${subject}" style='color: ${color}' target='_blank'>${email}</a>&nbsp&nbsp`;
+      return textLink;
+    },
+
+    getMailToLabel: function(email, subject) {
+      const textLink = this.mailToText(email, subject);
       const mailto = new qx.ui.basic.Label(textLink).set({
         alignX: "center",
         font: "text-14",
         selectable: true,
-        rich : true
+        rich: true
       });
       return mailto;
     },

--- a/services/static-webserver/client/source/class/osparc/ui/message/FlashMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/message/FlashMessage.js
@@ -114,6 +114,7 @@ qx.Class.define("osparc.ui.message.FlashMessage", {
         case "message":
           control = new qx.ui.basic.Label().set({
             font: "text-16",
+            selectable: true,
             rich: true
           });
           this._add(control, {

--- a/services/static-webserver/client/source/class/osparc/ui/window/Dialog.js
+++ b/services/static-webserver/client/source/class/osparc/ui/window/Dialog.js
@@ -73,6 +73,7 @@ qx.Class.define("osparc.ui.window.Dialog", {
     __buildLayout: function() {
       this.__messageLabel = new qx.ui.basic.Label().set({
         font: "text-14",
+        selectable: true,
         rich: true
       });
       this.add(this.__messageLabel, {

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -347,6 +347,31 @@ qx.Class.define("osparc.utils.Utils", {
       });
     },
 
+    // used for showing it to Guest users
+    createAccountMessage: function() {
+      return new Promise(resolve => {
+        Promise.all([
+          osparc.store.StaticInfo.getInstance().getDisplayName(),
+          osparc.store.Support.getManuals(),
+          osparc.store.VendorInfo.getInstance().getSupportEmail()
+        ])
+          .then(values => {
+            const productName = values[0];
+            const manuals = values[1];
+            const manualLink = (manuals && manuals.length) ? manuals[0].url : "";
+            const supportEmail = values[2];
+            let msg = "";
+            msg += qx.locale.Manager.tr("To use all ");
+            // product
+            const color = qx.theme.manager.Color.getInstance().resolve("text");
+            msg += `<a href=${manualLink} style='color: ${color}' target='_blank'>${productName} features/a>`;
+            msg += qx.locale.Manager.tr(", please send us an e-mail to create an account:");
+            msg += "</br>";
+            resolve(msg + supportEmail);
+          });
+      });
+    },
+
     getNameFromEmail: function(email) {
       return email.split("@")[0];
     },

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -363,7 +363,7 @@ qx.Class.define("osparc.utils.Utils", {
             let msg = "";
             msg += qx.locale.Manager.tr("To use all ");
             const color = qx.theme.manager.Color.getInstance().resolve("text");
-            msg += `<a href=${manualLink} style='color: ${color}' target='_blank'>${productName} features/a>`;
+            msg += `<a href=${manualLink} style='color: ${color}' target='_blank'>${productName} features</a>`;
             msg += qx.locale.Manager.tr(", please send us an e-mail to create an account:");
             msg += "</br>";
             resolve(msg + supportEmail);

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -362,7 +362,6 @@ qx.Class.define("osparc.utils.Utils", {
             const supportEmail = values[2];
             let msg = "";
             msg += qx.locale.Manager.tr("To use all ");
-            // product
             const color = qx.theme.manager.Color.getInstance().resolve("text");
             msg += `<a href=${manualLink} style='color: ${color}' target='_blank'>${productName} features/a>`;
             msg += qx.locale.Manager.tr(", please send us an e-mail to create an account:");

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -360,13 +360,15 @@ qx.Class.define("osparc.utils.Utils", {
             const manuals = values[1];
             const manualLink = (manuals && manuals.length) ? manuals[0].url : "";
             const supportEmail = values[2];
+            const mailto = osparc.store.Support.mailToText(supportEmail, "Request Account " + productName);
             let msg = "";
             msg += qx.locale.Manager.tr("To use all ");
             const color = qx.theme.manager.Color.getInstance().resolve("text");
             msg += `<a href=${manualLink} style='color: ${color}' target='_blank'>${productName} features</a>`;
             msg += qx.locale.Manager.tr(", please send us an e-mail to create an account:");
             msg += "</br>";
-            resolve(msg + supportEmail);
+            msg += mailto;
+            resolve(msg);
           });
       });
     },


### PR DESCRIPTION
## What do these changes do?

Update the Create account dialog and Warning message guests will see when account is required or when opening a published link:
"To use all [``productName``] (``productManual``) features, please send us an e-mail to create an account: ``supportEmail``"

Create account dialog:
![image](https://github.com/ITISFoundation/osparc-simcore/assets/33152403/b9ca8841-0404-44a9-b261-8517a5587c6a)

Warning flash message:
![image](https://github.com/ITISFoundation/osparc-simcore/assets/33152403/d4d943e0-1543-42dc-9a28-44aa8522684b)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
