### PR TITLE
✨ Auto-create wallet for new user in product

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,7 @@ Makefile                                  @pcrespov @sanderegg
 /packages/settings-library/               @pcrespov @sanderegg
 /requirements/                            @pcrespov @matusdrobuliak66
 /services/agent/                          @GitHK
-/services/api-server/                     @pcrespov
+/services/api-server/                     @pcrespov @bisgaard-itis
 /services/autoscaling/                    @sanderegg
 /services/catalog/                        @pcrespov @sanderegg
 /services/clusters-keeper/                @sanderegg

--- a/services/web/server/src/simcore_service_webserver/login/_confirmation.py
+++ b/services/web/server/src/simcore_service_webserver/login/_confirmation.py
@@ -54,8 +54,7 @@ def get_expiration_date(
     cfg: LoginOptions, confirmation: ConfirmationTokenDict
 ) -> datetime:
     lifetime = cfg.get_confirmation_lifetime(confirmation["action"])
-    estimated_expiration = confirmation["created_at"] + lifetime
-    return estimated_expiration
+    return confirmation["created_at"] + lifetime
 
 
 async def is_confirmation_allowed(

--- a/services/web/server/src/simcore_service_webserver/login/handlers_confirmation.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_confirmation.py
@@ -35,7 +35,14 @@ from .settings import (
     get_plugin_settings,
 )
 from .storage import AsyncpgStorage, ConfirmationTokenDict, get_plugin_storage
-from .utils import ACTIVE, CHANGE_EMAIL, REGISTRATION, RESET_PASSWORD, flash_response
+from .utils import (
+    ACTIVE,
+    CHANGE_EMAIL,
+    REGISTRATION,
+    RESET_PASSWORD,
+    flash_response,
+    notify_user_confirmation,
+)
 
 log = logging.getLogger(__name__)
 
@@ -66,6 +73,7 @@ async def validate_confirmation_and_redirect(request: web.Request):
     """
     db: AsyncpgStorage = get_plugin_storage(request.app)
     cfg: LoginOptions = get_plugin_options(request.app)
+    product: Product = get_current_product(request)
 
     path_params = parse_request_path_parameters_as(_PathParam, request)
 
@@ -83,6 +91,10 @@ async def validate_confirmation_and_redirect(request: web.Request):
                     user_id=user_id,
                     updates={"status": ACTIVE},
                     confirmation=confirmation,
+                )
+
+                await notify_user_confirmation(
+                    request.app, user_id=user_id, product_name=product.name
                 )
 
                 redirect_to_login_url = redirect_to_login_url.with_fragment(

--- a/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
@@ -207,7 +207,6 @@ async def register(request: web.Request):
     )
 
     # NOTE: PC->SAN: should this go here or when user is actually logged in?
-    # FIXME: do this in confirmation !!!!!
     await auto_add_user_to_groups(app=request.app, user_id=user["id"])
     await auto_add_user_to_product_group(
         app=request.app, user_id=user["id"], product_name=product.name

--- a/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
@@ -55,6 +55,7 @@ from .utils import (
     envelope_response,
     flash_response,
     get_client_ip,
+    notify_user_registration,
 )
 from .utils_email import get_template_path, send_email_from_template
 
@@ -210,6 +211,9 @@ async def register(request: web.Request):
     await auto_add_user_to_groups(app=request.app, user_id=user["id"])
     await auto_add_user_to_product_group(
         app=request.app, user_id=user["id"], product_name=product.name
+    )
+    await notify_user_registration(
+        request.app, user_id=user["id"], product_name=product.name
     )
 
     if settings.LOGIN_REGISTRATION_CONFIRMATION_REQUIRED:

--- a/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
@@ -55,7 +55,6 @@ from .utils import (
     envelope_response,
     flash_response,
     get_client_ip,
-    notify_user_registration,
 )
 from .utils_email import get_template_path, send_email_from_template
 
@@ -208,12 +207,10 @@ async def register(request: web.Request):
     )
 
     # NOTE: PC->SAN: should this go here or when user is actually logged in?
+    # FIXME: do this in confirmation !!!!!
     await auto_add_user_to_groups(app=request.app, user_id=user["id"])
     await auto_add_user_to_product_group(
         app=request.app, user_id=user["id"], product_name=product.name
-    )
-    await notify_user_registration(
-        request.app, user_id=user["id"], product_name=product.name
     )
 
     if settings.LOGIN_REGISTRATION_CONFIRMATION_REQUIRED:

--- a/services/web/server/src/simcore_service_webserver/login/utils.py
+++ b/services/web/server/src/simcore_service_webserver/login/utils.py
@@ -103,7 +103,7 @@ def check_password(password: str, password_hash: str) -> bool:
 
 def get_random_string(min_len: int, max_len: int | None = None) -> str:
     max_len = max_len or min_len
-    size = random.randint(min_len, max_len)  # noqa: S311 # nosec
+    size = random.randint(min_len, max_len)  # noqa: S311 # nosec # NOSONAR
     return cast(str, pwd.genword(entropy=52, length=size))
 
 

--- a/services/web/server/src/simcore_service_webserver/login/utils.py
+++ b/services/web/server/src/simcore_service_webserver/login/utils.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import passlib.hash
 from aiohttp import web
+from models_library.products import ProductName
 from models_library.users import UserID
 from passlib import pwd
 from servicelib.aiohttp import observer
@@ -13,7 +14,7 @@ from servicelib.json_serialization import json_dumps
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
 from simcore_postgres_database.models.users import UserRole
 
-from ..db.models import ConfirmationAction, UserRole, UserStatus
+from ..db.models import ConfirmationAction, UserStatus
 from ._constants import MSG_ACTIVATION_REQUIRED, MSG_USER_BANNED, MSG_USER_EXPIRED
 
 log = logging.getLogger(__name__)
@@ -62,6 +63,15 @@ def validate_user_status(*, user: dict, support_email: str):
         )  # 401
 
     assert user_status == ACTIVE  # nosec
+
+
+async def notify_user_registration(
+    app: web.Application,
+    user_id: UserID,
+    product_name: ProductName,
+):
+    """Broadcasts signa when 'user_id' has registered in 'product_name'"""
+    await observer.emit(app, "SIGNAL_USER_REGISTRATION", user_id, product_name, app)
 
 
 async def notify_user_logout(

--- a/services/web/server/src/simcore_service_webserver/login/utils.py
+++ b/services/web/server/src/simcore_service_webserver/login/utils.py
@@ -102,7 +102,7 @@ def check_password(password: str, password_hash: str) -> bool:
 
 def get_random_string(min_len: int, max_len: int | None = None) -> str:
     max_len = max_len or min_len
-    size = random.randint(min_len, max_len)
+    size = random.randint(min_len, max_len)  # noqa: S311 # nosec
     return cast(str, pwd.genword(entropy=52, length=size))
 
 

--- a/services/web/server/src/simcore_service_webserver/login/utils.py
+++ b/services/web/server/src/simcore_service_webserver/login/utils.py
@@ -70,8 +70,10 @@ async def notify_user_registration(
     user_id: UserID,
     product_name: ProductName,
 ):
-    """Broadcasts signa when 'user_id' has registered in 'product_name'"""
-    await observer.emit(app, "SIGNAL_USER_REGISTRATION", user_id, product_name, app)
+    """Broadcast that user with 'user_id' has registered in 'product_name'"""
+    await observer.emit(
+        app, "SIGNAL_ON_USER_REGISTERED", user_id=user_id, product_name=product_name
+    )
 
 
 async def notify_user_logout(

--- a/services/web/server/src/simcore_service_webserver/login/utils.py
+++ b/services/web/server/src/simcore_service_webserver/login/utils.py
@@ -65,14 +65,17 @@ def validate_user_status(*, user: dict, support_email: str):
     assert user_status == ACTIVE  # nosec
 
 
-async def notify_user_registration(
+async def notify_user_confirmation(
     app: web.Application,
     user_id: UserID,
     product_name: ProductName,
 ):
-    """Broadcast that user with 'user_id' has registered in 'product_name'"""
+    """Broadcast that user with 'user_id' has login for the first-time in 'product_name'"""
     await observer.emit(
-        app, "SIGNAL_ON_USER_REGISTERED", user_id=user_id, product_name=product_name
+        app,
+        "SIGNAL_ON_USER_CONFIRMATION",
+        user_id=user_id,
+        product_name=product_name,
     )
 
 

--- a/services/web/server/src/simcore_service_webserver/login/utils.py
+++ b/services/web/server/src/simcore_service_webserver/login/utils.py
@@ -71,6 +71,7 @@ async def notify_user_confirmation(
     product_name: ProductName,
 ):
     """Broadcast that user with 'user_id' has login for the first-time in 'product_name'"""
+    # NOTE: Follow up in https://github.com/ITISFoundation/osparc-simcore/issues/4822
     await observer.emit(
         app,
         "SIGNAL_ON_USER_CONFIRMATION",

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_consumers.py
@@ -1,6 +1,7 @@
 import functools
 import logging
-from typing import Any, AsyncIterator, Callable, Coroutine, Final
+from collections.abc import AsyncIterator, Callable, Coroutine
+from typing import Any, Final
 
 from aiohttp import web
 from models_library.rabbitmq_messages import (
@@ -177,7 +178,7 @@ async def _osparc_credits_message_parser(app: web.Application, data: bytes) -> b
         }
     ]
     wallet_groups = await wallets_api.list_wallet_groups_with_read_access_by_wallet(
-        app, rabbit_message.wallet_id
+        app, wallet_id=rabbit_message.wallet_id
     )
     rooms_to_notify = [f"{item.gid}" for item in wallet_groups]
     for room in rooms_to_notify:
@@ -198,17 +199,17 @@ EXCHANGE_TO_PARSER_CONFIG: Final[
     (
         LoggerRabbitMessage.get_channel_name(),
         _log_message_parser,
-        dict(topics=[]),
+        {"topics": []},
     ),
     (
         ProgressRabbitMessageNode.get_channel_name(),
         _progress_message_parser,
-        dict(topics=[]),
+        {"topics": []},
     ),
     (
         InstrumentationRabbitMessage.get_channel_name(),
         _instrumentation_message_parser,
-        dict(exclusive_queue=False),
+        {"exclusive_queue": False},
     ),
     (
         EventRabbitMessage.get_channel_name(),
@@ -218,7 +219,7 @@ EXCHANGE_TO_PARSER_CONFIG: Final[
     (
         WalletCreditsMessage.get_channel_name(),
         _osparc_credits_message_parser,
-        dict(topics=[]),
+        {"topics": []},
     ),
 )
 

--- a/services/web/server/src/simcore_service_webserver/wallets/_api.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_api.py
@@ -85,9 +85,7 @@ async def list_wallets_for_user(
     user_wallets: list[UserWalletDB] = await db.list_wallets_for_user(
         app=app, user_id=user_id, product_name=product_name
     )
-    wallets_api = parse_obj_as(list[WalletGet], user_wallets)
-
-    return wallets_api
+    return parse_obj_as(list[WalletGet], user_wallets)
 
 
 async def update_wallet(

--- a/services/web/server/src/simcore_service_webserver/wallets/_api.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_api.py
@@ -88,6 +88,26 @@ async def list_wallets_for_user(
     return parse_obj_as(list[WalletGet], user_wallets)
 
 
+async def any_wallet_owned_by_user(
+    app: web.Application,
+    user_id: UserID,
+    product_name: ProductName,
+) -> bool:
+    wallet_ids = await db.list_wallets_owned_by_user(
+        app, user_id=user_id, product_name=product_name
+    )
+
+    if len(wallet_ids) > 1:
+        _logger.warning(
+            "User %s owns more than one wallet for %s. Check %s",
+            f"{user_id=}",
+            f"{product_name=}",
+            f"{wallet_ids=}",
+        )
+
+    return len(wallet_ids) != 0
+
+
 async def update_wallet(
     app: web.Application,
     user_id: UserID,

--- a/services/web/server/src/simcore_service_webserver/wallets/_events.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_events.py
@@ -5,19 +5,20 @@ from models_library.products import ProductName
 from models_library.users import UserID
 from servicelib.aiohttp.observer import register_observer, setup_observer_registry
 
-from ._api import create_wallet, list_wallets_for_user
+from ._api import any_wallet_owned_by_user, create_wallet
 
 
 async def _auto_add_default_wallet(
     app: web.Application, user_id: UserID, product_name: ProductName
 ):
-    # TODO: check ANY OWNED wallets!
-    if not await list_wallets_for_user(app, user_id=user_id, product_name=product_name):
+    if not await any_wallet_owned_by_user(
+        app, user_id=user_id, product_name=product_name
+    ):
         await create_wallet(
             app,
             user_id=user_id,
             wallet_name="Credits",
-            description=None,
+            description="Keeps the credits in your account",
             thumbnail=None,
             product_name=product_name,
         )

--- a/services/web/server/src/simcore_service_webserver/wallets/_events.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_events.py
@@ -8,7 +8,7 @@ from servicelib.aiohttp.observer import register_observer, setup_observer_regist
 from ._api import create_wallet, list_wallets_for_user
 
 
-async def auto_add_default_wallet(
+async def _auto_add_default_wallet(
     app: web.Application, user_id: UserID, product_name: ProductName
 ):
     # TODO: check ANY OWNED wallets!
@@ -26,7 +26,7 @@ async def auto_add_default_wallet(
 async def _on_user_registration(
     app: web.Application, user_id: UserID, product_name: ProductName
 ):
-    await auto_add_default_wallet(app, user_id=user_id, product_name=product_name)
+    await _auto_add_default_wallet(app, user_id=user_id, product_name=product_name)
 
 
 def setup_wallets_events(app: web.Application):

--- a/services/web/server/src/simcore_service_webserver/wallets/_events.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_events.py
@@ -35,6 +35,7 @@ def setup_wallets_events(app: web.Application):
     setup_observer_registry(app)
 
     # registers SIGNAL_ON_USER_CONFIRMATION
+    # NOTE: should follow up on https://github.com/ITISFoundation/osparc-simcore/issues/4822
     register_observer(
         app,
         functools.partial(_on_user_confirmation, app=app),

--- a/services/web/server/src/simcore_service_webserver/wallets/_events.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_events.py
@@ -33,9 +33,9 @@ def setup_wallets_events(app: web.Application):
     # ensures registry in place
     setup_observer_registry(app)
 
-    # registers SIGNAL_USER_REGISTRATION
+    # registers SIGNAL_ON_USER_REGISTERED
     register_observer(
         app,
         functools.partial(_on_user_registration, app=app),
-        event="SIGNAL_USER_REGISTRATION",
+        event="SIGNAL_ON_USER_REGISTERED",
     )

--- a/services/web/server/src/simcore_service_webserver/wallets/_events.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_events.py
@@ -1,0 +1,41 @@
+import functools
+
+from aiohttp import web
+from models_library.products import ProductName
+from models_library.users import UserID
+from servicelib.aiohttp.observer import register_observer, setup_observer_registry
+
+from ._api import create_wallet, list_wallets_for_user
+
+
+async def auto_add_default_wallet(
+    app: web.Application, user_id: UserID, product_name: ProductName
+):
+    # TODO: check ANY OWNED wallets!
+    if not await list_wallets_for_user(app, user_id=user_id, product_name=product_name):
+        await create_wallet(
+            app,
+            user_id=user_id,
+            wallet_name="Credits",
+            description=None,
+            thumbnail=None,
+            product_name=product_name,
+        )
+
+
+async def _on_user_registration(
+    app: web.Application, user_id: UserID, product_name: ProductName
+):
+    await auto_add_default_wallet(app, user_id=user_id, product_name=product_name)
+
+
+def setup_wallets_events(app: web.Application):
+    # ensures registry in place
+    setup_observer_registry(app)
+
+    # registers SIGNAL_USER_REGISTRATION
+    register_observer(
+        app,
+        functools.partial(_on_user_registration, app=app),
+        event="SIGNAL_USER_REGISTRATION",
+    )

--- a/services/web/server/src/simcore_service_webserver/wallets/_events.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_events.py
@@ -24,7 +24,7 @@ async def _auto_add_default_wallet(
         )
 
 
-async def _on_user_registration(
+async def _on_user_confirmation(
     app: web.Application, user_id: UserID, product_name: ProductName
 ):
     await _auto_add_default_wallet(app, user_id=user_id, product_name=product_name)
@@ -34,9 +34,9 @@ def setup_wallets_events(app: web.Application):
     # ensures registry in place
     setup_observer_registry(app)
 
-    # registers SIGNAL_ON_USER_REGISTERED
+    # registers SIGNAL_ON_USER_CONFIRMATION
     register_observer(
         app,
-        functools.partial(_on_user_registration, app=app),
-        event="SIGNAL_ON_USER_REGISTERED",
+        functools.partial(_on_user_confirmation, app=app),
+        event="SIGNAL_ON_USER_CONFIRMATION",
     )

--- a/services/web/server/src/simcore_service_webserver/wallets/_events.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_events.py
@@ -18,7 +18,7 @@ async def _auto_add_default_wallet(
             app,
             user_id=user_id,
             wallet_name="Credits",
-            description="Keeps the credits in your account",
+            description="Purchased credits end up in here",
             thumbnail=None,
             product_name=product_name,
         )

--- a/services/web/server/src/simcore_service_webserver/wallets/_groups_api.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_groups_api.py
@@ -27,6 +27,7 @@ class WalletGroupGet(BaseModel):
 
 async def create_wallet_group(
     app: web.Application,
+    *,
     user_id: UserID,
     wallet_id: WalletID,
     group_id: GroupID,
@@ -58,6 +59,7 @@ async def create_wallet_group(
 
 async def list_wallet_groups_by_user_and_wallet(
     app: web.Application,
+    *,
     user_id: UserID,
     wallet_id: WalletID,
     product_name: ProductName,
@@ -83,6 +85,7 @@ async def list_wallet_groups_by_user_and_wallet(
 
 async def list_wallet_groups_with_read_access_by_wallet(
     app: web.Application,
+    *,
     wallet_id: WalletID,
 ) -> list[WalletGroupGet]:
     wallet_groups_db: list[
@@ -100,6 +103,7 @@ async def list_wallet_groups_with_read_access_by_wallet(
 
 async def update_wallet_group(
     app: web.Application,
+    *,
     user_id: UserID,
     wallet_id: WalletID,
     group_id: GroupID,
@@ -138,6 +142,7 @@ async def update_wallet_group(
 
 async def delete_wallet_group(
     app: web.Application,
+    *,
     user_id: UserID,
     wallet_id: WalletID,
     group_id: GroupID,

--- a/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
@@ -90,6 +90,8 @@ async def create_wallet(request: web.Request):
     req_ctx = WalletsRequestContext.parse_obj(request)
     body_params = await parse_request_body_as(CreateWalletBodyParams, request)
 
+    # TODO: should we limit this?
+
     wallet: WalletGet = await _api.create_wallet(
         request.app,
         user_id=req_ctx.user_id,

--- a/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
@@ -22,6 +22,7 @@ from servicelib.request_keys import RQT_USERID_KEY
 
 from .._constants import RQ_PRODUCT_KEY
 from .._meta import API_VTAG as VTAG
+from ..application_settings_utils import requires_dev_feature_enabled
 from ..login.decorators import login_required
 from ..payments.errors import (
     PaymentCompletedError,
@@ -83,14 +84,13 @@ class WalletsPathParams(StrictRequestParams):
 
 
 @routes.post(f"/{VTAG}/wallets", name="create_wallet")
+@requires_dev_feature_enabled  # NOTE: one wallet per user+product. SEE _events.py:_auto_add_default_wallet
 @login_required
 @permission_required("wallets.*")
 @handle_wallets_exceptions
 async def create_wallet(request: web.Request):
     req_ctx = WalletsRequestContext.parse_obj(request)
     body_params = await parse_request_body_as(CreateWalletBodyParams, request)
-
-    # TODO: should we limit this?
 
     wallet: WalletGet = await _api.create_wallet(
         request.app,

--- a/services/web/server/src/simcore_service_webserver/wallets/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/plugin.py
@@ -9,6 +9,7 @@ from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setu
 
 from ..payments.plugin import setup_payments
 from . import _groups_handlers, _handlers, _payments_handlers
+from ._events import setup_wallets_events
 
 _logger = logging.getLogger(__name__)
 
@@ -29,3 +30,5 @@ def setup_wallets(app: web.Application):
     setup_payments(app)
     if app[APP_SETTINGS_KEY].WEBSERVER_PAYMENTS:
         app.router.add_routes(_payments_handlers.routes)
+
+    setup_wallets_events()

--- a/services/web/server/src/simcore_service_webserver/wallets/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/plugin.py
@@ -24,6 +24,7 @@ _logger = logging.getLogger(__name__)
 def setup_wallets(app: web.Application):
     assert app[APP_SETTINGS_KEY].WEBSERVER_WALLETS  # nosec
 
+    # routes
     app.router.add_routes(_handlers.routes)
     app.router.add_routes(_groups_handlers.routes)
 
@@ -31,4 +32,5 @@ def setup_wallets(app: web.Application):
     if app[APP_SETTINGS_KEY].WEBSERVER_PAYMENTS:
         app.router.add_routes(_payments_handlers.routes)
 
+    # events
     setup_wallets_events(app)

--- a/services/web/server/src/simcore_service_webserver/wallets/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/plugin.py
@@ -31,4 +31,4 @@ def setup_wallets(app: web.Application):
     if app[APP_SETTINGS_KEY].WEBSERVER_PAYMENTS:
         app.router.add_routes(_payments_handlers.routes)
 
-    setup_wallets_events()
+    setup_wallets_events(app)

--- a/services/web/server/tests/unit/with_dbs/03/invitations/test_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/invitations/test_invitations.py
@@ -97,6 +97,7 @@ async def test_invitation_service_api_ping(
     mock_invitations_service_http_api: AioResponsesMock,
     base_url: URL,
 ):
+    assert client.app
     invitations_api: InvitationsServiceApi = get_invitations_service_api(app=client.app)
 
     # first request is mocked to pass

--- a/services/web/server/tests/unit/with_dbs/03/login/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/conftest.py
@@ -4,14 +4,12 @@
 
 
 import json
-from collections.abc import Iterator
-from typing import AsyncIterable
+from collections.abc import AsyncIterable, Iterator
 
 import pytest
 import sqlalchemy as sa
 from aiohttp.test_utils import TestClient
 from faker import Faker
-from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_dict
 from pytest_simcore.helpers.utils_login import NewUser, UserInfoDict
@@ -22,7 +20,7 @@ from simcore_service_webserver.login.storage import AsyncpgStorage, get_plugin_s
 
 
 @pytest.fixture
-def app_environment(app_environment: EnvVarsDict, monkeypatch: MonkeyPatch):
+def app_environment(app_environment: EnvVarsDict, monkeypatch: pytest.MonkeyPatch):
     envs_plugins = setenvs_from_dict(
         monkeypatch,
         {

--- a/services/web/server/tests/unit/with_dbs/03/login/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/conftest.py
@@ -22,12 +22,13 @@ def app_environment(app_environment: EnvVarsDict, monkeypatch: MonkeyPatch):
         monkeypatch,
         {
             "WEBSERVER_ACTIVITY": "null",
-            "WEBSERVER_NOTIFICATIONS": "0",
+            "WEBSERVER_DB_LISTENER": "0",
             "WEBSERVER_DIAGNOSTICS": "null",
             "WEBSERVER_EXPORTER": "null",
             "WEBSERVER_GARBAGE_COLLECTOR": "null",
             "WEBSERVER_GROUPS": "1",
             "WEBSERVER_META_MODELING": "0",
+            "WEBSERVER_NOTIFICATIONS": "0",
             "WEBSERVER_PRODUCTS": "1",
             "WEBSERVER_PUBLICATIONS": "0",
             "WEBSERVER_REMOTE_DEBUG": "0",
@@ -37,7 +38,7 @@ def app_environment(app_environment: EnvVarsDict, monkeypatch: MonkeyPatch):
             "WEBSERVER_TRACING": "null",
             "WEBSERVER_USERS": "1",
             "WEBSERVER_VERSION_CONTROL": "0",
-            "WEBSERVER_WALLETS": "0",
+            "WEBSERVER_WALLETS": "1",
         },
     )
 

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_2fa.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_2fa.py
@@ -114,6 +114,7 @@ async def test_workflow_register_and_login_with_2fa(
     fake_user_phone_number: str,
     mocked_twilio_service: dict[str, Mock],
     mocked_email_core_remove_comments: None,
+    cleanup_db_tables: None,
 ):
     assert client.app
 
@@ -238,15 +239,13 @@ async def test_workflow_register_and_login_with_2fa(
     assert user["phone"] == fake_user_phone_number
     assert user["status"] == UserStatus.ACTIVE.value
 
-    # cleanup
-    await db.delete_user(user)
-
 
 async def test_register_phone_fails_with_used_number(
     client: TestClient,
     fake_user_email: str,
     fake_user_password: str,
     fake_user_phone_number: str,
+    cleanup_db_tables: None,
 ):
     """
     Tests https://github.com/ITISFoundation/osparc-simcore/issues/3304
@@ -334,6 +333,7 @@ async def test_2fa_sms_failure_during_login(
     fake_user_phone_number: str,
     caplog: pytest.LogCaptureFixture,
     mocker: MockerFixture,
+    cleanup_db_tables: None,
 ):
     assert client.app
 

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_registration.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_registration.py
@@ -3,11 +3,9 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
-from collections.abc import Iterator
 from datetime import timedelta
 
 import pytest
-import sqlalchemy as sa
 from aiohttp import web
 from aiohttp.test_utils import TestClient
 from faker import Faker
@@ -16,8 +14,6 @@ from pytest_simcore.helpers.utils_assert import assert_error, assert_status
 from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_dict
 from pytest_simcore.helpers.utils_login import NewInvitation, NewUser, parse_link
 from servicelib.aiohttp.rest_responses import unwrap_envelope
-from simcore_postgres_database.models.users import users
-from simcore_postgres_database.models.wallets import wallets
 from simcore_service_webserver.db.models import ConfirmationAction, UserStatus
 from simcore_service_webserver.login._confirmation import _url_for_confirmation
 from simcore_service_webserver.login._constants import (
@@ -49,14 +45,6 @@ def app_environment(
     )
 
     return app_environment | login_envs
-
-
-@pytest.fixture
-def cleanup_db_tables(postgres_db: sa.engine.Engine) -> Iterator[None]:
-    yield
-    with postgres_db.connect() as conn:
-        conn.execute(wallets.delete())
-        conn.execute(users.delete())
 
 
 async def test_register_entrypoint(

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_registration.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_registration.py
@@ -3,15 +3,14 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
+from collections.abc import Iterator
 from datetime import timedelta
-from typing import Iterator
 
 import pytest
 import sqlalchemy as sa
 from aiohttp import web
 from aiohttp.test_utils import TestClient
 from faker import Faker
-from pytest import CaptureFixture, MonkeyPatch
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.utils_assert import assert_error, assert_status
 from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_dict
@@ -37,7 +36,7 @@ from simcore_service_webserver.users.schemas import ProfileGet
 
 @pytest.fixture
 def app_environment(
-    app_environment: EnvVarsDict, monkeypatch: MonkeyPatch
+    app_environment: EnvVarsDict, monkeypatch: pytest.MonkeyPatch
 ) -> EnvVarsDict:
     login_envs = setenvs_from_dict(
         monkeypatch,
@@ -349,7 +348,7 @@ async def test_registration_without_confirmation(
 async def test_registration_with_confirmation(
     client: TestClient,
     db: AsyncpgStorage,
-    capsys: CaptureFixture,
+    capsys: pytest.CaptureFixture,
     mocker: MockerFixture,
     fake_user_email: str,
     fake_user_password: str,

--- a/services/web/server/tests/unit/with_dbs/03/wallets/test_wallets.py
+++ b/services/web/server/tests/unit/with_dbs/03/wallets/test_wallets.py
@@ -151,7 +151,6 @@ async def test_wallets_full_workflow(
         assert errors
 
 
-@pytest.mark.testit
 @pytest.mark.parametrize("user_role,expected", [(UserRole.USER, web.HTTPOk)])
 async def test_auto_wallet_on_user_registration_confirmation(
     client: TestClient,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying. 
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

A user's default wallet is auto created **when the account registration is completed** (i.e. user clicks confirmation link)


- ✨ `login` triggers `SIGNAL_ON_USER_CONFIRMATION` when user clicks confirmation link (i.e. final step in registration)
- ✨ `wallets` plugin observers `SIGNAL_ON_USER_CONFIRMATION` and executes `_auto_add_default_wallet` that **ensures** that user **owns** one wallet.
- ♻️ `POST /v0/wallets` to create wallets restricted to `WEBSERVER_DEV_FEATURES_ENABLED=1`



## Related issue/s

- Implements `a user's default wallet (on account creation)` in https://github.com/ITISFoundation/osparc-issues/issues/1027


## How to test

Driving test are
- all `services/web/server/tests/unit/with_dbs/03/login/test_login_registration.py`
- `services/web/server/tests/unit/with_dbs/03/wallets/test_wallets.py:test_auto_wallet_on_user_registration_confirmation`

## DevOps

None