### PR TITLE
♻️Maintenance: attempt at fixing monkeypatch warnings

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_compose.py
@@ -172,7 +172,7 @@ def simcore_docker_compose(
 def inject_filestash_config_path_env(
     osparc_simcore_scripts_dir: Path,
     env_file_for_testing: Path,
-) -> dict[str, str]:
+) -> EnvVarsDict:
     create_filestash_config_py = (
         osparc_simcore_scripts_dir / "filestash" / "create_config.py"
     )

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_docker.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_docker.py
@@ -124,6 +124,7 @@ def run_docker_compose_config(
     project_dir: Path,
     env_file_path: Path,
     destination_path: Path | None = None,
+    additional_envs: dict[str, str] | None = None,
 ) -> dict:
     """Runs docker compose config to validate and resolve a compose file configuration
 
@@ -182,6 +183,7 @@ def run_docker_compose_config(
         check=True,
         cwd=project_dir,
         stdout=subprocess.PIPE,
+        env=additional_envs,
     )
 
     compose_file_str = process.stdout.decode("utf-8")

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_docker.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_docker.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import docker
 import yaml
+from pytest_simcore.helpers.typing_env import EnvVarsDict
 from tenacity import retry
 from tenacity.after import after_log
 from tenacity.stop import stop_after_attempt
@@ -124,7 +125,7 @@ def run_docker_compose_config(
     project_dir: Path,
     env_file_path: Path,
     destination_path: Path | None = None,
-    additional_envs: dict[str, str] | None = None,
+    additional_envs: EnvVarsDict | None = None,
 ) -> dict:
     """Runs docker compose config to validate and resolve a compose file configuration
 

--- a/packages/pytest-simcore/src/pytest_simcore/monkeypatch_extra.py
+++ b/packages/pytest-simcore/src/pytest_simcore/monkeypatch_extra.py
@@ -17,15 +17,6 @@ warnings.warn(
 # SEE https://github.com/pytest-dev/pytest/issues/363#issuecomment-289830794
 
 
-@pytest.fixture(scope="session")
-def monkeypatch_session(request: FixtureRequest) -> Iterator[MonkeyPatch]:
-    assert request.scope == "session"
-
-    mpatch_session = MonkeyPatch()
-    yield mpatch_session
-    mpatch_session.undo()
-
-
 @pytest.fixture(scope="module")
 def monkeypatch_module(request: FixtureRequest) -> Iterator[MonkeyPatch]:
     assert request.scope == "module"

--- a/packages/pytest-simcore/src/pytest_simcore/simcore_services.py
+++ b/packages/pytest-simcore/src/pytest_simcore/simcore_services.py
@@ -5,6 +5,7 @@
 import asyncio
 import json
 import logging
+import warnings
 from dataclasses import dataclass
 
 import aiohttp
@@ -174,6 +175,12 @@ def simcore_services_ready(
 def simcore_services_ready_module(
     services_endpoint: dict[str, URL], monkeypatch_module: MonkeyPatch
 ) -> None:
+    warnings.warn(
+        "This fixture uses deprecated monkeypatch_module fixture"
+        "Please do NOT use it!",
+        DeprecationWarning,
+        stacklevel=1,
+    )
     _wait_for_services_ready(services_endpoint)
     # patches environment variables with right host/port per service
     for service, endpoint in services_endpoint.items():

--- a/packages/pytest-simcore/src/pytest_simcore/simcore_services.py
+++ b/packages/pytest-simcore/src/pytest_simcore/simcore_services.py
@@ -133,13 +133,7 @@ def services_endpoint(
     return services_endpoint
 
 
-def _check_services_ready(services_endpoint: dict[str, URL]) -> None:
-    """
-    - Waits for services in `core_services_selection` to be healthy
-    - Sets environment with these (host:port) endpoitns
-
-    WARNING: not all services in the selection can be health-checked (see services_endpoint)
-    """
+def _wait_for_services_ready(services_endpoint: dict[str, URL]) -> None:
     # Compose and log healthcheck url entpoints
 
     health_endpoints = [
@@ -165,7 +159,7 @@ def _check_services_ready(services_endpoint: dict[str, URL]) -> None:
 def simcore_services_ready(
     services_endpoint: dict[str, URL], monkeypatch: MonkeyPatch
 ) -> None:
-    _check_services_ready(services_endpoint)
+    _wait_for_services_ready(services_endpoint)
     # patches environment variables with right host/port per service
     for service, endpoint in services_endpoint.items():
         env_prefix = service.upper().replace("-", "_")
@@ -180,7 +174,7 @@ def simcore_services_ready(
 def simcore_services_ready_module(
     services_endpoint: dict[str, URL], monkeypatch_module: MonkeyPatch
 ) -> None:
-    _check_services_ready(services_endpoint)
+    _wait_for_services_ready(services_endpoint)
     # patches environment variables with right host/port per service
     for service, endpoint in services_endpoint.items():
         env_prefix = service.upper().replace("-", "_")

--- a/packages/service-library/tests/conftest.py
+++ b/packages/service-library/tests/conftest.py
@@ -15,7 +15,6 @@ pytest_plugins = [
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_swarm",
     "pytest_simcore.file_extra",
-    "pytest_simcore.monkeypatch_extra",
     "pytest_simcore.pytest_global_environs",
     "pytest_simcore.rabbit_service",
     "pytest_simcore.redis_service",

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -54,7 +54,6 @@ pytest_plugins = [
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_swarm",
     "pytest_simcore.environment_configs",
-    "pytest_simcore.monkeypatch_extra",
     "pytest_simcore.rabbit_service",
     "pytest_simcore.repository_paths",
     "pytest_simcore.tmp_path_extra",

--- a/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_dynamic_scaling_core.py
@@ -194,16 +194,14 @@ async def drained_host_node(
     assert drained_node.Version.Index
     assert drained_node.Spec
     assert drained_node.Spec.Role
-    (
-        await async_docker_client.nodes.update(
-            node_id=drained_node.ID,
-            version=drained_node.Version.Index,
-            spec={
-                "Availability": old_availability.value,
-                "Labels": drained_node.Spec.Labels,
-                "Role": drained_node.Spec.Role.value,
-            },
-        ),
+    await async_docker_client.nodes.update(
+        node_id=drained_node.ID,
+        version=drained_node.Version.Index,
+        spec={
+            "Availability": old_availability.value,
+            "Labels": drained_node.Spec.Labels,
+            "Role": drained_node.Spec.Role.value,
+        },
     )
 
 

--- a/services/catalog/tests/unit/conftest.py
+++ b/services/catalog/tests/unit/conftest.py
@@ -14,7 +14,6 @@ pytest_plugins = [
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
-    "pytest_simcore.monkeypatch_extra",
     "pytest_simcore.postgres_service",
     "pytest_simcore.pydantic_models",
     "pytest_simcore.pytest_global_environs",

--- a/services/clusters-keeper/tests/unit/conftest.py
+++ b/services/clusters-keeper/tests/unit/conftest.py
@@ -41,7 +41,6 @@ pytest_plugins = [
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_swarm",
     "pytest_simcore.environment_configs",
-    "pytest_simcore.monkeypatch_extra",
     "pytest_simcore.rabbit_service",
     "pytest_simcore.repository_paths",
     "pytest_simcore.tmp_path_extra",

--- a/services/migration/tests/conftest.py
+++ b/services/migration/tests/conftest.py
@@ -2,7 +2,6 @@ pytest_plugins = [
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
-    "pytest_simcore.monkeypatch_extra",
     "pytest_simcore.repository_paths",
     "pytest_simcore.tmp_path_extra",
 ]

--- a/services/resource-usage-tracker/tests/unit/conftest.py
+++ b/services/resource-usage-tracker/tests/unit/conftest.py
@@ -27,19 +27,18 @@ from simcore_service_resource_usage_tracker.core.application import create_app
 from simcore_service_resource_usage_tracker.core.settings import ApplicationSettings
 
 pytest_plugins = [
+    "pytest_simcore.cli_runner",
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
-    "pytest_simcore.monkeypatch_extra",
+    "pytest_simcore.environment_configs",
     "pytest_simcore.postgres_service",
     "pytest_simcore.pydantic_models",
+    "pytest_simcore.pytest_global_environs",
+    "pytest_simcore.rabbit_service",
     "pytest_simcore.repository_paths",
     "pytest_simcore.schemas",
     "pytest_simcore.tmp_path_extra",
-    "pytest_simcore.pytest_global_environs",
-    "pytest_simcore.cli_runner",
-    "pytest_simcore.environment_configs",
-    "pytest_simcore.rabbit_service",
 ]
 
 

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -66,7 +66,6 @@ pytest_plugins = [
     "pytest_simcore.environment_configs",
     "pytest_simcore.file_extra",
     "pytest_simcore.httpbin_service",
-    "pytest_simcore.monkeypatch_extra",
     "pytest_simcore.postgres_service",
     "pytest_simcore.pytest_global_environs",
     "pytest_simcore.repository_paths",
@@ -77,7 +76,6 @@ pytest_plugins = [
 
 CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
-# TODO: replace by pytest_simcore
 sys.path.append(str(CURRENT_DIR / "helpers"))
 
 

--- a/services/web/server/tests/conftest.py
+++ b/services/web/server/tests/conftest.py
@@ -54,7 +54,6 @@ pytest_plugins = [
     "pytest_simcore.docker_swarm",
     "pytest_simcore.environment_configs",
     "pytest_simcore.hypothesis_type_strategies",
-    "pytest_simcore.monkeypatch_extra",
     "pytest_simcore.postgres_service",
     "pytest_simcore.pydantic_models",
     "pytest_simcore.pytest_global_environs",

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -125,13 +125,6 @@ async def director_v2_service_mock() -> AsyncIterable[aioresponses]:
         yield mock
 
 
-@pytest.fixture(autouse=True)
-async def auto_mock_director_v2(
-    director_v2_service_mock: aioresponses,
-) -> aioresponses:
-    return director_v2_service_mock
-
-
 @pytest.fixture
 def client(
     event_loop: asyncio.AbstractEventLoop,
@@ -143,6 +136,7 @@ def client(
     redis_client: aioredis.Redis,
     rabbit_service: RabbitSettings,
     simcore_services_ready: None,
+    director_v2_service_mock: aioresponses,
 ) -> TestClient:
     cfg = deepcopy(app_config)
 

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -78,20 +78,21 @@ def disable_swagger_doc_generation(
 
 
 @pytest.fixture(scope="session")
-def docker_compose_file(
-    default_app_cfg: ConfigDict, monkeypatch_session: pytest.MonkeyPatch
-) -> str:
+def docker_compose_env(default_app_cfg: ConfigDict) -> Iterator[pytest.MonkeyPatch]:
+    postgres_cfg = default_app_cfg["db"]["postgres"]
+
+    # docker-compose reads these environs
+    with pytest.MonkeyPatch().context() as patcher:
+        patcher.setenv("TEST_POSTGRES_DB", postgres_cfg["database"])
+        patcher.setenv("TEST_POSTGRES_USER", postgres_cfg["user"])
+        patcher.setenv("TEST_POSTGRES_PASSWORD", postgres_cfg["password"])
+        yield patcher
+
+
+@pytest.fixture(scope="session")
+def docker_compose_file(docker_compose_env: pytest.MonkeyPatch) -> str:
     """Overrides pytest-docker fixture"""
-
-    cfg = deepcopy(default_app_cfg["db"]["postgres"])
-
-    # docker compose reads these environs
-    monkeypatch_session.setenv("TEST_POSTGRES_DB", cfg["database"])
-    monkeypatch_session.setenv("TEST_POSTGRES_USER", cfg["user"])
-    monkeypatch_session.setenv("TEST_POSTGRES_PASSWORD", cfg["password"])
-
     compose_path = CURRENT_DIR / "docker-compose-devel.yml"
-
     assert compose_path.exists()
     return f"{compose_path}"
 

--- a/test.bash
+++ b/test.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo $MYTEST

--- a/tests/public-api/conftest.py
+++ b/tests/public-api/conftest.py
@@ -89,7 +89,7 @@ def simcore_docker_stack_and_registry_ready(
     event_loop: asyncio.AbstractEventLoop,
     docker_registry: UrlStr,
     docker_stack: StacksDeployedDict,
-    simcore_services_ready: None,
+    simcore_services_ready_module: None,
 ) -> StacksDeployedDict:
     # At this point `simcore_services_ready` waited until all services
     # are running. Let's make one more check on the web-api


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?
In an attempt to reduce the warnings and making tests outcome clearer, this shall reduce the warnings generated by the monkeypatch_extra module. The ```monkypatch_extra.py``` module was removed everywhere possible in a train ride. the last ones are still in and concern director-v2, dynamic-sidecar and simcore-sdk. Also some system tests are affected.

To all backend developers: Please do not use any fixture of monkeypatch_extra.py module

The bellow image show an example of tests passing without warnings (green outcome) and with warnings (yellow outcome). If we want to tackle all the SQLAlchemy2.0 warnings for instance. we need to go for warnings free tests.
![image](https://github.com/ITISFoundation/osparc-simcore/assets/35365065/c56bed6e-df3f-4fdd-a9a5-a1c4b73af8d1)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
