### PR TITLE
⬆️ Maintenance: upgrade of clusters-keeper

### DIFF
--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -4,14 +4,16 @@
 #
 #    pip-compile --output-file=requirements/_base.txt --strip-extras requirements/_base.in
 #
-aio-pika==9.2.2
+aio-pika==9.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==11.3.0
+aioboto3==12.0.0
     # via -r requirements/_base.in
-aiobotocore==2.6.0
-    # via aioboto3
+aiobotocore==2.7.0
+    # via
+    #   aioboto3
+    #   aiobotocore
 aiodebug==2.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
@@ -24,7 +26,7 @@ aiofiles==23.2.1
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiohttp==3.8.5
+aiohttp==3.8.6
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -43,11 +45,11 @@ aiormq==6.7.7
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
-anyio==3.7.1
+anyio==4.0.0
     # via
-    #   httpcore
+    #   httpx
     #   starlette
-arrow==1.2.3
+arrow==1.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -63,14 +65,14 @@ attrs==23.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.28.17
+boto3==1.28.64
     # via aiobotocore
-botocore==1.31.17
+botocore==1.31.64
     # via
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.31.36
+botocore-stubs==1.31.80
     # via types-aiobotocore
 certifi==2023.7.22
     # via
@@ -85,7 +87,7 @@ certifi==2023.7.22
     #   -c requirements/../../../requirements/constraints.txt
     #   httpcore
     #   httpx
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via aiohttp
 click==8.1.7
     # via
@@ -110,7 +112,7 @@ distributed==2023.3.2
     #   dask
 dnspython==2.4.2
     # via email-validator
-email-validator==2.0.0.post2
+email-validator==2.1.0.post1
     # via pydantic
 exceptiongroup==1.1.3
     # via anyio
@@ -139,9 +141,9 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==0.17.3
+httpcore==1.0.1
     # via httpx
-httpx==0.24.1
+httpx==0.25.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -153,6 +155,7 @@ httpx==0.24.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   respx
 idna==3.4
     # via
     #   anyio
@@ -180,7 +183,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.19.0
+jsonschema==4.19.2
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
@@ -208,7 +211,7 @@ multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-orjson==3.9.5
+orjson==3.9.10
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
@@ -229,7 +232,7 @@ psutil==5.9.5
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-pydantic==1.10.12
+pydantic==1.10.13
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -251,7 +254,7 @@ pydantic==1.10.12
     #   fastapi
 pygments==2.16.1
     # via rich
-pyinstrument==4.5.1
+pyinstrument==4.6.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -275,7 +278,7 @@ pyyaml==6.0.1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
-redis==5.0.0
+redis==5.0.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -294,23 +297,24 @@ referencing==0.29.3
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   jsonschema
     #   jsonschema-specifications
-rich==13.5.2
+respx==0.20.2
+    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
+rich==13.6.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-rpds-py==0.10.0
+rpds-py==0.12.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.6.2
+s3transfer==0.7.0
     # via boto3
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.0
     # via
     #   anyio
-    #   httpcore
     #   httpx
 sortedcontainers==2.4.0
     # via
@@ -357,19 +361,23 @@ typer==0.9.0
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/./../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-types-aiobotocore==2.6.0
+types-aiobotocore==2.7.0
     # via -r requirements/_base.in
-types-aiobotocore-ec2==2.6.0
+types-aiobotocore-ec2==2.7.0
     # via types-aiobotocore
-types-awscrt==0.19.1
+types-awscrt==0.19.8
     # via botocore-stubs
-typing-extensions==4.7.1
+types-python-dateutil==2.8.19.14
+    # via arrow
+typing-extensions==4.8.0
     # via
     #   aiodebug
     #   aiodocker
     #   fastapi
     #   pydantic
     #   typer
+    #   types-aiobotocore
+    #   types-aiobotocore-ec2
     #   uvicorn
 urllib3==1.26.16
     # via
@@ -385,7 +393,7 @@ urllib3==1.26.16
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   botocore
     #   distributed
-uvicorn==0.23.2
+uvicorn==0.24.0.post1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 wrapt==1.15.0
     # via aiobotocore

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -8,7 +8,7 @@ aiodocker==0.21.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-aiohttp==3.8.5
+aiohttp==3.8.6
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -17,10 +17,10 @@ aiosignal==1.3.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-anyio==3.7.1
+anyio==4.0.0
     # via
     #   -c requirements/_base.txt
-    #   httpcore
+    #   httpx
 asgi-lifespan==2.1.0
     # via -r requirements/_test.in
 async-timeout==4.0.3
@@ -42,12 +42,12 @@ aws-xray-sdk==2.12.1
     # via moto
 blinker==1.7.0
     # via flask
-boto3==1.28.17
+boto3==1.28.64
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.31.17
+botocore==1.31.64
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -65,7 +65,7 @@ cffi==1.16.0
     # via cryptography
 cfn-lint==0.83.1
     # via moto
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -86,7 +86,7 @@ cryptography==41.0.5
     #   sshpubkeys
 debugpy==1.8.0
     # via -r requirements/_test.in
-deepdiff==6.6.1
+deepdiff==6.7.0
     # via -r requirements/_test.in
 docker==6.1.3
     # via
@@ -123,11 +123,11 @@ h11==0.14.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==0.17.3
+httpcore==1.0.1
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.24.1
+httpx==0.25.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -165,7 +165,7 @@ jsonpickle==3.0.2
     # via jschema-to-python
 jsonpointer==2.4
     # via jsonpatch
-jsonschema==4.19.0
+jsonschema==4.19.2
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
@@ -201,7 +201,7 @@ multidict==6.0.4
     #   yarl
 networkx==3.2.1
     # via cfn-lint
-openapi-schema-validator==0.6.0
+openapi-schema-validator==0.6.2
     # via openapi-spec-validator
 openapi-spec-validator==0.7.1
     # via moto
@@ -216,7 +216,7 @@ parse==1.19.1
     # via -r requirements/_test.in
 pathable==0.4.3
     # via jsonschema-path
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   jschema-to-python
     #   sarif-om
@@ -234,7 +234,7 @@ pyasn1==0.5.0
     #   rsa
 pycparser==2.21
     # via cffi
-pydantic==1.10.12
+pydantic==1.10.13
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -264,7 +264,9 @@ python-dateutil==2.8.2
 python-dotenv==1.0.0
     # via -r requirements/_test.in
 python-jose==3.3.0
-    # via moto
+    # via
+    #   moto
+    #   python-jose
 pyyaml==6.0.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -273,7 +275,7 @@ pyyaml==6.0.1
     #   jsonschema-path
     #   moto
     #   responses
-redis==5.0.0
+redis==5.0.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -292,13 +294,15 @@ requests==2.31.0
     #   jsonschema-path
     #   moto
     #   responses
-responses==0.23.3
+responses==0.24.0
     # via moto
 respx==0.20.2
-    # via -r requirements/_test.in
+    # via
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.10.0
+rpds-py==0.12.0
     # via
     #   -c requirements/_base.txt
     #   jsonschema
@@ -307,7 +311,7 @@ rsa==4.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   python-jose
-s3transfer==0.6.2
+s3transfer==0.7.0
     # via
     #   -c requirements/_base.txt
     #   boto3
@@ -325,7 +329,6 @@ sniffio==1.3.0
     #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
-    #   httpcore
     #   httpx
 sortedcontainers==2.4.0
     # via
@@ -339,9 +342,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-types-pyyaml==6.0.12.12
-    # via responses
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   -c requirements/_base.txt
     #   aiodocker

--- a/services/clusters-keeper/requirements/_tools.txt
+++ b/services/clusters-keeper/requirements/_tools.txt
@@ -6,7 +6,7 @@
 #
 astroid==3.0.1
     # via pylint
-black==23.10.1
+black==23.11.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -66,7 +66,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.4
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -76,9 +76,9 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.2
     # via pylint
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt


### PR DESCRIPTION
###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 34
- #packages after : 35

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.2.2           | 9.3.0      | *minor*    | 1 | clusters-keeper⬆️ |
|   2 | aioboto3                  | 11.3.0          | 12.0.0     | **MAJOR**  | 1 | clusters-keeper⬆️ |
|   3 | aiobotocore               | 2.6.0           | 2.7.0      | *minor*    | 1 | clusters-keeper⬆️ |
|   4 | aiohttp                   | 3.8.5           | 3.8.6      |            | 2 | clusters-keeper⬆️🧪 |
|   5 | anyio                     | 3.7.1           | 4.0.0      | **MAJOR**  | 2 | clusters-keeper⬆️🧪 |
|   6 | arrow                     | 1.2.3           | 1.3.0      | *minor*    | 1 | clusters-keeper⬆️ |
|   7 | black                     | 23.10.1         | 23.11.0    | *minor*    | 1 | clusters-keeper🔧 |
|   8 | boto3                     | 1.28.17         | 1.28.64    |            | 2 | clusters-keeper⬆️🧪 |
|   9 | botocore                  | 1.31.17         | 1.31.64    |            | 2 | clusters-keeper⬆️🧪 |
|  10 | botocore-stubs            | 1.31.36         | 1.31.80    |            | 1 | clusters-keeper⬆️ |
|  11 | charset-normalizer        | 3.2.0           | 3.3.2      | *minor*    | 2 | clusters-keeper⬆️🧪 |
|  12 | deepdiff                  | 6.6.1           | 6.7.0      | *minor*    | 1 | clusters-keeper🧪 |
|  13 | email-validator           | 2.0.0.post2     | 2.1.0.post1 | *minor*    | 1 | clusters-keeper⬆️ |
|  14 | httpcore                  | 0.17.3          | 1.0.1      | **MAJOR**  | 2 | clusters-keeper⬆️🧪 |
|  15 | httpx                     | 0.24.1          | 0.25.1     | *minor*    | 2 | clusters-keeper⬆️🧪 |
|  16 | jsonschema                | 4.19.0          | 4.19.2     |            | 2 | clusters-keeper⬆️🧪 |
|  17 | openapi-schema-validator  | 0.6.0           | 0.6.2      |            | 1 | clusters-keeper🧪 |
|  18 | orjson                    | 3.9.5           | 3.9.10     |            | 1 | clusters-keeper⬆️ |
|  19 | pbr                       | 5.11.1          | 6.0.0      | **MAJOR**  | 1 | clusters-keeper🧪 |
|  20 | pydantic                  | 1.10.12         | 1.10.13    |            | 2 | clusters-keeper⬆️🧪 |
|  21 | pyinstrument              | 4.5.1           | 4.6.0      | *minor*    | 1 | clusters-keeper⬆️ |
|  22 | redis                     | 5.0.0           | 5.0.1      |            | 2 | clusters-keeper⬆️🧪 |
|  23 | responses                 | 0.23.3          | 0.24.0     | *minor*    | 1 | clusters-keeper🧪 |
|  24 | rich                      | 13.5.2          | 13.6.0     | *minor*    | 1 | clusters-keeper⬆️ |
|  25 | rpds-py                   | 0.10.0          | 0.12.0     | *minor*    | 2 | clusters-keeper⬆️🧪 |
|  26 | ruff                      | 0.1.3           | 0.1.4      |            | 1 | clusters-keeper🔧 |
|  27 | s3transfer                | 0.6.2           | 0.7.0      | *minor*    | 2 | clusters-keeper⬆️🧪 |
|  28 | tomlkit                   | 0.12.1          | 0.12.2     |            | 1 | clusters-keeper🔧 |
|  29 | types-aiobotocore         | 2.6.0           | 2.7.0      | *minor*    | 1 | clusters-keeper⬆️ |
|  30 | types-aiobotocore-ec2     | 2.6.0           | 2.7.0      | *minor*    | 1 | clusters-keeper⬆️ |
|  31 | types-awscrt              | 0.19.1          | 0.19.8     |            | 1 | clusters-keeper⬆️ |
|  32 | types-pyyaml              | 6.0.12.12       | 🗑️ removed |  | 1 | clusters-keeper🧪 |
|  33 | typing-extensions         | 4.7.1           | 4.8.0      | *minor*    | 3 | clusters-keeper⬆️🧪🔧 |
|  34 | uvicorn                   | 0.23.2          | 0.24.0.post1 | *minor*    | 1 | clusters-keeper⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency