### PR TITLE
⚗️ `storage` remove task concurrency locking while duplicating a project

### DIFF
--- a/packages/service-library/src/servicelib/sequences_utils.py
+++ b/packages/service-library/src/servicelib/sequences_utils.py
@@ -1,6 +1,6 @@
 import itertools
 from collections.abc import Generator, Iterable
-from typing import Any, TypeVar
+from typing import TypeVar
 
 import toolz
 from pydantic import NonNegativeInt
@@ -9,8 +9,8 @@ T = TypeVar("T")
 
 
 def partition_gen(
-    input_list: Iterable, *, slice_size: NonNegativeInt
-) -> Generator[tuple[Any, ...], None, None]:
+    input_list: Iterable[T], *, slice_size: NonNegativeInt
+) -> Generator[tuple[T, ...], None, None]:
     """
     Given an iterable and the slice_size yields tuples containing
     slice_size elements in them.

--- a/packages/service-library/src/servicelib/sequences_utils.py
+++ b/packages/service-library/src/servicelib/sequences_utils.py
@@ -1,0 +1,37 @@
+import itertools
+from collections.abc import Generator, Iterable
+from typing import Any, TypeVar
+
+import toolz
+from pydantic import NonNegativeInt
+
+T = TypeVar("T")
+
+
+def partition_gen(
+    input_list: Iterable, *, slice_size: NonNegativeInt
+) -> Generator[tuple[Any, ...], None, None]:
+    """
+    Given an iterable and the slice_size yields tuples containing
+    slice_size elements in them.
+    Inputs:
+        input_list= [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+        slice_size = 5
+    Outputs:
+        [(1, 2, 3, 4, 5), (6, 7, 8, 9, 10), (11, 12, 13)]
+    """
+    if not input_list:
+        yield ()
+
+    yield from toolz.partition_all(slice_size, input_list)
+
+
+def pairwise(iterable: Iterable[T]) -> Iterable[tuple[T, T]]:
+    """
+    s -> (s0,s1), (s1,s2), (s2, s3), ...
+    NOTE: it requires at least 2 elements to produce a pair,
+    otherwise an empty sequence will be returned
+    """
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b, strict=False)

--- a/packages/service-library/tests/test_sequences_utils.py
+++ b/packages/service-library/tests/test_sequences_utils.py
@@ -1,0 +1,72 @@
+from collections.abc import Iterable
+from typing import Any
+
+import pytest
+from servicelib.sequences_utils import T, pairwise, partition_gen
+
+
+@pytest.mark.parametrize(
+    "slice_size, input_list, expected, ",
+    [
+        pytest.param(
+            5,
+            list(range(13)),
+            [(0, 1, 2, 3, 4), (5, 6, 7, 8, 9), (10, 11, 12)],
+            id="group_5_last_group_is_smaller",
+        ),
+        pytest.param(
+            2,
+            list(range(5)),
+            [(0, 1), (2, 3), (4,)],
+            id="group_2_last_group_is_smaller",
+        ),
+        pytest.param(
+            2,
+            list(range(4)),
+            [(0, 1), (2, 3)],
+            id="group_2_last_group_is_the_same",
+        ),
+        pytest.param(
+            10,
+            list(range(4)),
+            [(0, 1, 2, 3)],
+            id="only_one_group_if_list_is_not_bit_enough",
+        ),
+        pytest.param(
+            3,
+            [],
+            [()],
+            id="input_is_empty_returns_an_empty_list",
+        ),
+        pytest.param(
+            5,
+            list(range(13)),
+            [(0, 1, 2, 3, 4), (5, 6, 7, 8, 9), (10, 11, 12)],
+            id="group_5_using_generator",
+        ),
+    ],
+)
+def test_partition_gen(
+    input_list: list[Any], expected: list[tuple[Any, ...]], slice_size: int
+):
+    # check returned result
+    result = list(partition_gen(input_list, slice_size=slice_size))
+    assert result == expected
+
+    # check returned type
+    for entry in result:
+        assert type(entry) == tuple
+
+
+@pytest.mark.parametrize(
+    "input_iter, expected",
+    [
+        pytest.param([], [], id="0_elements"),
+        pytest.param([1], [], id="1_element"),
+        pytest.param([1, 2], [(1, 2)], id="2_elements"),
+        pytest.param([1, 2, 3], [(1, 2), (2, 3)], id="3_elements"),
+        pytest.param([1, 2, 3, 4], [(1, 2), (2, 3), (3, 4)], id="4_elements"),
+    ],
+)
+def test_pairwise(input_iter: Iterable[T], expected: Iterable[tuple[T, T]]):
+    assert list(pairwise(input_iter)) == expected

--- a/packages/service-library/tests/test_utils.py
+++ b/packages/service-library/tests/test_utils.py
@@ -7,16 +7,10 @@ from collections.abc import Awaitable, Coroutine
 from copy import copy
 from pathlib import Path
 from random import randint
-from typing import Any
 
 import pytest
 from faker import Faker
-from servicelib.utils import (
-    ensure_ends_with,
-    fire_and_forget_task,
-    logged_gather,
-    partition_gen,
-)
+from servicelib.utils import ensure_ends_with, fire_and_forget_task, logged_gather
 
 
 async def _value_error(uid, *, delay=1):
@@ -181,56 +175,3 @@ def test_ensure_ends_with(original: str, termination: str, expected: str):
     assert original_copy == original
     assert terminated_string.endswith(termination)
     assert terminated_string == expected
-
-
-@pytest.mark.parametrize(
-    "slice_size, input_list, expected, ",
-    [
-        pytest.param(
-            5,
-            list(range(13)),
-            [(0, 1, 2, 3, 4), (5, 6, 7, 8, 9), (10, 11, 12)],
-            id="group_5_last_group_is_smaller",
-        ),
-        pytest.param(
-            2,
-            list(range(5)),
-            [(0, 1), (2, 3), (4,)],
-            id="group_2_last_group_is_smaller",
-        ),
-        pytest.param(
-            2,
-            list(range(4)),
-            [(0, 1), (2, 3)],
-            id="group_2_last_group_is_the_same",
-        ),
-        pytest.param(
-            10,
-            list(range(4)),
-            [(0, 1, 2, 3)],
-            id="only_one_group_if_list_is_not_bit_enough",
-        ),
-        pytest.param(
-            3,
-            [],
-            [()],
-            id="input_is_empty_returns_an_empty_list",
-        ),
-        pytest.param(
-            5,
-            list(range(13)),
-            [(0, 1, 2, 3, 4), (5, 6, 7, 8, 9), (10, 11, 12)],
-            id="group_5_using_generator",
-        ),
-    ],
-)
-def test_partition_gen(
-    input_list: list[Any], expected: list[tuple[Any, ...]], slice_size: int
-):
-    # check returned result
-    result = list(partition_gen(input_list, slice_size=slice_size))
-    assert result == expected
-
-    # check returned type
-    for entry in result:
-        assert type(entry) == tuple

--- a/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
+++ b/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
@@ -9,15 +9,7 @@ import json
 import logging
 import os
 from collections import namedtuple
-from collections.abc import (
-    AsyncIterable,
-    AsyncIterator,
-    Awaitable,
-    Callable,
-    Coroutine,
-    Iterable,
-)
-from itertools import tee
+from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Coroutine
 from pathlib import Path
 from typing import Any, Optional, cast
 from uuid import uuid4
@@ -64,6 +56,7 @@ from servicelib.fastapi.long_running_tasks.client import (
     periodic_task_result,
 )
 from servicelib.progress_bar import ProgressBarData
+from servicelib.sequences_utils import pairwise
 from settings_library.rabbit import RabbitSettings
 from settings_library.redis import RedisSettings
 from simcore_postgres_database.models.comp_pipeline import comp_pipeline
@@ -751,15 +744,8 @@ async def _wait_for_dy_services_to_fully_stop(
             assert False, "Timeout reached"
 
 
-def _pairwise(iterable) -> Iterable[tuple[Any, Any]]:
-    "s -> (s0,s1), (s1,s2), (s2, s3), ..."
-    a, b = tee(iterable)
-    next(b, None)
-    return zip(a, b)
-
-
 def _assert_same_set(*sets_to_compare: set[Any]) -> None:
-    for first, second in _pairwise(sets_to_compare):
+    for first, second in pairwise(sets_to_compare):
         assert first == second
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

- ✨ added `partition_gen` and `pairwise` sequence dividers
- ⚗️ I have a hunch something is wrong with `logged_gather` when providing the max_concurrency flag, using a different approach to achieve the same result.


Why am I trying this? We have a locking mechanism inside `logged_gather` (the `AsyncSemaphore`) and I think it could be the culprit why the copy of very large studies hangs. I have no explanation to why this happens.

This PR archives the same result without using blocking.

NOTE: if this is the issue I will refactor `logged_gather`'s internals to use `partition_gen` instead of an `AsyncSemaphore`


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
