### PR TITLE
♻️✨ Comp backend task state reporting fixed

### DIFF
--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/c4245e9e0f72_payment_transactions_states.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/c4245e9e0f72_payment_transactions_states.py
@@ -46,13 +46,19 @@ def upgrade():
         "payments_transactions", sa.Column("state_message", sa.Text(), nullable=True)
     )
     connection.execute(
-        "UPDATE payments_transactions SET state = 'SUCCESS' WHERE success = true"
+        sa.DDL(
+            "UPDATE payments_transactions SET state = 'SUCCESS' WHERE success = true"
+        )
     )
     connection.execute(
-        "UPDATE payments_transactions SET state = 'FAILED' WHERE success = false"
+        sa.DDL(
+            "UPDATE payments_transactions SET state = 'FAILED' WHERE success = false"
+        )
     )
     connection.execute(
-        "UPDATE payments_transactions SET state = 'PENDING' WHERE success IS NULL"
+        sa.DDL(
+            "UPDATE payments_transactions SET state = 'PENDING' WHERE success IS NULL"
+        )
     )
     connection.execute("UPDATE payments_transactions SET state_message = errors")
 
@@ -72,13 +78,19 @@ def downgrade():
 
     connection = op.get_bind()
     connection.execute(
-        "UPDATE payments_transactions SET success = true WHERE state = 'SUCCESS'"
+        sa.DDL(
+            "UPDATE payments_transactions SET success = true WHERE state = 'SUCCESS'"
+        )
     )
     connection.execute(
-        "UPDATE payments_transactions SET success = false WHERE completed_at IS NOT NULL AND state != 'SUCCESS'"
+        sa.DDL(
+            "UPDATE payments_transactions SET success = false WHERE completed_at IS NOT NULL AND state != 'SUCCESS'"
+        )
     )
     connection.execute(
-        "UPDATE payments_transactions SET success = NULL WHERE completed_at IS NULL AND state != 'SUCCESS'"
+        sa.DDL(
+            "UPDATE payments_transactions SET success = NULL WHERE completed_at IS NULL AND state != 'SUCCESS'"
+        )
     )
 
     op.drop_column("payments_transactions", "state_message")

--- a/packages/service-library/src/servicelib/rabbitmq/_rpc_router.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_rpc_router.py
@@ -34,16 +34,18 @@ class RPCRouter:
                     msg=f"calling {func.__name__} with {args}, {kwargs}",
                 ):
                     try:
-                        result = await func(*args, **kwargs)
-                        return result
+                        return await func(*args, **kwargs)
                     except asyncio.CancelledError:
                         _logger.debug("call was cancelled")
                         raise
                     except Exception as exc:  # pylint: disable=broad-except
                         _logger.exception("Unhandled exception:")
+                        # NOTE: we do not return internal exceptions over RPC
                         raise RPCServerError(
-                            method_name=func.__name__, exc_type=type(exc), msg=f"{exc}"
-                        ) from exc
+                            method_name=func.__name__,
+                            exc_type=f"{type(exc)}",
+                            msg=f"{exc}",
+                        ) from None
 
             self.routes[RPCMethodName(func.__name__)] = wrapper
             return func

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -195,13 +195,14 @@ async def create_computation(  # noqa: C901, PLR0912
             publish=computation.start_pipeline or False,
         )
         assert computation.product_name  # nosec
+        min_computation_nodes: list[NodeID] = [
+            NodeID(n) for n in minimal_computational_dag.nodes()
+        ]
         inserted_comp_tasks = await comp_tasks_repo.upsert_tasks_from_project(
             project,
             catalog_client,
             director_client,
-            published_nodes=list(minimal_computational_dag.nodes())
-            if computation.start_pipeline
-            else [],
+            published_nodes=min_computation_nodes if computation.start_pipeline else [],
             user_id=computation.user_id,
             product_name=computation.product_name,
         )

--- a/services/director-v2/src/simcore_service_director_v2/core/errors.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/errors.py
@@ -103,6 +103,10 @@ class ComputationalRunNotFoundError(PydanticErrorMixin, DirectorException):
     msg_template = "Computational run not found"
 
 
+class ComputationalTaskNotFoundError(PydanticErrorMixin, DirectorException):
+    msg_template = "Computational task {node_id} not found"
+
+
 class NodeRightsAcquireError(PydanticErrorMixin, DirectorException):
     msg_template = "Could not acquire a lock for {docker_node_id} since all {slots} slots are used."
 

--- a/services/director-v2/src/simcore_service_director_v2/models/dask_subsystem.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/dask_subsystem.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+# NOTE: mypy fails with src/simcore_service_director_v2/modules/dask_client.py:101:5: error: Dict entry 0 has incompatible type "str": "auto"; expected "Any": "DaskClientTaskState"  [dict-item]
+# when using StrAutoEnum
+class DaskClientTaskState(str, Enum):
+    PENDING = "PENDING"
+    NO_WORKER = "NO_WORKER"
+    PENDING_OR_STARTED = "PENDING_OR_STARTED"
+    LOST = "LOST"
+    ERRED = "ERRED"
+    ABORTED = "ABORTED"
+    SUCCESS = "SUCCESS"

--- a/services/director-v2/src/simcore_service_director_v2/modules/clusters_keeper.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/clusters_keeper.py
@@ -12,6 +12,7 @@ from servicelib.rabbitmq import (
     RemoteMethodNotRegisteredError,
     RPCMethodName,
     RPCNamespace,
+    RPCServerError,
 )
 
 from ..core.errors import (
@@ -58,4 +59,6 @@ async def get_or_create_on_demand_cluster(
         )
     except RemoteMethodNotRegisteredError as exc:
         # no clusters-keeper, that is not going to work!
+        raise ComputationalBackendOnDemandClustersKeeperNotReadyError from exc
+    except RPCServerError as exc:
         raise ComputationalBackendOnDemandClustersKeeperNotReadyError from exc

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
@@ -663,7 +663,7 @@ class BaseCompScheduler(ABC):
             project_id,
             list(tasks_ready_to_start.keys()),
             RunningState.PENDING,
-            optional_progress=0,
+            optional_progress=None,
             optional_started=arrow.utcnow().datetime,
         )
 
@@ -716,7 +716,7 @@ class BaseCompScheduler(ABC):
                     project_id,
                     list(tasks_ready_to_start.keys()),
                     RunningState.WAITING_FOR_CLUSTER,
-                    optional_progress=0,
+                    optional_progress=None,
                 )
                 comp_tasks[f"{t}"].state = RunningState.WAITING_FOR_CLUSTER
             elif isinstance(r, ComputationalBackendOnDemandNotReadyError):
@@ -735,7 +735,7 @@ class BaseCompScheduler(ABC):
                     project_id,
                     list(tasks_ready_to_start.keys()),
                     RunningState.WAITING_FOR_CLUSTER,
-                    optional_progress=0,
+                    optional_progress=None,
                 )
                 comp_tasks[f"{t}"].state = RunningState.WAITING_FOR_CLUSTER
             elif isinstance(r, Exception):

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
@@ -26,7 +26,8 @@ from ...core.errors import (
 )
 from ...models.comp_runs import RunMetadataDict
 from ...models.comp_tasks import CompTaskAtDB
-from ...modules.dask_client import DaskClient, DaskClientTaskState
+from ...models.dask_subsystem import DaskClientTaskState
+from ...modules.dask_client import DaskClient
 from ...modules.dask_clients_pool import DaskClientsPool
 from ...modules.db.repositories.clusters import ClustersRepository
 from ...utils.comp_scheduler import Iteration, get_resource_tracking_run_id

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -15,6 +15,7 @@ import traceback
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass, field
+from enum import auto
 from http.client import HTTPException
 from typing import Any
 
@@ -36,14 +37,15 @@ from dask_task_models_library.container_tasks.protocol import (
     ContainerTag,
     LogFileUploadURL,
 )
+from distributed.scheduler import TaskStateState as DaskSchedulerTaskState
 from fastapi import FastAPI
 from models_library.api_schemas_directorv2.clusters import ClusterDetails, Scheduler
 from models_library.clusters import ClusterAuthentication, ClusterID, ClusterTypeInModel
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
-from models_library.projects_state import RunningState
 from models_library.services_resources import BootMode
 from models_library.users import UserID
+from models_library.utils.enums import StrAutoEnum
 from pydantic import parse_obj_as
 from pydantic.networks import AnyUrl
 from servicelib.logging_utils import log_catch
@@ -89,16 +91,34 @@ from ..utils.dask_client_utils import (
 _logger = logging.getLogger(__name__)
 
 
+# NOTE: processing does not mean the task is currently being computed, it means
+# the task was accepted by a worker, but might still be queud in it
 # see https://distributed.dask.org/en/stable/scheduling-state.html#task-state
-_DASK_TASK_STATUS_RUNNING_STATE_MAP = {
-    "new": RunningState.PENDING,
-    "released": RunningState.PENDING,
-    "waiting": RunningState.PENDING,
-    "no-worker": RunningState.WAITING_FOR_RESOURCES,
-    "processing": RunningState.STARTED,  # the scheduler doesn’t know whether it’s in a worker queue or actively being computed
-    "memory": RunningState.SUCCESS,
-    "erred": RunningState.FAILED,
+
+
+class DaskClientTaskState(StrAutoEnum):
+    PENDING = auto()
+    NO_WORKER = auto()
+    PENDING_OR_STARTED = auto()
+    LOST = auto()
+    ERRED = auto()
+    ABORTED = auto()
+    SUCCESS = auto()
+
+
+_DASK_TASK_STATUS_DASK_CLIENT_TASK_STATE_MAP: dict[
+    DaskSchedulerTaskState, DaskClientTaskState
+] = {
+    "queued": DaskClientTaskState.PENDING,
+    "released": DaskClientTaskState.PENDING,
+    "waiting": DaskClientTaskState.PENDING,
+    "no-worker": DaskClientTaskState.NO_WORKER,
+    "processing": DaskClientTaskState.PENDING_OR_STARTED,
+    "memory": DaskClientTaskState.SUCCESS,
+    "erred": DaskClientTaskState.ERRED,
+    "forgotten": DaskClientTaskState.LOST,
 }
+
 
 _DASK_DEFAULT_TIMEOUT_S = 1
 
@@ -373,7 +393,7 @@ class DaskClient:
                 raise
         return list_of_node_id_to_job_id
 
-    async def get_tasks_status(self, job_ids: list[str]) -> list[RunningState]:
+    async def get_tasks_status(self, job_ids: list[str]) -> list[DaskClientTaskState]:
         check_scheduler_is_still_the_same(
             self.backend.scheduler_id, self.backend.client
         )
@@ -394,7 +414,7 @@ class DaskClient:
         )
         _logger.debug("found dask task statuses: %s", f"{task_statuses=}")
 
-        running_states: list[RunningState] = []
+        running_states: list[DaskClientTaskState] = []
         for job_id in job_ids:
             dask_status = task_statuses.get(job_id, "lost")
             if dask_status == "erred":
@@ -406,7 +426,7 @@ class DaskClient:
                 )
 
                 if isinstance(exception, TaskCancelledError):
-                    running_states.append(RunningState.ABORTED)
+                    running_states.append(DaskClientTaskState.ABORTED)
                 else:
                     assert exception  # nosec
                     _logger.warning(
@@ -415,11 +435,11 @@ class DaskClient:
                         exception,
                         "".join(traceback.format_exception(exception)),
                     )
-                    running_states.append(RunningState.FAILED)
+                    running_states.append(DaskClientTaskState.ERRED)
             else:
                 running_states.append(
-                    _DASK_TASK_STATUS_RUNNING_STATE_MAP.get(
-                        dask_status, RunningState.UNKNOWN
+                    _DASK_TASK_STATUS_DASK_CLIENT_TASK_STATE_MAP.get(
+                        dask_status, DaskClientTaskState.LOST
                     )
                 )
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -15,7 +15,6 @@ import traceback
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass, field
-from enum import auto
 from http.client import HTTPException
 from typing import Any
 
@@ -45,7 +44,6 @@ from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.services_resources import BootMode
 from models_library.users import UserID
-from models_library.utils.enums import StrAutoEnum
 from pydantic import parse_obj_as
 from pydantic.networks import AnyUrl
 from servicelib.logging_utils import log_catch
@@ -64,6 +62,7 @@ from ..core.errors import (
 from ..core.settings import AppSettings, ComputationalBackendSettings
 from ..models.comp_runs import RunMetadataDict
 from ..models.comp_tasks import Image
+from ..models.dask_subsystem import DaskClientTaskState
 from ..modules.storage import StorageClient
 from ..utils.dask import (
     check_communication_with_scheduler_is_open,
@@ -94,16 +93,6 @@ _logger = logging.getLogger(__name__)
 # NOTE: processing does not mean the task is currently being computed, it means
 # the task was accepted by a worker, but might still be queud in it
 # see https://distributed.dask.org/en/stable/scheduling-state.html#task-state
-
-
-class DaskClientTaskState(StrAutoEnum):
-    PENDING = auto()
-    NO_WORKER = auto()
-    PENDING_OR_STARTED = auto()
-    LOST = auto()
-    ERRED = auto()
-    ABORTED = auto()
-    SUCCESS = auto()
 
 
 _DASK_TASK_STATUS_DASK_CLIENT_TASK_STATE_MAP: dict[

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -29,6 +29,7 @@ from servicelib.logging_utils import log_context
 from servicelib.utils import logged_gather
 from simcore_postgres_database.utils_projects_nodes import ProjectNodesRepo
 from simcore_service_director_v2.core.errors import ComputationalTaskNotFoundError
+from simcore_service_director_v2.utils.comp_scheduler import COMPLETED_STATES
 from sqlalchemy import literal_column
 from sqlalchemy.dialects.postgresql import insert
 
@@ -217,13 +218,14 @@ async def _generate_tasks_list_from_project(
 
         assert node.state is not None  # nosec
         task_state = node.state.current_status
-        task_progress = node.state.progress
+        task_progress = None
+        if task_state in COMPLETED_STATES:
+            task_progress = node.state.progress
         if (
             NodeID(node_id) in published_nodes
             and to_node_class(node.key) == NodeClass.COMPUTATIONAL
         ):
             task_state = RunningState.PUBLISHED
-            task_progress = None
 
         task_db = CompTaskAtDB(
             project_id=project.uuid,

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -218,7 +218,7 @@ async def _generate_tasks_list_from_project(
             and to_node_class(node.key) == NodeClass.COMPUTATIONAL
         ):
             task_state = RunningState.PUBLISHED
-            task_progress = 0
+            task_progress = None
 
         task_db = CompTaskAtDB(
             project_id=project.uuid,

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from datetime import datetime
-from typing import Any, cast
+from typing import Any, Final, cast
 
 import aiopg.sa
 import arrow
@@ -88,13 +88,16 @@ def _compute_node_boot_mode(node_resources: dict[str, Any]) -> BootMode:
     raise RuntimeError(msg)
 
 
+_VALID_ENV_VALUE_NUM_PARTS: Final[int] = 2
+
+
 def _compute_node_envs(node_labels: SimcoreServiceLabels) -> ContainerEnvsDict:
     node_envs = {}
     for service_setting in cast(SimcoreServiceSettingsLabel, node_labels.settings):
         if service_setting.name == "env":
             for complete_env in service_setting.value:
                 parts = complete_env.split("=")
-                if len(parts) == 2:
+                if len(parts) == _VALID_ENV_VALUE_NUM_PARTS:
                     node_envs[parts[0]] = parts[1]
 
     return node_envs

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -219,7 +219,7 @@ async def _generate_tasks_list_from_project(
         task_state = node.state.current_status
         task_progress = node.state.progress
         if (
-            node_id in published_nodes
+            NodeID(node_id) in published_nodes
             and to_node_class(node.key) == NodeClass.COMPUTATIONAL
         ):
             task_state = RunningState.PUBLISHED
@@ -356,12 +356,12 @@ class CompTasksRepository(BaseRepository):
 
                 exclusion_rule = (
                     {"state", "progress"}
-                    if str(comp_task_db.node_id) not in published_nodes
+                    if comp_task_db.node_id not in published_nodes
                     else set()
                 )
                 update_values = (
                     {"progress": None}
-                    if f"{comp_task_db.node_id}" in published_nodes
+                    if comp_task_db.node_id in published_nodes
                     else {}
                 )
                 if to_node_class(comp_task_db.image.name) != NodeClass.FRONTEND:

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -84,7 +84,8 @@ def _compute_node_requirements(node_resources: dict[str, Any]) -> NodeRequiremen
 def _compute_node_boot_mode(node_resources: dict[str, Any]) -> BootMode:
     for image_data in node_resources.values():
         return BootMode(image_data.get("boot_modes")[0])
-    raise RuntimeError("No BootMode")
+    msg = "No BootMode"
+    raise RuntimeError(msg)
 
 
 def _compute_node_envs(node_labels: SimcoreServiceLabels) -> ContainerEnvsDict:

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks.py
@@ -341,11 +341,18 @@ class CompTasksRepository(BaseRepository):
                     if str(comp_task_db.node_id) not in published_nodes
                     else set()
                 )
+                update_values = (
+                    {"progress": None}
+                    if f"{comp_task_db.node_id}" in published_nodes
+                    else {}
+                )
                 if to_node_class(comp_task_db.image.name) != NodeClass.FRONTEND:
                     exclusion_rule.add("outputs")
+                    update_values = {}
                 on_update_stmt = insert_stmt.on_conflict_do_update(
                     index_elements=[comp_tasks.c.project_id, comp_tasks.c.node_id],
-                    set_=comp_task_db.to_db_model(exclude=exclusion_rule),
+                    set_=comp_task_db.to_db_model(exclude=exclusion_rule)
+                    | update_values,
                 ).returning(literal_column("*"))
                 result = await conn.execute(on_update_stmt)
                 row = await result.fetchone()

--- a/services/director-v2/src/simcore_service_director_v2/utils/comp_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/comp_scheduler.py
@@ -30,6 +30,7 @@ WAITING_FOR_START_STATES: set[RunningState] = {
     RunningState.PUBLISHED,
     RunningState.PENDING,
     RunningState.WAITING_FOR_RESOURCES,
+    RunningState.WAITING_FOR_CLUSTER,
 }
 
 PROCESSING_STATES: set[RunningState] = {

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -127,6 +127,7 @@ def fake_workbench_computational_pipeline_details_not_started(
     for node_state in completed_pipeline_details.node_states.values():
         node_state.modified = True
         node_state.current_status = RunningState.NOT_STARTED
+        node_state.progress = None
     return completed_pipeline_details
 
 
@@ -222,22 +223,22 @@ class PartialComputationParams:
                         "modified": True,
                         "dependencies": [],
                         "currentStatus": RunningState.PUBLISHED,
-                        "progress": 0,
+                        "progress": None,
                     },
                     2: {
                         "modified": True,
                         "dependencies": [1],
-                        "progress": 0,
+                        "progress": None,
                     },
                     3: {
                         "modified": True,
                         "dependencies": [],
-                        "progress": 0,
+                        "progress": None,
                     },
                     4: {
                         "modified": True,
                         "dependencies": [2, 3],
-                        "progress": 0,
+                        "progress": None,
                     },
                 },
                 exp_node_states_after_run={
@@ -250,17 +251,17 @@ class PartialComputationParams:
                     2: {
                         "modified": True,
                         "dependencies": [],
-                        "progress": 0,
+                        "progress": None,
                     },
                     3: {
                         "modified": True,
                         "dependencies": [],
-                        "progress": 0,
+                        "progress": None,
                     },
                     4: {
                         "modified": True,
                         "dependencies": [2, 3],
-                        "progress": 0,
+                        "progress": None,
                     },
                 },
                 exp_pipeline_adj_list_after_force_run={1: []},
@@ -269,25 +270,25 @@ class PartialComputationParams:
                         "modified": False,
                         "dependencies": [],
                         "currentStatus": RunningState.PUBLISHED,
-                        "progress": 0,
+                        "progress": None,
                     },
                     2: {
                         "modified": True,
                         "dependencies": [],
                         "currentStatus": RunningState.NOT_STARTED,
-                        "progress": 0,
+                        "progress": None,
                     },
                     3: {
                         "modified": True,
                         "dependencies": [],
                         "currentStatus": RunningState.NOT_STARTED,
-                        "progress": 0,
+                        "progress": None,
                     },
                     4: {
                         "modified": True,
                         "dependencies": [2, 3],
                         "currentStatus": RunningState.NOT_STARTED,
-                        "progress": 0,
+                        "progress": None,
                     },
                 },
             ),
@@ -302,25 +303,25 @@ class PartialComputationParams:
                         "modified": True,
                         "dependencies": [],
                         "currentStatus": RunningState.PUBLISHED,
-                        "progress": 0,
+                        "progress": None,
                     },
                     2: {
                         "modified": True,
                         "dependencies": [1],
                         "currentStatus": RunningState.PUBLISHED,
-                        "progress": 0,
+                        "progress": None,
                     },
                     3: {
                         "modified": True,
                         "dependencies": [],
                         "currentStatus": RunningState.PUBLISHED,
-                        "progress": 0,
+                        "progress": None,
                     },
                     4: {
                         "modified": True,
                         "dependencies": [2, 3],
                         "currentStatus": RunningState.PUBLISHED,
-                        "progress": 0,
+                        "progress": None,
                     },
                 },
                 exp_node_states_after_run={
@@ -355,13 +356,13 @@ class PartialComputationParams:
                         "modified": False,
                         "dependencies": [],
                         "currentStatus": RunningState.PUBLISHED,
-                        "progress": 0,
+                        "progress": None,
                     },
                     2: {
                         "modified": False,
                         "dependencies": [],
                         "currentStatus": RunningState.PUBLISHED,
-                        "progress": 0,
+                        "progress": None,
                     },
                     3: {
                         "modified": False,
@@ -373,7 +374,7 @@ class PartialComputationParams:
                         "modified": False,
                         "dependencies": [],
                         "currentStatus": RunningState.PUBLISHED,
-                        "progress": 0,
+                        "progress": None,
                     },
                 },
             ),

--- a/services/director-v2/tests/mocks/fake_workbench_computational_node_states.json
+++ b/services/director-v2/tests/mocks/fake_workbench_computational_node_states.json
@@ -3,13 +3,13 @@
     "modified": true,
     "dependencies": [],
     "currentStatus": "PUBLISHED",
-    "progress": 0
+    "progress": null
   },
   "e1e2ea96-ce8f-5abc-8712-b8ed312a782c": {
     "modified": true,
     "dependencies": [],
     "currentStatus": "PUBLISHED",
-    "progress": 0
+    "progress": null
   },
   "415fefd1-d08b-53c1-adb0-16bed3a687ef": {
     "modified": true,
@@ -17,7 +17,7 @@
       "3a710d8b-565c-5f46-870b-b45ebe195fc7"
     ],
     "currentStatus": "PUBLISHED",
-    "progress": 0
+    "progress": null
   },
   "6ede1209-b459-5735-91fc-761aa584808d": {
     "modified": true,
@@ -26,6 +26,6 @@
       "415fefd1-d08b-53c1-adb0-16bed3a687ef"
     ],
     "currentStatus": "PUBLISHED",
-    "progress": 0
+    "progress": null
   }
 }

--- a/services/payments/tests/unit/test_rpc_payments.py
+++ b/services/payments/tests/unit/test_rpc_payments.py
@@ -59,7 +59,7 @@ async def test_rpc_create_payment_fail(
         )
 
     exc = exc_info.value
-    assert exc.exc_type == httpx.ConnectError
+    assert exc.exc_type == f"{httpx.ConnectError}"
     assert exc.method_name == "create_payment"
     assert exc.msg
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

This PR shall fix the issues where the *Running* state of a task was shown although the task is not computing, but is taken by a dask-sidecar (Dask scheduler states make no difference between a task being processed or taken by a worker and queued on the worker memory).
Therefore this shall fix:
- when multiple computational services where shown as *Running*
- and also the *Running* state is now shown as soon as the computational service signaled it started progressing, therefore linked directly to the worker activity and not only from the dask-scheduler processing fct
- *pending* <-> *waiting_for_cluster* state now stable

This was achieved by:
- [x] properly separating *Dask task state* and *RunningState*
- [x] since Dask does not know the difference between *computing* and *queued in worker*, this can be computed on the dv-2 by checking if progress was already signaled through the Dask Pub/Sub mechanism

Bonus:
- ensure that RPC calls do not return internal exceptions


## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/4517
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/4756

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
