### PR TITLE
♻️Rabbitmq rpc: response shall not be jsonized

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -23,5 +23,8 @@ exclude_lines =
     if 0:
     if __name__ == .__main__.:
 
+    # Don't complain about abstract methods, they aren't run:
+    @(abc\.)?abstractmethod
+
 ignore_errors = True
 show_missing = True

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -51,7 +51,7 @@ target-version = "py310"
 
 
 [per-file-ignores]
-"{**/{tests, pytest_simcore}/**}" = [
+"**/{tests,pytest_simcore}/**" = [
   "T201",    # print found
   "ARG001",  # unused function argument
   "PT019",   # user pytest.mark.usefixture

--- a/packages/service-library/src/servicelib/rabbitmq/_errors.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_errors.py
@@ -20,3 +20,9 @@ class RemoteMethodNotRegisteredError(BaseRPCError):
         "Could not find a remote method named: '{method_name}'. "
         "Message from remote server was returned: {incoming_message}. "
     )
+
+
+class RPCServerError(BaseRPCError):
+    msg_template = (
+        "Unhandled error while running method '{exc_type}:{method_name}': '{msg}'"
+    )

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc_router.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc_router.py
@@ -3,7 +3,6 @@
 
 from collections.abc import Awaitable, Callable
 
-import orjson
 import pytest
 from faker import Faker
 from servicelib.rabbitmq import (
@@ -59,21 +58,21 @@ async def test_exposed_methods(
         router, router_namespace, a_arg, a_global_kwarg=a_kwargs
     )
 
-    json_result = await rpc_client.request(
+    rpc_result = await rpc_client.request(
         router_namespace,
         RPCMethodName(a_str_method.__name__),
         a_specific_kwarg=a_specific_kwarg,
     )
-    assert isinstance(json_result, bytes)
-    result = orjson.loads(json_result)
+    assert isinstance(rpc_result, str)
+    result = rpc_result
     assert result == f"{a_arg}, that was a winner! {a_kwargs} {a_specific_kwarg}"
 
-    json_result = await rpc_client.request(
+    rpc_result = await rpc_client.request(
         router_namespace,
         RPCMethodName(an_int_method.__name__),
     )
-    assert isinstance(json_result, bytes)
-    result = orjson.loads(json_result)
+    assert isinstance(rpc_result, int)
+    result = rpc_result
     assert result == 34
 
     with pytest.raises(RuntimeError):

--- a/scripts/common.Makefile
+++ b/scripts/common.Makefile
@@ -72,6 +72,12 @@ hel%:
 	@echo ""
 
 
+.env: .env-devel ## creates .env file from defaults in .env-devel
+	$(if $(wildcard $@), \
+	@echo "WARNING #####  $< is newer than $@ ####"; diff -uN $@ $<; false;,\
+	@echo "WARNING ##### $@ does not exist, cloning $< as $@ ############"; cp $< $@)
+
+
 .PHONY: devenv
 devenv: ## build development environment
 	@$(MAKE_C) $(REPO_BASE_DIR) $@

--- a/services/clusters-keeper/Makefile
+++ b/services/clusters-keeper/Makefile
@@ -4,10 +4,6 @@
 include ../../scripts/common.Makefile
 include ../../scripts/common-service.Makefile
 
-.env: .env-devel ## creates .env file from defaults in .env-devel
-	$(if $(wildcard $@), \
-	@echo "WARNING #####  $< is newer than $@ ####"; diff -uN $@ $<; false;,\
-	@echo "WARNING ##### $@ does not exist, cloning $< as $@ ############"; cp $< $@)
 
 
 .PHONY: test-local

--- a/services/clusters-keeper/tests/unit/test_rpc_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_rpc_clusters.py
@@ -152,7 +152,8 @@ async def test_get_or_create_cluster(
         wallet_id=wallet_id,
     )
     assert rpc_response
-    created_cluster = ClusterGet.parse_raw(rpc_response)
+    assert isinstance(rpc_response, ClusterGet)
+    created_cluster = rpc_response
     # check we do have a new machine in AWS
     await _assert_cluster_instance_created(ec2_client, user_id, wallet_id)
     # it is called once as moto server creates instances instantly
@@ -167,7 +168,8 @@ async def test_get_or_create_cluster(
         wallet_id=wallet_id,
     )
     assert rpc_response
-    returned_cluster = ClusterGet.parse_raw(rpc_response)
+    assert isinstance(rpc_response, OnDemandCluster)
+    returned_cluster = rpc_response
     # check we still have only 1 instance
     await _assert_cluster_heartbeat_on_instance(ec2_client)
     mocked_dask_ping_gateway.ping_gateway.assert_called_once()

--- a/services/clusters-keeper/tests/unit/test_rpc_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_rpc_clusters.py
@@ -168,7 +168,7 @@ async def test_get_or_create_cluster(
         wallet_id=wallet_id,
     )
     assert rpc_response
-    assert isinstance(rpc_response, OnDemandCluster)
+    assert isinstance(rpc_response, ClusterGet)
     returned_cluster = rpc_response
     # check we still have only 1 instance
     await _assert_cluster_heartbeat_on_instance(ec2_client)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?
- [x] do **not** jsonize the RPC response.
- [x] have a RPCServerError


The concept is to have a common/shared interface module that defines the types of whatever is returned through RPC


## Related issue/s
pre-requisite of https://github.com/ITISFoundation/osparc-simcore/pull/4703
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
