### PR TITLE
♻️Maintenance: remove backward compatibility code

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_api/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_api/_core.py
@@ -135,7 +135,7 @@ async def _get_service_latest_task(service_id: str) -> Mapping[str, Any]:
                 filters={"service": f"{service_id}"}
             )
             if not service_associated_tasks:
-                raise DockerServiceNotFoundError(service_id=service_id)  # noqa: TRY301
+                raise DockerServiceNotFoundError(service_id=service_id)
 
             # The service might have more then one task because the
             # previous might have died out.
@@ -183,7 +183,7 @@ async def get_dynamic_sidecar_placement(
         service_state = task["Status"]["State"]
 
         if service_state not in TASK_STATES_RUNNING:
-            raise TryAgain()
+            raise TryAgain
         return task
 
     task = await _get_task_data_when_service_running(service_id=service_id)
@@ -457,7 +457,7 @@ async def _update_service_spec(
                         e.status == status.HTTP_500_INTERNAL_SERVER_ERROR
                         and "out of sequence" in e.message
                     ):
-                        raise TryAgain() from e
+                        raise TryAgain from e
                     raise
 
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_api/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_api/_core.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import warnings
 from collections.abc import Mapping
 from typing import Any, Final
 
@@ -250,28 +249,21 @@ async def _list_docker_services(
     # shall be removed after 1-2 releases without issues
     # backwards compatibility part
 
-    def _make_filters(*, backwards_compatible: bool) -> Mapping[str, Any]:
+    def _make_filters() -> Mapping[str, Any]:
         filters = {
             "label": [
-                f"{'swarm_stack_name' if backwards_compatible else to_simcore_runtime_docker_label_key('swarm_stack_name')}={swarm_stack_name}",
+                f"{to_simcore_runtime_docker_label_key('swarm_stack_name')}={swarm_stack_name}",
             ],
         }
         if node_id:
             filters["label"].append(
-                f"{'uuid'  if backwards_compatible else to_simcore_runtime_docker_label_key('node_id')}={node_id}"
+                f"{to_simcore_runtime_docker_label_key('node_id')}={node_id}"
             )
         if return_only_sidecars:
             filters["name"] = [f"{DYNAMIC_SIDECAR_SERVICE_PREFIX}"]
         return filters
 
-    warnings.warn(
-        "After PR#4453 [https://github.com/ITISFoundation/osparc-simcore/pull/4453] reaches"
-        " production, the backwards compatible code may be removed",
-        stacklevel=2,
-    )
-    services_list: list[Mapping] = await client.services.list(
-        filters=_make_filters(backwards_compatible=True)
-    ) + await client.services.list(filters=_make_filters(backwards_compatible=False))
+    services_list: list[Mapping] = await client.services.list(filters=_make_filters())
     return services_list
 
 

--- a/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
@@ -17,6 +17,7 @@ from aiodocker.utils import clean_filters
 from aiodocker.volumes import DockerVolume
 from faker import Faker
 from fastapi.encoders import jsonable_encoder
+from models_library.docker import to_simcore_runtime_docker_label_key
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.services_enums import ServiceState
@@ -180,15 +181,15 @@ def dynamic_sidecar_service_spec(
         "name": dynamic_sidecar_service_name,
         "task_template": {"ContainerSpec": {"Image": "joseluisq/static-web-server"}},
         "labels": {
-            "swarm_stack_name": f"{dynamic_sidecar_settings.SWARM_STACK_NAME}",
-            "uuid": f"{uuid4()}",
-            "service_key": "simcore/services/dynamic/3dviewer",
-            "service_tag": "2.4.5",
             "traefik.docker.network": "",
             "io.simcore.zone": "",
-            "service_port": "80",
-            "study_id": f"{uuid4()}",
-            "user_id": "123",
+            f"{to_simcore_runtime_docker_label_key('project_id')}": f"{uuid4()}",
+            f"{to_simcore_runtime_docker_label_key('user_id')}": "123",
+            f"{to_simcore_runtime_docker_label_key('node_id')}": f"{uuid4()}",
+            f"{to_simcore_runtime_docker_label_key('swarm_stack_name')}": f"{dynamic_sidecar_settings.SWARM_STACK_NAME}",
+            f"{to_simcore_runtime_docker_label_key('service_port')}": "80",
+            f"{to_simcore_runtime_docker_label_key('service_key')}": "simcore/services/dynamic/3dviewer",
+            f"{to_simcore_runtime_docker_label_key('service_version')}": "2.4.5",
             DYNAMIC_SIDECAR_SCHEDULER_DATA_LABEL: scheduler_data_from_http_request.json(),
         },
     }
@@ -234,10 +235,13 @@ def dynamic_sidecar_stack_specs(
                 "ContainerSpec": {"Image": "joseluisq/static-web-server"}
             },
             "labels": {
-                "swarm_stack_name": f"{dynamic_sidecar_settings.SWARM_STACK_NAME}",
-                "uuid": f"{node_uuid}",
-                "user_id": f"{user_id}",
-                "study_id": f"{project_id}",
+                f"{to_simcore_runtime_docker_label_key('project_id')}": f"{project_id}",
+                f"{to_simcore_runtime_docker_label_key('user_id')}": f"{user_id}",
+                f"{to_simcore_runtime_docker_label_key('node_id')}": f"{node_uuid}",
+                f"{to_simcore_runtime_docker_label_key('swarm_stack_name')}": f"{dynamic_sidecar_settings.SWARM_STACK_NAME}",
+                f"{to_simcore_runtime_docker_label_key('service_port')}": "80",
+                f"{to_simcore_runtime_docker_label_key('service_key')}": "simcore/services/dynamic/3dviewer",
+                f"{to_simcore_runtime_docker_label_key('service_version')}": "2.4.5",
             },
         },
         {
@@ -246,10 +250,13 @@ def dynamic_sidecar_stack_specs(
                 "ContainerSpec": {"Image": "joseluisq/static-web-server"}
             },
             "labels": {
-                "swarm_stack_name": f"{dynamic_sidecar_settings.SWARM_STACK_NAME}",
-                "uuid": f"{node_uuid}",
-                "user_id": f"{user_id}",
-                "study_id": f"{project_id}",
+                f"{to_simcore_runtime_docker_label_key('project_id')}": f"{project_id}",
+                f"{to_simcore_runtime_docker_label_key('user_id')}": f"{user_id}",
+                f"{to_simcore_runtime_docker_label_key('node_id')}": f"{node_uuid}",
+                f"{to_simcore_runtime_docker_label_key('swarm_stack_name')}": f"{dynamic_sidecar_settings.SWARM_STACK_NAME}",
+                f"{to_simcore_runtime_docker_label_key('service_port')}": "80",
+                f"{to_simcore_runtime_docker_label_key('service_key')}": "simcore/services/dynamic/3dviewer",
+                f"{to_simcore_runtime_docker_label_key('service_version')}": "2.4.5",
             },
         },
     ]
@@ -573,8 +580,8 @@ async def test_remove_dynamic_sidecar_stack(
         services = await async_docker_client.services.list(
             filters={
                 "label": [
-                    f"swarm_stack_name={dynamic_sidecar_settings.SWARM_STACK_NAME}",
-                    f"uuid={node_uuid}",
+                    f"{to_simcore_runtime_docker_label_key('swarm_stack_name')}={dynamic_sidecar_settings.SWARM_STACK_NAME}",
+                    f"{to_simcore_runtime_docker_label_key('node_id')}={node_uuid}",
                 ]
             }
         )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

since [release 1.56.0](https://github.com/ITISFoundation/osparc-simcore/releases/tag/v1.56.0), the code from #4453 for backward compatibility can be safely removed, thus cleaning the logs.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
