### PR TITLE
🐛Dynamic autoscaling creates new machines indefinitely due to bad specifictions of service

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/dynamic_scaling.py
@@ -24,7 +24,7 @@ def try_assigning_task_to_node(
     instances_to_tasks: Iterable[tuple[AssociatedInstance, list[Task]]],
 ) -> bool:
     for instance, node_assigned_tasks in instances_to_tasks:
-        instance_total_resource = utils_docker.get_node_total_resources(instance.node)
+        instance_total_resource = instance.ec2_instance.resources
         tasks_needed_resources = utils_docker.compute_tasks_needed_resources(
             node_assigned_tasks
         )

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
@@ -902,6 +902,8 @@ def create_associated_instance(
     fake_ec2_instance_data: Callable[..., EC2InstanceData],
     app_settings: ApplicationSettings,
     faker: Faker,
+    host_cpu_count: int,
+    host_memory_total: ByteSize,
 ) -> Callable[[Node, bool], AssociatedInstance]:
     def _creator(node: Node, terminateable_time: bool) -> AssociatedInstance:
         assert app_settings.AUTOSCALING_EC2_INSTANCES
@@ -924,7 +926,8 @@ def create_associated_instance(
                     days=faker.pyint(min_value=0, max_value=100),
                     hours=faker.pyint(min_value=0, max_value=100),
                 )
-                + seconds_delta
+                + seconds_delta,
+                resources=Resources(cpus=host_cpu_count, ram=host_memory_total),
             ),
         )
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?
This PR ensures the same computation is done when autoscaling service tests if a service may fit in a machine and after the machine was created.



## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/5071
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
