### PR TITLE
🎨 Read-only permissions to wallets do not give access to wallet-payment info

### DIFF
--- a/services/web/server/src/simcore_service_webserver/payments/_autorecharge_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_autorecharge_api.py
@@ -15,7 +15,10 @@ from ._autorecharge_db import (
     replace_wallet_autorecharge,
 )
 from ._methods_db import list_successful_payment_methods
-from ._onetime_api import check_wallet_permissions
+from ._onetime_api import (
+    raise_for_wallet_read_n_write_permissions,
+    raise_for_wallet_read_permissions,
+)
 from .settings import get_plugin_settings
 
 _logger = logging.getLogger(__name__)
@@ -58,7 +61,7 @@ async def get_wallet_payment_autorecharge(
     user_id: UserID,
     wallet_id: WalletID,
 ) -> GetWalletAutoRecharge:
-    await check_wallet_permissions(
+    await raise_for_wallet_read_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 
@@ -95,7 +98,7 @@ async def replace_wallet_payment_autorecharge(
     wallet_id: WalletID,
     new: ReplaceWalletAutoRecharge,
 ) -> GetWalletAutoRecharge:
-    await check_wallet_permissions(
+    await raise_for_wallet_read_n_write_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 

--- a/services/web/server/src/simcore_service_webserver/payments/_autorecharge_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_autorecharge_api.py
@@ -15,10 +15,7 @@ from ._autorecharge_db import (
     replace_wallet_autorecharge,
 )
 from ._methods_db import list_successful_payment_methods
-from ._onetime_api import (
-    raise_for_wallet_read_n_write_permissions,
-    raise_for_wallet_read_permissions,
-)
+from ._onetime_api import raise_for_wallet_payments_permissions
 from .settings import get_plugin_settings
 
 _logger = logging.getLogger(__name__)
@@ -61,7 +58,7 @@ async def get_wallet_payment_autorecharge(
     user_id: UserID,
     wallet_id: WalletID,
 ) -> GetWalletAutoRecharge:
-    await raise_for_wallet_read_permissions(
+    await raise_for_wallet_payments_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 
@@ -98,7 +95,7 @@ async def replace_wallet_payment_autorecharge(
     wallet_id: WalletID,
     new: ReplaceWalletAutoRecharge,
 ) -> GetWalletAutoRecharge:
-    await raise_for_wallet_read_n_write_permissions(
+    await raise_for_wallet_payments_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 

--- a/services/web/server/src/simcore_service_webserver/payments/_methods_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_methods_api.py
@@ -28,7 +28,7 @@ from ._methods_db import (
     list_successful_payment_methods,
     udpate_payment_method,
 )
-from ._onetime_api import raise_for_wallet_read_n_write_permissions
+from ._onetime_api import raise_for_wallet_payments_permissions
 from ._socketio import notify_payment_method_acked
 from .settings import PaymentsSettings, get_plugin_settings
 
@@ -79,7 +79,7 @@ async def init_creation_of_wallet_payment_method(
     """
 
     # check permissions
-    await raise_for_wallet_read_n_write_permissions(
+    await raise_for_wallet_payments_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 
@@ -155,7 +155,7 @@ async def cancel_creation_of_wallet_payment_method(
     product_name: ProductName,
 ):
     """Acks as CANCELED"""
-    await raise_for_wallet_read_n_write_permissions(
+    await raise_for_wallet_payments_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 
@@ -189,7 +189,7 @@ async def list_wallet_payment_methods(
     product_name: ProductName,
 ) -> list[PaymentMethodGet]:
     # check permissions
-    await raise_for_wallet_read_n_write_permissions(
+    await raise_for_wallet_payments_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 
@@ -237,7 +237,7 @@ async def get_wallet_payment_method(
     product_name: ProductName,
 ) -> PaymentMethodGet:
     # check permissions
-    await raise_for_wallet_read_n_write_permissions(
+    await raise_for_wallet_payments_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 
@@ -268,7 +268,7 @@ async def delete_wallet_payment_method(
     product_name: ProductName,
 ):
     # check permissions
-    await raise_for_wallet_read_n_write_permissions(
+    await raise_for_wallet_payments_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
     assert payment_method_id  # nosec

--- a/services/web/server/src/simcore_service_webserver/payments/_methods_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_methods_api.py
@@ -28,7 +28,7 @@ from ._methods_db import (
     list_successful_payment_methods,
     udpate_payment_method,
 )
-from ._onetime_api import check_wallet_permissions
+from ._onetime_api import raise_for_wallet_read_n_write_permissions
 from ._socketio import notify_payment_method_acked
 from .settings import PaymentsSettings, get_plugin_settings
 
@@ -79,7 +79,7 @@ async def init_creation_of_wallet_payment_method(
     """
 
     # check permissions
-    await check_wallet_permissions(
+    await raise_for_wallet_read_n_write_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 
@@ -155,7 +155,7 @@ async def cancel_creation_of_wallet_payment_method(
     product_name: ProductName,
 ):
     """Acks as CANCELED"""
-    await check_wallet_permissions(
+    await raise_for_wallet_read_n_write_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 
@@ -189,7 +189,7 @@ async def list_wallet_payment_methods(
     product_name: ProductName,
 ) -> list[PaymentMethodGet]:
     # check permissions
-    await check_wallet_permissions(
+    await raise_for_wallet_read_n_write_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 
@@ -237,7 +237,7 @@ async def get_wallet_payment_method(
     product_name: ProductName,
 ) -> PaymentMethodGet:
     # check permissions
-    await check_wallet_permissions(
+    await raise_for_wallet_read_n_write_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 
@@ -268,7 +268,7 @@ async def delete_wallet_payment_method(
     product_name: ProductName,
 ):
     # check permissions
-    await check_wallet_permissions(
+    await raise_for_wallet_read_n_write_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
     assert payment_method_id  # nosec

--- a/services/web/server/src/simcore_service_webserver/payments/_onetime_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_onetime_api.py
@@ -31,6 +31,7 @@ MSG_WALLET_NO_ACCESS_ERROR = "User {user_id} does not have necessary permissions
 
 async def raise_for_wallet_read_permissions(
     app: web.Application,
+    *,
     user_id: UserID,
     wallet_id: WalletID,
     product_name: ProductName,
@@ -48,6 +49,7 @@ async def raise_for_wallet_read_permissions(
 
 async def raise_for_wallet_read_n_write_permissions(
     app: web.Application,
+    *,
     user_id: UserID,
     wallet_id: WalletID,
     product_name: ProductName,

--- a/services/web/server/src/simcore_service_webserver/payments/_onetime_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_onetime_api.py
@@ -26,7 +26,27 @@ from ._socketio import notify_payment_completed
 _logger = logging.getLogger(__name__)
 
 
-async def check_wallet_permissions(
+MSG_WALLET_NO_ACCESS_ERROR = "User {user_id} does not have necessary permissions to do a payment into wallet {wallet_id}"
+
+
+async def raise_for_wallet_read_permissions(
+    app: web.Application,
+    user_id: UserID,
+    wallet_id: WalletID,
+    product_name: ProductName,
+):
+    permissions = await get_wallet_with_permissions_by_user(
+        app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
+    )
+    if not permissions.read:
+        raise WalletAccessForbiddenError(
+            reason=MSG_WALLET_NO_ACCESS_ERROR.format(
+                user_id=user_id, wallet_id=wallet_id
+            )
+        )
+
+
+async def raise_for_wallet_read_n_write_permissions(
     app: web.Application,
     user_id: UserID,
     wallet_id: WalletID,
@@ -37,7 +57,9 @@ async def check_wallet_permissions(
     )
     if not permissions.read or not permissions.write:
         raise WalletAccessForbiddenError(
-            reason=f"User {user_id} does not have necessary permissions to do a payment into wallet {wallet_id}"
+            reason=MSG_WALLET_NO_ACCESS_ERROR.format(
+                user_id=user_id, wallet_id=wallet_id
+            )
         )
 
 
@@ -84,7 +106,7 @@ async def init_creation_of_wallet_payment(
     """
 
     # wallet: check permissions
-    await check_wallet_permissions(
+    await raise_for_wallet_read_n_write_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
     user_wallet = await get_wallet_by_user(
@@ -168,7 +190,7 @@ async def cancel_payment_to_wallet(
     wallet_id: WalletID,
     product_name: ProductName,
 ) -> PaymentTransaction:
-    await check_wallet_permissions(
+    await raise_for_wallet_read_n_write_permissions(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
 

--- a/services/web/server/tests/unit/with_dbs/03/wallets/payments/test_payments.py
+++ b/services/web/server/tests/unit/with_dbs/03/wallets/payments/test_payments.py
@@ -393,8 +393,10 @@ async def test_payment_on_wallet_without_access(
         assert f"{wallet.wallet_id}" in error_msg
 
 
-@pytest.mark.testit
-async def test_get_payment_autorecharge_in_shared_wallet(
+@pytest.mark.acceptance_test(
+    "https://github.com/ITISFoundation/osparc-simcore/pull/4897"
+)
+async def test_cannot_get_payment_info_in_shared_wallet(
     latest_osparc_price: Decimal,
     logged_user: UserInfoDict,
     logged_user_wallet: WalletGet,
@@ -402,7 +404,7 @@ async def test_get_payment_autorecharge_in_shared_wallet(
 ):
     assert client.app
 
-    async with NewUser(client) as new_user:
+    async with NewUser(app=client.app) as new_user:
         assert new_user["email"] != logged_user["email"]
 
         # logged client adds new user to this wallet add read-only
@@ -429,4 +431,4 @@ async def test_get_payment_autorecharge_in_shared_wallet(
         response = await client.get(
             f"/v0/wallets/{logged_user_wallet.wallet_id}/auto-recharge"
         )
-        await assert_status(response, web.HTTPOk)
+        await assert_status(response, web.HTTPForbidden)


### PR DESCRIPTION
## What do these changes do?

Payments can only be done to **owned wallets** . We can share this wallet with other users in read-mode. This allows them to consume credits from the wallet but cannot perform any kind of payment to it.  For that reason **we cannot allow users with read-only access to see any payment information associated to this wallet** (e.g. auto-recharge settings or payment methods). 

This PR reviews and fixes permissions required for sub resources as `/wallets/{wallet_id}/*` related to payments
- Reviewed checks on read operations for wallets
- Renamed check as `raise_for_...()`  (named analogous to `response.raise_for_status()`) that will be transformed into a [Forbidden 403](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) 


In the **front-end**, when a **shared read-only wallet** is presented to a non-owner, it **will not be able to show any information about the payment methods or auto-recharge settings**.

## Related issue/s

- @mguidon found that cannot read autorecharge info from a wallet he has read-only access
![image](https://github.com/ITISFoundation/osparc-simcore/assets/32402063/eb54b9b1-3095-41e9-904f-cac4c79fe390)


## How to test

driving test
```cmd
cd services/web/server
make install-dev
pytest -vv tests/unit/with_dbs/03/wallets/payments/test_payments.py:test_get_payment_autorecharge_in_shared_wallet
```

## DevOps
None