### PR TITLE
✨⚗️ Add additional docker image tag to simcore github actions (⚠️ DEVOPS)

### DIFF
--- a/ci/deploy/dockerhub-tag-version.bash
+++ b/ci/deploy/dockerhub-tag-version.bash
@@ -47,4 +47,28 @@ export DOCKER_IMAGE_TAG
 log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}"
 make push-version
 
+# push latest image to matching git tag if on git tag
+#
+# Explanation on how checking if a variable is set works with `set -o nounset`:
+#
+# - `${MY_ENV_VAR}`   : This would normally return the value of `MY_ENV_VAR`.
+#                       If `MY_ENV_VAR` is not set and `set -o nounset` is active, using this causes an error and the script would exit.
+# - `${MY_ENV_VAR+x}` : This is a form of parameter expansion. If `MY_ENV_VAR` is unset or null, this expands to nothing (i.e., it's an empty string).
+#                       If `MY_ENV_VAR` is set, this expands to `x`. Importantly, even if `MY_ENV_VAR` is unset, this will not cause an error even with `set -o nounset` active,
+#                       because you're not actually trying to use the value of an unset variable - you're just checking if it is set or not.
+# The `if [ ! -z ${MY_ENV_VAR+x} ]` line checks if `${MY_ENV_VAR+x}` is not an empty string (`! -z` checks for a non-empty string).
+# If `MY_ENV_VAR` is set, `${MY_ENV_VAR+x}` will be `x`, and the condition will be true. If `MY_ENV_VAR` is unset, `${MY_ENV_VAR+x}` will be an empty string, and the condition will be false.
+# `MY_ENV_VAR` is unset, this will not cause an error even with `set -o nounset` active.
+
+if [ ! -z ${GIT_TAG+x} ]; then
+    echo "GIT_TAG is '$GIT_TAG'"
+    DOCKER_IMAGE_TAG=${GIT_TAG}
+    export DOCKER_IMAGE_TAG
+    log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}"
+    make push-version
+else
+    echo "GIT_TAG is not set, we assume we are on the master branch."
+fi
+
+
 log_info "complete!"

--- a/ci/helpers/show_system_versions.bash
+++ b/ci/helpers/show_system_versions.bash
@@ -6,7 +6,7 @@ set -o pipefail # don't hide errors within pipes
 IFS=$'\n\t'
 
 echo "------------------------------ environs -----------------------------------"
-env
+env | sort
 
 echo "------------------------------ uname -----------------------------------"
 uname -a


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

Currently, we push two docker image tags to each docker image (identified by its digest) that we upload to dockerhub. One is "short" and one is "verbose" (including built date and git sha), like so:
- [master-github-2023-07-26--11-57.f6fa3ed338fa4875c76f02c37c22883bb660060d](https://hub.docker.com/layers/itisfoundation/webserver/master-github-2023-07-26--11-57.f6fa3ed338fa4875c76f02c37c22883bb660060d/images/sha256-6d297d6d54fe5d9eb9a930ab521556d7cc152dd2f8d4d46e088e7d97bc16e2c7?context=explore) (this is only for archiving purposes, it is not used anywhere)
- [master-github-latest](https://hub.docker.com/layers/itisfoundation/webserver/master-github-latest/images/sha256-6d297d6d54fe5d9eb9a930ab521556d7cc152dd2f8d4d46e088e7d97bc16e2c7?context=explore) (we use this actually)

This is equivalent for `staging` and `production`. For master, this works fine with respect to the osparc-deployment-agent. We watch (read: poll / querry) for new docker images corresponding to the tag `master-github-latest`, and we if we find one, we roll it out. 

We do the same for staging and production, but here this approach is not perfect. Ideally, we would want to roll out not the `latest` staging or release docker images, but the ones corresponding to the precise git tag that we are rolling out (e.g. `staging_Sundae1` or `v1.56.0`). The deployment-agent has the information about which staging/production he is currently rolling out, given as the git tag of the github/gitlab repositories. In the past, we had issues during releases when docker image tags (like `release-github-latest`) were generated some minutes after the corresponding git-tag in osparc-simcore, etc.

This PR brings a third naming convention to the docker image tags, which corresponds exactly to the current (pre-)release name. For master, no third docker image tag will be added, all will stay the same. For staging, this PR would make github actions create the following docker image tags on dockerhub:
- [staging-github-staging_Sundae1-2023-07-26--09-09.9988654d8bcdabba452321e45408e539bedc2669](https://hub.docker.com/layers/itisfoundation/webserver/staging-github-staging_Sundae1-2023-07-26--09-09.9988654d8bcdabba452321e45408e539bedc2669/images/sha256-52873b3bcb5387bbb714b8f11fdaf895a4a7230cef4d762cc52e4c21fd31731f?context=explore)
- [staging-github-latest](https://hub.docker.com/layers/itisfoundation/webserver/staging-github-latest/images/sha256-52873b3bcb5387bbb714b8f11fdaf895a4a7230cef4d762cc52e4c21fd31731f?context=explore)
- ✨ [staging_Sundae1](https://hub.docker.com/layers/itisfoundation/webserver/staging-github-latest/images/sha256-52873b3bcb5387bbb714b8f11fdaf895a4a7230cef4d762cc52e4c21fd31731f?context=explore)

The same would be the case for production.
In a next step, the deployment agent can be adjusted to utilize these specific docker image tags on dockerhub. This will mitigate some issues we have seen during simcore-releases in the past.


**BONUS**:
- Github-Action Debug step that prints env-vars now prints them sorted alphabetically.

## Related issue/s

I guess there are some, didnt go through the hazzle of compiling them here :(

## How to test

Merge it and pray.

## DevOps Checklist

To be checked once this is merged:
- [ ] Master github-actions still work
- [ ] Staging Release github-actions still work
- [ ] Production release github-actions still work
- [ ] Staging Hotfix github-actions still work
- [ ] Production Hotfix github-actions still work
