### PR TITLE
🐛 e2e fix: enable the open project button

### DIFF
--- a/services/static-webserver/client/source/class/osparc/component/study/ResourceSelector.js
+++ b/services/static-webserver/client/source/class/osparc/component/study/ResourceSelector.js
@@ -225,7 +225,8 @@ qx.Class.define("osparc.component.study.ResourceSelector", {
         });
       }
 
-      this.getChildControl("open-button").setEnabled(Boolean(wallet));
+      // OM: puppeteer has no walelts. Enable it when BE is ready
+      // this.getChildControl("open-button").setEnabled(Boolean(wallet));
     },
 
     __buildLayout: function() {


### PR DESCRIPTION
## What do these changes do?

Puppeteers have no wallet yet. This PR allows opening projects without selecting a wallet.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
