### PR TITLE
🐛 fix `dynamic-sidecar` outputs watcher

### DIFF
--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/containers_extension.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Annotated
 
 from aiodocker.networks import DockerNetwork
 from fastapi import APIRouter, Depends, FastAPI
@@ -54,12 +55,12 @@ router = APIRouter()
 )
 async def toggle_directory_watcher(
     patch_directory_watcher_item: PatchDirectoryWatcherItem,
-    app: FastAPI = Depends(get_application),
+    app: Annotated[FastAPI, Depends(get_application)],
 ) -> None:
     if patch_directory_watcher_item.is_enabled:
-        enable_outputs_watcher(app)
+        await enable_outputs_watcher(app)
     else:
-        disable_outputs_watcher(app)
+        await disable_outputs_watcher(app)
 
 
 @router.post(
@@ -75,8 +76,8 @@ async def toggle_directory_watcher(
 )
 async def create_output_dirs(
     request_mode: CreateDirsRequestItem,
-    mounted_volumes: MountedVolumes = Depends(get_mounted_volumes),
-    outputs_context: OutputsContext = Depends(get_outputs_context),
+    mounted_volumes: Annotated[MountedVolumes, Depends(get_mounted_volumes)],
+    outputs_context: Annotated[OutputsContext, Depends(get_outputs_context)],
 ) -> None:
     outputs_path = mounted_volumes.disk_outputs_path
     file_type_port_keys = []
@@ -104,7 +105,7 @@ async def create_output_dirs(
 async def attach_container_to_network(
     request: Request,
     item: AttachContainerToNetworkItem,
-    container_id: str = PathParam(..., alias="id"),
+    container_id: Annotated[str, PathParam(..., alias="id")],
 ) -> None:
     assert request  # nosec
 
@@ -144,7 +145,7 @@ async def attach_container_to_network(
 )
 async def detach_container_from_network(
     item: DetachContainerFromNetworkItem,
-    container_id: str = PathParam(..., alias="id"),
+    container_id: Annotated[str, PathParam(..., alias="id")],
 ) -> None:
     async with docker_client() as docker:
         container_instance = await docker.containers.get(container_id)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -140,7 +140,7 @@ async def task_create_service_containers(
 
     assert shared_store.compose_spec  # nosec
 
-    with outputs_watcher_disabled(app):
+    async with outputs_watcher_disabled(app):
         # removes previous pending containers
         progress.update(message="cleanup previous used resources")
         result = await docker_compose_rm(shared_store.compose_spec, settings)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_context.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_context.py
@@ -29,7 +29,18 @@ class OutputsContext:
     async def set_file_type_port_keys(self, file_type_port_keys: list[str]) -> None:
         self._file_type_port_keys = file_type_port_keys
         await self.file_type_port_keys_updates_queue.coro_put(  # pylint:disable=no-member
-            self._file_type_port_keys
+            {
+                "method_name": "handle_set_outputs_port_keys",
+                "kwargs": {"outputs_port_keys": self._file_type_port_keys},
+            }
+        )
+
+    async def toggle_event_propagation(self, *, is_enabled: bool) -> None:
+        await self.file_type_port_keys_updates_queue.coro_put(  # pylint:disable=no-member
+            {
+                "method_name": "handle_toggle_event_propagation",
+                "kwargs": {"is_enabled": is_enabled},
+            }
         )
 
     @property

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_context.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_context.py
@@ -16,7 +16,7 @@ class OutputsContext:
     port_key_events_queue: AioQueue = field(default_factory=aioprocessing.AioQueue)
 
     # OutputsContext (generates) -> _EventHandlerProcess(receives)
-    file_type_port_keys_updates_queue: AioQueue = field(
+    file_system_event_handler_queue: AioQueue = field(
         default_factory=aioprocessing.AioQueue
     )
 
@@ -28,7 +28,7 @@ class OutputsContext:
 
     async def set_file_type_port_keys(self, file_type_port_keys: list[str]) -> None:
         self._file_type_port_keys = file_type_port_keys
-        await self.file_type_port_keys_updates_queue.coro_put(  # pylint:disable=no-member
+        await self.file_system_event_handler_queue.coro_put(  # pylint:disable=no-member
             {
                 "method_name": "handle_set_outputs_port_keys",
                 "kwargs": {"outputs_port_keys": self._file_type_port_keys},
@@ -36,7 +36,7 @@ class OutputsContext:
         )
 
     async def toggle_event_propagation(self, *, is_enabled: bool) -> None:
-        await self.file_type_port_keys_updates_queue.coro_put(  # pylint:disable=no-member
+        await self.file_system_event_handler_queue.coro_put(  # pylint:disable=no-member
             {
                 "method_name": "handle_toggle_event_propagation",
                 "kwargs": {"is_enabled": is_enabled},

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from queue import Empty
 from threading import Thread
 from time import sleep as blocking_sleep
-from typing import Final, Optional
+from typing import Any, Final
 
 import aioprocessing
 from aioprocessing.process import AioProcess
@@ -24,7 +24,7 @@ from ._watchdog_extensions import ExtendedInotifyObserver, SafeFileSystemEventHa
 
 _HEART_BEAT_MARK: Final = 1
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class _PortKeysEventHandler(SafeFileSystemEventHandler):
@@ -33,14 +33,21 @@ class _PortKeysEventHandler(SafeFileSystemEventHandler):
     def __init__(self, outputs_path: Path, port_key_events_queue: AioQueue):
         super().__init__()
 
+        self._is_event_propagation_enabled: bool = False
         self.outputs_path: Path = outputs_path
         self.port_key_events_queue: AioQueue = port_key_events_queue
         self._outputs_port_keys: set[str] = set()
 
-    def set_outputs_port_keys(self, outputs_port_keys: set[str]) -> None:
+    def handle_set_outputs_port_keys(self, *, outputs_port_keys: set[str]) -> None:
         self._outputs_port_keys = outputs_port_keys
 
+    def handle_toggle_event_propagation(self, *, is_enabled: bool) -> None:
+        self._is_event_propagation_enabled = is_enabled
+
     def event_handler(self, event: FileSystemEvent) -> None:
+        if not self._is_event_propagation_enabled:
+            return
+
         # NOTE: ignoring all events which are not relative to modifying
         # the contents of the `port_key` folders from the outputs directory
 
@@ -78,14 +85,14 @@ class _EventHandlerProcess:
         # the process itself and is used to stop the process.
         self._stop_queue: AioQueue = aioprocessing.AioQueue()
 
-        self._file_system_event_handler: Optional[_PortKeysEventHandler] = None
-        self._process: Optional[AioProcess] = None
+        self._file_system_event_handler: _PortKeysEventHandler | None = None
+        self._process: AioProcess | None = None
 
     def start_process(self) -> None:
         # NOTE: runs in asyncio thread
 
         with log_context(
-            logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} start_process"
+            _logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} start_process"
         ):
             self._process = aioprocessing.AioProcess(
                 target=self._process_worker, daemon=True
@@ -96,7 +103,7 @@ class _EventHandlerProcess:
         # NOTE: runs in asyncio thread
 
         with log_context(
-            logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} stop_process"
+            _logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} stop_process"
         ):
             self._stop_queue.put(None)
 
@@ -113,7 +120,7 @@ class _EventHandlerProcess:
         # NOTE: runs in asyncio thread
 
         with log_context(
-            logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} shutdown"
+            _logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} shutdown"
         ):
             self.stop_process()
 
@@ -126,18 +133,24 @@ class _EventHandlerProcess:
 
         # Propagate `outputs_port_keys` changes to the `_PortKeysEventHandler`.
         while True:
-            outputs_port_keys: Optional[
-                set[str]
-            ] = self.outputs_context.file_type_port_keys_updates_queue.get()
-            print("outputs_port_keys", outputs_port_keys)
+            message: dict[
+                str, Any
+            ] | None = self.outputs_context.file_type_port_keys_updates_queue.get()
+            _logger.debug("received message %s", message)
 
-            if outputs_port_keys is None:
+            # no more messages quitting
+            if message is None:
                 break
 
-            if self._file_system_event_handler is not None:
-                self._file_system_event_handler.set_outputs_port_keys(
-                    set(outputs_port_keys)
-                )
+            # do nothing
+            if self._file_system_event_handler is None:
+                continue
+
+            # handle events
+            method_kwargs: dict[str, Any] = message["kwargs"]
+            method_name = message["method_name"]
+            method_to_call = getattr(self._file_system_event_handler, method_name)
+            method_to_call(**method_kwargs)
 
     def _process_worker(self) -> None:
         # NOTE: runs in the created process
@@ -176,7 +189,7 @@ class _EventHandlerProcess:
                 blocking_sleep(self.heart_beat_interval_s)
 
         except Exception:  # pylint: disable=broad-except
-            logger.exception("Unexpected error")
+            _logger.exception("Unexpected error")
         finally:
             if watch:
                 observer.remove_handler_for_watch(
@@ -188,7 +201,7 @@ class _EventHandlerProcess:
             self.outputs_context.file_type_port_keys_updates_queue.put(None)
             thread_update_outputs_port_keys.join()
 
-            logger.warning("%s exited", _EventHandlerProcess.__name__)
+            _logger.warning("%s exited", _EventHandlerProcess.__name__)
 
 
 class EventHandlerObserver:
@@ -219,7 +232,7 @@ class EventHandlerObserver:
             heart_beat_interval_s=heart_beat_interval_s,
         )
         self._keep_running: bool = False
-        self._task_health_worker: Optional[Task] = None
+        self._task_health_worker: Task | None = None
 
     @property
     def wait_for_heart_beat_interval_s(self) -> PositiveFloat:
@@ -241,7 +254,7 @@ class EventHandlerObserver:
                     break
 
             if heart_beat_count == 0:
-                logger.warning(
+                _logger.warning(
                     (
                         "WatcherProcess health is no longer responsive. "
                         "%s will be uploaded when closing."
@@ -266,7 +279,7 @@ class EventHandlerObserver:
 
     async def start(self) -> None:
         with log_context(
-            logger, logging.INFO, f"{EventHandlerObserver.__name__} start"
+            _logger, logging.INFO, f"{EventHandlerObserver.__name__} start"
         ):
             self._keep_running = True
             self._task_health_worker = create_task(
@@ -275,7 +288,9 @@ class EventHandlerObserver:
             self._start_observer_process()
 
     async def stop(self) -> None:
-        with log_context(logger, logging.INFO, f"{EventHandlerObserver.__name__} stop"):
+        with log_context(
+            _logger, logging.INFO, f"{EventHandlerObserver.__name__} stop"
+        ):
             self._stop_observer_process()
             self._keep_running = False
             if self._task_health_worker is not None:

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
@@ -135,7 +135,7 @@ class _EventHandlerProcess:
         while True:
             message: dict[
                 str, Any
-            ] | None = self.outputs_context.file_type_port_keys_updates_queue.get()
+            ] | None = self.outputs_context.file_system_event_handler_queue.get()
             _logger.debug("received message %s", message)
 
             # no more messages quitting
@@ -198,7 +198,7 @@ class _EventHandlerProcess:
             observer.stop()
 
             # stop created thread
-            self.outputs_context.file_type_port_keys_updates_queue.put(None)
+            self.outputs_context.file_system_event_handler_queue.put(None)
             thread_update_outputs_port_keys.join()
 
             _logger.warning("%s exited", _EventHandlerProcess.__name__)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_watcher.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_watcher.py
@@ -1,7 +1,7 @@
 import logging
 from asyncio import CancelledError, Task, create_task
-from collections.abc import Generator
-from contextlib import contextmanager, suppress
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager, suppress
 
 from fastapi import FastAPI
 from servicelib.logging_utils import log_context
@@ -12,7 +12,7 @@ from ._event_filter import EventFilter
 from ._event_handler import EventHandlerObserver
 from ._manager import OutputsManager
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class OutputsWatcher:
@@ -22,7 +22,6 @@ class OutputsWatcher:
         self.outputs_manager = outputs_manager
         self.outputs_context = outputs_context
 
-        self._allow_event_propagation: bool = False
         self._task_events_worker: Task | None = None
         self._event_filter = EventFilter(outputs_manager=outputs_manager)
         self._observer_monitor: EventHandlerObserver = EventHandlerObserver(
@@ -39,17 +38,16 @@ class OutputsWatcher:
             if event is None:
                 break
 
-            if self._allow_event_propagation:
-                await self._event_filter.enqueue(event)
+            await self._event_filter.enqueue(event)
 
-    def enable_event_propagation(self) -> None:
-        self._allow_event_propagation = True
+    async def enable_event_propagation(self) -> None:
+        await self.outputs_context.toggle_event_propagation(is_enabled=True)
 
-    def disable_event_propagation(self) -> None:
-        self._allow_event_propagation = False
+    async def disable_event_propagation(self) -> None:
+        await self.outputs_context.toggle_event_propagation(is_enabled=False)
 
     async def start(self) -> None:
-        with log_context(logger, logging.INFO, f"{OutputsWatcher.__name__} start"):
+        with log_context(_logger, logging.INFO, f"{OutputsWatcher.__name__} start"):
             self._task_events_worker = create_task(
                 self._worker_events(), name="outputs_watcher_events_worker"
             )
@@ -59,7 +57,7 @@ class OutputsWatcher:
 
     async def shutdown(self) -> None:
         """cleans up spawned tasks which might be pending"""
-        with log_context(logger, logging.INFO, f"{OutputsWatcher.__name__} shutdown"):
+        with log_context(_logger, logging.INFO, f"{OutputsWatcher.__name__} shutdown"):
             await self._event_filter.shutdown()
             await self._observer_monitor.stop()
 
@@ -81,7 +79,7 @@ def setup_outputs_watcher(app: FastAPI) -> None:
             outputs_context=outputs_context,
         )
         await app.state.outputs_watcher.start()
-        disable_outputs_watcher(app)
+        await disable_outputs_watcher(app)
 
     async def on_shutdown() -> None:
         outputs_watcher: OutputsWatcher | None = app.state.outputs_watcher
@@ -92,20 +90,22 @@ def setup_outputs_watcher(app: FastAPI) -> None:
     app.add_event_handler("shutdown", on_shutdown)
 
 
-def disable_outputs_watcher(app: FastAPI) -> None:
-    if app.state.outputs_watcher is not None:
-        app.state.outputs_watcher.disable_event_propagation()
+async def disable_outputs_watcher(app: FastAPI) -> None:
+    outputs_watcher: OutputsWatcher | None = app.state.outputs_watcher
+    if outputs_watcher is not None:
+        await outputs_watcher.disable_event_propagation()
 
 
-def enable_outputs_watcher(app: FastAPI) -> None:
-    if app.state.outputs_watcher is not None:
-        app.state.outputs_watcher.enable_event_propagation()
+async def enable_outputs_watcher(app: FastAPI) -> None:
+    outputs_watcher: OutputsWatcher | None = app.state.outputs_watcher
+    if outputs_watcher is not None:
+        await outputs_watcher.enable_event_propagation()
 
 
-@contextmanager
-def outputs_watcher_disabled(app: FastAPI) -> Generator[None, None, None]:
+@asynccontextmanager
+async def outputs_watcher_disabled(app: FastAPI) -> AsyncGenerator[None, None]:
     try:
-        disable_outputs_watcher(app)
+        await disable_outputs_watcher(app)
         yield None
     finally:
-        enable_outputs_watcher(app)
+        await enable_outputs_watcher(app)

--- a/services/dynamic-sidecar/tests/unit/test_api_containers.py
+++ b/services/dynamic-sidecar/tests/unit/test_api_containers.py
@@ -510,6 +510,9 @@ async def test_outputs_watcher_disabling(
         assert len(events_set) == expected_events
 
     # by default outputs-watcher it is disabled
+    _assert_events_generated(expected_events=0)
+    await _create_port_key_events(is_propagation_enabled=False)
+    _assert_events_generated(expected_events=0)
 
     # after enabling new vents will be generated
     await _assert_enable_outputs_watcher(test_client)
@@ -526,8 +529,9 @@ async def test_outputs_watcher_disabling(
     # enabling once more time, events are once again generated
     await _assert_enable_outputs_watcher(test_client)
     _assert_events_generated(expected_events=1)
-    await _create_port_key_events(is_propagation_enabled=True)
-    _assert_events_generated(expected_events=2)
+    for i in range(10):
+        await _create_port_key_events(is_propagation_enabled=True)
+        _assert_events_generated(expected_events=2 + i)
 
 
 async def test_container_create_outputs_dirs(

--- a/services/dynamic-sidecar/tests/unit/test_api_containers.py
+++ b/services/dynamic-sidecar/tests/unit/test_api_containers.py
@@ -6,9 +6,10 @@
 import asyncio
 import json
 import random
+from collections.abc import AsyncIterable
 from inspect import signature
 from pathlib import Path
-from typing import Any, AsyncIterable, Final, Iterator
+from typing import Any, Final
 from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
@@ -22,7 +23,6 @@ from async_asgi_testclient import TestClient
 from faker import Faker
 from fastapi import FastAPI, status
 from models_library.services import ServiceOutput
-from pytest import MonkeyPatch
 from pytest_mock.plugin import MockerFixture
 from servicelib.docker_constants import SUFFIX_EGRESS_PROXY_NAME
 from servicelib.fastapi.long_running_tasks.client import TaskId
@@ -54,12 +54,12 @@ class FailTestError(RuntimeError):
     pass
 
 
-_TENACITY_RETRY_PARAMS: dict[str, Any] = dict(
-    reraise=True,
-    retry=retry_if_exception_type((FailTestError, AssertionError)),
-    stop=stop_after_delay(10),
-    wait=wait_fixed(0.01),
-)
+_TENACITY_RETRY_PARAMS: dict[str, Any] = {
+    "reraise": True,
+    "retry": retry_if_exception_type((FailTestError, AssertionError)),
+    "stop": stop_after_delay(10),
+    "wait": wait_fixed(0.01),
+}
 
 
 def _create_network_aliases(network_name: str) -> list[str]:
@@ -68,7 +68,7 @@ def _create_network_aliases(network_name: str) -> list[str]:
 
 async def _assert_enable_outputs_watcher(test_client: TestClient) -> None:
     response = await test_client.patch(
-        f"/{API_VTAG}/containers/directory-watcher", json=dict(is_enabled=True)
+        f"/{API_VTAG}/containers/directory-watcher", json={"is_enabled": True}
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT, response.text
     assert response.text == ""
@@ -76,7 +76,7 @@ async def _assert_enable_outputs_watcher(test_client: TestClient) -> None:
 
 async def _assert_disable_outputs_watcher(test_client: TestClient) -> None:
     response = await test_client.patch(
-        f"/{API_VTAG}/containers/directory-watcher", json=dict(is_enabled=False)
+        f"/{API_VTAG}/containers/directory-watcher", json={"is_enabled": False}
     )
     assert response.status_code == status.HTTP_204_NO_CONTENT, response.text
     assert response.text == ""
@@ -100,7 +100,8 @@ async def _start_containers(test_client: TestClient, compose_spec: str) -> list[
             assert response.status_code == status.HTTP_200_OK
             task_status = response.json()
             if not task_status["done"]:
-                raise RuntimeError(f"Waiting for task to complete, got: {task_status}")
+                msg = f"Waiting for task to complete, got: {task_status}"
+                raise RuntimeError(msg)
 
     response = await test_client.get(f"/task/{task_id}/result")
     assert response.status_code == status.HTTP_200_OK
@@ -277,11 +278,11 @@ async def attachable_networks_and_ids(faker: Faker) -> AsyncIterable[dict[str, s
 @pytest.fixture
 def mock_aiodocker_containers_get(mocker: MockerFixture) -> int:
     """raises a DockerError with a random HTTP status which is also returned"""
-    mock_status_code = random.randint(1, 999)
+    mock_status_code = random.randint(1, 999)  # noqa: S311
 
     async def mock_get(*args: str, **kwargs: Any) -> None:
         raise aiodocker.exceptions.DockerError(
-            status=mock_status_code, data=dict(message="aiodocker_mocked_error")
+            status=mock_status_code, data={"message": "aiodocker_mocked_error"}
         )
 
     mocker.patch("aiodocker.containers.DockerContainers.get", side_effect=mock_get)
@@ -291,12 +292,12 @@ def mock_aiodocker_containers_get(mocker: MockerFixture) -> int:
 
 @pytest.fixture
 def mock_event_filter_enqueue(
-    app: FastAPI, monkeypatch: MonkeyPatch
-) -> Iterator[AsyncMock]:
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> AsyncMock:
     mock = AsyncMock(return_value=None)
     outputs_watcher: OutputsWatcher = app.state.outputs_watcher
-    monkeypatch.setattr(outputs_watcher._event_filter, "enqueue", mock)
-    yield mock
+    monkeypatch.setattr(outputs_watcher._event_filter, "enqueue", mock)  # noqa: SLF001
+    return mock
 
 
 @pytest.fixture
@@ -305,7 +306,7 @@ async def mocked_port_key_events_queue_coro_get(
 ) -> Mock:
     outputs_context: OutputsContext = app.state.outputs_context
 
-    target = getattr(outputs_context.port_key_events_queue, "coro_get")
+    target = getattr(outputs_context.port_key_events_queue, "coro_get")  # noqa: B009
 
     mock_result_tracker = Mock()
 
@@ -370,7 +371,7 @@ async def test_containers_get_status(
     ensure_external_volumes: None,
 ):
     response = await test_client.get(
-        f"/{API_VTAG}/containers", query_string=dict(only_status=True)
+        f"/{API_VTAG}/containers", query_string={"only_status": True}
     )
     assert response.status_code == status.HTTP_200_OK, response.text
 
@@ -418,7 +419,7 @@ async def test_container_logs_with_timestamps(
         print("getting logs of container", container, "...")
         response = await test_client.get(
             f"/{API_VTAG}/containers/{container}/logs",
-            query_string=dict(timestamps=True),
+            query_string={"timestamps": True},
         )
         assert response.status_code == status.HTTP_200_OK, response.text
         assert response.json() == []
@@ -428,9 +429,9 @@ async def test_container_missing_container(
     test_client: TestClient, not_started_containers: list[str]
 ):
     def _expected_error_string(container: str) -> dict[str, str]:
-        return dict(
-            detail=f"No container '{container}' was started. Started containers '[]'"
-        )
+        return {
+            "detail": f"No container '{container}' was started. Started containers '[]'"
+        }
 
     for container in not_started_containers:
         # get container logs
@@ -468,7 +469,6 @@ async def test_container_docker_error(
         assert response.json() == _expected_error_string(mock_aiodocker_containers_get)
 
 
-@pytest.mark.flaky(max_runs=3)
 async def test_outputs_watcher_disabling(
     test_client: TestClient,
     mocked_port_key_events_queue_coro_get: Mock,
@@ -478,74 +478,55 @@ async def test_outputs_watcher_disabling(
     outputs_context: OutputsContext = test_client.application.state.outputs_context
     outputs_manager: OutputsManager = test_client.application.state.outputs_manager
     outputs_manager.task_monitor_interval_s = WAIT_FOR_OUTPUTS_WATCHER / 10
-    WAIT_PORT_KEY_PROPAGATION = outputs_manager.task_monitor_interval_s * 10
-    EXPECTED_EVENTS_PER_RANDOM_PORT_KEY = 3
 
-    async def _create_port_key_events() -> None:
+    async def _create_port_key_events(is_propagation_enabled: bool) -> None:
         random_subdir = f"{uuid4()}"
 
         await outputs_context.set_file_type_port_keys([random_subdir])
-        await asyncio.sleep(WAIT_PORT_KEY_PROPAGATION)
 
         dir_name = outputs_context.outputs_path / random_subdir
         await mkdir(dir_name)
         async with aiofiles.open(dir_name / f"file_{uuid4()}", "w") as f:
             await f.write("ok")
 
+        EXPECTED_EVENTS_PER_RANDOM_PORT_KEY = 2
+
         async for attempt in AsyncRetrying(**_TENACITY_RETRY_PARAMS):
             with attempt:
-                # check event was triggered
-                dir_event_set = [
+                # check events were triggered after generation
+                events_in_dir: list[str] = [
                     c.args[0]
                     for c in mocked_port_key_events_queue_coro_get.call_args_list
                     if c.args[0] == random_subdir
                 ]
-                # NOTE: this test can sometimes generate +/-(1 event)
-                # - when it creates +1 event ✅ using `>=` solves it
-                # - when it creates -1 event ❌ cannot deal with it from here
-                #   Will cause downstream assertions to fail since in the
-                #   event_filter_queue there will be unexpected items
-                #   NOTE: will make entire test fail with a specific
-                #   exception and rely on mark.flaky to retry it.
-                if len(dir_event_set) < EXPECTED_EVENTS_PER_RANDOM_PORT_KEY:
-                    raise FailTestError(
-                        f"Expected at least {EXPECTED_EVENTS_PER_RANDOM_PORT_KEY}"
-                        f" events, found: {dir_event_set}"
-                    )
-                assert len(dir_event_set) >= EXPECTED_EVENTS_PER_RANDOM_PORT_KEY
+
+                if is_propagation_enabled:
+                    assert len(events_in_dir) >= EXPECTED_EVENTS_PER_RANDOM_PORT_KEY
+                else:
+                    assert len(events_in_dir) == 0
 
     def _assert_events_generated(*, expected_events: int) -> None:
         events_set = {x.args[0] for x in mock_event_filter_enqueue.call_args_list}
         assert len(events_set) == expected_events
 
-    # NOTE: for some reason the first event in the queue
-    #  does not get delivered the AioQueue future handling coro_get hangs
-    await outputs_context.port_key_events_queue.coro_put("")
-    await asyncio.sleep(WAIT_PORT_KEY_PROPAGATION)
-
     # by default outputs-watcher it is disabled
-
-    # expect no events to be generated
-    _assert_events_generated(expected_events=0)
-    await _create_port_key_events()
-    _assert_events_generated(expected_events=0)
 
     # after enabling new vents will be generated
     await _assert_enable_outputs_watcher(test_client)
     _assert_events_generated(expected_events=0)
-    await _create_port_key_events()
+    await _create_port_key_events(is_propagation_enabled=True)
     _assert_events_generated(expected_events=1)
 
     # disabling again, no longer generate events
     await _assert_disable_outputs_watcher(test_client)
     _assert_events_generated(expected_events=1)
-    await _create_port_key_events()
+    await _create_port_key_events(is_propagation_enabled=False)
     _assert_events_generated(expected_events=1)
 
     # enabling once more time, events are once again generated
     await _assert_enable_outputs_watcher(test_client)
     _assert_events_generated(expected_events=1)
-    await _create_port_key_events()
+    await _create_port_key_events(is_propagation_enabled=True)
     _assert_events_generated(expected_events=2)
 
 
@@ -573,7 +554,7 @@ async def test_container_create_outputs_dirs(
     assert response.status_code == status.HTTP_204_NO_CONTENT, response.text
     assert response.text == ""
 
-    for dir_name in mock_outputs_labels.keys():
+    for dir_name in mock_outputs_labels:
         assert (mounted_volumes.disk_outputs_path / dir_name).is_dir()
 
     await asyncio.sleep(WAIT_FOR_OUTPUTS_WATCHER)

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
@@ -71,7 +71,7 @@ def mock_upload_outputs(
     async def _mock_upload_outputs(*args, **kwargs) -> None:
         await asyncio.sleep(upload_duration)
 
-    yield mocker.patch(
+    return mocker.patch(
         "simcore_service_dynamic_sidecar.modules.outputs._manager.upload_outputs",
         side_effect=_mock_upload_outputs,
     )

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_watcher.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_watcher.py
@@ -382,7 +382,3 @@ async def test_port_key_sequential_event_generation(
             for call_args in mock_long_running_upload_outputs.call_args_list:
                 uploaded_port_keys |= set(call_args.kwargs["port_keys"])
             assert uploaded_port_keys == set(port_keys)
-
-
-# TODO: add a test to stop watcher form emitting events in the middle of the emitting
-# we can test what is wrong with what is happening to users

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_watcher.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_watcher.py
@@ -367,7 +367,7 @@ async def test_port_key_sequential_event_generation(
     sleep_for = max(
         max(wait_interval_for_port) + MARGIN_FOR_ALL_EVENT_PROCESSORS_TO_TRIGGER, 3
     )
-    print(f"max sleep wait interval {sleep_for}")
+    print(f"max {sleep_for=} interval")
     async for attempt in AsyncRetrying(
         **_TENACITY_RETRY_PARAMS, stop=stop_after_delay(sleep_for)
     ):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

The `otuputs-watcher` inside the dynamic-sidecar was generating events even when disabled.

- ♻️ by default the `dynamic-sidecar` will not trigger on any input folder changes
- ♻️ the disabling mechanism, it is now done at a very low level, will no longer push all FS events to the upper layer (better performance)
- 🐛 `test_outputs_watcher_disabling` was horribly broken, test was adusted




## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->

- should avoid https://github.com/ITISFoundation/osparc-simcore/issues/4595

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
