### PR TITLE
✨ Show editable Study title on Navigation Bar

### DIFF
--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -346,7 +346,6 @@ qx.Class.define("osparc.Application", {
       // Invalidate the entire cache
       osparc.store.Store.getInstance().invalidateEntireCache();
       await this.__preloadCalls();
-      await osparc.data.Resources.get("permissions");
       const profile = await osparc.data.Resources.getOne("profile");
       if (profile) {
         this.__connectWebSocket();

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -422,7 +422,6 @@ qx.Class.define("osparc.desktop.MainPage", {
       }, this);
       studyEditor.addListener("expandNavBar", () => this.__navBar.show());
       studyEditor.addListener("collapseNavBar", () => this.__navBar.exclude());
-      studyEditor.addListener("changeMaximized", e => this.__navBar.iframeMaximized(e.getData()));
       studyEditor.addListener("backToDashboardPressed", () => this.__backToDashboardPressed(), this);
       studyEditor.addListener("forceBackToDashboard", () => this.__showDashboard(), this);
       studyEditor.addListener("userIdled", () => this.__backToDashboard(), this);

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -114,11 +114,7 @@ qx.Class.define("osparc.desktop.MainPage", {
         if (!isReadOnly && preferencesSettings.getConfirmBackToDashboard()) {
           const studyName = this.__studyEditor.getStudy().getName();
           const win = new osparc.ui.window.Confirmation();
-          if (
-            osparc.product.Utils.isProduct("s4l") ||
-            osparc.product.Utils.isProduct("s4llite") ||
-            osparc.product.Utils.isProduct("s4lacad")
-          ) {
+          if (osparc.product.Utils.getProductName().includes("s4l")) {
             let msg = this.tr("Do you want to close ") + "<b>" + studyName + "</b>?";
             msg += "<br><br>";
             msg += this.tr("Make sure you saved your changes to:");

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -422,6 +422,7 @@ qx.Class.define("osparc.desktop.MainPage", {
       }, this);
       studyEditor.addListener("expandNavBar", () => this.__navBar.show());
       studyEditor.addListener("collapseNavBar", () => this.__navBar.exclude());
+      studyEditor.addListener("changeMaximized", e => this.__navBar.iframeMaximized(e.getData()));
       studyEditor.addListener("backToDashboardPressed", () => this.__backToDashboardPressed(), this);
       studyEditor.addListener("forceBackToDashboard", () => this.__showDashboard(), this);
       studyEditor.addListener("userIdled", () => this.__backToDashboard(), this);

--- a/services/static-webserver/client/source/class/osparc/desktop/SlideshowToolbar.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/SlideshowToolbar.js
@@ -32,22 +32,6 @@ qx.Class.define("osparc.desktop.SlideshowToolbar", {
     _createChildControlImpl: function(id) {
       let control;
       switch (id) {
-        case "study-info":
-          control = new qx.ui.form.Button(null, "@MaterialIcons/info_outline/16").set({
-            ...osparc.navigation.NavigationBar.BUTTON_OPTIONS,
-            toolTipText: this.tr("Study Information")
-          });
-          control.addListener("execute", () => this.__openStudyDetails(), this);
-          this._add(control);
-          break;
-        case "study-title":
-          control = new qx.ui.basic.Label().set({
-            marginLeft: 10,
-            maxWidth: 200,
-            font: "text-16"
-          });
-          this._add(control);
-          break;
         case "edit-slideshow-buttons": {
           control = new qx.ui.container.Stack();
           const editBtn = new qx.ui.form.Button(null, "@FontAwesome5Solid/edit/14").set({
@@ -146,9 +130,8 @@ qx.Class.define("osparc.desktop.SlideshowToolbar", {
 
     // overridden
     _buildLayout: function() {
-      this.getChildControl("study-info");
-      this.getChildControl("study-title");
-
+      const spacerLeft = new qx.ui.core.Spacer(); // match "stop-slideshow" to keep breadcrumbs centered
+      this._add(spacerLeft);
       this._add(new qx.ui.core.Spacer(), {
         flex: 1
       });
@@ -161,18 +144,10 @@ qx.Class.define("osparc.desktop.SlideshowToolbar", {
         flex: 1
       });
 
-      this.getChildControl("stop-slideshow");
-    },
-
-    // overridden
-    _applyStudy: function(study) {
-      this.base(arguments, study);
-
-      if (study) {
-        const studyTitle = this.getChildControl("study-title");
-        study.bind("name", studyTitle, "value");
-        study.bind("name", studyTitle, "toolTipText");
-      }
+      const stopSlideshowButton = this.getChildControl("stop-slideshow");
+      stopSlideshowButton.bind("visibility", spacerLeft, "width", {
+        converter: visible => visible ? 120 : 0
+      });
     },
 
     // overridden
@@ -201,14 +176,6 @@ qx.Class.define("osparc.desktop.SlideshowToolbar", {
           currentModeBtn.execute();
         }
       }
-    },
-
-    __openStudyDetails: function() {
-      const studyDetails = new osparc.info.StudyLarge(this.getStudy());
-      const title = this.tr("Study Information");
-      const width = osparc.info.CardLarge.WIDTH;
-      const height = osparc.info.CardLarge.HEIGHT;
-      osparc.ui.window.Window.popUpInWindow(studyDetails, title, width, height);
     },
 
     __evalButtonsIfEditing: function() {

--- a/services/static-webserver/client/source/class/osparc/desktop/SlideshowView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/SlideshowView.js
@@ -124,6 +124,14 @@ qx.Class.define("osparc.desktop.SlideshowView", {
       nullable: false
     },
 
+    maximized: {
+      check: "Boolean",
+      init: null,
+      nullable: false,
+      apply: "__applyMaximized",
+      event: "changeMaximized"
+    },
+
     pageContext: {
       check: ["guided", "app"],
       nullable: false,
@@ -210,8 +218,8 @@ qx.Class.define("osparc.desktop.SlideshowView", {
             iFrame
           ].forEach(widget => {
             if (widget) {
-              widget.addListener("maximize", () => this.__maximizeIframe(true), this);
-              widget.addListener("restore", () => this.__maximizeIframe(false), this);
+              widget.addListener("maximize", () => this.setMaximized(true), this);
+              widget.addListener("restore", () => this.setMaximized(false), this);
             }
           });
         }
@@ -334,7 +342,7 @@ qx.Class.define("osparc.desktop.SlideshowView", {
       this.getStudy().getUi().setCurrentNodeId(nodeId);
     },
 
-    __maximizeIframe: function(maximize) {
+    __applyMaximized: function(maximized) {
       [
         this.__slideshowToolbar,
         this.__prevButton,
@@ -342,10 +350,10 @@ qx.Class.define("osparc.desktop.SlideshowView", {
         this.__runButton,
         this.__nodeView.getHeaderLayout(),
         this.__nodeView.getLoggerPanel()
-      ].forEach(widget => widget.setVisibility(maximize ? "excluded" : "visible"));
+      ].forEach(widget => widget.setVisibility(maximized ? "excluded" : "visible"));
 
       this.__nodeView.set({
-        margin: maximize ? 0 : this.self().CARD_MARGIN
+        margin: maximized ? 0 : this.self().CARD_MARGIN
       });
     },
 

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -38,6 +38,9 @@ qx.Class.define("osparc.desktop.StudyEditor", {
       slideshowView.addListener(signalName, () => this.fireEvent(signalName));
     });
 
+    workbenchView.addListener("changeMaximized", e => this.fireDataEvent("changeMaximized", e.getData()));
+    slideshowView.addListener("changeMaximized", e => this.fireDataEvent("changeMaximized", e.getData()));
+
     workbenchView.addListener("slidesEdit", () => this.fireEvent("slidesEdit"), this);
     workbenchView.addListener("slidesAppStart", () => this.fireEvent("slidesAppStart"), this);
     slideshowView.addListener("slidesStop", () => this.fireEvent("slidesStop"));
@@ -93,6 +96,7 @@ qx.Class.define("osparc.desktop.StudyEditor", {
     "userIdled": "qx.event.type.Event",
     "collapseNavBar": "qx.event.type.Event",
     "expandNavBar": "qx.event.type.Event",
+    "changeMaximized": "qx.event.type.Data",
     "slidesEdit": "qx.event.type.Event",
     "slidesAppStart": "qx.event.type.Event",
     "slidesStop": "qx.event.type.Event",

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -38,9 +38,6 @@ qx.Class.define("osparc.desktop.StudyEditor", {
       slideshowView.addListener(signalName, () => this.fireEvent(signalName));
     });
 
-    workbenchView.addListener("changeMaximized", e => this.fireDataEvent("changeMaximized", e.getData()));
-    slideshowView.addListener("changeMaximized", e => this.fireDataEvent("changeMaximized", e.getData()));
-
     workbenchView.addListener("slidesEdit", () => this.fireEvent("slidesEdit"), this);
     workbenchView.addListener("slidesAppStart", () => this.fireEvent("slidesAppStart"), this);
     slideshowView.addListener("slidesStop", () => this.fireEvent("slidesStop"));
@@ -96,7 +93,6 @@ qx.Class.define("osparc.desktop.StudyEditor", {
     "userIdled": "qx.event.type.Event",
     "collapseNavBar": "qx.event.type.Event",
     "expandNavBar": "qx.event.type.Event",
-    "changeMaximized": "qx.event.type.Data",
     "slidesEdit": "qx.event.type.Event",
     "slidesAppStart": "qx.event.type.Event",
     "slidesStop": "qx.event.type.Event",

--- a/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
@@ -81,6 +81,14 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
       check: "osparc.data.model.Study",
       apply: "_applyStudy",
       nullable: false
+    },
+
+    maximized: {
+      check: "Boolean",
+      init: null,
+      nullable: false,
+      apply: "__applyMaximized",
+      event: "changeMaximized"
     }
   },
 
@@ -801,16 +809,16 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
       }
     },
 
-    __maximizeIframe: function(maximize) {
+    __applyMaximized: function(maximized) {
       this.getBlocker().setStyles({
-        display: maximize ? "none" : "block"
+        display: maximized ? "none" : "block"
       });
 
-      this.getChildControl("side-panels").setVisibility(maximize ? "excluded" : "visible");
+      this.getChildControl("side-panels").setVisibility(maximized ? "excluded" : "visible");
 
       const tabViewMain = this.getChildControl("main-panel-tabs");
-      const mainViewtopBar = tabViewMain.getChildControl("bar");
-      mainViewtopBar.setVisibility(maximize ? "excluded" : "visible");
+      const mainViewTopBar = tabViewMain.getChildControl("bar");
+      mainViewTopBar.setVisibility(maximized ? "excluded" : "visible");
     },
 
     __addIframe: function(node) {
@@ -824,8 +832,8 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
           iFrame
         ].forEach(widget => {
           if (widget) {
-            widget.addListener("maximize", () => this.__maximizeIframe(true), this);
-            widget.addListener("restore", () => this.__maximizeIframe(false), this);
+            widget.addListener("maximize", () => this.setMaximized(true), this);
+            widget.addListener("restore", () => this.setMaximized(false), this);
           }
         });
         this.__iFrameChanged(node);
@@ -1209,17 +1217,9 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
     },
 
     __attachEventHandlers: function() {
-      const maximizeIframeCb = msg => {
-        this.__maximizeIframe(msg.getData());
-      };
-
-      this.addListener("appear", () => {
-        qx.event.message.Bus.getInstance().subscribe("maximizeIframe", maximizeIframeCb, this);
-      }, this);
-
-      this.addListener("disappear", () => {
-        qx.event.message.Bus.getInstance().unsubscribe("maximizeIframe", maximizeIframeCb, this);
-      }, this);
+      const maximizeIframeCb = msg => this.setMaximized(msg.getData());
+      this.addListener("appear", () => qx.event.message.Bus.getInstance().subscribe("maximizeIframe", maximizeIframeCb, this), this);
+      this.addListener("disappear", () => qx.event.message.Bus.getInstance().unsubscribe("maximizeIframe", maximizeIframeCb, this), this);
     },
 
     __removeNode: function(nodeId) {
@@ -1310,7 +1310,7 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
         }, this, 10);
         return;
       }
-      this.__maximizeIframe(false);
+      this.setMaximized(false);
       this.nodeSelected(this.getStudy().getUuid());
     }
   }

--- a/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
@@ -201,51 +201,6 @@ qx.Class.define("osparc.navigation.NavigationBar", {
           osparc.utils.Utils.setIdToWidget(control, "dashboardLabel");
           this.getChildControl("left-items").add(control);
           break;
-        case "study-menu-info":
-          control = new qx.ui.menu.Button().set({
-            label: this.tr("Information..."),
-            icon: "@MaterialIcons/info_outline/14",
-            ...this.self().BUTTON_OPTIONS
-          });
-          control.addListener("execute", () => {
-            const infoMerged = new osparc.info.MergedLarge(this.getStudy());
-            const title = this.tr("Information");
-            const width = osparc.info.CardLarge.WIDTH;
-            const height = osparc.info.CardLarge.HEIGHT;
-            osparc.ui.window.Window.popUpInWindow(infoMerged, title, width, height);
-          });
-          break;
-        case "study-menu-download-logs":
-          control = new qx.ui.menu.Button().set({
-            label: this.tr("Download logs"),
-            icon: "@FontAwesome5Solid/download/14",
-            ...this.self().BUTTON_OPTIONS
-          });
-          control.addListener("execute", () => this.fireEvent("downloadStudyLogs"));
-          break;
-        case "study-menu-button": {
-          const optionsMenu = new qx.ui.menu.Menu();
-          optionsMenu.add(this.getChildControl("study-menu-info"));
-          optionsMenu.add(this.getChildControl("study-menu-download-logs"));
-          control = new qx.ui.form.MenuButton().set({
-            ...this.self().BUTTON_OPTIONS,
-            menu: optionsMenu,
-            icon: "@FontAwesome5Solid/ellipsis-v/16"
-          });
-          this.getChildControl("left-items").add(control);
-          break;
-        }
-        case "edit-title-label":
-          control = new osparc.ui.form.EditLabel().set({
-            labelFont: "text-16",
-            inputFont: "text-16"
-          });
-          control.addListener("editValue", e => {
-            const newLabel = e.getData();
-            this.getStudy().setName(newLabel);
-          });
-          this.getChildControl("left-items").add(control);
-          break;
         case "study-title-options":
           control = new osparc.navigation.StudyTitleWOptions();
           control.addListener("execute", () => this.fireEvent("downloadStudyLogs"));
@@ -360,10 +315,6 @@ qx.Class.define("osparc.navigation.NavigationBar", {
         case "dashboard":
           this.getChildControl("dashboard-label").show();
           this.getChildControl("dashboard-button").exclude();
-          if (osparc.product.Utils.isProduct("s4llite")) {
-            this.getChildControl("study-menu-button").exclude();
-            this.getChildControl("edit-title-label").exclude();
-          }
           this.getChildControl("study-title-options").exclude();
           this.getChildControl("read-only-info").exclude();
           if (this.__tabButtons) {
@@ -375,10 +326,6 @@ qx.Class.define("osparc.navigation.NavigationBar", {
         case "app":
           this.getChildControl("dashboard-label").exclude();
           this.getChildControl("dashboard-button").show();
-          if (osparc.product.Utils.isProduct("s4llite")) {
-            this.getChildControl("study-menu-button").show();
-            this.getChildControl("edit-title-label").show();
-          }
           if (this.__tabButtons) {
             this.__tabButtons.exclude();
           }
@@ -437,7 +384,6 @@ qx.Class.define("osparc.navigation.NavigationBar", {
         study.bind("readOnly", this.getChildControl("read-only-info"), "visibility", {
           converter: value => value ? "visible" : "excluded"
         });
-        study.bind("name", this.getChildControl("edit-title-label"), "value");
         this.getChildControl("study-title-options").setStudy(study);
       }
     },

--- a/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
@@ -326,15 +326,12 @@ qx.Class.define("osparc.navigation.NavigationBar", {
         case "app":
           this.getChildControl("dashboard-label").exclude();
           this.getChildControl("dashboard-button").show();
+          this.getChildControl("study-title-options").show();
           if (this.__tabButtons) {
             this.__tabButtons.exclude();
           }
           break;
       }
-    },
-
-    iframeMaximized: function(maximized) {
-      this.getChildControl("study-title-options").setVisibility(maximized ? "visible" : "excluded");
     },
 
     __createManualMenuBtn: function() {

--- a/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
@@ -71,6 +71,7 @@ qx.Class.define("osparc.navigation.NavigationBar", {
     study: {
       check: "osparc.data.model.Study",
       nullable: true,
+      event: "changeStudy",
       apply: "_applyStudy"
     },
 
@@ -245,6 +246,11 @@ qx.Class.define("osparc.navigation.NavigationBar", {
           });
           this.getChildControl("left-items").add(control);
           break;
+        case "study-title-options":
+          control = new osparc.navigation.StudyTitleWOptions();
+          control.addListener("execute", () => this.fireEvent("downloadStudyLogs"));
+          this.getChildControl("left-items").add(control);
+          break;
         case "read-only-info": {
           control = new qx.ui.basic.Atom().set({
             label: this.tr("Read only"),
@@ -358,6 +364,7 @@ qx.Class.define("osparc.navigation.NavigationBar", {
             this.getChildControl("study-menu-button").exclude();
             this.getChildControl("edit-title-label").exclude();
           }
+          this.getChildControl("study-title-options").exclude();
           this.getChildControl("read-only-info").exclude();
           if (this.__tabButtons) {
             this.__tabButtons.show();
@@ -377,6 +384,10 @@ qx.Class.define("osparc.navigation.NavigationBar", {
           }
           break;
       }
+    },
+
+    iframeMaximized: function(maximized) {
+      this.getChildControl("study-title-options").setVisibility(maximized ? "visible" : "excluded");
     },
 
     __createManualMenuBtn: function() {
@@ -427,6 +438,7 @@ qx.Class.define("osparc.navigation.NavigationBar", {
           converter: value => value ? "visible" : "excluded"
         });
         study.bind("name", this.getChildControl("edit-title-label"), "value");
+        this.getChildControl("study-title-options").setStudy(study);
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
@@ -203,7 +203,7 @@ qx.Class.define("osparc.navigation.NavigationBar", {
           break;
         case "study-title-options":
           control = new osparc.navigation.StudyTitleWOptions();
-          control.addListener("execute", () => this.fireEvent("downloadStudyLogs"));
+          control.addListener("downloadStudyLogs", () => this.fireEvent("downloadStudyLogs"));
           this.getChildControl("left-items").add(control);
           break;
         case "read-only-info": {

--- a/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
@@ -89,7 +89,8 @@ qx.Class.define("osparc.navigation.StudyTitleWOptions", {
         case "edit-title-label":
           control = new osparc.ui.form.EditLabel().set({
             labelFont: "text-14",
-            inputFont: "text-14"
+            inputFont: "text-14",
+            maxWidth: 300
           });
           control.addListener("editValue", e => {
             const newLabel = e.getData();

--- a/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
@@ -1,0 +1,105 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2023 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+qx.Class.define("osparc.navigation.StudyTitleWOptions", {
+  extend: qx.ui.core.Widget,
+
+  construct: function() {
+    this.base(arguments);
+
+    this._setLayout(new qx.ui.layout.HBox(5).set({
+      alignY: "middle"
+    }));
+
+    this.getChildControl("study-menu-button");
+    this.getChildControl("edit-title-label");
+  },
+
+  events: {
+    "downloadStudyLogs": "qx.event.type.Event"
+  },
+
+  properties: {
+    study: {
+      check: "osparc.data.model.Study",
+      nullable: true,
+      event: "changeStudy",
+      apply: "__applyStudy"
+    }
+  },
+
+  members: {
+    _createChildControlImpl: function(id) {
+      let control;
+      switch (id) {
+        case "study-menu-info":
+          control = new qx.ui.menu.Button().set({
+            label: this.tr("Information..."),
+            icon: "@MaterialIcons/info_outline/14",
+            ...this.self().BUTTON_OPTIONS
+          });
+          control.addListener("execute", () => {
+            const infoMerged = new osparc.info.MergedLarge(this.getStudy());
+            const title = this.tr("Information");
+            const width = osparc.info.CardLarge.WIDTH;
+            const height = osparc.info.CardLarge.HEIGHT;
+            osparc.ui.window.Window.popUpInWindow(infoMerged, title, width, height);
+          });
+          break;
+        case "study-menu-download-logs":
+          control = new qx.ui.menu.Button().set({
+            label: this.tr("Download logs"),
+            icon: "@FontAwesome5Solid/download/14"
+          });
+          control.addListener("execute", () => this.fireEvent("downloadStudyLogs"));
+          break;
+        case "study-menu-button": {
+          const optionsMenu = new qx.ui.menu.Menu();
+          optionsMenu.add(this.getChildControl("study-menu-info"));
+          optionsMenu.add(this.getChildControl("study-menu-download-logs"));
+          control = new qx.ui.form.MenuButton().set({
+            menu: optionsMenu,
+            icon: "@FontAwesome5Solid/ellipsis-v/14",
+            maxHeight: 28
+          });
+          this._add(control);
+          break;
+        }
+        case "edit-title-label":
+          control = new osparc.ui.form.EditLabel().set({
+            labelFont: "text-14",
+            inputFont: "text-14"
+          });
+          control.addListener("editValue", e => {
+            const newLabel = e.getData();
+            this.getStudy().setName(newLabel);
+          });
+          this._add(control);
+          break;
+      }
+      return control || this.base(arguments, id);
+    },
+
+    __applyStudy: function(study) {
+      if (study) {
+        study.bind("name", this.getChildControl("edit-title-label"), "value");
+      } else {
+        this.exclude();
+      }
+    }
+  }
+});

--- a/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
@@ -53,11 +53,16 @@ qx.Class.define("osparc.navigation.StudyTitleWOptions", {
             ...this.self().BUTTON_OPTIONS
           });
           control.addListener("execute", () => {
-            const infoMerged = new osparc.info.MergedLarge(this.getStudy());
+            let widget = null;
+            if (this.getStudy().isPipelineMononode()) {
+              widget = new osparc.info.MergedLarge(this.getStudy());
+            } else {
+              widget = new osparc.info.StudyLarge(this.getStudy());
+            }
             const title = this.tr("Information");
             const width = osparc.info.CardLarge.WIDTH;
             const height = osparc.info.CardLarge.HEIGHT;
-            osparc.ui.window.Window.popUpInWindow(infoMerged, title, width, height);
+            osparc.ui.window.Window.popUpInWindow(widget, title, width, height);
           });
           break;
         case "study-menu-download-logs":

--- a/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
@@ -21,7 +21,7 @@ qx.Class.define("osparc.navigation.StudyTitleWOptions", {
   construct: function() {
     this.base(arguments);
 
-    this._setLayout(new qx.ui.layout.HBox(5).set({
+    this._setLayout(new qx.ui.layout.HBox(10).set({
       alignY: "middle"
     }));
 

--- a/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
@@ -74,7 +74,9 @@ qx.Class.define("osparc.navigation.StudyTitleWOptions", {
           control = new qx.ui.form.MenuButton().set({
             menu: optionsMenu,
             icon: "@FontAwesome5Solid/ellipsis-v/14",
-            maxHeight: 28
+            width: 28,
+            height: 28,
+            allowGrowY: false
           });
           this._add(control);
           break;

--- a/services/static-webserver/client/source/class/osparc/ui/form/EditLabel.js
+++ b/services/static-webserver/client/source/class/osparc/ui/form/EditLabel.js
@@ -7,7 +7,7 @@
 
 /**
  * Renders a label and an input combined widget. The idea is to be able to edit a label quickly. Fires an event
- * whenever the input is modified to be able to update the value of the label externaly or to trigger some other
+ * whenever the input is modified to be able to update the value of the label externally or to trigger some other
  * logic (like API calls).
  */
 qx.Class.define("osparc.ui.form.EditLabel", {
@@ -54,7 +54,7 @@ qx.Class.define("osparc.ui.form.EditLabel", {
       apply: "_applyMode"
     },
     /**
-     * Master value of the widget. The label in display mode will allways show this value.
+     * Master value of the widget. The label in display mode will always show this value.
      */
     value: {
       check: "String",


### PR DESCRIPTION
## What do these changes do?

This feature was only enabled in ``s4l-lite``. Now ~~every time an iframe gets maximized,~~ the study title will be visible on the navigation bar. Request from @cosfor1 so that it also applies to use cases in ``s4l``.

![StudyTitleOnNavBar](https://github.com/ITISFoundation/osparc-simcore/assets/33152403/6ddb92c1-7b20-4e57-a98a-c631be33ab5d)

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
