### PR TITLE
♻️On-demand clusters: remove dask-gateway

### DIFF
--- a/packages/models-library/src/models_library/rpc_schemas_clusters_keeper/clusters.py
+++ b/packages/models-library/src/models_library/rpc_schemas_clusters_keeper/clusters.py
@@ -21,5 +21,5 @@ class OnDemandCluster(BaseModel):
     state: ClusterState
     user_id: UserID
     wallet_id: WalletID | None
-    gateway_ready: bool
+    dask_scheduler_ready: bool
     eta: datetime.timedelta

--- a/packages/pytest-simcore/src/pytest_simcore/dask_scheduler.py
+++ b/packages/pytest-simcore/src/pytest_simcore/dask_scheduler.py
@@ -1,0 +1,60 @@
+from collections.abc import AsyncIterable, Callable
+
+import pytest
+from distributed import Scheduler, SpecCluster, Worker
+from yarl import URL
+
+
+@pytest.fixture
+async def dask_spec_local_cluster(
+    monkeypatch: pytest.MonkeyPatch,
+    unused_tcp_port_factory: Callable,
+) -> AsyncIterable[SpecCluster]:
+    # in this mode we can precisely create a specific cluster
+    workers = {
+        "cpu-worker": {
+            "cls": Worker,
+            "options": {
+                "nthreads": 2,
+                "resources": {"CPU": 2, "RAM": 48e9},
+            },
+        },
+        "gpu-worker": {
+            "cls": Worker,
+            "options": {
+                "nthreads": 1,
+                "resources": {
+                    "CPU": 1,
+                    "GPU": 1,
+                    "RAM": 48e9,
+                },
+            },
+        },
+        "bigcpu-worker": {
+            "cls": Worker,
+            "options": {
+                "nthreads": 1,
+                "resources": {
+                    "CPU": 8,
+                    "RAM": 768e9,
+                },
+            },
+        },
+    }
+    scheduler = {
+        "cls": Scheduler,
+        "options": {
+            "port": unused_tcp_port_factory(),
+            "dashboard_address": f":{unused_tcp_port_factory()}",
+        },
+    }
+
+    async with SpecCluster(
+        workers=workers, scheduler=scheduler, asynchronous=True, name="pytest_cluster"
+    ) as cluster:
+        scheduler_address = URL(cluster.scheduler_address)
+        monkeypatch.setenv(
+            "COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_URL",
+            f"{scheduler_address}" or "invalid",
+        )
+        yield cluster

--- a/services/clusters-keeper/Makefile
+++ b/services/clusters-keeper/Makefile
@@ -6,10 +6,18 @@ include ../../scripts/common-service.Makefile
 
 
 
-.PHONY: test-local
+.PHONY: up-devel down
 up-devel: .env ## starts local test application (running bare metal against AWS)
 	# setting up dependencies
 	@docker compose up
 
 down: .env ## stops local test app dependencies (running bare metal against AWS)
 	-@docker compose down
+
+.PHONY: test-dask-schduler-deploy
+test-dask-scheduler-deploy:
+	# using local/dask-sidecar:production images
+	@DOCKER_IMAGE_TAG=production \
+	DOCKER_REGISTRY=local \
+	LOG_LEVEL=INFO \
+	docker compose --file=src/simcore_service_clusters_keeper/data/docker-compose.yml up

--- a/services/clusters-keeper/Makefile
+++ b/services/clusters-keeper/Makefile
@@ -14,10 +14,21 @@ up-devel: .env ## starts local test application (running bare metal against AWS)
 down: .env ## stops local test app dependencies (running bare metal against AWS)
 	-@docker compose down
 
+
+PHONY: .init-swarm
+.init-swarm:
+	# Ensures swarm is initialized
+	$(if $(SWARM_HOSTS),,docker swarm init --advertise-addr=$(get_my_ip))
+
+
 .PHONY: test-dask-schduler-deploy
-test-dask-scheduler-deploy:
+deploy-dask-stack: .init-swarm ## deploy the dask stack for local testing
 	# using local/dask-sidecar:production images
 	@DOCKER_IMAGE_TAG=production \
 	DOCKER_REGISTRY=local \
 	LOG_LEVEL=INFO \
-	docker compose --file=src/simcore_service_clusters_keeper/data/docker-compose.yml up
+	docker stack deploy --with-registry-auth --compose-file=src/simcore_service_clusters_keeper/data/docker-compose.yml osparc_dask_stack
+
+down-dask-stack: ## removes the dask stack
+	# stopping dask stack
+	-@docker stack rm osparc_dask_stack

--- a/services/clusters-keeper/requirements/_base.in
+++ b/services/clusters-keeper/requirements/_base.in
@@ -17,7 +17,6 @@
 
 aioboto3
 dask[distributed]
-dask-gateway
 fastapi
 packaging
 types-aiobotocore[ec2]

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -37,7 +37,6 @@ aiohttp==3.8.5
     #   -c requirements/../../../requirements/constraints.txt
     #   aiobotocore
     #   aiodocker
-    #   dask-gateway
 aioitertools==0.11.0
     # via aiobotocore
 aiormq==6.7.7
@@ -92,7 +91,6 @@ click==8.1.7
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-    #   dask-gateway
     #   distributed
     #   typer
     #   uvicorn
@@ -105,15 +103,11 @@ dask==2023.3.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/_base.in
-    #   dask-gateway
     #   distributed
-dask-gateway==2023.1.1
-    # via -r requirements/_base.in
 distributed==2023.3.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-    #   dask-gateway
 dnspython==2.4.2
     # via email-validator
 email-validator==2.0.0.post2
@@ -280,7 +274,6 @@ pyyaml==6.0.1
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
-    #   dask-gateway
     #   distributed
 redis==5.0.0
     # via
@@ -354,7 +347,6 @@ toolz==0.12.0
 tornado==6.3.3
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
-    #   dask-gateway
     #   distributed
 tqdm==4.66.1
     # via

--- a/services/clusters-keeper/requirements/_test.in
+++ b/services/clusters-keeper/requirements/_test.in
@@ -14,7 +14,6 @@
 aiodocker
 asgi-lifespan
 coverage
-dask-gateway-server[local]
 debugpy
 deepdiff
 docker

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -13,7 +13,6 @@ aiohttp==3.8.5
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aiodocker
-    #   dask-gateway-server
 aiosignal==1.3.1
     # via
     #   -c requirements/_base.txt
@@ -75,8 +74,6 @@ click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   flask
-colorlog==6.7.0
-    # via dask-gateway-server
 coverage==7.3.1
     # via
     #   -r requirements/_test.in
@@ -84,12 +81,9 @@ coverage==7.3.1
 cryptography==41.0.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
-    #   dask-gateway-server
     #   moto
     #   python-jose
     #   sshpubkeys
-dask-gateway-server==2023.1.1
-    # via -r requirements/_test.in
 debugpy==1.8.0
     # via -r requirements/_test.in
 deepdiff==6.5.0
@@ -125,8 +119,6 @@ frozenlist==1.4.0
     #   aiosignal
 graphql-core==3.2.3
     # via moto
-greenlet==2.0.2
-    # via sqlalchemy
 h11==0.14.0
     # via
     #   -c requirements/_base.txt
@@ -339,10 +331,6 @@ sortedcontainers==2.4.0
     # via
     #   -c requirements/_base.txt
     #   fakeredis
-sqlalchemy==1.4.49
-    # via
-    #   -c requirements/../../../requirements/constraints.txt
-    #   dask-gateway-server
 sshpubkeys==3.3.1
     # via moto
 sympy==1.12
@@ -351,8 +339,6 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-traitlets==5.9.0
-    # via dask-gateway-server
 types-pyyaml==6.0.12.11
     # via responses
 typing-extensions==4.7.1

--- a/services/clusters-keeper/setup.py
+++ b/services/clusters-keeper/setup.py
@@ -50,6 +50,7 @@ SETUP = dict(
     package_dir={
         "": "src",
     },
+    package_data={"": ["data/*.yml"]},
     include_package_data=True,
     install_requires=PROD_REQUIREMENTS,
     test_suite="tests",

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/_meta.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/_meta.py
@@ -2,6 +2,7 @@
 
 """
 from contextlib import suppress
+from pathlib import Path
 from typing import Final
 
 import pkg_resources
@@ -35,7 +36,11 @@ def get_summary() -> str:
 
 
 SUMMARY: Final[str] = get_summary()
-
+PACKAGE_DATA_FOLDER: Final[Path] = Path(
+    pkg_resources.resource_filename(
+        _current_distribution.project_name.replace("-", "_"), "data"
+    )
+)
 
 # https://patorjk.com/software/taag/#p=testall&f=Avatar&t=clusters_keeper
 APP_STARTED_BANNER_MSG = r"""

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/core/settings.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/core/settings.py
@@ -9,14 +9,7 @@ from models_library.basic_types import (
     LogLevel,
     VersionTag,
 )
-from pydantic import (
-    Field,
-    NonNegativeInt,
-    PositiveInt,
-    SecretStr,
-    parse_obj_as,
-    validator,
-)
+from pydantic import Field, NonNegativeInt, PositiveInt, parse_obj_as, validator
 from settings_library.base import BaseCustomSettings
 from settings_library.docker_registry import RegistrySettings
 from settings_library.rabbit import RabbitSettings
@@ -168,13 +161,8 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
         description="defines the image tag to use for the computational backend",
     )
 
-    CLUSTERS_KEEPER_COMPUTATIONAL_BACKEND_GATEWAY_PASSWORD: SecretStr = Field(
-        default=SecretStr("my_secure_P1ssword"),
-        description="very secure password, should change soon",
-    )
-
     @cached_property
-    def LOG_LEVEL(self):  # noqa: N802
+    def LOG_LEVEL(self) -> LogLevel:  # noqa: N802
         return self.CLUSTERS_KEEPER_LOGLEVEL
 
     @validator("CLUSTERS_KEEPER_LOGLEVEL")

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/core/settings.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/core/settings.py
@@ -161,6 +161,10 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
         description="defines the image tag to use for the computational backend",
     )
 
+    SWARM_STACK_NAME: str = Field(
+        ..., description="Stack name defined upon deploy (see main Makefile)"
+    )
+
     @cached_property
     def LOG_LEVEL(self) -> LogLevel:  # noqa: N802
         return self.CLUSTERS_KEEPER_LOGLEVEL

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.8"
+services:
+  dask-sidecar:
+    image: ${DOCKER_REGISTRY:-itisfoundation}/dask-sidecar:${DOCKER_IMAGE_TAG:-latest}
+    init: true
+    hostname: "{{.Node.Hostname}}-{{.Service.Name}}"
+    volumes:
+      - computational_shared_data:${SIDECAR_COMP_SERVICES_SHARED_FOLDER:-/home/scu/computational_shared_data}
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      DASK_LOG_FORMAT_LOCAL_DEV_ENABLED: 1
+      DASK_NPROCS: 1
+      DASK_SCHEDULER_URL: ${DASK_SCHEDULER_URL:-tcp://dask-scheduler:8786}
+      DASK_SIDECAR_NON_USABLE_RAM: 0
+      DASK_SIDECAR_NUM_NON_USABLE_CPUS: 0
+      LOG_LEVEL: ${LOG_LEVEL:-WARNING}
+      SIDECAR_COMP_SERVICES_SHARED_FOLDER: ${SIDECAR_COMP_SERVICES_SHARED_FOLDER:-/home/scu/computational_shared_data}
+      SIDECAR_COMP_SERVICES_SHARED_VOLUME_NAME: computational_shared_data
+    networks:
+      - default
+
+  dask-scheduler:
+    image: ${DOCKER_REGISTRY:-itisfoundation}/dask-sidecar:${DOCKER_IMAGE_TAG:-latest}
+    init: true
+    hostname: "{{.Node.Hostname}}-{{.Service.Name}}-{{.Task.Slot}}"
+    environment:
+      DASK_START_AS_SCHEDULER: 1
+      LOG_LEVEL: ${LOG_LEVEL:-WARNING}
+
+    networks:
+      - default
+
+volumes:
+  computational_shared_data:
+
+
+networks:
+  default:
+    attachable: true

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -36,7 +36,7 @@ services:
 
 volumes:
   computational_shared_data:
-
+    name: computational_shared_data
 
 networks:
   default:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   dask-sidecar:
-    image: ${DOCKER_REGISTRY:-itisfoundation}/dask-sidecar:${DOCKER_IMAGE_TAG:-latest}
+    image: ${DOCKER_REGISTRY:-itisfoundation}/dask-sidecar:${DOCKER_IMAGE_TAG}
     init: true
     hostname: "{{.Node.Hostname}}-{{.Service.Name}}"
     volumes:
@@ -18,15 +18,19 @@ services:
       SIDECAR_COMP_SERVICES_SHARED_VOLUME_NAME: computational_shared_data
     networks:
       - default
+    deploy:
+      mode: global
 
   dask-scheduler:
-    image: ${DOCKER_REGISTRY:-itisfoundation}/dask-sidecar:${DOCKER_IMAGE_TAG:-latest}
+    image: ${DOCKER_REGISTRY:-itisfoundation}/dask-sidecar:${DOCKER_IMAGE_TAG}
     init: true
     hostname: "{{.Node.Hostname}}-{{.Service.Name}}-{{.Task.Slot}}"
     environment:
       DASK_START_AS_SCHEDULER: 1
       LOG_LEVEL: ${LOG_LEVEL:-WARNING}
-
+    ports:
+      - 8786:8786
+      - 8787:8787
     networks:
       - default
 

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/dask.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/dask.py
@@ -1,13 +1,11 @@
 import logging
 from collections.abc import Coroutine
-from typing import Any, Final
+from typing import Any
 
 import distributed
 from pydantic import AnyUrl
 
 _logger = logging.getLogger(__name__)
-
-_PING_USERNAME: Final[str] = "osparc-cluster"
 
 
 async def _wrap_client_async_routine(

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/dask.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/dask.py
@@ -34,7 +34,7 @@ async def ping_scheduler(url: AnyUrl) -> bool:
 
 
 async def is_scheduler_busy(url: AnyUrl) -> bool:
-    async with distributed.Client(f"{url}", asynchronous=True) as client:
+    async with distributed.Client(url, asynchronous=True) as client:
         datasets_on_scheduler = await _wrap_client_async_routine(client.list_datasets())
         _logger.info("cluster currently has %s datasets", len(datasets_on_scheduler))
         num_processing_tasks = 0

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/dask.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/dask.py
@@ -21,7 +21,7 @@ async def _wrap_client_async_routine(
 
 async def ping_scheduler(url: AnyUrl) -> bool:
     try:
-        async with distributed.Client(f"{url}", asynchronous=True, timeout="5"):
+        async with distributed.Client(url, asynchronous=True, timeout="5"):
             ...
         return True
     except OSError:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
@@ -5,7 +5,6 @@ from models_library.wallets import WalletID
 from servicelib.rabbitmq import RPCRouter
 
 from ..core.errors import Ec2InstanceNotFoundError
-from ..core.settings import get_application_settings
 from ..models import EC2InstanceData
 from ..modules import clusters
 from ..modules.dask import ping_scheduler
@@ -38,12 +37,10 @@ async def get_or_create_cluster(
         assert len(new_ec2_instances) == 1  # nosec
         ec2_instance = new_ec2_instances[0]
     assert ec2_instance is not None  # nosec
-    app_settings = get_application_settings(app)
     return create_cluster_from_ec2_instance(
         ec2_instance,
         user_id,
         wallet_id,
-        app_settings.CLUSTERS_KEEPER_COMPUTATIONAL_BACKEND_GATEWAY_PASSWORD,
         gateway_ready=bool(
             ec2_instance.state == "running"
             and await ping_scheduler(url=get_scheduler_url(ec2_instance))

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
@@ -8,9 +8,9 @@ from ..core.errors import Ec2InstanceNotFoundError
 from ..core.settings import get_application_settings
 from ..models import EC2InstanceData
 from ..modules import clusters
-from ..modules.dask import ping_gateway
+from ..modules.dask import ping_scheduler
 from ..utils.clusters import create_cluster_from_ec2_instance
-from ..utils.dask import get_gateway_url
+from ..utils.dask import get_scheduler_url
 
 router = RPCRouter()
 
@@ -46,9 +46,6 @@ async def get_or_create_cluster(
         app_settings.CLUSTERS_KEEPER_COMPUTATIONAL_BACKEND_GATEWAY_PASSWORD,
         gateway_ready=bool(
             ec2_instance.state == "running"
-            and await ping_gateway(
-                url=get_gateway_url(ec2_instance),
-                password=app_settings.CLUSTERS_KEEPER_COMPUTATIONAL_BACKEND_GATEWAY_PASSWORD,
-            )
+            and await ping_scheduler(url=get_scheduler_url(ec2_instance))
         ),
     )

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
@@ -8,6 +8,7 @@ from ..core.errors import Ec2InstanceNotFoundError
 from ..models import EC2InstanceData
 from ..modules import clusters
 from ..modules.dask import ping_scheduler
+from ..modules.redis import get_redis_client
 from ..utils.clusters import create_cluster_from_ec2_instance
 from ..utils.dask import get_scheduler_url
 
@@ -24,18 +25,23 @@ async def get_or_create_cluster(
     Calling several time will always return the same cluster.
     """
     ec2_instance: EC2InstanceData | None = None
-    try:
-        ec2_instance = await clusters.get_cluster(
-            app, user_id=user_id, wallet_id=wallet_id
-        )
-        await clusters.cluster_heartbeat(app, user_id=user_id, wallet_id=wallet_id)
-    except Ec2InstanceNotFoundError:
-        new_ec2_instances = await clusters.create_cluster(
-            app, user_id=user_id, wallet_id=wallet_id
-        )
-        assert new_ec2_instances  # nosec
-        assert len(new_ec2_instances) == 1  # nosec
-        ec2_instance = new_ec2_instances[0]
+    redis = get_redis_client(app)
+    async with redis.lock_context(
+        f"get_or_create_cluster-{user_id=}-{wallet_id=}",
+        blocking_timeout_s=10,
+    ):
+        try:
+            ec2_instance = await clusters.get_cluster(
+                app, user_id=user_id, wallet_id=wallet_id
+            )
+            await clusters.cluster_heartbeat(app, user_id=user_id, wallet_id=wallet_id)
+        except Ec2InstanceNotFoundError:
+            new_ec2_instances = await clusters.create_cluster(
+                app, user_id=user_id, wallet_id=wallet_id
+            )
+            assert new_ec2_instances  # nosec
+            assert len(new_ec2_instances) == 1  # nosec
+            ec2_instance = new_ec2_instances[0]
     assert ec2_instance is not None  # nosec
     return create_cluster_from_ec2_instance(
         ec2_instance,

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
@@ -28,6 +28,7 @@ async def get_or_create_cluster(
     redis = get_redis_client(app)
     async with redis.lock_context(
         f"get_or_create_cluster-{user_id=}-{wallet_id=}",
+        blocking=True,
         blocking_timeout_s=10,
     ):
         try:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
@@ -41,7 +41,7 @@ async def get_or_create_cluster(
         ec2_instance,
         user_id,
         wallet_id,
-        gateway_ready=bool(
+        dask_scheduler_ready=bool(
             ec2_instance.state == "running"
             and await ping_scheduler(url=get_scheduler_url(ec2_instance))
         ),

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
@@ -51,7 +51,9 @@ def _convert_ec2_state_to_cluster_state(
 
 
 _EC2_INSTANCE_MAX_START_TIME: Final[datetime.timedelta] = datetime.timedelta(minutes=3)
-_GATEWAY_READYNESS_MAX_TIME: Final[datetime.timedelta] = datetime.timedelta(minutes=3)
+_DASK_SCHEDULER_READYNESS_MAX_TIME: Final[datetime.timedelta] = datetime.timedelta(
+    minutes=3
+)
 
 
 def _create_eta(
@@ -63,7 +65,7 @@ def _create_eta(
     estimated_time_to_running = (
         instance_launch_time
         + _EC2_INSTANCE_MAX_START_TIME
-        + _GATEWAY_READYNESS_MAX_TIME
+        + _DASK_SCHEDULER_READYNESS_MAX_TIME
         - now
     )
     if dask_scheduler_ready is True:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
@@ -52,7 +52,7 @@ def _convert_ec2_state_to_cluster_state(
 
 _EC2_INSTANCE_MAX_START_TIME: Final[datetime.timedelta] = datetime.timedelta(minutes=3)
 _DASK_SCHEDULER_READYNESS_MAX_TIME: Final[datetime.timedelta] = datetime.timedelta(
-    minutes=3
+    minutes=1
 )
 
 

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
@@ -57,7 +57,7 @@ _GATEWAY_READYNESS_MAX_TIME: Final[datetime.timedelta] = datetime.timedelta(minu
 def _create_eta(
     instance_launch_time: datetime.datetime,
     *,
-    gateway_ready: bool,
+    dask_scheduler_ready: bool,
 ) -> datetime.timedelta:
     now = datetime.datetime.now(datetime.timezone.utc)
     estimated_time_to_running = (
@@ -66,7 +66,7 @@ def _create_eta(
         + _GATEWAY_READYNESS_MAX_TIME
         - now
     )
-    if gateway_ready is True:
+    if dask_scheduler_ready is True:
         estimated_time_to_running = datetime.timedelta(seconds=0)
     return estimated_time_to_running
 
@@ -76,7 +76,7 @@ def create_cluster_from_ec2_instance(
     user_id: UserID,
     wallet_id: WalletID | None,
     *,
-    gateway_ready: bool,
+    dask_scheduler_ready: bool,
 ) -> OnDemandCluster:
     return OnDemandCluster(
         endpoint=get_scheduler_url(instance),
@@ -84,6 +84,8 @@ def create_cluster_from_ec2_instance(
         state=_convert_ec2_state_to_cluster_state(instance.state),
         user_id=user_id,
         wallet_id=wallet_id,
-        gateway_ready=gateway_ready,
-        eta=_create_eta(instance.launch_time, gateway_ready=gateway_ready),
+        dask_scheduler_ready=dask_scheduler_ready,
+        eta=_create_eta(
+            instance.launch_time, dask_scheduler_ready=dask_scheduler_ready
+        ),
     )

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
@@ -3,20 +3,19 @@ import datetime
 import functools
 from typing import Final
 
-from models_library.clusters import SimpleAuthentication
+from models_library.clusters import NoAuthentication
 from models_library.rpc_schemas_clusters_keeper.clusters import (
     ClusterState,
     OnDemandCluster,
 )
 from models_library.users import UserID
 from models_library.wallets import WalletID
-from pydantic import SecretStr
 from types_aiobotocore_ec2.literals import InstanceStateNameType
 
 from .._meta import PACKAGE_DATA_FOLDER
 from ..core.settings import ApplicationSettings
 from ..models import EC2InstanceData
-from .dask import get_gateway_url
+from .dask import get_scheduler_url
 
 _DOCKER_COMPOSE_FILE_NAME: Final[str] = "docker-compose.yml"
 
@@ -76,15 +75,12 @@ def create_cluster_from_ec2_instance(
     instance: EC2InstanceData,
     user_id: UserID,
     wallet_id: WalletID | None,
-    gateway_password: SecretStr,
     *,
     gateway_ready: bool,
 ) -> OnDemandCluster:
     return OnDemandCluster(
-        endpoint=get_gateway_url(instance),
-        authentication=SimpleAuthentication(
-            username=f"{user_id}", password=gateway_password
-        ),
+        endpoint=get_scheduler_url(instance),
+        authentication=NoAuthentication(),
         state=_convert_ec2_state_to_cluster_state(instance.state),
         user_id=user_id,
         wallet_id=wallet_id,

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/dask.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/dask.py
@@ -1,19 +1,6 @@
-from models_library.clusters import SimpleAuthentication
-from models_library.users import UserID
-from pydantic import AnyUrl, SecretStr, parse_obj_as
+from pydantic import AnyUrl, parse_obj_as
 
 from ..models import EC2InstanceData
-
-
-def get_gateway_url(ec2_instance: EC2InstanceData) -> AnyUrl:
-    url: AnyUrl = parse_obj_as(AnyUrl, f"http://{ec2_instance.aws_public_ip}:8000")
-    return url
-
-
-def get_gateway_authentication(
-    user_id: UserID, password: SecretStr
-) -> SimpleAuthentication:
-    return SimpleAuthentication(username=f"{user_id}", password=password)
 
 
 def get_scheduler_url(ec2_instance: EC2InstanceData) -> AnyUrl:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/dask.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/dask.py
@@ -14,3 +14,8 @@ def get_gateway_authentication(
     user_id: UserID, password: SecretStr
 ) -> SimpleAuthentication:
     return SimpleAuthentication(username=f"{user_id}", password=password)
+
+
+def get_scheduler_url(ec2_instance: EC2InstanceData) -> AnyUrl:
+    url: AnyUrl = parse_obj_as(AnyUrl, f"tcp://{ec2_instance.aws_public_ip}:8786")
+    return url

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/ec2.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/ec2.py
@@ -22,7 +22,7 @@ def creation_ec2_tags(
     assert app_settings.CLUSTERS_KEEPER_EC2_INSTANCES  # nosec
     return _DEFAULT_CLUSTERS_KEEPER_TAGS | {
         # NOTE: this one gets special treatment in AWS GUI and is applied to the name of the instance
-        "Name": f"osparc-dask-scheduler-{app_settings.CLUSTERS_KEEPER_EC2_INSTANCES.CLUSTERS_KEEPER_EC2_INSTANCES_KEY_NAME}-user_id:{user_id}-wallet_id:{wallet_id}",
+        "Name": f"osparc-computational-cluster-manager-{app_settings.SWARM_STACK_NAME}-user_id:{user_id}-wallet_id:{wallet_id}",
         "user_id": f"{user_id}",
         "wallet_id": f"{wallet_id}",
     }

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/ec2.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/ec2.py
@@ -22,7 +22,7 @@ def creation_ec2_tags(
     assert app_settings.CLUSTERS_KEEPER_EC2_INSTANCES  # nosec
     return _DEFAULT_CLUSTERS_KEEPER_TAGS | {
         # NOTE: this one gets special treatment in AWS GUI and is applied to the name of the instance
-        "Name": f"osparc-gateway-server-{app_settings.CLUSTERS_KEEPER_EC2_INSTANCES.CLUSTERS_KEEPER_EC2_INSTANCES_KEY_NAME}-user_id:{user_id}-wallet_id:{wallet_id}",
+        "Name": f"osparc-dask-scheduler-{app_settings.CLUSTERS_KEEPER_EC2_INSTANCES.CLUSTERS_KEEPER_EC2_INSTANCES_KEY_NAME}-user_id:{user_id}-wallet_id:{wallet_id}",
         "user_id": f"{user_id}",
         "wallet_id": f"{wallet_id}",
     }

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/ec2.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/ec2.py
@@ -32,11 +32,6 @@ def all_created_ec2_instances_filter() -> EC2Tags:
     return _DEFAULT_CLUSTERS_KEEPER_TAGS
 
 
-def get_user_id_from_tags(tags: EC2Tags) -> UserID:
-    assert "user_id" in tags  # nosec
-    return UserID(tags["user_id"])
-
-
 def ec2_instances_for_user_wallet_filter(
     user_id: UserID, wallet_id: WalletID | None
 ) -> EC2Tags:

--- a/services/clusters-keeper/tests/unit/conftest.py
+++ b/services/clusters-keeper/tests/unit/conftest.py
@@ -36,7 +36,6 @@ from types_aiobotocore_ec2.client import EC2Client
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
 pytest_plugins = [
-    "pytest_simcore.dask_gateway",
     "pytest_simcore.dask_scheduler",
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_swarm",

--- a/services/clusters-keeper/tests/unit/conftest.py
+++ b/services/clusters-keeper/tests/unit/conftest.py
@@ -37,6 +37,7 @@ from types_aiobotocore_ec2.literals import InstanceTypeType
 
 pytest_plugins = [
     "pytest_simcore.dask_gateway",
+    "pytest_simcore.dask_scheduler",
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_swarm",
     "pytest_simcore.environment_configs",

--- a/services/clusters-keeper/tests/unit/test__meta.py
+++ b/services/clusters-keeper/tests/unit/test__meta.py
@@ -1,0 +1,6 @@
+from simcore_service_clusters_keeper._meta import PACKAGE_DATA_FOLDER
+
+
+def test_access_to_docker_compose_yml_file():
+    assert f"{PACKAGE_DATA_FOLDER}".endswith("data")
+    assert (PACKAGE_DATA_FOLDER / "docker-compose.yml").exists()

--- a/services/clusters-keeper/tests/unit/test_cli.py
+++ b/services/clusters-keeper/tests/unit/test_cli.py
@@ -3,13 +3,16 @@
 # pylint:disable=redefined-outer-name
 
 
+import pytest
+from faker import Faker
 from simcore_service_clusters_keeper.cli import main
 from typer.testing import CliRunner
 
 runner = CliRunner()
 
 
-def test_settings():
+def test_settings(monkeypatch: pytest.MonkeyPatch, faker: Faker):
+    monkeypatch.setenv("SWARM_STACK_NAME", faker.pystr())
     result = runner.invoke(main, ["settings"])
     assert result.exit_code == 0
     assert "APP_NAME=simcore-service-clusters-keeper" in result.stdout

--- a/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
+++ b/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
@@ -90,20 +90,20 @@ async def _assert_cluster_exist_and_state(
 
 @dataclass
 class MockedDaskModule:
-    ping_gateway: MagicMock
-    is_gateway_busy: MagicMock
+    ping_scheduler: MagicMock
+    is_scheduler_busy: MagicMock
 
 
 @pytest.fixture
-def mocked_dask_ping_gateway(mocker: MockerFixture) -> MockedDaskModule:
+def mocked_dask_ping_scheduler(mocker: MockerFixture) -> MockedDaskModule:
     return MockedDaskModule(
-        ping_gateway=mocker.patch(
-            "simcore_service_clusters_keeper.modules.clusters_management_core.ping_gateway",
+        ping_scheduler=mocker.patch(
+            "simcore_service_clusters_keeper.modules.clusters_management_core.ping_scheduler",
             autospec=True,
             return_value=True,
         ),
-        is_gateway_busy=mocker.patch(
-            "simcore_service_clusters_keeper.modules.clusters_management_core.is_gateway_busy",
+        is_scheduler_busy=mocker.patch(
+            "simcore_service_clusters_keeper.modules.clusters_management_core.is_scheduler_busy",
             autospec=True,
             return_value=True,
         ),
@@ -117,7 +117,7 @@ async def test_cluster_management_core_properly_unused_instances(
     user_id: UserID,
     wallet_id: WalletID,
     initialized_app: FastAPI,
-    mocked_dask_ping_gateway: MockedDaskModule,
+    mocked_dask_ping_scheduler: MockedDaskModule,
 ):
     created_clusters = await create_cluster(
         initialized_app, user_id=user_id, wallet_id=wallet_id
@@ -129,10 +129,10 @@ async def test_cluster_management_core_properly_unused_instances(
     await _assert_cluster_exist_and_state(
         ec2_client, instances=created_clusters, state="running"
     )
-    mocked_dask_ping_gateway.ping_gateway.assert_called_once()
-    mocked_dask_ping_gateway.ping_gateway.reset_mock()
-    mocked_dask_ping_gateway.is_gateway_busy.assert_called_once()
-    mocked_dask_ping_gateway.is_gateway_busy.reset_mock()
+    mocked_dask_ping_scheduler.ping_scheduler.assert_called_once()
+    mocked_dask_ping_scheduler.ping_scheduler.reset_mock()
+    mocked_dask_ping_scheduler.is_scheduler_busy.assert_called_once()
+    mocked_dask_ping_scheduler.is_scheduler_busy.reset_mock()
 
     # running the cluster management task after the heartbeat came in shall not remove anything
     await asyncio.sleep(_FAST_TIME_BEFORE_TERMINATION_SECONDS + 1)
@@ -141,10 +141,10 @@ async def test_cluster_management_core_properly_unused_instances(
     await _assert_cluster_exist_and_state(
         ec2_client, instances=created_clusters, state="running"
     )
-    mocked_dask_ping_gateway.ping_gateway.assert_called_once()
-    mocked_dask_ping_gateway.ping_gateway.reset_mock()
-    mocked_dask_ping_gateway.is_gateway_busy.assert_called_once()
-    mocked_dask_ping_gateway.is_gateway_busy.reset_mock()
+    mocked_dask_ping_scheduler.ping_scheduler.assert_called_once()
+    mocked_dask_ping_scheduler.ping_scheduler.reset_mock()
+    mocked_dask_ping_scheduler.is_scheduler_busy.assert_called_once()
+    mocked_dask_ping_scheduler.is_scheduler_busy.reset_mock()
 
     # after waiting the termination time, running the task shall remove the cluster
     await asyncio.sleep(_FAST_TIME_BEFORE_TERMINATION_SECONDS + 1)
@@ -152,5 +152,5 @@ async def test_cluster_management_core_properly_unused_instances(
     await _assert_cluster_exist_and_state(
         ec2_client, instances=created_clusters, state="terminated"
     )
-    mocked_dask_ping_gateway.ping_gateway.assert_called_once()
-    mocked_dask_ping_gateway.is_gateway_busy.assert_called_once()
+    mocked_dask_ping_scheduler.ping_scheduler.assert_called_once()
+    mocked_dask_ping_scheduler.is_scheduler_busy.assert_called_once()

--- a/services/clusters-keeper/tests/unit/test_modules_dask.py
+++ b/services/clusters-keeper/tests/unit/test_modules_dask.py
@@ -3,36 +3,28 @@
 # pylint: disable=unused-variable
 import time
 
-from dask_gateway import GatewayCluster, auth
-from distributed import Client
+from distributed import Client, SpecCluster
 from faker import Faker
 from models_library.clusters import SimpleAuthentication
 from pydantic import AnyUrl, SecretStr, parse_obj_as
-from pytest_simcore.dask_gateway import DaskGatewayServer
-from simcore_service_clusters_keeper.modules.dask import is_gateway_busy, ping_gateway
+from simcore_service_clusters_keeper.modules.dask import (
+    is_gateway_busy,
+    is_scheduler_busy,
+    ping_scheduler,
+)
 from tenacity import retry
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_fixed
 
 
-async def test_ping_non_existing_gateway(faker: Faker):
-    assert (
-        await ping_gateway(
-            url=parse_obj_as(AnyUrl, faker.url()),
-            password=SecretStr(faker.password()),
-        )
-        is False
-    )
+async def test_ping_scheduler_non_existing_scheduler(faker: Faker):
+    assert await ping_scheduler(url=parse_obj_as(AnyUrl, faker.url())) is False
 
 
-async def test_ping_gateway(local_dask_gateway_server: DaskGatewayServer):
-    assert (
-        await ping_gateway(
-            url=parse_obj_as(AnyUrl, local_dask_gateway_server.address),
-            password=SecretStr(local_dask_gateway_server.password),
-        )
-        is True
+async def test_ping_scheduler(dask_spec_local_cluster: SpecCluster):
+    assert ping_scheduler(
+        parse_obj_as(AnyUrl, dask_spec_local_cluster.scheduler_address)
     )
 
 
@@ -41,40 +33,16 @@ async def test_ping_gateway(local_dask_gateway_server: DaskGatewayServer):
     stop=stop_after_delay(30),
     retry=retry_if_exception_type(AssertionError),
 )
-async def _assert_gateway_is_busy(
+async def _assert_scheduler_is_busy(
     url: AnyUrl, user: str, password: SecretStr, *, busy: bool
-):
+) -> None:
     print(f"--> waiting for gateway to become {busy=}")
-    assert (
-        await is_gateway_busy(
-            url=url,
-            gateway_auth=SimpleAuthentication(
-                username=user,
-                password=password,
-            ),
-        )
-        is busy
-    )
-    print(f"gateway is now {busy=}")
-
-
-async def test_is_gateway_busy_with_no_cluster(
-    local_dask_gateway_server: DaskGatewayServer, faker: Faker
-):
-    assert (
-        await is_gateway_busy(
-            url=parse_obj_as(AnyUrl, local_dask_gateway_server.address),
-            gateway_auth=SimpleAuthentication(
-                username=faker.user_name(),
-                password=SecretStr(local_dask_gateway_server.password),
-            ),
-        )
-        is False
-    )
+    assert await is_scheduler_busy(url=url) is busy
+    print(f"scheduler is now {busy=}")
 
 
 async def test_is_gateway_busy(
-    local_dask_gateway_server: DaskGatewayServer,
+    dask_spec_local_cluster: SpecCluster,
     dask_gateway_cluster: GatewayCluster,
     dask_gateway_cluster_client: Client,
 ):
@@ -110,7 +78,7 @@ async def test_is_gateway_busy(
 
     future = dask_gateway_cluster_client.submit(_some_long_running_fct, _SLEEP_TIME)
 
-    await _assert_gateway_is_busy(
+    await _assert_scheduler_is_busy(
         url=parse_obj_as(AnyUrl, local_dask_gateway_server.address),
         user=f"{dask_gateway_cluster.gateway.auth.username}",
         password=SecretStr(local_dask_gateway_server.password),

--- a/services/clusters-keeper/tests/unit/test_modules_dask.py
+++ b/services/clusters-keeper/tests/unit/test_modules_dask.py
@@ -41,7 +41,7 @@ async def test_ping_scheduler(dask_spec_local_cluster: SpecCluster):
     retry=retry_if_exception_type(AssertionError),
 )
 async def _assert_scheduler_is_busy(url: AnyUrl, *, busy: bool) -> None:
-    print(f"--> waiting for gateway to become {busy=}")
+    print(f"--> waiting for osparc-dask-scheduler to become {busy=}")
     assert await is_scheduler_busy(url=url) is busy
     print(f"scheduler is now {busy=}")
 

--- a/services/clusters-keeper/tests/unit/test_utils_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_utils_clusters.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 import pytest
 from faker import Faker
 from models_library.rpc_schemas_clusters_keeper.clusters import ClusterState
-from pydantic import SecretStr
 from simcore_service_clusters_keeper.models import EC2InstanceData
 from simcore_service_clusters_keeper.utils.clusters import (
     create_cluster_from_ec2_instance,
@@ -37,7 +36,6 @@ def test_create_cluster_from_ec2_instance(
         instance_data,
         faker.pyint(),
         faker.pyint(),
-        SecretStr(faker.password()),
         gateway_ready=faker.pybool(),
     )
     assert cluster_instance

--- a/services/clusters-keeper/tests/unit/test_utils_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_utils_clusters.py
@@ -23,6 +23,7 @@ from types_aiobotocore_ec2.literals import InstanceStateNameType
         ("stopped", ClusterState.STOPPED),
         ("stopping", ClusterState.STOPPED),
         ("terminated", ClusterState.STOPPED),
+        ("whatever", ClusterState.STOPPED),
     ],
 )
 def test_create_cluster_from_ec2_instance(

--- a/services/clusters-keeper/tests/unit/test_utils_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_utils_clusters.py
@@ -36,7 +36,7 @@ def test_create_cluster_from_ec2_instance(
         instance_data,
         faker.pyint(),
         faker.pyint(),
-        gateway_ready=faker.pybool(),
+        dask_scheduler_ready=faker.pybool(),
     )
     assert cluster_instance
     assert cluster_instance.state is expected_cluster_state

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -59,6 +59,8 @@ EXPOSE 8080
 EXPOSE 8786
 EXPOSE 8787
 
+# create dask configuration folder
+RUN mkdir --parents /home/${SC_USER_NAME}/.config/dask
 
 # -------------------------- Build stage -------------------
 # Installs build/package management tools and third party dependencies

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -60,7 +60,8 @@ EXPOSE 8786
 EXPOSE 8787
 
 # create dask configuration folder
-RUN mkdir --parents /home/${SC_USER_NAME}/.config/dask
+RUN mkdir --parents /home/scu/.config/dask \
+  && chown -R scu:scu /home/scu/.config
 
 # -------------------------- Build stage -------------------
 # Installs build/package management tools and third party dependencies

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -46,9 +46,12 @@ if [ ${DASK_START_AS_SCHEDULER+x} ]; then
         --pattern="*.py;*/src/*" \
         --ignore-patterns="*test*;pytest_simcore/*;setup.py;*ignore*" \
         --ignore-directories -- \
-      dask scheduler
+        dask scheduler \
+        --preload simcore_service_dask_sidecar.scheduler
   else
-    exec dask scheduler
+    exec dask scheduler \
+    --preload simcore_service_dask_sidecar.scheduler
+
   fi
 
 else

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -99,8 +99,8 @@ else
   # 'daemonic processes are not allowed to have children' arises when running the sidecar.cli
   # because multi-processing library is used by the sidecar and the nanny does not like it
   # setting --no-nanny fixes this: see https://github.com/dask/distributed/issues/2142
-  echo "$INFO" "Starting as a ${DASK_WORKER_VERSION} -> ${DASK_SCHEDULER_URL} ..."
-  echo "$INFO" "Worker resources set as: $resources"
+  echo "$INFO" "Starting as a dask worker "${DASK_WORKER_VERSION}" -> "${DASK_SCHEDULER_URL}" ..."
+  echo "$INFO" "Worker resources set as: "$resources""
   if [ "${SC_BOOT_MODE}" = "debug-ptvsd" ]; then
     exec watchmedo auto-restart --recursive --pattern="*.py;*/src/*" --ignore-patterns="*test*;pytest_simcore/*;setup.py;*ignore*" --ignore-directories -- \
       dask worker "${DASK_SCHEDULER_URL}" \

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/_meta.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/_meta.py
@@ -17,14 +17,15 @@ API_VERSION: Final[str] = info.__version__
 
 # https://patorjk.com/software/taag/#p=display&f=Standard&t=dask%20sidecar
 APP_STARTED_BANNER_MSG = rf"""
-      _           _          _     _
-   __| | __ _ ___| | __  ___(_) __| | ___  ___ __ _ _ __
-  / _` |/ _` / __| |/ / / __| |/ _` |/ _ \/ __/ _` | '__|
- | (_| | (_| \__ \   <  \__ \ | (_| |  __/ (_| (_| | |
-  \__,_|\__,_|___/_|\_\ |___/_|\__,_|\___|\___\__,_|_|    v{__version__} with dask=={dask.__version__}
 
+                                       _           _          _     _
+   ___  ___ _ __   __ _ _ __ ___    __| | __ _ ___| | __  ___(_) __| | ___  ___ __ _ _ __
+  / _ \/ __| '_ \ / _` | '__/ __|  / _` |/ _` / __| |/ / / __| |/ _` |/ _ \/ __/ _` | '__|
+ | (_) \__ \ |_) | (_| | | | (__  | (_| | (_| \__ \   <  \__ \ | (_| |  __/ (_| (_| | |
+  \___/|___/ .__/ \__,_|_|  \___|  \__,_|\__,_|___/_|\_\ |___/_|\__,_|\___|\___\__,_|_|             v{__version__} with dask=={dask.__version__}
+           |_|
 """
 
 
-def print_banner() -> None:
+def print_dask_sidecar_banner() -> None:
     print(APP_STARTED_BANNER_MSG, flush=True)  # noqa: T201

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/_meta.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/_meta.py
@@ -16,7 +16,7 @@ PROJECT_NAME: Final[str] = info.project_name
 API_VERSION: Final[str] = info.__version__
 
 # https://patorjk.com/software/taag/#p=display&f=Standard&t=dask%20sidecar
-APP_STARTED_BANNER_MSG = rf"""
+DASK_SIDECAR_APP_STARTED_BANNER_MSG = rf"""
 
                                        _           _          _     _
    ___  ___ _ __   __ _ _ __ ___    __| | __ _ ___| | __  ___(_) __| | ___  ___ __ _ _ __
@@ -26,6 +26,21 @@ APP_STARTED_BANNER_MSG = rf"""
            |_|
 """
 
+DASK_SCHEDULER_APP_STARTED_BANNER_MSG = rf"""
+
+                                       _           _               _              _       _
+   ___  ___ _ __   __ _ _ __ ___    __| | __ _ ___| | __  ___  ___| |__   ___  __| |_   _| | ___ _ __
+  / _ \/ __| '_ \ / _` | '__/ __|  / _` |/ _` / __| |/ / / __|/ __| '_ \ / _ \/ _` | | | | |/ _ \ '__|
+ | (_) \__ \ |_) | (_| | | | (__  | (_| | (_| \__ \   <  \__ \ (__| | | |  __/ (_| | |_| | |  __/ |
+  \___/|___/ .__/ \__,_|_|  \___|  \__,_|\__,_|___/_|\_\ |___/\___|_| |_|\___|\__,_|\__,_|_|\___|_|                          v{__version__} with dask=={dask.__version__}
+           |_|
+
+"""
+
 
 def print_dask_sidecar_banner() -> None:
-    print(APP_STARTED_BANNER_MSG, flush=True)  # noqa: T201
+    print(DASK_SIDECAR_APP_STARTED_BANNER_MSG, flush=True)  # noqa: T201
+
+
+def print_dask_scheduler_banner() -> None:
+    print(DASK_SCHEDULER_APP_STARTED_BANNER_MSG, flush=True)  # noqa: T201

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/scheduler.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/scheduler.py
@@ -1,0 +1,18 @@
+import logging
+
+import distributed
+
+from ._meta import print_dask_scheduler_banner
+
+_logger = logging.getLogger(__name__)
+
+
+async def dask_setup(scheduler: distributed.Scheduler) -> None:
+    """This is a special function recognized by the dask worker when starting with flag --preload"""
+    _logger.info("Setting up scheduler...")
+    assert scheduler  # nosec
+    print_dask_scheduler_banner()
+
+
+async def dask_teardown(_worker: distributed.Worker) -> None:
+    _logger.info("Shutting down scheduler")

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/tasks.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/tasks.py
@@ -24,7 +24,7 @@ from models_library.services_resources import BootMode
 from servicelib.logging_utils import config_all_loggers
 from settings_library.s3 import S3Settings
 
-from ._meta import print_banner
+from ._meta import print_dask_sidecar_banner
 from .computational_sidecar.core import ComputationalSidecar
 from .dask_utils import TaskPublisher, get_current_task_resources, monitor_task_abortion
 from .settings import Settings
@@ -76,7 +76,7 @@ async def dask_setup(worker: distributed.Worker) -> None:
     logger.info("Setting up worker...")
     logger.info("Settings: %s", pformat(settings.dict()))
 
-    print_banner()
+    print_dask_sidecar_banner()
 
     if threading.current_thread() is threading.main_thread():
         loop = asyncio.get_event_loop()

--- a/services/director-v2/src/simcore_service_director_v2/modules/clusters_keeper.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/clusters_keeper.py
@@ -44,7 +44,7 @@ async def get_or_create_on_demand_cluster(
             raise ComputationalBackendOnDemandNotReadyError(
                 eta=_format_delta(returned_cluster.eta)
             )
-        if not returned_cluster.gateway_ready:
+        if not returned_cluster.dask_scheduler_ready:
             raise ComputationalBackendOnDemandNotReadyError(
                 eta=_format_delta(returned_cluster.eta)
             )

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
@@ -619,7 +619,11 @@ class BaseCompScheduler(ABC):
         comp_tasks_repo = CompTasksRepository.instance(self.db_engine)
         await comp_tasks_repo.mark_project_published_tasks_as_aborted(project_id)
         # stop any remaining running task, these are already submitted
-        tasks_to_stop = [t for t in comp_tasks.values() if t.state in PROCESSING_STATES]
+        tasks_to_stop = [
+            t
+            for t in comp_tasks.values()
+            if t.state in PROCESSING_STATES | {RunningState.WAITING_FOR_CLUSTER}
+        ]
         await self._stop_tasks(user_id, tasks_to_stop, pipeline_params)
 
     async def _schedule_tasks_to_start(

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -263,7 +263,7 @@ class DaskClient:
             # is runnable because we CAN'T. A cluster might auto-scale, the worker(s)
             # might also auto-scale and the gateway does not know that a priori.
             # So, we'll just send the tasks over and see what happens after a while.
-            if (self.cluster_type == ClusterTypeInModel.ON_DEMAND) and (
+            if (self.cluster_type == ClusterTypeInModel.ON_DEMAND.value) and (
                 self.backend.gateway is None
             ):
                 _logger.warning("cluster type: %s", self.cluster_type)

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -89,12 +89,13 @@ from ..utils.dask_client_utils import (
 _logger = logging.getLogger(__name__)
 
 
+# see https://distributed.dask.org/en/stable/scheduling-state.html#task-state
 _DASK_TASK_STATUS_RUNNING_STATE_MAP = {
     "new": RunningState.PENDING,
     "released": RunningState.PENDING,
     "waiting": RunningState.PENDING,
     "no-worker": RunningState.WAITING_FOR_RESOURCES,
-    "processing": RunningState.STARTED,
+    "processing": RunningState.STARTED,  # the scheduler doesn’t know whether it’s in a worker queue or actively being computed
     "memory": RunningState.SUCCESS,
     "erred": RunningState.FAILED,
 }
@@ -262,7 +263,7 @@ class DaskClient:
             # is runnable because we CAN'T. A cluster might auto-scale, the worker(s)
             # might also auto-scale and the gateway does not know that a priori.
             # So, we'll just send the tasks over and see what happens after a while.
-            if (self.cluster_type is not ClusterTypeInModel.ON_DEMAND) and (
+            if (self.cluster_type == ClusterTypeInModel.ON_DEMAND) and (
                 self.backend.gateway is None
             ):
                 _logger.warning("cluster type: %s", self.cluster_type)

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -263,7 +263,7 @@ class DaskClient:
             # is runnable because we CAN'T. A cluster might auto-scale, the worker(s)
             # might also auto-scale and the gateway does not know that a priori.
             # So, we'll just send the tasks over and see what happens after a while.
-            if (self.cluster_type == ClusterTypeInModel.ON_DEMAND.value) and (
+            if (self.cluster_type != ClusterTypeInModel.ON_DEMAND) and (
                 self.backend.gateway is None
             ):
                 _logger.warning("cluster type: %s", self.cluster_type)

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_clients_pool.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_clients_pool.py
@@ -92,6 +92,7 @@ class DaskClientsPool:
                         endpoint=cluster.endpoint,
                         authentication=cluster.authentication,
                         tasks_file_link_type=tasks_file_link_type,
+                        cluster_type=cluster.type,
                     )
                     if self._task_handlers:
                         dask_client.register_handlers(self._task_handlers)

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask_client_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask_client_utils.py
@@ -154,14 +154,14 @@ async def _connect_with_gateway_and_create_cluster(
         raise DaskGatewayServerError(endpoint=endpoint, error=exc) from exc
 
 
-def _is_internal_scheduler(authentication: ClusterAuthentication) -> bool:
+def _is_dask_scheduler(authentication: ClusterAuthentication) -> bool:
     return isinstance(authentication, NoAuthentication)
 
 
 async def create_internal_client_based_on_auth(
     endpoint: AnyUrl, authentication: ClusterAuthentication
 ) -> DaskSubSystem:
-    if _is_internal_scheduler(authentication):
+    if _is_dask_scheduler(authentication):
         # if no auth then we go for a standard scheduler connection
         return await _connect_to_dask_scheduler(endpoint)
     # we do have some auth, so it is going through a gateway
@@ -201,7 +201,7 @@ async def test_scheduler_endpoint(
     :raises ConfigurationError: contians some information as to why the connection failed
     """
     try:
-        if _is_internal_scheduler(authentication):
+        if _is_dask_scheduler(authentication):
             async with distributed.Client(
                 address=endpoint, timeout=f"{_PING_TIMEOUT_S}", asynchronous=True
             ) as dask_client:

--- a/services/director-v2/tests/conftest.py
+++ b/services/director-v2/tests/conftest.py
@@ -27,6 +27,7 @@ from starlette.testclient import ASGI3App, TestClient
 pytest_plugins = [
     "pytest_simcore.db_entries_mocks",
     "pytest_simcore.dask_gateway",
+    "pytest_simcore.dask_scheduler",
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -45,7 +45,12 @@ from faker import Faker
 from fastapi.applications import FastAPI
 from models_library.api_schemas_directorv2.services import NodeRequirements
 from models_library.api_schemas_storage import LinkType
-from models_library.clusters import ClusterID, NoAuthentication, SimpleAuthentication
+from models_library.clusters import (
+    ClusterID,
+    ClusterTypeInModel,
+    NoAuthentication,
+    SimpleAuthentication,
+)
 from models_library.docker import to_simcore_runtime_docker_label_key
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
@@ -165,6 +170,7 @@ async def create_dask_client_from_scheduler(
             endpoint=parse_obj_as(AnyUrl, dask_spec_local_cluster.scheduler_address),
             authentication=NoAuthentication(),
             tasks_file_link_type=tasks_file_link_type,
+            cluster_type=ClusterTypeInModel.ON_PREMISE,
         )
         assert client
         assert client.app == minimal_app
@@ -208,6 +214,7 @@ async def create_dask_client_from_gateway(
                 password=SecretStr(local_dask_gateway_server.password),
             ),
             tasks_file_link_type=tasks_file_link_type,
+            cluster_type=ClusterTypeInModel.AWS,
         )
         assert client
         assert client.app == minimal_app

--- a/services/director-v2/tests/unit/test_modules_dask_clients_pool.py
+++ b/services/director-v2/tests/unit/test_modules_dask_clients_pool.py
@@ -15,6 +15,7 @@ from models_library.clusters import (
     DEFAULT_CLUSTER_ID,
     Cluster,
     ClusterAuthentication,
+    ClusterTypeInModel,
     JupyterHubTokenAuthentication,
     KerberosAuthentication,
     NoAuthentication,
@@ -189,6 +190,7 @@ async def test_dask_clients_pool_acquisition_creates_client_on_demand(
                 authentication=cluster.authentication,
                 endpoint=cluster.endpoint,
                 tasks_file_link_type=client.app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_DEFAULT_FILE_LINK_TYPE,
+                cluster_type=ClusterTypeInModel.ON_PREMISE,
             )
         )
         async with clients_pool.acquire(cluster) as dask_client:

--- a/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
@@ -92,6 +92,7 @@ def _assert_dask_client_correctly_initialized(
         endpoint=mock.ANY,
         authentication=mock.ANY,
         tasks_file_link_type=mock.ANY,
+        cluster_type=mock.ANY,
     )
     mocked_dask_client.register_handlers.assert_called_once_with(
         TaskHandlers(

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       - RABBIT_USER=${RABBIT_USER}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PORT=${REDIS_PORT}
+      - SWARM_STACK_NAME=${SWARM_STACK_NAME}
 
   director:
     image: ${DOCKER_REGISTRY:-itisfoundation}/director:${DOCKER_IMAGE_TAG:-latest}
@@ -221,7 +222,6 @@ services:
       - RABBIT_PORT=${RABBIT_PORT}
       - RABBIT_SECURE=${RABBIT_SECURE}
       - RABBIT_USER=${RABBIT_USER}
-
 
   resource-usage-tracker:
     image: ${DOCKER_REGISTRY:-itisfoundation}/resource-usage-tracker:${DOCKER_IMAGE_TAG:-latest}


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?
#### Clusters-keeper
- [x] the clusters-keeper deployed machines now start a dask-scheduler/dask-worker directly instead of osparc-dask-gateway
  - deploys a docker-compose.yml stack in the machine,
  - the dask-sidecar is set as global
- [x] removed dask-gateway/dask-gateway-server dependencies in clusters-keeper
- [x] moved dask-scheduler fixture to pytest-simcore (shared between dv-2 and clusters-keeper, and soon autoscaling)
- [x] @mguidon the name of the machine created on EC2 was modified to be more user-friendly, it now goes along: ```osparc-computational-cluster-manager-{app_settings.SWARM_STACK_NAME}-user_id:{user_id}-wallet_id:{wallet_id}```
- [x] add a distributed lock mechanism to prevent creating multiple clusters for the same user_id/wallet_id pair if the RPC is called in a short burst
- [x] fixed pipeline cannot be stopped when *waiting for cluster*

#### dask-sidecar
- [x] scheduler now also shows a logo on start
- [x] fixed issue in devel mode where ```/home/scu/.config/dask/distributed.yml``` was not writable

### director-v2
- [x]   adapted code to change from dask-gateway to dask-scheduler


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
