### PR TITLE
🐛 `rclone` preserves symlinks even if broken

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone.py
@@ -179,7 +179,7 @@ async def _sync_sources(
             # filter options
             *_get_exclude_filters(exclude_patterns),
             "--progress",
-            "--copy-links",
+            "--links",
             "--verbose",
         )
 

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_r_clone.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_r_clone.py
@@ -198,7 +198,7 @@ async def test__get_exclude_filter(
         "rclone",
         "--quiet",
         "--dry-run",
-        "--copy-links",
+        "--links",
         *r_clone._get_exclude_filters(exclude_patterns),  # noqa: SLF001
         "lsf",
         "--absolute",


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

Unfortunately `rclone` was configured to copy the content pointed by the symlink. This caused `rclone` to fail if the symlink was broken (the pointed file did not exists).

- ✨ adds regression test
- 🐛 rclone copies symlinks as they are without following them


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->

- https://github.com/ITISFoundation/osparc-issues/issues/675

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
