### PR TITLE
🐛 Bugfix: Reset Store after logging out

### DIFF
--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -331,10 +331,6 @@ qx.Class.define("osparc.Application", {
     __loadMainPage: async function(studyId = null) {
       // logged in
 
-      // Invalidate the entire cache
-      osparc.store.Store.getInstance().invalidateEntireCache();
-      await this.__preloadCalls();
-
       const walletsEnabled = osparc.desktop.credits.Utils.areWalletsEnabled();
       if (osparc.product.Utils.shouldHaveWalletsEnabled() && !walletsEnabled) {
         const infoLabel = this.tr("Credits information is not ready.<br>Please contact us by email:<br>");
@@ -402,10 +398,6 @@ qx.Class.define("osparc.Application", {
     },
 
     __loadNodeViewerPage: async function(studyId, viewerNodeId) {
-      // Invalidate the entire cache
-      osparc.store.Store.getInstance().invalidateEntireCache();
-      await this.__preloadCalls();
-
       this.__connectWebSocket();
       this.__loadView(new osparc.viewer.MainPage(studyId, viewerNodeId));
     },
@@ -449,7 +441,11 @@ qx.Class.define("osparc.Application", {
         this.__mainPage.closeEditor();
       }
       osparc.utils.Utils.closeHangingWindows();
-      osparc.store.Store.getInstance().dispose();
+
+      // Remove all bindings and Invalidate the entire cache
+      const store = osparc.store.Store.getInstance();
+      store.removeAllBindings();
+      store.invalidateEntireCache();
 
       // back to the dark theme to make pretty forms
       const validThemes = osparc.ui.switch.ThemeSwitcher.getValidThemes();

--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -98,8 +98,7 @@ qx.Class.define("osparc.Application", {
     },
 
     __preloadCalls: async function() {
-      await osparc.data.Resources.get("config");
-      await osparc.data.Resources.get("statics");
+      osparc.store.Store.getInstance().preloadCalls();
     },
 
     __initRouting: function() {

--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -98,7 +98,7 @@ qx.Class.define("osparc.Application", {
     },
 
     __preloadCalls: async function() {
-      osparc.store.Store.getInstance().preloadCalls();
+      await osparc.store.Store.getInstance().preloadCalls();
     },
 
     __initRouting: function() {

--- a/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsIndicator.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsIndicator.js
@@ -86,7 +86,7 @@ qx.Class.define("osparc.desktop.credits.CreditsIndicator", {
         });
 
         const indicator = this.getChildControl("credits-bar");
-        const progress = osparc.desktop.credits.Utils.normalizeCredits(credits);
+        const progress = credits > 0 ? osparc.desktop.credits.Utils.normalizeCredits(credits) : 100; // make bar red
         const creditsColor = osparc.desktop.credits.Utils.creditsToColor(credits, "strong-main");
         const color1 = qx.theme.manager.Color.getInstance().resolve(creditsColor);
         const textColor = qx.theme.manager.Color.getInstance().resolve("text");

--- a/services/static-webserver/client/source/class/osparc/navigation/CreditsMenuButton.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/CreditsMenuButton.js
@@ -116,11 +116,12 @@ qx.Class.define("osparc.navigation.CreditsMenuButton", {
         const creditsLeft = wallet.getCreditsAvailable();
         if (creditsLeft !== null) {
           text = "<span style='font-size:12px;display:inline-block'>CREDITS</span><br>";
-          let creditsLeftText = osparc.desktop.credits.Utils.creditsToFixed(creditsLeft);
+          let nCreditsText = "";
           if (used !== null) {
-            creditsLeftText += " / " + osparc.desktop.credits.Utils.creditsToFixed(used);
+            nCreditsText += osparc.desktop.credits.Utils.creditsToFixed(used) + " / ";
           }
-          text += `<span>${creditsLeftText}</span>`;
+          nCreditsText += osparc.desktop.credits.Utils.creditsToFixed(creditsLeft);
+          text += `<span>${nCreditsText}</span>`;
           this.set({
             minWidth: used ? 90 : null,
             width: used ? 90 : null

--- a/services/static-webserver/client/source/class/osparc/navigation/UserMenuButton.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/UserMenuButton.js
@@ -92,7 +92,7 @@ qx.Class.define("osparc.navigation.UserMenuButton", {
       if (contextWallet) {
         const credits = contextWallet.getCreditsAvailable();
         if (credits !== null) {
-          const progress = osparc.desktop.credits.Utils.normalizeCredits(credits);
+          const progress = credits > 0 ? osparc.desktop.credits.Utils.normalizeCredits(credits) : 100; // make hallo red
           const creditsColor = osparc.desktop.credits.Utils.creditsToColor(credits, "strong-main");
           const color1 = qx.theme.manager.Color.getInstance().resolve(creditsColor);
           const textColor = qx.theme.manager.Color.getInstance().resolve("text");

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -310,13 +310,17 @@ qx.Class.define("osparc.store.Store", {
       if (typeof resources === "string" || resources instanceof String) {
         this.reset(resources);
       } else {
-        let propertyArray;
+        let propertyKeys;
         if (resources == null) {
-          propertyArray = Object.keys(qx.util.PropertyUtil.getProperties(osparc.store.Store));
+          propertyKeys = Object.keys(qx.util.PropertyUtil.getProperties(osparc.store.Store));
         } else if (Array.isArray(resources)) {
-          propertyArray = resources;
+          propertyKeys = resources;
         }
-        propertyArray.forEach(propName => {
+        propertyKeys.forEach(propName => {
+          // do not reset these resources
+          if (["statics", "config"].includes(propName)) {
+            return;
+          }
           this.reset(propName);
           // Not sure reset actually works
           const initVal = qx.util.PropertyUtil.getInitValue(this, propName);

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -726,14 +726,15 @@ qx.Class.define("osparc.store.Store", {
 
       const socket = osparc.wrapper.WebSocket.getInstance();
       const slotName = "walletOsparcCreditsUpdated";
-      socket.removeSlot(slotName);
-      socket.on(slotName, jsonString => {
-        const data = JSON.parse(jsonString);
-        const walletFound = store.getWallets().find(wallet => wallet.getWalletId() === parseInt(data["wallet_id"]));
-        if (walletFound) {
-          walletFound.setCreditsAvailable(parseFloat(data["osparc_credits"]));
-        }
-      }, this);
+      if (!socket.slotExists(slotName)) {
+        socket.on(slotName, jsonString => {
+          const data = JSON.parse(jsonString);
+          const walletFound = store.getWallets().find(wallet => wallet.getWalletId() === parseInt(data["wallet_id"]));
+          if (walletFound) {
+            walletFound.setCreditsAvailable(parseFloat(data["osparc_credits"]));
+          }
+        }, this);
+      }
 
       store.setWallets([]);
       return new Promise((resolve, reject) => {

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -215,6 +215,12 @@ qx.Class.define("osparc.store.Store", {
   },
 
   members: {
+    // fetch resources that do not require log in
+    preloadCalls: async function() {
+      await osparc.data.Resources.get("config");
+      await osparc.data.Resources.get("statics");
+    },
+
     /**
      * Updates an element or a set of elements in the store.
      * @param {String} resource Name of the resource property. If used with {osparc.data.Resources}, it has to be the same there.


### PR DESCRIPTION
## What do these changes do?

The tear down of the App's Store (cache) after logging out was not optimal. This was visible on the Credits Indicator after logging out and logging back in (but it was also the case for some other resources).


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
