### PR TITLE
⬆️ rclone to 1.63.1

### DIFF
--- a/ci/github/helpers/install_rclone_docker_volume_plugin.bash
+++ b/ci/github/helpers/install_rclone_docker_volume_plugin.bash
@@ -11,7 +11,7 @@ IFS=$'\n\t'
 
 
 # Installation instructions from https://rclone.org/docker/
-R_CLONE_VERSION="1.62.2"
+R_CLONE_VERSION="1.63.1"
 mkdir --parents /var/lib/docker-plugins/rclone/config
 mkdir --parents /var/lib/docker-plugins/rclone/cache
 docker plugin install rclone/docker-volume-rclone:amd64-${R_CLONE_VERSION} args="-v" --alias rclone --grant-all-permissions

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone.py
@@ -38,7 +38,7 @@ class BaseRCloneError(PydanticErrorMixin, RuntimeError):
 
 
 class RCloneFailedError(BaseRCloneError):
-    msg_template: str = "Command {command} finished with exception:\n{stdout}"
+    msg_template: str = "Command {command} finished with exception:\n{stdout}\n{stderr}"
 
 
 class RCloneFileFoundError(BaseRCloneError):
@@ -87,10 +87,10 @@ async def _async_command(
     if r_clone_log_parsers:
         await asyncio.wait([_read_stream(proc.stdout, r_clone_log_parsers)])
 
-    stdout, _ = await proc.communicate()
+    stdout, stderr = await proc.communicate()
     decoded_stdout = stdout.decode()
     if proc.returncode != 0:
-        raise RCloneFailedError(command=str_cmd, stdout=decoded_stdout)
+        raise RCloneFailedError(command=str_cmd, stdout=decoded_stdout, stderr=stderr)
 
     _logger.debug("'%s' result:\n%s", str_cmd, decoded_stdout)
     return decoded_stdout

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone.py
@@ -38,7 +38,9 @@ class BaseRCloneError(PydanticErrorMixin, RuntimeError):
 
 
 class RCloneFailedError(BaseRCloneError):
-    msg_template: str = "Command {command} finished with exception:\n{stdout}\n{stderr}"
+    msg_template: str = (
+        "Command {command} finished with exit code={returncode}:\n{stdout}\n{stderr}"
+    )
 
 
 class RCloneFileFoundError(BaseRCloneError):
@@ -90,7 +92,12 @@ async def _async_command(
     stdout, stderr = await proc.communicate()
     decoded_stdout = stdout.decode()
     if proc.returncode != 0:
-        raise RCloneFailedError(command=str_cmd, stdout=decoded_stdout, stderr=stderr)
+        raise RCloneFailedError(
+            command=str_cmd,
+            stdout=decoded_stdout,
+            stderr=stderr,
+            returncode=proc.returncode,
+        )
 
     _logger.debug("'%s' result:\n%s", str_cmd, decoded_stdout)
     return decoded_stdout

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone.py
@@ -146,7 +146,8 @@ class SyncProgressLogParser(BaseRCloneLogParser):
 
 class DebugLogParser(BaseRCloneLogParser):
     async def __call__(self, logs: str) -> None:
-        _logger.debug("|>>>| %s |", logs)
+        no_new_line_ending_logs = logs.rstrip("\n")
+        print(f"|{no_new_line_ending_logs}|")
 
 
 async def _sync_sources(
@@ -159,7 +160,7 @@ async def _sync_sources(
     s3_config_key: str,
     s3_retries: int = S3_RETRIES,
     s3_parallelism: int = S3_PARALLELISM,
-    debug_progress: bool = False,
+    debug_logs: bool,
 ) -> None:
     r_clone_config_file_content = get_r_clone_config(
         r_clone_settings, s3_config_key=s3_config_key
@@ -194,7 +195,7 @@ async def _sync_sources(
 
         async with progress_bar.sub_progress(steps=100) as sub_progress:
             r_clone_log_parsers: list[BaseRCloneLogParser] = (
-                [DebugLogParser()] if debug_progress else []
+                [DebugLogParser()] if debug_logs else []
             )
             r_clone_log_parsers.append(SyncProgressLogParser(sub_progress))
 
@@ -216,6 +217,7 @@ async def sync_local_to_s3(
     *,
     local_directory_path: Path,
     upload_s3_link: AnyUrl,
+    debug_logs: bool = False,
 ) -> None:
     """transfer the contents of a local directory to an s3 path
 
@@ -233,6 +235,7 @@ async def sync_local_to_s3(
         destination=f"{_S3_CONFIG_KEY_DESTINATION}:{upload_s3_path}",
         local_dir=local_directory_path,
         s3_config_key=_S3_CONFIG_KEY_DESTINATION,
+        debug_logs=debug_logs,
     )
 
 
@@ -242,6 +245,7 @@ async def sync_s3_to_local(
     *,
     local_directory_path: Path,
     download_s3_link: AnyUrl,
+    debug_logs: bool = False,
 ) -> None:
     """transfer the contents of a path in s3 to a local directory
 
@@ -259,4 +263,5 @@ async def sync_s3_to_local(
         destination=f"{local_directory_path}",
         local_dir=local_directory_path,
         s3_config_key=_S3_CONFIG_KEY_SOURCE,
+        debug_logs=debug_logs,
     )

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
@@ -6,8 +6,9 @@ import filecmp
 import os
 import re
 import urllib.parse
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Final
+from typing import Final
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -16,7 +17,6 @@ import aiofiles
 import pytest
 from faker import Faker
 from pydantic import AnyUrl, ByteSize, parse_obj_as
-from pytest import FixtureRequest
 from servicelib.progress_bar import ProgressBarData
 from servicelib.utils import logged_gather
 from settings_library.r_clone import RCloneSettings
@@ -44,7 +44,7 @@ WAIT_FOR_S3_BACKEND_TO_UPDATE: Final[float] = 1.0
         "öä$äö2-34 no extension",
     ]
 )
-def file_name(request: FixtureRequest) -> str:
+def file_name(request: pytest.FixtureRequest) -> str:
     return request.param  # type: ignore
 
 

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
@@ -145,6 +145,7 @@ async def _upload_local_dir_to_s3(
             progress_bar,
             local_directory_path=source_dir,
             upload_s3_link=s3_directory_link,
+            debug_logs=True,
         )
     if check_progress:
         # NOTE: a progress of 1 is always sent ny the progress bar
@@ -168,6 +169,7 @@ async def _download_from_s3_to_local_dir(
             progress_bar,
             local_directory_path=destination_dir,
             download_s3_link=s3_directory_link,
+            debug_logs=True,
         )
 
 
@@ -368,6 +370,7 @@ async def test_raises_error_if_local_directory_path_is_a_file(
             progress_bar=AsyncMock(),
             local_directory_path=file_path,
             upload_s3_link=AsyncMock(),
+            debug_logs=True,
         )
     with pytest.raises(r_clone.RCloneFileFoundError):
         await r_clone.sync_s3_to_local(
@@ -375,4 +378,5 @@ async def test_raises_error_if_local_directory_path_is_a_file(
             progress_bar=AsyncMock(),
             local_directory_path=file_path,
             download_s3_link=AsyncMock(),
+            debug_logs=True,
         )

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_r_clone.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_r_clone.py
@@ -4,7 +4,7 @@
 
 import subprocess
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable
 from unittest.mock import Mock
 
 import pytest
@@ -48,7 +48,7 @@ def mock_async_command(mocker: MockerFixture) -> Iterable[Mock]:
 
     original_async_command = r_clone._async_command
 
-    async def _mock_async_command(*cmd: str, cwd: Optional[str] = None) -> str:
+    async def _mock_async_command(*cmd: str, cwd: str | None = None) -> str:
         mock()
         return await original_async_command(*cmd, cwd=cwd)
 
@@ -96,5 +96,5 @@ async def test__async_command_error(cmd: list[str]) -> None:
         await r_clone._async_command(*cmd)
     assert (
         f"{exe_info.value}"
-        == f"Command {' '.join(cmd)} finished with exception:\n/bin/sh: 1: {cmd[0]}: not found\n"
+        == f"Command {' '.join(cmd)} finished with exit code=127:\n/bin/sh: 1: {cmd[0]}: not found\n\nNone"
     )

--- a/scripts/install_rclone.bash
+++ b/scripts/install_rclone.bash
@@ -10,7 +10,7 @@ set -o pipefail  # don't hide errors within pipes
 IFS=$'\n\t'
 
 
-R_CLONE_VERSION="1.62.2"
+R_CLONE_VERSION="1.63.1"
 curl --silent --location --remote-name "https://downloads.rclone.org/v${R_CLONE_VERSION}/rclone-v${R_CLONE_VERSION}-linux-amd64.deb"
 dpkg --install "rclone-v${R_CLONE_VERSION}-linux-amd64.deb"
 rm "rclone-v${R_CLONE_VERSION}-linux-amd64.deb"


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

The error we are getting in the CI, does not provide any context. Trying to upgrade rclone in the hopes that this will fix the issues. I see two releases with fixes for deadlocks due to progress being logged.

https://rclone.org/changelog/#v1-63-1-2023-07-17


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
