### PR TITLE
🐛 fix e2e: openWithResources

### DIFF
--- a/services/static-webserver/client/source/class/osparc/component/study/ResourceSelector.js
+++ b/services/static-webserver/client/source/class/osparc/component/study/ResourceSelector.js
@@ -168,6 +168,7 @@ qx.Class.define("osparc.component.study.ResourceSelector", {
             width: 70,
             center: true
           });
+          osparc.utils.Utils.setIdToWidget(control, "openWithResources");
           this.getChildControl("buttons-layout").add(control);
           break;
         case "cancel-button":

--- a/tests/e2e/utils/auto.js
+++ b/tests/e2e/utils/auto.js
@@ -159,7 +159,7 @@ async function dashboardOpenFirstTemplate(page, templateName) {
   if (children.length) {
     const firstChildId = '[osparc-test-id="' + children[0] + '"]';
     await utils.waitAndClick(page, firstChildId);
-    await utils.waitAndClick(page, '[osparc-test-id="openResource"]');
+    await __openResource(page);
     return true;
   }
   console.log("Creating New Study from template: no template found");
@@ -192,11 +192,23 @@ async function dashboardOpenService(page, serviceName) {
     }
     const firstChildId = '[osparc-test-id="' + children[idx] + '"]';
     await utils.waitAndClick(page, firstChildId);
-    await utils.waitAndClick(page, '[osparc-test-id="openResource"]');
+    await __openResource();
     return true;
   }
   console.log("Creating New Study from service: no service found");
   return false;
+}
+
+async function __openResource(page) {
+  await utils.waitAndClick(page, '[osparc-test-id="openResource"]');
+
+  // Under some circumstances, users might need to also go through the resource selection window
+  const id = '[osparc-test-id=openWithResources]';
+  await page.waitForSelector(id, {
+    timeout: 5000
+  })
+    .then(() => page.click(id))
+    .catch(() => console.log("Accept Cookies button not found"));
 }
 
 async function __filterStudiesByText(page, studyName) {


### PR DESCRIPTION
## What do these changes do?
Under some circumstances, puppeteer might need to also go through the resource selection window


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
