### PR TITLE
🐛 Fixes `enum`-ports breaks compatibility matching

### DIFF
--- a/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
@@ -11,20 +11,20 @@ from ._models import ServiceInputGetFactory, ServiceOutputGetFactory, get_unit_n
 
 
 def _get_type_name(port: BaseServiceIOModel) -> str:
-    _type_name: str = port.property_type
+    type_name: str = port.property_type
     if port.property_type == "ref_contentSchema":
         assert port.content_schema is not None  # nosec
 
         try:
-            _type_name = port.content_schema["type"]
+            type_name = port.content_schema["type"]
 
         except KeyError:
             # NOTE: hybrid enums do not require 'type'
             # SEE https://github.com/pcrespov/sandbox-python/blob/98fb613a41e9c6a5a54f52be321cb652bfe047da/json-schemas/test_schemas_with_enums.py
             #
             # In this case, the type_name is defined by creating a string of all the enum values
-            _type_name = f"{sorted(port.content_schema.get('enum', []))}"
-    return _type_name
+            type_name = f"{sorted(port.content_schema.get('enum', []))}"
+    return type_name
 
 
 def _can_convert_units(from_unit: str, to_unit: str, ureg: UnitRegistry) -> bool:

--- a/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
@@ -10,12 +10,21 @@ from pint import PintError, UnitRegistry
 from ._models import ServiceInputGetFactory, ServiceOutputGetFactory, get_unit_name
 
 
-def _get_type_name(port: BaseServiceIOModel) -> str:
-    _type: str = port.property_type
+def _get_type_name(port: BaseServiceIOModel) -> str | list:
+    _type_name: str = port.property_type
     if port.property_type == "ref_contentSchema":
         assert port.content_schema is not None  # nosec
-        _type = port.content_schema["type"]
-    return _type
+
+        try:
+            _type_name = port.content_schema["type"]
+
+        except KeyError:
+            # NOTE: hybrid enums do not require 'type'
+            # SEE https://github.com/pcrespov/sandbox-python/blob/98fb613a41e9c6a5a54f52be321cb652bfe047da/json-schemas/test_schemas_with_enums.py
+            #
+            # In this case, the type_name is defined by creating a string of all the enum values
+            _type_name = f"{sorted(port.content_schema.get('enum', []))}"
+    return _type_name
 
 
 def _can_convert_units(from_unit: str, to_unit: str, ureg: UnitRegistry) -> bool:

--- a/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
@@ -10,7 +10,7 @@ from pint import PintError, UnitRegistry
 from ._models import ServiceInputGetFactory, ServiceOutputGetFactory, get_unit_name
 
 
-def _get_type_name(port: BaseServiceIOModel) -> str | list:
+def _get_type_name(port: BaseServiceIOModel) -> str:
     _type_name: str = port.property_type
     if port.property_type == "ref_contentSchema":
         assert port.content_schema is not None  # nosec

--- a/services/web/server/tests/unit/isolated/test_catalog_api_units.py
+++ b/services/web/server/tests/unit/isolated/test_catalog_api_units.py
@@ -9,11 +9,10 @@ import pytest
 from models_library.function_services_catalog.services import demo_units
 from models_library.services import ServiceInput, ServiceOutput
 from pint import UnitRegistry
-from pydantic import Field, create_model
 from simcore_service_webserver.catalog._api_units import can_connect
 
 
-def create_port_data(schema: dict[str, Any]):
+def _create_port_data(schema: dict[str, Any]):
     description = schema.pop("description", schema["title"])
 
     return {
@@ -24,29 +23,38 @@ def create_port_data(schema: dict[str, Any]):
     }
 
 
-def upgrade_port_data(old_port) -> dict[str, Any]:
-    _type = old_port["type"]
-    if _type in ("number", "integer", "string"):
-        # creates schema from old data
-        title = old_port["label"].upper()
-        field_kwargs = {"description": old_port["description"]}
-        if unit := old_port.get("unit"):
-            field_kwargs["x_unit"] = unit
-        python_type = {"number": float, "integer": int, "string": str}
-        schema = create_model(
-            title, __root__=(python_type[_type], Field(..., **field_kwargs))
-        ).schema_json(indent=1)
-        return create_port_data(schema)
-    return old_port
-
-
 @pytest.fixture(scope="module")
 def unit_registry():
     return UnitRegistry()
 
 
-def test_can_connect_for_gh_osparc_issues_442(unit_registry: UnitRegistry):
-    # Reproduces https://github.com/ITISFoundation/osparc-issues/issues/442
+@pytest.mark.acceptance_test(
+    "Reproduces https://github.com/ITISFoundation/osparc-simcore/issues/4793"
+)
+def test_can_connect_enums(unit_registry: UnitRegistry):
+    enum_port = {
+        "displayOrder": 4,
+        "label": "Solution method",
+        "description": "desc",
+        "type": "ref_contentSchema",
+        "contentSchema": {
+            "title": "Solution method",
+            "default": "Iterative (GMRES)",
+            "enum": ["Iterative (GMRES)", "FMM-LU"],
+        },
+    }
+
+    assert can_connect(
+        from_output=ServiceOutput.parse_obj(enum_port),
+        to_input=ServiceInput.parse_obj(enum_port),
+        units_registry=unit_registry,
+    )
+
+
+@pytest.mark.acceptance_test(
+    "Reproduces https://github.com/ITISFoundation/osparc-issues/issues/442"
+)
+def test_can_connect_generic_data_types(unit_registry: UnitRegistry):
     file_picker_outfile = {
         "displayOrder": 2,
         "label": "File Picker",
@@ -82,7 +90,7 @@ PORTS_WITH_UNITS = [
         "description": "output w/o unit old format",
         "type": "integer",
     },
-    create_port_data(
+    _create_port_data(
         {
             "title": "port-W/O",
             "description": "output w/o unit",
@@ -98,7 +106,7 @@ PORTS_WITHOUT_UNITS = [
         "type": "integer",
         "unit": "m",  # <---
     },
-    create_port_data(
+    _create_port_data(
         {
             "title": "port-W/",
             "description": "port w/ unit",
@@ -151,7 +159,7 @@ def test_units_compatible(
     # TODO: does it make sense to have a string or bool with x_unit??
     #
 
-    from_port = create_port_data(
+    from_port = _create_port_data(
         {
             "title": "src",
             "description": "source port",
@@ -159,7 +167,7 @@ def test_units_compatible(
             "x_unit": from_unit,
         }
     )
-    to_port = create_port_data(
+    to_port = _create_port_data(
         {
             "title": "dst",
             "description": "destination port",


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

json-schema does not require `type` field with `enum` since the values of the enumeration can have different types. This PR prevents that this case breaks matching.

Nonetheless, since we mostly use "pure-string" enums it is recommended to add `"type": "string"`. For instance, in this case modify the json-schema such that makes the enum strictly of `strings` by adding a  `type` field:
```json
 {
   "title": "Solution method",
   "description": "An enumeration",
   "enum": [ "Iterative (GMRES)",  "FMM-LU"],
   "type": "string"  # <-- NOTE THIS
}
```
This is legal in json-schema and you are basically saying that the values of the enum are strings. For more insight on the enum schemas you can look at https://github.com/pcrespov/sandbox-python/blob/98fb613a41e9c6a5a54f52be321cb652bfe047da/json-schemas/test_schemas_with_enums.py



## Related issue/s

- Fixes #4793

## How to test

```cmd
cd services/web/server/
make install-dev
pytest -vv tests/unit/isolated/test_catalog_api_units.py:test_can_connect_enums
```
## DevOps

None