### PR TITLE
🎨 Payments-methods logic in `payments` service

### DIFF
--- a/api/specs/web-server/_wallets.py
+++ b/api/specs/web-server/_wallets.py
@@ -17,13 +17,13 @@ from models_library.api_schemas_webserver.wallets import (
     PaymentID,
     PaymentMethodGet,
     PaymentMethodID,
-    PaymentMethodInit,
+    PaymentMethodInitiated,
     PaymentTransaction,
     PutWalletBodyParams,
     ReplaceWalletAutoRecharge,
     WalletGet,
     WalletGetWithAvailableCredits,
-    WalletPaymentCreated,
+    WalletPaymentInitiated,
 )
 from models_library.generics import Envelope
 from models_library.rest_pagination import Page, PageQueryParameters
@@ -89,7 +89,7 @@ async def update_wallet(wallet_id: WalletID, body: PutWalletBodyParams):
 
 @router.post(
     "/wallets/{wallet_id}/payments",
-    response_model=Envelope[WalletPaymentCreated],
+    response_model=Envelope[WalletPaymentInitiated],
     response_description="Successfully initialized",
     status_code=status.HTTP_202_ACCEPTED,
 )
@@ -119,7 +119,7 @@ async def cancel_payment(wallet_id: WalletID, payment_id: PaymentID):
 
 @router.post(
     "/wallets/{wallet_id}/payments-methods:init",
-    response_model=Envelope[PaymentMethodInit],
+    response_model=Envelope[PaymentMethodInitiated],
     response_description="Successfully initialized",
     status_code=status.HTTP_202_ACCEPTED,
 )

--- a/packages/models-library/src/models_library/api_schemas_webserver/wallets.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/wallets.py
@@ -59,10 +59,12 @@ class CreateWalletPayment(InputSchema):
     comment: str = FieldNotRequired(max_length=100)
 
 
-class WalletPaymentCreated(OutputSchema):
+class WalletPaymentInitiated(OutputSchema):
     payment_id: PaymentID
-    payment_form_url: HttpUrl = Field(
-        ..., description="Link to external site that holds the payment submission form"
+    payment_form_url: HttpUrl | None = Field(
+        None,
+        description="Link to external site that holds the payment submission form."
+        "None if no prompt step is required (e.g. pre-selected credit card)",
     )
 
 
@@ -82,7 +84,7 @@ class PaymentTransaction(OutputSchema):
     invoice_url: HttpUrl = FieldNotRequired()
 
 
-class PaymentMethodInit(OutputSchema):
+class PaymentMethodInitiated(OutputSchema):
     wallet_id: WalletID
     payment_method_id: PaymentMethodID
     payment_method_form_url: HttpUrl = Field(

--- a/packages/models-library/src/models_library/api_schemas_webserver/wallets.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/wallets.py
@@ -62,7 +62,7 @@ class CreateWalletPayment(InputSchema):
 class WalletPaymentInitiated(OutputSchema):
     payment_id: PaymentID
     payment_form_url: HttpUrl | None = Field(
-        None,
+        default=None,
         description="Link to external site that holds the payment submission form."
         "None if no prompt step is required (e.g. pre-selected credit card)",
     )

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/rawdata_fakers.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/rawdata_fakers.py
@@ -248,7 +248,7 @@ def random_api_key(product_name: str, user_id: int, **overrides) -> dict[str, An
     return data
 
 
-def random_payment_method_data(**overrides):
+def random_payment_method_data(**overrides) -> dict[str, Any]:
     # Produces data for GetPaymentMethod
     data = {
         "idr": FAKE.uuid4(),

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/rawdata_fakers.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/rawdata_fakers.py
@@ -260,6 +260,7 @@ def random_payment_method_data(**overrides):
         "street_address": FAKE.street_address(),
         "zipcode": FAKE.zipcode(),
         "country": FAKE.country(),
+        "created": utcnow(),
     }
     data.update(**overrides)
     return data

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/rawdata_fakers.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/rawdata_fakers.py
@@ -246,3 +246,20 @@ def random_api_key(product_name: str, user_id: int, **overrides) -> dict[str, An
     assert set(data.keys()).issubset({c.name for c in api_keys.columns})  # nosec
     data.update(**overrides)
     return data
+
+
+def random_payment_method_data(**overrides):
+    # Produces data for GetPaymentMethod
+    data = {
+        "idr": FAKE.uuid4(),
+        "card_holder_name": FAKE.name(),
+        "card_number_masked": f"**** **** **** {FAKE.credit_card_number()[:4]}",
+        "card_type": FAKE.credit_card_provider(),
+        "expiration_month": FAKE.random_int(min=1, max=12),
+        "expiration_year": FAKE.future_date().year,
+        "street_address": FAKE.street_address(),
+        "zipcode": FAKE.zipcode(),
+        "country": FAKE.country(),
+    }
+    data.update(**overrides)
+    return data

--- a/services/payments/scripts/fake_payment_gateway.py
+++ b/services/payments/scripts/fake_payment_gateway.py
@@ -46,9 +46,9 @@ logging.basicConfig(level=logging.INFO)
 
 
 class Settings(BaseCustomSettings):
-    PAYMENTS_SERVICE_API_BASE_URL: HttpUrl
-    PAYMENTS_USERNAME: str
-    PAYMENTS_PASSWORD: SecretStr
+    PAYMENTS_SERVICE_API_BASE_URL: HttpUrl = "http://replace-with-ack-service.io"
+    PAYMENTS_USERNAME: str = "replace-with_username"
+    PAYMENTS_PASSWORD: SecretStr = "replace-with-password"
 
 
 def set_operation_id_as_handler_function_name(router: APIRouter):
@@ -344,7 +344,7 @@ async def _app_lifespan(app: FastAPI):
 def create_app():
     app = FastAPI(
         title="fake-payment-gateway",
-        version="0.2.0",
+        version="0.2.1",
         lifespan=_app_lifespan,
         debug=True,
     )

--- a/services/payments/scripts/fake_payment_gateway.py
+++ b/services/payments/scripts/fake_payment_gateway.py
@@ -323,6 +323,7 @@ def create_payment_method_router():
         payment: InitPayment,
         auth: Annotated[int, Depends(auth_session)],
     ):
+        assert id  # nosec
         assert payment  # nosec
         assert auth  # nosec
 

--- a/services/payments/scripts/fake_payment_gateway.py
+++ b/services/payments/scripts/fake_payment_gateway.py
@@ -29,6 +29,7 @@ from settings_library.base import BaseCustomSettings
 from simcore_service_payments.models.payments_gateway import (
     BatchGetPaymentMethods,
     ErrorModel,
+    GetPaymentMethod,
     InitPayment,
     InitPaymentMethod,
     PaymentCancelled,
@@ -290,7 +291,7 @@ def create_payment_method_router():
 
     @router.get(
         "/{id}",
-        response_class=HTMLResponse,
+        response_class=GetPaymentMethod,
         responses=ERROR_RESPONSES,
     )
     def get_payment_method(

--- a/services/payments/scripts/fake_payment_gateway.py
+++ b/services/payments/scripts/fake_payment_gateway.py
@@ -318,7 +318,7 @@ def create_payment_method_router():
         response_model=PaymentInitiated,
         responses=ERROR_RESPONSES,
     )
-    def pay_with_payment_method(
+    def init_payment_with_payment_method(
         id: PaymentMethodID,
         payment: InitPayment,
         auth: Annotated[int, Depends(auth_session)],

--- a/services/payments/setup.cfg
+++ b/services/payments/setup.cfg
@@ -9,5 +9,6 @@ commit_args = --no-verify
 
 [tool:pytest]
 asyncio_mode = auto
-markers = 
+markers =
 	testit: "marks test to run during development"
+	acceptance_test: "marks tests as 'acceptance tests' i.e. does the system do what the user expects? Typically those are workflows."

--- a/services/payments/src/simcore_service_payments/api/rest/_acknowledgements.py
+++ b/services/payments/src/simcore_service_payments/api/rest/_acknowledgements.py
@@ -7,10 +7,10 @@ from simcore_postgres_database.models.payments_methods import InitPromptAckFlowS
 from simcore_postgres_database.models.payments_transactions import (
     PaymentTransactionState,
 )
-from simcore_service_payments.db.payments_methods_repo import PaymentsMethodsRepo
 
 from ..._constants import ACKED, PGDB, RUT
 from ...core.errors import PaymentMethodNotFoundError, PaymentNotFoundError
+from ...db.payments_methods_repo import PaymentsMethodsRepo
 from ...db.payments_transactions_repo import PaymentsTransactionsRepo
 from ...models.auth import SessionData
 from ...models.db import PaymentsMethodsDB, PaymentsTransactionsDB

--- a/services/payments/src/simcore_service_payments/api/rest/_acknowledgements.py
+++ b/services/payments/src/simcore_service_payments/api/rest/_acknowledgements.py
@@ -145,18 +145,14 @@ async def acknowledge_payment_method(
     ):
         try:
 
-            payment_method = (
-                await payments_methods.acknowledge_creation_of_payment_method(
-                    repo=repo, payment_method_id=payment_method_id, ack=ack
-                )
+            acked = await payments_methods.acknowledge_creation_of_payment_method(
+                repo=repo, payment_method_id=payment_method_id, ack=ack
             )
         except PaymentMethodNotFoundError as err:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail=f"{err}"
             ) from err
 
-    if payment_method.state == InitPromptAckFlowState.SUCCESS:
-        assert f"{payment_method_id}" == f"{payment_method.payment_method_id}"  # nosec
-        background_tasks.add_task(
-            payments_methods.on_payment_method_completed, payment_method
-        )
+    if acked.state == InitPromptAckFlowState.SUCCESS:
+        assert f"{payment_method_id}" == f"{acked.payment_method_id}"  # nosec
+        background_tasks.add_task(payments_methods.on_payment_method_completed, acked)

--- a/services/payments/src/simcore_service_payments/api/rest/_dependencies.py
+++ b/services/payments/src/simcore_service_payments/api/rest/_dependencies.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from ..._meta import API_VTAG
 from ...core.settings import ApplicationSettings
-from ...db.payments_transactions_repo import BaseRepository
+from ...db.base import BaseRepository
 from ...models.auth import SessionData
 from ...services.auth import get_session_data
 from ...services.resource_usage_tracker import ResourceUsageTrackerApi

--- a/services/payments/src/simcore_service_payments/api/rpc/_payments.py
+++ b/services/payments/src/simcore_service_payments/api/rpc/_payments.py
@@ -15,12 +15,9 @@ from servicelib.rabbitmq import RPCRouter
 from simcore_postgres_database.models.payments_transactions import (
     PaymentTransactionState,
 )
-from simcore_service_payments.core.errors import (
-    PaymentAlreadyAckedError,
-    PaymentNotFoundError,
-)
 
 from ..._constants import PAG, PGDB
+from ...core.errors import PaymentAlreadyAckedError, PaymentNotFoundError
 from ...db.payments_transactions_repo import PaymentsTransactionsRepo
 from ...models.payments_gateway import InitPayment, PaymentInitiated
 from ...services.payments_gateway import PaymentsGatewayApi

--- a/services/payments/src/simcore_service_payments/api/rpc/_payments.py
+++ b/services/payments/src/simcore_service_payments/api/rpc/_payments.py
@@ -3,7 +3,10 @@ from decimal import Decimal
 
 import arrow
 from fastapi import FastAPI
-from models_library.api_schemas_webserver.wallets import PaymentID, WalletPaymentCreated
+from models_library.api_schemas_webserver.wallets import (
+    PaymentID,
+    WalletPaymentInitiated,
+)
 from models_library.users import UserID
 from models_library.wallets import WalletID
 from pydantic import EmailStr
@@ -41,7 +44,7 @@ async def init_payment(
     user_name: str,
     user_email: EmailStr,
     comment: str | None = None,
-) -> WalletPaymentCreated:
+) -> WalletPaymentInitiated:
     initiated_at = arrow.utcnow().datetime
 
     # Payment-Gateway
@@ -90,7 +93,7 @@ async def init_payment(
         )
         assert payment_id == init.payment_id  # nosec
 
-    return WalletPaymentCreated(
+    return WalletPaymentInitiated(
         payment_id=f"{payment_id}",
         payment_form_url=f"{submission_link}",
     )

--- a/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
+++ b/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
@@ -4,10 +4,10 @@ from decimal import Decimal
 import arrow
 from fastapi import FastAPI
 from models_library.api_schemas_webserver.wallets import (
-    PaymentID,
+    PaymentMethodGet,
     PaymentMethodID,
-    PaymentMethodInit,
-    WalletPaymentCreated,
+    PaymentMethodInitiated,
+    WalletPaymentInitiated,
 )
 from models_library.basic_types import IDStr
 from models_library.users import UserID
@@ -17,7 +17,12 @@ from servicelib.logging_utils import get_log_record_extra, log_context
 from servicelib.rabbitmq import RPCRouter
 from simcore_postgres_database.models.payments_methods import InitPromptAckFlowState
 from simcore_service_payments.db.payments_methods_repo import PaymentsMethodsRepo
-from simcore_service_payments.models.payments_gateway import InitPaymentMethod
+from simcore_service_payments.models.db import PaymentsMethodsDB
+from simcore_service_payments.models.payments_gateway import (
+    GetPaymentMethod,
+    InitPayment,
+    InitPaymentMethod,
+)
 
 from ..._constants import PAG, PGDB
 from ...db.payments_transactions_repo import PaymentsTransactionsRepo
@@ -38,7 +43,7 @@ async def init_creation_of_payment_method(
     user_id: UserID,
     user_name: IDStr,
     user_email: EmailStr,
-) -> PaymentMethodInit:
+) -> PaymentMethodInitiated:
     initiated_at = arrow.utcnow().datetime
 
     # Payment-Gateway
@@ -50,9 +55,9 @@ async def init_creation_of_payment_method(
         f"{wallet_id=}",
         extra=get_log_record_extra(user_id=user_id),
     ):
-        payments_gateway_api = PaymentsGatewayApi.get_from_app_state(app)
+        gateway = PaymentsGatewayApi.get_from_app_state(app)
 
-        init = await payments_gateway_api.init_payment_method(
+        init = await gateway.init_payment_method(
             InitPaymentMethod(
                 user_name=user_name,
                 user_email=user_email,
@@ -60,9 +65,7 @@ async def init_creation_of_payment_method(
             )
         )
 
-        form_link = payments_gateway_api.get_form_payment_method_url(
-            init.payment_method_id
-        )
+        form_link = gateway.get_form_payment_method_url(init.payment_method_id)
 
     # Database
     with log_context(
@@ -82,7 +85,7 @@ async def init_creation_of_payment_method(
         )
         assert payment_method_id == init.payment_method_id  # nosec
 
-    return PaymentMethodInit(
+    return PaymentMethodInitiated(
         wallet_id=wallet_id,
         payment_method_id=payment_method_id,
         payment_method_form_url=f"{form_link}",
@@ -110,14 +113,33 @@ async def cancel_creation_of_payment_method(
     # TODO: Notify?
 
     # gateway delete
-    payments_gateway_api = PaymentsGatewayApi.get_from_app_state(app)
-    await payments_gateway_api.delete_payment_method(payment_method_id)
+    gateway = PaymentsGatewayApi.get_from_app_state(app)
+    await gateway.delete_payment_method(payment_method_id)
 
     # delete payment-method in db
     await repo.delete_payment_method(
         payment_method_id,
         user_id=user_id,
         wallet_id=wallet_id,
+    )
+
+
+def _merge_models(got: GetPaymentMethod, acked: PaymentsMethodsDB) -> PaymentMethodGet:
+    assert acked.completed_at  # nosec
+
+    return PaymentMethodGet(
+        idr=acked.payment_method_id,
+        wallet_id=acked.wallet_id,
+        card_holder_name=got.card_holder_name,
+        card_number_masked=got.card_number_masked,
+        card_type=got.card_type,
+        expiration_month=got.expiration_month,
+        expiration_year=got.expiration_year,
+        street_address=got.street_address,
+        zipcode=got.zipcode,
+        country=got.country,
+        created=acked.completed_at,
+        auto_recharge=False,  # this will be fileld in the web/server
     )
 
 
@@ -128,7 +150,22 @@ async def list_payment_methods(
     user_id: UserID,
     wallet_id: WalletID,
 ):
-    raise NotImplementedError
+
+    repo = PaymentsMethodsRepo(db_engine=app.state.engine)
+    acked_many = await repo.list_user_payment_methods(
+        user_id=user_id, wallet_id=wallet_id
+    )
+    assert not any(acked.completed_at is None for acked in acked_many)  # nosec
+
+    gateway: PaymentsGatewayApi = PaymentsGatewayApi.get_from_app_state(app)
+    got_many: list[GetPaymentMethod] = await gateway.get_many_payment_methods(
+        [acked.payment_method_id for acked in acked_many]
+    )
+
+    return [
+        _merge_models(got, acked)
+        for acked, got in zip(acked_many, got_many, strict=True)
+    ]
 
 
 @router.expose()
@@ -138,8 +175,19 @@ async def get_payment_method(
     payment_method_id: PaymentMethodID,
     user_id: UserID,
     wallet_id: WalletID,
-):
-    raise NotImplementedError
+) -> PaymentMethodGet:
+
+    repo = PaymentsMethodsRepo(db_engine=app.state.engine)
+    acked = await repo.get_payment_method(
+        payment_method_id, user_id=user_id, wallet_id=wallet_id
+    )
+
+    #
+    gateway: PaymentsGatewayApi = PaymentsGatewayApi.get_from_app_state(app)
+    got: GetPaymentMethod = await gateway.get_payment_method(acked.payment_method_id)
+    assert acked.completed_at is not None  # nosec
+
+    return _merge_models(got, acked)
 
 
 @router.expose()
@@ -150,7 +198,17 @@ async def delete_payment_method(
     user_id: UserID,
     wallet_id: WalletID,
 ):
-    raise NotImplementedError
+    repo = PaymentsMethodsRepo(db_engine=app.state.engine)
+    acked = await repo.get_payment_method(
+        payment_method_id, user_id=user_id, wallet_id=wallet_id
+    )
+
+    gateway: PaymentsGatewayApi = PaymentsGatewayApi.get_from_app_state(app)
+    await gateway.delete_payment_method(acked.payment_method_id)
+
+    await repo.delete_payment_method(
+        acked.payment_method_id, user_id=acked.user_id, wallet_id=acked.wallet_id
+    )
 
 
 @router.expose()
@@ -167,12 +225,43 @@ async def init_payment_with_payment_method(
     user_name: str,
     user_email: EmailStr,
     comment: str | None = None,
-) -> WalletPaymentCreated:
+) -> WalletPaymentInitiated:
 
-    payment_id: PaymentID = "123"
+    initiated_at = arrow.utcnow().datetime
 
-    payments_gateway_api = PaymentsGatewayApi.get_from_app_state(app)
+    # check acked payment_method_id
+    repo = PaymentsMethodsRepo(db_engine=app.state.engine)
+    acked = await repo.get_payment_method(
+        payment_method_id, user_id=user_id, wallet_id=wallet_id
+    )
 
-    repo = PaymentsTransactionsRepo(db_engine=app.state.engine)
+    # init -> gateway
+    gateway: PaymentsGatewayApi = PaymentsGatewayApi.get_from_app_state(app)
+    payment_inited = await gateway.init_payment_with_payment_method(
+        acked.payment_method_id,
+        payment=InitPayment(
+            amount_dollars=amount_dollars,
+            credits=target_credits,
+            user_name=user_name,
+            user_email=user_email,
+            wallet_name=wallet_name,
+        ),
+    )
 
-    raise NotImplementedError
+    payment_repo = PaymentsTransactionsRepo(db_engine=app.state.engine)
+    payment_id = await payment_repo.insert_init_payment_transaction(
+        payment_id=payment_inited.payment_id,
+        price_dollars=amount_dollars,
+        osparc_credits=target_credits,
+        product_name=product_name,
+        user_id=user_id,
+        user_email=user_email,
+        wallet_id=wallet_id,
+        comment=comment,
+        initiated_at=initiated_at,
+    )
+
+    return WalletPaymentInitiated(
+        payment_id=f"{payment_id}",
+        payment_form_url=None,
+    )

--- a/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
+++ b/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
@@ -16,16 +16,12 @@ from pydantic import EmailStr
 from servicelib.logging_utils import get_log_record_extra, log_context
 from servicelib.rabbitmq import RPCRouter
 from simcore_postgres_database.models.payments_methods import InitPromptAckFlowState
-from simcore_service_payments.db.payments_methods_repo import PaymentsMethodsRepo
-from simcore_service_payments.models.db import PaymentsMethodsDB
-from simcore_service_payments.models.payments_gateway import (
-    GetPaymentMethod,
-    InitPayment,
-    InitPaymentMethod,
-)
 
 from ..._constants import PAG, PGDB
+from ...db.payments_methods_repo import PaymentsMethodsRepo
 from ...db.payments_transactions_repo import PaymentsTransactionsRepo
+from ...models.db import PaymentsMethodsDB
+from ...models.payments_gateway import GetPaymentMethod, InitPayment, InitPaymentMethod
 from ...services.payments_gateway import PaymentsGatewayApi
 
 _logger = logging.getLogger(__name__)

--- a/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
+++ b/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
@@ -96,8 +96,6 @@ async def cancel_creation_of_payment_method(
     user_id: UserID,
     wallet_id: WalletID,
 ) -> None:
-    # TODO: with db transaction
-
     # Prevents card from being used
     repo = PaymentsMethodsRepo(db_engine=app.state.engine)
 
@@ -106,7 +104,6 @@ async def cancel_creation_of_payment_method(
         completion_state=InitPromptAckFlowState.CANCELED,
         state_message="User cancelled",
     )
-    # TODO: Notify?
 
     # gateway delete
     gateway = PaymentsGatewayApi.get_from_app_state(app)
@@ -177,11 +174,10 @@ async def get_payment_method(
     acked = await repo.get_payment_method(
         payment_method_id, user_id=user_id, wallet_id=wallet_id
     )
+    assert acked.state == InitPromptAckFlowState.SUCCESS  # nosec
 
-    #
     gateway: PaymentsGatewayApi = PaymentsGatewayApi.get_from_app_state(app)
     got: GetPaymentMethod = await gateway.get_payment_method(acked.payment_method_id)
-    assert acked.completed_at is not None  # nosec
 
     return _merge_models(got, acked)
 

--- a/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
+++ b/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
@@ -1,10 +1,13 @@
 import logging
+from decimal import Decimal
 
 import arrow
 from fastapi import FastAPI
 from models_library.api_schemas_webserver.wallets import (
+    PaymentID,
     PaymentMethodID,
     PaymentMethodInit,
+    WalletPaymentCreated,
 )
 from models_library.basic_types import IDStr
 from models_library.users import UserID
@@ -17,6 +20,7 @@ from simcore_service_payments.db.payments_methods_repo import PaymentsMethodsRep
 from simcore_service_payments.models.payments_gateway import InitPaymentMethod
 
 from ..._constants import PAG, PGDB
+from ...db.payments_transactions_repo import PaymentsTransactionsRepo
 from ...services.payments_gateway import PaymentsGatewayApi
 
 _logger = logging.getLogger(__name__)
@@ -35,7 +39,6 @@ async def init_creation_of_payment_method(
     user_name: IDStr,
     user_email: EmailStr,
 ) -> PaymentMethodInit:
-
     initiated_at = arrow.utcnow().datetime
 
     # Payment-Gateway
@@ -116,3 +119,60 @@ async def cancel_creation_of_payment_method(
         user_id=user_id,
         wallet_id=wallet_id,
     )
+
+
+@router.expose()
+async def list_payment_methods(
+    app: FastAPI,
+    *,
+    user_id: UserID,
+    wallet_id: WalletID,
+):
+    raise NotImplementedError
+
+
+@router.expose()
+async def get_payment_method(
+    app: FastAPI,
+    *,
+    payment_method_id: PaymentMethodID,
+    user_id: UserID,
+    wallet_id: WalletID,
+):
+    raise NotImplementedError
+
+
+@router.expose()
+async def delete_payment_method(
+    app: FastAPI,
+    *,
+    payment_method_id: PaymentMethodID,
+    user_id: UserID,
+    wallet_id: WalletID,
+):
+    raise NotImplementedError
+
+
+@router.expose()
+async def init_payment_with_payment_method(
+    app: FastAPI,
+    *,
+    payment_method_id: PaymentMethodID,
+    amount_dollars: Decimal,
+    target_credits: Decimal,
+    product_name: str,
+    wallet_id: WalletID,
+    wallet_name: str,
+    user_id: UserID,
+    user_name: str,
+    user_email: EmailStr,
+    comment: str | None = None,
+) -> WalletPaymentCreated:
+
+    payment_id: PaymentID = "123"
+
+    payments_gateway_api = PaymentsGatewayApi.get_from_app_state(app)
+
+    repo = PaymentsTransactionsRepo(db_engine=app.state.engine)
+
+    raise NotImplementedError

--- a/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
+++ b/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
@@ -1,0 +1,118 @@
+import logging
+
+import arrow
+from fastapi import FastAPI
+from models_library.api_schemas_webserver.wallets import (
+    PaymentMethodID,
+    PaymentMethodInit,
+)
+from models_library.basic_types import IDStr
+from models_library.users import UserID
+from models_library.wallets import WalletID
+from pydantic import EmailStr
+from servicelib.logging_utils import get_log_record_extra, log_context
+from servicelib.rabbitmq import RPCRouter
+from simcore_postgres_database.models.payments_methods import InitPromptAckFlowState
+from simcore_service_payments.db.payments_methods_repo import PaymentsMethodsRepo
+from simcore_service_payments.models.payments_gateway import InitPaymentMethod
+
+from ..._constants import PAG, PGDB
+from ...services.payments_gateway import PaymentsGatewayApi
+
+_logger = logging.getLogger(__name__)
+
+
+router = RPCRouter()
+
+
+@router.expose()
+async def init_creation_of_payment_method(
+    app: FastAPI,
+    *,
+    wallet_id: WalletID,
+    wallet_name: IDStr,
+    user_id: UserID,
+    user_name: IDStr,
+    user_email: EmailStr,
+) -> PaymentMethodInit:
+
+    initiated_at = arrow.utcnow().datetime
+
+    # Payment-Gateway
+    with log_context(
+        _logger,
+        logging.INFO,
+        "%s: Init payment-method %s in payments-gateway",
+        PAG,
+        f"{wallet_id=}",
+        extra=get_log_record_extra(user_id=user_id),
+    ):
+        payments_gateway_api = PaymentsGatewayApi.get_from_app_state(app)
+
+        init = await payments_gateway_api.init_payment_method(
+            InitPaymentMethod(
+                user_name=user_name,
+                user_email=user_email,
+                wallet_name=wallet_name,
+            )
+        )
+
+        form_link = payments_gateway_api.get_form_payment_method_url(
+            init.payment_method_id
+        )
+
+    # Database
+    with log_context(
+        _logger,
+        logging.INFO,
+        "%s: Annotate INIT payment-method %s in db",
+        PGDB,
+        f"{init.payment_method_id=}",
+        extra=get_log_record_extra(user_id=user_id),
+    ):
+        repo = PaymentsMethodsRepo(db_engine=app.state.engine)
+        payment_method_id = await repo.insert_init_payment_method(
+            init.payment_method_id,
+            user_id=user_id,
+            wallet_id=wallet_id,
+            initiated_at=initiated_at,
+        )
+        assert payment_method_id == init.payment_method_id  # nosec
+
+    return PaymentMethodInit(
+        wallet_id=wallet_id,
+        payment_method_id=payment_method_id,
+        payment_method_form_url=f"{form_link}",
+    )
+
+
+@router.expose()
+async def cancel_creation_of_payment_method(
+    app: FastAPI,
+    *,
+    payment_method_id: PaymentMethodID,
+    user_id: UserID,
+    wallet_id: WalletID,
+) -> None:
+    # TODO: with db transaction
+
+    # Prevents card from being used
+    repo = PaymentsMethodsRepo(db_engine=app.state.engine)
+
+    await repo.update_ack_payment_method(
+        payment_method_id,
+        completion_state=InitPromptAckFlowState.CANCELED,
+        state_message="User cancelled",
+    )
+    # TODO: Notify?
+
+    # gateway delete
+    payments_gateway_api = PaymentsGatewayApi.get_from_app_state(app)
+    await payments_gateway_api.delete_payment_method(payment_method_id)
+
+    # delete payment-method in db
+    await repo.delete_payment_method(
+        payment_method_id,
+        user_id=user_id,
+        wallet_id=wallet_id,
+    )

--- a/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
+++ b/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
@@ -212,7 +212,7 @@ async def delete_payment_method(
 
 
 @router.expose()
-async def init_payment_with_payment_method(
+async def init_payment_with_payment_method(  # noqa: PLR0913 # pylint: disable=too-many-arguments
     app: FastAPI,
     *,
     payment_method_id: PaymentMethodID,

--- a/services/payments/src/simcore_service_payments/api/rpc/routes.py
+++ b/services/payments/src/simcore_service_payments/api/rpc/routes.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from models_library.api_schemas_payments import PAYMENTS_RPC_NAMESPACE
 
 from ...services.rabbitmq import get_rabbitmq_rpc_server
-from . import _payments
+from . import _payments, _payments_methods
 
 _logger = logging.getLogger(__name__)
 
@@ -12,6 +12,10 @@ _logger = logging.getLogger(__name__)
 def setup_rpc_api_routes(app: FastAPI) -> None:
     async def _on_startup() -> None:
         rpc_server = get_rabbitmq_rpc_server(app)
-        await rpc_server.register_router(_payments.router, PAYMENTS_RPC_NAMESPACE, app)
+        for router in (
+            _payments.router,
+            _payments_methods.router,
+        ):
+            await rpc_server.register_router(router, PAYMENTS_RPC_NAMESPACE, app)
 
     app.add_event_handler("startup", _on_startup)

--- a/services/payments/src/simcore_service_payments/core/errors.py
+++ b/services/payments/src/simcore_service_payments/core/errors.py
@@ -18,4 +18,4 @@ class PaymentAlreadyAckedError(PaymentsValueError):
 
 
 class PaymentMethodNotFoundError(PaymentsValueError):
-    msg_template = "Payment method '{payment_method_id}' was not found"
+    msg_template = "The specified payment method '{payment_method_id}' does not exist"

--- a/services/payments/src/simcore_service_payments/core/errors.py
+++ b/services/payments/src/simcore_service_payments/core/errors.py
@@ -15,3 +15,7 @@ class PaymentAlreadyExistsError(PaymentsValueError):
 
 class PaymentAlreadyAckedError(PaymentsValueError):
     msg_template = "Payment transaction '{payment_id}' cannot be changes since it was already closed."
+
+
+class PaymentMethodNotFoundError(PaymentsValueError):
+    msg_template = "Payment method '{payment_method_id}' was not found"

--- a/services/payments/src/simcore_service_payments/core/errors.py
+++ b/services/payments/src/simcore_service_payments/core/errors.py
@@ -1,21 +1,35 @@
 from pydantic.errors import PydanticErrorMixin
 
 
-class PaymentsValueError(PydanticErrorMixin, ValueError):
+class PaymentsError(PydanticErrorMixin, ValueError):
     msg_template = "Error in payment transaction '{payment_id}'"
 
 
-class PaymentNotFoundError(PaymentsValueError):
+class PaymentNotFoundError(PaymentsError):
     msg_template = "Payment transaction '{payment_id}' was not found"
 
 
-class PaymentAlreadyExistsError(PaymentsValueError):
+class PaymentAlreadyExistsError(PaymentsError):
     msg_template = "Payment transaction '{payment_id}' was already initialized"
 
 
-class PaymentAlreadyAckedError(PaymentsValueError):
+class PaymentAlreadyAckedError(PaymentsError):
     msg_template = "Payment transaction '{payment_id}' cannot be changes since it was already closed."
 
 
-class PaymentMethodNotFoundError(PaymentsValueError):
+class PaymentsMethodsError(PaymentsError):
+    ...
+
+
+class PaymentMethodNotFoundError(PaymentsMethodsError):
     msg_template = "The specified payment method '{payment_method_id}' does not exist"
+
+
+class PaymentMethodAlreadyAckedError(PaymentsMethodsError):
+    msg_template = (
+        "Cannot create payment-method '{payment_method_id}' since it was already closed"
+    )
+
+
+class PaymentMethodUniqueViolationError(PaymentsMethodsError):
+    msg_template = "Payment method '{payment_method_id}' aready exists"

--- a/services/payments/src/simcore_service_payments/db/_base.py
+++ b/services/payments/src/simcore_service_payments/db/_base.py
@@ -1,0 +1,11 @@
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+class BaseRepository:
+    """
+    Repositories are pulled at every request
+    """
+
+    def __init__(self, db_engine: AsyncEngine):
+        assert db_engine is not None  # nosec
+        self.db_engine = db_engine

--- a/services/payments/src/simcore_service_payments/db/base.py
+++ b/services/payments/src/simcore_service_payments/db/base.py
@@ -9,11 +9,3 @@ class BaseRepository:
     def __init__(self, db_engine: AsyncEngine):
         assert db_engine is not None  # nosec
         self.db_engine = db_engine
-
-    # FIXME:
-    # async def transaction(self, connection: None) -> Iterable[]:
-    #     if connection is not None:
-    #         yield connection
-    #     else:
-    #         with self.db_engine.begin() as conn:
-    #             yield conn

--- a/services/payments/src/simcore_service_payments/db/base.py
+++ b/services/payments/src/simcore_service_payments/db/base.py
@@ -9,3 +9,11 @@ class BaseRepository:
     def __init__(self, db_engine: AsyncEngine):
         assert db_engine is not None  # nosec
         self.db_engine = db_engine
+
+    # FIXME:
+    # async def transaction(self, connection: None) -> Iterable[]:
+    #     if connection is not None:
+    #         yield connection
+    #     else:
+    #         with self.db_engine.begin() as conn:
+    #             yield conn

--- a/services/payments/src/simcore_service_payments/db/payments_methods_repo.py
+++ b/services/payments/src/simcore_service_payments/db/payments_methods_repo.py
@@ -6,7 +6,7 @@ from models_library.api_schemas_webserver.wallets import PaymentMethodID
 from models_library.users import UserID
 from models_library.wallets import WalletID
 from pydantic import parse_obj_as
-from simcore_postgres_database.models.payments_transactions import (
+from simcore_postgres_database.models.payments_methods import (
     InitPromptAckFlowState,
     payments_methods,
 )

--- a/services/payments/src/simcore_service_payments/db/payments_methods_repo.py
+++ b/services/payments/src/simcore_service_payments/db/payments_methods_repo.py
@@ -102,7 +102,7 @@ class PaymentsMethodsRepo(BaseRepository):
         completion_state: InitPromptAckFlowState,
         state_message: str | None,
     ) -> PaymentsMethodsDB:
-        # TODO: how to do this on a single begin()?
+
         await self.insert_init_payment_method(
             payment_method_id,
             user_id=user_id,

--- a/services/payments/src/simcore_service_payments/db/payments_methods_repo.py
+++ b/services/payments/src/simcore_service_payments/db/payments_methods_repo.py
@@ -18,7 +18,7 @@ from ..core.errors import (
     PaymentMethodUniqueViolationError,
 )
 from ..models.db import PaymentsMethodsDB
-from ._base import BaseRepository
+from .base import BaseRepository
 
 
 class PaymentsMethodsRepo(BaseRepository):

--- a/services/payments/src/simcore_service_payments/db/payments_methods_repo.py
+++ b/services/payments/src/simcore_service_payments/db/payments_methods_repo.py
@@ -1,0 +1,150 @@
+import datetime
+
+import simcore_postgres_database.errors as db_errors
+import sqlalchemy as sa
+from models_library.api_schemas_webserver.wallets import PaymentMethodID
+from models_library.users import UserID
+from models_library.wallets import WalletID
+from pydantic import parse_obj_as
+from simcore_postgres_database.models.payments_transactions import (
+    InitPromptAckFlowState,
+    payments_methods,
+)
+
+from ..core.errors import (
+    PaymentMethodAlreadyAckedError,
+    PaymentMethodNotFoundError,
+    PaymentMethodUniqueViolationError,
+)
+from ..models.db import PaymentsMethodsDB
+from ._base import BaseRepository
+
+
+class PaymentsMethodsRepo(BaseRepository):
+    async def insert_init_payment_method(
+        self,
+        payment_method_id: PaymentMethodID,
+        *,
+        user_id: UserID,
+        wallet_id: WalletID,
+        initiated_at: datetime.datetime,
+    ) -> PaymentMethodID:
+        try:
+            async with self.db_engine.begin() as conn:
+                await conn.execute(
+                    payments_methods.insert().values(
+                        payment_method_id=payment_method_id,
+                        user_id=user_id,
+                        wallet_id=wallet_id,
+                        initiated_at=initiated_at,
+                    )
+                )
+                return payment_method_id
+
+        except db_errors.UniqueViolation as err:
+            raise PaymentMethodUniqueViolationError(
+                payment_method_id=payment_method_id
+            ) from err
+
+    async def update_ack_payment_method(
+        self,
+        payment_method_id: PaymentMethodID,
+        *,
+        state: InitPromptAckFlowState,
+        state_message: str | None,
+    ):
+        if state == InitPromptAckFlowState.PENDING:
+            msg = f"{state} is not a completion state"
+            raise ValueError(msg)
+
+        optional = {}
+        if state_message:
+            optional["state_message"] = state_message
+
+        async with self.db_engine.begin() as conn:
+            row = (
+                await conn.execute(
+                    sa.select(
+                        payments_methods.c.initiated_at,
+                        payments_methods.c.completed_at,
+                    )
+                    .where(payments_methods.c.payment_method_id == payment_method_id)
+                    .with_for_update()
+                )
+            ).fetchone()
+
+            if row is None:
+                raise PaymentMethodNotFoundError(payment_method_id=payment_method_id)
+
+            if row.completed_at is not None:
+                raise PaymentMethodAlreadyAckedError(
+                    payment_method_id=payment_method_id
+                )
+
+            result = await conn.execute(
+                payments_methods.update()
+                .values(completed_at=sa.func.now(), state=state, **optional)
+                .where(payments_methods.c.payment_method_id == payment_method_id)
+                .returning(sa.literal_column("*"))
+            )
+            row = result.first()
+            assert row, "execute above should have caught this"  # nosec
+
+            return PaymentsMethodsDB.from_orm(row)
+
+    async def list_user_payment_methods(
+        self,
+        *,
+        user_id: UserID,
+        wallet_id: WalletID,
+    ):
+        async with self.db_engine.begin() as conn:
+            result = await conn.execute(
+                payments_methods.select()
+                .where(
+                    (payments_methods.c.user_id == user_id)
+                    & (payments_methods.c.wallet_id == wallet_id)
+                    & (payments_methods.c.state == InitPromptAckFlowState.SUCCESS)
+                )
+                .order_by(payments_methods.c.created.desc())
+            )  # newest first
+        rows = result.fetchall() or []
+        return parse_obj_as(list[PaymentsMethodsDB], rows)
+
+    async def get_payment_method(
+        self,
+        payment_method_id: PaymentMethodID,
+        *,
+        user_id: UserID,
+        wallet_id: WalletID,
+    ):
+        async with self.db_engine.begin() as conn:
+            result = await conn.execute(
+                payments_methods.select().where(
+                    (payments_methods.c.user_id == user_id)
+                    & (payments_methods.c.wallet_id == wallet_id)
+                    & (payments_methods.c.payment_method_id == payment_method_id)
+                    & (payments_methods.c.state == InitPromptAckFlowState.SUCCESS)
+                )
+            )
+            row = result.first()
+            if row is None:
+                raise PaymentMethodNotFoundError(payment_method_id=payment_method_id)
+
+            return PaymentsMethodsDB.from_orm(row)
+
+    async def delete_payment_method(
+        self,
+        payment_method_id: PaymentMethodID,
+        *,
+        user_id: UserID,
+        wallet_id: WalletID,
+    ):
+        async with self.db_engine.begin() as conn:
+            await conn.execute(
+                payments_methods.delete().where(
+                    (payments_methods.c.user_id == user_id)
+                    & (payments_methods.c.wallet_id == wallet_id)
+                    & (payments_methods.c.payment_method_id == payment_method_id)
+                )
+            )

--- a/services/payments/src/simcore_service_payments/db/payments_transactions_repo.py
+++ b/services/payments/src/simcore_service_payments/db/payments_transactions_repo.py
@@ -11,7 +11,6 @@ from simcore_postgres_database.models.payments_transactions import (
     PaymentTransactionState,
     payments_transactions,
 )
-from sqlalchemy.ext.asyncio import AsyncEngine
 
 from ..core.errors import (
     PaymentAlreadyAckedError,
@@ -19,22 +18,14 @@ from ..core.errors import (
     PaymentNotFoundError,
 )
 from ..models.db import PaymentsTransactionsDB
-
-
-class BaseRepository:
-    """
-    Repositories are pulled at every request
-    """
-
-    def __init__(self, db_engine: AsyncEngine):
-        assert db_engine is not None  # nosec
-        self.db_engine = db_engine
+from ._base import BaseRepository
 
 
 class PaymentsTransactionsRepo(BaseRepository):
     async def insert_init_payment_transaction(
         self,
         payment_id: PaymentID,
+        *,
         price_dollars: Decimal,
         osparc_credits: Decimal,
         product_name: str,

--- a/services/payments/src/simcore_service_payments/db/payments_transactions_repo.py
+++ b/services/payments/src/simcore_service_payments/db/payments_transactions_repo.py
@@ -18,7 +18,7 @@ from ..core.errors import (
     PaymentNotFoundError,
 )
 from ..models.db import PaymentsTransactionsDB
-from ._base import BaseRepository
+from .base import BaseRepository
 
 
 class PaymentsTransactionsRepo(BaseRepository):

--- a/services/payments/src/simcore_service_payments/models/db.py
+++ b/services/payments/src/simcore_service_payments/models/db.py
@@ -2,12 +2,13 @@ import datetime
 from decimal import Decimal
 from typing import Any, ClassVar
 
-from models_library.api_schemas_webserver.wallets import PaymentID
+from models_library.api_schemas_webserver.wallets import PaymentID, PaymentMethodID
 from models_library.emails import LowerCaseEmailStr
 from models_library.products import ProductName
 from models_library.users import UserID
 from models_library.wallets import WalletID
 from pydantic import BaseModel, HttpUrl
+from simcore_postgres_database.models.payments_methods import InitPromptAckFlowState
 from simcore_postgres_database.models.payments_transactions import (
     PaymentTransactionState,
 )
@@ -54,6 +55,42 @@ class PaymentsTransactionsDB(BaseModel):
                     "completed_at": "2023-09-27T10:00:10",
                     "state": "SUCCESS",
                     "state_message": "Payment completed successfully",
+                },
+            ]
+        }
+
+
+_EXAMPLE_AFTER_INIT_PAYMENT_METHOD = {
+    "payment_method_id": "12345",
+    "user_id": _EXAMPLE_AFTER_INIT["user_id"],
+    "user_email": _EXAMPLE_AFTER_INIT["user_email"],
+    "wallet_id": _EXAMPLE_AFTER_INIT["wallet_id"],
+    "initiated_at": _EXAMPLE_AFTER_INIT["initiated_at"],
+    "state": InitPromptAckFlowState.PENDING,
+}
+
+
+class PaymentsMethodsDB(BaseModel):
+    payment_method_id: PaymentMethodID
+    user_id: UserID
+    wallet_id: WalletID
+    # State in Flow
+    initiated_at: datetime.datetime
+    completed_at: datetime.datetime | None
+    state: InitPromptAckFlowState
+    state_message: str | None
+
+    class Config:
+        orm_mode = True
+        schema_extra: ClassVar[dict[str, Any]] = {
+            "examples": [
+                _EXAMPLE_AFTER_INIT_PAYMENT_METHOD,
+                # successful completion
+                {
+                    **_EXAMPLE_AFTER_INIT_PAYMENT_METHOD,
+                    "completed_at": "2023-09-27T10:00:15",
+                    "state": "SUCCESS",
+                    "state_message": "Payment method completed successfully",
                 },
             ]
         }

--- a/services/payments/src/simcore_service_payments/models/utils.py
+++ b/services/payments/src/simcore_service_payments/models/utils.py
@@ -1,0 +1,23 @@
+from models_library.api_schemas_webserver.wallets import PaymentMethodGet
+
+from .db import PaymentsMethodsDB
+from .payments_gateway import GetPaymentMethod
+
+
+def merge_models(got: GetPaymentMethod, acked: PaymentsMethodsDB) -> PaymentMethodGet:
+    assert acked.completed_at  # nosec
+
+    return PaymentMethodGet(
+        idr=acked.payment_method_id,
+        wallet_id=acked.wallet_id,
+        card_holder_name=got.card_holder_name,
+        card_number_masked=got.card_number_masked,
+        card_type=got.card_type,
+        expiration_month=got.expiration_month,
+        expiration_year=got.expiration_year,
+        street_address=got.street_address,
+        zipcode=got.zipcode,
+        country=got.country,
+        created=acked.completed_at,
+        auto_recharge=False,  # this will be fileld in the web/server
+    )

--- a/services/payments/src/simcore_service_payments/services/payments.py
+++ b/services/payments/src/simcore_service_payments/services/payments.py
@@ -1,0 +1,17 @@
+from models_library.api_schemas_webserver.wallets import WalletPaymentInitiated
+
+
+async def init_one_time_payment() -> WalletPaymentInitiated:
+    raise NotImplementedError
+
+
+async def cancel_one_time_payment() -> None:
+    raise NotImplementedError
+
+
+async def acknowledge_one_time_payment():
+    raise NotImplementedError
+
+
+async def get_user_payments_page():
+    raise NotImplementedError

--- a/services/payments/src/simcore_service_payments/services/payments.py
+++ b/services/payments/src/simcore_service_payments/services/payments.py
@@ -3,6 +3,7 @@
 - Payment w/ payment-method
 
 """
+# pylint: disable=too-many-arguments
 
 import logging
 from decimal import Decimal
@@ -136,7 +137,7 @@ async def acknowledge_one_time_payment(
 
 
 async def on_payment_completed(
-    *, transaction: PaymentsTransactionsDB, rut_api: ResourceUsageTrackerApi
+    transaction: PaymentsTransactionsDB, rut_api: ResourceUsageTrackerApi
 ):
     assert transaction.completed_at is not None  # nosec
     assert transaction.initiated_at < transaction.completed_at  # nosec
@@ -172,7 +173,7 @@ async def on_payment_completed(
     )
 
 
-async def init_payment_with_payment_method(  # noqa: PLR0913 # pylint: disable=too-many-arguments
+async def init_payment_with_payment_method(
     gateway: PaymentsGatewayApi,
     repo_transactions: PaymentsTransactionsRepo,
     repo_methods: PaymentsMethodsRepo,

--- a/services/payments/src/simcore_service_payments/services/payments.py
+++ b/services/payments/src/simcore_service_payments/services/payments.py
@@ -1,17 +1,239 @@
-from models_library.api_schemas_webserver.wallets import WalletPaymentInitiated
+""" Functions here support two types of payments worklows:
+- One-time payment
+- Payment w/ payment-method
+
+"""
+
+import logging
+from decimal import Decimal
+
+import arrow
+from models_library.api_schemas_webserver.wallets import (
+    PaymentID,
+    PaymentMethodID,
+    WalletPaymentInitiated,
+)
+from models_library.users import UserID
+from models_library.wallets import WalletID
+from pydantic import EmailStr
+from servicelib.logging_utils import log_context
+from simcore_postgres_database.models.payments_transactions import (
+    PaymentTransactionState,
+)
+from simcore_service_payments.db.payments_methods_repo import PaymentsMethodsRepo
+
+from .._constants import RUT
+from ..core.errors import PaymentAlreadyAckedError, PaymentNotFoundError
+from ..db.payments_transactions_repo import PaymentsTransactionsRepo
+from ..models.db import PaymentsTransactionsDB
+from ..models.payments_gateway import InitPayment, PaymentInitiated
+from ..models.schemas.acknowledgements import AckPayment
+from ..services.resource_usage_tracker import ResourceUsageTrackerApi
+from .payments_gateway import PaymentsGatewayApi
+
+_logger = logging.getLogger()
 
 
-async def init_one_time_payment() -> WalletPaymentInitiated:
-    raise NotImplementedError
+async def init_one_time_payment(
+    gateway: PaymentsGatewayApi,
+    repo: PaymentsTransactionsRepo,
+    *,
+    amount_dollars: Decimal,
+    target_credits: Decimal,
+    product_name: str,
+    wallet_id: WalletID,
+    wallet_name: str,
+    user_id: UserID,
+    user_name: str,
+    user_email: EmailStr,
+    comment: str | None = None,
+) -> WalletPaymentInitiated:
+    initiated_at = arrow.utcnow().datetime
+
+    init = await gateway.init_payment(
+        payment=InitPayment(
+            amount_dollars=amount_dollars,
+            credits=target_credits,
+            user_name=user_name,
+            user_email=user_email,
+            wallet_name=wallet_name,
+        )
+    )
+
+    submission_link = gateway.get_form_payment_url(init.payment_id)
+
+    payment_id = await repo.insert_init_payment_transaction(
+        payment_id=init.payment_id,
+        price_dollars=amount_dollars,
+        osparc_credits=target_credits,
+        product_name=product_name,
+        user_id=user_id,
+        user_email=user_email,
+        wallet_id=wallet_id,
+        comment=comment,
+        initiated_at=initiated_at,
+    )
+
+    assert payment_id == init.payment_id  # nosec
+
+    return WalletPaymentInitiated(
+        payment_id=f"{payment_id}",
+        payment_form_url=f"{submission_link}",
+    )
 
 
-async def cancel_one_time_payment() -> None:
-    raise NotImplementedError
+async def cancel_one_time_payment(
+    gateway: PaymentsGatewayApi,
+    repo: PaymentsTransactionsRepo,
+    *,
+    payment_id: PaymentID,
+    user_id: UserID,
+    wallet_id: WalletID,
+) -> None:
+
+    payment = await repo.get_payment_transaction(
+        payment_id=payment_id, user_id=user_id, wallet_id=wallet_id
+    )
+
+    if payment is None:
+        raise PaymentNotFoundError(payment_id=payment_id)
+
+    if payment.state.is_completed():
+        if payment.state == PaymentTransactionState.CANCELED:
+            # Avoids error if multiple cancel calls
+            return
+        raise PaymentAlreadyAckedError(payment_id=payment_id)
+
+    payment_cancelled = await gateway.cancel_payment(
+        PaymentInitiated(payment_id=payment_id)
+    )
+
+    await repo.update_ack_payment_transaction(
+        payment_id=payment_id,
+        completion_state=PaymentTransactionState.CANCELED,
+        state_message=payment_cancelled.message,
+        invoice_url=None,
+    )
 
 
-async def acknowledge_one_time_payment():
-    raise NotImplementedError
+async def acknowledge_one_time_payment(
+    repo_transactions: PaymentsTransactionsRepo,
+    *,
+    payment_id: PaymentID,
+    ack: AckPayment,
+) -> PaymentsTransactionsDB:
+
+    return await repo_transactions.update_ack_payment_transaction(
+        payment_id=payment_id,
+        completion_state=(
+            PaymentTransactionState.SUCCESS
+            if ack.success
+            else PaymentTransactionState.FAILED
+        ),
+        state_message=ack.message,
+        invoice_url=ack.invoice_url,
+    )
 
 
-async def get_user_payments_page():
-    raise NotImplementedError
+async def on_payment_completed(
+    *, transaction: PaymentsTransactionsDB, rut_api: ResourceUsageTrackerApi
+):
+    assert transaction.completed_at is not None  # nosec
+    assert transaction.initiated_at < transaction.completed_at  # nosec
+
+    _logger.debug(
+        "Notify front-end of payment -> sio SOCKET_IO_PAYMENT_COMPLETED_EVENT "
+    )
+
+    with log_context(
+        _logger,
+        logging.INFO,
+        "%s: Top-up %s credits for %s",
+        RUT,
+        f"{transaction.osparc_credits}",
+        f"{transaction.payment_id=}",
+    ):
+        credit_transaction_id = await rut_api.create_credit_transaction(
+            product_name=transaction.product_name,
+            wallet_id=transaction.wallet_id,
+            wallet_name="id={transaction.wallet_id}",
+            user_id=transaction.user_id,
+            user_email=transaction.user_email,
+            osparc_credits=transaction.osparc_credits,
+            payment_transaction_id=transaction.payment_id,
+            created_at=transaction.completed_at,
+        )
+
+    _logger.debug(
+        "%s: Response to %s was %s",
+        RUT,
+        f"{transaction.payment_id=}",
+        f"{credit_transaction_id=}",
+    )
+
+
+async def init_payment_with_payment_method(  # noqa: PLR0913 # pylint: disable=too-many-arguments
+    gateway: PaymentsGatewayApi,
+    repo_transactions: PaymentsTransactionsRepo,
+    repo_methods: PaymentsMethodsRepo,
+    *,
+    payment_method_id: PaymentMethodID,
+    amount_dollars: Decimal,
+    target_credits: Decimal,
+    product_name: str,
+    wallet_id: WalletID,
+    wallet_name: str,
+    user_id: UserID,
+    user_name: str,
+    user_email: EmailStr,
+    comment: str | None = None,
+) -> WalletPaymentInitiated:
+    initiated_at = arrow.utcnow().datetime
+
+    acked = await repo_methods.get_payment_method(
+        payment_method_id, user_id=user_id, wallet_id=wallet_id
+    )
+
+    payment_inited = await gateway.init_payment_with_payment_method(
+        acked.payment_method_id,
+        payment=InitPayment(
+            amount_dollars=amount_dollars,
+            credits=target_credits,
+            user_name=user_name,
+            user_email=user_email,
+            wallet_name=wallet_name,
+        ),
+    )
+
+    payment_id = await repo_transactions.insert_init_payment_transaction(
+        payment_id=payment_inited.payment_id,
+        price_dollars=amount_dollars,
+        osparc_credits=target_credits,
+        product_name=product_name,
+        user_id=user_id,
+        user_email=user_email,
+        wallet_id=wallet_id,
+        comment=comment,
+        initiated_at=initiated_at,
+    )
+
+    return WalletPaymentInitiated(
+        payment_id=f"{payment_id}",
+        payment_form_url=None,
+    )
+
+
+async def get_payments_page(
+    repo: PaymentsTransactionsRepo,
+    *,
+    user_id: UserID,
+    limit: int,
+    offset: int,
+) -> tuple[int, list[PaymentsTransactionsDB]]:
+    """All payments associated to a user (i.e. including all the owned wallets)"""
+
+    total_number_of_items, page = await repo.list_user_payment_transactions(
+        user_id=user_id, offset=offset, limit=limit
+    )
+
+    return total_number_of_items, page

--- a/services/payments/src/simcore_service_payments/services/payments_gateway.py
+++ b/services/payments/src/simcore_service_payments/services/payments_gateway.py
@@ -16,6 +16,7 @@ from models_library.api_schemas_webserver.wallets import PaymentID, PaymentMetho
 
 from ..core.settings import ApplicationSettings
 from ..models.payments_gateway import (
+    BatchGetPaymentMethods,
     GetPaymentMethod,
     InitPayment,
     InitPaymentMethod,
@@ -78,7 +79,11 @@ class PaymentsGatewayApi(BaseHttpApi, AppStateMixin):
     async def get_form_payment_method(self, id_: PaymentMethodID) -> URL:
         raise NotImplementedError
 
-    async def list_payment_methods(self) -> list[GetPaymentMethod]:
+    # CRUD
+
+    async def get_many_payment_methods(
+        self, selection: BatchGetPaymentMethods
+    ) -> list[GetPaymentMethod]:
         raise NotImplementedError
 
     async def get_payment_method(

--- a/services/payments/src/simcore_service_payments/services/payments_gateway.py
+++ b/services/payments/src/simcore_service_payments/services/payments_gateway.py
@@ -111,7 +111,7 @@ class PaymentsGatewayApi(BaseHttpApi, AppStateMixin):
         response = await self.client.delete(f"/payment-methods/{id_}")
         response.raise_for_status()
 
-    async def pay_with_payment_method(
+    async def init_payment_with_payment_method(
         self, id_: PaymentMethodID, payment: InitPayment
     ) -> PaymentInitiated:
         response = await self.client.post(

--- a/services/payments/src/simcore_service_payments/services/payments_gateway.py
+++ b/services/payments/src/simcore_service_payments/services/payments_gateway.py
@@ -23,6 +23,7 @@ from ..models.payments_gateway import (
     PaymentCancelled,
     PaymentInitiated,
     PaymentMethodInitiated,
+    PaymentMethodsBatch,
 )
 from ..utils.http_client import AppStateMixin, BaseHttpApi
 
@@ -74,29 +75,51 @@ class PaymentsGatewayApi(BaseHttpApi, AppStateMixin):
         self,
         payment_method: InitPaymentMethod,
     ) -> PaymentMethodInitiated:
-        raise NotImplementedError
+        response = await self.client.post(
+            "/payment-methods:init",
+            json=jsonable_encoder(payment_method),
+        )
+        response.raise_for_status()
+        return PaymentMethodInitiated.parse_obj(response.json())
 
-    async def get_form_payment_method(self, id_: PaymentMethodID) -> URL:
-        raise NotImplementedError
+    async def get_form_payment_method_url(self, id_: PaymentMethodID) -> URL:
+        return self.client.base_url.copy_with(
+            path="/payment-methods/form", params={"id": f"{id_}"}
+        )
 
     # CRUD
 
     async def get_many_payment_methods(
-        self, selection: BatchGetPaymentMethods
+        self, batch: BatchGetPaymentMethods
     ) -> list[GetPaymentMethod]:
-        raise NotImplementedError
+        response = await self.client.post(
+            "/payment-methods:batchGet",
+            json=jsonable_encoder(batch),
+        )
+        response.raise_for_status()
+        return PaymentMethodsBatch.parse_obj(response.json()).items
 
     async def get_payment_method(
         self,
         id_: PaymentMethodID,
     ) -> GetPaymentMethod:
-        raise NotImplementedError
+        response = await self.client.get(f"/payment-methods/{id_}")
+        response.raise_for_status()
+        return GetPaymentMethod.parse_obj(response.json())
 
     async def delete_payment_method(self, id_: PaymentMethodID) -> None:
-        raise NotImplementedError
+        response = await self.client.delete(f"/payment-methods/{id_}")
+        response.raise_for_status()
 
-    async def pay_with_payment_method(self, payment: InitPayment) -> PaymentInitiated:
-        raise NotImplementedError
+    async def pay_with_payment_method(
+        self, id_: PaymentMethodID, payment: InitPayment
+    ) -> PaymentInitiated:
+        response = await self.client.post(
+            f"/payment-methods/{id_}:pay",
+            json=jsonable_encoder(payment),
+        )
+        response.raise_for_status()
+        return PaymentInitiated.parse_obj(response.json())
 
 
 def setup_payments_gateway(app: FastAPI):

--- a/services/payments/src/simcore_service_payments/services/payments_gateway.py
+++ b/services/payments/src/simcore_service_payments/services/payments_gateway.py
@@ -7,16 +7,13 @@
 
 
 import logging
-from contextlib import contextmanager
 
 import httpx
-from fastapi import FastAPI, status
+from fastapi import FastAPI
 from fastapi.encoders import jsonable_encoder
 from httpx import URL
 from models_library.api_schemas_webserver.wallets import PaymentID, PaymentMethodID
 
-from .._constants import PAG
-from ..core.errors import PaymentMethodNotFoundError
 from ..core.settings import ApplicationSettings
 from ..models.payments_gateway import (
     BatchGetPaymentMethods,
@@ -40,18 +37,6 @@ class _GatewayApiAuth(httpx.Auth):
     def auth_flow(self, request):
         request.headers["X-Init-Api-Secret"] = self.token
         yield request
-
-
-@contextmanager
-def _handle_payment_methods_errors(**ctx):
-    try:
-
-        yield
-
-    except httpx.HTTPStatusError as err:
-        _logger.debug("%s handled error: %s", PAG, err)
-        if err.response.status_code == status.HTTP_404_NOT_FOUND:
-            raise PaymentMethodNotFoundError(**ctx) from err
 
 
 class PaymentsGatewayApi(BaseHttpApi, AppStateMixin):
@@ -107,35 +92,31 @@ class PaymentsGatewayApi(BaseHttpApi, AppStateMixin):
     async def get_many_payment_methods(
         self, ids_: list[PaymentMethodID]
     ) -> list[GetPaymentMethod]:
-        with _handle_payment_methods_errors(payments_methods_ids=ids_):
-            response = await self.client.post(
-                "/payment-methods:batchGet",
-                json=jsonable_encoder(BatchGetPaymentMethods(payment_methods_ids=ids_)),
-            )
-            response.raise_for_status()
-            return PaymentMethodsBatch.parse_obj(response.json()).items
+        response = await self.client.post(
+            "/payment-methods:batchGet",
+            json=jsonable_encoder(BatchGetPaymentMethods(payment_methods_ids=ids_)),
+        )
+        response.raise_for_status()
+        return PaymentMethodsBatch.parse_obj(response.json()).items
 
     async def get_payment_method(self, id_: PaymentMethodID) -> GetPaymentMethod:
-        with _handle_payment_methods_errors(payment_method_id=id_):
-            response = await self.client.get(f"/payment-methods/{id_}")
-            response.raise_for_status()
-            return GetPaymentMethod.parse_obj(response.json())
+        response = await self.client.get(f"/payment-methods/{id_}")
+        response.raise_for_status()
+        return GetPaymentMethod.parse_obj(response.json())
 
     async def delete_payment_method(self, id_: PaymentMethodID) -> None:
-        with _handle_payment_methods_errors(payment_method_id=id_):
-            response = await self.client.delete(f"/payment-methods/{id_}")
-            response.raise_for_status()
+        response = await self.client.delete(f"/payment-methods/{id_}")
+        response.raise_for_status()
 
     async def init_payment_with_payment_method(
         self, id_: PaymentMethodID, payment: InitPayment
     ) -> PaymentInitiated:
-        with _handle_payment_methods_errors(payment_method_id=id_):
-            response = await self.client.post(
-                f"/payment-methods/{id_}:pay",
-                json=jsonable_encoder(payment),
-            )
-            response.raise_for_status()
-            return PaymentInitiated.parse_obj(response.json())
+        response = await self.client.post(
+            f"/payment-methods/{id_}:pay",
+            json=jsonable_encoder(payment),
+        )
+        response.raise_for_status()
+        return PaymentInitiated.parse_obj(response.json())
 
 
 def setup_payments_gateway(app: FastAPI):

--- a/services/payments/src/simcore_service_payments/services/payments_methods.py
+++ b/services/payments/src/simcore_service_payments/services/payments_methods.py
@@ -1,0 +1,25 @@
+# create is init + acknowledge / cancel
+
+
+async def init_creation_of_payment_method():
+    raise NotImplementedError
+
+
+async def cancel_creation_of_payment_method():
+    raise NotImplementedError
+
+
+async def acknowledge_creation_of_payment_method():
+    raise NotImplementedError
+
+
+async def list_payments_methods():
+    raise NotImplementedError
+
+
+async def get_payment_method():
+    raise NotImplementedError
+
+
+async def delete_payment_method():
+    raise NotImplementedError

--- a/services/payments/src/simcore_service_payments/services/payments_methods.py
+++ b/services/payments/src/simcore_service_payments/services/payments_methods.py
@@ -1,25 +1,170 @@
-# create is init + acknowledge / cancel
+import logging
+
+import arrow
+from models_library.api_schemas_webserver.wallets import (
+    PaymentMethodGet,
+    PaymentMethodID,
+    PaymentMethodInitiated,
+)
+from models_library.basic_types import IDStr
+from models_library.users import UserID
+from models_library.wallets import WalletID
+from pydantic import EmailStr
+from simcore_postgres_database.models.payments_methods import InitPromptAckFlowState
+
+from ..db.payments_methods_repo import PaymentsMethodsRepo
+from ..models.db import PaymentsMethodsDB
+from ..models.payments_gateway import GetPaymentMethod, InitPaymentMethod
+from ..models.schemas.acknowledgements import AckPaymentMethod
+from ..models.utils import merge_models
+from .payments_gateway import PaymentsGatewayApi
+
+_logger = logging.getLogger(__name__)
 
 
-async def init_creation_of_payment_method():
-    raise NotImplementedError
+async def init_creation_of_payment_method(
+    gateway: PaymentsGatewayApi,
+    repo: PaymentsMethodsRepo,
+    *,
+    wallet_id: WalletID,
+    wallet_name: IDStr,
+    user_id: UserID,
+    user_name: IDStr,
+    user_email: EmailStr,
+) -> PaymentMethodInitiated:
+    initiated_at = arrow.utcnow().datetime
+
+    init = await gateway.init_payment_method(
+        InitPaymentMethod(
+            user_name=user_name,
+            user_email=user_email,
+            wallet_name=wallet_name,
+        )
+    )
+    form_link = gateway.get_form_payment_method_url(init.payment_method_id)
+
+    payment_method_id = await repo.insert_init_payment_method(
+        init.payment_method_id,
+        user_id=user_id,
+        wallet_id=wallet_id,
+        initiated_at=initiated_at,
+    )
+    assert payment_method_id == init.payment_method_id  # nosec
+
+    return PaymentMethodInitiated(
+        wallet_id=wallet_id,
+        payment_method_id=payment_method_id,
+        payment_method_form_url=f"{form_link}",
+    )
 
 
-async def cancel_creation_of_payment_method():
-    raise NotImplementedError
+async def cancel_creation_of_payment_method(
+    gateway: PaymentsGatewayApi,
+    repo: PaymentsMethodsRepo,
+    *,
+    payment_method_id: PaymentMethodID,
+    user_id: UserID,
+    wallet_id: WalletID,
+):
+    # Prevents card from being used
+    await repo.update_ack_payment_method(
+        payment_method_id,
+        completion_state=InitPromptAckFlowState.CANCELED,
+        state_message="User cancelled",
+    )
+
+    # gateway delete
+    await gateway.delete_payment_method(payment_method_id)
+
+    # delete payment-method in db
+    await repo.delete_payment_method(
+        payment_method_id,
+        user_id=user_id,
+        wallet_id=wallet_id,
+    )
 
 
-async def acknowledge_creation_of_payment_method():
-    raise NotImplementedError
+async def acknowledge_creation_of_payment_method(
+    repo: PaymentsMethodsRepo,
+    *,
+    payment_method_id: PaymentMethodID,
+    ack: AckPaymentMethod,
+) -> PaymentsMethodsDB:
+    payment_method: PaymentsMethodsDB = await repo.update_ack_payment_method(
+        payment_method_id=payment_method_id,
+        completion_state=(
+            InitPromptAckFlowState.SUCCESS
+            if ack.success
+            else InitPromptAckFlowState.FAILED
+        ),
+        state_message=ack.message,
+    )
+    return payment_method
 
 
-async def list_payments_methods():
-    raise NotImplementedError
+async def on_payment_method_completed(payment_method: PaymentsMethodsDB):
+    assert payment_method.state == InitPromptAckFlowState.SUCCESS  # nosec
+    assert payment_method.completed_at is not None  # nosec
+    assert payment_method.initiated_at < payment_method.completed_at  # nosec
+
+    _logger.debug(
+        "Notify front-end of payment -> sio (SOCKET_IO_PAYMENT_METHOD_ACKED_EVENT) "
+    )
 
 
-async def get_payment_method():
-    raise NotImplementedError
+async def list_payments_methods(
+    gateway: PaymentsGatewayApi,
+    repo: PaymentsMethodsRepo,
+    *,
+    user_id: UserID,
+    wallet_id: WalletID,
+):
+    acked_many = await repo.list_user_payment_methods(
+        user_id=user_id, wallet_id=wallet_id
+    )
+    assert not any(acked.completed_at is None for acked in acked_many)  # nosec
+
+    got_many: list[GetPaymentMethod] = await gateway.get_many_payment_methods(
+        [acked.payment_method_id for acked in acked_many]
+    )
+
+    return [
+        merge_models(got, acked)
+        for acked, got in zip(acked_many, got_many, strict=True)
+    ]
 
 
-async def delete_payment_method():
-    raise NotImplementedError
+async def get_payment_method(
+    gateway: PaymentsGatewayApi,
+    repo: PaymentsMethodsRepo,
+    *,
+    payment_method_id: PaymentMethodID,
+    user_id: UserID,
+    wallet_id: WalletID,
+) -> PaymentMethodGet:
+    acked = await repo.get_payment_method(
+        payment_method_id, user_id=user_id, wallet_id=wallet_id
+    )
+    assert acked.state == InitPromptAckFlowState.SUCCESS  # nosec
+
+    got: GetPaymentMethod = await gateway.get_payment_method(acked.payment_method_id)
+    return merge_models(got, acked)
+
+
+async def delete_payment_method(
+    gateway: PaymentsGatewayApi,
+    repo: PaymentsMethodsRepo,
+    *,
+    payment_method_id: PaymentMethodID,
+    user_id: UserID,
+    wallet_id: WalletID,
+):
+    acked = await repo.get_payment_method(
+        payment_method_id, user_id=user_id, wallet_id=wallet_id
+    )
+
+    await gateway.delete_payment_method(acked.payment_method_id)
+
+    await repo.delete_payment_method(
+        acked.payment_method_id, user_id=acked.user_id, wallet_id=acked.wallet_id
+    )

--- a/services/payments/tests/conftest.py
+++ b/services/payments/tests/conftest.py
@@ -12,6 +12,7 @@ import simcore_service_payments
 import yaml
 from faker import Faker
 from models_library.basic_types import IDStr
+from models_library.products import ProductName
 from models_library.users import UserID
 from models_library.wallets import WalletID
 from pydantic import EmailStr, parse_obj_as
@@ -123,13 +124,8 @@ def app_environment(
 
 
 @pytest.fixture
-def wallet_id(faker: Faker) -> WalletID:
-    return parse_obj_as(WalletID, faker.pyint())
-
-
-@pytest.fixture
-def wallet_name(faker: Faker) -> IDStr:
-    return parse_obj_as(IDStr, f"wallet-{faker.word()}")
+def product_name(faker: Faker) -> ProductName:
+    return parse_obj_as(IDStr, f"product-{faker.word()}")
 
 
 @pytest.fixture
@@ -145,3 +141,13 @@ def user_email(faker: Faker) -> EmailStr:
 @pytest.fixture
 def user_name(user_email: str) -> IDStr:
     return parse_obj_as(IDStr, user_email.split("@")[0])
+
+
+@pytest.fixture
+def wallet_id(faker: Faker) -> WalletID:
+    return parse_obj_as(WalletID, faker.pyint())
+
+
+@pytest.fixture
+def wallet_name(faker: Faker) -> IDStr:
+    return parse_obj_as(IDStr, f"wallet-{faker.word()}")

--- a/services/payments/tests/conftest.py
+++ b/services/payments/tests/conftest.py
@@ -11,6 +11,10 @@ import pytest
 import simcore_service_payments
 import yaml
 from faker import Faker
+from models_library.basic_types import IDStr
+from models_library.users import UserID
+from models_library.wallets import WalletID
+from pydantic import EmailStr, parse_obj_as
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict
 from servicelib.utils_secrets import generate_token_secret_key
@@ -111,3 +115,33 @@ def app_environment(
             "PAYMENTS_PASSWORD": fake_password,
         },
     )
+
+
+#
+# Fakes
+#
+
+
+@pytest.fixture
+def wallet_id(faker: Faker) -> WalletID:
+    return parse_obj_as(WalletID, faker.pyint())
+
+
+@pytest.fixture
+def wallet_name(faker: Faker) -> IDStr:
+    return parse_obj_as(IDStr, f"wallet-{faker.word()}")
+
+
+@pytest.fixture
+def user_id(faker: Faker) -> UserID:
+    return parse_obj_as(UserID, faker.pyint())
+
+
+@pytest.fixture
+def user_email(faker: Faker) -> EmailStr:
+    return parse_obj_as(EmailStr, faker.email())
+
+
+@pytest.fixture
+def user_name(user_email: str) -> IDStr:
+    return parse_obj_as(IDStr, user_email.split("@")[0])

--- a/services/payments/tests/unit/api/test__one_time_payment_workflows.py
+++ b/services/payments/tests/unit/api/test__one_time_payment_workflows.py
@@ -11,8 +11,9 @@ import httpx
 import pytest
 from faker import Faker
 from fastapi import FastAPI, status
-from models_library.api_schemas_webserver.wallets import WalletPaymentCreated
+
 from models_library.rabbitmq_basic_types import RPCMethodName
+from models_library.api_schemas_webserver.wallets import WalletPaymentInitiated
 from pydantic import parse_obj_as
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
@@ -100,7 +101,7 @@ async def test_successful_one_time_payment_workflow(
         **init_payment_kwargs,
         timeout_s=None,  # for debug
     )
-    assert isinstance(result, WalletPaymentCreated)
+    assert isinstance(result, WalletPaymentInitiated)
 
     assert mock_payments_gateway_service_or_none.routes["init_payment"].called
 

--- a/services/payments/tests/unit/api/test__one_time_payment_workflows.py
+++ b/services/payments/tests/unit/api/test__one_time_payment_workflows.py
@@ -11,9 +11,8 @@ import httpx
 import pytest
 from faker import Faker
 from fastapi import FastAPI, status
-
-from models_library.rabbitmq_basic_types import RPCMethodName
 from models_library.api_schemas_webserver.wallets import WalletPaymentInitiated
+from models_library.rabbitmq_basic_types import RPCMethodName
 from pydantic import parse_obj_as
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
@@ -88,7 +87,7 @@ async def test_successful_one_time_payment_workflow(
     ), "cannot run against external because we ACK here"
 
     mock_on_payment_completed = mocker.patch(
-        "simcore_service_payments.api.rest._acknowledgements.on_payment_completed",
+        "simcore_service_payments.api.rest._acknowledgements.payments.on_payment_completed",
         autospec=True,
     )
 

--- a/services/payments/tests/unit/api/test__payment_method_workflows.py
+++ b/services/payments/tests/unit/api/test__payment_method_workflows.py
@@ -95,7 +95,7 @@ async def test_successful_create_payment_method_workflow(
     )
 
     assert isinstance(inited, PaymentMethodInitiated)
-    assert mock_payments_gateway_service_or_none.routes["init_payment"].called
+    assert mock_payments_gateway_service_or_none.routes["init_payment_method"].called
 
     # ACK via api/rest
     response = await client.post(

--- a/services/payments/tests/unit/api/test_rest_acknowledgements.py
+++ b/services/payments/tests/unit/api/test_rest_acknowledgements.py
@@ -115,7 +115,7 @@ async def test_payments_methods_api_authentication(
 
     # w/o header
     response = await client.post(
-        f"/v1/payments-method/{payment_method_id}:ack",
+        f"/v1/payments-methods/{payment_method_id}:ack",
         json=payment_method_ack,
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.json()

--- a/services/payments/tests/unit/conftest.py
+++ b/services/payments/tests/unit/conftest.py
@@ -37,6 +37,14 @@ from simcore_service_payments.models.payments_gateway import (
     PaymentMethodsBatch,
 )
 
+
+@pytest.fixture
+def is_pdb_enabled(request: pytest.FixtureRequest):
+    """Returns true if tests are set to use interactive debugger, i.e. --pdb"""
+    options = request.config.option
+    return options.usepdb
+
+
 #
 # rabbit-MQ
 #

--- a/services/payments/tests/unit/conftest.py
+++ b/services/payments/tests/unit/conftest.py
@@ -5,7 +5,7 @@
 # pylint: disable=unused-variable
 
 
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from pathlib import Path
 from typing import NamedTuple
 from unittest.mock import Mock
@@ -24,6 +24,7 @@ from pytest_simcore.helpers.rawdata_fakers import random_payment_method_data
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import load_dotenv
 from respx import MockRouter
+from servicelib.rabbitmq import RabbitMQRPCClient
 from simcore_postgres_database.models.payments_transactions import payments_transactions
 from simcore_service_payments.core.application import create_app
 from simcore_service_payments.core.settings import ApplicationSettings
@@ -63,6 +64,13 @@ def disable_rabbitmq_and_rpc_setup(mocker: MockerFixture) -> Callable:
 @pytest.fixture
 def with_disabled_rabbitmq_and_rpc(disable_rabbitmq_and_rpc_setup: Callable):
     disable_rabbitmq_and_rpc_setup()
+
+
+@pytest.fixture
+async def rpc_client(
+    faker: Faker, rabbitmq_rpc_client: Callable[[str], Awaitable[RabbitMQRPCClient]]
+) -> RabbitMQRPCClient:
+    return await rabbitmq_rpc_client(f"web-server-client-{faker.word()}")
 
 
 #

--- a/services/payments/tests/unit/test_db_payments_methods_repo.py
+++ b/services/payments/tests/unit/test_db_payments_methods_repo.py
@@ -1,0 +1,96 @@
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+
+import pytest
+from fastapi import FastAPI
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from pytest_simcore.helpers.utils_envs import setenvs_from_dict
+from simcore_service_payments.db.payments_methods_repo import PaymentsMethodsRepo
+from simcore_service_payments.models.db import InitPromptAckFlowState, PaymentsMethodsDB
+
+pytest_simcore_core_services_selection = [
+    "postgres",
+    "rabbit",
+]
+pytest_simcore_ops_services_selection = [
+    "adminer",
+]
+
+
+@pytest.fixture
+def app_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    app_environment: EnvVarsDict,
+    postgres_env_vars_dict: EnvVarsDict,
+    with_disabled_rabbitmq_and_rpc: None,
+    wait_for_postgres_ready_and_db_migrated: None,
+):
+    # set environs
+    monkeypatch.delenv("PAYMENTS_POSTGRES", raising=False)
+
+    return setenvs_from_dict(
+        monkeypatch,
+        {
+            **app_environment,
+            **postgres_env_vars_dict,
+            "POSTGRES_CLIENT_NAME": "payments-service-pg-client",
+        },
+    )
+
+
+async def test_create_payments_method_annotations_workflow(app: FastAPI):
+
+    fake = PaymentsMethodsDB(**PaymentsMethodsDB.Config.schema_extra["examples"][1])
+
+    repo = PaymentsMethodsRepo(app.state.engine)
+
+    # annotate init
+    payment_method_id = await repo.insert_init_payment_method(
+        fake.payment_method_id,
+        user_id=fake.user_id,
+        wallet_id=fake.wallet_id,
+        initiated_at=fake.initiated_at,
+    )
+
+    assert payment_method_id == fake.payment_method_id
+
+    # annotate ack
+    acked = await repo.update_ack_payment_method(
+        fake.payment_method_id,
+        completion_state=InitPromptAckFlowState.SUCCESS,
+        state_message="DONE",
+    )
+
+    # list
+    listed = await repo.list_user_payment_methods(
+        user_id=fake.user_id,
+        wallet_id=fake.wallet_id,
+    )
+    assert len(listed) == 1
+    assert listed[0] == acked
+
+    # get
+    got = await repo.get_payment_method(
+        payment_method_id,
+        user_id=fake.user_id,
+        wallet_id=fake.wallet_id,
+    )
+    assert got == acked
+
+    # delete
+    deleted = await repo.delete_payment_method(
+        payment_method_id,
+        user_id=fake.user_id,
+        wallet_id=fake.wallet_id,
+    )
+    assert deleted == got
+
+    listed = await repo.list_user_payment_methods(
+        user_id=fake.user_id,
+        wallet_id=fake.wallet_id,
+    )
+    assert not listed

--- a/services/payments/tests/unit/test_db_payments_methods_repo.py
+++ b/services/payments/tests/unit/test_db_payments_methods_repo.py
@@ -14,7 +14,6 @@ from simcore_service_payments.models.db import InitPromptAckFlowState, PaymentsM
 
 pytest_simcore_core_services_selection = [
     "postgres",
-    "rabbit",
 ]
 pytest_simcore_ops_services_selection = [
     "adminer",

--- a/services/payments/tests/unit/test_db_payments_transactions_repo.py
+++ b/services/payments/tests/unit/test_db_payments_transactions_repo.py
@@ -77,6 +77,8 @@ async def test_one_time_payment_annotations_workflow(app: FastAPI):
         state_message="DONE",
     )
 
+    assert transaction_acked.payment_id == payment_id
+
     # list
     total_number_of_items, user_payments = await repo.list_user_payment_transactions(
         user_id=fake.user_id

--- a/services/payments/tests/unit/test_db_payments_transactions_repo.py
+++ b/services/payments/tests/unit/test_db_payments_transactions_repo.py
@@ -19,7 +19,6 @@ from simcore_service_payments.models.db import (
 
 pytest_simcore_core_services_selection = [
     "postgres",
-    "rabbit",
 ]
 pytest_simcore_ops_services_selection = [
     "adminer",

--- a/services/payments/tests/unit/test_rpc_payments.py
+++ b/services/payments/tests/unit/test_rpc_payments.py
@@ -11,8 +11,8 @@ import httpx
 import pytest
 from faker import Faker
 from fastapi import FastAPI
-from models_library.api_schemas_webserver.wallets import WalletPaymentCreated
 from models_library.rabbitmq_basic_types import RPCMethodName
+from models_library.api_schemas_webserver.wallets import WalletPaymentInitiated
 from pydantic import parse_obj_as
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict
@@ -108,7 +108,7 @@ async def test_webserver_one_time_payment_workflow(
         **init_payment_kwargs,
     )
 
-    assert isinstance(result, WalletPaymentCreated)
+    assert isinstance(result, WalletPaymentInitiated)
 
     if mock_payments_gateway_service_or_none:
         assert mock_payments_gateway_service_or_none.routes["init_payment"].called

--- a/services/payments/tests/unit/test_rpc_payments.py
+++ b/services/payments/tests/unit/test_rpc_payments.py
@@ -4,15 +4,14 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
-from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
 import pytest
 from faker import Faker
 from fastapi import FastAPI
-from models_library.rabbitmq_basic_types import RPCMethodName
 from models_library.api_schemas_webserver.wallets import WalletPaymentInitiated
+from models_library.rabbitmq_basic_types import RPCMethodName
 from pydantic import parse_obj_as
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict
@@ -71,12 +70,11 @@ def init_payment_kwargs(faker: Faker) -> dict[str, Any]:
 
 async def test_rpc_init_payment_fail(
     app: FastAPI,
-    rabbitmq_rpc_client: Callable[[str], Awaitable[RabbitMQRPCClient]],
+    rpc_client: RabbitMQRPCClient,
     init_payment_kwargs: dict[str, Any],
     payments_clean_db: None,
 ):
     assert app
-    rpc_client = await rabbitmq_rpc_client("web-server-client")
 
     with pytest.raises(RPCServerError) as exc_info:
         await rpc_client.request(
@@ -93,14 +91,12 @@ async def test_rpc_init_payment_fail(
 
 async def test_webserver_one_time_payment_workflow(
     app: FastAPI,
-    rabbitmq_rpc_client: Callable[[str], Awaitable[RabbitMQRPCClient]],
+    rpc_client: RabbitMQRPCClient,
     mock_payments_gateway_service_or_none: MockRouter | None,
     init_payment_kwargs: dict[str, Any],
     payments_clean_db: None,
 ):
     assert app
-
-    rpc_client = await rabbitmq_rpc_client("web-server-client")
 
     result = await rpc_client.request(
         PAYMENTS_RPC_NAMESPACE,
@@ -129,15 +125,13 @@ async def test_webserver_one_time_payment_workflow(
 
 
 async def test_cancel_invalid_payment_id(
-    rabbitmq_rpc_client: Callable[[str], Awaitable[RabbitMQRPCClient]],
+    rpc_client: RabbitMQRPCClient,
     mock_payments_gateway_service_or_none: MockRouter | None,
     init_payment_kwargs: dict[str, Any],
     faker: Faker,
     payments_clean_db: None,
 ):
     invalid_payment_id = faker.uuid4()
-
-    rpc_client = await rabbitmq_rpc_client("web-server-client")
 
     with pytest.raises(RPCServerError) as exc_info:
         await rpc_client.request(

--- a/services/payments/tests/unit/test_rpc_payments_methods.py
+++ b/services/payments/tests/unit/test_rpc_payments_methods.py
@@ -1,0 +1,98 @@
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+from faker import Faker
+from fastapi import FastAPI
+from models_library.api_schemas_webserver.wallets import PaymentMethodInit
+from pydantic import parse_obj_as
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from pytest_simcore.helpers.utils_envs import setenvs_from_dict
+from respx import MockRouter
+from servicelib.rabbitmq import RabbitMQRPCClient, RPCMethodName
+from simcore_service_payments.api.rpc.routes import PAYMENTS_RPC_NAMESPACE
+
+pytest_simcore_core_services_selection = [
+    "postgres",
+    "rabbit",
+]
+pytest_simcore_ops_services_selection = [
+    "adminer",
+]
+
+
+@pytest.fixture
+def app_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    app_environment: EnvVarsDict,
+    rabbit_env_vars_dict: EnvVarsDict,  # rabbitMQ settings from 'rabbit' service
+    postgres_env_vars_dict: EnvVarsDict,
+    wait_for_postgres_ready_and_db_migrated: None,
+    external_environment: EnvVarsDict,
+):
+    # set environs
+    monkeypatch.delenv("PAYMENTS_RABBITMQ", raising=False)
+    monkeypatch.delenv("PAYMENTS_POSTGRES", raising=False)
+
+    return setenvs_from_dict(
+        monkeypatch,
+        {
+            **app_environment,
+            **rabbit_env_vars_dict,
+            **postgres_env_vars_dict,
+            **external_environment,
+            "POSTGRES_CLIENT_NAME": "payments-service-pg-client",
+        },
+    )
+
+
+async def test_webserver_add_payment_method_workflow(
+    app: FastAPI,
+    rabbitmq_rpc_client: Callable[[str], Awaitable[RabbitMQRPCClient]],
+    mock_payments_gateway_service_or_none: MockRouter | None,
+    faker: Faker,
+    payments_clean_db: None,
+):
+    assert app
+    user_id = faker.pyint()
+    wallet_id = faker.pyint()
+
+    rpc_client = await rabbitmq_rpc_client("web-server-client")
+
+    result = await rpc_client.request(
+        PAYMENTS_RPC_NAMESPACE,
+        parse_obj_as(RPCMethodName, "init_creation_of_payment_method"),
+        wallet_id=wallet_id,
+        wallet_name=faker.word(),
+        user_id=user_id,
+        user_name=faker.name(),
+        user_email=faker.email(),
+    )
+
+    assert isinstance(result, PaymentMethodInit)
+
+    if mock_payments_gateway_service_or_none:
+        assert mock_payments_gateway_service_or_none.routes[
+            "init_payment_method"
+        ].called
+
+    result = await rpc_client.request(
+        PAYMENTS_RPC_NAMESPACE,
+        parse_obj_as(RPCMethodName, "cancel_creation_of_payment_method"),
+        payment_method_id=result.payment_method_id,
+        user_id=user_id,
+        wallet_id=wallet_id,
+        timeout_s=20,  # while debugging to avoid failures withe breakpoints
+    )
+
+    assert result is None
+
+    if mock_payments_gateway_service_or_none:
+        assert mock_payments_gateway_service_or_none.routes[
+            "delete_payment_method"
+        ].called

--- a/services/payments/tests/unit/test_rpc_payments_methods.py
+++ b/services/payments/tests/unit/test_rpc_payments_methods.py
@@ -234,7 +234,7 @@ async def test_webserver_pay_with_payment_method_workflow(
         user_id=user_id,
         user_name=faker.name(),
         user_email=faker.email(),
-        comments="Payment with stored credit-card",
+        comment="Payment with stored credit-card",
     )
 
     assert isinstance(payment_inited, WalletPaymentInitiated)
@@ -245,4 +245,6 @@ async def test_webserver_pay_with_payment_method_workflow(
         payment_inited.payment_id, user_id=user_id, wallet_id=wallet_id
     )
     assert payment is not None
+    assert payment.payment_id == payment_inited.payment_id
     assert payment.state == PaymentTransactionState.PENDING
+    assert payment.comment == "Payment with stored credit-card"

--- a/services/payments/tests/unit/test_rpc_payments_methods.py
+++ b/services/payments/tests/unit/test_rpc_payments_methods.py
@@ -9,7 +9,7 @@ from collections.abc import Awaitable, Callable
 import pytest
 from faker import Faker
 from fastapi import FastAPI
-from models_library.api_schemas_webserver.wallets import PaymentMethodInit
+from models_library.api_schemas_webserver.wallets import PaymentMethodInitiated
 from pydantic import parse_obj_as
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict
@@ -76,7 +76,7 @@ async def test_webserver_init_and_cancel_payment_method_workflow(
         user_email=faker.email(),
     )
 
-    assert isinstance(initiated, PaymentMethodInit)
+    assert isinstance(initiated, PaymentMethodInitiated)
 
     if mock_payments_gateway_service_or_none:
         assert mock_payments_gateway_service_or_none.routes[
@@ -123,7 +123,7 @@ async def test_webserver_crud_payment_method_workflow(
         user_email=faker.email(),
     )
 
-    assert isinstance(inited, PaymentMethodInit)
+    assert isinstance(inited, PaymentMethodInitiated)
 
     if mock_payments_gateway_service_or_none:
         assert mock_payments_gateway_service_or_none.routes[

--- a/services/payments/tests/unit/test_rpc_payments_methods.py
+++ b/services/payments/tests/unit/test_rpc_payments_methods.py
@@ -229,6 +229,7 @@ async def test_webserver_pay_with_payment_method_workflow(
         payment_method_id=payment_method_id,
         amount_dollars=faker.pyint(),
         target_credits=faker.pyint(),
+        product_name=faker.word(),
         wallet_id=wallet_id,
         wallet_name=faker.word(),
         user_id=user_id,

--- a/services/payments/tests/unit/test_rpc_payments_methods.py
+++ b/services/payments/tests/unit/test_rpc_payments_methods.py
@@ -12,8 +12,12 @@ from models_library.api_schemas_webserver.wallets import (
     PaymentMethodInitiated,
     WalletPaymentInitiated,
 )
+from models_library.basic_types import IDStr
+from models_library.products import ProductName
 from models_library.rabbitmq_basic_types import RPCMethodName
-from pydantic import parse_obj_as
+from models_library.users import UserID
+from models_library.wallets import WalletID
+from pydantic import EmailStr, parse_obj_as
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict
 from respx import MockRouter
@@ -69,21 +73,23 @@ async def test_webserver_init_and_cancel_payment_method_workflow(
     app: FastAPI,
     rpc_client: RabbitMQRPCClient,
     mock_payments_gateway_service_or_none: MockRouter | None,
-    faker: Faker,
+    user_id: UserID,
+    user_name: IDStr,
+    user_email: EmailStr,
+    wallet_name: IDStr,
+    wallet_id: WalletID,
     payments_clean_db: None,
 ):
     assert app
-    user_id = faker.pyint()
-    wallet_id = faker.pyint()
 
     initiated = await rpc_client.request(
         PAYMENTS_RPC_NAMESPACE,
         parse_obj_as(RPCMethodName, "init_creation_of_payment_method"),
         wallet_id=wallet_id,
-        wallet_name=faker.word(),
+        wallet_name=wallet_name,
         user_id=user_id,
-        user_name=faker.name(),
-        user_email=faker.email(),
+        user_name=user_name,
+        user_email=user_email,
     )
 
     assert isinstance(initiated, PaymentMethodInitiated)
@@ -115,21 +121,23 @@ async def test_webserver_crud_payment_method_workflow(
     app: FastAPI,
     rpc_client: RabbitMQRPCClient,
     mock_payments_gateway_service_or_none: MockRouter | None,
-    faker: Faker,
+    user_id: UserID,
+    user_name: IDStr,
+    user_email: EmailStr,
+    wallet_name: IDStr,
+    wallet_id: WalletID,
     payments_clean_db: None,
 ):
     assert app
-    user_id = faker.pyint()
-    wallet_id = faker.pyint()
 
     inited = await rpc_client.request(
         PAYMENTS_RPC_NAMESPACE,
         parse_obj_as(RPCMethodName, "init_creation_of_payment_method"),
         wallet_id=wallet_id,
-        wallet_name=faker.word(),
+        wallet_name=wallet_name,
         user_id=user_id,
-        user_name=faker.name(),
-        user_email=faker.email(),
+        user_name=user_name,
+        user_email=user_email,
     )
 
     assert isinstance(inited, PaymentMethodInitiated)
@@ -195,11 +203,15 @@ async def test_webserver_pay_with_payment_method_workflow(
     rpc_client: RabbitMQRPCClient,
     mock_payments_gateway_service_or_none: MockRouter | None,
     faker: Faker,
+    product_name: ProductName,
+    user_id: UserID,
+    user_name: IDStr,
+    user_email: EmailStr,
+    wallet_name: IDStr,
+    wallet_id: WalletID,
     payments_clean_db: None,
 ):
     assert app
-    user_id = faker.pyint()
-    wallet_id = faker.pyint()
 
     # faking Payment method
     created = await create_payment_method(
@@ -216,12 +228,12 @@ async def test_webserver_pay_with_payment_method_workflow(
         payment_method_id=created.payment_method_id,
         amount_dollars=faker.pyint(),
         target_credits=faker.pyint(),
-        product_name=faker.word(),
+        product_name=product_name,
         wallet_id=wallet_id,
-        wallet_name=faker.word(),
+        wallet_name=wallet_name,
         user_id=user_id,
-        user_name=faker.name(),
-        user_email=faker.email(),
+        user_name=user_name,
+        user_email=user_email,
         comment="Payment with stored credit-card",
     )
 

--- a/services/payments/tests/unit/test_services_payments_gateway.py
+++ b/services/payments/tests/unit/test_services_payments_gateway.py
@@ -133,11 +133,13 @@ async def test_payment_methods_workflow(
     amount_dollars: float,
 ):
 
-    payment_gateway_api: PaymentsGatewayApi = PaymentsGatewayApi.get_from_app_state(app)
-    assert payment_gateway_api
+    payments_gateway_api: PaymentsGatewayApi = PaymentsGatewayApi.get_from_app_state(
+        app
+    )
+    assert payments_gateway_api
 
     # init payment-method
-    initiated = await payment_gateway_api.init_payment_method(
+    initiated = await payments_gateway_api.init_payment_method(
         InitPaymentMethod(
             user_name=faker.user_name(),
             user_email=faker.email(),
@@ -146,7 +148,7 @@ async def test_payment_methods_workflow(
     )
 
     # from url
-    form_link = payment_gateway_api.get_form_payment_method_url(
+    form_link = payments_gateway_api.get_form_payment_method_url(
         initiated.payment_method_id
     )
 
@@ -157,19 +159,21 @@ async def test_payment_methods_workflow(
     payment_method_id = initiated.payment_method_id
 
     # get payment-method
-    got_payment_method = await payment_gateway_api.get_payment_method(payment_method_id)
+    got_payment_method = await payments_gateway_api.get_payment_method(
+        payment_method_id
+    )
     assert got_payment_method.idr == payment_method_id
     print(got_payment_method.json(indent=2))
 
     # list payment-methods
-    items = await payment_gateway_api.get_many_payment_methods([payment_method_id])
+    items = await payments_gateway_api.get_many_payment_methods([payment_method_id])
 
     assert items
     assert len(items) == 1
     assert items[0] == got_payment_method
 
     # init payments with payment-method (needs to be ACK to complete)
-    payment_initiated = await payment_gateway_api.init_payment_with_payment_method(
+    payment_initiated = await payments_gateway_api.init_payment_with_payment_method(
         id_=payment_method_id,
         payment=InitPayment(
             amount_dollars=amount_dollars,
@@ -181,14 +185,14 @@ async def test_payment_methods_workflow(
     )
 
     # cancel payment
-    payment_canceled = await payment_gateway_api.cancel_payment(payment_initiated)
+    payment_canceled = await payments_gateway_api.cancel_payment(payment_initiated)
     assert payment_canceled is not None
 
     # delete payment-method
-    await payment_gateway_api.delete_payment_method(payment_method_id)
+    await payments_gateway_api.delete_payment_method(payment_method_id)
 
     with pytest.raises(httpx.HTTPStatusError) as err_info:
-        await payment_gateway_api.get_payment_method(payment_method_id)
+        await payments_gateway_api.get_payment_method(payment_method_id)
 
     http_status_error = err_info.value
     assert http_status_error.response.status_code == status.HTTP_404_NOT_FOUND

--- a/services/payments/tests/unit/test_services_payments_gateway.py
+++ b/services/payments/tests/unit/test_services_payments_gateway.py
@@ -125,7 +125,6 @@ async def test_one_time_payment_workflow(
         assert mock_payments_gateway_service_or_none.routes["cancel_payment"].called
 
 
-@pytest.mark.testit()
 async def test_payment_methods_workflow(
     app: FastAPI,
     faker: Faker,

--- a/services/payments/tests/unit/test_services_payments_gateway.py
+++ b/services/payments/tests/unit/test_services_payments_gateway.py
@@ -141,7 +141,7 @@ async def test_payment_methods_workflow(
     assert payment_gateway_api
 
     # init payment-method
-    inited = await payment_gateway_api.init_payment_method(
+    initiated = await payment_gateway_api.init_payment_method(
         InitPaymentMethod(
             user_name=faker.user_name(),
             user_email=faker.email(),
@@ -156,14 +156,14 @@ async def test_payment_methods_workflow(
     assert form_link.host == app_settings.PAYMENTS_GATEWAY_URL.host
 
     # CRUD
-    payment_method_id = inited.payment_method_id
+    payment_method_id = initiated.payment_method_id
 
     # get payment-method
     got = await payment_gateway_api.get_payment_methods(payment_method_id)
     assert got.id == payment_method_id
 
     # list payment-methods
-    batch = await payment_gateway_api.batch_get_payment_methods(
+    batch = await payment_gateway_api.get_many_payment_methods(
         BatchGetPaymentMethods(
             payment_methods_ids=[
                 payment_method_id,

--- a/services/web/server/src/simcore_service_webserver/payments/_methods_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_methods_api.py
@@ -10,7 +10,7 @@ from faker import Faker
 from models_library.api_schemas_webserver.wallets import (
     PaymentMethodGet,
     PaymentMethodID,
-    PaymentMethodInit,
+    PaymentMethodInitiated,
     PaymentMethodTransaction,
 )
 from models_library.products import ProductName
@@ -70,7 +70,7 @@ async def init_creation_of_wallet_payment_method(
     user_id: UserID,
     wallet_id: WalletID,
     product_name: ProductName,
-) -> PaymentMethodInit:
+) -> PaymentMethodInitiated:
     """
 
     Raises:
@@ -107,7 +107,7 @@ async def init_creation_of_wallet_payment_method(
         initiated_at=initiated_at,
     )
 
-    return PaymentMethodInit(
+    return PaymentMethodInitiated(
         wallet_id=wallet_id,
         payment_method_id=payment_method_id,
         payment_method_form_url=f"{form_link}",

--- a/services/web/server/src/simcore_service_webserver/payments/_onetime_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_onetime_api.py
@@ -6,7 +6,7 @@ from aiohttp import web
 from models_library.api_schemas_webserver.wallets import (
     PaymentID,
     PaymentTransaction,
-    WalletPaymentCreated,
+    WalletPaymentInitiated,
 )
 from models_library.products import ProductName
 from models_library.users import UserID
@@ -87,7 +87,7 @@ async def init_creation_of_wallet_payment(
     user_id: UserID,
     wallet_id: WalletID,
     comment: str | None,
-) -> WalletPaymentCreated:
+) -> WalletPaymentInitiated:
     """
 
     Raises:
@@ -108,7 +108,7 @@ async def init_creation_of_wallet_payment(
     user = await get_user_name_and_email(app, user_id=user_id)
 
     # call to payment-service
-    payment_inited: WalletPaymentCreated = await _rpc.init_payment(
+    payment_inited: WalletPaymentInitiated = await _rpc.init_payment(
         app,
         amount_dollars=price_dollars,
         target_credits=osparc_credits,

--- a/services/web/server/src/simcore_service_webserver/payments/_rpc.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_rpc.py
@@ -7,8 +7,11 @@ from decimal import Decimal
 
 from aiohttp import web
 from models_library.api_schemas_payments import PAYMENTS_RPC_NAMESPACE
-from models_library.api_schemas_webserver.wallets import PaymentID, WalletPaymentCreated
 from models_library.rabbitmq_basic_types import RPCMethodName
+from models_library.api_schemas_webserver.wallets import (
+    PaymentID,
+    WalletPaymentInitiated,
+)
 from models_library.users import UserID
 from models_library.wallets import WalletID
 from pydantic import parse_obj_as
@@ -58,7 +61,7 @@ async def init_payment(
     user_name: str,
     user_email: str,
     comment: str | None = None,
-) -> WalletPaymentCreated:
+) -> WalletPaymentInitiated:
     rpc_client = app[_APP_PAYMENTS_RPC_CLIENT_KEY]
 
     # NOTE: remote errors are aio_pika.MessageProcessError
@@ -75,7 +78,7 @@ async def init_payment(
         user_email=user_email,
         comment=comment,
     )
-    assert isinstance(result, WalletPaymentCreated)  # nosec
+    assert isinstance(result, WalletPaymentInitiated)  # nosec
     return result
 
 

--- a/services/web/server/src/simcore_service_webserver/wallets/_payments_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_payments_handlers.py
@@ -6,10 +6,10 @@ from models_library.api_schemas_webserver.wallets import (
     GetWalletAutoRecharge,
     PaymentID,
     PaymentMethodGet,
-    PaymentMethodInit,
+    PaymentMethodInitiated,
     PaymentTransaction,
     ReplaceWalletAutoRecharge,
-    WalletPaymentCreated,
+    WalletPaymentInitiated,
 )
 from models_library.rest_pagination import Page, PageQueryParameters
 from models_library.rest_pagination_utils import paginate_data
@@ -76,7 +76,7 @@ async def create_payment(request: web.Request):
             # '0 or None' should raise
             raise web.HTTPConflict(reason=MSG_PRICE_NOT_DEFINED_ERROR)
 
-        payment: WalletPaymentCreated = await init_creation_of_wallet_payment(
+        payment: WalletPaymentInitiated = await init_creation_of_wallet_payment(
             request.app,
             user_id=req_ctx.user_id,
             product_name=req_ctx.product_name,
@@ -182,11 +182,13 @@ async def init_creation_of_payment_method(request: web.Request):
         log_duration=True,
         extra=get_log_record_extra(user_id=req_ctx.user_id),
     ):
-        initiated: PaymentMethodInit = await init_creation_of_wallet_payment_method(
-            request.app,
-            user_id=req_ctx.user_id,
-            wallet_id=path_params.wallet_id,
-            product_name=req_ctx.product_name,
+        initiated: PaymentMethodInitiated = (
+            await init_creation_of_wallet_payment_method(
+                request.app,
+                user_id=req_ctx.user_id,
+                wallet_id=path_params.wallet_id,
+                product_name=req_ctx.product_name,
+            )
         )
 
         # NOTE: the request has been accepted to create a payment-method

--- a/services/web/server/tests/unit/with_dbs/03/wallets/payments/test_payments.py
+++ b/services/web/server/tests/unit/with_dbs/03/wallets/payments/test_payments.py
@@ -16,7 +16,7 @@ from models_library.api_schemas_webserver.wallets import (
     PaymentID,
     PaymentTransaction,
     WalletGet,
-    WalletPaymentCreated,
+    WalletPaymentInitiated,
 )
 from models_library.rest_pagination import Page
 from models_library.users import UserID
@@ -109,7 +109,7 @@ def mock_rpc_payments_service_api(
                 )
                 == payment_id
             )
-        return WalletPaymentCreated(
+        return WalletPaymentInitiated(
             payment_id=payment_id, payment_form_url=f"{external_form_link}"
         )
 
@@ -176,7 +176,7 @@ async def test_payments_worfklow(
     )
     data, error = await assert_status(response, web.HTTPCreated)
     assert error is None
-    payment = WalletPaymentCreated.parse_obj(data)
+    payment = WalletPaymentInitiated.parse_obj(data)
 
     assert payment.payment_id
     assert payment.payment_form_url.host == "some-fake-gateway.com"
@@ -259,7 +259,7 @@ async def test_multiple_payments(
         data, error = await assert_status(response, web.HTTPCreated)
         assert data
         assert not error
-        payment = WalletPaymentCreated.parse_obj(data)
+        payment = WalletPaymentInitiated.parse_obj(data)
 
         if n % 2:
             transaction = await _ack_creation_of_wallet_payment(
@@ -343,7 +343,7 @@ async def test_complete_payment_errors(
     assert mock_rpc_payments_service_api["init_payment"].called
 
     data, _ = await assert_status(response, web.HTTPCreated)
-    payment = WalletPaymentCreated.parse_obj(data)
+    payment = WalletPaymentInitiated.parse_obj(data)
 
     # Cannot complete as PENDING
     with pytest.raises(ValueError):

--- a/services/web/server/tests/unit/with_dbs/03/wallets/payments/test_payments_methods.py
+++ b/services/web/server/tests/unit/with_dbs/03/wallets/payments/test_payments_methods.py
@@ -11,7 +11,7 @@ from models_library.api_schemas_webserver.wallets import (
     GetWalletAutoRecharge,
     PaymentMethodGet,
     PaymentMethodID,
-    PaymentMethodInit,
+    PaymentMethodInitiated,
     WalletGet,
 )
 from models_library.wallets import WalletID
@@ -54,7 +54,7 @@ async def test_payment_method_worfklow(
     )
     data, error = await assert_status(response, web.HTTPAccepted)
     assert error is None
-    inited = PaymentMethodInit.parse_obj(data)
+    inited = PaymentMethodInitiated.parse_obj(data)
 
     assert inited.payment_method_id
     assert inited.payment_method_form_url.query
@@ -122,7 +122,7 @@ async def test_init_and_cancel_payment_method(
     )
     data, error = await assert_status(response, web.HTTPAccepted)
     assert error is None
-    inited = PaymentMethodInit.parse_obj(data)
+    inited = PaymentMethodInitiated.parse_obj(data)
 
     # cancel Create
     response = await client.post(
@@ -146,7 +146,7 @@ async def _add_payment_method(
     )
     data, error = await assert_status(response, web.HTTPAccepted)
     assert error is None
-    inited = PaymentMethodInit.parse_obj(data)
+    inited = PaymentMethodInitiated.parse_obj(data)
     await _ack_creation_of_wallet_payment_method(
         client.app,
         payment_method_id=inited.payment_method_id,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

Implements payment-methods logic in the `payments` service. The logic has been basically copied and adapted from that existing in the `webserver.payments` plugin. Nonetheless, the code in the `webserver` will still fake the payment-method until app-motion's app-gateway fully implements the payment-method infrastructure (https://github.com/ITISFoundation/appmotion-exchange/issues/11)

### Highlights
![payments](https://github.com/ITISFoundation/osparc-simcore/assets/32402063/b7755dd2-5683-4761-8670-d3df97581c48)

- ✨`db/payments_methods_repo`: implemented a repository layer for payment-methods
- ✨`api/rest/_acknowledgements` : implemented the rest interface to ACK payment-methods
- ✨`api/rpc/_payments_methods` : implements rpc interface for payment-methods exposed to the web-server
- ✨`services/payments_gateway` : implements the http client calls to the  payment-gateway API for payment-methods
- ♻️ minor models rename, tests etc

## Related issue/s

- Moves logic to payment service in #4751

## How to test

Driving tests
```
cd services/payments
make install-dev
pytest -vv tests/unit
```

## DevOps 

- None