### PR TITLE
🐛 if node has it's state stored a directory it will now display the content in the preview

### DIFF
--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/protocol.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/protocol.py
@@ -18,7 +18,7 @@ ContainerLabelsDict: TypeAlias = dict[DockerLabelKey, str]
 
 
 class ContainerRemoteFct(Protocol):
-    def __call__(  # noqa: PLR0913
+    def __call__(  # pylint: disable=too-many-arguments # noqa: PLR0913
         self,
         *,
         docker_auth: DockerBasicAuth,

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -341,7 +341,7 @@ async def upload_path(
     return UploadedFolder() if e_tag is None else UploadedFile(store_id, e_tag)
 
 
-async def _upload_to_s3(  # noqa: PLR0913
+async def _upload_to_s3(  # pylint: disable=too-many-arguments # noqa: PLR0913
     *,
     user_id: UserID,
     store_id: LocationID | None,

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/tasks.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/tasks.py
@@ -90,7 +90,7 @@ async def dask_teardown(_worker: distributed.Worker) -> None:
     logger.warning("Tearing down worker!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 
 
-async def _run_computational_sidecar_async(
+async def _run_computational_sidecar_async(  # pylint: disable=too-many-arguments # noqa: PLR0913
     *,
     docker_auth: DockerBasicAuth,
     service_key: ContainerImage,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -213,7 +213,7 @@ class DaskClient:
         """actually sends the function remote_fct to be remotely executed. if None is kept then the default
         function that runs container will be started."""
 
-        def _comp_sidecar_fct(  # noqa: PLR0913
+        def _comp_sidecar_fct(  # pylint: disable=too-many-arguments # noqa: PLR0913
             *,
             docker_auth: DockerBasicAuth,
             service_key: ContainerImage,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_compose_specs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_compose_specs.py
@@ -253,7 +253,7 @@ def _update_container_labels(
                 labels.append(docker_label)
 
 
-async def assemble_spec(
+async def assemble_spec(  # pylint: disable=too-many-arguments # noqa: PLR0913
     *,
     app: FastAPI,
     service_key: ServiceKey,
@@ -279,9 +279,9 @@ async def assemble_spec(
     the dynamic-sidecar to start the service
     """
 
-    docker_registry_settings: RegistrySettings = (
-        app.state.settings.DIRECTOR_V2_DOCKER_REGISTRY
-    )
+    docker_registry_settings: (
+        RegistrySettings
+    ) = app.state.settings.DIRECTOR_V2_DOCKER_REGISTRY
 
     docker_compose_version = (
         app.state.settings.DYNAMIC_SERVICES.DYNAMIC_SIDECAR.DYNAMIC_SIDECAR_DOCKER_COMPOSE_VERSION

--- a/services/director-v2/src/simcore_service_director_v2/utils/rabbitmq.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/rabbitmq.py
@@ -67,7 +67,7 @@ async def publish_service_stopped_metrics(
     await rabbitmq_client.publish(message.channel_name, message)
 
 
-async def publish_service_resource_tracking_started(  # noqa: PLR0913
+async def publish_service_resource_tracking_started(  # pylint: disable=too-many-arguments # noqa: PLR0913
     rabbitmq_client: RabbitMQClient,
     service_run_id: str,
     *,

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm_utils.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm_utils.py
@@ -55,6 +55,8 @@ async def expand_directory(
                 entity_tag=x.e_tag,
                 is_soft_link=False,
                 is_directory=False,
+                project_id=fmd.project_id,
+                node_id=fmd.node_id,
             )
         )
         for x in files_in_folder

--- a/services/web/server/src/simcore_service_webserver/director_v2/_core_dynamic_services.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2/_core_dynamic_services.py
@@ -82,7 +82,7 @@ async def get_dynamic_service(app: web.Application, node_uuid: str) -> DataType:
     return service_state
 
 
-async def run_dynamic_service(
+async def run_dynamic_service(  # pylint: disable=too-many-arguments # noqa: PLR0913
     *,
     app: web.Application,
     product_name: str,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

Opsie, this is an embarrassing one.

Fixed the preview for nodes with state stored as directories.

![Screenshot 2023-10-27 at 08 29 49](https://github.com/ITISFoundation/osparc-simcore/assets/5694077/8eb1a58d-a2a4-49dc-b785-4d6dcc0a85e1)


And also deeply nested directories are supported

![Screenshot 2023-10-27 at 08 35 10](https://github.com/ITISFoundation/osparc-simcore/assets/5694077/9e5c3525-50d0-4cd6-86e6-5fd2e47794fe)



Bonus: pylint fixes after tooling update

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->

- https://github.com/ITISFoundation/osparc-issues/issues/1108
- fixes: https://github.com/ITISFoundation/osparc-issues/issues/1150
## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
