### PR TITLE
⬆️  repo-wide upgrade to aiohttp==3.8.5

### DIFF
--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -14,7 +14,7 @@ aiodocker==0.21.0
     #   -r requirements/_base.in
 aiofiles==22.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiohttp==3.8.3
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt

--- a/services/agent/requirements/_test.txt
+++ b/services/agent/requirements/_test.txt
@@ -10,7 +10,7 @@ aioboto3==9.6.0
     #   -r requirements/_test.in
 aiobotocore==2.3.0
     # via aioboto3
-aiohttp==3.8.3
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -45,7 +45,7 @@ aiofiles==23.1.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -25,7 +25,7 @@ aiofiles==23.1.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -22,7 +22,7 @@ aiofiles==0.8.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -23,7 +23,7 @@ aiofiles==22.1.0
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -20,7 +20,7 @@ aiofiles==22.1.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt

--- a/services/osparc-gateway-server/tests/system/requirements/_test.txt
+++ b/services/osparc-gateway-server/tests/system/requirements/_test.txt
@@ -23,7 +23,7 @@ charset-normalizer==3.2.0
     # via
     #   aiohttp
     #   requests
-click==8.1.3
+click==8.1.6
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -57,7 +57,7 @@ frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.5.0
+fsspec==2023.6.0
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -67,7 +67,7 @@ idna==3.4
     # via
     #   requests
     #   yarl
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -87,7 +87,7 @@ lz4==4.3.2
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/_test.in
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
     #   jinja2
@@ -161,7 +161,7 @@ sortedcontainers==2.4.0
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-tblib==1.7.0
+tblib==2.0.0
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
@@ -201,7 +201,7 @@ zict==3.0.0
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-zipp==3.15.0
+zipp==3.16.2
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
     #   importlib-metadata

--- a/services/osparc-gateway-server/tests/system/requirements/_tools.txt
+++ b/services/osparc-gateway-server/tests/system/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../../../requirements/devenv.txt
 cfgv==3.3.1
     # via pre-commit
-click==8.1.3
+click==8.1.6
     # via
     #   -c requirements/_test.txt
     #   black

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -22,7 +22,7 @@ aiofiles==23.1.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -27,7 +27,7 @@ aiofiles==0.8.0
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiohttp==3.8.3
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-aiohttp==3.8.3
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -30,7 +30,7 @@ aiofiles==0.8.0
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-aiohttp==3.8.3
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -240,9 +240,7 @@ openapi-core==0.12.0
 openapi-schema-validator==0.2.3
     # via openapi-spec-validator
 openapi-spec-validator==0.4.0
-    # via
-    #   -c requirements/../../../../packages/simcore-sdk/requirements/./constraints.txt
-    #   openapi-core
+    # via openapi-core
 openpyxl==3.0.9
     # via -r requirements/_base.in
 orjson==3.7.2

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-aiohttp==3.8.3
+aiohttp==3.8.5
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt


### PR DESCRIPTION
## What do these changes do?

Master deploy presents sporadic errors in the `web-server` logged as
```cmd
Task exception was never retrieved
future: <Task finished name='Task-262869' coro=<RequestHandler.start() done, defined at /home/scu/.venv/lib/python3.10/site-packages/aiohttp/web_protocol.py:462> exception=AttributeError("'NoneType' object has no attribute 'get_extra_info'")>
Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.10/site-packages/aiohttp/web_protocol.py", line 505, in start
    request = self._request_factory(message, payload, self, writer, handler)
  File "/home/scu/.venv/lib/python3.10/site-packages/aiohttp/web_app.py", line 446, in _make_request
    return _cls(
  File "/home/scu/.venv/lib/python3.10/site-packages/aiohttp/web_request.py", line 811, in __init__
    super().__init__(*args, **kwargs)
  File "/home/scu/.venv/lib/python3.10/site-packages/aiohttp/web_request.py", line 189, in __init__
    self._transport_sslcontext = transport.get_extra_info("sslcontext")
AttributeError: 'NoneType' object has no attribute 'get_extra_info'
```
- A reference published in https://github.com/aio-libs/aiohttp/issues/3355 mentions a fix in latest release. 
- This might also be the origin of the [502](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502) error observed in the e2e. Note that 502 `indicates that the server, while acting as a gateway or proxy, received an invalid response from the upstream server`.
    - When this PR merges, we should follow up observing the logs in combination with https://github.com/ITISFoundation/osparc-ops-environments/issues/290
- NOTE: `aiohttp` was upgraded in all services except the `dynamic-sidecar` to avoid conflicts with ongoing https://github.com/ITISFoundation/osparc-simcore/issues/4507

###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 7
- #packages after : 7

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aiohttp                   | 3.8.4, 3.8.3    | 3.8.5      |            | 13 | agent⬆️🧪</br>api-server⬆️</br>autoscaling⬆️</br>catalog⬆️🧪</br>datcore-adapter⬆️</br>invitations⬆️</br>resource-usage-tracker⬆️</br>storage⬆️🧪</br>web⬆️🧪 |
|   2 | click                     | 8.1.3           | 8.1.6      |            | 2 | osparc-gateway-server🧪🧪 |
|   3 | fsspec                    | 2023.5.0        | 2023.6.0   | *minor*    | 1 | osparc-gateway-server🧪 |
|   4 | importlib-metadata        | 6.6.0           | 6.8.0      | *minor*    | 1 | osparc-gateway-server🧪 |
|   5 | markupsafe                | 2.1.2           | 2.1.3      |            | 1 | osparc-gateway-server🧪 |
|   6 | tblib                     | 1.7.0           | 2.0.0      | **MAJOR**  | 1 | osparc-gateway-server🧪 |
|   7 | zipp                      | 3.15.0          | 3.16.2     | *minor*    | 1 | osparc-gateway-server🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
