### PR TITLE
✨ Dask sidecar: find out on start on which EC2 instance it runs if available

### DIFF
--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -100,12 +100,23 @@ else
   # check whether we might have an EC2 instance and retrieve its type
   get_ec2_instance_type() {
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-    print_info "Finding out if we are running on EC2 instance"
-    if ec2_instance_type=$(curl --max-time 5 --silent http://169.254.169.254/latest/meta-data/instance-type 2>/dev/null); then
-      print_info "Running on EC2 instance of type: $ec2_instance_type"
-      resources="$resources,EC2-INSTANCE-TYPE:$ec2_instance_type=1"
+    print_info "Finding out if we are running on an EC2 instance"
+
+    # fetch headers only
+    if http_response=$(curl --max-time 5 --silent --head http://169.254.169.254/latest/meta-data/instance-type 2>/dev/null); then
+      # Extract the HTTP status code (e.g., 200, 404)
+      http_status_code=$(echo "$http_response" | awk '/^HTTP/ {print $2}')
+
+      if [ "$http_status_code" = "200" ]; then
+        # Instance type is available
+        ec2_instance_type=$(curl --max-time 5 --silent http://169.254.169.254/latest/meta-data/instance-type)
+        print_info "Running on an EC2 instance of type: $ec2_instance_type"
+        resources="$resources,EC2-INSTANCE-TYPE:$ec2_instance_type=1"
+      else
+        print_info "Not running on an EC2 instance. HTTP Status Code: $http_status_code"
+      fi
     else
-      print_info "Not running on an EC2 instance."
+      print_info "Failed to fetch instance type. Not running on an EC2 instance."
     fi
   }
   get_ec2_instance_type

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -99,8 +99,9 @@ else
 
   # check whether we might have an EC2 instance and retrieve its type
   get_ec2_instance_type() {
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
     print_info "Finding out if we are running on EC2 instance"
-    if ec2_instance_type=$(curl --max-time 2 --silent http://169.254.169.254/latest/meta-data/instance-type 2>/dev/null); then
+    if ec2_instance_type=$(curl --max-time 5 --silent http://169.254.169.254/latest/meta-data/instance-type 2>/dev/null); then
       print_info "Running on EC2 instance of type: $ec2_instance_type"
       resources="$resources,EC2-INSTANCE-TYPE:$ec2_instance_type=1"
     else

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -66,6 +66,7 @@ else
   # GPU: number GPUs available (= num of GPUs if a nvidia-smi can be run inside a docker container)
   # RAM: amount of RAM available (= CPU/nproc * total virtual memory given by python psutil - DASK_SIDECAR_NON_USABLE_RAM)
   # VRAM: amount of VRAM available (in bytes)
+  # DASK_SIDECAR_CUSTOM_RESOURCES: any amount of anything (in name=NUMBER,name2=NUMBER2,..., see https://distributed.dask.org/en/stable/resources.html#worker-resources)
 
   # CPUs
   num_cpus=$(($(nproc) - ${DASK_SIDECAR_NUM_NON_USABLE_CPUS:-2}))
@@ -90,6 +91,10 @@ else
     resources="$resources,GPU=$num_gpus,VRAM=$total_vram"
   fi
 
+  # add custom resources if any
+  if [ -n "${DASK_SIDECAR_CUSTOM_RESOURCES-}" ]; then
+    resources="$resources,${DASK_SIDECAR_CUSTOM_RESOURCES}"
+  fi
 
   #
   # DASK RESOURCES DEFINITION --------------------------------- END

--- a/tests/swarm-deploy/conftest.py
+++ b/tests/swarm-deploy/conftest.py
@@ -106,7 +106,9 @@ def simcore_stack_deployed_services(
     finally:
         for stack_namespace in (core_stack_namespace, ops_stack_namespace):
             subprocess.run(
-                f"docker stack ps {stack_namespace}", shell=True, check=False
+                f"docker stack ps {stack_namespace}",
+                shell=True,  # noqa: S602
+                check=False,
             )
 
         # logs table like
@@ -117,7 +119,6 @@ def simcore_stack_deployed_services(
         # 1lh2hulxmc4q        simcore_director.1    itisfoundation/director:latest             crespo-wkstn        Running             Running 34 seconds ago
         # ...
 
-    # TODO: find a more reliable way to list services in a stack
     core_stack_services: list[Service] = list(
         docker_client.services.list(
             filters={"label": f"com.docker.stack.namespace={core_stack_namespace}"}
@@ -148,7 +149,6 @@ def ops_services_selection(ops_docker_compose: ComposeSpec) -> list[ServiceNameS
 @pytest.fixture(scope="module")
 def ops_stack_namespace(testing_environ_vars: EnvVarsDict) -> str:
     """returns 'com.docker.stack.namespace' service label operations stack"""
-    # TODO: set in environment
     return "pytest-ops"
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

This PR changes the way the dask-sidecar starts by retrieving on which EC2 instance it runs if available.
see [https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html) for details.
![image](https://github.com/ITISFoundation/osparc-simcore/assets/35365065/f99eb7f0-5764-4de7-909e-545bf545b7a1)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
