### PR TITLE
⬆️ Complete upgrade of director v2 dependencies

### DIFF
--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -105,11 +105,8 @@ certifi==2022.12.7
     # via
     #   httpcore
     #   httpx
-    #   requests
 charset-normalizer==2.0.12
-    # via
-    #   aiohttp
-    #   requests
+    # via aiohttp
 click==8.1.3
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
@@ -146,7 +143,7 @@ email-validator==1.2.1
     # via
     #   fastapi
     #   pydantic
-fastapi==0.85.0
+fastapi==0.98.0
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
@@ -167,7 +164,6 @@ fastapi==0.85.0
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
-    #   -c requirements/./constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
 frozenlist==1.3.0
@@ -211,12 +207,12 @@ httpx==0.24.0
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
+    #   fastapi
 idna==2.10
     # via
     #   anyio
     #   email-validator
     #   httpx
-    #   requests
     #   yarl
 importlib-metadata==6.6.0
     # via
@@ -440,8 +436,6 @@ redis==4.5.4
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-requests==2.31.0
-    # via fastapi
 rich==12.5.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
@@ -489,8 +483,28 @@ sqlalchemy==1.4.47
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
     #   aiopg
     #   alembic
-starlette==0.20.4
-    # via fastapi
+starlette==0.27.0
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 tblib==1.7.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
@@ -577,7 +591,6 @@ urllib3==1.26.16
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-    #   requests
 uvicorn==0.15.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-aio-pika==9.1.2
+aio-pika==9.1.4
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiocache==0.11.1
+aiocache==0.12.1
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
@@ -19,19 +19,19 @@ aiodebug==2.3.0
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-aiodocker==0.19.1
+aiodocker==0.21.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiofiles==0.8.0
+aiofiles==23.1.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-aiohttp==3.8.3
+aiohttp==3.8.4
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
@@ -59,21 +59,19 @@ aiopg==1.4.0
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-aioredis==2.0.1
-    # via aiocache
 aiormq==6.7.6
     # via aio-pika
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via aiohttp
-alembic==1.8.1
+alembic==1.11.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-anyio==3.6.2
+anyio==3.7.1
     # via
     #   httpcore
     #   starlette
-    #   watchgod
+    #   watchfiles
 arrow==1.2.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
@@ -85,27 +83,25 @@ arrow==1.2.3
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-asgiref==3.5.2
-    # via uvicorn
 async-timeout==4.0.2
     # via
     #   aiohttp
     #   aiopg
-    #   aioredis
     #   redis
 asyncpg==0.28.0
     # via sqlalchemy
-attrs==21.4.0
+attrs==23.1.0
     # via
     #   aiohttp
     #   jsonschema
+    #   referencing
 blosc==1.11.1
     # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   httpcore
     #   httpx
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via aiohttp
 click==8.1.3
     # via
@@ -120,8 +116,6 @@ cloudpickle==2.2.1
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-commonmark==0.9.1
-    # via rich
 dask==2023.3.2
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
@@ -130,20 +124,20 @@ dask==2023.3.2
     #   distributed
 dask-gateway==2023.1.1
     # via -r requirements/_base.in
-decorator==4.4.2
-    # via networkx
 distributed==2023.3.2
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   dask-gateway
-dnspython==2.1.0
+dnspython==2.4.0
     # via email-validator
-email-validator==1.2.1
+email-validator==2.0.0.post2
     # via
     #   fastapi
     #   pydantic
-fastapi==0.98.0
+exceptiongroup==1.1.2
+    # via anyio
+fastapi==0.99.1
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
@@ -166,7 +160,7 @@ fastapi==0.98.0
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-frozenlist==1.3.0
+frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
@@ -176,15 +170,17 @@ fsspec==2023.5.0
     #   dask
 greenlet==2.0.2
     # via sqlalchemy
-h11==0.12.0
+h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==0.15.0
-    # via httpx
-httptools==0.2.0
+httpcore==0.17.3
+    # via
+    #   dnspython
+    #   httpx
+httptools==0.6.0
     # via uvicorn
-httpx==0.24.0
+httpx==0.24.1
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
@@ -208,7 +204,7 @@ httpx==0.24.0
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   fastapi
-idna==2.10
+idna==3.4
     # via
     #   anyio
     #   email-validator
@@ -218,7 +214,7 @@ importlib-metadata==6.6.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-itsdangerous==1.1.0
+itsdangerous==2.1.2
     # via fastapi
 jinja2==3.1.2
     # via
@@ -244,7 +240,7 @@ jinja2==3.1.2
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
     #   fastapi
-jsonschema==3.2.0
+jsonschema==4.18.4
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -252,6 +248,8 @@ jsonschema==3.2.0
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+jsonschema-specifications==2023.7.1
+    # via jsonschema
 locket==1.0.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
@@ -259,7 +257,7 @@ locket==1.0.0
     #   partd
 lz4==4.3.2
     # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
-mako==1.2.2
+mako==1.2.4
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
@@ -281,25 +279,29 @@ mako==1.2.2
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   alembic
+markdown-it-py==3.0.0
+    # via rich
 markupsafe==2.1.2
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   jinja2
     #   mako
+mdurl==0.1.2
+    # via markdown-it-py
 msgpack==1.0.5
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   aiocache
     #   distributed
-multidict==6.0.2
+multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-networkx==2.5.1
+networkx==3.1
     # via -r requirements/_base.in
 ordered-set==4.1.0
     # via -r requirements/_base.in
-orjson==3.7.2
+orjson==3.9.2
     # via
     #   -r requirements/_base.in
     #   fastapi
@@ -315,7 +317,7 @@ partd==1.4.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-pint==0.19.2
+pint==0.22
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 psutil==5.9.5
     # via
@@ -325,7 +327,7 @@ psycopg2-binary==2.9.6
     # via
     #   aiopg
     #   sqlalchemy
-pydantic==1.9.0
+pydantic==1.10.11
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
@@ -364,22 +366,20 @@ pydantic==1.9.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
     #   fastapi
-pygments==2.13.0
+pygments==2.15.1
     # via rich
-pyinstrument==4.1.1
+pyinstrument==4.5.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-pyrsistent==0.18.1
-    # via jsonschema
 python-dateutil==2.8.2
     # via arrow
-python-dotenv==0.20.0
+python-dotenv==1.0.0
     # via
     #   pydantic
     #   uvicorn
-python-multipart==0.0.5
+python-multipart==0.0.6
     # via fastapi
 pyyaml==6.0.1
     # via
@@ -411,7 +411,7 @@ pyyaml==6.0.1
     #   distributed
     #   fastapi
     #   uvicorn
-redis==4.5.4
+redis==4.6.0
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
@@ -436,7 +436,12 @@ redis==4.5.4
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-rich==12.5.1
+    #   aiocache
+referencing==0.30.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+rich==13.4.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/settings-library/requirements/_base.in
@@ -444,21 +449,23 @@ rich==12.5.1
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
-six==1.15.0
+rpds-py==0.9.2
     # via
     #   jsonschema
-    #   python-dateutil
-    #   python-multipart
-sniffio==1.2.0
+    #   referencing
+six==1.16.0
+    # via python-dateutil
+sniffio==1.3.0
     # via
     #   anyio
+    #   dnspython
     #   httpcore
     #   httpx
 sortedcontainers==2.4.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-sqlalchemy==1.4.47
+sqlalchemy==1.4.49
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
@@ -509,7 +516,7 @@ tblib==1.7.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-tenacity==8.0.1
+tenacity==8.2.2
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -527,26 +534,30 @@ tornado==6.3.2
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask-gateway
     #   distributed
-tqdm==4.64.0
+tqdm==4.65.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-typer==0.4.1
+typer==0.9.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
-typing-extensions==4.3.0
+typing-extensions==4.7.1
     # via
     #   aiodebug
     #   aiodocker
-    #   aioredis
+    #   alembic
+    #   fastapi
+    #   pint
     #   pydantic
-ujson==5.5.0
+    #   typer
+    #   uvicorn
+ujson==5.8.0
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
@@ -591,15 +602,15 @@ urllib3==1.26.16
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-uvicorn==0.15.0
+uvicorn==0.23.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   fastapi
-uvloop==0.16.0
+uvloop==0.17.0
     # via uvicorn
-watchgod==0.8.2
+watchfiles==0.19.0
     # via uvicorn
-websockets==10.1
+websockets==11.0.3
     # via uvicorn
 yarl==1.9.2
     # via
@@ -616,6 +627,3 @@ zipp==3.15.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -267,7 +267,6 @@ pyyaml==6.0.1
     #   distributed
 requests==2.31.0
     # via
-    #   -c requirements/_base.txt
     #   async-asgi-testclient
     #   docker
 respx==0.20.1

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-aio-pika==9.1.2
+aio-pika==9.1.4
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -12,7 +12,7 @@ aioboto3==11.2.0
     # via -r requirements/_test.in
 aiobotocore==2.5.0
     # via aioboto3
-aiohttp==3.8.3
+aiohttp==3.8.4
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -25,15 +25,15 @@ aiormq==6.7.6
     # via
     #   -c requirements/_base.txt
     #   aio-pika
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-alembic==1.8.1
+alembic==1.11.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-anyio==3.6.2
+anyio==3.7.1
     # via
     #   -c requirements/_base.txt
     #   httpcore
@@ -45,7 +45,7 @@ async-timeout==4.0.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-attrs==21.4.0
+attrs==23.1.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -59,7 +59,7 @@ botocore==1.29.76
     #   aiobotocore
     #   boto3
     #   s3transfer
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   -c requirements/_base.txt
     #   httpcore
@@ -68,7 +68,7 @@ certifi==2022.12.7
     #   requests
 cffi==1.15.1
     # via cryptography
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -87,7 +87,7 @@ colorlog==6.7.0
     # via dask-gateway-server
 coverage==7.2.7
     # via pytest-cov
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   dask-gateway-server
@@ -104,15 +104,18 @@ distributed==2023.3.2
     #   dask
 docker==6.1.3
     # via -r requirements/_test.in
-exceptiongroup==1.1.1
-    # via pytest
-execnet==1.9.0
+exceptiongroup==1.1.2
+    # via
+    #   -c requirements/_base.txt
+    #   anyio
+    #   pytest
+execnet==2.0.2
     # via pytest-xdist
-faker==18.10.1
+faker==19.1.0
     # via -r requirements/_test.in
 flaky==3.7.0
     # via -r requirements/_test.in
-frozenlist==1.3.0
+frozenlist==1.4.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -125,22 +128,22 @@ greenlet==2.0.2
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
-h11==0.12.0
+h11==0.14.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==0.15.0
+httpcore==0.17.3
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.24.0
+httpx==0.24.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   respx
 icdiff==2.0.6
     # via pytest-icdiff
-idna==2.10
+idna==3.4
     # via
     #   -c requirements/_base.txt
     #   anyio
@@ -169,7 +172,7 @@ locket==1.0.0
     #   -c requirements/_base.txt
     #   distributed
     #   partd
-mako==1.2.2
+mako==1.2.4
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -187,17 +190,17 @@ msgpack==1.0.5
     # via
     #   -c requirements/_base.txt
     #   distributed
-multidict==6.0.2
+multidict==6.0.4
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   async-asgi-testclient
     #   yarl
-mypy==1.3.0
+mypy==1.4.1
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
-numpy==1.24.3
+numpy==1.25.1
     # via bokeh
 packaging==23.1
     # via
@@ -215,9 +218,9 @@ partd==1.4.0
     # via
     #   -c requirements/_base.txt
     #   dask
-pillow==9.5.0
+pillow==10.0.0
     # via bokeh
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
@@ -227,7 +230,7 @@ psutil==5.9.5
     #   distributed
 pycparser==2.21
     # via cffi
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   -r requirements/_test.in
     #   pytest-aiohttp
@@ -239,7 +242,7 @@ pytest==7.3.1
     #   pytest-xdist
 pytest-aiohttp==1.0.4
     # via -r requirements/_test.in
-pytest-asyncio==0.21.0
+pytest-asyncio==0.21.1
     # via pytest-aiohttp
 pytest-cov==4.1.0
     # via -r requirements/_test.in
@@ -247,7 +250,7 @@ pytest-docker==1.0.1
     # via -r requirements/_test.in
 pytest-icdiff==0.6
     # via -r requirements/_test.in
-pytest-mock==3.10.0
+pytest-mock==3.11.1
     # via -r requirements/_test.in
 pytest-runner==6.0.0
     # via -r requirements/_test.in
@@ -273,11 +276,11 @@ respx==0.20.1
     # via -r requirements/_test.in
 s3transfer==0.6.1
     # via boto3
-six==1.15.0
+six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil
-sniffio==1.2.0
+sniffio==1.3.0
     # via
     #   -c requirements/_base.txt
     #   anyio
@@ -288,14 +291,14 @@ sortedcontainers==2.4.0
     # via
     #   -c requirements/_base.txt
     #   distributed
-sqlalchemy==1.4.47
+sqlalchemy==1.4.49
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   alembic
     #   dask-gateway-server
-sqlalchemy2-stubs==0.0.2a34
+sqlalchemy2-stubs==0.0.2a35
     # via sqlalchemy
 tblib==1.7.0
     # via
@@ -319,9 +322,10 @@ tornado==6.3.2
     #   distributed
 traitlets==5.9.0
     # via dask-gateway-server
-typing-extensions==4.3.0
+typing-extensions==4.7.1
     # via
     #   -c requirements/_base.txt
+    #   alembic
     #   bokeh
     #   mypy
     #   sqlalchemy2-stubs
@@ -334,7 +338,7 @@ urllib3==1.26.16
     #   docker
     #   minio
     #   requests
-websocket-client==1.5.2
+websocket-client==1.6.1
     # via docker
 wrapt==1.15.0
     # via aiobotocore

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==2.15.5
+astroid==2.15.6
     # via pylint
-black==23.3.0
+black==23.7.0
     # via -r requirements/../../../requirements/devenv.txt
 build==0.10.0
     # via pip-tools
@@ -22,9 +22,9 @@ click==8.1.3
     #   pip-tools
 dill==0.3.6
     # via pylint
-distlib==0.3.6
+distlib==0.3.7
     # via virtualenv
-filelock==3.12.0
+filelock==3.12.2
     # via virtualenv
 identify==2.5.24
     # via pre-commit
@@ -50,14 +50,14 @@ packaging==23.1
     #   build
 pathspec==0.11.1
     # via black
-pip-tools==7.0.0
+pip-tools==7.1.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.5.1
+platformdirs==3.9.1
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.3.2
+pre-commit==3.3.3
     # via -r requirements/../../../requirements/devenv.txt
 pylint==2.17.4
     # via -r requirements/../../../requirements/devenv.txt
@@ -82,12 +82,12 @@ tomli==2.0.1
     #   pyproject-hooks
 tomlkit==0.11.8
     # via pylint
-typing-extensions==4.3.0
+typing-extensions==4.7.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   astroid
-virtualenv==20.23.0
+virtualenv==20.24.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in

--- a/services/director-v2/requirements/constraints.txt
+++ b/services/director-v2/requirements/constraints.txt
@@ -1,9 +1,0 @@
-
-
-# SEE https://github.com/ITISFoundation/osparc-simcore/issues/4332
-fastapi==0.85.0
-
-# WARNING: this constraint is incompatible with security 'requirements/constraints.txt':
-#      starlette>=0.27.0                             # https://github.com/advisories/GHSA-qj8w-rv5x-2v9h
-# Until the issue above is not resolve, the only way to upgrade these requirements is to comment out
-# the line above in 'requirements/constraints.txt' !!

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -378,7 +378,7 @@ class PartialComputationParams:
     ],
 )
 async def test_run_partial_computation(
-    catalog_ready: Callable[[UserID, str], Awaitable[None]],
+    wait_for_catalog_service: Callable[[UserID, str], Awaitable[None]],
     minimal_configuration: None,
     async_client: httpx.AsyncClient,
     registered_user: Callable,
@@ -390,7 +390,7 @@ async def test_run_partial_computation(
     create_pipeline: Callable[..., Awaitable[ComputationGet]],
 ):
     user = registered_user()
-    await catalog_ready(user["id"], osparc_product_name)
+    await wait_for_catalog_service(user["id"], osparc_product_name)
     sleepers_project: ProjectAtDB = await project(
         user, workbench=fake_workbench_without_outputs
     )
@@ -530,7 +530,7 @@ async def test_run_partial_computation(
 
 
 async def test_run_computation(
-    catalog_ready: Callable[[UserID, str], Awaitable[None]],
+    wait_for_catalog_service: Callable[[UserID, str], Awaitable[None]],
     minimal_configuration: None,
     async_client: httpx.AsyncClient,
     registered_user: Callable,
@@ -543,7 +543,7 @@ async def test_run_computation(
     create_pipeline: Callable[..., Awaitable[ComputationGet]],
 ):
     user = registered_user()
-    await catalog_ready(user["id"], osparc_product_name)
+    await wait_for_catalog_service(user["id"], osparc_product_name)
     sleepers_project = await project(user, workbench=fake_workbench_without_outputs)
     # send a valid project with sleepers
     task_out = await create_pipeline(

--- a/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
+++ b/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
@@ -140,7 +140,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture
 async def minimal_configuration(
-    catalog_ready: Callable[[UserID, str], Awaitable[None]],
+    wait_for_catalog_service: Callable[[UserID, str], Awaitable[None]],
     sleeper_service: dict,
     dy_static_file_server_dynamic_sidecar_service: dict,
     dy_static_file_server_dynamic_sidecar_compose_spec_service: dict,
@@ -156,7 +156,7 @@ async def minimal_configuration(
     current_user: dict[str, Any],
     osparc_product_name: str,
 ) -> AsyncIterator[None]:
-    await catalog_ready(current_user["id"], osparc_product_name)
+    await wait_for_catalog_service(current_user["id"], osparc_product_name)
     with postgres_db.connect() as conn:
         # pylint: disable=no-value-for-parameter
         conn.execute(comp_tasks.delete())

--- a/services/director-v2/tests/integration/02/test_mixed_dynamic_sidecar_and_legacy_project.py
+++ b/services/director-v2/tests/integration/02/test_mixed_dynamic_sidecar_and_legacy_project.py
@@ -213,7 +213,7 @@ def mock_sidecars_client(mocker: MockerFixture) -> mock.Mock:
 @pytest.mark.flaky(max_runs=3)
 async def test_legacy_and_dynamic_sidecar_run(
     minimal_app: FastAPI,
-    catalog_ready: Callable[[UserID, str], Awaitable[None]],
+    wait_for_catalog_service: Callable[[UserID, str], Awaitable[None]],
     dy_static_file_server_project: ProjectAtDB,
     user_dict: dict[str, Any],
     services_endpoint: dict[str, URL],
@@ -234,7 +234,7 @@ async def test_legacy_and_dynamic_sidecar_run(
     - dy-static-file-server-dynamic-sidecar  (sidecared w/ std config)
     - dy-static-file-server-dynamic-sidecar-compose (sidecared w/ docker-compose)
     """
-    await catalog_ready(user_dict["id"], osparc_product_name)
+    await wait_for_catalog_service(user_dict["id"], osparc_product_name)
     await asyncio.gather(
         *(
             assert_start_service(

--- a/services/director-v2/tests/integration/02/test_mixed_dynamic_sidecar_and_legacy_project.py
+++ b/services/director-v2/tests/integration/02/test_mixed_dynamic_sidecar_and_legacy_project.py
@@ -17,6 +17,7 @@ from faker import Faker
 from fastapi import FastAPI
 from models_library.projects import ProjectAtDB
 from models_library.services_resources import ServiceResourcesDict
+from models_library.users import UserID
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_docker import get_localhost_ip
@@ -212,6 +213,7 @@ def mock_sidecars_client(mocker: MockerFixture) -> mock.Mock:
 @pytest.mark.flaky(max_runs=3)
 async def test_legacy_and_dynamic_sidecar_run(
     minimal_app: FastAPI,
+    catalog_ready: Callable[[UserID, str], Awaitable[None]],
     dy_static_file_server_project: ProjectAtDB,
     user_dict: dict[str, Any],
     services_endpoint: dict[str, URL],
@@ -232,6 +234,7 @@ async def test_legacy_and_dynamic_sidecar_run(
     - dy-static-file-server-dynamic-sidecar  (sidecared w/ std config)
     - dy-static-file-server-dynamic-sidecar-compose (sidecared w/ docker-compose)
     """
+    await catalog_ready(user_dict["id"], osparc_product_name)
     await asyncio.gather(
         *(
             assert_start_service(

--- a/services/director-v2/tests/integration/conftest.py
+++ b/services/director-v2/tests/integration/conftest.py
@@ -118,7 +118,7 @@ def mock_projects_repository(mocker: MockerFixture) -> None:
 
 
 @pytest.fixture
-async def catalog_ready(
+async def wait_for_catalog_service(
     services_endpoint: dict[str, URL]
 ) -> Callable[[UserID, str], Awaitable[None]]:
     async def _waiter(user_id: UserID, product_name: str) -> None:

--- a/services/director-v2/tests/unit/with_dbs/test_api_route_dynamic_services.py
+++ b/services/director-v2/tests/unit/with_dbs/test_api_route_dynamic_services.py
@@ -305,6 +305,7 @@ def test_create_dynamic_services(
         "/v2/dynamic_services",
         headers=dynamic_sidecar_headers,
         json=json.loads(post_data.json()),
+        follow_redirects=False,
     )
     assert (
         response.status_code == exp_status_code

--- a/services/director-v2/tests/unit/with_dbs/test_api_route_dynamic_services.py
+++ b/services/director-v2/tests/unit/with_dbs/test_api_route_dynamic_services.py
@@ -6,8 +6,9 @@ import json
 import logging
 import os
 import urllib.parse
+from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Iterator, NamedTuple
+from typing import Any, NamedTuple
 from uuid import UUID
 
 import pytest
@@ -16,7 +17,6 @@ from fastapi import FastAPI
 from httpx import URL, QueryParams
 from models_library.projects_nodes_io import NodeID
 from models_library.service_settings_labels import SimcoreServiceLabels
-from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from respx import MockRouter
@@ -67,7 +67,7 @@ def minimal_config(
     disable_rabbitmq: None,
     mock_env: EnvVarsDict,
     postgres_host_config: dict[str, str],
-    monkeypatch: MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """set a minimal configuration for testing the director connection only"""
     monkeypatch.setenv("SC_BOOT_MODE", "default")
@@ -85,9 +85,9 @@ def dynamic_sidecar_headers() -> dict[str, str]:
     }
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def mock_env(
-    disable_postgres: None, disable_rabbitmq: None, monkeypatch: MonkeyPatch
+    disable_postgres: None, disable_rabbitmq: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # Works as below line in docker.compose.yml
     # ${DOCKER_REGISTRY:-itisfoundation}/dynamic-sidecar:${DOCKER_IMAGE_TAG:-latest}
@@ -160,10 +160,10 @@ async def mock_retrieve_features(
             service_name = "service_name"
 
             # pylint: disable=protected-access
-            dynamic_sidecar_scheduler._scheduler._inverse_search_mapping[
+            dynamic_sidecar_scheduler._scheduler._inverse_search_mapping[  # noqa: SLF001
                 node_uuid
             ] = service_name
-            dynamic_sidecar_scheduler._scheduler._to_observe[
+            dynamic_sidecar_scheduler._scheduler._to_observe[  # noqa: SLF001
                 service_name
             ] = scheduler_data_from_http_request
 
@@ -184,8 +184,12 @@ async def mock_retrieve_features(
 
             yield respx_mock
 
-            dynamic_sidecar_scheduler._scheduler._inverse_search_mapping.pop(node_uuid)
-            dynamic_sidecar_scheduler._scheduler._to_observe.pop(service_name)
+            dynamic_sidecar_scheduler._scheduler._inverse_search_mapping.pop(
+                node_uuid
+            )  # noqa: SLF001
+            dynamic_sidecar_scheduler._scheduler._to_observe.pop(
+                service_name
+            )  # noqa: SLF001
 
 
 @pytest.fixture
@@ -366,7 +370,7 @@ def test_get_service_status(
 ):
     url = URL(f"/v2/dynamic_services/{service['node_uuid']}")
 
-    response = client.get(str(url), allow_redirects=False)
+    response = client.get(str(url), follow_redirects=False)
     assert (
         response.status_code == exp_status_code
     ), f"expected status code {exp_status_code}, received {response.status_code}: {response.text}"
@@ -433,7 +437,7 @@ def test_delete_service(
     if can_save is not None:
         url = url.copy_with(params={"can_save": can_save})
 
-    response = client.delete(str(url), allow_redirects=False)
+    response = client.delete(str(url), follow_redirects=False)
     assert (
         response.status_code == exp_status_code
     ), f"expected status code {exp_status_code}, received {response.status_code}: {response.text}"
@@ -491,7 +495,7 @@ def test_delete_service_waiting_for_manual_intervention(
 
     # mark service as failed and waiting for human intervention
     node_uuid = UUID(service["node_uuid"])
-    scheduler_data = dynamic_sidecar_scheduler._scheduler.get_scheduler_data(  # pylint: disable=protected-access
+    scheduler_data = dynamic_sidecar_scheduler._scheduler.get_scheduler_data(  # pylint: disable=protected-access  # noqa: SLF001
         node_uuid
     )
     scheduler_data.dynamic_sidecar.status.update_failing_status("failed")
@@ -499,7 +503,7 @@ def test_delete_service_waiting_for_manual_intervention(
 
     # check response
     url = URL(f"/v2/dynamic_services/{node_uuid}")
-    stop_response = client.delete(str(url), allow_redirects=False)
+    stop_response = client.delete(str(url), follow_redirects=False)
     assert stop_response.json()["errors"][0] == "waiting_for_intervention"
 
 
@@ -546,7 +550,7 @@ def test_retrieve(
     is_legacy: bool,
 ) -> None:
     url = URL(f"/v2/dynamic_services/{service['node_uuid']}:retrieve")
-    response = client.post(str(url), json=dict(port_keys=[]), allow_redirects=False)
+    response = client.post(str(url), json={"port_keys": []}, follow_redirects=False)
     assert (
         response.status_code == exp_status_code
     ), f"expected status code {exp_status_code}, received {response.status_code}: {response.text}"


### PR DESCRIPTION
###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 74
- #packages after : 73

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.1.2           | 9.1.4      |            | 2 | director-v2⬆️🧪 |
|   2 | aiocache                  | 0.11.1          | 0.12.1     | *minor*    | 1 | director-v2⬆️ |
|   3 | aiodocker                 | 0.19.1          | 0.21.0     | *minor*    | 1 | director-v2⬆️ |
|   4 | aiofiles                  | 0.8.0           | 23.1.0     | **MAJOR**  | 1 | director-v2⬆️ |
|   5 | aiohttp                   | 3.8.3           | 3.8.4      |            | 2 | director-v2⬆️🧪 |
|   6 | aioredis                  | 2.0.1           | 🗑️ removed |  | 1 | director-v2⬆️ |
|   7 | aiosignal                 | 1.2.0           | 1.3.1      | *minor*    | 2 | director-v2⬆️🧪 |
|   8 | alembic                   | 1.8.1           | 1.11.1     | *minor*    | 2 | director-v2⬆️🧪 |
|   9 | anyio                     | 3.6.2           | 3.7.1      | *minor*    | 2 | director-v2⬆️🧪 |
|  10 | asgiref                   | 3.5.2           | 🗑️ removed |  | 1 | director-v2⬆️ |
|  11 | astroid                   | 2.15.5          | 2.15.6     |            | 1 | director-v2🔧 |
|  12 | attrs                     | 21.4.0          | 23.1.0     | **MAJOR**  | 2 | director-v2⬆️🧪 |
|  13 | black                     | 23.3.0          | 23.7.0     | *minor*    | 1 | director-v2🔧 |
|  14 | certifi                   | 2022.12.7       | 2023.5.7   | **MAJOR**  | 2 | director-v2⬆️🧪 |
|  15 | charset-normalizer        | 2.0.12          | 3.2.0      | **MAJOR**  | 2 | director-v2⬆️🧪 |
|  16 | commonmark                | 0.9.1           | 🗑️ removed |  | 1 | director-v2⬆️ |
|  17 | cryptography              | 41.0.1          | 41.0.2     |            | 1 | director-v2🧪 |
|  18 | decorator                 | 4.4.2           | 🗑️ removed |  | 1 | director-v2⬆️ |
|  19 | distlib                   | 0.3.6           | 0.3.7      |            | 1 | director-v2🔧 |
|  20 | dnspython                 | 2.1.0           | 2.4.0      | *minor*    | 1 | director-v2⬆️ |
|  21 | email-validator           | 1.2.1           | 2.0.0.post2 | **MAJOR**  | 1 | director-v2⬆️ |
|  22 | exceptiongroup            | 1.1.1           | 1.1.2      |            | 1 | director-v2🧪 |
|  23 | execnet                   | 1.9.0           | 2.0.2      | **MAJOR**  | 1 | director-v2🧪 |
|  24 | faker                     | 18.10.1         | 19.1.0     | **MAJOR**  | 1 | director-v2🧪 |
|  25 | fastapi                   | 0.85.0          | 0.99.1     | *minor*    | 2 | director-v2⬆️⬆️ |
|  26 | filelock                  | 3.12.0          | 3.12.2     |            | 1 | director-v2🔧 |
|  27 | frozenlist                | 1.3.0           | 1.4.0      | *minor*    | 2 | director-v2⬆️🧪 |
|  28 | h11                       | 0.12.0          | 0.14.0     | *minor*    | 2 | director-v2⬆️🧪 |
|  29 | httpcore                  | 0.15.0          | 0.17.3     | *minor*    | 2 | director-v2⬆️🧪 |
|  30 | httptools                 | 0.2.0           | 0.6.0      | *minor*    | 1 | director-v2⬆️ |
|  31 | httpx                     | 0.24.0          | 0.24.1     |            | 2 | director-v2⬆️🧪 |
|  32 | idna                      | 2.10            | 3.4        | **MAJOR**  | 2 | director-v2⬆️🧪 |
|  33 | itsdangerous              | 1.1.0           | 2.1.2      | **MAJOR**  | 1 | director-v2⬆️ |
|  34 | jsonschema                | 3.2.0           | 4.18.4     | **MAJOR**  | 1 | director-v2⬆️ |
|  35 | mako                      | 1.2.2           | 1.2.4      |            | 2 | director-v2⬆️🧪 |
|  36 | multidict                 | 6.0.2           | 6.0.4      |            | 2 | director-v2⬆️🧪 |
|  37 | mypy                      | 1.3.0           | 1.4.1      | *minor*    | 1 | director-v2🧪 |
|  38 | networkx                  | 2.5.1           | 3.1        | **MAJOR**  | 1 | director-v2⬆️ |
|  39 | numpy                     | 1.24.3          | 1.25.1     | *minor*    | 1 | director-v2🧪 |
|  40 | orjson                    | 3.7.2           | 3.9.2      | *minor*    | 1 | director-v2⬆️ |
|  41 | pillow                    | 9.5.0           | 10.0.0     | **MAJOR**  | 1 | director-v2🧪 |
|  42 | pint                      | 0.19.2          | 0.22       | *minor*    | 1 | director-v2⬆️ |
|  43 | pip-tools                 | 7.0.0           | 7.1.0      | *minor*    | 1 | director-v2🔧 |
|  44 | platformdirs              | 3.5.1           | 3.9.1      | *minor*    | 1 | director-v2🔧 |
|  45 | pluggy                    | 1.0.0           | 1.2.0      | *minor*    | 1 | director-v2🧪 |
|  46 | pre-commit                | 3.3.2           | 3.3.3      |            | 1 | director-v2🔧 |
|  47 | pydantic                  | 1.9.0           | 1.10.11    | *minor*    | 1 | director-v2⬆️ |
|  48 | pygments                  | 2.13.0          | 2.15.1     | *minor*    | 1 | director-v2⬆️ |
|  49 | pyinstrument              | 4.1.1           | 4.5.0      | *minor*    | 1 | director-v2⬆️ |
|  50 | pyrsistent                | 0.18.1          | 🗑️ removed |  | 1 | director-v2⬆️ |
|  51 | pytest                    | 7.3.1           | 7.4.0      | *minor*    | 1 | director-v2🧪 |
|  52 | pytest-asyncio            | 0.21.0          | 0.21.1     |            | 1 | director-v2🧪 |
|  53 | pytest-mock               | 3.10.0          | 3.11.1     | *minor*    | 1 | director-v2🧪 |
|  54 | python-dotenv             | 0.20.0          | 1.0.0      | **MAJOR**  | 1 | director-v2⬆️ |
|  55 | python-multipart          | 0.0.5           | 0.0.6      |            | 1 | director-v2⬆️ |
|  56 | redis                     | 4.5.4           | 4.6.0      | *minor*    | 1 | director-v2⬆️ |
|  57 | requests                  | 2.31.0          | 🗑️ removed |  | 1 | director-v2⬆️ |
|  58 | rich                      | 12.5.1          | 13.4.2     | **MAJOR**  | 1 | director-v2⬆️ |
|  59 | six                       | 1.15.0          | 1.16.0     | *minor*    | 2 | director-v2⬆️🧪 |
|  60 | sniffio                   | 1.2.0           | 1.3.0      | *minor*    | 2 | director-v2⬆️🧪 |
|  61 | sqlalchemy                | 1.4.47          | 1.4.49     |            | 2 | director-v2⬆️🧪 |
|  62 | sqlalchemy2-stubs         | 0.0.2           | 0.0.2      |            | 1 | director-v2🧪 |
|  63 | starlette                 | 0.20.4          | 0.27.0     | *minor*    | 1 | director-v2⬆️ |
|  64 | tenacity                  | 8.0.1           | 8.2.2      | *minor*    | 1 | director-v2⬆️ |
|  65 | tqdm                      | 4.64.0          | 4.65.0     | *minor*    | 1 | director-v2⬆️ |
|  66 | typer                     | 0.4.1           | 0.9.0      | *minor*    | 1 | director-v2⬆️ |
|  67 | typing-extensions         | 4.3.0           | 4.7.1      | *minor*    | 3 | director-v2⬆️🧪🔧 |
|  68 | ujson                     | 5.5.0           | 5.8.0      | *minor*    | 1 | director-v2⬆️ |
|  69 | uvicorn                   | 0.15.0          | 0.23.1     | *minor*    | 1 | director-v2⬆️ |
|  70 | uvloop                    | 0.16.0          | 0.17.0     | *minor*    | 1 | director-v2⬆️ |
|  71 | virtualenv                | 20.23.0         | 20.24.0    | *minor*    | 1 | director-v2🔧 |
|  72 | watchgod                  | 0.8.2           | 🗑️ removed |  | 1 | director-v2⬆️ |
|  73 | websocket-client          | 1.5.2           | 1.6.1      | *minor*    | 1 | director-v2🧪 |
|  74 | websockets                | 10.1            | 11.0.3     | **MAJOR**  | 1 | director-v2⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 76

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.1.2, 9.1.3, 9.1.4       | 9.1.2, 9.1.4              |                           |
|   2 | aioboto3                  | 9.6.0, 10.4.0             | 9.6.0, 11.2.0             |                           |
|   3 | aiobotocore               | 2.3.0, 2.4.2, 2.5.0       | 2.3.0, 2.5.0              |                           |
|   4 | aiocache                  | 0.11.1, 0.12.1            | 0.12.1                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.19.1, 0.21.0            | 0.21.0                    |                           |
|   7 | aiofiles                  | 0.8.0, 22.1.0, 23.1.0     | 23.1.0                    |                           |
|   8 | aiohttp                   | 3.8.3, 3.8.4              | 3.8.3, 3.8.4              |                           |
|   9 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  10 | aiohttp-security          | 0.4.0                     |                           |                           |
|  11 | aiohttp-session           | 2.11.0                    |                           |                           |
|  12 | aiohttp-swagger           | 1.0.16                    |                           |                           |
|  13 | aioitertools              | 0.10.0, 0.11.0            | 0.11.0                    |                           |
|  14 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  15 | aioprocessing             | 2.0.1                     |                           |                           |
|  16 | aioredis                  | 2.0.1                     |                           |                           |
|  17 | aioresponses              |                           | 0.7.4                     |                           |
|  18 | aiormq                    | 6.7.6                     | 6.7.6                     |                           |
|  19 | aiosignal                 | 1.2.0, 1.3.1              | 1.2.0, 1.3.1              |                           |
|  20 | aiosmtplib                | 1.1.6                     |                           |                           |
|  21 | aiozipkin                 | 1.1.1                     |                           |                           |
|  22 | alembic                   | 1.8.1, 1.11.1             | 1.8.1, 1.11.1             |                           |
|  23 | anyio                     | 3.6.2, 3.7.0, 3.7.1       | 3.6.2, 3.7.0, 3.7.1       |                           |
|  24 | arrow                     | 1.2.3                     | 1.2.3                     |                           |
|  25 | asgi-lifespan             |                           | 2.1.0                     |                           |
|  26 | asgiref                   | 3.5.2                     |                           |                           |
|  27 | astroid                   |                           |                           | 2.15.5, 2.15.6            |
|  28 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  29 | async-timeout             | 4.0.2                     | 4.0.2                     |                           |
|  30 | asyncpg                   | 0.27.0, 0.28.0            | 0.27.0                    |                           |
|  31 | attrs                     | 21.4.0, 23.1.0            | 21.4.0, 23.1.0            |                           |
|  32 | aws-sam-translator        |                           | 1.55.0, 1.68.0            |                           |
|  33 | aws-xray-sdk              |                           | 2.12.0                    |                           |
|  34 | bcrypt                    | 3.2.0                     |                           |                           |
|  35 | bidict                    | 0.22.0                    |                           |                           |
|  36 | black                     |                           |                           | 23.3.0, 23.7.0            |
|  37 | blinker                   |                           | 1.6.2                     |                           |
|  38 | blosc                     | 1.11.1                    |                           |                           |
|  39 | bokeh                     | 2.4.3                     | 2.4.3                     |                           |
|  40 | boto3                     | 1.21.21, 1.24.59, 1.24.96 | 1.21.21, 1.24.59, 1.26.76, 1.26.159 |                           |
|  41 | boto3-stubs               |                           | 1.26.159                  |                           |
|  42 | botocore                  | 1.24.21, 1.27.59, 1.27.96, 1.29.76 | 1.24.21, 1.27.59, 1.29.76, 1.29.159 |                           |
|  43 | botocore-stubs            | 1.27.17, 1.29.78          | 1.29.159                  |                           |
|  44 | build                     |                           |                           | 0.10.0                    |
|  45 | bump2version              |                           |                           | 1.0.1                     |
|  46 | certifi                   | 2022.12.7, 2023.5.7       | 2022.12.7, 2023.5.7       |                           |
|  47 | cffi                      | 1.15.0, 1.15.1            | 1.15.1                    |                           |
|  48 | cfgv                      |                           |                           | 3.3.1                     |
|  49 | cfn-lint                  |                           | 0.72.0, 0.72.6, 0.77.6    |                           |
|  50 | change-case               |                           |                           | 0.5.2                     |
|  51 | charset-normalizer        | 2.0.12, 2.1.1, 3.0.1, 3.1.0, 3.2.0 | 2.0.12, 2.1.1, 3.0.1, 3.1.0, 3.2.0 |                           |
|  52 | click                     | 8.1.3, 8.1.5              | 8.1.3                     | 8.1.3, 8.1.5              |
|  53 | cloudpickle               | 2.2.1                     | 2.2.1                     |                           |
|  54 | colorama                  | 0.4.6                     |                           |                           |
|  55 | colorlog                  | 6.7.0                     | 6.7.0                     |                           |
|  56 | commonmark                | 0.9.1                     |                           |                           |
|  57 | contourpy                 | 1.0.7                     |                           |                           |
|  58 | coverage                  |                           | 7.2.7                     |                           |
|  59 | cryptography              | 39.0.1, 40.0.2, 41.0.1    | 41.0.1, 41.0.2            |                           |
|  60 | cycler                    | 0.11.0                    |                           |                           |
|  61 | cython                    | 0.29.36                   |                           |                           |
|  62 | dask                      | 2023.3.2, 2023.5.1        | 2023.3.2                  |                           |
|  63 | dask-gateway              | 2023.1.1                  | 2023.1.1                  |                           |
|  64 | dask-gateway-server       | 2023.1.1                  | 2023.1.1                  |                           |
|  65 | dateparser                | 1.1.8                     |                           |                           |
|  66 | debugpy                   |                           | 1.6.7                     |                           |
|  67 | deepdiff                  |                           | 6.3.0                     |                           |
|  68 | dill                      |                           |                           | 0.3.6                     |
|  69 | distlib                   |                           |                           | 0.3.6, 0.3.7              |
|  70 | distributed               | 2023.3.2, 2023.5.1        | 2023.3.2                  |                           |
|  71 | distro                    | 1.5.0                     |                           |                           |
|  72 | dnspython                 | 2.1.0, 2.2.1, 2.3.0, 2.4.0 | 2.3.0                     |                           |
|  73 | docker                    | 6.0.0, 6.1.3              | 6.1.3                     |                           |
|  74 | docker-compose            | 1.29.1                    |                           |                           |
|  75 | dockerpty                 | 0.4.1                     |                           |                           |
|  76 | docopt                    | 0.6.2                     |                           |                           |
|  77 | ecdsa                     |                           | 0.18.0                    |                           |
|  78 | email-validator           | 1.2.1, 1.3.0, 1.3.1, 2.0.0.post2 | 2.0.0.post2               |                           |
|  79 | et-xmlfile                | 1.1.0                     |                           |                           |
|  80 | exceptiongroup            | 1.1.1, 1.1.2              | 1.1.1, 1.1.2              |                           |
|  81 | execnet                   |                           | 1.9.0, 2.0.2              |                           |
|  82 | expiringdict              | 1.2.1                     |                           |                           |
|  83 | faker                     |                           | 18.10.1, 18.11.1, 19.1.0  |                           |
|  84 | fakeredis                 |                           | 2.14.0, 2.15.0            |                           |
|  85 | fastapi                   | 0.96.0, 0.98.0, 0.99.1    |                           |                           |
|  86 | fastapi-pagination        | 0.10.0, 0.12.5            |                           |                           |
|  87 | filelock                  |                           |                           | 3.12.0, 3.12.2            |
|  88 | flaky                     |                           | 3.7.0                     |                           |
|  89 | flask                     |                           | 2.1.3, 2.2.5, 2.3.2       |                           |
|  90 | flask-cors                |                           | 3.0.10                    |                           |
|  91 | fonttools                 | 4.39.4                    |                           |                           |
|  92 | frozenlist                | 1.3.0, 1.3.1, 1.3.3, 1.4.0 | 1.3.0, 1.3.1, 1.3.3, 1.4.0 |                           |
|  93 | fsspec                    | 2023.5.0                  | 2023.5.0                  |                           |
|  94 | graphql-core              |                           | 3.2.3                     |                           |
|  95 | greenlet                  | 2.0.2                     | 2.0.2                     |                           |
|  96 | gunicorn                  | 20.1.0                    |                           |                           |
|  97 | h11                       | 0.12.0, 0.14.0            | 0.12.0, 0.14.0            |                           |
|  98 | h2                        | 4.1.0                     |                           |                           |
|  99 | hpack                     | 4.0.0                     |                           |                           |
| 100 | httmock                   | 1.4.0                     |                           |                           |
| 101 | httpcore                  | 0.15.0, 0.16.3, 0.17.1, 0.17.2, 0.17.3 | 0.15.0, 0.16.3, 0.17.1, 0.17.2, 0.17.3 |                           |
| 102 | httptools                 | 0.2.0, 0.5.0, 0.6.0       |                           |                           |
| 103 | httpx                     | 0.24.0, 0.24.1            | 0.24.0, 0.24.1            |                           |
| 104 | hyperframe                | 6.0.1                     |                           |                           |
| 105 | hypothesis                |                           | 6.76.0                    |                           |
| 106 | icdiff                    |                           | 2.0.6                     |                           |
| 107 | identify                  |                           |                           | 2.5.24                    |
| 108 | idna                      | 2.10, 3.3, 3.4            | 2.10, 3.3, 3.4            |                           |
| 109 | importlib-metadata        | 6.6.0                     | 6.6.0                     |                           |
| 110 | iniconfig                 | 2.0.0                     | 2.0.0                     |                           |
| 111 | inotify                   |                           |                           | 0.2.10                    |
| 112 | isodate                   | 0.6.1                     |                           |                           |
| 113 | isort                     |                           |                           | 5.12.0                    |
| 114 | itsdangerous              | 1.1.0, 2.1.2              | 2.1.2                     |                           |
| 115 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 116 | jinja2                    | 3.1.2                     | 3.1.2                     | 3.1.2                     |
| 117 | jmespath                  | 1.0.0, 1.0.1              | 1.0.0, 1.0.1              |                           |
| 118 | jschema-to-python         |                           | 1.2.3                     |                           |
| 119 | json2html                 | 1.3.0                     |                           |                           |
| 120 | jsondiff                  | 2.0.0                     | 2.0.0                     |                           |
| 121 | jsonpatch                 |                           | 1.32, 1.33                |                           |
| 122 | jsonpickle                |                           | 3.0.1                     |                           |
| 123 | jsonpointer               |                           | 2.3, 2.4                  |                           |
| 124 | jsonschema                | 3.2.0, 4.17.3, 4.18.4     | 3.2.0, 4.17.3, 4.18.4     |                           |
| 125 | jsonschema-spec           |                           | 0.2.3                     |                           |
| 126 | jsonschema-specifications | 2023.6.1, 2023.7.1        | 2023.6.1                  |                           |
| 127 | junit-xml                 |                           | 1.9                       |                           |
| 128 | kiwisolver                | 1.4.4                     |                           |                           |
| 129 | lazy-object-proxy         | 1.7.1                     | 1.9.0                     | 1.7.1, 1.9.0              |
| 130 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 131 | lupa                      |                           | 1.14.1                    |                           |
| 132 | lz4                       | 4.3.2                     | 4.3.2                     |                           |
| 133 | mako                      | 1.2.2, 1.2.4              | 1.2.2, 1.2.4              |                           |
| 134 | markdown-it-py            | 2.2.0, 3.0.0              | 3.0.0                     |                           |
| 135 | markupsafe                | 2.1.1, 2.1.2, 2.1.3       | 2.1.1, 2.1.2, 2.1.3       | 2.1.3                     |
| 136 | matplotlib                | 3.7.1                     |                           |                           |
| 137 | mccabe                    |                           |                           | 0.7.0                     |
| 138 | mdurl                     | 0.1.2                     | 0.1.2                     |                           |
| 139 | minio                     |                           | 7.0.4                     |                           |
| 140 | more-itertools            |                           |                           |                           |
| 141 | moto                      |                           | 4.0.1, 4.1.11             |                           |
| 142 | mpmath                    |                           | 1.3.0                     |                           |
| 143 | msgpack                   | 1.0.3, 1.0.5              | 1.0.5                     |                           |
| 144 | multidict                 | 6.0.2, 6.0.3, 6.0.4       | 6.0.2, 6.0.4              |                           |
| 145 | mypy                      |                           | 1.3.0, 1.4.0, 1.4.1       |                           |
| 146 | mypy-extensions           |                           | 1.0.0                     | 1.0.0                     |
| 147 | networkx                  | 3.1                       | 2.8.8, 3.1                |                           |
| 148 | nodeenv                   |                           |                           | 1.8.0                     |
| 149 | nose                      |                           |                           | 1.3.7                     |
| 150 | numpy                     | 1.24.3                    | 1.24.3, 1.25.1            |                           |
| 151 | openapi-core              | 0.12.0                    |                           |                           |
| 152 | openapi-schema-validator  | 0.2.3                     | 0.2.3, 0.6.0              |                           |
| 153 | openapi-spec-validator    | 0.4.0                     | 0.4.0, 0.6.0              |                           |
| 154 | openpyxl                  | 3.0.9                     |                           |                           |
| 155 | ordered-set               | 4.1.0                     | 4.1.0                     |                           |
| 156 | orjson                    | 3.7.2, 3.9.1, 3.9.2       |                           |                           |
| 157 | packaging                 | 23.0, 23.1                | 23.0, 23.1                | 23.0, 23.1                |
| 158 | pamqp                     | 3.2.1                     | 3.2.1                     |                           |
| 159 | pandas                    | 2.0.1                     | 2.0.2                     |                           |
| 160 | paramiko                  | 2.11.0                    |                           |                           |
| 161 | parse                     |                           |                           |                           |
| 162 | partd                     | 1.4.0                     | 1.4.0                     |                           |
| 163 | passlib                   | 1.7.4                     |                           |                           |
| 164 | pathable                  |                           | 0.4.3                     |                           |
| 165 | pathspec                  |                           |                           | 0.11.1                    |
| 166 | pbr                       |                           | 5.11.1                    |                           |
| 167 | pillow                    | 9.5.0                     | 10.0.0                    |                           |
| 168 | pint                      | 0.19.2, 0.22              | 0.22                      |                           |
| 169 | pip-tools                 |                           |                           | 7.0.0, 7.1.0              |
| 170 | platformdirs              |                           |                           | 3.5.1, 3.5.3, 3.8.0, 3.9.1 |
| 171 | pluggy                    | 1.0.0                     | 1.0.0, 1.2.0              |                           |
| 172 | pprintpp                  |                           | 0.4.0                     |                           |
| 173 | pre-commit                |                           |                           | 3.3.2, 3.3.3              |
| 174 | prometheus-api-client     | 0.5.3                     |                           |                           |
| 175 | prometheus-client         | 0.14.1                    |                           |                           |
| 176 | psutil                    | 5.9.1, 5.9.5              | 5.9.5                     |                           |
| 177 | psycopg2-binary           | 2.9.6                     | 2.9.6                     |                           |
| 178 | ptvsd                     |                           | 4.3.2                     |                           |
| 179 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 180 | py-partiql-parser         |                           | 0.3.3                     |                           |
| 181 | pyasn1                    |                           | 0.5.0                     |                           |
| 182 | pycparser                 | 2.20, 2.21                | 2.21                      |                           |
| 183 | pydantic                  | 1.9.0, 1.10.2, 1.10.7, 1.10.8, 1.10.9, 1.10.11 | 1.10.2, 1.10.8            |                           |
| 184 | pyftpdlib                 |                           | 1.5.7                     |                           |
| 185 | pygments                  | 2.14.0, 2.15.1            | 2.15.1                    |                           |
| 186 | pyinstrument              | 3.4.2, 4.1.1, 4.3.0, 4.4.0, 4.5.0 | 4.5.0                     |                           |
| 187 | pyinstrument-cext         | 0.2.4                     |                           |                           |
| 188 | pyjwt                     | 2.4.0                     |                           |                           |
| 189 | pylint                    |                           |                           | 2.17.4                    |
| 190 | pynacl                    | 1.4.0                     |                           |                           |
| 191 | pyopenssl                 |                           | 23.2.0                    |                           |
| 192 | pyparsing                 | 3.0.9                     | 3.0.9, 3.1.0              |                           |
| 193 | pyproject-hooks           |                           |                           | 1.0.0                     |
| 194 | pyrsistent                | 0.18.1, 0.19.2, 0.19.3    | 0.18.1, 0.19.2, 0.19.3    |                           |
| 195 | pytest                    | 7.3.1                     | 7.3.1, 7.4.0              |                           |
| 196 | pytest-aiohttp            |                           | 1.0.4                     |                           |
| 197 | pytest-asyncio            |                           | 0.21.0, 0.21.1            |                           |
| 198 | pytest-benchmark          |                           | 4.0.0                     |                           |
| 199 | pytest-cov                |                           | 4.1.0                     |                           |
| 200 | pytest-docker             |                           | 1.0.1                     |                           |
| 201 | pytest-icdiff             |                           | 0.6                       |                           |
| 202 | pytest-instafail          |                           | 0.5.0                     |                           |
| 203 | pytest-lazy-fixture       |                           | 0.6.3                     |                           |
| 204 | pytest-localftpserver     |                           | 1.1.4                     |                           |
| 205 | pytest-mock               |                           | 3.10.0, 3.11.1            |                           |
| 206 | pytest-runner             |                           | 6.0.0                     |                           |
| 207 | pytest-sugar              |                           | 0.9.7                     |                           |
| 208 | pytest-xdist              |                           | 3.3.1                     |                           |
| 209 | python-dateutil           | 2.8.2                     | 2.8.2                     |                           |
| 210 | python-dotenv             | 0.20.0, 0.21.0, 1.0.0     | 0.21.0, 1.0.0             |                           |
| 211 | python-engineio           | 4.3.4                     |                           |                           |
| 212 | python-jose               |                           | 3.3.0                     |                           |
| 213 | python-magic              | 0.4.25                    |                           |                           |
| 214 | python-multipart          | 0.0.5, 0.0.6              |                           |                           |
| 215 | python-socketio           | 5.8.0                     |                           |                           |
| 216 | pytz                      | 2022.1, 2023.3            | 2023.3                    |                           |
| 217 | pyyaml                    | 5.4.1, 6.0.1              | 6.0.1                     | 5.4.1, 6.0.1              |
| 218 | redis                     | 4.5.4, 4.5.5, 4.6.0       | 4.5.4, 4.5.5              |                           |
| 219 | referencing               | 0.29.3, 0.30.0            | 0.29.3                    |                           |
| 220 | regex                     | 2023.5.5                  | 2023.6.3                  |                           |
| 221 | requests                  | 2.30.0, 2.31.0            | 2.30.0, 2.31.0            |                           |
| 222 | requests-mock             |                           | 1.10.0                    |                           |
| 223 | responses                 |                           | 0.23.1                    |                           |
| 224 | respx                     |                           | 0.20.1                    |                           |
| 225 | rfc3339-validator         |                           | 0.1.4                     |                           |
| 226 | rich                      | 12.6.0, 13.3.5, 13.4.1, 13.4.2 | 13.4.2                    |                           |
| 227 | rpds-py                   | 0.8.11, 0.9.2             | 0.8.11                    |                           |
| 228 | rsa                       |                           | 4.9                       |                           |
| 229 | ruff                      |                           |                           | 0.0.275, 0.0.278          |
| 230 | s3fs                      | 2023.5.0                  |                           |                           |
| 231 | s3transfer                | 0.5.2, 0.6.0              | 0.5.2, 0.6.0, 0.6.1       |                           |
| 232 | sarif-om                  |                           | 1.0.4                     |                           |
| 233 | semantic-version          | 2.9.0                     |                           |                           |
| 234 | setproctitle              | 1.2.3                     |                           |                           |
| 235 | shellingham               | 1.5.0.post1               |                           |                           |
| 236 | six                       | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            |                           |
| 237 | sniffio                   | 1.2.0, 1.3.0              | 1.2.0, 1.3.0              |                           |
| 238 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 239 | sqlalchemy                | 1.4.47, 1.4.48, 1.4.49    | 1.4.47, 1.4.48, 1.4.49    |                           |
| 240 | sqlalchemy2-stubs         |                           | 0.0.2a34, 0.0.2a35        |                           |
| 241 | sshpubkeys                |                           | 3.3.1                     |                           |
| 242 | starlette                 | 0.27.0                    |                           |                           |
| 243 | strict-rfc3339            | 0.7                       |                           |                           |
| 244 | sympy                     |                           | 1.12                      |                           |
| 245 | tblib                     | 1.7.0                     | 1.7.0                     |                           |
| 246 | tenacity                  | 8.0.1, 8.1.0, 8.2.1, 8.2.2 | 8.0.1, 8.2.2              |                           |
| 247 | termcolor                 |                           | 2.3.0                     |                           |
| 248 | texttable                 | 1.6.3                     |                           |                           |
| 249 | tomli                     | 2.0.1                     | 2.0.1                     | 2.0.1                     |
| 250 | tomlkit                   |                           |                           | 0.11.8                    |
| 251 | toolz                     | 0.12.0                    | 0.12.0                    |                           |
| 252 | tornado                   | 6.3.2                     | 6.3.2                     |                           |
| 253 | tqdm                      | 4.64.0, 4.64.1, 4.65.0    | 4.65.0                    |                           |
| 254 | traitlets                 | 5.9.0                     | 5.9.0                     |                           |
| 255 | twilio                    | 7.12.0                    |                           |                           |
| 256 | typer                     | 0.4.1, 0.6.1, 0.7.0, 0.9.0 | 0.9.0                     | 0.9.0                     |
| 257 | types-aiobotocore         | 2.3.3, 2.4.2.post1        |                           |                           |
| 258 | types-aiobotocore-ec2     | 2.4.2                     |                           |                           |
| 259 | types-aiobotocore-s3      | 2.3.3                     |                           |                           |
| 260 | types-aiofiles            |                           | 23.1.0.3                  |                           |
| 261 | types-awscrt              | 0.16.10                   | 0.16.19                   |                           |
| 262 | types-boto3               |                           | 1.0.2                     |                           |
| 263 | types-pkg-resources       |                           | 0.1.3                     |                           |
| 264 | types-pyyaml              |                           | 6.0.12.10                 |                           |
| 265 | types-s3transfer          |                           | 0.6.1                     |                           |
| 266 | typing-extensions         | 4.3.0, 4.4.0, 4.5.0, 4.6.0, 4.6.1, 4.6.3, 4.7.1 | 4.3.0, 4.4.0, 4.5.0, 4.6.0, 4.6.1, 4.6.3, 4.7.1 | 4.3.0, 4.4.0, 4.5.0, 4.6.0, 4.6.1, 4.6.3, 4.7.1 |
| 267 | tzdata                    | 2023.3                    | 2023.3                    |                           |
| 268 | tzlocal                   | 5.0.1                     |                           |                           |
| 269 | ujson                     | 5.5.0, 5.8.0              |                           |                           |
| 270 | urllib3                   | 1.26.9, 1.26.11, 1.26.12, 1.26.14, 1.26.16, 2.0.2 | 1.26.9, 1.26.11, 1.26.12, 1.26.14, 1.26.16, 2.0.2, 2.0.3 |                           |
| 271 | uvicorn                   | 0.15.0, 0.17.0, 0.19.0, 0.20.0, 0.22.0, 0.23.1 |                           |                           |
| 272 | uvloop                    | 0.16.0, 0.17.0            |                           |                           |
| 273 | virtualenv                |                           |                           | 20.23.0, 20.23.1, 20.24.0 |
| 274 | watchdog                  | 2.1.5                     |                           | 3.0.0                     |
| 275 | watchfiles                | 0.18.0, 0.18.1, 0.19.0    |                           |                           |
| 276 | watchgod                  | 0.8.2                     |                           |                           |
| 277 | websocket-client          | 0.59.0, 1.5.2             | 0.59.0, 1.5.2, 1.6.0, 1.6.1 |                           |
| 278 | websockets                | 10.1, 10.3, 10.4, 11.0.3  | 11.0.3                    |                           |
| 279 | werkzeug                  | 2.1.2, 2.2.2              | 2.1.2, 2.2.2, 2.3.4       |                           |
| 280 | wheel                     |                           |                           | 0.40.0                    |
| 281 | wrapt                     | 1.14.1, 1.15.0            | 1.14.1, 1.15.0            | 1.14.1, 1.15.0            |
| 282 | xmltodict                 |                           | 0.13.0                    |                           |
| 283 | yarl                      | 1.5.1, 1.9.2              | 1.5.1, 1.9.2              |                           |
| 284 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 285 | zipp                      | 3.15.0                    | 3.15.0                    |                           |
