### PR TITLE
🐛 Make sure openapi is happy about abort endpoint

### DIFF
--- a/services/api-server/src/simcore_service_api_server/api/routes/files.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/files.py
@@ -295,6 +295,7 @@ async def complete_multipart_upload(
 @cancel_on_disconnect
 async def abort_multipart_upload(
     request: Request,
+    file_id: UUID,
     user_id: Annotated[PositiveInt, Depends(get_current_user_id)],
     abort_upload_link: Annotated[AnyUrl, Body(..., embed=True)],
 ):
@@ -309,6 +310,7 @@ async def abort_multipart_upload(
     """
     assert request  # nosec
     assert user_id  # nosec
+    assert file_id  # nosec
     await abort_upload(abort_upload_link=abort_upload_link)
 
 

--- a/services/api-server/src/simcore_service_api_server/api/routes/files.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/files.py
@@ -217,8 +217,8 @@ async def get_upload_links(
         "abort_multipart_upload", file_id=file_meta.id
     ).include_query_params(**dict(item.split("=") for item in query.split("&")))
 
-    upload_links.links.complete_upload = parse_obj_as(AnyUrl, str(complete_url))
-    upload_links.links.abort_upload = parse_obj_as(AnyUrl, str(abort_url))
+    upload_links.links.complete_upload = parse_obj_as(AnyUrl, f"{complete_url}")
+    upload_links.links.abort_upload = parse_obj_as(AnyUrl, f"{abort_url}")
     return ClientFileUploadSchema(file_id=file_meta.id, upload_schema=upload_links)
 
 

--- a/services/api-server/src/simcore_service_api_server/api/routes/files.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/files.py
@@ -213,11 +213,12 @@ async def get_upload_links(
         file_size=ByteSize(client_file.filesize),
         is_directory=False,
     )
-    query = str(upload_links.links.complete_upload.query).rstrip(":complete")
+    rstrip = lambda s, rs: s[: -len(rs)] if s.endswith(rs) else s
+    query = rstrip(str(upload_links.links.complete_upload.query), ":complete")
     complete_url = request.url_for(
         "complete_multipart_upload", file_id=file_meta.id
     ).include_query_params(**dict(item.split("=") for item in query.split("&")))
-    query = str(upload_links.links.abort_upload.query).rstrip(":abort")
+    query = rstrip(upload_links.links.abort_upload.query, ":abort")
     abort_url = request.url_for(
         "abort_multipart_upload", file_id=file_meta.id
     ).include_query_params(**dict(item.split("=") for item in query.split("&")))

--- a/services/api-server/src/simcore_service_api_server/api/routes/files.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/files.py
@@ -264,7 +264,7 @@ async def complete_multipart_upload(
 
     e_tag: ETag = await complete_file_upload(
         uploaded_parts=uploaded_parts.parts,
-        upload_completion_link=parse_obj_as(AnyUrl, str(complete_link)),
+        upload_completion_link=parse_obj_as(AnyUrl, f"{complete_link}"),
     )
 
     file.checksum = e_tag

--- a/services/api-server/src/simcore_service_api_server/api/routes/files.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/files.py
@@ -213,12 +213,11 @@ async def get_upload_links(
         file_size=ByteSize(client_file.filesize),
         is_directory=False,
     )
-    rstrip = lambda s, rs: s[: -len(rs)] if s.endswith(rs) else s
-    query = rstrip(str(upload_links.links.complete_upload.query), ":complete")
+    query = str(upload_links.links.complete_upload.query).removesuffix(":complete")
     complete_url = request.url_for(
         "complete_multipart_upload", file_id=file_meta.id
     ).include_query_params(**dict(item.split("=") for item in query.split("&")))
-    query = rstrip(upload_links.links.abort_upload.query, ":abort")
+    query = str(upload_links.links.abort_upload.query).removesuffix(":abort")
     abort_url = request.url_for(
         "abort_multipart_upload", file_id=file_meta.id
     ).include_query_params(**dict(item.split("=") for item in query.split("&")))

--- a/services/api-server/src/simcore_service_api_server/models/schemas/files.py
+++ b/services/api-server/src/simcore_service_api_server/models/schemas/files.py
@@ -145,7 +145,7 @@ class File(BaseModel):
 
 
 class ClientFileUploadSchema(BaseModel):
-    upload_file_id: StorageFileID = Field(..., description="The upload file id")
+    file_id: UUID = Field(..., description="The file id")
     upload_schema: FileUploadSchema = Field(
         ..., description="Schema for uploading file"
     )

--- a/services/api-server/src/simcore_service_api_server/models/schemas/files.py
+++ b/services/api-server/src/simcore_service_api_server/models/schemas/files.py
@@ -8,15 +8,7 @@ import aiofiles
 from fastapi import UploadFile
 from models_library.api_schemas_storage import FileUploadSchema
 from models_library.projects_nodes_io import StorageFileID
-from pydantic import (
-    AnyUrl,
-    BaseModel,
-    ByteSize,
-    ConstrainedStr,
-    Field,
-    parse_obj_as,
-    validator,
-)
+from pydantic import BaseModel, ByteSize, ConstrainedStr, Field, parse_obj_as, validator
 
 from ...utils.hash import create_md5_checksum
 
@@ -139,16 +131,8 @@ class File(BaseModel):
         return _quote(self.storage_file_id, safe="")
 
 
-class ClientFileUploadLinks(BaseModel):
-    complete_upload: AnyUrl = Field(..., description="Link for completing upload")
-    abort_upload: AnyUrl = Field(..., description="Link for aborting upload")
-
-
 class ClientFileUploadSchema(BaseModel):
-    file: File = Field(..., description="The File to be created")
-    storage_upload_schema: FileUploadSchema = Field(
+    upload_file_id: StorageFileID = Field(..., description="The upload file id")
+    upload_schema: FileUploadSchema = Field(
         ..., description="Schema for uploading file"
-    )
-    links: ClientFileUploadLinks = Field(
-        ..., description="Links for handling further upload process"
     )

--- a/services/api-server/src/simcore_service_api_server/services/storage.py
+++ b/services/api-server/src/simcore_service_api_server/services/storage.py
@@ -110,8 +110,7 @@ class StorageApi(BaseServiceClientApi):
         self, file: File, query: dict[str, str] | None = None
     ) -> URL:
         url = URL(
-            str(self.client.base_url)
-            + f"locations/{self.SIMCORE_S3_ID}/files/{file.quoted_storage_file_id}:complete"
+            f"{self.client.base_url}locations/{self.SIMCORE_S3_ID}/files/{file.quoted_storage_file_id}:complete"
         )
         if query is not None:
             url = url.include_query_params(**query)

--- a/services/api-server/src/simcore_service_api_server/services/storage.py
+++ b/services/api-server/src/simcore_service_api_server/services/storage.py
@@ -120,8 +120,7 @@ class StorageApi(BaseServiceClientApi):
         self, file: File, query: dict[str, str] | None = None
     ) -> URL:
         url = URL(
-            str(self.client.base_url)
-            + f"locations/{self.SIMCORE_S3_ID}/files/{file.quoted_storage_file_id}:abort"
+            f"{self.client.base_url}locations/{self.SIMCORE_S3_ID}/files/{file.quoted_storage_file_id}:abort"
         )
         if query:
             url = url.include_query_params(**query)

--- a/services/api-server/tests/unit/test_api_files.py
+++ b/services/api-server/tests/unit/test_api_files.py
@@ -173,7 +173,9 @@ async def test_download_content(
     assert response.headers["content-type"] == "application/octet-stream"
 
 
-@pytest.mark.parametrize("follow_up_request", ["complete", "abort"])
+# @pytest.mark.parametrize("follow_up_request", ["complete", "abort"])
+@pytest.mark.testit
+@pytest.mark.parametrize("follow_up_request", ["abort"])
 async def test_get_upload_links(
     follow_up_request: str,
     client: AsyncClient,

--- a/services/api-server/tests/unit/test_api_files.py
+++ b/services/api-server/tests/unit/test_api_files.py
@@ -180,9 +180,7 @@ async def test_download_content(
     assert response.headers["content-type"] == "application/octet-stream"
 
 
-# @pytest.mark.parametrize("follow_up_request", ["complete", "abort"])
-@pytest.mark.testit
-@pytest.mark.parametrize("follow_up_request", ["abort"])
+@pytest.mark.parametrize("follow_up_request", ["complete", "abort"])
 async def test_get_upload_links(
     follow_up_request: str,
     client: AsyncClient,
@@ -228,3 +226,5 @@ async def test_get_upload_links(
             upload_schema.links.abort_upload, json=body, auth=auth
         )
         assert response.status_code == status.HTTP_200_OK
+    else:
+        assert False

--- a/services/api-server/tests/unit/test_api_files.py
+++ b/services/api-server/tests/unit/test_api_files.py
@@ -13,17 +13,18 @@ import pytest
 from aioresponses import aioresponses as AioResponsesMock
 from faker import Faker
 from fastapi import status
+from fastapi.encoders import jsonable_encoder
 from httpx import AsyncClient
 from models_library.api_schemas_storage import (
     ETag,
-    FileUploadCompleteLinks,
     FileUploadCompletionBody,
+    FileUploadSchema,
     UploadedPart,
 )
 from pydantic import parse_obj_as
 from respx import MockRouter
 from simcore_service_api_server._meta import API_VTAG
-from simcore_service_api_server.models.schemas.files import ClientFileUploadSchema, File
+from simcore_service_api_server.models.schemas.files import ClientFile, File
 
 _FAKER = Faker()
 
@@ -46,6 +47,12 @@ class DummyFileData:
             ),
             filename=cls._file_name,
             checksum="",
+        )
+
+    @classmethod
+    def client_file(cls) -> ClientFile:
+        return parse_obj_as(
+            ClientFile, {"filename": cls._file_name, "filesize": cls._file_size}
         )
 
     @classmethod
@@ -196,31 +203,28 @@ async def test_get_upload_links(
     payload: dict[str, str] = response.json()
 
     assert response.status_code == status.HTTP_200_OK
-    upload_schema: ClientFileUploadSchema = ClientFileUploadSchema.parse_obj(payload)
+    upload_schema: FileUploadSchema = FileUploadSchema.parse_obj(payload)
 
     if follow_up_request == "complete":
-        msg = {
-            "file": upload_schema.file.dict(),
-            "uploaded_parts": DummyFileData.uploaded_parts().dict(),
-            "completion_link": FileUploadCompleteLinks(
-                state=upload_schema.storage_upload_schema.links.complete_upload
-            ).dict(),
+        body = {
+            "client_file": jsonable_encoder(DummyFileData.client_file()),
+            "uploaded_parts": jsonable_encoder(DummyFileData.uploaded_parts()),
         }
-        msg["file"]["id"] = str(msg["file"]["id"])
         response = await client.post(
-            upload_schema.links.complete_upload, json=msg, auth=auth
+            upload_schema.links.complete_upload,
+            json=body,
+            auth=auth,
         )
+
         payload: dict[str, str] = response.json()
 
         assert response.status_code == status.HTTP_200_OK
         _ = parse_obj_as(File, payload)
     elif follow_up_request == "abort":
-        msg = {
-            "abort_upload_link": str(
-                upload_schema.storage_upload_schema.links.abort_upload
-            )
+        body = {
+            "client_file": jsonable_encoder(DummyFileData.client_file()),
         }
         response = await client.post(
-            upload_schema.links.abort_upload, json=msg, auth=auth
+            upload_schema.links.abort_upload, json=body, auth=auth
         )
         assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?
Make sure `file_id` is a path parameter according to openapi. I found an openapi validator which complained because FastApi does not add a path parameter to the openapi specification unless the parameter is specified as an input to the given function.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
