### PR TITLE
✨ WIP: Is4652/job logs stream

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
@@ -81,7 +81,7 @@ async def rabbit_service(
 
 
 @pytest.fixture
-async def rabbitmq_client(
+async def create_rabbitmq_client(
     rabbit_service: RabbitSettings,
 ) -> AsyncIterator[Callable[[str], RabbitMQClient]]:
     created_clients = []
@@ -101,6 +101,7 @@ async def rabbitmq_client(
         return client
 
     yield _creator
+
     # cleanup, properly close the clients
     await asyncio.gather(*(client.close() for client in created_clients))
 
@@ -126,3 +127,11 @@ async def rabbitmq_rpc_client(
     yield _creator
     # cleanup, properly close the clients
     await asyncio.gather(*(client.close() for client in created_clients))
+
+
+
+async def rabbitmq_client(create_rabbitmq_client):
+    # NOTE: Legacy fixture
+    # Use create_rabbitmq_client instead of rabbitmq_client
+    # SEE docs/coding-conventions.md::CC4
+    return create_rabbitmq_client

--- a/packages/service-library/src/servicelib/fastapi/errors.py
+++ b/packages/service-library/src/servicelib/fastapi/errors.py
@@ -1,0 +1,9 @@
+from pydantic.errors import PydanticErrorMixin
+
+
+class ApplicationRuntimeError(PydanticErrorMixin, RuntimeError):
+    pass
+
+
+class ApplicationStateError(ApplicationRuntimeError):
+    msg_template: str = "Invalid app.state.{state}: {msg}"

--- a/packages/service-library/src/servicelib/fastapi/rabbitmq.py
+++ b/packages/service-library/src/servicelib/fastapi/rabbitmq.py
@@ -1,0 +1,81 @@
+import logging
+
+from fastapi import FastAPI
+from settings_library.rabbit import RabbitSettings
+
+from ..rabbitmq import RabbitMQClient
+from ..rabbitmq_utils import wait_till_rabbitmq_responsive
+from .errors import ApplicationStateError
+
+_logger = logging.getLogger(__name__)
+
+
+def _create_client(app: FastAPI):
+    app.state.rabbitmq_client = RabbitMQClient(
+        client_name=app.state.rabbitmq_client_name,
+        settings=app.state.rabbitmq_settings,
+    )
+
+
+async def _remove_client(app: FastAPI):
+    await app.state.rabbitmq_client.close()
+    app.state.rabbitmq_client = None
+
+
+async def connect(app: FastAPI):
+    assert app.state.rabbitmq_settings  # nosec
+    await wait_till_rabbitmq_responsive(app.state.rabbitmq_settings.dsn)
+    _create_client(app)
+
+
+async def disconnect(app: FastAPI):
+    if app.state.rabbitmq_client:
+        await _remove_client(app)
+
+
+async def reconnect(app: FastAPI):
+    await disconnect(app)
+    await connect(app)
+
+
+def setup_rabbit(
+    app: FastAPI,
+    *,
+    settings: RabbitSettings,
+    name: str,
+) -> None:
+    """Sets up rabbit in a given app
+
+    - Inits app.states for rabbitmq
+    - Creates a client to communicate with rabbitmq
+
+    Arguments:
+        app -- fastapi app
+        settings -- Rabbit settings or if None, the connection to rabbit is not done upon startup
+        name -- name for the rmq client name
+    """
+    app.state.rabbitmq_client = None  # RabbitMQClient | None
+    app.state.rabbitmq_client_name = name
+    app.state.rabbitmq_settings = settings
+
+    if settings is None:
+        return
+
+    async def on_startup() -> None:
+        await connect(app)
+
+    app.add_event_handler("startup", on_startup)
+
+    async def on_shutdown() -> None:
+        await disconnect(app)
+
+    app.add_event_handler("shutdown", on_shutdown)
+
+
+def get_rabbitmq_client(app: FastAPI) -> RabbitMQClient:
+    if not app.state.rabbitmq_client:
+        raise ApplicationStateError(
+            state="rabbitmq_client",
+            msg="Rabbitmq service unavailable. Check app settings",
+        )
+    return app.state.rabbitmq_client

--- a/packages/service-library/tests/fastapi/test_rabbitmq.py
+++ b/packages/service-library/tests/fastapi/test_rabbitmq.py
@@ -1,0 +1,157 @@
+# pylint:disable=unused-variable
+# pylint:disable=unused-argument
+# pylint:disable=redefined-outer-name
+
+import asyncio
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import aiodocker
+import pytest
+from faker import Faker
+from fastapi import FastAPI
+from models_library.rabbitmq_messages import LoggerRabbitMessage, RabbitMessageBase
+from pytest_mock.plugin import MockerFixture
+from servicelib.fastapi.rabbitmq import get_rabbitmq_client
+from servicelib.rabbitmq import BIND_TO_ALL_TOPICS, RabbitMQClient
+from settings_library.rabbit import RabbitSettings
+from tenacity import retry
+from tenacity._asyncio import AsyncRetrying
+from tenacity.retry import retry_if_exception_type
+from tenacity.stop import stop_after_delay
+from tenacity.wait import wait_fixed
+
+_TENACITY_RETRY_PARAMS = {
+    "reraise": True,
+    "retry": retry_if_exception_type(AssertionError),
+    "stop": stop_after_delay(30),
+    "wait": wait_fixed(0.1),
+}
+
+# Selection of core and tool services started in this swarm fixture (integration)
+pytest_simcore_core_services_selection = [
+    "rabbit",
+]
+
+pytest_simcore_ops_services_selection = []
+
+
+@pytest.fixture
+def rabbit_log_message(faker: Faker) -> LoggerRabbitMessage:
+    return LoggerRabbitMessage(
+        user_id=faker.pyint(min_value=1),
+        project_id=faker.uuid4(),
+        node_id=faker.uuid4(),
+        messages=faker.pylist(allowed_types=(str,)),
+    )
+
+
+@pytest.fixture(params=["rabbit_log_message"])
+def rabbit_message(
+    request: pytest.FixtureRequest,
+    rabbit_log_message: LoggerRabbitMessage,
+) -> RabbitMessageBase:
+    return {
+        "rabbit_log_message": rabbit_log_message,
+    }[request.param]
+
+
+def test_rabbitmq_does_not_initialize_if_deactivated(
+    disabled_rabbitmq: None,
+    initialized_app: FastAPI,
+):
+    assert hasattr(initialized_app.state, "rabbitmq_client")
+    assert initialized_app.state.rabbitmq_client is None
+    with pytest.raises(ConfigurationError):
+        get_rabbitmq_client(initialized_app)
+
+
+def test_rabbitmq_initializes(
+    enabled_rabbitmq: RabbitSettings,
+    initialized_app: FastAPI,
+):
+    assert hasattr(initialized_app.state, "rabbitmq_client")
+    assert initialized_app.state.rabbitmq_client is not None
+    assert get_rabbitmq_client(initialized_app) == initialized_app.state.rabbitmq_client
+
+
+async def test_post_message(
+    enabled_rabbitmq: RabbitSettings,
+    initialized_app: FastAPI,
+    rabbit_message: RabbitMessageBase,
+    create_rabbitmq_client: Callable[[str], RabbitMQClient],
+    mocker: MockerFixture,
+):
+    mocked_message_handler = mocker.AsyncMock(return_value=True)
+    consumer_rmq = create_rabbitmq_client("pytest_consumer")
+    await consumer_rmq.subscribe(
+        rabbit_message.channel_name,
+        mocked_message_handler,
+        topics=[BIND_TO_ALL_TOPICS] if rabbit_message.routing_key() else None,
+    )
+
+    producer_rmq = get_rabbitmq_client(initialized_app)
+    assert producer_rmq is not None
+    await producer_rmq.publish(rabbit_message.channel_name, rabbit_message)
+
+    async for attempt in AsyncRetrying(**_TENACITY_RETRY_PARAMS):
+        with attempt:
+            print(
+                f"--> checking for message in rabbit exchange {rabbit_message.channel_name}, {attempt.retry_state.retry_object.statistics}"
+            )
+            mocked_message_handler.assert_called_once_with(
+                rabbit_message.json().encode()
+            )
+            print("... message received")
+
+
+async def test_post_message_with_disabled_rabbit_does_not_raise(
+    disabled_rabbitmq: None,
+    disabled_ec2: None,
+    mocked_redis_server: None,
+    initialized_app: FastAPI,
+    rabbit_message: RabbitMessageBase,
+):
+    await post_message(initialized_app, message=rabbit_message)
+
+
+async def _switch_off_rabbit_mq_instance(async_docker_client: aiodocker.Docker) -> None:
+    # remove the rabbit MQ instance
+    rabbit_services = [
+        s
+        for s in await async_docker_client.services.list()
+        if "rabbit" in s["Spec"]["Name"]
+    ]
+    await asyncio.gather(
+        *(async_docker_client.services.delete(s["ID"]) for s in rabbit_services)
+    )
+
+    @retry(**_TENACITY_RETRY_PARAMS)
+    async def _check_service_task_gone(service: Mapping[str, Any]) -> None:
+        print(
+            f"--> checking if service {service['ID']}:{service['Spec']['Name']} is really gone..."
+        )
+        list_of_tasks = await async_docker_client.containers.list(
+            all=True,
+            filters={
+                "label": [f"com.docker.swarm.service.id={service['ID']}"],
+            },
+        )
+        assert not list_of_tasks
+        print(f"<-- service {service['ID']}:{service['Spec']['Name']} is gone.")
+
+    await asyncio.gather(*(_check_service_task_gone(s) for s in rabbit_services))
+
+
+async def test_post_message_when_rabbit_disconnected(
+    enabled_rabbitmq: RabbitSettings,
+    disabled_ec2: None,
+    mocked_redis_server: None,
+    initialized_app: FastAPI,
+    rabbit_log_message: LoggerRabbitMessage,
+    async_docker_client: aiodocker.Docker,
+):
+    await _switch_off_rabbit_mq_instance(async_docker_client)
+
+    # now posting should not raise out
+    await post_message(initialized_app, message=rabbit_log_message)

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_connection.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_connection.py
@@ -58,10 +58,12 @@ async def async_docker_client() -> AsyncIterator[aiodocker.Docker]:
 
 
 async def test_rabbit_client_lose_connection(
-    rabbitmq_client: Callable[[str], RabbitMQClient],
     async_docker_client: aiodocker.Docker,
+    cleanup_check_rabbitmq_server_has_no_errors: None,
+    create_rabbitmq_client: Callable[[str], RabbitMQClient],
+    docker_client: docker.client.DockerClient,
 ):
-    rabbit_client = rabbitmq_client("pinger")
+    rabbit_client = create_rabbitmq_client("pinger")
     assert await rabbit_client.ping() is True
     async with paused_container(async_docker_client, "rabbit"):
         # check that connection was lost
@@ -192,11 +194,11 @@ async def _assert_rabbit_client_state(
 @pytest.mark.no_cleanup_check_rabbitmq_server_has_no_errors()
 async def test_rabbit_server_closes_connection(
     rabbit_service: RabbitSettings,
-    rabbitmq_client: Callable[[str, int], RabbitMQClient],
+    create_rabbitmq_client: Callable[[str, int], RabbitMQClient],
     docker_client: docker.client.DockerClient,
 ):
     _assert_rabbitmq_has_connections(rabbit_service, 0)
-    rabbit_client = rabbitmq_client("tester", heartbeat=2)
+    rabbit_client = create_rabbitmq_client("tester", heartbeat=2)
     message = PytestRabbitMessage(message="blahblah", topic="topic")
     await rabbit_client.publish("test", message)
     await asyncio.sleep(5)

--- a/services/api-server/src/simcore_service_api_server/core/application.py
+++ b/services/api-server/src/simcore_service_api_server/core/application.py
@@ -19,6 +19,7 @@ from ..api.errors.validation_error import http422_error_handler
 from ..api.root import create_router
 from ..api.routes.health import router as health_router
 from ..services import catalog, director_v2, remote_debug, storage, webserver
+from ..services.rabbitmq import setup_rabbitmq
 from .events import create_start_app_handler, create_stop_app_handler
 from .openapi import override_openapi_method, use_route_names_as_operation_ids
 from .settings import ApplicationSettings
@@ -75,6 +76,8 @@ def init_app(settings: ApplicationSettings | None = None) -> FastAPI:
     # setup modules
     if settings.SC_BOOT_MODE == BootModeEnum.DEBUG:
         remote_debug.setup(app)
+
+    setup_rabbitmq(app)
 
     if settings.API_SERVER_WEBSERVER:
         webserver.setup(app, settings.API_SERVER_WEBSERVER)

--- a/services/api-server/src/simcore_service_api_server/core/settings.py
+++ b/services/api-server/src/simcore_service_api_server/core/settings.py
@@ -122,7 +122,7 @@ class ApplicationSettings(BasicSettings):
 
     API_SERVER_POSTGRES: PostgresSettings | None = Field(auto_default_from_env=True)
 
-    PAYMENTS_RABBITMQ: RabbitSettings = Field(
+    API_SERVER_RABBITMQ: RabbitSettings = Field(
         auto_default_from_env=True, description="settings for service/rabbitmq"
     )
 

--- a/services/api-server/src/simcore_service_api_server/core/settings.py
+++ b/services/api-server/src/simcore_service_api_server/core/settings.py
@@ -8,6 +8,7 @@ from settings_library.base import BaseCustomSettings
 from settings_library.basic_types import PortInt, VersionTag
 from settings_library.catalog import CatalogSettings
 from settings_library.postgres import PostgresSettings
+from settings_library.rabbit import RabbitSettings
 from settings_library.storage import StorageSettings
 from settings_library.utils_logging import MixinLoggingSettings
 from settings_library.utils_service import (
@@ -119,8 +120,11 @@ class ApplicationSettings(BasicSettings):
     # DOCKER BOOT
     SC_BOOT_MODE: BootModeEnum | None
 
-    # POSTGRES
     API_SERVER_POSTGRES: PostgresSettings | None = Field(auto_default_from_env=True)
+
+    PAYMENTS_RABBITMQ: RabbitSettings = Field(
+        auto_default_from_env=True, description="settings for service/rabbitmq"
+    )
 
     # SERVICES with http API
     API_SERVER_WEBSERVER: WebServerSettings | None = Field(auto_default_from_env=True)

--- a/services/api-server/src/simcore_service_api_server/services/rabbitmq.py
+++ b/services/api-server/src/simcore_service_api_server/services/rabbitmq.py
@@ -1,0 +1,38 @@
+import logging
+from typing import cast
+
+from fastapi import FastAPI
+from models_library.rabbitmq_messages import RabbitMessageBase
+from servicelib.rabbitmq import RabbitMQClient, wait_till_rabbitmq_responsive
+from settings_library.rabbit import RabbitSettings
+
+_logger = logging.getLogger(__name__)
+
+
+def setup_rabbitmq(app: FastAPI) -> None:
+    settings: RabbitSettings = app.state.settings.PAYMENTS_RABBITMQ
+    app.state.rabbitmq_client = None
+    app.state.rabbitmq_rpc_server = None
+
+    async def _on_startup() -> None:
+        await wait_till_rabbitmq_responsive(settings.dsn)
+
+        app.state.rabbitmq_client = RabbitMQClient(
+            client_name="api_server", settings=settings
+        )
+
+    async def _on_shutdown() -> None:
+        if app.state.rabbitmq_client:
+            await app.state.rabbitmq_client.close()
+
+    app.add_event_handler("startup", _on_startup)
+    app.add_event_handler("shutdown", _on_shutdown)
+
+
+def get_rabbitmq_client(app: FastAPI) -> RabbitMQClient:
+    assert app.state.rabbitmq_client  # nosec
+    return cast(RabbitMQClient, app.state.rabbitmq_client)
+
+
+async def post_message(app: FastAPI, message: RabbitMessageBase) -> None:
+    await get_rabbitmq_client(app).publish(message.channel_name, message)

--- a/services/api-server/tests/conftest.py
+++ b/services/api-server/tests/conftest.py
@@ -14,12 +14,16 @@ CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve(
 
 pytest_plugins = [
     "pytest_simcore.cli_runner",
+    "pytest_simcore.docker_compose",
+    "pytest_simcore.docker_swarm",
     "pytest_simcore.httpbin_service",
     "pytest_simcore.pydantic_models",
     "pytest_simcore.pytest_global_environs",
+    "pytest_simcore.rabbit_service",
     "pytest_simcore.repository_paths",
     "pytest_simcore.schemas",
     "pytest_simcore.services_api_mocks_for_aiohttp_clients",
+    "pytest_simcore.tmp_path_extra",
 ]
 
 

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_logs.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_logs.py
@@ -1,0 +1,61 @@
+import asyncio
+import datetime
+import json
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+
+# - docker OAS: Container logs https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerLogs
+# - Streaming with FastAPI: https://python.plainenglish.io/streaming-with-fastapi-4b86f33bfca
+# - Server Side Events (SSE) https://amittallapragada.github.io/docker/fastapi/python/2020/12/23/server-side-events.html
+# - Streaming with FastAPI https://python.plainenglish.io/streaming-with-fastapi-4b86f33bfca
+
+
+_NEW_LINE = "\n"
+
+
+@pytest.fixture()
+def app() -> FastAPI:
+    _app = FastAPI()
+
+    async def _text_generator():
+        for i in range(10):
+            yield f"some log data {i}\n"
+            await asyncio.sleep(1)
+
+    async def _json_generator():
+        i = 0
+        async for text in _text_generator():
+            yield json.dumps({"envent_id": i, "data": text}, indent=None) + _NEW_LINE
+            i += 1
+
+    @_app.get("/logs")
+    async def stream_logs(as_json: bool = False):
+        if as_json:
+            return StreamingResponse(
+                _json_generator(), media_type="application/x-ndjson"
+            )
+        return StreamingResponse(_text_generator())
+
+    return _app
+
+
+@pytest.mark.parametrize("as_json", [True, False])
+async def test_it(client: httpx.AsyncClient, as_json: bool):
+    # https://www.python-httpx.org/quickstart/#streaming-responses
+
+    async with client.stream("GET", "/logs") as r:
+        async for text in r.aiter_text():
+            print(text)
+
+    async with client.stream("GET", f"/logs?as_json={1 if as_json else 0}") as r:
+        async for line in r.aiter_lines():
+            if as_json:
+                data = json.loads(line)
+                txt = json.dumps(data, indent=1)
+            else:
+                txt = line
+
+            print(f"{datetime.datetime.now(tz=datetime.timezone.utc)}", txt, flush=True)

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_logs.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_logs.py
@@ -19,7 +19,7 @@ from fastapi.responses import StreamingResponse
 # - Streaming with FastAPI: https://python.plainenglish.io/streaming-with-fastapi-4b86f33bfca
 # - Server Side Events (SSE) https://amittallapragada.github.io/docker/fastapi/python/2020/12/23/server-side-events.html
 # - Streaming with FastAPI https://python.plainenglish.io/streaming-with-fastapi-4b86f33bfca
-
+# -
 
 _NEW_LINE = "\n"
 CHUNK_MSG = "expected" + _NEW_LINE
@@ -58,8 +58,8 @@ async def test_it(client: httpx.AsyncClient, as_json: bool):
     chunk_size = len(CHUNK_MSG)
 
     received = []
-    async with client.stream("GET", "/logs") as r:
-        async for text in r.aiter_text(chunk_size):
+    async with client.stream("GET", "/logs") as response:
+        async for text in response.aiter_text(chunk_size):
             received.append(text)
 
     assert (
@@ -70,8 +70,8 @@ async def test_it(client: httpx.AsyncClient, as_json: bool):
         * 10
     )
 
-    async with client.stream("GET", f"/logs?as_json={1 if as_json else 0}") as r:
-        async for line in r.aiter_lines():
+    async with client.stream("GET", f"/logs?as_json={1 if as_json else 0}") as response:
+        async for line in response.aiter_lines():
             if as_json:
                 data = json.loads(line)
                 txt = json.dumps(data, indent=1)

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_logs.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_logs.py
@@ -1,6 +1,14 @@
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+
 import asyncio
 import datetime
 import json
+from typing import AsyncIterable
 
 import httpx
 import pytest
@@ -18,20 +26,20 @@ _NEW_LINE = "\n"
 
 @pytest.fixture()
 def app() -> FastAPI:
-    _app = FastAPI()
+    app = FastAPI()
 
-    async def _text_generator():
+    async def _text_generator() -> AsyncIterable[str]:
         for i in range(10):
             yield f"some log data {i}\n"
             await asyncio.sleep(1)
 
-    async def _json_generator():
+    async def _json_generator() -> AsyncIterable[str]:
         i = 0
         async for text in _text_generator():
             yield json.dumps({"envent_id": i, "data": text}, indent=None) + _NEW_LINE
             i += 1
 
-    @_app.get("/logs")
+    @app.get("/logs")
     async def stream_logs(as_json: bool = False):
         if as_json:
             return StreamingResponse(
@@ -39,7 +47,7 @@ def app() -> FastAPI:
             )
         return StreamingResponse(_text_generator())
 
-    return _app
+    return app
 
 
 @pytest.mark.parametrize("as_json", [True, False])

--- a/services/api-server/tests/unit/conftest.py
+++ b/services/api-server/tests/unit/conftest.py
@@ -19,7 +19,6 @@ from asgi_lifespan import LifespanManager
 from cryptography.fernet import Fernet
 from faker import Faker
 from fastapi import FastAPI, status
-from httpx._transports.asgi import ASGITransport
 from models_library.api_schemas_long_running_tasks.tasks import (
     TaskGet,
     TaskProgress,
@@ -34,7 +33,6 @@ from models_library.utils.fastapi_encoders import jsonable_encoder
 from moto.server import ThreadedMotoServer
 from packaging.version import Version
 from pydantic import HttpUrl, parse_obj_as
-from pytest import MonkeyPatch  # noqa: PT013
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_dict
 from pytest_simcore.helpers.utils_host import get_localhost_ip
@@ -59,7 +57,7 @@ SideEffectCallback: TypeAlias = Callable[
 
 @pytest.fixture
 def app_environment(
-    monkeypatch: MonkeyPatch, default_app_env_vars: EnvVarsDict
+    monkeypatch: pytest.MonkeyPatch, default_app_env_vars: EnvVarsDict
 ) -> EnvVarsDict:
     """Config that disables many plugins e.g. database or tracing"""
 
@@ -92,18 +90,14 @@ async def client(app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
     #
     # Prefer this client instead of fastapi.testclient.TestClient
     #
-    async with LifespanManager(app):
-        # needed for app to trigger start/stop event handlers
-        async with httpx.AsyncClient(
-            app=app,
-            base_url="http://api.testserver.io",
-            headers={"Content-Type": "application/json"},
-        ) as client:
-            assert isinstance(client._transport, ASGITransport)
-            # rewires location test's app to client.app
-            client.app = client._transport.app
 
-            yield client
+    # LifespanManager will trigger app's startup&shutown event handlers
+    async with LifespanManager(app), httpx.AsyncClient(
+        app=app,
+        base_url="http://api.testserver.io",
+        headers={"Content-Type": "application/json"},
+    ) as httpx_async_client:
+        yield httpx_async_client
 
 
 ## MOCKED Repositories --------------------------------------------------
@@ -490,7 +484,8 @@ def respx_mock_from_capture() -> (
         capture_path: Path,
         side_effects_callbacks: list[SideEffectCallback],
     ) -> list[respx.MockRouter]:
-        assert capture_path.is_file() and capture_path.suffix == ".json"
+        assert capture_path.is_file()
+        assert capture_path.suffix == ".json"
         captures: list[HttpApiCallCaptureModel] = parse_obj_as(
             list[HttpApiCallCaptureModel], json.loads(capture_path.read_text())
         )
@@ -509,9 +504,8 @@ def respx_mock_from_capture() -> (
             for router in respx_mock:
                 if capture.host == router._bases["host"].value:
                     return router
-            raise RuntimeError(
-                f"Missing respx.MockRouter for capture with {capture.host}"
-            )
+            msg = f"Missing respx.MockRouter for capture with {capture.host}"
+            raise RuntimeError(msg)
 
         class CaptureSideEffect:
             def __init__(

--- a/services/api-server/tests/unit/test__fastapi.py
+++ b/services/api-server/tests/unit/test__fastapi.py
@@ -114,7 +114,7 @@ def test_fastapi_route_paths_in_paths(client: TestClient, faker: Faker):
     }
 
 
-def test_fastapi_route_name_parsing(client: TestClient, faker: Faker):
+def test_fastapi_route_name_parsing(client: TestClient, app: FastAPI, faker: Faker):
     #
     # Ensures ':' is allowed in routes
     # SEE https://github.com/encode/starlette/pull/1657
@@ -125,7 +125,7 @@ def test_fastapi_route_name_parsing(client: TestClient, faker: Faker):
 
     # Checks whether parse correctly ":action" suffix
     for action in ("start", "stop"):
-        expected_path = client.app.router.url_path_for(
+        expected_path = app.router.url_path_for(
             f"{action}_job", solver_key=solver_key, version=version, job_id=job_id
         )
         resp = client.post(

--- a/services/api-server/tests/unit/test_services_rabbitmq.py
+++ b/services/api-server/tests/unit/test_services_rabbitmq.py
@@ -4,12 +4,19 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
+import asyncio
+from collections.abc import Callable
+from unittest.mock import AsyncMock
 
+import httpx
+import pytest
+from faker import Faker
 from fastapi import FastAPI
-from simcore_service_api_server.services.rabbitmq import (
-    get_rabbitmq_client,
-    setup_rabbitmq,
-)
+from models_library.rabbitmq_messages import LoggerRabbitMessage
+from pytest_mock import MockerFixture
+from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_dict
+from servicelib.rabbitmq import RabbitMQClient
+from simcore_service_api_server.services.rabbitmq import get_rabbitmq_client
 
 pytest_simcore_core_services_selection = [
     "rabbit",
@@ -17,8 +24,73 @@ pytest_simcore_core_services_selection = [
 pytest_simcore_ops_services_selection = []
 
 
-def test_it(app: FastAPI):
+@pytest.fixture
+def app_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    app_environment: EnvVarsDict,
+    rabbit_env_vars_dict: EnvVarsDict,
+    mocker: MockerFixture,
+) -> EnvVarsDict:
+    # do not init other services
+    mocker.patch("simcore_service_api_server.core.application.webserver.setup")
+    mocker.patch("simcore_service_api_server.core.application.catalog.setup")
+    mocker.patch("simcore_service_api_server.core.application.storage.setup")
+    mocker.patch("simcore_service_api_server.core.application.director_v2.setup")
 
-    setup_rabbitmq(app)
+    return setenvs_from_dict(
+        monkeypatch,
+        {
+            **rabbit_env_vars_dict,
+            "API_SERVER_POSTGRES": "null",
+        },
+    )
 
-    rabbit_client = get_rabbitmq_client(app)
+
+async def test_it(
+    client: httpx.AsyncClient,
+    app: FastAPI,
+    faker: Faker,
+    create_rabbitmq_client: Callable[[str], RabbitMQClient],
+):
+    # create exchange
+    # create producer
+    rabbitmq_producer = create_rabbitmq_client("pytest_producer")
+
+    # create consumer & subscribe
+    rabbit_client: RabbitMQClient = get_rabbitmq_client(app)
+
+    project_id = faker.uuid4()
+    user_id = faker.pyint()
+    node_id = faker.uuid4()
+    exchange_name = LoggerRabbitMessage.get_channel_name()
+    topics = [f"{project_id}.*"]
+
+    _comsumer_message_handler = AsyncMock(return_value=True)
+
+    await rabbit_client.subscribe(
+        exchange_name,
+        _comsumer_message_handler,
+        exclusive_queue=False,  # this instance should receive the incoming messages
+        topics=topics,
+    )
+
+    # produce log
+    log_message = LoggerRabbitMessage(
+        user_id=user_id,
+        project_id=project_id,
+        node_id=node_id,
+        messages=[faker.text() for _ in range(10)],
+    )
+    await rabbitmq_producer.publish(log_message.channel_name, log_message)
+
+    # check it received
+
+    await asyncio.sleep(1)
+
+    assert _comsumer_message_handler.await_count
+    (data,) = _comsumer_message_handler.call_args[0]
+    assert isinstance(data, bytes)
+    assert LoggerRabbitMessage.parse_raw(data) == log_message
+
+    # unsuscribe
+    await rabbit_client.remove_topics(exchange_name, topics=topics)

--- a/services/api-server/tests/unit/test_services_rabbitmq.py
+++ b/services/api-server/tests/unit/test_services_rabbitmq.py
@@ -5,21 +5,25 @@
 # pylint: disable=unused-variable
 
 import asyncio
-from collections.abc import Callable
-from contextlib import asynccontextmanager
+import json
+import logging
+from collections.abc import AsyncIterable, Callable
+from contextlib import asynccontextmanager, suppress
 from unittest.mock import AsyncMock
 
 import httpx
 import pytest
 from faker import Faker
 from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.rabbitmq_messages import LoggerRabbitMessage
 from models_library.users import UserID
-from pydantic import parse_obj_as
+from pydantic import BaseModel, parse_obj_as
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_dict
+from servicelib.logging_utils import LogLevelInt, LogMessageStr
 from servicelib.rabbitmq import RabbitMQClient
 from simcore_service_api_server.services.rabbitmq import get_rabbitmq_client
 
@@ -109,50 +113,63 @@ async def test_subscribe_publish_receive_logs(
 
 
 @asynccontextmanager
-async def rabbit_consuming_context(app: FastAPI):
-    _comsumer_message_handler = AsyncMock(return_value=True)
+async def rabbit_consuming_context(
+    app: FastAPI,
+    project_id: ProjectID,
+    comsumer_message_handler: Callable | None = None,
+):
+    if not comsumer_message_handler:
+        comsumer_message_handler = AsyncMock(return_value=True)
 
     rabbit_consumer: RabbitMQClient = get_rabbitmq_client(app)
     queue_name = await rabbit_consumer.subscribe(
         LoggerRabbitMessage.get_channel_name(),
-        _comsumer_message_handler,
-        exclusive_queue=False,  # this instance should receive the incoming messages
+        comsumer_message_handler,
+        exclusive_queue=True,
         topics=[f"{project_id}.*"],
     )
 
-    yield _comsumer_message_handler
+    yield comsumer_message_handler
 
-    await rabbit_consumer.remove_topics(queue_name, topics=[f"{project_id}.*"])
+    await rabbit_consumer.unsubscribe(queue_name)
+
+
+@pytest.fixture
+def produce_logs(
+    faker: Faker,
+    create_rabbitmq_client: Callable[[str], RabbitMQClient],
+    user_id: UserID,
+):
+    async def _go(name, project_id_=None, node_id_=None, messages_=None, level_=None):
+        rabbitmq_producer = create_rabbitmq_client(f"pytest_producer_{name}")
+        log_message = LoggerRabbitMessage(
+            user_id=user_id,
+            project_id=project_id_ or faker.uuid4(),
+            node_id=node_id_,
+            messages=messages_ or [faker.text() for _ in range(10)],
+            log_level=level_ or logging.INFO,
+        )
+        await rabbitmq_producer.publish(log_message.channel_name, log_message)
+
+    return _go
 
 
 async def test_multiple_producers_and_single_consumer(
     client: httpx.AsyncClient,
     app: FastAPI,
-    faker: Faker,
     user_id: UserID,
     project_id: ProjectID,
     node_id: NodeID,
-    create_rabbitmq_client: Callable[[str], RabbitMQClient],
+    produce_logs: Callable,
 ):
+    await produce_logs("lost", project_id)
 
-    async with rabbit_consuming_context(app) as consumer_message_handler:
+    async with rabbit_consuming_context(app, project_id) as consumer_message_handler:
         # multiple producers
-        async def _produce_logs(name, project_id_=None, node_id_=None, messages_=None):
-            rabbitmq_producer = create_rabbitmq_client(f"pytest_producer_{name}")
-            log_message = LoggerRabbitMessage(
-                user_id=user_id,
-                project_id=project_id_ or faker.uuid4(),
-                node_id=node_id_,
-                messages=messages_ or [faker.text() for _ in range(10)],
-            )
-            await rabbitmq_producer.publish(log_message.channel_name, log_message)
-
         asyncio.gather(
             *[
-                _produce_logs(
-                    "expected", project_id, node_id, ["expected message"] * 3
-                ),
-                *(_produce_logs(f"{n}") for n in range(5)),
+                produce_logs("expected", project_id, node_id, ["expected message"] * 3),
+                *(produce_logs(f"{n}") for n in range(5)),
             ]
         )
 
@@ -167,3 +184,99 @@ async def test_multiple_producers_and_single_consumer(
     assert received_message.project_id == project_id
     assert received_message.node_id == node_id
     assert received_message.messages == ["expected message"] * 3
+
+
+#
+# --------------------
+#
+
+
+class JobLog(BaseModel):
+    job_id: ProjectID
+    node_id: NodeID | None
+    log_level: LogLevelInt
+    messages: list[LogMessageStr]
+
+
+@pytest.fixture
+def new_routes_injected(app: FastAPI):
+    # https://docs.python.org/3/library/asyncio-queue.html#queue
+
+    _NEW_LINE = "\n"
+
+    async def _json_logs_generator(
+        queue: asyncio.Queue, follow: bool
+    ) -> AsyncIterable[str]:
+        if follow:
+            # forever
+            while True:
+                # if queue is empty, it waits
+                job_log = await queue.get()
+                yield job_log.json() + _NEW_LINE
+        else:
+            try:
+                # Return an item if one is immediately available
+                job_log = queue.get_nowait()
+                yield job_log.json() + _NEW_LINE
+
+            except asyncio.QueueEmpty as err:
+                raise StopAsyncIteration from err
+
+    @app.get("/projects/{project_id}/logs")
+    async def _stream_logs_handler(project_id: ProjectID, *, follow: bool = False):
+        buffer = asyncio.Queue()
+
+        async def _consume_log(data: bytes):
+            got = LoggerRabbitMessage.parse_raw(data)
+            assert got.project_id == project_id
+
+            item = JobLog(
+                job_id=got.project_id,
+                node_id=got.node_id,
+                log_level=got.log_level,
+                messages=got.messages,
+            )
+
+            if follow:
+                await buffer.put(item)
+            else:
+                with suppress(asyncio.QueueFull):
+                    buffer.put_nowait(item)
+
+            return True
+
+        # listen to project_id
+        async with rabbit_consuming_context(app, project_id, _consume_log):
+            # FXIME: when return, it will disconnect and we need to keep it connected
+            # and shutdown when client disconnects
+            return StreamingResponse(
+                _json_logs_generator(buffer, follow=follow),
+                media_type="application/x-ndjson",
+            )
+
+
+@pytest.mark.testit
+async def test_it(
+    new_routes_injected: None,
+    app: FastAPI,
+    client: httpx.AsyncClient,
+    user_id: UserID,
+    project_id: ProjectID,
+    produce_logs: Callable,
+):
+
+    async with client.stream("GET", f"/projects/{project_id}/logs") as r:
+
+        # sends log
+        await produce_logs(
+            "expected", project_id, node_id, ["expected message"] * 3, logging.DEBUG
+        )
+
+        async for line in r.aiter_lines():
+            data = json.loads(line)
+            log = JobLog.parse_obj(data)
+            assert log.job_id == project_id
+            assert log.log_level == logging.DEBUG
+            assert log.messages == ["expected message"] * 3
+
+            print(log.json(indent=3))

--- a/services/api-server/tests/unit/test_services_rabbitmq.py
+++ b/services/api-server/tests/unit/test_services_rabbitmq.py
@@ -1,0 +1,24 @@
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+
+from fastapi import FastAPI
+from simcore_service_api_server.services.rabbitmq import (
+    get_rabbitmq_client,
+    setup_rabbitmq,
+)
+
+pytest_simcore_core_services_selection = [
+    "rabbit",
+]
+pytest_simcore_ops_services_selection = []
+
+
+def test_it(app: FastAPI):
+
+    setup_rabbitmq(app)
+
+    rabbit_client = get_rabbitmq_client(app)

--- a/services/autoscaling/tests/unit/test_modules_rabbitmq.py
+++ b/services/autoscaling/tests/unit/test_modules_rabbitmq.py
@@ -109,11 +109,11 @@ async def test_post_message(
     mocked_redis_server: None,
     initialized_app: FastAPI,
     rabbit_message: RabbitMessageBase,
-    rabbitmq_client: Callable[[str], RabbitMQClient],
+    create_rabbitmq_client: Callable[[str], RabbitMQClient],
     mocker: MockerFixture,
 ):
     mocked_message_handler = mocker.AsyncMock(return_value=True)
-    client = rabbitmq_client("pytest_consumer")
+    client = create_rabbitmq_client("pytest_consumer")
     await client.subscribe(
         rabbit_message.channel_name,
         mocked_message_handler,

--- a/services/autoscaling/tests/unit/test_utils_rabbitmq.py
+++ b/services/autoscaling/tests/unit/test_utils_rabbitmq.py
@@ -51,7 +51,7 @@ async def test_post_task_log_message(
     disabled_ec2: None,
     mocked_redis_server: None,
     initialized_app: FastAPI,
-    rabbitmq_client: Callable[[str], RabbitMQClient],
+    create_rabbitmq_client: Callable[[str], RabbitMQClient],
     mocker: MockerFixture,
     async_docker_client: aiodocker.Docker,
     create_service: Callable[
@@ -62,7 +62,7 @@ async def test_post_task_log_message(
     faker: Faker,
 ):
     mocked_message_handler = mocker.AsyncMock(return_value=True)
-    client = rabbitmq_client("pytest_consumer")
+    client = create_rabbitmq_client("pytest_consumer")
     await client.subscribe(
         LoggerRabbitMessage.get_channel_name(),
         mocked_message_handler,
@@ -141,7 +141,7 @@ async def test_post_task_progress_message(
     disabled_ec2: None,
     mocked_redis_server: None,
     initialized_app: FastAPI,
-    rabbitmq_client: Callable[[str], RabbitMQClient],
+    create_rabbitmq_client: Callable[[str], RabbitMQClient],
     mocker: MockerFixture,
     async_docker_client: aiodocker.Docker,
     create_service: Callable[
@@ -152,7 +152,7 @@ async def test_post_task_progress_message(
     faker: Faker,
 ):
     mocked_message_handler = mocker.AsyncMock(return_value=True)
-    client = rabbitmq_client("pytest_consumer")
+    client = create_rabbitmq_client("pytest_consumer")
     await client.subscribe(
         ProgressRabbitMessageNode.get_channel_name(),
         mocked_message_handler,

--- a/services/clusters-keeper/tests/unit/test_modules_rabbitmq.py
+++ b/services/clusters-keeper/tests/unit/test_modules_rabbitmq.py
@@ -100,11 +100,11 @@ async def test_post_message(
     mocked_redis_server: None,
     initialized_app: FastAPI,
     rabbit_message: RabbitMessageBase,
-    rabbitmq_client: Callable[[str], RabbitMQClient],
+    create_rabbitmq_client: Callable[[str], RabbitMQClient],
     mocker: MockerFixture,
 ):
     mocked_message_handler = mocker.AsyncMock(return_value=True)
-    client = rabbitmq_client("pytest_consumer")
+    client = create_rabbitmq_client("pytest_consumer")
     await client.subscribe(
         rabbit_message.channel_name,
         mocked_message_handler,

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_consumers.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 from collections.abc import AsyncIterator, Callable, Coroutine
-from typing import Any, Final
+from typing import Any, Final, NamedTuple
 
 from aiohttp import web
 from models_library.rabbitmq_messages import (
@@ -186,37 +186,34 @@ async def _osparc_credits_message_parser(app: web.Application, data: bytes) -> b
     return True
 
 
-EXCHANGE_TO_PARSER_CONFIG: Final[
-    tuple[
-        tuple[
-            str,
-            Callable[[web.Application, bytes], Coroutine[Any, Any, bool]],
-            dict[str, Any],
-        ],
-        ...,
-    ]
-] = (
-    (
+class SubcribeArgumentsTuple(NamedTuple):
+    exchange_name: str
+    parser_fct: Callable[[web.Application, bytes], Coroutine[Any, Any, bool]]
+    queue_kwargs: dict[str, Any]
+
+
+_EXCHANGE_TO_PARSER_CONFIG: Final[tuple[SubcribeArgumentsTuple, ...,]] = (
+    SubcribeArgumentsTuple(
         LoggerRabbitMessage.get_channel_name(),
         _log_message_parser,
         {"topics": []},
     ),
-    (
+    SubcribeArgumentsTuple(
         ProgressRabbitMessageNode.get_channel_name(),
         _progress_message_parser,
         {"topics": []},
     ),
-    (
+    SubcribeArgumentsTuple(
         InstrumentationRabbitMessage.get_channel_name(),
         _instrumentation_message_parser,
         {"exclusive_queue": False},
     ),
-    (
+    SubcribeArgumentsTuple(
         EventRabbitMessage.get_channel_name(),
         _events_message_parser,
         {},
     ),
-    (
+    SubcribeArgumentsTuple(
         WalletCreditsMessage.get_channel_name(),
         _osparc_credits_message_parser,
         {"topics": []},
@@ -230,16 +227,18 @@ async def _subscribe_to_rabbitmq(app) -> dict[str, str]:
         subscribed_queues = await logged_gather(
             *(
                 rabbit_client.subscribe(
-                    exchange_name, functools.partial(parser_fct, app), **queue_kwargs
+                    p.exchange_name,
+                    functools.partial(p.parser_fct, app),
+                    **p.queue_kwargs,
                 )
-                for exchange_name, parser_fct, queue_kwargs in EXCHANGE_TO_PARSER_CONFIG
+                for p in _EXCHANGE_TO_PARSER_CONFIG
             ),
             reraise=False,
         )
     return {
         exchange_name: queue_name
         for (exchange_name, *_), queue_name in zip(
-            EXCHANGE_TO_PARSER_CONFIG, subscribed_queues
+            _EXCHANGE_TO_PARSER_CONFIG, subscribed_queues, strict=True
         )
     }
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

A first iteration on job logs streaming. 

- common functionality of `rabbit`?
- `api-server` now interact with `rabbit` service
- services/api-server/tests/unit/test_services_rabbitmq.py to test how logs can be captured
- services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_logs.py to draft how logs a


## Related issue/s

- part of #4652

## How to test

Driving test `services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_logs.py`


## DevOps 

None