### PR TITLE
🐛 Fix issue with paths not found in attribute monitor

### DIFF
--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
@@ -30,16 +30,17 @@ class _LoggingEventHandler(SafeFileSystemEventHandler):
         # NOTE: runs in the created process
 
         file_path = Path(event.src_path)
-        file_stat = file_path.stat()
-        logger.info(
-            "Attribute change to: '%s': permissions=%s uid=%s gid=%s size=%s\nFile stat: %s",
-            file_path,
-            stat.filemode(file_stat.st_mode),
-            file_stat.st_uid,
-            file_stat.st_gid,
-            ByteSize(file_stat.st_size).human_readable(),
-            file_stat,
-        )
+        with suppress(FileNotFoundError):
+            file_stat = file_path.stat()
+            logger.info(
+                "Attribute change to: '%s': permissions=%s uid=%s gid=%s size=%s\nFile stat: %s",
+                file_path,
+                stat.filemode(file_stat.st_mode),
+                file_stat.st_uid,
+                file_stat.st_gid,
+                ByteSize(file_stat.st_size).human_readable(),
+                file_stat,
+            )
 
 
 class _LoggingEventHandlerProcess:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).


or from https://gitmoji.dev/
-->

## What do these changes do?

Fixes the following issue where the attribute monitor will fail if the file would be removed immediately after being created.

```python
Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.10/site-packages/servicelib/logging_utils.py", line 225, in log_catch
    yield
  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_dynamic_sidecar/modules/attribute_monitor/_watchdog_extensions.py", line 70, in on_any_event
    self.event_handler(event)
  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py", line 33, in event_handler
    file_stat = file_path.stat()
  File "/usr/local/lib/python3.10/pathlib.py", line 1097, in stat
    return self._accessor.stat(self, follow_symlinks=follow_symlinks)
FileNotFoundError: [Errno 2] No such file or directory: '/dy-volumes/home/smu/work/workspace/.FILE_WAS_CRETATED_AND_DELETED_IMMEDIATELY'
```

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->

- https://github.com/ITISFoundation/osparc-issues/issues/638

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
