### PR TITLE
✨Api-server: allow usage of on-demand clusters if defined in groups_extra_properties

### DIFF
--- a/services/api-server/src/simcore_service_api_server/api/dependencies/authentication.py
+++ b/services/api-server/src/simcore_service_api_server/api/dependencies/authentication.py
@@ -12,7 +12,7 @@ from .database import get_repository
 basic_scheme = HTTPBasic()
 
 
-def _create_exception():
+def _create_exception() -> HTTPException:
     _unauthorized_headers = {
         "WWW-Authenticate": f'Basic realm="{basic_scheme.realm}"'
         if basic_scheme.realm
@@ -49,8 +49,3 @@ async def get_active_user_email(
         exc = _create_exception()
         raise exc
     return email
-
-
-# alias
-get_active_user_id = get_current_user_id
-get_active_user_id = get_current_user_id

--- a/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs.py
@@ -15,6 +15,7 @@ from models_library.clusters import ClusterID
 from models_library.projects_nodes_io import BaseFileLink
 from pydantic.types import PositiveInt
 
+from ...db.repositories.groups_extra_properties import GroupsExtraPropertiesRepository
 from ...models.basic_types import VersionStr
 from ...models.pagination import Page, PaginationParams
 from ...models.schemas.errors import ErrorGet
@@ -42,7 +43,7 @@ from ...services.storage import StorageApi, to_file_api_model
 from ...services.webserver import ProjectNotFoundError
 from ..dependencies.application import get_product_name, get_reverse_url_mapper
 from ..dependencies.authentication import get_current_user_id
-from ..dependencies.database import Engine, get_db_engine
+from ..dependencies.database import Engine, get_db_engine, get_repository
 from ..dependencies.services import get_api_client
 from ..dependencies.webserver import AuthSession, get_webserver_session
 from ..errors.http_error import create_error_json_response
@@ -272,6 +273,10 @@ async def start_job(
     user_id: Annotated[PositiveInt, Depends(get_current_user_id)],
     director2_api: Annotated[DirectorV2Api, Depends(get_api_client(DirectorV2Api))],
     product_name: Annotated[str, Depends(get_product_name)],
+    groups_extra_properties_repository: Annotated[
+        GroupsExtraPropertiesRepository,
+        Depends(get_repository(GroupsExtraPropertiesRepository)),
+    ],
     cluster_id: ClusterID | None = None,
 ):
     """Starts job job_id created with the solver solver_key:version
@@ -287,6 +292,7 @@ async def start_job(
         user_id=user_id,
         product_name=product_name,
         cluster_id=cluster_id,
+        groups_extra_properties_repository=groups_extra_properties_repository,
     )
     job_status: JobStatus = create_jobstatus_from_task(task)
     return job_status

--- a/services/api-server/src/simcore_service_api_server/db/repositories/api_keys.py
+++ b/services/api-server/src/simcore_service_api_server/db/repositories/api_keys.py
@@ -7,11 +7,7 @@ from simcore_postgres_database.errors import DatabaseError
 from .. import tables as tbl
 from ._base import BaseRepository
 
-logger = logging.getLogger(__name__)
-
-
-# TODO: see if can use services/api-server/src/simcore_service_api_server/models/domain/api_keys.py
-# NOTE: For psycopg2 errors SEE https://www.psycopg.org/docs/errors.html#sqlstate-exception-classes
+_logger = logging.getLogger(__name__)
 
 
 class ApiKeysRepository(BaseRepository):
@@ -28,17 +24,7 @@ class ApiKeysRepository(BaseRepository):
                 user_id: PositiveInt | None = await conn.scalar(stmt)
 
         except DatabaseError as err:
-            logger.debug("Failed to get user id: %s", err)
+            _logger.debug("Failed to get user id: %s", err)
             user_id = None
 
         return user_id
-
-    async def any_user_with_id(self, user_id: int) -> bool:
-        # FIXME: shall identify api_key or api_secret instead
-        stmt = sa.select(
-            [
-                tbl.api_keys.c.user_id,
-            ]
-        ).where(tbl.api_keys.c.user_id == user_id)
-        async with self.db_engine.acquire() as conn:
-            return (await conn.scalar(stmt)) is not None

--- a/services/api-server/src/simcore_service_api_server/db/repositories/groups_extra_properties.py
+++ b/services/api-server/src/simcore_service_api_server/db/repositories/groups_extra_properties.py
@@ -1,0 +1,27 @@
+import logging
+
+from models_library.users import UserID
+from simcore_postgres_database.errors import DatabaseError
+from simcore_postgres_database.utils_groups_extra_properties import (
+    GroupExtraPropertiesRepo,
+)
+
+from ._base import BaseRepository
+
+_logger = logging.getLogger(__name__)
+
+
+class GroupsExtraPropertiesRepository(BaseRepository):
+    async def use_on_demand_clusters(self, user_id: UserID, product_name: str) -> bool:
+        try:
+            async with self.db_engine.acquire() as conn:
+                group_properties = (
+                    await GroupExtraPropertiesRepo.get_aggregated_properties_for_user(
+                        conn, user_id=user_id, product_name=product_name
+                    )
+                )
+            return group_properties.use_on_demand_clusters
+
+        except DatabaseError:
+            _logger.exception("Unexpected error while access DB:")
+            return False

--- a/services/api-server/src/simcore_service_api_server/db/repositories/groups_extra_properties.py
+++ b/services/api-server/src/simcore_service_api_server/db/repositories/groups_extra_properties.py
@@ -20,7 +20,7 @@ class GroupsExtraPropertiesRepository(BaseRepository):
                         conn, user_id=user_id, product_name=product_name
                     )
                 )
-            return group_properties.use_on_demand_clusters
+            return bool(group_properties.use_on_demand_clusters)
 
         except DatabaseError:
             _logger.exception("Unexpected error while access DB:")

--- a/services/api-server/src/simcore_service_api_server/db/repositories/users.py
+++ b/services/api-server/src/simcore_service_api_server/db/repositories/users.py
@@ -1,30 +1,10 @@
 import sqlalchemy as sa
 
-from ..tables import api_keys, users
+from ..tables import users
 from ._base import BaseRepository
 
 
 class UsersRepository(BaseRepository):
-    async def get_user_id(self, api_key: str, api_secret: str) -> int | None:
-        stmt = sa.select(api_keys.c.user_id,).where(
-            sa.and_(
-                api_keys.c.api_key == api_key,
-                api_keys.c.api_secret == api_secret,
-            )
-        )
-        async with self.db_engine.acquire() as conn:
-            user_id: int | None = await conn.scalar(stmt)
-        return user_id
-
-    async def any_user_with_id(self, user_id: int) -> bool:
-        stmt = sa.select(
-            [
-                api_keys.c.user_id,
-            ]
-        ).where(api_keys.c.user_id == user_id)
-        async with self.db_engine.acquire() as conn:
-            return (await conn.scalar(stmt)) is not None
-
     async def get_email_from_user_id(self, user_id: int) -> str | None:
         stmt = sa.select(
             [

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
+# pylint: disable=too-many-arguments
 
 from collections.abc import Iterator
 from pathlib import Path
@@ -66,7 +67,7 @@ def presigned_download_link(
         "s3",
         endpoint_url=mocked_s3_server_url,
         # Some fake auth, otherwise botocore.exceptions.NoCredentialsError: Unable to locate credentials
-        aws_secret_access_key="xxx",
+        aws_secret_access_key="xxx",  # noqa: S106
         aws_access_key_id="xxx",
     )
     s3_client.create_bucket(Bucket=bucket_name)
@@ -202,7 +203,7 @@ async def test_solver_logs(
     assert resp0.headers["location"] == presigned_download_link
 
     assert resp.url == presigned_download_link
-    pprint(dict(resp.headers))
+    pprint(dict(resp.headers))  # noqa: T203
 
 
 @pytest.fixture
@@ -215,7 +216,7 @@ def mocked_groups_extra_properties(mocker: MockerFixture) -> mock.Mock:
         GroupsExtraPropertiesRepository,
         "use_on_demand_clusters",
         autospec=True,
-        return_value=False,
+        return_value=True,
     )
 
 

--- a/services/api-server/tests/unit/conftest.py
+++ b/services/api-server/tests/unit/conftest.py
@@ -131,11 +131,6 @@ def auth(mocker, app: FastAPI, faker: Faker) -> HTTPBasicAuth:
         return_value=faker_user_id,
     )
     mocker.patch(
-        "simcore_service_api_server.db.repositories.users.UsersRepository.get_user_id",
-        autospec=True,
-        return_value=faker_user_id,
-    )
-    mocker.patch(
         "simcore_service_api_server.db.repositories.users.UsersRepository.get_email_from_user_id",
         autospec=True,
         return_value=faker.email(),
@@ -481,9 +476,9 @@ def patch_webserver_long_running_project_tasks(
 
 @pytest.fixture
 @respx.mock(assert_all_mocked=False)
-def respx_mock_from_capture() -> Callable[
-    [respx.MockRouter, Path, list[SideEffectCallback]], respx.MockRouter
-]:
+def respx_mock_from_capture() -> (
+    Callable[[respx.MockRouter, Path, list[SideEffectCallback]], respx.MockRouter]
+):
     def _generate_mock(
         respx_mock: respx.MockRouter,
         capture_path: Path,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

This PR permits PublicAPI users that have the right permissions to access on-demand clusters to use them.


Bonus: some cleanup so some people get more %!!

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
