### PR TITLE
✨ new `clone_study` in api-server

### DIFF
--- a/packages/service-library/src/servicelib/long_running_tasks/_models.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/_models.py
@@ -1,6 +1,7 @@
 from asyncio import Task
+from collections.abc import Awaitable, Callable, Coroutine
 from datetime import datetime
-from typing import Any, Awaitable, Callable, Coroutine
+from typing import Any, TypeAlias
 
 from models_library.api_schemas_long_running_tasks.base import (
     ProgressMessage,
@@ -15,11 +16,13 @@ from models_library.api_schemas_long_running_tasks.tasks import (
 )
 from pydantic import BaseModel, Field, PositiveFloat
 
-TaskName = str
+TaskName: TypeAlias = str
 
-TaskType = Callable[..., Coroutine[Any, Any, Any]]
+TaskType: TypeAlias = Callable[..., Coroutine[Any, Any, Any]]
 
-ProgressCallback = Callable[[ProgressMessage, ProgressPercent, TaskId], Awaitable[None]]
+ProgressCallback: TypeAlias = Callable[
+    [ProgressMessage, ProgressPercent, TaskId], Awaitable[None]
+]
 
 
 class TrackedTask(BaseModel):

--- a/packages/service-library/src/servicelib/long_running_tasks/_task.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/_task.py
@@ -158,6 +158,7 @@ class TasksManager:
         task: asyncio.Task,
         task_progress: TaskProgress,
         task_context: TaskContext,
+        *,
         fire_and_forget: bool,
     ) -> TrackedTask:
         task_id = self._create_task_id(task_name)

--- a/services/api-server/openapi.json
+++ b/services/api-server/openapi.json
@@ -637,7 +637,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "201": {
             "description": "Successful Response",
             "content": {
               "application/json": {

--- a/services/api-server/src/simcore_service_api_server/api/errors/httpx_client_error.py
+++ b/services/api-server/src/simcore_service_api_server/api/errors/httpx_client_error.py
@@ -6,10 +6,11 @@
 import logging
 
 from fastapi import status
-from fastapi.encoders import jsonable_encoder
 from httpx import HTTPStatusError
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+
+from .http_error import create_error_json_response
 
 _logger = logging.getLogger(__file__)
 
@@ -46,6 +47,4 @@ async def httpx_client_error_handler(_: Request, exc: HTTPStatusError) -> JSONRe
             exc.response.text,
         )
 
-    return JSONResponse(
-        content=jsonable_encoder({"errors": errors}), status_code=status_code
-    )
+    return create_error_json_response(*errors, status_code=status_code)

--- a/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
@@ -39,6 +39,7 @@ from ...services.solver_job_models_converters import (
 )
 from ...services.solver_job_outputs import ResultsTypes, get_solver_output_results
 from ...services.storage import StorageApi, to_file_api_model
+from ...services.webserver import ProjectNotFoundError
 from ..dependencies.application import get_product_name, get_reverse_url_mapper
 from ..dependencies.authentication import get_current_user_id
 from ..dependencies.database import Engine, get_db_engine
@@ -253,12 +254,11 @@ async def delete_job(
     try:
         await webserver_api.delete_project(project_id=job_id)
 
-    except HTTPException as err:
-        if err.status_code == status.HTTP_404_NOT_FOUND:
-            return create_error_json_response(
-                f"Cannot find job={job_name} to delete",
-                status_code=status.HTTP_404_NOT_FOUND,
-            )
+    except ProjectNotFoundError:
+        return create_error_json_response(
+            f"Cannot find job={job_name} to delete",
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
 
 
 @router.post(

--- a/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
@@ -161,6 +161,7 @@ async def get_jobs_page(
 @router.post(
     "/{solver_key:path}/releases/{version}/jobs",
     response_model=Job,
+    status_code=status.HTTP_201_CREATED,
 )
 async def create_job(
     solver_key: SolverKeyId,

--- a/services/api-server/src/simcore_service_api_server/api/routes/studies.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/studies.py
@@ -88,7 +88,7 @@ async def get_study(
 
 
 @router.post(
-    "/{study_id:uuid}",
+    "/{study_id:uuid}:clone",
     response_model=Study,
     responses={**_COMMON_ERROR_RESPONSES},
     include_in_schema=API_SERVER_DEV_FEATURES_ENABLED,

--- a/services/api-server/src/simcore_service_api_server/api/routes/studies.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/studies.py
@@ -93,9 +93,19 @@ async def get_study(
     responses={**_COMMON_ERROR_RESPONSES},
     include_in_schema=API_SERVER_DEV_FEATURES_ENABLED,
 )
-async def clone_study(study_id: StudyID):
-    msg = f"cloning study with study_id={study_id!r}. SEE https://github.com/ITISFoundation/osparc-simcore/issues/4651"
-    raise NotImplementedError(msg)
+async def clone_study(
+    study_id: StudyID,
+    webserver_api: Annotated[AuthSession, Depends(get_webserver_session)],
+):
+    try:
+        project: ProjectGet = await webserver_api.clone_project(project_id=study_id)
+        return _create_study_from_project(project)
+
+    except ProjectNotFoundError:
+        return create_error_json_response(
+            f"Cannot find study={study_id!r}.",
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
 
 
 @router.get(

--- a/services/api-server/src/simcore_service_api_server/api/routes/studies.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/studies.py
@@ -90,6 +90,7 @@ async def get_study(
 @router.post(
     "/{study_id:uuid}:clone",
     response_model=Study,
+    status_code=status.HTTP_201_CREATED,
     responses={**_COMMON_ERROR_RESPONSES},
     include_in_schema=API_SERVER_DEV_FEATURES_ENABLED,
 )

--- a/services/api-server/src/simcore_service_api_server/api/routes/studies_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/studies_jobs.py
@@ -42,6 +42,7 @@ async def list_study_jobs(
 @router.post(
     "/{study_id:uuid}/jobs",
     response_model=Job,
+    status_code=status.HTTP_201_CREATED,
     include_in_schema=API_SERVER_DEV_FEATURES_ENABLED,
 )
 async def create_study_job(study_id: StudyID):

--- a/services/api-server/src/simcore_service_api_server/models/types.py
+++ b/services/api-server/src/simcore_service_api_server/models/types.py
@@ -4,4 +4,4 @@ AnyDict: TypeAlias = dict[str, Any]
 ListAnyDict: TypeAlias = list[AnyDict]
 
 # Represent the type returned by e.g. json.load
-JSON: TypeAlias = AnyDict | ListAnyDict
+AnyJson: TypeAlias = AnyDict | ListAnyDict

--- a/services/api-server/src/simcore_service_api_server/services/webserver.py
+++ b/services/api-server/src/simcore_service_api_server/services/webserver.py
@@ -33,7 +33,7 @@ from tenacity.wait import wait_fixed
 from ..core.settings import WebServerSettings
 from ..models.pagination import MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE
 from ..models.schemas.jobs import MetaValueType
-from ..models.types import JSON
+from ..models.types import AnyJson
 from ..utils.client_base import BaseServiceClientApi, setup_client_instance
 
 _logger = logging.getLogger(__name__)
@@ -131,7 +131,7 @@ class AuthSession:
         resp: Response,
         client_status_code_to_exception_map: dict[int, WebServerValueError]
         | None = None,
-    ) -> JSON | None:
+    ) -> AnyJson | None:
         """
         Raises:
             WebServerValueError: any client error converted to module error
@@ -139,8 +139,8 @@ class AuthSession:
 
         """
         # enveloped answer
-        data = None
-        error: JSON | None = None
+        data: AnyJson | None = None
+        error: AnyJson | None = None
 
         if resp.status_code != status.HTTP_204_NO_CONTENT:
             try:
@@ -185,7 +185,7 @@ class AuthSession:
     def client(self):
         return self._api.client
 
-    async def get(self, path: str) -> JSON | None:
+    async def get(self, path: str) -> AnyJson | None:
         url = path.lstrip("/")
         try:
             resp = await self.client.get(url, cookies=self.session_cookies)
@@ -195,7 +195,7 @@ class AuthSession:
 
         return self._get_data_or_raise(resp)
 
-    async def put(self, path: str, body: dict) -> JSON | None:
+    async def put(self, path: str, body: dict) -> AnyJson | None:
         url = path.lstrip("/")
         try:
             resp = await self.client.put(url, json=body, cookies=self.session_cookies)

--- a/services/api-server/src/simcore_service_api_server/services/webserver.py
+++ b/services/api-server/src/simcore_service_api_server/services/webserver.py
@@ -45,6 +45,7 @@ class WebServerValueError(PydanticErrorMixin, ValueError):
 
 class ProjectNotFoundError(WebServerValueError):
     code = "webserver.project_not_found"
+    msg_template = "Project '{project_id}' not found"
 
 
 @contextmanager

--- a/services/api-server/src/simcore_service_api_server/services/webserver.py
+++ b/services/api-server/src/simcore_service_api_server/services/webserver.py
@@ -237,6 +237,17 @@ class AuthSession:
         data = await self.get(f"{result_url}")
         return ProjectGet.parse_obj(data)
 
+    async def clone_project(self, project_id: UUID) -> ProjectGet:
+        response = await self.client.post(
+            f"/projects/{project_id}:clone",
+            cookies=self.session_cookies,
+        )
+        if response.status_code == status.HTTP_404_NOT_FOUND:
+            raise ProjectNotFoundError(project_id=project_id)
+
+        data: JSON | None = self._get_data_or_raise_http_exception(response)
+        return ProjectGet.parse_obj(data)
+
     async def get_project(self, project_id: UUID) -> ProjectGet:
         response = await self.client.get(
             f"/projects/{project_id}",

--- a/services/api-server/tests/unit/api_solvers/conftest.py
+++ b/services/api-server/tests/unit/api_solvers/conftest.py
@@ -28,12 +28,12 @@ def solver_version() -> str:
 def mocked_webserver_service_api(
     app: FastAPI,
     mocked_webserver_service_api_base: MockRouter,
-    patch_webserver_service_project_workflow: Callable[[MockRouter], MockRouter],
+    patch_webserver_long_running_project_tasks: Callable[[MockRouter], MockRouter],
 ) -> MockRouter:
     settings: ApplicationSettings = app.state.settings
     assert settings.API_SERVER_WEBSERVER
 
-    patch_webserver_service_project_workflow(mocked_webserver_service_api_base)
+    patch_webserver_long_running_project_tasks(mocked_webserver_service_api_base)
 
     return mocked_webserver_service_api_base
 

--- a/services/api-server/tests/unit/api_solvers/conftest.py
+++ b/services/api-server/tests/unit/api_solvers/conftest.py
@@ -3,16 +3,12 @@
 # pylint: disable=unused-variable
 
 
-import json
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
 
-import httpx
 import pytest
-from faker import Faker
-from fastapi import FastAPI, status
-from models_library.api_schemas_webserver.projects import ProjectGet
-from models_library.utils.fastapi_encoders import jsonable_encoder
+from fastapi import FastAPI
 from pytest_simcore.helpers import faker_catalog
 from respx import MockRouter
 from simcore_service_api_server.core.settings import ApplicationSettings
@@ -30,78 +26,14 @@ def solver_version() -> str:
 
 @pytest.fixture
 def mocked_webserver_service_api(
-    app: FastAPI, mocked_webserver_service_api_base: MockRouter, faker: Faker
+    app: FastAPI,
+    mocked_webserver_service_api_base: MockRouter,
+    patch_webserver_service_project_workflow: Callable[[MockRouter], MockRouter],
 ) -> MockRouter:
     settings: ApplicationSettings = app.state.settings
     assert settings.API_SERVER_WEBSERVER
 
-    class _SideEffects:
-        def __init__(self):
-            # cached
-            self._projects: dict[str, ProjectGet] = {}
-
-        @staticmethod
-        def get_body_as_json(request):
-            return json.load(request)
-
-        def create_project(self, request: httpx.Request):
-            task_id = faker.uuid4()
-
-            project_create = self.get_body_as_json(request)
-            self._projects[task_id] = ProjectGet.parse_obj(
-                {
-                    "creationDate": "2018-07-01T11:13:43Z",
-                    "lastChangeDate": "2018-07-01T11:13:43Z",
-                    "prjOwner": "owner@email.com",
-                    **project_create,
-                }
-            )
-
-            return httpx.Response(
-                status.HTTP_202_ACCEPTED,
-                json={
-                    "data": {
-                        "task_id": task_id,
-                        "status_href": f"{settings.API_SERVER_WEBSERVER.api_base_url}/tasks/{task_id}",
-                        "result_href": f"{settings.API_SERVER_WEBSERVER.api_base_url}/tasks/{task_id}/result",
-                    }
-                },
-            )
-
-        def get_result(self, request: httpx.Request, *, task_id: str):
-            # TODO: replace with ProjectGet
-            project_get = jsonable_encoder(self._projects[task_id].dict(by_alias=True))
-            return httpx.Response(
-                status.HTTP_200_OK,
-                json={"data": project_get},
-            )
-
-    fake_workflow = _SideEffects()
-
-    # http://webserver:8080/v0/projects?hidden=true
-    mocked_webserver_service_api_base.post(
-        path__regex="/projects$",
-        name="create_projects",
-    ).mock(side_effect=fake_workflow.create_project)
-
-    mocked_webserver_service_api_base.get(
-        path__regex=r"/tasks/(?P<task_id>[\w-]+)/result$",
-        name="get_task_result",
-    ).mock(side_effect=fake_workflow.get_result)
-
-    mocked_webserver_service_api_base.get(
-        path__regex=r"/tasks/(?P<task_id>[\w/%]+)",
-        name="get_task_status",
-    ).respond(
-        status.HTTP_200_OK,
-        json={
-            "data": {
-                "task_progress": {"message": "fake job done", "percent": 1},
-                "done": True,
-                "started": "2018-07-01T11:13:43Z",
-            }
-        },
-    )
+    patch_webserver_service_project_workflow(mocked_webserver_service_api_base)
 
     return mocked_webserver_service_api_base
 

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs.py
@@ -349,7 +349,7 @@ async def test_run_solver_job(
             }
         ).dict(),
     )
-    assert resp.status_code == status.HTTP_200_OK
+    assert resp.status_code == status.HTTP_201_CREATED
 
     assert mocked_webserver_service_api["create_projects"].called
     assert mocked_webserver_service_api["get_task_status"].called

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_delete.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_delete.py
@@ -110,6 +110,7 @@ def mocked_backend_services_apis_for_create_and_delete_solver_job(
     )
 
 
+@pytest.mark.testit
 @pytest.mark.acceptance_test(
     "For https://github.com/ITISFoundation/osparc-simcore/issues/4111"
 )
@@ -131,7 +132,7 @@ async def test_create_and_delete_solver_job(
             }
         ).dict(),
     )
-    assert resp.status_code == status.HTTP_200_OK
+    assert resp.status_code == status.HTTP_201_CREATED
     job = Job.parse_obj(resp.json())
 
     # Delete Job after creation

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_delete.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_delete.py
@@ -110,7 +110,6 @@ def mocked_backend_services_apis_for_create_and_delete_solver_job(
     )
 
 
-@pytest.mark.testit
 @pytest.mark.acceptance_test(
     "For https://github.com/ITISFoundation/osparc-simcore/issues/4111"
 )

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_metadata.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_metadata.py
@@ -113,7 +113,7 @@ async def test_get_and_update_job_metadata(
             }
         ).dict(),
     )
-    assert resp.status_code == status.HTTP_200_OK
+    assert resp.status_code == status.HTTP_201_CREATED
     job = Job.parse_obj(resp.json())
 
     # Get metadata

--- a/services/api-server/tests/unit/api_studies/conftest.py
+++ b/services/api-server/tests/unit/api_studies/conftest.py
@@ -3,19 +3,14 @@
 # pylint: disable=unused-variable
 
 
-from collections.abc import Iterator
 from copy import deepcopy
 from typing import Any
 
 import pytest
-import respx
 from faker import Faker
-from fastapi import FastAPI
 from pytest_simcore.helpers.faker_webserver import (
     PROJECTS_METADATA_PORTS_RESPONSE_BODY_DATA,
 )
-from respx import MockRouter
-from simcore_service_api_server.core.settings import ApplicationSettings
 from simcore_service_api_server.models.schemas.studies import StudyID
 
 
@@ -29,51 +24,3 @@ def fake_study_ports() -> list[dict[str, Any]]:
     # NOTE: Reuses fakes used to test web-server API responses of /projects/{project_id}/metadata/ports
     # as reponses in this mock. SEE services/web/server/tests/unit/with_dbs/02/test_projects_ports_handlers.py
     return deepcopy(PROJECTS_METADATA_PORTS_RESPONSE_BODY_DATA)
-
-
-@pytest.fixture
-def mocked_webserver_service_api(
-    app: FastAPI,
-    webserver_service_openapi_specs: dict[str, Any],
-    fake_study_ports: list[dict[str, Any]],
-    faker: Faker,
-) -> Iterator[MockRouter]:
-    """
-    Mocks web/server http API
-    """
-    settings: ApplicationSettings = app.state.settings
-    assert settings.API_SERVER_WEBSERVER
-
-    openapi = deepcopy(webserver_service_openapi_specs)
-    oas_paths = openapi["paths"]
-
-    # ENTRYPOINTS ---------
-    # pylint: disable=not-context-manager
-    with respx.mock(
-        base_url=settings.API_SERVER_WEBSERVER.api_base_url,
-        assert_all_called=False,
-        assert_all_mocked=True,
-    ) as respx_mock:
-        # Mocks /health
-        assert oas_paths["/v0/health"]
-        assert (
-            oas_paths["/v0/health"]["get"]["operationId"]
-            == "healthcheck_liveness_probe"
-        )
-        # 'http://webserver:8080/v0/health'
-        respx_mock.get("/health", name="healthcheck_liveness_probe").respond(
-            200,
-            json={
-                "data": {
-                    "name": "simcore-director-service",
-                    "api_version": "0.1.0-dev+NJuzzD9S",
-                    "version": "0.1.0-dev+N127Mfv9H",
-                }
-            },
-        )
-
-        # Mocks /projects/{*}/metadata/ports
-        assert oas_paths["/v0/projects/{project_id}/metadata/ports"]
-        assert "get" in oas_paths["/v0/projects/{project_id}/metadata/ports"]
-
-        yield respx_mock

--- a/services/api-server/tests/unit/api_studies/test_api_routes_studies.py
+++ b/services/api-server/tests/unit/api_studies/test_api_routes_studies.py
@@ -142,9 +142,9 @@ async def test_clone_study(
     faker: Faker,
     mocked_webserver_service_api: MockRouter,
 ):
-    mocked_webserver_service_api.get(
+    mocked_webserver_service_api.post(
         path__regex=r"/projects/(?P<project_id>[\w-]+):clone$",
-        name="list_project_metadata_ports",
+        name="project_clone",
     ).respond(
         status.HTTP_404_NOT_FOUND,
     )
@@ -152,6 +152,9 @@ async def test_clone_study(
     invalid_study_id = faker.uuid4()
     resp = await client.post(f"/v0/studies/{invalid_study_id}:clone", auth=auth)
     assert resp.status_code == status.HTTP_404_NOT_FOUND
+    assert len(resp.json()["errors"]) == 1
+    assert invalid_study_id in resp.json()["errors"][0]
 
-    resp = await client.post(f"/v0/studies/{study_id}:clone", auth=auth)
-    assert resp.status_code == status.HTTP_201_CREATED
+    # TODO
+    # resp = await client.post(f"/v0/studies/{study_id}:clone", auth=auth)
+    # assert resp.status_code == status.HTTP_201_CREATED

--- a/services/api-server/tests/unit/api_studies/test_api_routes_studies.py
+++ b/services/api-server/tests/unit/api_studies/test_api_routes_studies.py
@@ -142,10 +142,10 @@ async def test_clone_study(
     auth: httpx.BasicAuth,
     study_id: StudyID,
     mocked_webserver_service_api_base: MockRouter,
-    patch_webserver_service_project_workflow: Callable[[MockRouter], MockRouter],
+    patch_webserver_long_running_project_tasks: Callable[[MockRouter], MockRouter],
 ):
     # Mocks /projects/{project_id}:clone
-    patch_webserver_service_project_workflow(mocked_webserver_service_api_base)
+    patch_webserver_long_running_project_tasks(mocked_webserver_service_api_base)
 
     resp = await client.post(f"/v0/studies/{study_id}:clone", auth=auth)
 

--- a/services/api-server/tests/unit/api_studies/test_api_routes_studies.py
+++ b/services/api-server/tests/unit/api_studies/test_api_routes_studies.py
@@ -3,6 +3,7 @@
 # pylint: disable=unused-variable
 
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -136,10 +137,9 @@ async def test_list_study_ports(
 @pytest.mark.acceptance_test(
     "Implements https://github.com/ITISFoundation/osparc-simcore/issues/4651"
 )
-async def test_clone_study(
+async def test_clone_study_not_found(
     client: httpx.AsyncClient,
     auth: httpx.BasicAuth,
-    study_id: StudyID,
     faker: Faker,
     mocked_webserver_service_api_base: MockRouter,
 ):
@@ -160,6 +160,20 @@ async def test_clone_study(
     assert len(resp.json()["errors"]) == 1
     assert invalid_study_id in resp.json()["errors"][0]
 
-    # TODO
-    # resp = await client.post(f"/v0/studies/{study_id}:clone", auth=auth)
-    # assert resp.status_code == status.HTTP_201_CREATED
+
+@pytest.mark.acceptance_test(
+    "Implements https://github.com/ITISFoundation/osparc-simcore/issues/4651"
+)
+async def test_clone_study(
+    client: httpx.AsyncClient,
+    auth: httpx.BasicAuth,
+    study_id: StudyID,
+    mocked_webserver_service_api_base: MockRouter,
+    patch_webserver_service_project_workflow: Callable[[MockRouter], MockRouter],
+):
+    # Mocks /projects/{project_id}:clone
+    patch_webserver_service_project_workflow(mocked_webserver_service_api_base)
+
+    resp = await client.post(f"/v0/studies/{study_id}:clone", auth=auth)
+
+    assert resp.status_code == status.HTTP_201_CREATED

--- a/services/api-server/tests/unit/api_studies/test_api_routes_studies.py
+++ b/services/api-server/tests/unit/api_studies/test_api_routes_studies.py
@@ -137,6 +137,21 @@ async def test_list_study_ports(
 @pytest.mark.acceptance_test(
     "Implements https://github.com/ITISFoundation/osparc-simcore/issues/4651"
 )
+async def test_clone_study(
+    client: httpx.AsyncClient,
+    auth: httpx.BasicAuth,
+    study_id: StudyID,
+    mocked_webserver_service_api_base: MockRouter,
+    patch_webserver_service_project_workflow: Callable[[MockRouter], MockRouter],
+):
+    # Mocks /projects/{project_id}:clone
+    patch_webserver_service_project_workflow(mocked_webserver_service_api_base)
+
+    resp = await client.post(f"/v0/studies/{study_id}:clone", auth=auth)
+
+    assert resp.status_code == status.HTTP_201_CREATED
+
+
 async def test_clone_study_not_found(
     client: httpx.AsyncClient,
     auth: httpx.BasicAuth,
@@ -159,21 +174,3 @@ async def test_clone_study_not_found(
     assert resp.status_code == status.HTTP_404_NOT_FOUND
     assert len(resp.json()["errors"]) == 1
     assert invalid_study_id in resp.json()["errors"][0]
-
-
-@pytest.mark.acceptance_test(
-    "Implements https://github.com/ITISFoundation/osparc-simcore/issues/4651"
-)
-async def test_clone_study(
-    client: httpx.AsyncClient,
-    auth: httpx.BasicAuth,
-    study_id: StudyID,
-    mocked_webserver_service_api_base: MockRouter,
-    patch_webserver_service_project_workflow: Callable[[MockRouter], MockRouter],
-):
-    # Mocks /projects/{project_id}:clone
-    patch_webserver_service_project_workflow(mocked_webserver_service_api_base)
-
-    resp = await client.post(f"/v0/studies/{study_id}:clone", auth=auth)
-
-    assert resp.status_code == status.HTTP_201_CREATED

--- a/services/api-server/tests/unit/api_studies/test_api_routes_studies_jobs.py
+++ b/services/api-server/tests/unit/api_studies/test_api_routes_studies_jobs.py
@@ -20,7 +20,7 @@ from simcore_service_api_server.models.schemas.studies import Study, StudyID
 async def test_studies_jobs_workflow(
     client: httpx.AsyncClient,
     auth: httpx.BasicAuth,
-    mocked_webserver_service_api: MockRouter,
+    mocked_webserver_service_api_base: MockRouter,
     study_id: StudyID,
 ):
     # get_study

--- a/services/api-server/tests/unit/api_studies/test_api_studies_mocks.py
+++ b/services/api-server/tests/unit/api_studies/test_api_studies_mocks.py
@@ -11,7 +11,7 @@ from simcore_service_api_server.core.settings import ApplicationSettings
 
 def test_mocked_webserver_service_api(
     app: FastAPI,
-    mocked_webserver_service_api: MockRouter,
+    mocked_webserver_service_api_base: MockRouter,
 ):
     #
     # This test intends to help building the urls in mocked_webserver_service_api
@@ -21,7 +21,10 @@ def test_mocked_webserver_service_api(
     assert settings.API_SERVER_WEBSERVER
     webserver_api_baseurl = settings.API_SERVER_WEBSERVER.api_base_url
 
+    resp = httpx.get(f"{webserver_api_baseurl}/")
+    assert resp.status_code == status.HTTP_200_OK
+
     resp = httpx.get(f"{webserver_api_baseurl}/health")
     assert resp.status_code == status.HTTP_200_OK
 
-    mocked_webserver_service_api.assert_all_called()
+    mocked_webserver_service_api_base.assert_all_called()

--- a/services/api-server/tests/unit/conftest.py
+++ b/services/api-server/tests/unit/conftest.py
@@ -219,7 +219,6 @@ def mocked_directorv2_service_api_base(
         assert_all_called=False,
         assert_all_mocked=True,  # IMPORTANT: KEEP always True!
     ) as respx_mock:
-
         assert openapi
         assert (
             openapi["paths"]["/"]["get"]["operationId"] == "check_service_health__get"

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__clone.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__clone.py
@@ -82,7 +82,6 @@ async def test_clone_project(
     ), "clone does NOT preserve node ids"
 
 
-@pytest.mark.testit()
 @pytest.mark.parametrize(
     "user_role",
     [UserRole.USER],

--- a/services/web/server/tests/unit/with_dbs/03/meta_modeling/test_meta_modeling_iterations.py
+++ b/services/web/server/tests/unit/with_dbs/03/meta_modeling/test_meta_modeling_iterations.py
@@ -68,7 +68,6 @@ async def context_with_logged_user(client: TestClient, logged_user: UserInfoDict
         await conn.execute(projects.delete())
 
 
-@pytest.mark.testit
 @pytest.mark.acceptance_test()
 async def test_iterators_workflow(
     client: TestClient,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

- ✨ NEW `clone_study` as `POST   /v0/studies/{study_id}:clone`
- 🐛 `create_*` and `clone_*` operations respond with `201 Created`
- 🔨 New generic fixture for long-running-tasks 

@bisgaard-itis we can now use this feature to clone templates for the tutorial?

## Related issue/s

- follows up from PR 
- resolves #4651


## How to test
Driving tests are  `test_clone_study*` in 
```cmd
pytest -vv tests/unit/api_studies/test_api_routes_studies.py
```

## DevOps
None