### PR TITLE
✨Dask sidecar: pass job origin and show child computational service logs in workbench

### DIFF
--- a/packages/dask-task-models-library/requirements/_base.in
+++ b/packages/dask-task-models-library/requirements/_base.in
@@ -3,6 +3,7 @@
 #
 --constraint ../../../requirements/constraints.txt
 --requirement ../../../packages/models-library/requirements/_base.in
+--requirement ../../../packages/settings-library/requirements/_base.in
 
 dask[distributed]
 pydantic[email]

--- a/packages/dask-task-models-library/requirements/ci.txt
+++ b/packages/dask-task-models-library/requirements/ci.txt
@@ -14,6 +14,7 @@
 # installs this repo's packages
 ../pytest-simcore/
 ../models-library/
+../settings-library/
 
 # current module
 .

--- a/packages/dask-task-models-library/requirements/dev.txt
+++ b/packages/dask-task-models-library/requirements/dev.txt
@@ -14,6 +14,7 @@
 # installs this repo's packages
 --editable ../pytest-simcore/
 --editable ../models-library/
+--editable ../settings-library/
 
 # current module
 --editable .

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/events.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/events.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import TypeAlias, Union
+from typing import Any, ClassVar, TypeAlias
 
 from distributed.worker import get_worker
 from pydantic import BaseModel, Extra, validator
@@ -31,7 +31,7 @@ class TaskProgressEvent(BaseTaskEvent):
         return cls(job_id=get_worker().get_current_task(), progress=progress)
 
     class Config(BaseTaskEvent.Config):
-        schema_extra = {
+        schema_extra: ClassVar[dict[str, Any]] = {
             "examples": [
                 {
                     "job_id": "simcore/services/comp/sleeper:1.1.0:projectid_ec7e595a-63ee-46a1-a04a-901b11b649f8:nodeid_39467d89-b659-4914-9359-c40b1b6d1d6d:uuid_5ee5c655-450d-4711-a3ec-32ffe16bc580",
@@ -69,7 +69,7 @@ class TaskLogEvent(BaseTaskEvent):
         return cls(job_id=get_worker().get_current_task(), log=log, log_level=log_level)
 
     class Config(BaseTaskEvent.Config):
-        schema_extra = {
+        schema_extra: ClassVar[dict[str, Any]] = {
             "examples": [
                 {
                     "job_id": "simcore/services/comp/sleeper:1.1.0:projectid_ec7e595a-63ee-46a1-a04a-901b11b649f8:nodeid_39467d89-b659-4914-9359-c40b1b6d1d6d:uuid_5ee5c655-450d-4711-a3ec-32ffe16bc580",
@@ -78,6 +78,3 @@ class TaskLogEvent(BaseTaskEvent):
                 },
             ]
         }
-
-
-DaskTaskEvents = type[Union[TaskLogEvent, TaskProgressEvent]]

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/events.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/events.py
@@ -5,9 +5,12 @@ from typing import Any, ClassVar, TypeAlias
 from distributed.worker import get_worker
 from pydantic import BaseModel, Extra, validator
 
+from .protocol import TaskOwner
+
 
 class BaseTaskEvent(BaseModel, ABC):
     job_id: str
+    task_owner: TaskOwner
     msg: str | None = None
 
     @staticmethod
@@ -27,8 +30,14 @@ class TaskProgressEvent(BaseTaskEvent):
         return "task_progress"
 
     @classmethod
-    def from_dask_worker(cls, progress: float) -> "TaskProgressEvent":
-        return cls(job_id=get_worker().get_current_task(), progress=progress)
+    def from_dask_worker(
+        cls, progress: float, *, task_owner: TaskOwner
+    ) -> "TaskProgressEvent":
+        return cls(
+            job_id=get_worker().get_current_task(),
+            progress=progress,
+            task_owner=task_owner,
+        )
 
     class Config(BaseTaskEvent.Config):
         schema_extra: ClassVar[dict[str, Any]] = {
@@ -36,10 +45,24 @@ class TaskProgressEvent(BaseTaskEvent):
                 {
                     "job_id": "simcore/services/comp/sleeper:1.1.0:projectid_ec7e595a-63ee-46a1-a04a-901b11b649f8:nodeid_39467d89-b659-4914-9359-c40b1b6d1d6d:uuid_5ee5c655-450d-4711-a3ec-32ffe16bc580",
                     "progress": 0,
+                    "task_owner": {
+                        "user_id": 32,
+                        "project_id": "ec7e595a-63ee-46a1-a04a-901b11b649f8",
+                        "node_id": "39467d89-b659-4914-9359-c40b1b6d1d6d",
+                        "parent_project_id": None,
+                        "parent_node_id": None,
+                    },
                 },
                 {
                     "job_id": "simcore/services/comp/sleeper:1.1.0:projectid_ec7e595a-63ee-46a1-a04a-901b11b649f8:nodeid_39467d89-b659-4914-9359-c40b1b6d1d6d:uuid_5ee5c655-450d-4711-a3ec-32ffe16bc580",
                     "progress": 1.0,
+                    "task_owner": {
+                        "user_id": 32,
+                        "project_id": "ec7e595a-63ee-46a1-a04a-901b11b649f8",
+                        "node_id": "39467d89-b659-4914-9359-c40b1b6d1d6d",
+                        "parent_project_id": "887e595a-63ee-46a1-a04a-901b11b649f8",
+                        "parent_node_id": "aa467d89-b659-4914-9359-c40b1b6d1d6d",
+                    },
                 },
             ]
         }
@@ -65,8 +88,15 @@ class TaskLogEvent(BaseTaskEvent):
         return "task_logs"
 
     @classmethod
-    def from_dask_worker(cls, log: str, log_level: LogLevelInt) -> "TaskLogEvent":
-        return cls(job_id=get_worker().get_current_task(), log=log, log_level=log_level)
+    def from_dask_worker(
+        cls, log: str, log_level: LogLevelInt, *, task_owner: TaskOwner
+    ) -> "TaskLogEvent":
+        return cls(
+            job_id=get_worker().get_current_task(),
+            log=log,
+            log_level=log_level,
+            task_owner=task_owner,
+        )
 
     class Config(BaseTaskEvent.Config):
         schema_extra: ClassVar[dict[str, Any]] = {
@@ -75,6 +105,13 @@ class TaskLogEvent(BaseTaskEvent):
                     "job_id": "simcore/services/comp/sleeper:1.1.0:projectid_ec7e595a-63ee-46a1-a04a-901b11b649f8:nodeid_39467d89-b659-4914-9359-c40b1b6d1d6d:uuid_5ee5c655-450d-4711-a3ec-32ffe16bc580",
                     "log": "some logs",
                     "log_level": logging.INFO,
+                    "task_owner": {
+                        "user_id": 32,
+                        "project_id": "ec7e595a-63ee-46a1-a04a-901b11b649f8",
+                        "node_id": "39467d89-b659-4914-9359-c40b1b6d1d6d",
+                        "parent_project_id": None,
+                        "parent_node_id": None,
+                    },
                 },
             ]
         }

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/events.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/events.py
@@ -33,8 +33,11 @@ class TaskProgressEvent(BaseTaskEvent):
     def from_dask_worker(
         cls, progress: float, *, task_owner: TaskOwner
     ) -> "TaskProgressEvent":
+        worker = get_worker()
+        job_id = worker.get_current_task()
+
         return cls(
-            job_id=get_worker().get_current_task(),
+            job_id=job_id,
             progress=progress,
             task_owner=task_owner,
         )
@@ -91,8 +94,10 @@ class TaskLogEvent(BaseTaskEvent):
     def from_dask_worker(
         cls, log: str, log_level: LogLevelInt, *, task_owner: TaskOwner
     ) -> "TaskLogEvent":
+        worker = get_worker()
+        job_id = worker.get_current_task()
         return cls(
-            job_id=get_worker().get_current_task(),
+            job_id=job_id,
             log=log,
             log_level=log_level,
             task_owner=task_owner,

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/protocol.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/protocol.py
@@ -72,6 +72,25 @@ class ContainerTaskParameters(BaseModel):
     boot_mode: BootMode
     task_owner: TaskOwner
 
+    class Config:
+        schema_extra: ClassVar[dict[str, Any]] = {
+            "examples": [
+                {
+                    "image": "ubuntu",
+                    "tag": "latest",
+                    "input_data": TaskInputData.Config.schema_extra["examples"][0],
+                    "output_data_keys": TaskOutputDataSchema.Config.schema_extra[
+                        "examples"
+                    ][0],
+                    "command": ["sleep 10", "echo hello"],
+                    "envs": {"MYENV": "is an env"},
+                    "labels": {"io.simcore.thelabel": "is amazing"},
+                    "boot_mode": BootMode.CPU.value,
+                    "task_owner": TaskOwner.Config.schema_extra["examples"][0],
+                },
+            ]
+        }
+
 
 class ContainerRemoteFct(Protocol):
     def __call__(

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/protocol.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/protocol.py
@@ -28,6 +28,10 @@ class TaskOwner(BaseModel):
     parent_project_id: ProjectID | None
     parent_node_id: NodeID | None
 
+    @property
+    def has_parent(self) -> bool:
+        return bool(self.parent_node_id and self.parent_project_id)
+
     @root_validator
     @classmethod
     def check_parent_valid(cls, values: dict[str, Any]) -> dict[str, Any]:

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/protocol.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/protocol.py
@@ -1,9 +1,12 @@
-from typing import Protocol, TypeAlias
+from typing import Any, Protocol, TypeAlias
 
 from models_library.basic_types import EnvVarKey
 from models_library.docker import DockerLabelKey
+from models_library.projects import ProjectID
+from models_library.projects_nodes_io import NodeID
 from models_library.services_resources import BootMode
-from pydantic import AnyUrl
+from models_library.users import UserID
+from pydantic import AnyUrl, BaseModel, root_validator
 from settings_library.s3 import S3Settings
 
 from .docker import DockerBasicAuth
@@ -17,20 +20,46 @@ ContainerEnvsDict: TypeAlias = dict[EnvVarKey, str]
 ContainerLabelsDict: TypeAlias = dict[DockerLabelKey, str]
 
 
+class TaskOwner(BaseModel):
+    user_id: UserID
+    project_id: ProjectID
+    node_id: NodeID
+
+    parent_project_id: ProjectID | None
+    parent_node_id: NodeID | None
+
+    @root_validator
+    @classmethod
+    def check_parent_valid(cls, values: dict[str, Any]) -> dict[str, Any]:
+        parent_project_id = values.get("parent_project_id")
+        parent_node_id = values.get("parent_node_id")
+        if (parent_node_id is None and parent_project_id is not None) or (
+            parent_node_id is not None and parent_project_id is None
+        ):
+            msg = "either both parent_node_id and parent_project_id are None or both are set!"
+            raise ValueError(msg)
+        return values
+
+
+class ContainerTaskParameters(BaseModel):
+    image: ContainerImage
+    tag: ContainerTag
+    input_data: TaskInputData
+    output_data_keys: TaskOutputDataSchema
+    command: ContainerCommands
+    envs: ContainerEnvsDict
+    labels: ContainerLabelsDict
+    boot_mode: BootMode
+    task_owner: TaskOwner
+
+
 class ContainerRemoteFct(Protocol):
-    def __call__(  # pylint: disable=too-many-arguments # noqa: PLR0913
+    def __call__(
         self,
         *,
+        task_parameters: ContainerTaskParameters,
         docker_auth: DockerBasicAuth,
-        service_key: ContainerImage,
-        service_version: ContainerTag,
-        input_data: TaskInputData,
-        output_data_keys: TaskOutputDataSchema,
         log_file_url: LogFileUploadURL,
-        command: ContainerCommands,
-        task_envs: ContainerEnvsDict,
-        task_labels: ContainerLabelsDict,
         s3_settings: S3Settings | None,
-        boot_mode: BootMode,
     ) -> TaskOutputData:
         ...

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/protocol.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/protocol.py
@@ -1,4 +1,4 @@
-from typing import Any, Protocol, TypeAlias
+from typing import Any, ClassVar, Protocol, TypeAlias
 
 from models_library.basic_types import EnvVarKey
 from models_library.docker import DockerLabelKey
@@ -39,6 +39,26 @@ class TaskOwner(BaseModel):
             msg = "either both parent_node_id and parent_project_id are None or both are set!"
             raise ValueError(msg)
         return values
+
+    class Config:
+        schema_extra: ClassVar[dict[str, Any]] = {
+            "examples": [
+                {
+                    "user_id": 32,
+                    "project_id": "ec7e595a-63ee-46a1-a04a-901b11b649f8",
+                    "node_id": "39467d89-b659-4914-9359-c40b1b6d1d6d",
+                    "parent_project_id": None,
+                    "parent_node_id": None,
+                },
+                {
+                    "user_id": 32,
+                    "project_id": "ec7e595a-63ee-46a1-a04a-901b11b649f8",
+                    "node_id": "39467d89-b659-4914-9359-c40b1b6d1d6d",
+                    "parent_project_id": "887e595a-63ee-46a1-a04a-901b11b649f8",
+                    "parent_node_id": "aa467d89-b659-4914-9359-c40b1b6d1d6d",
+                },
+            ]
+        }
 
 
 class ContainerTaskParameters(BaseModel):

--- a/packages/dask-task-models-library/tests/container_tasks/test_events.py
+++ b/packages/dask-task-models-library/tests/container_tasks/test_events.py
@@ -37,13 +37,12 @@ def test_events_models_examples(model_cls):
 
 
 @pytest.fixture()
-def mocked_dask_worker_job_id(mocker: MockerFixture) -> str:
+def mocked_dask_worker_job_id(mocker: MockerFixture, job_id: str) -> str:
     mock_get_worker = mocker.patch(
         "dask_task_models_library.container_tasks.events.get_worker", autospec=True
     )
-    fake_job_id = "some_fake_job_id"
-    mock_get_worker.return_value.get_current_task.return_value = fake_job_id
-    return fake_job_id
+    mock_get_worker.return_value.get_current_task.return_value = job_id
+    return job_id
 
 
 @pytest.fixture(params=TaskOwner.Config.schema_extra["examples"])

--- a/packages/dask-task-models-library/tests/container_tasks/test_events.py
+++ b/packages/dask-task-models-library/tests/container_tasks/test_events.py
@@ -14,6 +14,7 @@ from dask_task_models_library.container_tasks.events import (
     TaskProgressEvent,
 )
 from dask_task_models_library.container_tasks.protocol import TaskOwner
+from faker import Faker
 from pytest_mock.plugin import MockerFixture
 
 
@@ -34,6 +35,11 @@ def test_events_models_examples(model_cls):
         assert model_instance
 
         assert model_instance.topic_name()
+
+
+@pytest.fixture
+def job_id(faker: Faker) -> str:
+    return faker.pystr()
 
 
 @pytest.fixture()

--- a/packages/dask-task-models-library/tests/container_tasks/test_events.py
+++ b/packages/dask-task-models-library/tests/container_tasks/test_events.py
@@ -13,6 +13,8 @@ from dask_task_models_library.container_tasks.events import (
     TaskLogEvent,
     TaskProgressEvent,
 )
+from dask_task_models_library.container_tasks.protocol import TaskOwner
+from faker import Faker
 from pytest_mock.plugin import MockerFixture
 
 
@@ -43,6 +45,11 @@ def mocked_dask_worker_job_id(mocker: MockerFixture) -> str:
     fake_job_id = "some_fake_job_id"
     mock_get_worker.return_value.get_current_task.return_value = fake_job_id
     return fake_job_id
+
+
+@pytest.fixture()
+def task_owner(faker: Faker) -> TaskOwner:
+    return False
 
 
 def test_task_progress_from_worker(mocked_dask_worker_job_id: str):

--- a/packages/dask-task-models-library/tests/container_tasks/test_protocol.py
+++ b/packages/dask-task-models-library/tests/container_tasks/test_protocol.py
@@ -1,0 +1,31 @@
+import pytest
+from dask_task_models_library.container_tasks.protocol import (
+    ContainerTaskParameters,
+    TaskOwner,
+)
+from faker import Faker
+from pydantic import ValidationError
+
+
+@pytest.mark.parametrize("model_cls", [TaskOwner, ContainerTaskParameters])
+def test_events_models_examples(model_cls):
+    examples = model_cls.Config.schema_extra["examples"]
+
+    for index, example in enumerate(examples):
+        print(f"{index:-^10}:\n", example)
+
+        model_instance = model_cls(**example)
+        assert model_instance
+
+
+def test_task_owner_parent_valid(faker: Faker):
+    invalid_task_owner_example = TaskOwner.Config.schema_extra["examples"][0]
+    invalid_task_owner_example["parent_project_id"] = faker.uuid4()
+    assert invalid_task_owner_example["parent_node_id"] is None
+    with pytest.raises(ValidationError, match=r".+ are None or both are set!"):
+        TaskOwner(**invalid_task_owner_example)
+
+    invalid_task_owner_example["parent_project_id"] = None
+    invalid_task_owner_example["parent_node_id"] = faker.uuid4()
+    with pytest.raises(ValidationError, match=r".+ are None or both are set!"):
+        TaskOwner(**invalid_task_owner_example)

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -3,30 +3,20 @@ import json
 import logging
 import os
 import socket
+from collections.abc import Coroutine
 from dataclasses import dataclass
 from pathlib import Path
 from pprint import pformat
 from types import TracebackType
-from typing import Coroutine, cast
+from typing import cast
 from uuid import uuid4
 
 from aiodocker import Docker
 from dask_task_models_library.container_tasks.docker import DockerBasicAuth
 from dask_task_models_library.container_tasks.errors import ServiceRuntimeError
 from dask_task_models_library.container_tasks.events import TaskLogEvent
-from dask_task_models_library.container_tasks.io import (
-    FileUrl,
-    TaskInputData,
-    TaskOutputData,
-    TaskOutputDataSchema,
-)
-from dask_task_models_library.container_tasks.protocol import (
-    ContainerEnvsDict,
-    ContainerImage,
-    ContainerLabelsDict,
-    ContainerTag,
-)
-from models_library.services_resources import BootMode
+from dask_task_models_library.container_tasks.io import FileUrl, TaskOutputData
+from dask_task_models_library.container_tasks.protocol import ContainerTaskParameters
 from packaging import version
 from pydantic import ValidationError
 from pydantic.networks import AnyUrl
@@ -53,20 +43,14 @@ logger = logging.getLogger(__name__)
 CONTAINER_WAIT_TIME_SECS = 2
 
 
-@dataclass
-class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
+@dataclass(kw_only=True, frozen=True, slots=True)
+class ComputationalSidecar:
+    task_parameters: ContainerTaskParameters
     docker_auth: DockerBasicAuth
-    service_key: ContainerImage
-    service_version: ContainerTag
-    input_data: TaskInputData
-    output_data_keys: TaskOutputDataSchema
     log_file_url: AnyUrl
-    boot_mode: BootMode
     task_max_resources: dict[str, float]
     task_publishers: TaskPublisher
     s3_settings: S3Settings | None
-    task_envs: ContainerEnvsDict
-    task_labels: ContainerLabelsDict
 
     async def _write_input_data(
         self,
@@ -80,7 +64,7 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
         local_input_data_file = {}
         download_tasks = []
 
-        for input_key, input_params in self.input_data.items():
+        for input_key, input_params in self.task_parameters.input_data.items():
             if isinstance(input_params, FileUrl):
                 file_name = (
                     input_params.file_mapping
@@ -125,11 +109,11 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
             )
             logger.debug(
                 "following outputs will be searched for:\n%s",
-                self.output_data_keys.json(indent=1),
+                self.task_parameters.output_data_keys.json(indent=1),
             )
 
             output_data = TaskOutputData.from_task_output(
-                self.output_data_keys,
+                self.task_parameters.output_data_keys,
                 task_volumes.outputs_folder,
                 "outputs.json"
                 if integration_version > LEGACY_INTEGRATION_VERSION
@@ -160,8 +144,8 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
 
         except (ValueError, ValidationError) as exc:
             raise ServiceBadFormattedOutputError(
-                service_key=self.service_key,
-                service_version=self.service_version,
+                service_key=self.task_parameters.image,
+                service_version=self.task_parameters.tag,
                 exc=exc,
             ) from exc
 
@@ -177,7 +161,7 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
     async def run(self, command: list[str]) -> TaskOutputData:
         # ensure we pass the initial logs and progress
         await self._publish_sidecar_log(
-            f"Starting task for {self.service_key}:{self.service_version} on {socket.gethostname()}..."
+            f"Starting task for {self.task_parameters.image}:{self.task_parameters.tag} on {socket.gethostname()}..."
         )
         self.task_publishers.publish_progress(0)
 
@@ -189,27 +173,30 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
             await pull_image(
                 docker_client,
                 self.docker_auth,
-                self.service_key,
-                self.service_version,
+                self.task_parameters.image,
+                self.task_parameters.tag,
                 self._publish_sidecar_log,
             )
 
             image_labels: ImageLabels = await get_image_labels(
-                docker_client, self.docker_auth, self.service_key, self.service_version
+                docker_client,
+                self.docker_auth,
+                self.task_parameters.image,
+                self.task_parameters.tag,
             )
             computational_shared_data_mount_point = (
                 await get_computational_shared_data_mount_point(docker_client)
             )
             config = await create_container_config(
                 docker_registry=self.docker_auth.server_address,
-                image=self.service_key,
-                tag=self.service_version,
+                image=self.task_parameters.image,
+                tag=self.task_parameters.tag,
                 command=command,
                 comp_volume_mount_point=f"{computational_shared_data_mount_point}/{run_id}",
-                boot_mode=self.boot_mode,
+                boot_mode=self.task_parameters.boot_mode,
                 task_max_resources=self.task_max_resources,
-                envs=self.task_envs,
-                labels=self.task_labels,
+                envs=self.task_parameters.envs,
+                labels=self.task_parameters.labels,
             )
             await self._write_input_data(
                 task_volumes, image_labels.get_integration_version()
@@ -219,12 +206,12 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
             async with managed_container(
                 docker_client,
                 config,
-                name=f"{self.service_key.split(sep='/')[-1]}_{run_id}",
+                name=f"{self.task_parameters.image.split(sep='/')[-1]}_{run_id}",
             ) as container, managed_monitor_container_log_task(
                 container=container,
                 progress_regexp=image_labels.get_progress_regexp(),
-                service_key=self.service_key,
-                service_version=self.service_version,
+                service_key=self.task_parameters.image,
+                service_version=self.task_parameters.tag,
                 task_publishers=self.task_publishers,
                 integration_version=image_labels.get_integration_version(),
                 task_volumes=task_volumes,
@@ -241,8 +228,8 @@ class ComputationalSidecar:  # pylint: disable=too-many-instance-attributes
                     await asyncio.sleep(CONTAINER_WAIT_TIME_SECS)
                 if container_data["State"]["ExitCode"] > os.EX_OK:
                     raise ServiceRuntimeError(
-                        service_key=self.service_key,
-                        service_version=self.service_version,
+                        service_key=self.task_parameters.image,
+                        service_version=self.task_parameters.tag,
                         container_id=container.id,
                         exit_code=container_data["State"]["ExitCode"],
                         service_logs=await cast(

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -14,7 +14,6 @@ from uuid import uuid4
 from aiodocker import Docker
 from dask_task_models_library.container_tasks.docker import DockerBasicAuth
 from dask_task_models_library.container_tasks.errors import ServiceRuntimeError
-from dask_task_models_library.container_tasks.events import TaskLogEvent
 from dask_task_models_library.container_tasks.io import FileUrl, TaskOutputData
 from dask_task_models_library.container_tasks.protocol import ContainerTaskParameters
 from packaging import version
@@ -24,7 +23,7 @@ from servicelib.logging_utils import LogLevelInt, LogMessageStr
 from settings_library.s3 import S3Settings
 from yarl import URL
 
-from ..dask_utils import TaskPublisher, publish_event
+from ..dask_utils import TaskPublisher
 from ..file_utils import pull_file_from_remote, push_file_to_remote
 from ..settings import Settings
 from .docker_utils import (
@@ -152,10 +151,10 @@ class ComputationalSidecar:
     async def _publish_sidecar_log(
         self, log: LogMessageStr, log_level: LogLevelInt = logging.INFO
     ) -> None:
-        publish_event(
-            self.task_publishers.logs,
-            TaskLogEvent.from_dask_worker(log=f"[sidecar] {log}", log_level=log_level),
+        self.task_publishers.publish_logs(
+            message=f"[sidecar] {log}", log_level=log_level
         )
+
         logger.log(log_level, log)
 
     async def run(self, command: list[str]) -> TaskOutputData:

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/tasks.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/tasks.py
@@ -135,8 +135,7 @@ async def _run_computational_sidecar_async(  # pylint: disable=too-many-argument
         return output_data
 
 
-def run_computational_sidecar(
-    # pylint: disable=too-many-arguments
+def run_computational_sidecar(  # pylint: disable=too-many-arguments # noqa: PLR0913
     docker_auth: DockerBasicAuth,
     service_key: ContainerImage,
     service_version: ContainerTag,

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/tasks.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/tasks.py
@@ -88,7 +88,7 @@ async def _run_computational_sidecar_async(
     log_file_url: LogFileUploadURL,
     s3_settings: S3Settings | None,
 ) -> TaskOutputData:
-    task_publishers = TaskPublisher()
+    task_publishers = TaskPublisher(task_owner=task_parameters.task_owner)
 
     _logger.debug(
         "run_computational_sidecar %s",
@@ -97,7 +97,7 @@ async def _run_computational_sidecar_async(
     current_task = asyncio.current_task()
     assert current_task  # nosec
     async with monitor_task_abortion(
-        task_name=current_task.get_name(), log_publisher=task_publishers.logs
+        task_name=current_task.get_name(), task_publishers=task_publishers
     ):
         task_max_resources = get_current_task_resources()
         async with ComputationalSidecar(

--- a/services/dask-sidecar/tests/unit/test_file_utils.py
+++ b/services/dask-sidecar/tests/unit/test_file_utils.py
@@ -5,16 +5,16 @@
 import asyncio
 import mimetypes
 import zipfile
+from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, AsyncIterable, cast
+from typing import Any, cast
 from unittest import mock
 
 import fsspec
 import pytest
 from faker import Faker
 from pydantic import AnyUrl, parse_obj_as
-from pytest import FixtureRequest
 from pytest_localftpserver.servers import ProcessFTPServer
 from pytest_mock.plugin import MockerFixture
 from settings_library.s3 import S3Settings
@@ -79,7 +79,7 @@ class StorageParameters:
 
 @pytest.fixture(params=["ftp", "s3"])
 def remote_parameters(
-    request: FixtureRequest,
+    request: pytest.FixtureRequest,
     ftp_remote_file_url: AnyUrl,
     s3_remote_file_url: AnyUrl,
     s3_settings: S3Settings,
@@ -314,9 +314,8 @@ async def test_pull_compressed_zip_file_from_remote(
             mode="wb",
             **storage_kwargs,
         ),
-    ) as dest_fp:
-        with local_zip_file_path.open("rb") as src_fp:
-            dest_fp.write(src_fp.read())
+    ) as dest_fp, local_zip_file_path.open("rb") as src_fp:
+        dest_fp.write(src_fp.read())
 
     # now we want to download that file so it becomes the source
     src_url = destination_url

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -65,26 +65,6 @@ from simcore_service_dask_sidecar.tasks import run_computational_sidecar
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture
-def job_id() -> str:
-    return "some_incredible_string"
-
-
-@pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
-@pytest.fixture
-def project_id(faker: Faker) -> ProjectID:
-    return faker.uuid4(cast_to=None)
-
-
-@pytest.fixture
-def node_id(faker: Faker) -> NodeID:
-    return faker.uuid4(cast_to=None)
-
-
 @pytest.fixture()
 def dask_subsystem_mock(mocker: MockerFixture) -> dict[str, mock.Mock]:
     # mock dask client
@@ -202,17 +182,6 @@ def integration_version(request: pytest.FixtureRequest) -> version.Version:
 @pytest.fixture
 def additional_envs(faker: Faker) -> dict[EnvVarKey, str]:
     return parse_obj_as(dict[EnvVarKey, str], faker.pydict(allowed_types=(str,)))
-
-
-@pytest.fixture
-def task_owner(user_id: UserID, project_id: ProjectID, node_id: NodeID) -> TaskOwner:
-    return TaskOwner(
-        user_id=user_id,
-        project_id=project_id,
-        node_id=node_id,
-        parent_project_id=None,
-        parent_node_id=None,
-    )
 
 
 @pytest.fixture

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -38,11 +38,8 @@ from dask_task_models_library.container_tasks.protocol import (
 )
 from faker import Faker
 from models_library.basic_types import EnvVarKey
-from models_library.projects import ProjectID
-from models_library.projects_nodes_io import NodeID
 from models_library.services import ServiceDockerData
 from models_library.services_resources import BootMode
-from models_library.users import UserID
 from packaging import version
 from pydantic import AnyUrl, SecretStr, parse_obj_as
 from pytest_mock.plugin import MockerFixture
@@ -192,9 +189,6 @@ def sleeper_task(
     boot_mode: BootMode,
     additional_envs: dict[EnvVarKey, str],
     faker: Faker,
-    user_id: UserID,
-    project_id: ProjectID,
-    node_id: NodeID,
     task_owner: TaskOwner,
     s3_settings: S3Settings,
 ) -> ServiceExampleParam:

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -638,7 +638,7 @@ async def test_run_computational_sidecar_dask(
         ), f"Could not find {log} in worker_logs:\n {pformat(worker_logs, width=240)}"
 
     # check that the task produce the expected data, not less not more
-    assert isinstance(output_data, dict)
+    assert isinstance(output_data, TaskOutputData)
     for k, v in sleeper_task.expected_output_data.items():
         assert k in output_data
         assert output_data[k] == v

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -18,6 +18,7 @@ from dask_task_models_library.container_tasks.io import (
 from dask_task_models_library.container_tasks.protocol import (
     ContainerEnvsDict,
     ContainerLabelsDict,
+    TaskOwner,
 )
 from fastapi import FastAPI
 from models_library.api_schemas_directorv2.services import NodeRequirements
@@ -39,8 +40,8 @@ from simcore_sdk.node_ports_common.exceptions import (
 from simcore_sdk.node_ports_v2 import FileLinkType, Port, links, port_utils
 from simcore_sdk.node_ports_v2.links import ItemValue as _NPItemValue
 from simcore_sdk.node_ports_v2.ports_mapping import PortKey
-from simcore_service_director_v2.constants import UNDEFINED_DOCKER_LABEL
 
+from ..constants import UNDEFINED_DOCKER_LABEL
 from ..core.errors import (
     ComputationalBackendNotConnectedError,
     ComputationalSchedulerChangedError,
@@ -48,7 +49,7 @@ from ..core.errors import (
     MissingComputationalResourcesError,
     PortsValidationError,
 )
-from ..models.comp_runs import RunMetadataDict
+from ..models.comp_runs import ProjectMetadataDict, RunMetadataDict
 from ..models.comp_tasks import Image
 from ..modules.osparc_variables_substitutions import (
     resolve_and_substitute_session_variables_in_specs,
@@ -623,3 +624,18 @@ async def wrap_client_async_routine(
     a union of types. this wrapper makes both mypy and pylance happy"""
     assert client_coroutine  # nosec
     return await client_coroutine
+
+
+def compute_task_owner(
+    user_id: UserID,
+    project_id: ProjectID,
+    node_id: ProjectID,
+    project_metadata: ProjectMetadataDict,
+) -> TaskOwner:
+    return TaskOwner(
+        user_id=user_id,
+        project_id=project_id,
+        node_id=node_id,
+        parent_node_id=project_metadata.get("parent_node_id"),
+        parent_project_id=project_metadata.get("parent_project_id"),
+    )

--- a/services/director-v2/tests/unit/_dask_helpers.py
+++ b/services/director-v2/tests/unit/_dask_helpers.py
@@ -1,21 +1,9 @@
 # pylint:disable=unused-variable
 # pylint:disable=unused-argument
 
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 from dask_gateway_server.app import DaskGateway
-from dask_task_models_library.container_tasks.docker import DockerBasicAuth
-from dask_task_models_library.container_tasks.io import (
-    TaskInputData,
-    TaskOutputData,
-    TaskOutputDataSchema,
-)
-from dask_task_models_library.container_tasks.protocol import (
-    ContainerCommands,
-    ContainerImage,
-    ContainerTag,
-    LogFileUploadURL,
-)
 
 
 class DaskGatewayServer(NamedTuple):
@@ -23,42 +11,3 @@ class DaskGatewayServer(NamedTuple):
     proxy_address: str
     password: str
     server: DaskGateway
-
-
-def fake_sidecar_fct(
-    docker_auth: DockerBasicAuth,
-    service_key: ContainerImage,
-    service_version: ContainerTag,
-    input_data: TaskInputData,
-    output_data_keys: TaskOutputDataSchema,
-    log_file_url: LogFileUploadURL,
-    command: ContainerCommands,
-    expected_annotations: dict[str, Any],
-) -> TaskOutputData:
-    import time
-
-    from dask.distributed import get_worker
-
-    # sleep a bit in case someone is aborting us
-    time.sleep(1)
-
-    # get the task data
-    worker = get_worker()
-    task = worker.state.tasks.get(worker.get_current_task())
-    assert task is not None
-    assert task.annotations == expected_annotations
-
-    return TaskOutputData.parse_obj({"some_output_key": 123})
-
-
-def fake_failing_sidecar_fct(
-    docker_auth: DockerBasicAuth,
-    service_key: ContainerImage,
-    service_version: ContainerTag,
-    input_data: TaskInputData,
-    output_data_keys: TaskOutputDataSchema,
-    log_file_url: LogFileUploadURL,
-    command: ContainerCommands,
-) -> TaskOutputData:
-    err_msg = "sadly we are failing to execute anything cause we are dumb..."
-    raise ValueError(err_msg)

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -374,20 +374,20 @@ def image_params(
 @pytest.fixture
 def _mocked_node_ports(mocker: MockerFixture) -> None:
     mocker.patch(
-        "simcore_service_director_v2.modules.dask_client.create_node_ports",
+        "simcore_service_director_v2.modules.dask_client.dask_utils.create_node_ports",
         return_value=None,
     )
 
     mocker.patch(
-        "simcore_service_director_v2.modules.dask_client.compute_input_data",
+        "simcore_service_director_v2.modules.dask_client.dask_utils.compute_input_data",
         return_value=TaskInputData.parse_obj({}),
     )
     mocker.patch(
-        "simcore_service_director_v2.modules.dask_client.compute_output_data_schema",
+        "simcore_service_director_v2.modules.dask_client.dask_utils.compute_output_data_schema",
         return_value=TaskOutputDataSchema.parse_obj({}),
     )
     mocker.patch(
-        "simcore_service_director_v2.modules.dask_client.compute_service_log_file_upload_link",
+        "simcore_service_director_v2.modules.dask_client.dask_utils.compute_service_log_file_upload_link",
         return_value=parse_obj_as(AnyUrl, "file://undefined"),
     )
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?
This PR brings:
- refactoring/cleaning of the dask-sidecar remote function signature
- allows to pass optional _parent_node_id_ and _parent_project_id_ arguments to the computational job, which is also passed back through the logs/progress events
- _director-v2_ then sends the logs of the node in the _logs_ exchange in RabbitMQ using both the topic of the current project id and of the parent project id if it exists, which means that the _logs_ pane in the GUI shows the logs of a computational service started by a parent service through the public API (sim4life use-case)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
