### PR TITLE
⬆️Comp backend: ensure numpy installed in client

### DIFF
--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -4,18 +4,9 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-aio-pika==9.1.2
-    # via
-    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiobotocore==2.5.2
+aio-pika==9.2.2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+aiobotocore==2.5.4
     # via s3fs
 aiodebug==2.3.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
@@ -23,7 +14,7 @@ aiodocker==0.21.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiofiles==23.1.0
+aiofiles==23.2.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
@@ -44,19 +35,17 @@ aiohttp==3.8.5
     #   s3fs
 aioitertools==0.11.0
     # via aiobotocore
-aiormq==6.7.6
+aiormq==6.7.7
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
-anyio==3.7.1
-    # via httpcore
 arrow==1.2.3
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   aiohttp
     #   redis
@@ -69,17 +58,15 @@ blosc==1.11.1
     # via -r requirements/_base.in
 bokeh==2.4.3
     # via dask
-botocore==1.29.161
+botocore==1.31.17
     # via aiobotocore
 certifi==2023.7.22
-    # via
-    #   httpcore
-    #   requests
+    # via requests
 charset-normalizer==3.2.0
     # via
     #   aiohttp
     #   requests
-click==8.1.6
+click==8.1.7
     # via
     #   dask
     #   dask-gateway
@@ -102,12 +89,10 @@ distributed==2023.3.2
     # via
     #   dask
     #   dask-gateway
-dnspython==2.4.0
+dnspython==2.4.2
     # via email-validator
 email-validator==2.0.0.post2
     # via pydantic
-exceptiongroup==1.1.2
-    # via anyio
 frozenlist==1.4.0
     # via
     #   aiohttp
@@ -117,13 +102,8 @@ fsspec==2023.6.0
     #   -r requirements/_base.in
     #   dask
     #   s3fs
-h11==0.14.0
-    # via httpcore
-httpcore==0.17.3
-    # via dnspython
 idna==3.4
     # via
-    #   anyio
     #   email-validator
     #   requests
     #   yarl
@@ -144,7 +124,7 @@ jinja2==3.1.2
     #   distributed
 jmespath==1.0.1
     # via botocore
-jsonschema==4.18.4
+jsonschema==4.19.0
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -169,7 +149,7 @@ multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-numpy==1.25.1
+numpy==1.25.2
     # via bokeh
 packaging==23.1
     # via
@@ -184,7 +164,7 @@ pillow==10.0.0
     # via bokeh
 psutil==5.9.5
     # via distributed
-pydantic==1.10.11
+pydantic==1.10.12
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
@@ -202,7 +182,7 @@ pydantic==1.10.11
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
-pygments==2.15.1
+pygments==2.16.1
     # via rich
 pyinstrument==4.5.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
@@ -227,7 +207,7 @@ pyyaml==6.0.1
     #   dask
     #   dask-gateway
     #   distributed
-redis==4.6.0
+redis==5.0.0
     # via
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
@@ -245,7 +225,7 @@ referencing==0.29.3
     #   jsonschema-specifications
 requests==2.31.0
     # via fsspec
-rich==13.4.2
+rich==13.5.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
@@ -257,28 +237,24 @@ s3fs==2023.6.0
     # via fsspec
 six==1.16.0
     # via python-dateutil
-sniffio==1.3.0
-    # via
-    #   anyio
-    #   dnspython
-    #   httpcore
 sortedcontainers==2.4.0
     # via distributed
 tblib==2.0.0
     # via distributed
-tenacity==8.2.2
+tenacity==8.2.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 toolz==0.12.0
     # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
     #   partd
-tornado==6.3.2
+tornado==6.3.3
     # via
     #   bokeh
     #   dask-gateway
     #   distributed
-tqdm==4.65.0
+tqdm==4.66.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 typer==0.9.0
     # via

--- a/services/dask-sidecar/requirements/_dask-distributed.in
+++ b/services/dask-sidecar/requirements/_dask-distributed.in
@@ -10,3 +10,4 @@
 dask[distributed]
 blosc # for compression
 lz4 # for compression
+numpy

--- a/services/dask-sidecar/requirements/_dask-distributed.txt
+++ b/services/dask-sidecar/requirements/_dask-distributed.txt
@@ -8,7 +8,7 @@ blosc==1.11.1
     # via
     #   -c requirements/./_base.txt
     #   -r requirements/_dask-distributed.in
-click==8.1.6
+click==8.1.7
     # via
     #   -c requirements/./_base.txt
     #   dask
@@ -56,6 +56,10 @@ msgpack==1.0.5
     # via
     #   -c requirements/./_base.txt
     #   distributed
+numpy==1.25.2
+    # via
+    #   -c requirements/./_base.txt
+    #   -r requirements/_dask-distributed.in
 packaging==23.1
     # via
     #   -c requirements/./_base.txt
@@ -88,7 +92,7 @@ toolz==0.12.0
     #   dask
     #   distributed
     #   partd
-tornado==6.3.2
+tornado==6.3.3
     # via
     #   -c requirements/./_base.txt
     #   distributed

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -13,7 +13,7 @@ aiosignal==1.3.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -31,11 +31,11 @@ aws-xray-sdk==2.12.0
     # via moto
 blinker==1.6.2
     # via flask
-boto3==1.26.161
+boto3==1.28.17
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.29.161
+botocore==1.31.17
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -55,7 +55,7 @@ charset-normalizer==3.2.0
     #   -c requirements/_base.txt
     #   aiohttp
     #   requests
-click==8.1.6
+click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   flask
@@ -79,10 +79,8 @@ ecdsa==0.18.0
     #   moto
     #   python-jose
     #   sshpubkeys
-exceptiongroup==1.1.2
-    # via
-    #   -c requirements/_base.txt
-    #   pytest
+exceptiongroup==1.1.3
+    # via pytest
 faker==19.3.0
     # via -r requirements/_test.in
 flask==2.3.2
@@ -130,14 +128,14 @@ jsonpickle==3.0.2
     # via jschema-to-python
 jsonpointer==2.4
     # via jsonpatch
-jsonschema==4.18.4
+jsonschema==4.19.0
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   cfn-lint
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-spec==0.2.3
+jsonschema-spec==0.2.4
     # via openapi-spec-validator
 jsonschema-specifications==2023.7.1
     # via
@@ -192,7 +190,7 @@ pyasn1==0.5.0
     #   rsa
 pycparser==2.21
     # via cffi
-pydantic==1.10.11
+pydantic==1.10.12
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -278,7 +276,7 @@ rsa==4.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   python-jose
-s3transfer==0.6.1
+s3transfer==0.6.2
     # via boto3
 sarif-om==1.0.4
     # via cfn-lint

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
-click==8.1.6
+click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -70,7 +70,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.0.284
+ruff==0.0.285
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -6,26 +6,7 @@
 #
 aio-pika==9.1.2
     # via
-    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/./../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/./../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/./../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
@@ -122,7 +103,7 @@ certifi==2023.7.22
     #   httpx
 charset-normalizer==3.2.0
     # via aiohttp
-click==8.1.6
+click==8.1.7
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -318,6 +299,8 @@ multidict==6.0.4
     #   yarl
 networkx==3.1
     # via -r requirements/_base.in
+numpy==1.25.2
+    # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
 ordered-set==4.1.0
     # via -r requirements/_base.in
 orjson==3.9.2
@@ -547,11 +530,14 @@ tenacity==8.2.2
     #   -r requirements/_base.in
 toolz==0.12.0
     # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
     #   partd
-tornado==6.3.2
+tornado==6.3.3
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask-gateway

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -73,7 +73,7 @@ charset-normalizer==3.2.0
     #   -c requirements/_base.txt
     #   aiohttp
     #   requests
-click==8.1.6
+click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   dask
@@ -201,7 +201,9 @@ mypy==1.5.0
 mypy-extensions==1.0.0
     # via mypy
 numpy==1.25.2
-    # via bokeh
+    # via
+    #   -c requirements/_base.txt
+    #   bokeh
 packaging==23.1
     # via
     #   -c requirements/_base.txt
@@ -315,7 +317,7 @@ toolz==0.12.0
     #   dask
     #   distributed
     #   partd
-tornado==6.3.2
+tornado==6.3.3
     # via
     #   -c requirements/_base.txt
     #   bokeh

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
-click==8.1.6
+click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt

--- a/services/osparc-gateway-server/requirements/_test.txt
+++ b/services/osparc-gateway-server/requirements/_test.txt
@@ -30,7 +30,7 @@ charset-normalizer==3.2.0
     #   -c requirements/_base.txt
     #   aiohttp
     #   requests
-click==8.1.6
+click==8.1.7
     # via
     #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -203,7 +203,7 @@ toolz==0.12.0
     #   dask
     #   distributed
     #   partd
-tornado==6.3.2
+tornado==6.3.3
     # via
     #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask-gateway

--- a/services/osparc-gateway-server/requirements/_tools.txt
+++ b/services/osparc-gateway-server/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
-click==8.1.6
+click==8.1.7
     # via
     #   -c requirements/_test.txt
     #   black

--- a/services/osparc-gateway-server/tests/system/requirements/_test.txt
+++ b/services/osparc-gateway-server/tests/system/requirements/_test.txt
@@ -23,7 +23,7 @@ charset-normalizer==3.2.0
     # via
     #   aiohttp
     #   requests
-click==8.1.6
+click==8.1.7
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -100,7 +100,9 @@ multidict==6.0.4
     #   aiohttp
     #   yarl
 numpy==1.25.2
-    # via -r requirements/_test.in
+    # via
+    #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
+    #   -r requirements/_test.in
 packaging==23.1
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
@@ -179,7 +181,7 @@ toolz==0.12.0
     #   dask
     #   distributed
     #   partd
-tornado==6.3.2
+tornado==6.3.3
     # via
     #   -c requirements/../../../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask-gateway

--- a/services/osparc-gateway-server/tests/system/requirements/_tools.txt
+++ b/services/osparc-gateway-server/tests/system/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
-click==8.1.6
+click==8.1.7
     # via
     #   -c requirements/_test.txt
     #   black


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

- [x] removes bug in dv-2 showing issue with client numpy not being on par with scheduler and workers.
- [x] upgrade of dask-sidecar and dependencies (without being able to upgrade distributed as [explained here](https://github.com/ITISFoundation/osparc-simcore/issues/4526))

###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 26
- #packages after : 22

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.1.2           | 9.2.2      | *minor*    | 1 | dask-sidecar⬆️ |
|   2 | aiobotocore               | 2.5.2           | 2.5.4      |            | 1 | dask-sidecar⬆️ |
|   3 | aiofiles                  | 23.1.0          | 23.2.1     | *minor*    | 1 | dask-sidecar⬆️ |
|   4 | aiormq                    | 6.7.6           | 6.7.7      |            | 1 | dask-sidecar⬆️ |
|   5 | anyio                     | 3.7.1           | 🗑️ removed |  | 1 | dask-sidecar⬆️ |
|   6 | async-timeout             | 4.0.2           | 4.0.3      |            | 2 | dask-sidecar⬆️🧪 |
|   7 | boto3                     | 1.26.161        | 1.28.17    | *minor*    | 1 | dask-sidecar🧪 |
|   8 | botocore                  | 1.29.161        | 1.31.17    | *minor*    | 2 | dask-sidecar⬆️🧪 |
|   9 | click                     | 8.1.6           | 8.1.7      |            | 11 | dask-sidecar⬆️⬆️🧪🔧</br>director-v2⬆️🧪🔧</br>osparc-gateway-server🧪🔧🧪🧪 |
|  10 | dnspython                 | 2.4.0           | 2.4.2      |            | 1 | dask-sidecar⬆️ |
|  11 | exceptiongroup            | 1.1.2           | 1.1.3      |            | 2 | dask-sidecar⬆️🧪 |
|  12 | h11                       | 0.14.0          | 🗑️ removed |  | 1 | dask-sidecar⬆️ |
|  13 | httpcore                  | 0.17.3          | 🗑️ removed |  | 1 | dask-sidecar⬆️ |
|  14 | jsonschema                | 4.18.4          | 4.19.0     | *minor*    | 2 | dask-sidecar⬆️🧪 |
|  15 | jsonschema-spec           | 0.2.3           | 0.2.4      |            | 1 | dask-sidecar🧪 |
|  16 | numpy                     | 1.25.1          | 1.25.2     |            | 1 | dask-sidecar⬆️ |
|  17 | pydantic                  | 1.10.11         | 1.10.12    |            | 2 | dask-sidecar⬆️🧪 |
|  18 | pygments                  | 2.15.1          | 2.16.1     | *minor*    | 1 | dask-sidecar⬆️ |
|  19 | redis                     | 4.6.0           | 5.0.0      | **MAJOR**  | 1 | dask-sidecar⬆️ |
|  20 | rich                      | 13.4.2          | 13.5.2     | *minor*    | 1 | dask-sidecar⬆️ |
|  21 | ruff                      | 0.0.284         | 0.0.285    |            | 1 | dask-sidecar🔧 |
|  22 | s3transfer                | 0.6.1           | 0.6.2      |            | 1 | dask-sidecar🧪 |
|  23 | sniffio                   | 1.3.0           | 🗑️ removed |  | 1 | dask-sidecar⬆️ |
|  24 | tenacity                  | 8.2.2           | 8.2.3      |            | 1 | dask-sidecar⬆️ |
|  25 | tornado                   | 6.3.2           | 6.3.3      |            | 6 | dask-sidecar⬆️⬆️</br>director-v2⬆️🧪</br>osparc-gateway-server🧪🧪 |
|  26 | tqdm                      | 4.65.0          | 4.66.1     | *minor*    | 1 | dask-sidecar⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency