### PR TITLE
⬆️Storage: dependencies upgrade

### DIFF
--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -4,16 +4,14 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-aio-pika==9.1.2
+aio-pika==9.2.2
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==9.6.0
+aioboto3==11.3.0
     # via -r requirements/_base.in
-aiobotocore==2.3.0
-    # via
-    #   aioboto3
-    #   types-aiobotocore
+aiobotocore==2.6.0
+    # via aioboto3
 aiodebug==2.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
@@ -22,7 +20,7 @@ aiodocker==0.21.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiofiles==0.8.0
+aiofiles==23.2.1
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -47,19 +45,19 @@ aiohttp==3.8.5
     #   aiozipkin
 aiohttp-swagger==1.0.16
     # via -r requirements/_base.in
-aioitertools==0.10.0
+aioitertools==0.11.0
     # via aiobotocore
 aiopg==1.4.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_aiohttp.in
     #   -r requirements/_base.in
-aiormq==6.7.6
+aiormq==6.7.7
     # via aio-pika
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via aiohttp
 aiozipkin==1.1.1
     # via -r requirements/../../../packages/service-library/requirements/_aiohttp.in
-alembic==1.8.1
+alembic==1.11.3
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
 arrow==1.2.3
     # via
@@ -68,45 +66,52 @@ arrow==1.2.3
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-async-timeout==4.0.2
+asgiref==3.7.2
+    # via openapi-core
+async-timeout==4.0.3
     # via
     #   aiohttp
     #   aiopg
     #   redis
-asyncpg==0.27.0
+asyncpg==0.28.0
     # via sqlalchemy
-attrs==21.4.0
+attrs==23.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_aiohttp.in
     #   aiohttp
     #   jsonschema
-    #   openapi-core
-boto3==1.21.21
+    #   referencing
+boto3==1.28.17
     # via aiobotocore
-botocore==1.24.21
+botocore==1.31.17
     # via
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.27.17
+botocore-stubs==1.31.38
     # via types-aiobotocore
-charset-normalizer==2.0.12
-    # via aiohttp
-click==8.1.3
+certifi==2023.7.22
+    # via requests
+charset-normalizer==3.2.0
+    # via
+    #   aiohttp
+    #   requests
+click==8.1.7
     # via typer
-dnspython==2.2.1
+dnspython==2.4.2
     # via email-validator
-email-validator==1.2.1
+email-validator==2.0.0.post2
     # via pydantic
-frozenlist==1.3.0
+frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
 greenlet==2.0.2
     # via sqlalchemy
-idna==3.3
+idna==3.4
     # via
     #   email-validator
+    #   requests
     #   yarl
 isodate==0.6.1
     # via openapi-core
@@ -123,21 +128,30 @@ jinja2==3.1.2
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   aiohttp-swagger
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==3.2.0
+jsonschema==4.19.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_aiohttp.in
+    #   openapi-core
     #   openapi-schema-validator
     #   openapi-spec-validator
-lazy-object-proxy==1.7.1
-    # via openapi-core
-mako==1.2.2
+jsonschema-spec==0.2.4
+    # via
+    #   openapi-core
+    #   openapi-spec-validator
+jsonschema-specifications==2023.7.1
+    # via
+    #   jsonschema
+    #   openapi-schema-validator
+lazy-object-proxy==1.9.0
+    # via openapi-spec-validator
+mako==1.2.4
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -152,32 +166,45 @@ mako==1.2.2
     #   alembic
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.1
+markupsafe==2.1.3
     # via
     #   jinja2
     #   mako
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.0.2
+more-itertools==10.1.0
+    # via openapi-core
+multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-openapi-core==0.12.0
+openapi-core==0.18.0
     # via -r requirements/../../../packages/service-library/requirements/_aiohttp.in
-openapi-schema-validator==0.2.3
-    # via openapi-spec-validator
-openapi-spec-validator==0.4.0
+openapi-schema-validator==0.6.0
+    # via
+    #   openapi-core
+    #   openapi-spec-validator
+openapi-spec-validator==0.6.0
     # via openapi-core
+orjson==3.9.5
+    # via
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/./../../../packages/models-library/requirements/_base.in
 pamqp==3.2.1
     # via aiormq
-prometheus-client==0.14.1
+parse==1.19.1
+    # via openapi-core
+pathable==0.4.3
+    # via jsonschema-spec
+prometheus-client==0.17.1
     # via -r requirements/../../../packages/service-library/requirements/_aiohttp.in
-psycopg2-binary==2.9.6
+psycopg2-binary==2.9.7
     # via
     #   aiopg
     #   sqlalchemy
-pydantic==1.9.0
+pydantic==1.10.12
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -197,14 +224,12 @@ pydantic==1.9.0
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-pygments==2.15.1
+pygments==2.16.1
     # via rich
-pyinstrument==4.1.1
+pyinstrument==4.5.1
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-pyrsistent==0.18.1
-    # via jsonschema
 python-dateutil==2.8.2
     # via
     #   arrow
@@ -224,8 +249,8 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aiohttp-swagger
-    #   openapi-spec-validator
-redis==4.5.4
+    #   jsonschema-spec
+redis==5.0.0
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -239,22 +264,36 @@ redis==4.5.4
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-rich==13.4.2
+referencing==0.29.3
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
+    #   jsonschema
+    #   jsonschema-spec
+    #   jsonschema-specifications
+requests==2.31.0
+    # via jsonschema-spec
+rfc3339-validator==0.1.4
+    # via openapi-schema-validator
+rich==13.5.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-s3transfer==0.5.2
+rpds-py==0.10.0
+    # via
+    #   jsonschema
+    #   referencing
+s3transfer==0.6.2
     # via boto3
-semantic-version==2.9.0
+semantic-version==2.10.0
     # via -r requirements/_base.in
 six==1.16.0
     # via
     #   isodate
-    #   jsonschema
-    #   openapi-core
     #   python-dateutil
-sqlalchemy==1.4.47
+    #   rfc3339-validator
+sqlalchemy==1.4.49
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -269,36 +308,40 @@ sqlalchemy==1.4.47
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   aiopg
     #   alembic
-strict-rfc3339==0.7
-    # via openapi-core
-tenacity==8.0.1
+tenacity==8.2.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-tqdm==4.64.0
+toolz==0.12.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.4.1
+tqdm==4.66.1
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+typer==0.9.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
-types-aiobotocore==2.3.3
+types-aiobotocore==2.6.0
     # via -r requirements/_base.in
-types-aiobotocore-s3==2.3.3
+types-aiobotocore-s3==2.6.0
     # via types-aiobotocore
-typing-extensions==4.3.0
+types-awscrt==0.19.1
+    # via botocore-stubs
+typing-extensions==4.7.1
     # via
     #   aiodebug
     #   aiodocker
-    #   botocore-stubs
+    #   alembic
+    #   asgiref
     #   pydantic
-    #   types-aiobotocore
-    #   types-aiobotocore-s3
-ujson==5.5.0
+    #   typer
+ujson==5.8.0
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -311,7 +354,7 @@ ujson==5.5.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   aiohttp-swagger
-urllib3==1.26.9
+urllib3==1.26.16
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
@@ -324,9 +367,12 @@ urllib3==1.26.9
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   botocore
-werkzeug==2.2.2
-    # via -r requirements/../../../packages/service-library/requirements/_aiohttp.in
-wrapt==1.14.1
+    #   requests
+werkzeug==2.3.7
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_aiohttp.in
+    #   openapi-core
+wrapt==1.15.0
     # via aiobotocore
 yarl==1.9.2
     # via
@@ -334,6 +380,3 @@ yarl==1.9.2
     #   aio-pika
     #   aiohttp
     #   aiormq
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -13,31 +13,34 @@ aiohttp==3.8.5
     #   simcore-service-storage-sdk
 aioresponses==0.7.4
     # via -r requirements/_test.in
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-attrs==21.4.0
+attrs==23.1.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   jschema-to-python
     #   jsonschema
+    #   referencing
     #   sarif-om
-aws-sam-translator==1.55.0
+aws-sam-translator==1.73.0
     # via cfn-lint
 aws-xray-sdk==2.12.0
     # via moto
-boto3==1.21.21
+blinker==1.6.2
+    # via flask
+boto3==1.28.17
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.24.21
+botocore==1.31.17
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -46,18 +49,19 @@ botocore==1.24.21
     #   s3transfer
 certifi==2023.7.22
     # via
+    #   -c requirements/_base.txt
     #   requests
     #   simcore-service-storage-sdk
 cffi==1.15.1
     # via cryptography
-cfn-lint==0.72.6
+cfn-lint==0.77.10
     # via moto
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   requests
-click==8.1.3
+click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   flask
@@ -82,15 +86,15 @@ ecdsa==0.18.0
     #   sshpubkeys
 exceptiongroup==1.1.3
     # via pytest
-faker==19.3.0
+faker==19.3.1
     # via -r requirements/_test.in
-flask==2.2.5
+flask==2.3.3
     # via
     #   flask-cors
     #   moto
 flask-cors==4.0.0
     # via moto
-frozenlist==1.3.0
+frozenlist==1.4.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -101,9 +105,9 @@ greenlet==2.0.2
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
-icdiff==2.0.6
+icdiff==2.0.7
     # via pytest-icdiff
-idna==3.3
+idna==3.4
     # via
     #   -c requirements/_base.txt
     #   requests
@@ -118,7 +122,7 @@ jinja2==3.1.2
     #   -c requirements/_base.txt
     #   flask
     #   moto
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   -c requirements/_base.txt
     #   boto3
@@ -133,40 +137,55 @@ jsonpickle==3.0.2
     # via jschema-to-python
 jsonpointer==2.4
     # via jsonpatch
-jsonschema==3.2.0
+jsonschema==4.19.0
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   cfn-lint
     #   openapi-schema-validator
     #   openapi-spec-validator
+jsonschema-spec==0.2.4
+    # via
+    #   -c requirements/_base.txt
+    #   openapi-spec-validator
+jsonschema-specifications==2023.7.1
+    # via
+    #   -c requirements/_base.txt
+    #   jsonschema
+    #   openapi-schema-validator
 junit-xml==1.9
     # via cfn-lint
-markupsafe==2.1.1
+lazy-object-proxy==1.9.0
+    # via
+    #   -c requirements/_base.txt
+    #   openapi-spec-validator
+markupsafe==2.1.3
     # via
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==4.1.14
+moto==4.2.0
     # via -r requirements/_test.in
-multidict==6.0.2
+mpmath==1.3.0
+    # via sympy
+multidict==6.0.4
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-mypy==1.5.0
+mypy==1.5.1
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
-networkx==2.8.8
+networkx==3.1
     # via cfn-lint
 numpy==1.25.2
     # via pandas
-openapi-schema-validator==0.2.3
+openapi-schema-validator==0.6.0
     # via
     #   -c requirements/_base.txt
     #   openapi-spec-validator
-openapi-spec-validator==0.4.0
+openapi-spec-validator==0.6.0
     # via
     #   -c requirements/_base.txt
     #   moto
@@ -175,13 +194,17 @@ packaging==23.1
     #   docker
     #   pytest
     #   pytest-sugar
-pandas==2.0.3
+pandas==2.1.0
     # via -r requirements/_test.in
+pathable==0.4.3
+    # via
+    #   -c requirements/_base.txt
+    #   jsonschema-spec
 pbr==5.11.1
     # via
     #   jschema-to-python
     #   sarif-om
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
@@ -193,12 +216,13 @@ pyasn1==0.5.0
     #   rsa
 pycparser==2.21
     # via cffi
+pydantic==1.10.12
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   aws-sam-translator
 pyparsing==3.1.1
     # via moto
-pyrsistent==0.18.1
-    # via
-    #   -c requirements/_base.txt
-    #   jsonschema
 pytest==7.4.0
     # via
     #   -r requirements/_test.in
@@ -244,21 +268,40 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   cfn-lint
+    #   jsonschema-spec
     #   moto
-    #   openapi-spec-validator
     #   responses
+referencing==0.29.3
+    # via
+    #   -c requirements/_base.txt
+    #   jsonschema
+    #   jsonschema-spec
+    #   jsonschema-specifications
+regex==2023.8.8
+    # via cfn-lint
 requests==2.31.0
     # via
+    #   -c requirements/_base.txt
     #   docker
+    #   jsonschema-spec
     #   moto
     #   responses
 responses==0.23.3
     # via moto
+rfc3339-validator==0.1.4
+    # via
+    #   -c requirements/_base.txt
+    #   openapi-schema-validator
+rpds-py==0.10.0
+    # via
+    #   -c requirements/_base.txt
+    #   jsonschema
+    #   referencing
 rsa==4.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   python-jose
-s3transfer==0.5.2
+s3transfer==0.6.2
     # via
     #   -c requirements/_base.txt
     #   boto3
@@ -270,11 +313,11 @@ six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   ecdsa
-    #   jsonschema
     #   junit-xml
     #   python-dateutil
+    #   rfc3339-validator
     #   simcore-service-storage-sdk
-sqlalchemy==1.4.47
+sqlalchemy==1.4.49
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -283,6 +326,8 @@ sqlalchemy2-stubs==0.0.2a35
     # via sqlalchemy
 sshpubkeys==3.3.1
     # via moto
+sympy==1.12
+    # via cfn-lint
 termcolor==2.3.0
     # via pytest-sugar
 tomli==2.0.1
@@ -292,14 +337,16 @@ tomli==2.0.1
     #   pytest
 types-pyyaml==6.0.12.11
     # via responses
-typing-extensions==4.3.0
+typing-extensions==4.7.1
     # via
     #   -c requirements/_base.txt
+    #   aws-sam-translator
     #   mypy
+    #   pydantic
     #   sqlalchemy2-stubs
 tzdata==2023.3
     # via pandas
-urllib3==1.26.9
+urllib3==1.26.16
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -308,14 +355,14 @@ urllib3==1.26.9
     #   requests
     #   responses
     #   simcore-service-storage-sdk
-websocket-client==1.6.1
+websocket-client==1.6.2
     # via docker
-werkzeug==2.2.2
+werkzeug==2.3.7
     # via
     #   -c requirements/_base.txt
     #   flask
     #   moto
-wrapt==1.14.1
+wrapt==1.15.0
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk

--- a/services/storage/requirements/_tools.txt
+++ b/services/storage/requirements/_tools.txt
@@ -14,7 +14,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
-click==8.1.3
+click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -24,17 +24,18 @@ dill==0.3.7
     # via pylint
 distlib==0.3.7
     # via virtualenv
-filelock==3.12.2
+filelock==3.12.3
     # via virtualenv
-identify==2.5.26
+identify==2.5.27
     # via pre-commit
 isort==5.12.0
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
-lazy-object-proxy==1.7.1
+lazy-object-proxy==1.9.0
     # via
     #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   astroid
 mccabe==0.7.0
     # via pylint
@@ -71,7 +72,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.0.284
+ruff==0.0.286
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -83,18 +84,19 @@ tomli==2.0.1
     #   pyproject-hooks
 tomlkit==0.12.1
     # via pylint
-typing-extensions==4.3.0
+typing-extensions==4.7.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   astroid
-virtualenv==20.24.3
+    #   filelock
+virtualenv==20.24.4
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.1
+wheel==0.41.2
     # via pip-tools
-wrapt==1.14.1
+wrapt==1.15.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt

--- a/services/storage/src/simcore_service_storage/application.py
+++ b/services/storage/src/simcore_service_storage/application.py
@@ -34,7 +34,6 @@ def create(settings: Settings) -> web.Application:
         settings.json(indent=2, sort_keys=True),
     )
 
-    # TODO: tmp using {} until webserver is also pydantic-compatible
     app = create_safe_application(None)
     app[APP_CONFIG_KEY] = settings
 
@@ -78,7 +77,7 @@ def run(settings: Settings, app: web.Application | None = None):
         app = create(settings)
 
     async def welcome_banner(_app: web.Application):
-        print(WELCOME_MSG, flush=True)
+        print(WELCOME_MSG, flush=True)  # noqa: T201
 
     app.on_startup.append(welcome_banner)
 

--- a/services/storage/src/simcore_service_storage/datcore_adapter/datcore_adapter_exceptions.py
+++ b/services/storage/src/simcore_service_storage/datcore_adapter/datcore_adapter_exceptions.py
@@ -1,30 +1,27 @@
-from typing import Optional
-
-
-class DatcoreAdapterException(Exception):
+class DatcoreAdapterError(Exception):
     """basic exception for errors raised in datcore-adapter"""
 
-    def __init__(self, msg: Optional[str] = None) -> None:
+    def __init__(self, msg: str | None = None) -> None:
         super().__init__(
             msg or "Unexpected error occured in datcore-adapter subpackage"
         )
 
 
-class DatcoreAdapterClientError(DatcoreAdapterException):
+class DatcoreAdapterClientError(DatcoreAdapterError):
     """client error when accessing server"""
 
     def __init__(self, msg: str) -> None:
         super().__init__(msg=msg)
 
 
-class DatcoreAdapterTimeoutError(DatcoreAdapterException):
+class DatcoreAdapterTimeoutError(DatcoreAdapterError):
     """client timeout when accessing datcore adapter server"""
 
     def __init__(self, msg: str) -> None:
         super().__init__(msg=msg)
 
 
-class DatcoreAdapterServerError(DatcoreAdapterException):
+class DatcoreAdapterServerError(DatcoreAdapterError):
     """server error"""
 
     def __init__(self, msg: str) -> None:

--- a/services/storage/src/simcore_service_storage/datcore_adapter/datcore_adapter_settings.py
+++ b/services/storage/src/simcore_service_storage/datcore_adapter/datcore_adapter_settings.py
@@ -8,7 +8,7 @@ from settings_library.base import BaseCustomSettings
 class DatcoreAdapterSettings(BaseCustomSettings):
     DATCORE_ADAPTER_ENABLED: bool = True
     DATCORE_ADAPTER_HOST: str = "datcore-adapter"
-    DATCORE_ADAPTER_PORT: PortInt = 8000
+    DATCORE_ADAPTER_PORT: PortInt = PortInt(8000)
     DATCORE_ADAPTER_VTAG: VersionTag = Field(
         "v0", description="Datcore-adapter service API's version tag"
     )

--- a/services/storage/src/simcore_service_storage/db_projects.py
+++ b/services/storage/src/simcore_service_storage/db_projects.py
@@ -1,5 +1,5 @@
+from collections.abc import AsyncIterator
 from contextlib import suppress
-from typing import AsyncIterator
 
 import sqlalchemy as sa
 from aiopg.sa.connection import SAConnection

--- a/services/storage/src/simcore_service_storage/db_tokens.py
+++ b/services/storage/src/simcore_service_storage/db_tokens.py
@@ -16,20 +16,16 @@ async def _get_tokens_from_db(engine: Engine, user_id: UserID) -> dict[str, Any]
     async with engine.acquire() as conn:
         result = await conn.execute(
             sa.select(
-                [
-                    tokens,
-                ]
+                tokens,
             ).where(tokens.c.user_id == user_id)
         )
         row = await result.first()
-        data = dict(row) if row else {}
-        return data
+        return dict(row) if row else {}
 
 
 async def get_api_token_and_secret(
     app: web.Application, user_id: UserID
 ) -> tuple[str, str]:
-    # FIXME: this is a temporary solution. This information should be sent in some form
     # from the client side together with the userid?
     engine = app[APP_DB_ENGINE_KEY]
 

--- a/services/storage/src/simcore_service_storage/dsm_cleaner.py
+++ b/services/storage/src/simcore_service_storage/dsm_cleaner.py
@@ -47,13 +47,11 @@ async def dsm_cleaner_task(app: web.Application) -> None:
         try:
             await simcore_s3_dsm.clean_expired_uploads()
 
-        except asyncio.CancelledError:
+        except asyncio.CancelledError:  # noqa: PERF203
             logger.info("cancelled dsm cleaner task")
             raise
         except Exception:  # pylint: disable=broad-except
-            logger.exception(
-                "Unhandled error in dsm cleaner task, restarting task...", exc_info=True
-            )
+            logger.exception("Unhandled error in dsm cleaner task, restarting task...")
 
 
 def setup_dsm_cleaner(app: web.Application):

--- a/services/storage/src/simcore_service_storage/dsm_factory.py
+++ b/services/storage/src/simcore_service_storage/dsm_factory.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Callable
 
 from aiohttp import web
 from models_library.api_schemas_storage import LinkType, UploadedPart

--- a/services/storage/src/simcore_service_storage/handlers_health.py
+++ b/services/storage/src/simcore_service_storage/handlers_health.py
@@ -10,9 +10,9 @@ from models_library.api_schemas_storage import HealthCheck, S3BucketName
 from models_library.app_diagnostics import AppStatusCheck
 from servicelib.json_serialization import json_dumps
 from servicelib.rest_constants import RESPONSE_MODEL_POLICY
-from simcore_service_storage.constants import APP_CONFIG_KEY
 
 from ._meta import api_version, api_version_prefix, app_name
+from .constants import APP_CONFIG_KEY
 from .db import get_engine_state
 from .db import is_service_responsive as is_pg_responsive
 from .exceptions import S3AccessError, S3BucketInvalidError

--- a/services/storage/src/simcore_service_storage/handlers_locations.py
+++ b/services/storage/src/simcore_service_storage/handlers_locations.py
@@ -78,7 +78,7 @@ async def synchronise_meta_data_table(request: web.Request) -> web.Response:
                     len(result),
                 )
             except asyncio.TimeoutError:
-                log.error("Sync metadata table timed out (%s seconds)", timeout)
+                log.exception("Sync metadata table timed out (%s seconds)", timeout)
 
         fire_and_forget_task(
             _go(),

--- a/services/storage/src/simcore_service_storage/handlers_simcore_s3.py
+++ b/services/storage/src/simcore_service_storage/handlers_simcore_s3.py
@@ -22,7 +22,6 @@ from settings_library.s3 import S3Settings
 from simcore_service_storage.dsm import get_dsm_provider
 from simcore_service_storage.simcore_s3_dsm import SimcoreS3DataManager
 
-# Exclusive for simcore-s3 storage -----------------------
 from . import sts
 from ._meta import api_vtag
 from .models import (

--- a/services/storage/src/simcore_service_storage/s3_client.py
+++ b/services/storage/src/simcore_service_storage/s3_client.py
@@ -19,7 +19,6 @@ from pydantic import AnyUrl, ByteSize, NonNegativeInt, parse_obj_as
 from servicelib.logging_utils import log_context
 from servicelib.utils import logged_gather
 from settings_library.s3 import S3Settings
-from simcore_service_storage.constants import MULTIPART_UPLOADS_MIN_TOTAL_SIZE
 from types_aiobotocore_s3 import S3Client
 from types_aiobotocore_s3.type_defs import (
     ListObjectsV2OutputTypeDef,
@@ -27,7 +26,7 @@ from types_aiobotocore_s3.type_defs import (
     PaginatorConfigTypeDef,
 )
 
-from .constants import EXPAND_DIR_MAX_ITEM_COUNT
+from .constants import EXPAND_DIR_MAX_ITEM_COUNT, MULTIPART_UPLOADS_MIN_TOTAL_SIZE
 from .models import ETag, MultiPartUploadLinks, S3BucketName, UploadID
 from .s3_utils import compute_num_file_chunks, s3_exception_handler
 

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -958,7 +958,6 @@ class SimcoreS3DataManager(BaseDataManager):
     ) -> FileMetaData:
         session = get_client_session(self.app)
         # 2 steps: Get download link for local copy, then upload to S3
-        # TODO: This should be a redirect stream!
         api_token, api_secret = await db_tokens.get_api_token_and_secret(
             self.app, user_id
         )

--- a/services/storage/src/simcore_service_storage/utils_handlers.py
+++ b/services/storage/src/simcore_service_storage/utils_handlers.py
@@ -3,10 +3,8 @@ from aiohttp.typedefs import Handler
 from aiohttp.web_request import Request
 from pydantic import ValidationError
 from servicelib.aiohttp.aiopg_utils import DBAPIError
-from simcore_service_storage.datcore_adapter.datcore_adapter_exceptions import (
-    DatcoreAdapterTimeoutError,
-)
 
+from .datcore_adapter.datcore_adapter_exceptions import DatcoreAdapterTimeoutError
 from .db_access_layer import InvalidFileIdentifierError
 from .exceptions import (
     FileAccessRightError,

--- a/services/storage/src/simcore_service_storage/utils_handlers.py
+++ b/services/storage/src/simcore_service_storage/utils_handlers.py
@@ -7,7 +7,7 @@ from simcore_service_storage.datcore_adapter.datcore_adapter_exceptions import (
     DatcoreAdapterTimeoutError,
 )
 
-from .db_access_layer import InvalidFileIdentifier
+from .db_access_layer import InvalidFileIdentifierError
 from .exceptions import (
     FileAccessRightError,
     FileMetaDataNotFoundError,
@@ -25,7 +25,7 @@ async def dsm_exception_handler(
 ) -> web.StreamResponse:
     try:
         return await handler(request)
-    except InvalidFileIdentifier as err:
+    except InvalidFileIdentifierError as err:
         raise web.HTTPUnprocessableEntity(
             reason=f"{err} is an invalid file identifier"
         ) from err

--- a/services/storage/tests/unit/conftest.py
+++ b/services/storage/tests/unit/conftest.py
@@ -8,11 +8,10 @@ from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, AsyncContextManager
+from typing import AsyncContextManager
 
 import openapi_core
 import pytest
-import yaml
 from aiohttp import web
 from aiohttp.test_utils import TestClient
 from models_library.api_schemas_storage import (
@@ -41,11 +40,9 @@ from yarl import URL
 
 
 @pytest.fixture(scope="module")
-def openapi_specs():
+def openapi_specs() -> openapi_core.Spec:
     spec_path: Path = storage_resources.get_path(f"api/{api_vtag}/openapi.yaml")
-    spec_dict: dict[str, Any] = yaml.safe_load(spec_path.read_text())
-    api_specs = openapi_core.create_spec(spec_dict, spec_path.as_uri())
-    return api_specs
+    return openapi_core.Spec.from_path(spec_path)
 
 
 @pytest.fixture

--- a/services/storage/tests/unit/test__openapi_specs.py
+++ b/services/storage/tests/unit/test__openapi_specs.py
@@ -9,7 +9,7 @@ import pytest
 import simcore_service_storage.application
 from aiohttp import web
 from faker import Faker
-from openapi_core.schema.specs.models import Spec as OpenApiSpecs
+from openapi_core import Spec as OpenApiSpecs
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict
 from simcore_service_storage.settings import Settings
@@ -52,13 +52,13 @@ def expected_openapi_entrypoints(openapi_specs: OpenApiSpecs) -> set[Entrypoint]
     entrypoints: set[Entrypoint] = set()
 
     # openapi-specifications, i.e. "contract"
-    for path, path_obj in openapi_specs.paths.items():
-        for operation, operation_obj in path_obj.operations.items():
+    for path, path_obj in openapi_specs["paths"].items():
+        for operation, operation_obj in path_obj.items():
             entrypoints.add(
                 Entrypoint(
                     method=operation.upper(),
                     path=path,
-                    name=operation_obj.operation_id,
+                    name=operation_obj["operationId"],
                 )
             )
     return entrypoints

--- a/services/storage/tests/unit/test_aiobotocore.py
+++ b/services/storage/tests/unit/test_aiobotocore.py
@@ -3,8 +3,6 @@
 # pylint: disable=unused-variable
 
 
-from contextlib import AsyncExitStack
-
 import pytest
 from aiobotocore.session import get_session
 from botocore import exceptions as boto_exceptions
@@ -17,21 +15,16 @@ async def test_s3_client_fails_if_no_s3():
     with pytest.raises(boto_exceptions.ClientError):
         async with session.create_client(
             "s3",
-            aws_secret_access_key="xxx",
+            aws_secret_access_key="xxx",  # noqa: S106
             aws_access_key_id="xxx",
         ) as client:
-            assert client
             await client.list_buckets()
     with pytest.raises(boto_exceptions.ClientError):
-        async with AsyncExitStack() as exit_stack:
-            client = await exit_stack.enter_async_context(
-                session.create_client(
-                    "s3",
-                    aws_secret_access_key="xxx",
-                    aws_access_key_id="xxx",
-                )
-            )
-            assert client
+        async with session.create_client(
+            "s3",
+            aws_secret_access_key="xxx",  # noqa: S106
+            aws_access_key_id="xxx",
+        ) as client:
             await client.list_buckets()
 
 
@@ -43,8 +36,8 @@ async def test_s3_client_reconnects_if_s3_server_restarts(
     # pylint: disable=protected-access
     async with session.create_client(
         "s3",
-        endpoint_url=f"http://{mocked_s3_server._ip_address}:{mocked_s3_server._port}",
-        aws_secret_access_key="xxx",
+        endpoint_url=f"http://{mocked_s3_server._ip_address}:{mocked_s3_server._port}",  # noqa: SLF001
+        aws_secret_access_key="xxx",  # noqa: S106
         aws_access_key_id="xxx",
     ) as client:
         assert client

--- a/services/storage/tests/unit/test_cli.py
+++ b/services/storage/tests/unit/test_cli.py
@@ -11,33 +11,32 @@ import pytest
 from dotenv import dotenv_values
 from simcore_service_storage.cli import main
 from simcore_service_storage.settings import Settings
+from typer.testing import CliRunner
 
 
 @pytest.mark.parametrize(
     "arguments", ["--help", "run --help".split(), "settings --help".split()]
 )
-def test_cli_help(arguments, cli_runner):
+def test_cli_help(arguments: list[str] | str, cli_runner: CliRunner):
     result = cli_runner.invoke(main, arguments)
-    print(result.stdout)
     assert result.exit_code == os.EX_OK, result
-    assert "Usage: simcore-service-storage" in result.stdout
 
 
-def test_cli_settings_as_json(project_env_devel_environment, cli_runner):
-    # $ (set -o allexport; source .env; simcore-service-storage settings  --as-json ) > env.json
-
+def test_cli_settings_as_json(
+    project_env_devel_environment: None, cli_runner: CliRunner
+):
     result = cli_runner.invoke(main, ["settings", "--as-json"])
-    print(result.stdout)
-
+    assert result.exit_code == os.EX_OK, result
     # reuse resulting json to build settings
     settings: dict = json.loads(result.stdout)
     assert Settings.parse_obj(settings)
 
 
-def test_cli_settings_env_file(project_env_devel_environment, cli_runner):
-    # $ (set -o allexport; source .env; simcore-service-storage settings  --compact ) > .env
+def test_cli_settings_env_file(
+    project_env_devel_environment: None, cli_runner: CliRunner
+):
     result = cli_runner.invoke(main, ["settings", "--compact"])
-    print(result.stdout)
+    assert result.exit_code == os.EX_OK, result
 
     # reuse resulting env_file to build settings
     env_file = StringIO(result.stdout)

--- a/services/storage/tests/unit/test_cli.py
+++ b/services/storage/tests/unit/test_cli.py
@@ -2,6 +2,7 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
+import contextlib
 import json
 import os
 from io import StringIO
@@ -43,9 +44,7 @@ def test_cli_settings_env_file(project_env_devel_environment, cli_runner):
 
     settings: dict = dotenv_values(stream=env_file)
     for key, value in settings.items():
-        try:
+        with contextlib.suppress(json.decoder.JSONDecodeError):
             settings[key] = json.loads(str(value))
-        except json.decoder.JSONDecodeError:
-            pass
 
     assert Settings.parse_obj(settings)

--- a/services/storage/tests/unit/test_utils_handlers.py
+++ b/services/storage/tests/unit/test_utils_handlers.py
@@ -9,7 +9,7 @@ from aiohttp.typedefs import Handler
 from pydantic import BaseModel, ValidationError
 from pytest_mock import MockerFixture
 from servicelib.aiohttp.aiopg_utils import DBAPIError
-from simcore_service_storage.db_access_layer import InvalidFileIdentifier
+from simcore_service_storage.db_access_layer import InvalidFileIdentifierError
 from simcore_service_storage.exceptions import (
     FileAccessRightError,
     FileMetaDataNotFoundError,
@@ -42,7 +42,7 @@ class FakeErrorModel(BaseModel):
 @pytest.mark.parametrize(
     "handler_exception, expected_web_response",
     [
-        (InvalidFileIdentifier(identifier="x"), web.HTTPUnprocessableEntity),
+        (InvalidFileIdentifierError(identifier="x"), web.HTTPUnprocessableEntity),
         (FileMetaDataNotFoundError(file_id="x"), web.HTTPNotFound),
         (S3KeyNotFoundError(key="x", bucket="x"), web.HTTPNotFound),
         (ProjectNotFoundError(project_id="x"), web.HTTPNotFound),


### PR DESCRIPTION
###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 68
- #packages after : 84

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.1.2           | 9.2.2      | *minor*    | 1 | storage⬆️ |
|   2 | aioboto3                  | 9.6.0           | 11.3.0     | **MAJOR**  | 1 | storage⬆️ |
|   3 | aiobotocore               | 2.3.0           | 2.6.0      | *minor*    | 1 | storage⬆️ |
|   4 | aiofiles                  | 0.8.0           | 23.2.1     | **MAJOR**  | 1 | storage⬆️ |
|   5 | aioitertools              | 0.10.0          | 0.11.0     | *minor*    | 1 | storage⬆️ |
|   6 | aiormq                    | 6.7.6           | 6.7.7      |            | 1 | storage⬆️ |
|   7 | aiosignal                 | 1.2.0           | 1.3.1      | *minor*    | 2 | storage⬆️🧪 |
|   8 | alembic                   | 1.8.1           | 1.11.3     | *minor*    | 1 | storage⬆️ |
|   9 | async-timeout             | 4.0.2           | 4.0.3      |            | 2 | storage⬆️🧪 |
|  10 | asyncpg                   | 0.27.0          | 0.28.0     | *minor*    | 1 | storage⬆️ |
|  11 | attrs                     | 21.4.0          | 23.1.0     | **MAJOR**  | 2 | storage⬆️🧪 |
|  12 | aws-sam-translator        | 1.55.0          | 1.73.0     | *minor*    | 1 | storage🧪 |
|  13 | boto3                     | 1.21.21         | 1.28.17    | *minor*    | 2 | storage⬆️🧪 |
|  14 | botocore                  | 1.24.21         | 1.31.17    | *minor*    | 2 | storage⬆️🧪 |
|  15 | botocore-stubs            | 1.27.17         | 1.31.38    | *minor*    | 1 | storage⬆️ |
|  16 | cfn-lint                  | 0.72.6          | 0.77.10    | *minor*    | 1 | storage🧪 |
|  17 | charset-normalizer        | 2.0.12          | 3.2.0      | **MAJOR**  | 2 | storage⬆️🧪 |
|  18 | click                     | 8.1.3           | 8.1.7      |            | 3 | storage⬆️🧪🔧 |
|  19 | dnspython                 | 2.2.1           | 2.4.2      | *minor*    | 1 | storage⬆️ |
|  20 | email-validator           | 1.2.1           | 2.0.0.post2 | **MAJOR**  | 1 | storage⬆️ |
|  21 | faker                     | 19.3.0          | 19.3.1     |            | 1 | storage🧪 |
|  22 | filelock                  | 3.12.2          | 3.12.3     |            | 1 | storage🔧 |
|  23 | flask                     | 2.2.5           | 2.3.3      | *minor*    | 1 | storage🧪 |
|  24 | frozenlist                | 1.3.0           | 1.4.0      | *minor*    | 2 | storage⬆️🧪 |
|  25 | icdiff                    | 2.0.6           | 2.0.7      |            | 1 | storage🧪 |
|  26 | identify                  | 2.5.26          | 2.5.27     |            | 1 | storage🔧 |
|  27 | idna                      | 3.3             | 3.4        | *minor*    | 2 | storage⬆️🧪 |
|  28 | jmespath                  | 1.0.0           | 1.0.1      |            | 2 | storage⬆️🧪 |
|  29 | jsonschema                | 3.2.0           | 4.19.0     | **MAJOR**  | 2 | storage⬆️🧪 |
|  30 | lazy-object-proxy         | 1.7.1           | 1.9.0      | *minor*    | 2 | storage⬆️🔧 |
|  31 | mako                      | 1.2.2           | 1.2.4      |            | 1 | storage⬆️ |
|  32 | markupsafe                | 2.1.1           | 2.1.3      |            | 2 | storage⬆️🧪 |
|  33 | moto                      | 4.1.14          | 4.2.0      | *minor*    | 1 | storage🧪 |
|  34 | multidict                 | 6.0.2           | 6.0.4      |            | 2 | storage⬆️🧪 |
|  35 | mypy                      | 1.5.0           | 1.5.1      |            | 1 | storage🧪 |
|  36 | networkx                  | 2.8.8           | 3.1        | **MAJOR**  | 1 | storage🧪 |
|  37 | openapi-core              | 0.12.0          | 0.18.0     | *minor*    | 1 | storage⬆️ |
|  38 | openapi-schema-validator  | 0.2.3           | 0.6.0      | *minor*    | 2 | storage⬆️🧪 |
|  39 | openapi-spec-validator    | 0.4.0           | 0.6.0      | *minor*    | 2 | storage⬆️🧪 |
|  40 | pandas                    | 2.0.3           | 2.1.0      | *minor*    | 1 | storage🧪 |
|  41 | pluggy                    | 1.2.0           | 1.3.0      | *minor*    | 1 | storage🧪 |
|  42 | prometheus-client         | 0.14.1          | 0.17.1     | *minor*    | 1 | storage⬆️ |
|  43 | psycopg2-binary           | 2.9.6           | 2.9.7      |            | 1 | storage⬆️ |
|  44 | pydantic                  | 1.9.0           | 1.10.12    | *minor*    | 1 | storage⬆️ |
|  45 | pygments                  | 2.15.1          | 2.16.1     | *minor*    | 1 | storage⬆️ |
|  46 | pyinstrument              | 4.1.1           | 4.5.1      | *minor*    | 1 | storage⬆️ |
|  47 | pyparsing                 | 3.1.1           | 3.1.1      |            | 1 | storage🧪 |
|  48 | pyrsistent                | 0.18.1          | 🗑️ removed |  | 2 | storage⬆️🧪 |
|  49 | redis                     | 4.5.4           | 5.0.0      | **MAJOR**  | 1 | storage⬆️ |
|  50 | rich                      | 13.4.2          | 13.5.2     | *minor*    | 1 | storage⬆️ |
|  51 | ruff                      | 0.0.284         | 0.0.286    |            | 1 | storage🔧 |
|  52 | s3transfer                | 0.5.2           | 0.6.2      | *minor*    | 2 | storage⬆️🧪 |
|  53 | semantic-version          | 2.9.0           | 2.10.0     | *minor*    | 1 | storage⬆️ |
|  54 | sqlalchemy                | 1.4.47          | 1.4.49     |            | 2 | storage⬆️🧪 |
|  55 | strict-rfc3339            | 0.7             | 🗑️ removed |  | 1 | storage⬆️ |
|  56 | tenacity                  | 8.0.1           | 8.2.3      | *minor*    | 1 | storage⬆️ |
|  57 | tqdm                      | 4.64.0          | 4.66.1     | *minor*    | 1 | storage⬆️ |
|  58 | typer                     | 0.4.1           | 0.9.0      | *minor*    | 1 | storage⬆️ |
|  59 | types-aiobotocore         | 2.3.3           | 2.6.0      | *minor*    | 1 | storage⬆️ |
|  60 | types-aiobotocore-s3      | 2.3.3           | 2.6.0      | *minor*    | 1 | storage⬆️ |
|  61 | typing-extensions         | 4.3.0           | 4.7.1      | *minor*    | 3 | storage⬆️🧪🔧 |
|  62 | ujson                     | 5.5.0           | 5.8.0      | *minor*    | 1 | storage⬆️ |
|  63 | urllib3                   | 1.26.9          | 1.26.16    |            | 2 | storage⬆️🧪 |
|  64 | virtualenv                | 20.24.3         | 20.24.4    |            | 1 | storage🔧 |
|  65 | websocket-client          | 1.6.1           | 1.6.2      |            | 1 | storage🧪 |
|  66 | werkzeug                  | 2.2.2           | 2.3.7      | *minor*    | 2 | storage⬆️🧪 |
|  67 | wheel                     | 0.41.1          | 0.41.2     |            | 1 | storage🔧 |
|  68 | wrapt                     | 1.14.1          | 1.15.0     | *minor*    | 3 | storage⬆️🧪🔧 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency