### PR TITLE
🐛♻️ Comp backend: progress of a processing container is now limited to 99%

### DIFF
--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from pprint import pformat
 from types import TracebackType
-from typing import cast
+from typing import Final, cast
 from uuid import uuid4
 
 from aiodocker import Docker
@@ -40,6 +40,7 @@ from .task_shared_volume import TaskSharedVolumes
 
 logger = logging.getLogger(__name__)
 CONTAINER_WAIT_TIME_SECS = 2
+MAX_PROCESSING_PROGRESS_VALUE: Final[float] = 0.95
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
@@ -217,6 +218,7 @@ class ComputationalSidecar:
                 log_file_url=self.log_file_url,
                 log_publishing_cb=self._publish_sidecar_log,
                 s3_settings=self.s3_settings,
+                max_monitoring_progress_value=MAX_PROCESSING_PROGRESS_VALUE,
             ):
                 await container.start()
                 await self._publish_sidecar_log(

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -40,7 +40,7 @@ from .task_shared_volume import TaskSharedVolumes
 
 logger = logging.getLogger(__name__)
 CONTAINER_WAIT_TIME_SECS = 2
-MAX_PROCESSING_PROGRESS_VALUE: Final[float] = 0.95
+_TASK_PROCESSING_PROGRESS_WEIGHT: Final[float] = 0.99
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
@@ -218,7 +218,7 @@ class ComputationalSidecar:
                 log_file_url=self.log_file_url,
                 log_publishing_cb=self._publish_sidecar_log,
                 s3_settings=self.s3_settings,
-                max_monitoring_progress_value=MAX_PROCESSING_PROGRESS_VALUE,
+                container_processing_progress_weight=_TASK_PROCESSING_PROGRESS_WEIGHT,
             ):
                 await container.start()
                 await self._publish_sidecar_log(

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
@@ -183,6 +183,7 @@ async def _parse_and_publish_logs(
     progress_value = await _try_parse_progress(
         log_line, progress_regexp=progress_regexp
     )
+    assert 0 < container_processing_progress_weight <= 1.0  # nosec  # noqa: PLR2004
     if progress_value is not None:
         task_publishers.publish_progress(
             container_processing_progress_weight * progress_value
@@ -193,7 +194,7 @@ async def _parse_and_publish_logs(
     )
 
 
-async def _parse_container_log_file(  # noqa: PLR0913
+async def _parse_container_log_file(  # noqa: PLR0913 # pylint: disable=too-many-arguments
     *,
     container: DockerContainer,
     progress_regexp: re.Pattern[str],
@@ -298,7 +299,7 @@ async def _parse_container_docker_logs(
             )
 
 
-async def _monitor_container_logs(  # noqa: PLR0913
+async def _monitor_container_logs(  # noqa: PLR0913 # pylint: disable=too-many-arguments
     *,
     container: DockerContainer,
     progress_regexp: re.Pattern[str],
@@ -355,7 +356,7 @@ async def _monitor_container_logs(  # noqa: PLR0913
 
 
 @contextlib.asynccontextmanager
-async def managed_monitor_container_log_task(  # noqa: PLR0913
+async def managed_monitor_container_log_task(  # noqa: PLR0913 # pylint: disable=too-many-arguments
     container: DockerContainer,
     progress_regexp: re.Pattern[str],
     service_key: ContainerImage,

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
@@ -151,6 +151,9 @@ def _guess_progress_value(progress_match: re.Match[str]) -> float:
     return float(value_str.strip())
 
 
+_OSPARC_LOG_NUM_PARTS: Final[int] = 2
+
+
 async def _try_parse_progress(
     line: str, *, progress_regexp: re.Pattern[str]
 ) -> float | None:
@@ -158,8 +161,10 @@ async def _try_parse_progress(
         # pattern might be like "timestamp log"
         log = line.strip("\n")
         splitted_log = log.split(" ", maxsplit=1)
-        with contextlib.suppress(arrow.ParserError):
-            if len(splitted_log) == 2 and arrow.get(splitted_log[0]):
+        with contextlib.suppress(arrow.ParserError, ValueError):
+            if len(splitted_log) == _OSPARC_LOG_NUM_PARTS and arrow.get(
+                splitted_log[0]
+            ):
                 log = splitted_log[1]
         if match := re.search(progress_regexp, log):
             return _guess_progress_value(match)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?
This PR changes slightly how progress of a computational service is reported by weighting the parsed progress with a value of 0.99.

This will fix the issue where a job is hitting 100% progress but which state is still not one of FAILED/SUCCESS. This confused users. Running the container will amount to 99% progress, the remaining 1% is basically reserved for uploading outputs/service logs.




## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-issues/issues/1181
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
