### PR TITLE
✨Comp backend: Clusters-keeper can create a cluster with no wallet ID defined

### DIFF
--- a/packages/models-library/src/models_library/rpc_schemas_clusters_keeper/clusters.py
+++ b/packages/models-library/src/models_library/rpc_schemas_clusters_keeper/clusters.py
@@ -20,6 +20,6 @@ class OnDemandCluster(BaseModel):
     authentication: ClusterAuthentication
     state: ClusterState
     user_id: UserID
-    wallet_id: WalletID
+    wallet_id: WalletID | None
     gateway_ready: bool
     eta: datetime.timedelta

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
@@ -24,7 +24,7 @@ _logger = logging.getLogger(__name__)
 
 
 async def create_cluster(
-    app: FastAPI, *, user_id: UserID, wallet_id: WalletID
+    app: FastAPI, *, user_id: UserID, wallet_id: WalletID | None
 ) -> list[EC2InstanceData]:
     ec2_client = get_ec2_client(app)
     app_settings = get_application_settings(app)
@@ -56,7 +56,7 @@ async def get_all_clusters(app: FastAPI) -> list[EC2InstanceData]:
 
 
 async def get_cluster(
-    app: FastAPI, *, user_id: UserID, wallet_id: WalletID
+    app: FastAPI, *, user_id: UserID, wallet_id: WalletID | None
 ) -> EC2InstanceData:
     app_settings = get_application_settings(app)
     assert app_settings.CLUSTERS_KEEPER_EC2_INSTANCES  # nosec
@@ -70,7 +70,7 @@ async def get_cluster(
 
 
 async def cluster_heartbeat(
-    app: FastAPI, *, user_id: UserID, wallet_id: WalletID
+    app: FastAPI, *, user_id: UserID, wallet_id: WalletID | None
 ) -> None:
     app_settings = get_application_settings(app)
     assert app_settings.CLUSTERS_KEEPER_EC2_INSTANCES  # nosec

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
@@ -17,7 +17,7 @@ router = RPCRouter()
 
 @router.expose()
 async def get_or_create_cluster(
-    app: FastAPI, *, user_id: UserID, wallet_id: WalletID
+    app: FastAPI, *, user_id: UserID, wallet_id: WalletID | None
 ) -> OnDemandCluster:
     """Get or create cluster for user_id and wallet_id
     This function will create a new instance on AWS if needed or return the already running one.

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
@@ -66,7 +66,7 @@ def _create_eta(
 def create_cluster_from_ec2_instance(
     instance: EC2InstanceData,
     user_id: UserID,
-    wallet_id: WalletID,
+    wallet_id: WalletID | None,
     gateway_password: SecretStr,
     *,
     gateway_ready: bool,

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/ec2.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/ec2.py
@@ -17,7 +17,7 @@ HEARTBEAT_TAG_KEY: Final[str] = "last_heartbeat"
 
 
 def creation_ec2_tags(
-    app_settings: ApplicationSettings, *, user_id: UserID, wallet_id: WalletID
+    app_settings: ApplicationSettings, *, user_id: UserID, wallet_id: WalletID | None
 ) -> EC2Tags:
     assert app_settings.CLUSTERS_KEEPER_EC2_INSTANCES  # nosec
     return _DEFAULT_CLUSTERS_KEEPER_TAGS | {
@@ -38,7 +38,7 @@ def get_user_id_from_tags(tags: EC2Tags) -> UserID:
 
 
 def ec2_instances_for_user_wallet_filter(
-    user_id: UserID, wallet_id: WalletID
+    user_id: UserID, wallet_id: WalletID | None
 ) -> EC2Tags:
     return (
         _DEFAULT_CLUSTERS_KEEPER_TAGS

--- a/services/director-v2/src/simcore_service_director_v2/modules/clusters_keeper.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/clusters_keeper.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-from typing import Final
 
 from models_library.clusters import BaseCluster, ClusterTypeInModel
 from models_library.rpc_schemas_clusters_keeper.clusters import (
@@ -8,7 +7,6 @@ from models_library.rpc_schemas_clusters_keeper.clusters import (
     OnDemandCluster,
 )
 from models_library.users import UserID
-from models_library.wallets import WalletID
 from servicelib.rabbitmq import (
     RabbitMQRPCClient,
     RemoteMethodNotRegisteredError,
@@ -23,7 +21,6 @@ from ..core.errors import (
 
 _logger = logging.getLogger(__name__)
 
-_TEMPORARY_DEFAULT_WALLET_ID: Final[WalletID] = 43
 _TIME_FORMAT = "{:02d}:{:02d}"  # format for minutes:seconds
 
 
@@ -40,7 +37,7 @@ async def get_or_create_on_demand_cluster(
             RPCMethodName("get_or_create_cluster"),
             timeout_s=300,
             user_id=user_id,
-            wallet_id=_TEMPORARY_DEFAULT_WALLET_ID,
+            wallet_id=None,  # NOTE: --> MD this will need to be replaced by the real walletID
         )
         _logger.info("received cluster: %s", returned_cluster)
         if returned_cluster.state is not ClusterState.RUNNING:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?
allows an EC2 instance created by clusters-keeper to have a walletID set to None


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
