### PR TITLE
🐛Dynamic autoscaling: not scaling beside 1 machine

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -1,8 +1,11 @@
 from dataclasses import dataclass, field
 from typing import Any, TypeAlias
 
-from aws_library.ec2.models import EC2InstanceData
+from aws_library.ec2.models import EC2InstanceData, EC2InstanceType, Resources
 from models_library.generated_models.docker_rest_api import Node
+
+AssignedTasksToInstance: TypeAlias = tuple[EC2InstanceData, list, Resources]
+AssignedTasksToInstanceType: TypeAlias = tuple[EC2InstanceType, list]
 
 
 @dataclass(frozen=True)

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -4,8 +4,18 @@ from typing import Any, TypeAlias
 from aws_library.ec2.models import EC2InstanceData, EC2InstanceType, Resources
 from models_library.generated_models.docker_rest_api import Node
 
-AssignedTasksToInstance: TypeAlias = tuple[EC2InstanceData, list, Resources]
-AssignedTasksToInstanceType: TypeAlias = tuple[EC2InstanceType, list]
+
+@dataclass(frozen=True, kw_only=True)
+class AssignedTasksToInstance:
+    instance: EC2InstanceData
+    available_resources: Resources
+    assigned_tasks: list
+
+
+@dataclass(frozen=True, kw_only=True)
+class AssignedTasksToInstanceType:
+    instance_type: EC2InstanceType
+    assigned_tasks: list
 
 
 @dataclass(frozen=True)

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -285,7 +285,8 @@ async def _find_needed_instances(
         (
             i.ec2_instance,
             [],
-            await auto_scaling_mode.compute_node_used_resources(app, i),
+            i.ec2_instance.resources
+            - await auto_scaling_mode.compute_node_used_resources(app, i),
         )
         for i in cluster.active_nodes
     ]

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -292,6 +292,13 @@ async def _find_needed_instances(
         task_defined_ec2_type = await auto_scaling_mode.get_task_defined_instance(
             app, task
         )
+        _logger.info(
+            "task %s %s",
+            task,
+            f"defines ec2 type as {task_defined_ec2_type}"
+            if task_defined_ec2_type
+            else "does NOT define ec2 type",
+        )
         (
             filtered_active_instance_to_task,
             filtered_pending_instance_to_task,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -392,7 +392,7 @@ async def _find_needed_instances(
         # check if some are already pending
         remaining_pending_instances = [
             instance
-            for instance, assigned_tasks in pending_instances_to_tasks
+            for instance, assigned_tasks, _ in pending_instances_to_tasks
             if not assigned_tasks
         ]
         if len(remaining_pending_instances) < (

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -319,7 +319,7 @@ async def _find_needed_instances(
             drained_instances_to_tasks,
             needed_new_instance_types_for_tasks,
         )
-
+        _logger.info("%s", f"{filtered_active_instance_to_task=}")
         # try to assign the task to one of the active, pending or net created instances
         _logger.debug(
             "Try to assign %s to any active/pending/created instance in the %s",

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -319,7 +319,7 @@ async def _find_needed_instances(
             drained_instances_to_tasks,
             needed_new_instance_types_for_tasks,
         )
-        _logger.info("%s", f"{list(filtered_active_instance_to_task)=}")
+        # _logger.info("%s", f"{list(filtered_active_instance_to_task)=}")
         # try to assign the task to one of the active, pending or net created instances
         _logger.debug(
             "Try to assign %s to any active/pending/created instance in the %s",

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -326,7 +326,6 @@ async def _find_needed_instances(
             f"{task}",
             f"{cluster=}",
         )
-        _logger.warning("%s", f"{filtered_active_instance_to_task}")
         if (
             await auto_scaling_mode.try_assigning_task_to_instances(
                 app,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -319,7 +319,6 @@ async def _find_needed_instances(
             drained_instances_to_tasks,
             needed_new_instance_types_for_tasks,
         )
-        # _logger.info("%s", f"{list(filtered_active_instance_to_task)=}")
         # try to assign the task to one of the active, pending or net created instances
         _logger.debug(
             "Try to assign %s to any active/pending/created instance in the %s",

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -319,7 +319,7 @@ async def _find_needed_instances(
             drained_instances_to_tasks,
             needed_new_instance_types_for_tasks,
         )
-        _logger.info("%s", f"{filtered_active_instance_to_task=}")
+        _logger.info("%s", f"{list(filtered_active_instance_to_task)=}")
         # try to assign the task to one of the active, pending or net created instances
         _logger.debug(
             "Try to assign %s to any active/pending/created instance in the %s",

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -325,6 +325,7 @@ async def _find_needed_instances(
             f"{task}",
             f"{cluster=}",
         )
+        _logger.warning("%s", f"{filtered_active_instance_to_task}")
         if (
             await auto_scaling_mode.try_assigning_task_to_instances(
                 app,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -622,9 +622,13 @@ async def _autoscale_cluster(
 ) -> Cluster:
     # 1. check if we have pending tasks and resolve them by activating some drained nodes
     unrunnable_tasks = await auto_scaling_mode.list_unrunnable_tasks(app)
+    _logger.info("found %s unrunnable tasks", len(unrunnable_tasks))
     # 2. try to activate drained nodes to cover some of the tasks
     still_unrunnable_tasks, cluster = await _activate_drained_nodes(
         app, cluster, unrunnable_tasks, auto_scaling_mode
+    )
+    _logger.info(
+        "still %s unrunnable tasks after node activation", len(still_unrunnable_tasks)
     )
 
     # let's check if there are still pending tasks or if the reserve was used

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_base.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_base.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
 from dataclasses import dataclass
 
 from aws_library.ec2.models import EC2InstanceData, Resources
@@ -52,7 +51,7 @@ class BaseAutoscaling(ABC):  # pragma: no cover
     async def try_assigning_task_to_instances(
         app: FastAPI,
         pending_task,
-        instances_to_tasks: Iterable[AssignedTasksToInstance],
+        instances_to_tasks: list[AssignedTasksToInstance],
         *,
         notify_progress: bool
     ) -> bool:
@@ -62,7 +61,7 @@ class BaseAutoscaling(ABC):  # pragma: no cover
     @abstractmethod
     def try_assigning_task_to_instance_types(
         pending_task,
-        instance_types_to_tasks: Iterable[AssignedTasksToInstanceType],
+        instance_types_to_tasks: list[AssignedTasksToInstanceType],
     ) -> bool:
         ...
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_base.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_base.py
@@ -2,14 +2,18 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from aws_library.ec2.models import EC2InstanceData, EC2InstanceType, Resources
+from aws_library.ec2.models import EC2InstanceData, Resources
 from fastapi import FastAPI
 from models_library.docker import DockerLabelKey
 from models_library.generated_models.docker_rest_api import Node as DockerNode
 from servicelib.logging_utils import LogLevelInt
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
-from ..models import AssociatedInstance
+from ..models import (
+    AssignedTasksToInstance,
+    AssignedTasksToInstanceType,
+    AssociatedInstance,
+)
 
 
 @dataclass
@@ -48,8 +52,7 @@ class BaseAutoscaling(ABC):  # pragma: no cover
     async def try_assigning_task_to_instances(
         app: FastAPI,
         pending_task,
-        instances_to_tasks: Iterable[tuple[EC2InstanceData, list]],
-        type_to_instance_map: dict[str, EC2InstanceType],
+        instances_to_tasks: Iterable[AssignedTasksToInstance],
         *,
         notify_progress: bool
     ) -> bool:
@@ -59,7 +62,7 @@ class BaseAutoscaling(ABC):  # pragma: no cover
     @abstractmethod
     def try_assigning_task_to_instance_types(
         pending_task,
-        instance_types_to_tasks: Iterable[tuple[EC2InstanceType, list]],
+        instance_types_to_tasks: Iterable[AssignedTasksToInstanceType],
     ) -> bool:
         ...
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
@@ -65,7 +65,7 @@ class ComputationalAutoscaling(BaseAutoscaling):
     async def try_assigning_task_to_instances(
         app: FastAPI,
         pending_task,
-        instances_to_tasks: Iterable[AssignedTasksToInstance],
+        instances_to_tasks: list[AssignedTasksToInstance],
         *,
         notify_progress: bool
     ) -> bool:
@@ -79,7 +79,7 @@ class ComputationalAutoscaling(BaseAutoscaling):
     @staticmethod
     def try_assigning_task_to_instance_types(
         pending_task,
-        instance_types_to_tasks: Iterable[tuple[EC2InstanceType, list]],
+        instance_types_to_tasks: list[tuple[EC2InstanceType, list]],
     ) -> bool:
         return utils.try_assigning_task_to_instance_types(
             pending_task, instance_types_to_tasks

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
@@ -2,7 +2,7 @@ import collections
 import logging
 from collections.abc import Iterable
 
-from aws_library.ec2.models import EC2InstanceData, EC2InstanceType, Resources
+from aws_library.ec2.models import EC2InstanceData, Resources
 from fastapi import FastAPI
 from models_library.docker import (
     DOCKER_TASK_EC2_INSTANCE_TYPE_PLACEMENT_CONSTRAINT_KEY,
@@ -15,7 +15,12 @@ from servicelib.utils import logged_gather
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
 from ..core.settings import get_application_settings
-from ..models import AssignedTasksToInstance, AssociatedInstance, DaskTask
+from ..models import (
+    AssignedTasksToInstance,
+    AssignedTasksToInstanceType,
+    AssociatedInstance,
+    DaskTask,
+)
 from ..utils import computational_scaling as utils
 from ..utils import utils_docker, utils_ec2
 from . import dask
@@ -79,7 +84,7 @@ class ComputationalAutoscaling(BaseAutoscaling):
     @staticmethod
     def try_assigning_task_to_instance_types(
         pending_task,
-        instance_types_to_tasks: list[tuple[EC2InstanceType, list]],
+        instance_types_to_tasks: list[AssignedTasksToInstanceType],
     ) -> bool:
         return utils.try_assigning_task_to_instance_types(
             pending_task, instance_types_to_tasks

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
@@ -15,7 +15,7 @@ from servicelib.utils import logged_gather
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
 from ..core.settings import get_application_settings
-from ..models import AssociatedInstance, DaskTask
+from ..models import AssignedTasksToInstance, AssociatedInstance, DaskTask
 from ..utils import computational_scaling as utils
 from ..utils import utils_docker, utils_ec2
 from . import dask
@@ -65,12 +65,10 @@ class ComputationalAutoscaling(BaseAutoscaling):
     async def try_assigning_task_to_instances(
         app: FastAPI,
         pending_task,
-        instances_to_tasks: Iterable[tuple[EC2InstanceData, list]],
-        type_to_instance_map: dict[str, EC2InstanceType],
+        instances_to_tasks: Iterable[AssignedTasksToInstance],
         *,
         notify_progress: bool
     ) -> bool:
-        assert type_to_instance_map  # nosec
         return await utils.try_assigning_task_to_instances(
             app,
             pending_task,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_dynamic.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_dynamic.py
@@ -61,7 +61,7 @@ class DynamicAutoscaling(BaseAutoscaling):
     async def try_assigning_task_to_instances(
         app: FastAPI,
         pending_task,
-        instances_to_tasks: Iterable[AssignedTasksToInstance],
+        instances_to_tasks: list[AssignedTasksToInstance],
         *,
         notify_progress: bool
     ) -> bool:
@@ -75,7 +75,7 @@ class DynamicAutoscaling(BaseAutoscaling):
     @staticmethod
     def try_assigning_task_to_instance_types(
         pending_task,
-        instance_types_to_tasks: Iterable[AssignedTasksToInstanceType],
+        instance_types_to_tasks: list[AssignedTasksToInstanceType],
     ) -> bool:
         return utils.try_assigning_task_to_instance_types(
             pending_task, instance_types_to_tasks

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_dynamic.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_dynamic.py
@@ -62,7 +62,7 @@ class DynamicAutoscaling(BaseAutoscaling):
         *,
         notify_progress: bool
     ) -> bool:
-        return await utils.try_assigning_task_to_pending_instances(
+        return await utils.try_assigning_task_to_instances(
             app,
             pending_task,
             instances_to_tasks,
@@ -75,7 +75,7 @@ class DynamicAutoscaling(BaseAutoscaling):
         pending_task,
         instance_types_to_tasks: Iterable[tuple[EC2InstanceType, list]],
     ) -> bool:
-        return utils.try_assigning_task_to_instances(
+        return utils.try_assigning_task_to_instance_types(
             pending_task, instance_types_to_tasks
         )
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_dynamic.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_dynamic.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 
-from aws_library.ec2.models import EC2InstanceData, EC2InstanceType, Resources
+from aws_library.ec2.models import EC2InstanceData, Resources
 from fastapi import FastAPI
 from models_library.docker import DockerLabelKey
 from models_library.generated_models.docker_rest_api import Node, Task
@@ -8,7 +8,11 @@ from servicelib.logging_utils import LogLevelInt
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
 from ..core.settings import get_application_settings
-from ..models import AssociatedInstance
+from ..models import (
+    AssignedTasksToInstance,
+    AssignedTasksToInstanceType,
+    AssociatedInstance,
+)
 from ..utils import dynamic_scaling as utils
 from ..utils import utils_docker, utils_ec2
 from ..utils.rabbitmq import log_tasks_message, progress_tasks_message
@@ -57,8 +61,7 @@ class DynamicAutoscaling(BaseAutoscaling):
     async def try_assigning_task_to_instances(
         app: FastAPI,
         pending_task,
-        instances_to_tasks: Iterable[tuple[EC2InstanceData, list]],
-        type_to_instance_map: dict[str, EC2InstanceType],
+        instances_to_tasks: Iterable[AssignedTasksToInstance],
         *,
         notify_progress: bool
     ) -> bool:
@@ -66,14 +69,13 @@ class DynamicAutoscaling(BaseAutoscaling):
             app,
             pending_task,
             instances_to_tasks,
-            type_to_instance_map,
             notify_progress=notify_progress,
         )
 
     @staticmethod
     def try_assigning_task_to_instance_types(
         pending_task,
-        instance_types_to_tasks: Iterable[tuple[EC2InstanceType, list]],
+        instance_types_to_tasks: Iterable[AssignedTasksToInstanceType],
     ) -> bool:
         return utils.try_assigning_task_to_instance_types(
             pending_task, instance_types_to_tasks

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 import re
-from typing import Final, Iterable
+from typing import Final
 
 from aws_library.ec2.models import EC2InstanceData, EC2InstanceType, Resources
 from models_library.generated_models.docker_rest_api import Node
@@ -112,57 +112,65 @@ def _instance_type_by_type_name(
 
 
 def _instance_type_map_by_type_name(
-    mapping: tuple[EC2InstanceType, list], *, type_name: InstanceTypeType | None
+    mapping: AssignedTasksToInstanceType, *, type_name: InstanceTypeType | None
 ) -> bool:
     ec2_type, _ = mapping
     return _instance_type_by_type_name(ec2_type, type_name=type_name)
 
 
 def _instance_data_map_by_type_name(
-    mapping: tuple[EC2InstanceData, list], *, type_name: InstanceTypeType | None
+    mapping: AssignedTasksToInstance, *, type_name: InstanceTypeType | None
 ) -> bool:
     if type_name is None:
         return True
-    ec2_data, _ = mapping
+    ec2_data, *_ = mapping
     return bool(ec2_data.type == type_name)
 
 
 def filter_by_task_defined_instance(
     instance_type_name: InstanceTypeType | None,
-    active_instances_to_tasks: Iterable[AssignedTasksToInstance],
-    pending_instances_to_tasks: Iterable[AssignedTasksToInstance],
-    drained_instances_to_tasks: Iterable[AssignedTasksToInstance],
-    needed_new_instance_types_for_tasks: Iterable[AssignedTasksToInstanceType],
+    active_instances_to_tasks: list[AssignedTasksToInstance],
+    pending_instances_to_tasks: list[AssignedTasksToInstance],
+    drained_instances_to_tasks: list[AssignedTasksToInstance],
+    needed_new_instance_types_for_tasks: list[AssignedTasksToInstanceType],
 ) -> tuple[
-    Iterable[AssignedTasksToInstance],
-    Iterable[AssignedTasksToInstance],
-    Iterable[AssignedTasksToInstance],
-    Iterable[AssignedTasksToInstanceType],
+    list[AssignedTasksToInstance],
+    list[AssignedTasksToInstance],
+    list[AssignedTasksToInstance],
+    list[AssignedTasksToInstanceType],
 ]:
     return (
-        filter(
-            functools.partial(
-                _instance_data_map_by_type_name, type_name=instance_type_name
-            ),
-            active_instances_to_tasks,
+        list(
+            filter(
+                functools.partial(
+                    _instance_data_map_by_type_name, type_name=instance_type_name
+                ),
+                active_instances_to_tasks,
+            )
         ),
-        filter(
-            functools.partial(
-                _instance_data_map_by_type_name, type_name=instance_type_name
-            ),
-            pending_instances_to_tasks,
+        list(
+            filter(
+                functools.partial(
+                    _instance_data_map_by_type_name, type_name=instance_type_name
+                ),
+                pending_instances_to_tasks,
+            )
         ),
-        filter(
-            functools.partial(
-                _instance_data_map_by_type_name, type_name=instance_type_name
-            ),
-            drained_instances_to_tasks,
+        list(
+            filter(
+                functools.partial(
+                    _instance_data_map_by_type_name, type_name=instance_type_name
+                ),
+                drained_instances_to_tasks,
+            )
         ),
-        filter(
-            functools.partial(
-                _instance_type_map_by_type_name, type_name=instance_type_name
-            ),
-            needed_new_instance_types_for_tasks,
+        list(
+            filter(
+                functools.partial(
+                    _instance_type_map_by_type_name, type_name=instance_type_name
+                ),
+                needed_new_instance_types_for_tasks,
+            )
         ),
     )
 

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
@@ -114,8 +114,7 @@ def _instance_type_by_type_name(
 def _instance_type_map_by_type_name(
     mapping: AssignedTasksToInstanceType, *, type_name: InstanceTypeType | None
 ) -> bool:
-    ec2_type, _ = mapping
-    return _instance_type_by_type_name(ec2_type, type_name=type_name)
+    return _instance_type_by_type_name(mapping.instance_type, type_name=type_name)
 
 
 def _instance_data_map_by_type_name(
@@ -123,8 +122,7 @@ def _instance_data_map_by_type_name(
 ) -> bool:
     if type_name is None:
         return True
-    ec2_data, *_ = mapping
-    return bool(ec2_data.type == type_name)
+    return bool(mapping.instance.type == type_name)
 
 
 def filter_by_task_defined_instance(

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 import re
-from typing import Final
+from typing import Final, Iterable
 
 from aws_library.ec2.models import EC2InstanceData, EC2InstanceType, Resources
 from models_library.generated_models.docker_rest_api import Node
@@ -9,7 +9,11 @@ from types_aiobotocore_ec2.literals import InstanceTypeType
 
 from ..core.errors import Ec2InstanceInvalidError, Ec2InvalidDnsNameError
 from ..core.settings import ApplicationSettings
-from ..models import AssociatedInstance
+from ..models import (
+    AssignedTasksToInstance,
+    AssignedTasksToInstanceType,
+    AssociatedInstance,
+)
 from ..modules.auto_scaling_mode_base import BaseAutoscaling
 from . import utils_docker
 
@@ -125,11 +129,16 @@ def _instance_data_map_by_type_name(
 
 def filter_by_task_defined_instance(
     instance_type_name: InstanceTypeType | None,
-    active_instances_to_tasks,
-    pending_instances_to_tasks,
-    drained_instances_to_tasks,
-    needed_new_instance_types_for_tasks,
-) -> tuple:
+    active_instances_to_tasks: Iterable[AssignedTasksToInstance],
+    pending_instances_to_tasks: Iterable[AssignedTasksToInstance],
+    drained_instances_to_tasks: Iterable[AssignedTasksToInstance],
+    needed_new_instance_types_for_tasks: Iterable[AssignedTasksToInstanceType],
+) -> tuple[
+    Iterable[AssignedTasksToInstance],
+    Iterable[AssignedTasksToInstance],
+    Iterable[AssignedTasksToInstance],
+    Iterable[AssignedTasksToInstanceType],
+]:
     return (
         filter(
             functools.partial(

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/computational_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/computational_scaling.py
@@ -1,16 +1,21 @@
 import datetime
 import logging
 from collections.abc import Iterable
-from typing import Final, TypeAlias
+from typing import Final
 
-from aws_library.ec2.models import EC2InstanceData, EC2InstanceType, Resources
+from aws_library.ec2.models import Resources
 from dask_task_models_library.constants import DASK_TASK_EC2_RESOURCE_RESTRICTION_KEY
 from fastapi import FastAPI
 from servicelib.utils_formatting import timedelta_as_minute_second
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
 from ..core.settings import get_application_settings
-from ..models import AssociatedInstance, DaskTask
+from ..models import (
+    AssignedTasksToInstance,
+    AssignedTasksToInstanceType,
+    AssociatedInstance,
+    DaskTask,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -51,15 +56,10 @@ def try_assigning_task_to_node(
     return False
 
 
-AssignedDaskTasksToInstance: TypeAlias = tuple[
-    EC2InstanceData, list[DaskTask], Resources
-]
-
-
 async def try_assigning_task_to_instances(
     app: FastAPI,
     pending_task: DaskTask,
-    instances_to_tasks: list[AssignedDaskTasksToInstance],
+    instances_to_tasks: list[AssignedTasksToInstance],
     *,
     notify_progress: bool,
 ) -> bool:
@@ -68,23 +68,23 @@ async def try_assigning_task_to_instances(
     instance_max_time_to_start = (
         app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MAX_START_TIME
     )
-    for (
-        instance,
-        instance_assigned_tasks,
-        instance_available_resources,
-    ) in instances_to_tasks:
+    for assigned_tasks_to_instance in instances_to_tasks:
         tasks_needed_resources = _compute_tasks_needed_resources(
-            instance_assigned_tasks
+            assigned_tasks_to_instance.assigned_tasks
         )
         if (
-            instance_available_resources - tasks_needed_resources
+            assigned_tasks_to_instance.available_resources - tasks_needed_resources
         ) >= get_max_resources_from_dask_task(pending_task):
-            instance_assigned_tasks.append(pending_task)
+            assigned_tasks_to_instance.assigned_tasks.append(pending_task)
             if notify_progress:
                 now = datetime.datetime.now(datetime.timezone.utc)
-                time_since_launch = now - instance.launch_time
+                time_since_launch = (
+                    now - assigned_tasks_to_instance.instance.launch_time
+                )
                 estimated_time_to_completion = (
-                    instance.launch_time + instance_max_time_to_start - now
+                    assigned_tasks_to_instance.instance.launch_time
+                    + instance_max_time_to_start
+                    - now
                 )
                 _logger.info(
                     "LOG: %s",
@@ -102,16 +102,19 @@ async def try_assigning_task_to_instances(
 
 def try_assigning_task_to_instance_types(
     pending_task: DaskTask,
-    instance_types_to_tasks: list[tuple[EC2InstanceType, list[DaskTask]]],
+    instance_types_to_tasks: list[AssignedTasksToInstanceType],
 ) -> bool:
-    for instance, instance_assigned_tasks in instance_types_to_tasks:
-        instance_total_resource = Resources(cpus=instance.cpus, ram=instance.ram)
+    for assigned_tasks_to_instance_type in instance_types_to_tasks:
+        instance_total_resource = Resources(
+            cpus=assigned_tasks_to_instance_type.instance_type.cpus,
+            ram=assigned_tasks_to_instance_type.instance_type.ram,
+        )
         tasks_needed_resources = _compute_tasks_needed_resources(
-            instance_assigned_tasks
+            assigned_tasks_to_instance_type.assigned_tasks
         )
         if (
             instance_total_resource - tasks_needed_resources
         ) >= get_max_resources_from_dask_task(pending_task):
-            instance_assigned_tasks.append(pending_task)
+            assigned_tasks_to_instance_type.assigned_tasks.append(pending_task)
             return True
     return False

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/computational_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/computational_scaling.py
@@ -59,7 +59,7 @@ AssignedDaskTasksToInstance: TypeAlias = tuple[
 async def try_assigning_task_to_instances(
     app: FastAPI,
     pending_task: DaskTask,
-    instances_to_tasks: Iterable[AssignedDaskTasksToInstance],
+    instances_to_tasks: list[AssignedDaskTasksToInstance],
     *,
     notify_progress: bool,
 ) -> bool:
@@ -102,7 +102,7 @@ async def try_assigning_task_to_instances(
 
 def try_assigning_task_to_instance_types(
     pending_task: DaskTask,
-    instance_types_to_tasks: Iterable[tuple[EC2InstanceType, list[DaskTask]]],
+    instance_types_to_tasks: list[tuple[EC2InstanceType, list[DaskTask]]],
 ) -> bool:
     for instance, instance_assigned_tasks in instance_types_to_tasks:
         instance_total_resource = Resources(cpus=instance.cpus, ram=instance.ram)

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -35,7 +35,7 @@ def try_assigning_task_to_node(
 
 def try_assigning_task_to_instance_types(
     pending_task: Task,
-    instance_types_to_tasks: Iterable[tuple[EC2InstanceType, list[Task]]],
+    instance_types_to_tasks: list[tuple[EC2InstanceType, list[Task]]],
 ) -> bool:
     for instance, instance_assigned_tasks in instance_types_to_tasks:
         instance_total_resource = Resources(cpus=instance.cpus, ram=instance.ram)
@@ -56,7 +56,7 @@ AssignedDockerTasksToInstance: TypeAlias = tuple[EC2InstanceData, list[Task], Re
 async def try_assigning_task_to_instances(
     app: FastAPI,
     pending_task: Task,
-    instances_to_tasks: Iterable[AssignedDockerTasksToInstance],
+    instances_to_tasks: list[AssignedDockerTasksToInstance],
     *,
     notify_progress: bool,
 ) -> bool:

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -32,7 +32,7 @@ def try_assigning_task_to_node(
     return False
 
 
-def try_assigning_task_to_instances(
+def try_assigning_task_to_instance_types(
     pending_task: Task,
     instance_types_to_tasks: Iterable[tuple[EC2InstanceType, list[Task]]],
 ) -> bool:
@@ -49,7 +49,7 @@ def try_assigning_task_to_instances(
     return False
 
 
-async def try_assigning_task_to_pending_instances(
+async def try_assigning_task_to_instances(
     app: FastAPI,
     pending_task: Task,
     instances_to_tasks: Iterable[tuple[EC2InstanceData, list[Task]]],

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -1,15 +1,18 @@
 import datetime
 import logging
 from collections.abc import Iterable
-from typing import TypeAlias
 
-from aws_library.ec2.models import EC2InstanceData, EC2InstanceType, Resources
+from aws_library.ec2.models import Resources
 from fastapi import FastAPI
 from models_library.generated_models.docker_rest_api import Task
 from servicelib.utils_formatting import timedelta_as_minute_second
 
 from ..core.settings import get_application_settings
-from ..models import AssociatedInstance
+from ..models import (
+    AssignedTasksToInstance,
+    AssignedTasksToInstanceType,
+    AssociatedInstance,
+)
 from . import utils_docker
 from .rabbitmq import log_tasks_message, progress_tasks_message
 
@@ -35,28 +38,28 @@ def try_assigning_task_to_node(
 
 def try_assigning_task_to_instance_types(
     pending_task: Task,
-    instance_types_to_tasks: list[tuple[EC2InstanceType, list[Task]]],
+    instance_types_to_tasks: list[AssignedTasksToInstanceType],
 ) -> bool:
-    for instance, instance_assigned_tasks in instance_types_to_tasks:
-        instance_total_resource = Resources(cpus=instance.cpus, ram=instance.ram)
+    for assigned_tasks_to_instance_type in instance_types_to_tasks:
+        instance_total_resource = Resources(
+            cpus=assigned_tasks_to_instance_type.instance_type.cpus,
+            ram=assigned_tasks_to_instance_type.instance_type.ram,
+        )
         tasks_needed_resources = utils_docker.compute_tasks_needed_resources(
-            instance_assigned_tasks
+            assigned_tasks_to_instance_type.assigned_tasks
         )
         if (
             instance_total_resource - tasks_needed_resources
         ) >= utils_docker.get_max_resources_from_docker_task(pending_task):
-            instance_assigned_tasks.append(pending_task)
+            assigned_tasks_to_instance_type.assigned_tasks.append(pending_task)
             return True
     return False
-
-
-AssignedDockerTasksToInstance: TypeAlias = tuple[EC2InstanceData, list[Task], Resources]
 
 
 async def try_assigning_task_to_instances(
     app: FastAPI,
     pending_task: Task,
-    instances_to_tasks: list[AssignedDockerTasksToInstance],
+    instances_to_tasks: list[AssignedTasksToInstance],
     *,
     notify_progress: bool,
 ) -> bool:
@@ -65,23 +68,23 @@ async def try_assigning_task_to_instances(
     instance_max_time_to_start = (
         app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MAX_START_TIME
     )
-    for (
-        instance,
-        instance_assigned_tasks,
-        instance_available_resources,
-    ) in instances_to_tasks:
+    for assigned_tasks_to_instance in instances_to_tasks:
         tasks_needed_resources = utils_docker.compute_tasks_needed_resources(
-            instance_assigned_tasks
+            assigned_tasks_to_instance.assigned_tasks
         )
         if (
-            instance_available_resources - tasks_needed_resources
+            assigned_tasks_to_instance.available_resources - tasks_needed_resources
         ) >= utils_docker.get_max_resources_from_docker_task(pending_task):
-            instance_assigned_tasks.append(pending_task)
+            assigned_tasks_to_instance.assigned_tasks.append(pending_task)
             if notify_progress:
                 now = datetime.datetime.now(datetime.timezone.utc)
-                time_since_launch = now - instance.launch_time
+                time_since_launch = (
+                    now - assigned_tasks_to_instance.instance.launch_time
+                )
                 estimated_time_to_completion = (
-                    instance.launch_time + instance_max_time_to_start - now
+                    assigned_tasks_to_instance.instance.launch_time
+                    + instance_max_time_to_start
+                    - now
                 )
 
                 await log_tasks_message(

--- a/services/autoscaling/tests/manual/.env-devel
+++ b/services/autoscaling/tests/manual/.env-devel
@@ -10,6 +10,11 @@ EC2_INSTANCES_SUBNET_ID=XXXXXXXXXX
 EC2_SECRET_ACCESS_KEY=XXXXXXXXXX
 EC2_INSTANCES_NAME_PREFIX=testing-osparc-computational-cluster
 LOG_FORMAT_LOCAL_DEV_ENABLED=True
+# define the following to activate dynamic autoscaling
+# NODES_MONITORING_NEW_NODES_LABELS="[\"testing.autoscaled-node\"]"
+# NODES_MONITORING_NODE_LABELS="[\"testing.monitored-node\"]"
+# NODES_MONITORING_SERVICE_LABELS="[\"testing.monitored-service\"]"
+
 # may be activated or not
 # RABBIT_HOST=rabbit
 # RABBIT_PASSWORD=test

--- a/services/autoscaling/tests/manual/Makefile
+++ b/services/autoscaling/tests/manual/Makefile
@@ -18,10 +18,14 @@ include ../../../../scripts/common-service.Makefile
 
 up-devel: .init-swarm .stack-devel.yml ## starts local test application
 	@docker stack deploy --with-registry-auth --compose-file=.stack-devel.yml autoscaling
+	# to follow logs of autoscaling, run
+	# docker service logs --follow autoscaling_autoscaling
 
 up-computational-devel: .init-swarm .stack-computational-devel.yml ## starts local test application in computational mode
 	# DASK_MONITORING_URL set to $(DASK_MONITORING_URL)
 	@docker stack deploy --with-registry-auth --compose-file=.stack-computational-devel.yml comp-autoscaling
+	# to follow logs of autoscaling, run
+	# docker service logs --follow comp-autoscaling_autoscaling
 
 down: .env ## stops local test app dependencies (running bare metal against AWS)
 	# remove stacks

--- a/services/autoscaling/tests/manual/README.md
+++ b/services/autoscaling/tests/manual/README.md
@@ -5,14 +5,16 @@ The autoscaling service may be started either in computational mode or in dynami
 The computational mode is used in conjunction with a dask-scheduler/dask-worker subsystem.
 The dynamic mode is used directly with docker swarm facilities.
 
-## computational mode
-
-When ```DASK_MONITORING_URL``` is set the computational mode is enabled.
-
 ### requirements
 
 1. AWS EC2 access
 2. a machine running in EC2 with docker installed and access to osparc-simcore repository
+
+
+## computational mode
+
+When ```DASK_MONITORING_URL``` is set the computational mode is enabled.
+
 
 ### instructions
 
@@ -66,4 +68,41 @@ future.done() # shall return True once done
 
 # remove the future from the dask-scheduler memory, shall trigger the autoscaling service to remove the created machine
 del future
+```
+
+
+## dynamic mode
+
+When ```NODES_MONITORING_NEW_NODES_LABELS```, ```NODES_MONITORING_NODE_LABELS``` and ```NODES_MONITORING_SERVICE_LABELS``` are set the dynamic mode is enabled.
+
+### instructions
+
+1. prepare autoscaling
+
+```bash
+# run on EC2 instance
+git clone https://github.com/ITISFoundation/osparc-simcore.git
+cd osparc-simcore/services/autoscaling
+make build-devel # this will build the autoscaling devel image
+```
+
+2. setup environment variables
+```bash
+# run on EC2 instance
+cd osparc-simcore/services/autoscaling/tests/manual
+make .env # generate an initial .env file
+nano .env # edit .env and set the variables as needed
+```
+
+3. start autoscaling stack
+```bash
+# run on EC2 instance
+cd osparc-simcore/services/autoscaling/tests/manual
+make up-devel # this will deploy the autoscaling stack
+```
+
+4. start some docker services to trigger autoscaling
+```bash
+# run on EC2 instance
+docker service create --reserve-cpu=4 --reserve-memory=1GiB --constraint=node.label==testing.monitored-node --label=testing.monitored-service redis # will create a redis service reserving 4 CPUs and 1GiB of RAM
 ```

--- a/services/autoscaling/tests/manual/README.md
+++ b/services/autoscaling/tests/manual/README.md
@@ -104,5 +104,5 @@ make up-devel # this will deploy the autoscaling stack
 4. start some docker services to trigger autoscaling
 ```bash
 # run on EC2 instance
-docker service create --reserve-cpu=4 --reserve-memory=1GiB --constraint=node.label==testing.monitored-node --label=testing.monitored-service redis # will create a redis service reserving 4 CPUs and 1GiB of RAM
+docker service create --name=test-service --reserve-cpu=4 --reserve-memory=1GiB --constraint=node.labels.testing.monitored-node==true --label=testing.monitored-service=true redis # will create a redis service reserving 4 CPUs and 1GiB of RAM
 ```

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -597,7 +597,7 @@ async def create_dask_task(
 
 
 @pytest.fixture
-def mock_set_node_availability(mocker: MockerFixture) -> mock.Mock:
+def mock_docker_set_node_availability(mocker: MockerFixture) -> mock.Mock:
     async def _fake_set_node_availability(
         docker_client: AutoscalingDocker, node: Node, *, available: bool
     ) -> Node:

--- a/services/autoscaling/tests/unit/test_utils_computational_scaling.py
+++ b/services/autoscaling/tests/unit/test_utils_computational_scaling.py
@@ -14,6 +14,8 @@ from models_library.generated_models.docker_rest_api import Node as DockerNode
 from pydantic import ByteSize, parse_obj_as
 from pytest_mock import MockerFixture
 from simcore_service_autoscaling.models import (
+    AssignedTasksToInstance,
+    AssignedTasksToInstanceType,
     AssociatedInstance,
     DaskTask,
     DaskTaskResources,
@@ -22,7 +24,6 @@ from simcore_service_autoscaling.models import (
 from simcore_service_autoscaling.utils.computational_scaling import (
     _DEFAULT_MAX_CPU,
     _DEFAULT_MAX_RAM,
-    AssignedDaskTasksToInstance,
     get_max_resources_from_dask_task,
     try_assigning_task_to_instance_types,
     try_assigning_task_to_instances,
@@ -152,8 +153,12 @@ async def test_try_assigning_task_to_instances(
 ):
     task = fake_task(required_resources={"CPU": 2})
     ec2_instance = fake_ec2_instance_data()
-    pending_instance_to_tasks: list[AssignedDaskTasksToInstance] = [
-        (ec2_instance, [], Resources(cpus=4, ram=ByteSize(1024**2)))
+    pending_instance_to_tasks: list[AssignedTasksToInstance] = [
+        AssignedTasksToInstance(
+            instance=ec2_instance,
+            assigned_tasks=[],
+            available_resources=Resources(cpus=4, ram=ByteSize(1024**2)),
+        )
     ]
 
     # calling once should allow to add that task to the instance
@@ -166,7 +171,7 @@ async def test_try_assigning_task_to_instances(
         )
         is True
     )
-    assert pending_instance_to_tasks[0][1] == [task]
+    assert pending_instance_to_tasks[0].assigned_tasks == [task]
     # calling a second time as well should allow to add that task to the instance
     assert (
         await try_assigning_task_to_instances(
@@ -177,7 +182,7 @@ async def test_try_assigning_task_to_instances(
         )
         is True
     )
-    assert pending_instance_to_tasks[0][1] == [task, task]
+    assert pending_instance_to_tasks[0].assigned_tasks == [task, task]
     # calling a third time should fail
     assert (
         await try_assigning_task_to_instances(
@@ -188,7 +193,7 @@ async def test_try_assigning_task_to_instances(
         )
         is False
     )
-    assert pending_instance_to_tasks[0][1] == [task, task]
+    assert pending_instance_to_tasks[0].assigned_tasks == [task, task]
 
 
 def test_try_assigning_task_to_instance_types_with_empty_types(
@@ -206,16 +211,16 @@ def test_try_assigning_task_to_instance_types(
     fake_instance_type = EC2InstanceType(
         name=faker.name(), cpus=6, ram=parse_obj_as(ByteSize, "2GiB")
     )
-    instance_type_to_tasks: list[tuple[EC2InstanceType, list[DaskTask]]] = [
-        (fake_instance_type, [])
+    instance_type_to_tasks: list[AssignedTasksToInstanceType] = [
+        AssignedTasksToInstanceType(instance_type=fake_instance_type, assigned_tasks=[])
     ]
     # now this should work 3 times
     assert try_assigning_task_to_instance_types(task, instance_type_to_tasks) is True
-    assert instance_type_to_tasks[0][1] == [task]
+    assert instance_type_to_tasks[0].assigned_tasks == [task]
     assert try_assigning_task_to_instance_types(task, instance_type_to_tasks) is True
-    assert instance_type_to_tasks[0][1] == [task, task]
+    assert instance_type_to_tasks[0].assigned_tasks == [task, task]
     assert try_assigning_task_to_instance_types(task, instance_type_to_tasks) is True
-    assert instance_type_to_tasks[0][1] == [task, task, task]
+    assert instance_type_to_tasks[0].assigned_tasks == [task, task, task]
     # now it should fail
     assert try_assigning_task_to_instance_types(task, instance_type_to_tasks) is False
-    assert instance_type_to_tasks[0][1] == [task, task, task]
+    assert instance_type_to_tasks[0].assigned_tasks == [task, task, task]

--- a/services/autoscaling/tests/unit/test_utils_computational_scaling.py
+++ b/services/autoscaling/tests/unit/test_utils_computational_scaling.py
@@ -22,6 +22,7 @@ from simcore_service_autoscaling.models import (
 from simcore_service_autoscaling.utils.computational_scaling import (
     _DEFAULT_MAX_CPU,
     _DEFAULT_MAX_RAM,
+    AssignedDaskTasksToInstance,
     get_max_resources_from_dask_task,
     try_assigning_task_to_instance_types,
     try_assigning_task_to_instances,
@@ -133,7 +134,7 @@ async def test_try_assigning_task_to_node(
     assert instance_to_tasks[0][1] == [task, task]
 
 
-async def test_try_assigning_task_to_pending_instances_with_no_instances(
+async def test_try_assigning_task_to_instances_with_no_instances(
     fake_app: mock.Mock,
     fake_task: Callable[..., DaskTask],
 ):
@@ -144,15 +145,15 @@ async def test_try_assigning_task_to_pending_instances_with_no_instances(
     )
 
 
-async def test_try_assigning_task_to_pending_instances(
+async def test_try_assigning_task_to_instances(
     fake_app: mock.Mock,
     fake_task: Callable[..., DaskTask],
     fake_ec2_instance_data: Callable[..., EC2InstanceData],
 ):
     task = fake_task(required_resources={"CPU": 2})
     ec2_instance = fake_ec2_instance_data()
-    pending_instance_to_tasks: list[tuple[EC2InstanceData, list[DaskTask]]] = [
-        (ec2_instance, [])
+    pending_instance_to_tasks: list[AssignedDaskTasksToInstance] = [
+        (ec2_instance, [], Resources(cpus=4, ram=ByteSize(1024**2)))
     ]
 
     # calling once should allow to add that task to the instance

--- a/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
+++ b/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
@@ -13,8 +13,8 @@ from faker import Faker
 from models_library.generated_models.docker_rest_api import Task
 from pydantic import ByteSize
 from pytest_mock import MockerFixture
+from simcore_service_autoscaling.models import AssignedTasksToInstance
 from simcore_service_autoscaling.utils.dynamic_scaling import (
-    AssignedDockerTasksToInstance,
     try_assigning_task_to_instances,
 )
 
@@ -56,8 +56,12 @@ async def test_try_assigning_task_to_instances(
         Spec={"Resources": {"Reservations": {"NanoCPUs": 2 * 1e9}}}
     )
     fake_instance = fake_ec2_instance_data()
-    pending_instance_to_tasks: list[AssignedDockerTasksToInstance] = [
-        (fake_instance, [], Resources(cpus=4, ram=ByteSize(1024**3)))
+    pending_instance_to_tasks: list[AssignedTasksToInstance] = [
+        AssignedTasksToInstance(
+            instance=fake_instance,
+            assigned_tasks=[],
+            available_resources=Resources(cpus=4, ram=ByteSize(1024**3)),
+        )
     ]
 
     # calling once should allow to add that task to the instance

--- a/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
+++ b/services/autoscaling/tests/unit/test_utils_dynamic_scaling.py
@@ -8,13 +8,14 @@ from collections.abc import Callable
 from datetime import timedelta
 
 import pytest
-from aws_library.ec2.models import EC2InstanceData, EC2InstanceType
+from aws_library.ec2.models import EC2InstanceData, Resources
 from faker import Faker
 from models_library.generated_models.docker_rest_api import Task
 from pydantic import ByteSize
 from pytest_mock import MockerFixture
 from simcore_service_autoscaling.utils.dynamic_scaling import (
-    try_assigning_task_to_pending_instances,
+    AssignedDockerTasksToInstance,
+    try_assigning_task_to_instances,
 )
 
 
@@ -28,22 +29,21 @@ def fake_task(faker: Faker) -> Callable[..., Task]:
     return _creator
 
 
-async def test_try_assigning_task_to_pending_instances_with_no_instances(
+async def test_try_assigning_task_to_instances_with_no_instances(
     mocker: MockerFixture,
     fake_task: Callable[..., Task],
-    fake_ec2_instance_data: Callable[..., EC2InstanceData],
 ):
     fake_app = mocker.Mock()
     pending_task = fake_task()
     assert (
-        await try_assigning_task_to_pending_instances(
-            fake_app, pending_task, [], {}, notify_progress=True
+        await try_assigning_task_to_instances(
+            fake_app, pending_task, [], notify_progress=True
         )
         is False
     )
 
 
-async def test_try_assigning_task_to_pending_instances(
+async def test_try_assigning_task_to_instances(
     mocker: MockerFixture,
     fake_task: Callable[..., Task],
     fake_ec2_instance_data: Callable[..., EC2InstanceData],
@@ -56,43 +56,36 @@ async def test_try_assigning_task_to_pending_instances(
         Spec={"Resources": {"Reservations": {"NanoCPUs": 2 * 1e9}}}
     )
     fake_instance = fake_ec2_instance_data()
-    pending_instance_to_tasks: list[tuple[EC2InstanceData, list[Task]]] = [
-        (fake_instance, [])
+    pending_instance_to_tasks: list[AssignedDockerTasksToInstance] = [
+        (fake_instance, [], Resources(cpus=4, ram=ByteSize(1024**3)))
     ]
-    type_to_instance_map = {
-        fake_instance.type: EC2InstanceType(
-            name=fake_instance.type, cpus=4, ram=ByteSize(1024 * 1024)
-        )
-    }
+
     # calling once should allow to add that task to the instance
     assert (
-        await try_assigning_task_to_pending_instances(
+        await try_assigning_task_to_instances(
             fake_app,
             pending_task,
             pending_instance_to_tasks,
-            type_to_instance_map,
             notify_progress=True,
         )
         is True
     )
     # calling a second time as well should allow to add that task to the instance
     assert (
-        await try_assigning_task_to_pending_instances(
+        await try_assigning_task_to_instances(
             fake_app,
             pending_task,
             pending_instance_to_tasks,
-            type_to_instance_map,
             notify_progress=True,
         )
         is True
     )
     # calling a third time should fail
     assert (
-        await try_assigning_task_to_pending_instances(
+        await try_assigning_task_to_instances(
             fake_app,
             pending_task,
             pending_instance_to_tasks,
-            type_to_instance_map,
             notify_progress=True,
         )
         is False


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?
This PR fixes the following issue:
- dynamic autoscaling service setup
- creating dynamic services does create a new machine and goes there
- creating another service **does not** create a new machine and the service stays forever


root cause:
- autoscaling analyzes the current cluster and divides it in active, pending, drained and missing nodes respectively,
- it then tries to assign the "unrunnable" tasks to these 4 types of nodes in this order,
- it was not subtracting the current usage of the active node, therefore always thinking there were enough machines around.

Testing can only be made directly on AWS machines, which makes testing a bit annoying.

to @pcrespov : I will not refactor yet the filter function as I do not want to break this now again. especially since testing is tedious.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
