### PR TITLE
🔨 Removes `respx` library from base requirements listing (`fastapi.in`)

### DIFF
--- a/packages/service-library/requirements/_fastapi.in
+++ b/packages/service-library/requirements/_fastapi.in
@@ -8,5 +8,4 @@
 
 fastapi
 httpx
-respx
 uvicorn

--- a/packages/service-library/requirements/_fastapi.txt
+++ b/packages/service-library/requirements/_fastapi.txt
@@ -51,7 +51,6 @@ httpx==0.25.0
     #   -c requirements/./../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/./../../../requirements/constraints.txt
     #   -r requirements/_fastapi.in
-    #   respx
 idna==3.4
     # via
     #   anyio
@@ -85,8 +84,6 @@ referencing==0.29.3
     #   -c requirements/././constraints.txt
     #   jsonschema
     #   jsonschema-specifications
-respx==0.20.2
-    # via -r requirements/_fastapi.in
 rich==13.6.0
     # via -r requirements/./../../../packages/settings-library/requirements/_base.in
 rpds-py==0.10.6

--- a/packages/service-library/requirements/_test.in
+++ b/packages/service-library/requirements/_test.in
@@ -17,6 +17,7 @@ coverage
 docker
 faker
 flaky
+respx
 openapi-spec-validator
 pytest
 pytest-aiohttp  # incompatible with pytest-asyncio. See https://github.com/pytest-dev/pytest-asyncio/issues/76
@@ -29,4 +30,3 @@ pytest-runner
 pytest-sugar
 pytest-xdist
 python-dotenv
-respx

--- a/packages/service-library/requirements/_test.in
+++ b/packages/service-library/requirements/_test.in
@@ -29,3 +29,4 @@ pytest-runner
 pytest-sugar
 pytest-xdist
 python-dotenv
+respx

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -15,6 +15,10 @@ aiosignal==1.3.1
     #   -c requirements/_aiohttp.txt
     #   -c requirements/_base.txt
     #   aiohttp
+anyio==4.0.0
+    # via
+    #   -c requirements/_fastapi.txt
+    #   httpcore
 asgi-lifespan==2.1.0
     # via -r requirements/_test.in
 async-timeout==4.0.3
@@ -36,6 +40,8 @@ certifi==2023.7.22
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_aiohttp.txt
     #   -c requirements/_fastapi.txt
+    #   httpcore
+    #   httpx
     #   requests
 charset-normalizer==3.3.2
     # via
@@ -52,6 +58,7 @@ docker==6.1.3
 exceptiongroup==1.1.3
     # via
     #   -c requirements/_fastapi.txt
+    #   anyio
     #   pytest
 execnet==2.0.2
     # via pytest-xdist
@@ -65,11 +72,26 @@ frozenlist==1.4.0
     #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
+h11==0.14.0
+    # via
+    #   -c requirements/_fastapi.txt
+    #   httpcore
+httpcore==0.18.0
+    # via
+    #   -c requirements/_fastapi.txt
+    #   httpx
+httpx==0.25.0
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_fastapi.txt
+    #   respx
 idna==3.4
     # via
     #   -c requirements/_aiohttp.txt
     #   -c requirements/_base.txt
     #   -c requirements/_fastapi.txt
+    #   anyio
+    #   httpx
     #   requests
     #   yarl
 iniconfig==2.0.0
@@ -182,6 +204,8 @@ requests==2.31.0
     #   -c requirements/_aiohttp.txt
     #   docker
     #   jsonschema-spec
+respx==0.20.2
+    # via -r requirements/_test.in
 rfc3339-validator==0.1.4
     # via
     #   -c requirements/_aiohttp.txt
@@ -203,7 +227,10 @@ six==1.16.0
 sniffio==1.3.0
     # via
     #   -c requirements/_fastapi.txt
+    #   anyio
     #   asgi-lifespan
+    #   httpcore
+    #   httpx
 termcolor==2.3.0
     # via pytest-sugar
 tomli==2.0.1

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -11,9 +11,7 @@ aio-pika==9.3.0
 aioboto3==12.0.0
     # via -r requirements/_base.in
 aiobotocore==2.7.0
-    # via
-    #   aioboto3
-    #   aiobotocore
+    # via aioboto3
 aiodebug==2.3.0
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
@@ -155,7 +153,6 @@ httpx==0.25.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   respx
 idna==3.4
     # via
     #   anyio
@@ -297,8 +294,6 @@ referencing==0.29.3
     #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   jsonschema
     #   jsonschema-specifications
-respx==0.20.2
-    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 rich==13.6.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -264,9 +264,7 @@ python-dateutil==2.8.2
 python-dotenv==1.0.0
     # via -r requirements/_test.in
 python-jose==3.3.0
-    # via
-    #   moto
-    #   python-jose
+    # via moto
 pyyaml==6.0.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -297,9 +295,7 @@ requests==2.31.0
 responses==0.24.0
     # via moto
 respx==0.20.2
-    # via
-    #   -c requirements/_base.txt
-    #   -r requirements/_test.in
+    # via -r requirements/_test.in
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rpds-py==0.12.0

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_task.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_task.py
@@ -35,7 +35,7 @@ def on_app_startup(app: FastAPI) -> Callable[[], Awaitable[None]]:
 
 def on_app_shutdown(app: FastAPI) -> Callable[[], Awaitable[None]]:
     async def _stop() -> None:
-        await stop_periodic_task(app.state.clusters_cleaning_task)
+        await stop_periodic_task(app.state.clusters_cleaning_task, timeout=5)
 
     return _stop
 

--- a/services/clusters-keeper/tests/unit/conftest.py
+++ b/services/clusters-keeper/tests/unit/conftest.py
@@ -152,7 +152,7 @@ def enabled_rabbitmq(
 async def initialized_app(app_environment: EnvVarsDict) -> AsyncIterator[FastAPI]:
     settings = ApplicationSettings.create_from_envs()
     app = create_app(settings)
-    async with LifespanManager(app):
+    async with LifespanManager(app, shutdown_timeout=20):
         yield app
 
 

--- a/tests/environment-setup/test_requirements.py
+++ b/tests/environment-setup/test_requirements.py
@@ -12,10 +12,25 @@ SERVICES_DIR = REPO_DIR / "services"
 assert SERVICES_DIR.exists()
 
 
-@pytest.mark.parametrize("exclude", ["pytest", "respx", "aioresponses"])
-@pytest.mark.parametrize("base_path", SERVICES_DIR.rglob("_base.txt"))
+@pytest.mark.parametrize(
+    "exclude",
+    [
+        "aioresponses",
+        "coverage",
+        "flaky",
+        "hypothesis",
+        "pytest",
+        "moto",
+        "respx",
+    ],
+)
+@pytest.mark.parametrize(
+    "base_path",
+    SERVICES_DIR.rglob("_base.txt"),
+    ids=lambda p: f"{p.relative_to(SERVICES_DIR)}",
+)
 def test_libraries_are_not_allowed_in_base_requirements(base_path: Path, exclude: str):
     requirements_text = re.sub(
-        r"(^|\s)(#.*|\n)", "", base_path.read_text(), flags=re.MULTILINE
+        r"(^|\s)(#.*|\n)", "", base_path.read_text().lower(), flags=re.MULTILINE
     )
     assert exclude not in requirements_text

--- a/tests/environment-setup/test_requirements.py
+++ b/tests/environment-setup/test_requirements.py
@@ -1,0 +1,21 @@
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
+REPO_DIR = CURRENT_DIR.parent.parent
+assert any(REPO_DIR.glob(".git"))
+
+SERVICES_DIR = REPO_DIR / "services"
+assert SERVICES_DIR.exists()
+
+
+@pytest.mark.parametrize("exclude", ["pytest", "respx", "aioresponses"])
+@pytest.mark.parametrize("base_path", SERVICES_DIR.rglob("_base.txt"))
+def test_libraries_are_not_allowed_in_base_requirements(base_path: Path, exclude: str):
+    requirements_text = re.sub(
+        r"(^|\s)(#.*|\n)", "", base_path.read_text(), flags=re.MULTILINE
+    )
+    assert exclude not in requirements_text

--- a/tests/environment-setup/test_requirements.py
+++ b/tests/environment-setup/test_requirements.py
@@ -19,7 +19,7 @@ assert SERVICES_DIR.exists()
         "coverage",
         "flaky",
         "hypothesis",
-        "pytest",
+        "pytest",  # NOTE: this includes all pytest plugins since they are named as pytest-*
         "moto",
         "respx",
     ],

--- a/tests/environment-setup/test_used_docker_compose.py
+++ b/tests/environment-setup/test_used_docker_compose.py
@@ -6,9 +6,9 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Iterable
 from itertools import chain
 from pathlib import Path
-from typing import Iterable
 
 import pytest
 import yaml


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

- In PR https://github.com/ITISFoundation/osparc-simcore/pull/4982 I did a mistake by adding a testing library like `respx` in a base listing. This propagated into the cluster-keeper  after https://github.com/ITISFoundation/osparc-simcore/pull/4997
- Adds a tests that detects some test libraries in base requirements listing
- EXTRA: adds patch by @sanderegg that might fix timeout error in cluster-keeper tests.

## Related issue/s

- Fixes requirements modified in https://github.com/ITISFoundation/osparc-simcore/pull/4982
- Fixes problem caused in https://github.com/ITISFoundation/osparc-simcore/pull/4997


## How to test

- adds a test that check for some common test libraries
 
## DevOps 

None