### PR TITLE
⬆️Maintenance: upgrade autoscaling

### DIFF
--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -47,8 +47,6 @@
     "./services/web/server/src",
     "./services/web/server/tests/unit/with_dbs"
   ],
-  "python.linting.pylintEnabled": true,
-  "python.linting.enabled": true,
   "[python]": {
     "editor.detectIndentation": false,
     "editor.tabSize": 4
@@ -72,7 +70,7 @@
   ],
   "python.analysis.autoImportCompletions": true,
   "python.analysis.typeCheckingMode": "basic",
-  "ruff.args": [
+  "ruff.lint.args": [
     "--config=${workspaceFolder}/.ruff.toml"
   ],
   "ruff.path": [

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-aio-pika==9.1.2
+aio-pika==9.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==10.4.0
+aioboto3==12.0.0
     # via -r requirements/_base.in
-aiobotocore==2.4.2
+aiobotocore==2.7.0
     # via
     #   aioboto3
     #   aiobotocore
@@ -23,11 +23,11 @@ aiodocker==0.21.0
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiofiles==23.1.0
+aiofiles==23.2.1
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiohttp==3.8.5
+aiohttp==3.8.6
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -42,37 +42,38 @@ aiohttp==3.8.5
     #   aiodocker
 aioitertools==0.11.0
     # via aiobotocore
-aiormq==6.7.6
+aiormq==6.7.7
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
-anyio==3.6.2
+anyio==4.0.0
     # via
     #   httpcore
     #   starlette
-arrow==1.2.3
+arrow==1.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   aiohttp
     #   redis
-attrs==21.4.0
+attrs==23.1.0
     # via
     #   aiohttp
     #   jsonschema
-boto3==1.24.59
+    #   referencing
+boto3==1.28.64
     # via aiobotocore
-botocore==1.27.59
+botocore==1.31.64
     # via
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.29.78
+botocore-stubs==1.31.76
     # via types-aiobotocore
 certifi==2023.7.22
     # via
@@ -87,7 +88,7 @@ certifi==2023.7.22
     #   -c requirements/../../../requirements/constraints.txt
     #   httpcore
     #   httpx
-charset-normalizer==3.0.1
+charset-normalizer==3.3.2
     # via aiohttp
 click==8.1.7
     # via
@@ -110,11 +111,13 @@ distributed==2023.3.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-dnspython==2.3.0
+dnspython==2.4.2
     # via email-validator
-email-validator==1.3.1
+email-validator==2.1.0.post1
     # via pydantic
-fastapi==0.96.0
+exceptiongroup==1.1.3
+    # via anyio
+fastapi==0.99.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -127,7 +130,7 @@ fastapi==0.96.0
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-frozenlist==1.3.3
+frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
@@ -139,9 +142,9 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==0.16.3
+httpcore==0.18.0
     # via httpx
-httpx==0.24.0
+httpx==0.25.0
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -180,11 +183,13 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==3.2.0
+jsonschema==4.19.2
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/models-library/requirements/_base.in
+jsonschema-specifications==2023.7.1
+    # via jsonschema
 locket==1.0.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
@@ -206,7 +211,7 @@ multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-orjson==3.9.7
+orjson==3.9.10
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
@@ -227,7 +232,7 @@ psutil==5.9.5
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-pydantic==1.10.2
+pydantic==1.10.13
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -247,14 +252,12 @@ pydantic==1.10.2
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   fastapi
-pygments==2.15.1
+pygments==2.16.1
     # via rich
-pyinstrument==4.4.0
+pyinstrument==4.6.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-pyrsistent==0.19.3
-    # via jsonschema
 python-dateutil==2.8.2
     # via
     #   arrow
@@ -275,7 +278,7 @@ pyyaml==6.0.1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
-redis==4.5.4
+redis==5.0.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -288,17 +291,25 @@ redis==4.5.4
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-rich==13.4.2
+referencing==0.29.3
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/././constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
+    #   jsonschema
+    #   jsonschema-specifications
+rich==13.6.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-s3transfer==0.6.0
-    # via boto3
-six==1.16.0
+rpds-py==0.10.6
     # via
     #   jsonschema
-    #   python-dateutil
+    #   referencing
+s3transfer==0.7.0
+    # via boto3
+six==1.16.0
+    # via python-dateutil
 sniffio==1.3.0
     # via
     #   anyio
@@ -324,7 +335,7 @@ tblib==2.0.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-tenacity==8.2.1
+tenacity==8.2.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -340,28 +351,33 @@ tornado==6.3.3
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-tqdm==4.64.1
+tqdm==4.66.1
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.7.0
+typer==0.9.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-types-aiobotocore==2.4.2.post1
+types-aiobotocore==2.7.0
     # via -r requirements/_base.in
-types-aiobotocore-ec2==2.4.2
+types-aiobotocore-ec2==2.7.0
     # via types-aiobotocore
-types-awscrt==0.16.10
+types-awscrt==0.19.8
     # via botocore-stubs
-typing-extensions==4.5.0
+types-python-dateutil==2.8.19.14
+    # via arrow
+typing-extensions==4.8.0
     # via
     #   aiodebug
     #   aiodocker
+    #   fastapi
     #   pydantic
+    #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
+    #   uvicorn
 urllib3==1.26.16
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -376,9 +392,9 @@ urllib3==1.26.16
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   botocore
     #   distributed
-uvicorn==0.20.0
+uvicorn==0.23.2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-wrapt==1.14.1
+wrapt==1.15.0
     # via aiobotocore
 yarl==1.9.2
     # via
@@ -393,6 +409,3 @@ zipp==3.16.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -73,7 +73,7 @@ botocore==1.31.64
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.31.76
+botocore-stubs==1.31.77
     # via types-aiobotocore
 certifi==2023.7.22
     # via

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -240,7 +240,9 @@ python-dateutil==2.8.2
 python-dotenv==1.0.0
     # via -r requirements/_test.in
 python-jose==3.3.0
-    # via moto
+    # via
+    #   moto
+    #   python-jose
 pyyaml==6.0.1
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -4,21 +4,22 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-anyio==3.6.2
+anyio==4.0.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
 asgi-lifespan==2.1.0
     # via -r requirements/_test.in
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via
     #   -c requirements/_base.txt
     #   redis
-attrs==21.4.0
+attrs==23.1.0
     # via
     #   -c requirements/_base.txt
     #   jschema-to-python
     #   jsonschema
+    #   referencing
     #   sarif-om
 aws-sam-translator==1.79.0
     # via cfn-lint
@@ -26,12 +27,12 @@ aws-xray-sdk==2.12.1
     # via moto
 blinker==1.7.0
     # via flask
-boto3==1.24.59
+boto3==1.28.64
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.27.59
+botocore==1.31.64
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -49,7 +50,7 @@ cffi==1.16.0
     # via cryptography
 cfn-lint==0.83.1
     # via moto
-charset-normalizer==3.0.1
+charset-normalizer==3.3.2
     # via
     #   -c requirements/_base.txt
     #   requests
@@ -79,7 +80,10 @@ ecdsa==0.18.0
     #   python-jose
     #   sshpubkeys
 exceptiongroup==1.1.3
-    # via pytest
+    # via
+    #   -c requirements/_base.txt
+    #   anyio
+    #   pytest
 faker==19.13.0
     # via -r requirements/_test.in
 fakeredis==2.20.0
@@ -96,11 +100,11 @@ h11==0.14.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==0.16.3
+httpcore==0.18.0
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.24.0
+httpx==0.25.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -139,15 +143,24 @@ jsonpickle==3.0.2
     # via jschema-to-python
 jsonpointer==2.4
     # via jsonpatch
-jsonschema==3.2.0
+jsonschema==4.19.2
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   cfn-lint
     #   openapi-schema-validator
     #   openapi-spec-validator
+jsonschema-path==0.3.1
+    # via openapi-spec-validator
+jsonschema-specifications==2023.7.1
+    # via
+    #   -c requirements/_base.txt
+    #   jsonschema
+    #   openapi-schema-validator
 junit-xml==1.9
     # via cfn-lint
+lazy-object-proxy==1.9.0
+    # via openapi-spec-validator
 lupa==2.0
     # via fakeredis
 markupsafe==2.1.3
@@ -155,15 +168,15 @@ markupsafe==2.1.3
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==4.2.6
+moto==4.2.7
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
 networkx==3.2.1
     # via cfn-lint
-openapi-schema-validator==0.2.3
+openapi-schema-validator==0.6.2
     # via openapi-spec-validator
-openapi-spec-validator==0.4.0
+openapi-spec-validator==0.7.1
     # via moto
 ordered-set==4.1.0
     # via deepdiff
@@ -172,6 +185,8 @@ packaging==23.1
     #   -c requirements/_base.txt
     #   docker
     #   pytest
+pathable==0.4.3
+    # via jsonschema-path
 pbr==5.11.1
     # via
     #   jschema-to-python
@@ -184,7 +199,7 @@ psutil==5.9.5
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-py-partiql-parser==0.4.0
+py-partiql-parser==0.4.1
     # via moto
 pyasn1==0.5.0
     # via
@@ -192,17 +207,13 @@ pyasn1==0.5.0
     #   rsa
 pycparser==2.21
     # via cffi
-pydantic==1.10.2
+pydantic==1.10.13
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aws-sam-translator
 pyparsing==3.1.1
     # via moto
-pyrsistent==0.19.3
-    # via
-    #   -c requirements/_base.txt
-    #   jsonschema
 pytest==7.4.3
     # via
     #   -r requirements/_test.in
@@ -235,30 +246,44 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   cfn-lint
+    #   jsonschema-path
     #   moto
-    #   openapi-spec-validator
     #   responses
-redis==4.5.4
+redis==5.0.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   fakeredis
+referencing==0.29.3
+    # via
+    #   -c requirements/_base.txt
+    #   jsonschema
+    #   jsonschema-path
+    #   jsonschema-specifications
 regex==2023.10.3
     # via cfn-lint
 requests==2.31.0
     # via
     #   docker
+    #   jsonschema-path
     #   moto
     #   responses
 responses==0.23.3
     # via moto
 respx==0.20.2
     # via -r requirements/_test.in
+rfc3339-validator==0.1.4
+    # via openapi-schema-validator
+rpds-py==0.10.6
+    # via
+    #   -c requirements/_base.txt
+    #   jsonschema
+    #   referencing
 rsa==4.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   python-jose
-s3transfer==0.6.0
+s3transfer==0.7.0
     # via
     #   -c requirements/_base.txt
     #   boto3
@@ -268,9 +293,9 @@ six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   ecdsa
-    #   jsonschema
     #   junit-xml
     #   python-dateutil
+    #   rfc3339-validator
 sniffio==1.3.0
     # via
     #   -c requirements/_base.txt
@@ -292,7 +317,7 @@ tomli==2.0.1
     #   pytest
 types-pyyaml==6.0.12.12
     # via responses
-typing-extensions==4.5.0
+typing-extensions==4.8.0
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
@@ -311,7 +336,7 @@ werkzeug==3.0.1
     # via
     #   flask
     #   moto
-wrapt==1.14.1
+wrapt==1.15.0
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk


### PR DESCRIPTION
### Bonus
- removed deprecated entries in vscode ```.settings-template.yml```
- wait longer in e2e testing

###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 61
- #packages after : 69

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.1.2           | 9.3.0      | *minor*    | 1 | autoscaling⬆️ |
|   2 | aioboto3                  | 10.4.0          | 12.0.0     | **MAJOR**  | 1 | autoscaling⬆️ |
|   3 | aiobotocore               | 2.4.2           | 2.7.0      | *minor*    | 1 | autoscaling⬆️ |
|   4 | aiofiles                  | 23.1.0          | 23.2.1     | *minor*    | 1 | autoscaling⬆️ |
|   5 | aiohttp                   | 3.8.5           | 3.8.6      |            | 1 | autoscaling⬆️ |
|   6 | aiormq                    | 6.7.6           | 6.7.7      |            | 1 | autoscaling⬆️ |
|   7 | anyio                     | 3.6.2           | 4.0.0      | **MAJOR**  | 2 | autoscaling⬆️🧪 |
|   8 | arrow                     | 1.2.3           | 1.3.0      | *minor*    | 1 | autoscaling⬆️ |
|   9 | async-timeout             | 4.0.2           | 4.0.3      |            | 2 | autoscaling⬆️🧪 |
|  10 | attrs                     | 21.4.0          | 23.1.0     | **MAJOR**  | 2 | autoscaling⬆️🧪 |
|  11 | aws-sam-translator        | 1.74.0          | 1.79.0     | *minor*    | 1 | autoscaling🧪 |
|  12 | aws-xray-sdk              | 2.12.0          | 2.12.1     |            | 1 | autoscaling🧪 |
|  13 | blinker                   | 1.6.2           | 1.7.0      | *minor*    | 1 | autoscaling🧪 |
|  14 | boto3                     | 1.24.59         | 1.28.64    | *minor*    | 2 | autoscaling⬆️🧪 |
|  15 | botocore                  | 1.27.59         | 1.31.64    | *minor*    | 2 | autoscaling⬆️🧪 |
|  16 | botocore-stubs            | 1.29.78         | 1.31.76    | *minor*    | 1 | autoscaling⬆️ |
|  17 | cffi                      | 1.15.1          | 1.16.0     | *minor*    | 1 | autoscaling🧪 |
|  18 | cfn-lint                  | 0.79.10         | 0.83.1     | *minor*    | 1 | autoscaling🧪 |
|  19 | charset-normalizer        | 3.0.1           | 3.3.2      | *minor*    | 2 | autoscaling⬆️🧪 |
|  20 | coverage                  | 7.3.1           | 7.3.2      |            | 1 | autoscaling🧪 |
|  21 | cryptography              | 41.0.3          | 41.0.5     |            | 1 | autoscaling🧪 |
|  22 | deepdiff                  | 6.5.0           | 6.6.1      | *minor*    | 1 | autoscaling🧪 |
|  23 | dnspython                 | 2.3.0           | 2.4.2      | *minor*    | 1 | autoscaling⬆️ |
|  24 | email-validator           | 1.3.1           | 2.1.0.post1 | **MAJOR**  | 1 | autoscaling⬆️ |
|  25 | faker                     | 19.6.1          | 19.13.0    | *minor*    | 1 | autoscaling🧪 |
|  26 | fakeredis                 | 2.18.1          | 2.20.0     | *minor*    | 1 | autoscaling🧪 |
|  27 | fastapi                   | 0.96.0          | 0.99.1     | *minor*    | 1 | autoscaling⬆️ |
|  28 | flask                     | 2.3.3           | 3.0.0      | **MAJOR**  | 1 | autoscaling🧪 |
|  29 | frozenlist                | 1.3.3           | 1.4.0      | *minor*    | 1 | autoscaling⬆️ |
|  30 | httpcore                  | 0.16.3          | 0.18.0     | *minor*    | 2 | autoscaling⬆️🧪 |
|  31 | httpx                     | 0.24.0          | 0.25.0     | *minor*    | 2 | autoscaling⬆️🧪 |
|  32 | jsonschema                | 3.2.0           | 4.19.2     | **MAJOR**  | 2 | autoscaling⬆️🧪 |
|  33 | moto                      | 4.2.2           | 4.2.7      |            | 1 | autoscaling🧪 |
|  34 | networkx                  | 3.1             | 3.2.1      | *minor*    | 1 | autoscaling🧪 |
|  35 | openapi-schema-validator  | 0.2.3           | 0.6.2      | *minor*    | 1 | autoscaling🧪 |
|  36 | openapi-spec-validator    | 0.4.0           | 0.7.1      | *minor*    | 1 | autoscaling🧪 |
|  37 | orjson                    | 3.9.7           | 3.9.10     |            | 1 | autoscaling⬆️ |
|  38 | py-partiql-parser         | 0.3.6           | 0.4.1      | *minor*    | 1 | autoscaling🧪 |
|  39 | pydantic                  | 1.10.2          | 1.10.13    |            | 2 | autoscaling⬆️🧪 |
|  40 | pygments                  | 2.15.1          | 2.16.1     | *minor*    | 1 | autoscaling⬆️ |
|  41 | pyinstrument              | 4.4.0           | 4.6.0      | *minor*    | 1 | autoscaling⬆️ |
|  42 | pyrsistent                | 0.19.3          | 🗑️ removed |  | 2 | autoscaling⬆️🧪 |
|  43 | pytest                    | 7.4.2           | 7.4.3      |            | 1 | autoscaling🧪 |
|  44 | pytest-mock               | 3.11.1          | 3.12.0     | *minor*    | 1 | autoscaling🧪 |
|  45 | redis                     | 4.5.4           | 5.0.1      | **MAJOR**  | 2 | autoscaling⬆️🧪 |
|  46 | regex                     | 2023.8.8        | 2023.10.3  | *minor*    | 1 | autoscaling🧪 |
|  47 | rich                      | 13.4.2          | 13.6.0     | *minor*    | 1 | autoscaling⬆️ |
|  48 | s3transfer                | 0.6.0           | 0.7.0      | *minor*    | 2 | autoscaling⬆️🧪 |
|  49 | six                       | 1.16.0          | 1.16.0     |            | 1 | autoscaling⬆️ |
|  50 | tenacity                  | 8.2.1           | 8.2.3      |            | 1 | autoscaling⬆️ |
|  51 | tqdm                      | 4.64.1          | 4.66.1     | *minor*    | 1 | autoscaling⬆️ |
|  52 | typer                     | 0.7.0           | 0.9.0      | *minor*    | 1 | autoscaling⬆️ |
|  53 | types-aiobotocore         | 2.4.2.post1     | 2.7.0      | *minor*    | 1 | autoscaling⬆️ |
|  54 | types-aiobotocore-ec2     | 2.4.2           | 2.7.0      | *minor*    | 1 | autoscaling⬆️ |
|  55 | types-awscrt              | 0.16.10         | 0.19.8     | *minor*    | 1 | autoscaling⬆️ |
|  56 | types-pyyaml              | 6.0.12.11       | 6.0.12.12  |            | 1 | autoscaling🧪 |
|  57 | typing-extensions         | 4.5.0           | 4.8.0      | *minor*    | 2 | autoscaling⬆️🧪 |
|  58 | uvicorn                   | 0.20.0          | 0.23.2     | *minor*    | 1 | autoscaling⬆️ |
|  59 | websocket-client          | 1.6.3           | 1.6.4      |            | 1 | autoscaling🧪 |
|  60 | werkzeug                  | 2.3.7           | 3.0.1      | **MAJOR**  | 1 | autoscaling🧪 |
|  61 | wrapt                     | 1.14.1          | 1.15.0     | *minor*    | 2 | autoscaling⬆️🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 82

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.1.2, 9.2.2, 9.2.3, 9.3.0 | 9.1.2, 9.2.3              |                           |
|   2 | aioboto3                  | 11.3.0, 12.0.0            | 9.6.0, 11.3.0             |                           |
|   3 | aiobotocore               | 2.5.4, 2.6.0, 2.7.0       | 2.3.0, 2.6.0              |                           |
|   4 | aiocache                  | 0.11.1, 0.12.1, 0.12.2    | 0.12.2                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.21.0                    | 0.21.0                    |                           |
|   7 | aiofiles                  | 0.8.0, 22.1.0, 23.1.0, 23.2.1 | 23.2.1                    |                           |
|   8 | aiohttp                   | 3.8.5, 3.8.6              | 3.8.5                     |                           |
|   9 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  10 | aiohttp-security          | 0.4.0                     |                           |                           |
|  11 | aiohttp-session           | 2.11.0                    |                           |                           |
|  12 | aiohttp-swagger           | 1.0.16                    |                           |                           |
|  13 | aioitertools              | 0.11.0                    | 0.11.0                    |                           |
|  14 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  15 | aioprocessing             | 2.0.1                     |                           |                           |
|  16 | aioredis                  | 2.0.1                     |                           |                           |
|  17 | aioresponses              |                           | 0.7.4                     |                           |
|  18 | aiormq                    | 6.7.6, 6.7.7              | 6.7.6, 6.7.7              |                           |
|  19 | aiosignal                 | 1.2.0, 1.3.1              | 1.2.0, 1.3.1              |                           |
|  20 | aiosmtplib                | 1.1.6                     |                           |                           |
|  21 | aiozipkin                 | 1.1.1                     |                           |                           |
|  22 | alembic                   | 1.8.1, 1.11.1, 1.11.3, 1.12.0 | 1.8.1, 1.11.1, 1.12.0     |                           |
|  23 | anyio                     | 3.6.2, 3.7.0, 3.7.1, 4.0.0 | 3.6.2, 3.7.0, 3.7.1, 4.0.0 |                           |
|  24 | arrow                     | 1.2.3, 1.3.0              | 1.2.3                     |                           |
|  25 | asgi-lifespan             |                           | 2.1.0                     |                           |
|  26 | asgiref                   | 3.5.2, 3.7.2              |                           |                           |
|  27 | astroid                   |                           |                           | 3.0.1                     |
|  28 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  29 | async-timeout             | 4.0.2, 4.0.3              | 4.0.2, 4.0.3              |                           |
|  30 | asyncpg                   | 0.27.0, 0.28.0            | 0.28.0                    |                           |
|  31 | attrs                     | 21.4.0, 23.1.0            | 21.4.0, 23.1.0            |                           |
|  32 | aws-sam-translator        |                           | 1.55.0, 1.74.0, 1.79.0    |                           |
|  33 | aws-xray-sdk              |                           | 2.12.0, 2.12.1            |                           |
|  34 | bidict                    | 0.22.0                    |                           |                           |
|  35 | black                     |                           |                           | 23.10.1                   |
|  36 | blinker                   |                           | 1.6.2, 1.7.0              |                           |
|  37 | blosc                     | 1.11.1                    |                           |                           |
|  38 | bokeh                     | 2.4.3                     | 2.4.3                     |                           |
|  39 | boto3                     | 1.24.96, 1.28.17, 1.28.64 | 1.21.21, 1.28.17, 1.28.46, 1.28.64 |                           |
|  40 | boto3-stubs               |                           | 1.28.46                   |                           |
|  41 | botocore                  | 1.27.96, 1.31.17, 1.31.64 | 1.24.21, 1.31.17, 1.31.46, 1.31.64 |                           |
|  42 | botocore-stubs            | 1.31.36, 1.31.38, 1.31.76 | 1.31.46                   |                           |
|  43 | build                     |                           |                           | 1.0.3                     |
|  44 | bump2version              |                           |                           | 1.0.1                     |
|  45 | certifi                   | 2023.7.22                 | 2023.7.22                 |                           |
|  46 | cffi                      | 1.15.0, 1.15.1            | 1.15.1, 1.16.0            |                           |
|  47 | cfgv                      |                           |                           | 3.4.0                     |
|  48 | cfn-lint                  |                           | 0.72.0, 0.77.10, 0.79.10, 0.83.1 |                           |
|  49 | change-case               |                           |                           | 0.5.2                     |
|  50 | charset-normalizer        | 2.0.12, 2.1.1, 3.1.0, 3.2.0, 3.3.2 | 2.0.12, 2.1.1, 3.1.0, 3.2.0, 3.3.2 |                           |
|  51 | click                     | 8.1.3, 8.1.6, 8.1.7       | 8.1.3, 8.1.7              | 8.1.3, 8.1.6, 8.1.7       |
|  52 | cloudpickle               | 2.2.1                     | 2.2.1                     |                           |
|  53 | colorama                  | 0.4.6                     |                           |                           |
|  54 | colorlog                  | 6.7.0                     | 6.7.0                     |                           |
|  55 | commonmark                | 0.9.1                     |                           |                           |
|  56 | contourpy                 | 1.0.7                     |                           |                           |
|  57 | coverage                  |                           | 7.3.1, 7.3.2              |                           |
|  58 | cryptography              | 41.0.3                    | 41.0.3, 41.0.5            |                           |
|  59 | cycler                    | 0.11.0                    |                           |                           |
|  60 | dask                      | 2023.3.2, 2023.9.1        | 2023.3.2                  |                           |
|  61 | dask-gateway              | 2023.1.1                  | 2023.1.1                  |                           |
|  62 | dask-gateway-server       | 2023.1.1                  | 2023.1.1                  |                           |
|  63 | dateparser                | 1.1.8                     |                           |                           |
|  64 | debugpy                   |                           | 1.8.0                     |                           |
|  65 | deepdiff                  |                           | 6.5.0, 6.6.1              |                           |
|  66 | dill                      |                           |                           | 0.3.7                     |
|  67 | distlib                   |                           |                           | 0.3.7                     |
|  68 | distributed               | 2023.3.2, 2023.9.1        | 2023.3.2                  |                           |
|  69 | dnspython                 | 2.1.0, 2.2.1, 2.3.0, 2.4.0, 2.4.1, 2.4.2 | 2.4.2                     |                           |
|  70 | docker                    | 6.1.3                     | 6.1.3                     |                           |
|  71 | ecdsa                     | 0.18.0                    | 0.18.0                    |                           |
|  72 | email-validator           | 1.2.1, 1.3.0, 2.0.0.post2, 2.1.0.post1 | 2.0.0.post2               |                           |
|  73 | et-xmlfile                | 1.1.0                     |                           |                           |
|  74 | exceptiongroup            | 1.1.1, 1.1.2, 1.1.3       | 1.1.1, 1.1.2, 1.1.3       |                           |
|  75 | execnet                   |                           | 2.0.2                     |                           |
|  76 | expiringdict              | 1.2.1                     |                           |                           |
|  77 | faker                     | 19.6.1                    | 19.6.1, 19.13.0           |                           |
|  78 | fakeredis                 |                           | 2.18.1, 2.20.0            |                           |
|  79 | fastapi                   | 0.96.0, 0.98.0, 0.99.1    |                           |                           |
|  80 | fastapi-pagination        | 0.10.0, 0.12.5            |                           |                           |
|  81 | filelock                  |                           |                           | 3.12.4                    |
|  82 | flaky                     |                           | 3.7.0                     |                           |
|  83 | flask                     |                           | 2.1.3, 2.3.3, 3.0.0       |                           |
|  84 | flask-cors                |                           | 4.0.0                     |                           |
|  85 | fonttools                 | 4.39.4                    |                           |                           |
|  86 | frozenlist                | 1.3.0, 1.3.1, 1.3.3, 1.4.0 | 1.3.0, 1.3.1, 1.3.3, 1.4.0 |                           |
|  87 | fsspec                    | 2023.6.0, 2023.9.0        | 2023.6.0                  |                           |
|  88 | graphql-core              |                           | 3.2.3                     |                           |
|  89 | greenlet                  | 2.0.2                     | 2.0.2                     |                           |
|  90 | gunicorn                  | 20.1.0                    |                           |                           |
|  91 | h11                       | 0.12.0, 0.14.0            | 0.12.0, 0.14.0            |                           |
|  92 | h2                        | 4.1.0                     |                           |                           |
|  93 | hpack                     | 4.0.0                     |                           |                           |
|  94 | httmock                   | 1.4.0                     |                           |                           |
|  95 | httpcore                  | 0.15.0, 0.16.3, 0.17.1, 0.17.2, 0.17.3, 0.18.0 | 0.15.0, 0.16.3, 0.17.1, 0.17.2, 0.17.3, 0.18.0 |                           |
|  96 | httptools                 | 0.2.0, 0.5.0, 0.6.0       |                           |                           |
|  97 | httpx                     | 0.24.0, 0.24.1, 0.25.0    | 0.24.0, 0.24.1, 0.25.0    |                           |
|  98 | hyperframe                | 6.0.1                     |                           |                           |
|  99 | hypothesis                |                           | 6.84.3                    |                           |
| 100 | icdiff                    |                           | 2.0.7                     |                           |
| 101 | identify                  |                           |                           | 2.5.30                    |
| 102 | idna                      | 2.10, 3.3, 3.4            | 2.10, 3.3, 3.4            |                           |
| 103 | importlib-metadata        | 6.8.0                     | 6.8.0                     |                           |
| 104 | iniconfig                 | 2.0.0                     | 2.0.0                     |                           |
| 105 | inotify                   |                           |                           | 0.2.10                    |
| 106 | isodate                   | 0.6.1                     |                           |                           |
| 107 | isort                     |                           |                           | 5.12.0                    |
| 108 | itsdangerous              | 1.1.0, 2.1.2              | 2.1.2                     |                           |
| 109 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 110 | jinja2                    | 3.1.2                     | 3.1.2                     | 3.1.2                     |
| 111 | jmespath                  | 1.0.1                     | 1.0.1                     |                           |
| 112 | jschema-to-python         |                           | 1.2.3                     |                           |
| 113 | json2html                 | 1.3.0                     |                           |                           |
| 114 | jsondiff                  | 2.0.0                     | 2.0.0                     |                           |
| 115 | jsonpatch                 |                           | 1.33                      |                           |
| 116 | jsonpickle                |                           | 3.0.2                     |                           |
| 117 | jsonpointer               |                           | 2.4                       |                           |
| 118 | jsonref                   |                           | 1.1.0                     |                           |
| 119 | jsonschema                | 3.2.0, 4.18.4, 4.19.0, 4.19.2 | 3.2.0, 4.19.0, 4.19.2     |                           |
| 120 | jsonschema-path           |                           | 0.3.1                     |                           |
| 121 | jsonschema-spec           | 0.2.4                     | 0.2.4                     |                           |
| 122 | jsonschema-specifications | 2023.7.1                  | 2023.7.1                  |                           |
| 123 | junit-xml                 |                           | 1.9                       |                           |
| 124 | kiwisolver                | 1.4.4                     |                           |                           |
| 125 | lazy-object-proxy         | 1.7.1, 1.9.0              | 1.9.0                     |                           |
| 126 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 127 | lupa                      |                           | 2.0                       |                           |
| 128 | lz4                       | 4.3.2                     | 4.3.2                     |                           |
| 129 | mako                      | 1.2.2, 1.2.4              | 1.2.2, 1.2.4              |                           |
| 130 | markdown-it-py            | 2.2.0, 3.0.0              | 3.0.0                     |                           |
| 131 | markupsafe                | 2.1.1, 2.1.3              | 2.1.1, 2.1.3              | 2.1.3                     |
| 132 | matplotlib                | 3.7.1                     |                           |                           |
| 133 | mccabe                    |                           |                           | 0.7.0                     |
| 134 | mdurl                     | 0.1.2                     | 0.1.2                     |                           |
| 135 | minio                     |                           | 7.0.4                     |                           |
| 136 | more-itertools            | 10.1.0                    |                           |                           |
| 137 | moto                      |                           | 4.0.1, 4.2.2, 4.2.7       |                           |
| 138 | mpmath                    |                           | 1.3.0                     |                           |
| 139 | msgpack                   | 1.0.3, 1.0.5              | 1.0.5                     |                           |
| 140 | multidict                 | 6.0.2, 6.0.3, 6.0.4       | 6.0.2, 6.0.4              |                           |
| 141 | mypy                      |                           | 1.5.1                     |                           |
| 142 | mypy-extensions           |                           | 1.0.0                     | 1.0.0                     |
| 143 | networkx                  | 3.1                       | 2.8.8, 3.1, 3.2.1         |                           |
| 144 | nodeenv                   |                           |                           | 1.8.0                     |
| 145 | nose                      |                           |                           | 1.3.7                     |
| 146 | numpy                     | 1.24.3, 1.25.2            | 1.25.2                    |                           |
| 147 | openapi-core              | 0.12.0, 0.18.0            |                           |                           |
| 148 | openapi-schema-validator  | 0.2.3, 0.6.0              | 0.2.3, 0.6.0, 0.6.2       |                           |
| 149 | openapi-spec-validator    | 0.4.0, 0.6.0              | 0.4.0, 0.6.0, 0.7.1       |                           |
| 150 | openpyxl                  | 3.0.9                     |                           |                           |
| 151 | ordered-set               | 4.1.0                     | 4.1.0                     |                           |
| 152 | orjson                    | 3.7.2, 3.9.1, 3.9.2, 3.9.5, 3.9.7, 3.9.10 | 3.9.7                     |                           |
| 153 | packaging                 | 23.0, 23.1                | 23.0, 23.1                | 23.0, 23.1                |
| 154 | pamqp                     | 3.2.1                     | 3.2.1                     |                           |
| 155 | pandas                    | 2.0.1                     | 2.1.0                     |                           |
| 156 | parse                     | 1.19.1                    | 1.19.1                    |                           |
| 157 | partd                     | 1.4.0                     | 1.4.0                     |                           |
| 158 | passlib                   | 1.7.4                     |                           |                           |
| 159 | pathable                  | 0.4.3                     | 0.4.3                     |                           |
| 160 | pathspec                  |                           |                           | 0.11.2                    |
| 161 | pbr                       |                           | 5.11.1                    |                           |
| 162 | pillow                    | 9.5.0, 10.0.0             | 10.0.0                    |                           |
| 163 | pint                      | 0.19.2, 0.22              | 0.22                      |                           |
| 164 | pip-tools                 |                           |                           | 7.3.0                     |
| 165 | platformdirs              |                           |                           | 3.11.0                    |
| 166 | pluggy                    | 1.3.0                     | 1.3.0                     |                           |
| 167 | pprintpp                  |                           | 0.4.0                     |                           |
| 168 | pre-commit                |                           |                           | 3.5.0                     |
| 169 | prometheus-api-client     | 0.5.3                     |                           |                           |
| 170 | prometheus-client         | 0.14.1, 0.17.1            |                           |                           |
| 171 | psutil                    | 5.9.5                     | 5.9.5                     |                           |
| 172 | psycopg2-binary           | 2.9.6, 2.9.7              | 2.9.7                     |                           |
| 173 | ptvsd                     |                           | 4.3.2                     |                           |
| 174 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 175 | py-partiql-parser         |                           | 0.3.6, 0.4.1              |                           |
| 176 | pyasn1                    | 0.5.0                     | 0.5.0                     |                           |
| 177 | pycparser                 | 2.21                      | 2.21                      |                           |
| 178 | pydantic                  | 1.9.0, 1.10.2, 1.10.7, 1.10.9, 1.10.11, 1.10.12, 1.10.13 | 1.10.2, 1.10.12, 1.10.13  |                           |
| 179 | pyftpdlib                 |                           | 1.5.7                     |                           |
| 180 | pygments                  | 2.14.0, 2.15.1, 2.16.1    | 2.16.1                    |                           |
| 181 | pyinstrument              | 3.4.2, 4.1.1, 4.3.0, 4.4.0, 4.5.0, 4.5.1, 4.5.3, 4.6.0 | 4.5.0, 4.5.3              |                           |
| 182 | pyinstrument-cext         | 0.2.4                     |                           |                           |
| 183 | pyjwt                     | 2.4.0                     |                           |                           |
| 184 | pylint                    |                           |                           | 3.0.2                     |
| 185 | pyopenssl                 |                           | 23.2.0                    |                           |
| 186 | pyparsing                 | 3.0.9                     | 3.1.1                     |                           |
| 187 | pyproject-hooks           |                           |                           | 1.0.0                     |
| 188 | pyrsistent                | 0.18.1, 0.19.2, 0.19.3    | 0.18.1, 0.19.2, 0.19.3    |                           |
| 189 | pytest                    | 7.4.2                     | 7.4.2, 7.4.3              |                           |
| 190 | pytest-aiohttp            |                           | 1.0.5                     |                           |
| 191 | pytest-asyncio            |                           | 0.21.1                    |                           |
| 192 | pytest-benchmark          |                           | 4.0.0                     |                           |
| 193 | pytest-cov                |                           | 4.1.0                     |                           |
| 194 | pytest-docker             |                           | 2.0.1                     |                           |
| 195 | pytest-icdiff             |                           | 0.7, 0.8                  |                           |
| 196 | pytest-instafail          |                           | 0.5.0                     |                           |
| 197 | pytest-lazy-fixture       |                           | 0.6.3                     |                           |
| 198 | pytest-localftpserver     |                           | 1.1.4                     |                           |
| 199 | pytest-mock               |                           | 3.11.1, 3.12.0            |                           |
| 200 | pytest-runner             |                           | 6.0.0                     |                           |
| 201 | pytest-sugar              |                           | 0.9.7                     |                           |
| 202 | pytest-xdist              |                           | 3.3.1                     |                           |
| 203 | python-dateutil           | 2.8.2                     | 2.8.2                     |                           |
| 204 | python-dotenv             | 0.20.0, 0.21.0, 1.0.0     | 0.21.0, 1.0.0             |                           |
| 205 | python-engineio           | 4.3.4                     |                           |                           |
| 206 | python-jose               | 3.3.0                     | 3.3.0                     |                           |
| 207 | python-magic              | 0.4.25, 0.4.27            |                           |                           |
| 208 | python-multipart          | 0.0.5, 0.0.6              |                           |                           |
| 209 | python-socketio           | 5.8.0                     |                           |                           |
| 210 | pytz                      | 2022.1, 2023.3            | 2023.3.post1              |                           |
| 211 | pyyaml                    | 6.0.1                     | 6.0.1                     | 6.0.1                     |
| 212 | redis                     | 4.5.4, 4.5.5, 4.6.0, 5.0.0, 5.0.1 | 4.5.4, 4.5.5, 5.0.0, 5.0.1 |                           |
| 213 | referencing               | 0.29.3, 0.30.2            | 0.29.3, 0.30.2            |                           |
| 214 | regex                     | 2023.5.5                  | 2023.8.8, 2023.10.3       |                           |
| 215 | requests                  | 2.30.0, 2.31.0            | 2.30.0, 2.31.0            |                           |
| 216 | requests-mock             |                           | 1.11.0                    |                           |
| 217 | responses                 |                           | 0.23.3                    |                           |
| 218 | respx                     |                           | 0.20.2                    |                           |
| 219 | rfc3339-validator         | 0.1.4                     | 0.1.4                     |                           |
| 220 | rich                      | 12.6.0, 13.3.5, 13.4.2, 13.5.2, 13.6.0 | 13.5.2                    |                           |
| 221 | rpds-py                   | 0.9.2, 0.10.0, 0.10.3, 0.10.6 | 0.9.2, 0.10.0, 0.10.3, 0.10.6 |                           |
| 222 | rsa                       | 4.9                       | 4.9                       |                           |
| 223 | ruff                      |                           |                           | 0.1.2                     |
| 224 | s3fs                      | 2023.6.0                  |                           |                           |
| 225 | s3transfer                | 0.6.0, 0.6.2, 0.7.0       | 0.5.2, 0.6.2, 0.7.0       |                           |
| 226 | sarif-om                  |                           | 1.0.4                     |                           |
| 227 | semantic-version          | 2.10.0                    |                           |                           |
| 228 | setproctitle              | 1.2.3                     |                           |                           |
| 229 | shellingham               | 1.5.0.post1, 1.5.3        |                           |                           |
| 230 | six                       | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            |                           |
| 231 | sniffio                   | 1.2.0, 1.3.0              | 1.2.0, 1.3.0              |                           |
| 232 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 233 | sqlalchemy                | 1.4.47, 1.4.48, 1.4.49    | 1.4.47, 1.4.48, 1.4.49    |                           |
| 234 | sqlalchemy2-stubs         |                           | 0.0.2a35                  |                           |
| 235 | sshpubkeys                |                           | 3.3.1                     |                           |
| 236 | starlette                 | 0.27.0                    |                           |                           |
| 237 | strict-rfc3339            | 0.7                       |                           |                           |
| 238 | sympy                     |                           | 1.12                      |                           |
| 239 | tblib                     | 2.0.0                     | 2.0.0                     |                           |
| 240 | tenacity                  | 8.0.1, 8.1.0, 8.2.2, 8.2.3 | 8.0.1, 8.2.3              |                           |
| 241 | termcolor                 |                           | 2.3.0                     |                           |
| 242 | tomli                     | 2.0.1                     | 2.0.1                     | 2.0.1                     |
| 243 | tomlkit                   |                           |                           | 0.12.1                    |
| 244 | toolz                     | 0.12.0                    | 0.12.0                    |                           |
| 245 | tornado                   | 6.3.3                     | 6.3.3                     |                           |
| 246 | tqdm                      | 4.64.0, 4.64.1, 4.65.0, 4.66.1 | 4.66.1                    |                           |
| 247 | traitlets                 | 5.9.0                     | 5.9.0                     |                           |
| 248 | twilio                    | 7.12.0                    |                           |                           |
| 249 | typer                     | 0.4.1, 0.6.1, 0.7.0, 0.9.0 | 0.9.0                     | 0.9.0                     |
| 250 | types-aiobotocore         | 2.6.0, 2.7.0              |                           |                           |
| 251 | types-aiobotocore-ec2     | 2.6.0, 2.7.0              |                           |                           |
| 252 | types-aiobotocore-s3      | 2.6.0                     | 2.6.0                     |                           |
| 253 | types-aiofiles            |                           | 23.2.0.0                  |                           |
| 254 | types-awscrt              | 0.19.1, 0.19.8            | 0.19.1                    |                           |
| 255 | types-boto3               |                           | 1.0.2                     |                           |
| 256 | types-pkg-resources       |                           | 0.1.3                     |                           |
| 257 | types-python-dateutil     | 2.8.19.14                 |                           |                           |
| 258 | types-pyyaml              |                           | 6.0.12.11, 6.0.12.12      |                           |
| 259 | types-s3transfer          |                           | 0.6.2                     |                           |
| 260 | typing-extensions         | 4.3.0, 4.4.0, 4.5.0, 4.6.3, 4.7.1, 4.8.0 | 4.3.0, 4.4.0, 4.5.0, 4.6.3, 4.7.1, 4.8.0 | 4.3.0, 4.4.0, 4.5.0, 4.6.3, 4.7.1, 4.8.0 |
| 261 | tzdata                    | 2023.3                    | 2023.3                    |                           |
| 262 | tzlocal                   | 5.0.1                     |                           |                           |
| 263 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 264 | ujson                     | 5.5.0, 5.8.0              |                           |                           |
| 265 | urllib3                   | 1.26.11, 1.26.12, 1.26.16, 2.0.2, 2.0.4 | 1.26.11, 1.26.12, 1.26.16, 2.0.2, 2.0.4 |                           |
| 266 | uvicorn                   | 0.15.0, 0.19.0, 0.20.0, 0.22.0, 0.23.1, 0.23.2 |                           |                           |
| 267 | uvloop                    | 0.16.0, 0.17.0            |                           |                           |
| 268 | virtualenv                |                           |                           | 20.24.6                   |
| 269 | watchdog                  | 3.0.0                     |                           | 3.0.0                     |
| 270 | watchfiles                | 0.18.0, 0.18.1, 0.19.0, 0.20.0 |                           |                           |
| 271 | watchgod                  | 0.8.2                     |                           |                           |
| 272 | websocket-client          | 1.6.3                     | 1.6.3, 1.6.4              |                           |
| 273 | websockets                | 10.1, 10.3, 10.4, 11.0.3  | 11.0.3                    |                           |
| 274 | werkzeug                  | 2.1.2, 2.3.7              | 2.1.2, 2.3.7, 3.0.1       |                           |
| 275 | wheel                     |                           |                           | 0.41.2                    |
| 276 | wrapt                     | 1.15.0                    | 1.15.0                    |                           |
| 277 | xmltodict                 |                           | 0.13.0                    |                           |
| 278 | yarl                      | 1.5.1, 1.9.2              | 1.5.1, 1.9.2              |                           |
| 279 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 280 | zipp                      | 3.16.2                    | 3.16.2                    |                           |



- relates to https://github.com/ITISFoundation/osparc-issues/issues/1108