### PR TITLE
♻️✨Comp backend: refactor progress + allow internal progress bar to use weights

### DIFF
--- a/packages/service-library/src/servicelib/archiving_utils.py
+++ b/packages/service-library/src/servicelib/archiving_utils.py
@@ -171,7 +171,7 @@ async def unarchive_dir(
     ::raise ArchiveError
     """
     if not progress_bar:
-        progress_bar = ProgressBarData(steps=1)
+        progress_bar = ProgressBarData(num_steps=1)
     async with AsyncExitStack() as zip_stack:
         zip_file_handler = zip_stack.enter_context(
             zipfile.ZipFile(  # pylint: disable=consider-using-with
@@ -355,10 +355,9 @@ async def archive_dir(
     ::raise ArchiveError
     """
     if not progress_bar:
-        progress_bar = ProgressBarData(steps=1)
+        progress_bar = ProgressBarData(num_steps=1)
 
     async with AsyncExitStack() as stack:
-
         folder_size_bytes = sum(
             file.stat().st_size
             for file in _iter_files_to_compress(dir_to_compress, exclude_patterns)

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -129,7 +129,7 @@ class ProgressBarData:
         )
 
     async def update(self, steps: float = 1) -> None:
-        parent_update_value = 0
+        parent_update_value = 0.0
         async with self._continuous_value_lock:
             new_steps_value = self._current_steps + steps
             if new_steps_value > self.num_steps:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -118,6 +118,10 @@ class ProgressBarData:
         await self._update_parent(value)
         await self._report_external(new_progress_value)
 
+    async def set_progress(self, new_value: float) -> None:
+        update_value = round(new_value - self._continuous_progress_value)
+        return await self.update(update_value)
+
     async def finish(self) -> None:
         await self.update(self.steps - self._continuous_progress_value)
         await self._report_external(self.steps, force=True)

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -123,11 +123,10 @@ class ProgressBarData:
         if not self.step_weights:
             return steps / self.num_steps
         weight_index = int(steps)
-        weighted_normalized_progress = (
+        return (
             sum(self.step_weights[:weight_index])
             + steps % 1 * self.step_weights[weight_index]
         )
-        return weighted_normalized_progress * self.num_steps
 
     async def update(self, steps: float = 1) -> None:
         parent_update_value = 0
@@ -163,10 +162,14 @@ class ProgressBarData:
     async def finish(self) -> None:
         await self.set_(self.num_steps)
 
-    def sub_progress(self, steps: int) -> "ProgressBarData":
+    def sub_progress(
+        self, steps: int, step_weights: list[float] | None = None
+    ) -> "ProgressBarData":
         if len(self._children) == self.num_steps:
             msg = "Too many sub progresses created already. Wrong usage of the progress bar"
             raise RuntimeError(msg)
-        child = ProgressBarData(num_steps=steps, _parent=self)
+        child = ProgressBarData(
+            num_steps=steps, step_weights=step_weights, _parent=self
+        )
         self._children.append(child)
         return child

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -12,17 +12,17 @@ from servicelib.progress_bar import ProgressBarData
 
 async def test_progress_bar():
     async with ProgressBarData(steps=2) as root:
-        assert root._continuous_progress_value == pytest.approx(0)
+        assert root._continuous_progress_value == pytest.approx(0)  # noqa: SLF001
         assert root.steps == 2
         async with root.sub_progress(steps=50) as sub:
             for _ in range(50):
                 await sub.update()
-        assert root._continuous_progress_value == pytest.approx(1)
+        assert root._continuous_progress_value == pytest.approx(1)  # noqa: SLF001
         assert root.steps == 2
         async with root.sub_progress(steps=50) as sub:
             for _ in range(50):
                 await sub.update()
-        assert root._continuous_progress_value == pytest.approx(2)
+        assert root._continuous_progress_value == pytest.approx(2)  # noqa: SLF001
         assert root.steps == 2
 
 
@@ -30,16 +30,16 @@ async def test_concurrent_progress_bar():
     async def do_something(root: ProgressBarData):
         async with root.sub_progress(steps=50) as sub:
             assert sub.steps == 50
-            assert sub._continuous_progress_value == 0
+            assert sub._continuous_progress_value == 0  # noqa: SLF001
             for n in range(50):
                 await sub.update()
-                assert sub._continuous_progress_value == (n + 1)
+                assert sub._continuous_progress_value == (n + 1)  # noqa: SLF001
 
     async with ProgressBarData(steps=12) as root:
-        assert root._continuous_progress_value == pytest.approx(0)
+        assert root._continuous_progress_value == pytest.approx(0)  # noqa: SLF001
         assert root.steps == 12
         await asyncio.gather(*[do_something(root) for n in range(12)])
-        assert root._continuous_progress_value == pytest.approx(12)
+        assert root._continuous_progress_value == pytest.approx(12)  # noqa: SLF001
 
 
 async def test_too_many_sub_progress_bars_raises():
@@ -51,10 +51,10 @@ async def test_too_many_sub_progress_bars_raises():
         async with root.sub_progress(steps=50) as sub:
             for _ in range(50):
                 await sub.update()
+
         with pytest.raises(RuntimeError):
             async with root.sub_progress(steps=50) as sub:
-                for _ in range(50):
-                    await sub.update()
+                ...
 
 
 async def test_too_many_updates_does_not_raise_but_show_warning_with_stack(

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -17,20 +17,36 @@ def mocked_progress_bar_cb(mocker: MockerFixture) -> mock.Mock:
     return mocker.Mock()
 
 
-async def test_progress_bar(mocked_progress_bar_cb: mock.Mock):
-    async with ProgressBarData(
-        num_steps=3, progress_report_cb=mocked_progress_bar_cb
-    ) as root:
+@pytest.fixture
+def async_mocked_progress_bar_cb(mocker: MockerFixture) -> mock.AsyncMock:
+    return mocker.AsyncMock()
+
+
+@pytest.mark.parametrize(
+    "progress_report_cb_type",
+    ["mocked_progress_bar_cb", "async_mocked_progress_bar_cb"],
+)
+async def test_progress_bar(
+    progress_report_cb_type: str,
+    mocked_progress_bar_cb: mock.Mock,
+    async_mocked_progress_bar_cb: mock.AsyncMock,
+):
+    mocked_cb = {
+        "mocked_progress_bar_cb": mocked_progress_bar_cb,
+        "async_mocked_progress_bar_cb": async_mocked_progress_bar_cb,
+    }[progress_report_cb_type]
+
+    async with ProgressBarData(num_steps=3, progress_report_cb=mocked_cb) as root:
         assert root.num_steps == 3
         assert root.step_weights is None  # i.e. all steps have equal weight
         assert root._current_steps == pytest.approx(0)  # noqa: SLF001
-        mocked_progress_bar_cb.assert_called_once_with(pytest.approx(0))
-        mocked_progress_bar_cb.reset_mock()
+        mocked_cb.assert_called_once_with(pytest.approx(0))
+        mocked_cb.reset_mock()
         # first step is done right away
         await root.update()
         assert root._current_steps == pytest.approx(1)  # noqa: SLF001
-        mocked_progress_bar_cb.assert_called_once_with(pytest.approx(1 / 3))
-        mocked_progress_bar_cb.reset_mock()
+        mocked_cb.assert_called_once_with(pytest.approx(1 / 3))
+        mocked_cb.reset_mock()
 
         # 2nd step is a sub progress bar of 10 steps
         async with root.sub_progress(steps=10) as sub:
@@ -43,10 +59,10 @@ async def test_progress_bar(mocked_progress_bar_cb: mock.Mock):
                     1 + float(i + 1) / 10.0
                 )
         assert root._current_steps == pytest.approx(2)  # noqa: SLF001
-        mocked_progress_bar_cb.assert_called()
-        assert mocked_progress_bar_cb.call_count == 10
-        assert mocked_progress_bar_cb.call_args_list[9].args[0] == pytest.approx(2 / 3)
-        mocked_progress_bar_cb.reset_mock()
+        mocked_cb.assert_called()
+        assert mocked_cb.call_count == 10
+        assert mocked_cb.call_args_list[9].args[0] == pytest.approx(2 / 3)
+        mocked_cb.reset_mock()
 
         # 3rd step is another subprogress of 50 steps
         async with root.sub_progress(steps=50) as sub:
@@ -59,12 +75,30 @@ async def test_progress_bar(mocked_progress_bar_cb: mock.Mock):
                     2 + float(i + 1) / 50.0
                 )
         assert root._current_steps == pytest.approx(3)  # noqa: SLF001
-        mocked_progress_bar_cb.assert_called()
-        assert mocked_progress_bar_cb.call_count == 25
-        assert mocked_progress_bar_cb.call_args_list[24].args[0] == pytest.approx(1)
-        mocked_progress_bar_cb.reset_mock()
+        mocked_cb.assert_called()
+        assert mocked_cb.call_count == 25
+        assert mocked_cb.call_args_list[24].args[0] == pytest.approx(1)
+        mocked_cb.reset_mock()
     # we were already done here
-    mocked_progress_bar_cb.assert_not_called()
+    mocked_cb.assert_not_called()
+
+
+async def test_progress_bar_always_reports_0_on_creation(
+    mocked_progress_bar_cb: mock.Mock,
+):
+    progress_bar = ProgressBarData(
+        num_steps=3, progress_report_cb=mocked_progress_bar_cb
+    )
+    assert progress_bar._current_steps == -1  # noqa: SLF001
+    async with progress_bar as root:
+        assert root is progress_bar
+        assert root._current_steps == 0  # noqa: SLF001
+        mocked_progress_bar_cb.assert_called_once_with(0)
+        mocked_progress_bar_cb.reset_mock()
+    # going out of scope always updates to final number of steps
+    assert progress_bar._current_steps == 3  # noqa: SLF001
+    mocked_progress_bar_cb.assert_called_once_with(1)
+    mocked_progress_bar_cb.reset_mock()
 
 
 async def test_set_progress(
@@ -213,3 +247,20 @@ async def test_weighted_progress_bar_with_weighted_sub_progress(
     mocked_progress_bar_cb.assert_called_once_with(1)
     mocked_progress_bar_cb.reset_mock()
     assert root._current_steps == pytest.approx(3)  # noqa: SLF001
+
+
+async def test_weighted_progress_bar_wrong_num_weights_raises():
+    with pytest.raises(RuntimeError):
+        async with ProgressBarData(
+            num_steps=3,
+            step_weights=[3, 1],
+        ):
+            ...
+
+
+async def test_weighted_progress_bar_with_0_weights_is_equivalent_to_standard_progress_bar():
+    async with ProgressBarData(
+        num_steps=3,
+        step_weights=[0, 0, 0],
+    ) as root:
+        assert root.step_weights == [1, 1, 1, 0]

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -19,46 +19,65 @@ def mocked_progress_bar_cb(mocker: MockerFixture) -> mock.Mock:
 
 async def test_progress_bar(mocked_progress_bar_cb: mock.Mock):
     async with ProgressBarData(
-        steps=2, progress_report_cb=mocked_progress_bar_cb
+        num_steps=3, progress_report_cb=mocked_progress_bar_cb
     ) as root:
-        assert root._continuous_progress_value == pytest.approx(0)  # noqa: SLF001
+        assert root.num_steps == 3
+        assert root.step_weights is None  # i.e. all steps have equal weight
+        assert root._current_steps == pytest.approx(0)  # noqa: SLF001
         mocked_progress_bar_cb.assert_called_once_with(pytest.approx(0))
         mocked_progress_bar_cb.reset_mock()
-        assert root.steps == 2
-        assert root.step_weights is None
-        async with root.sub_progress(steps=50) as sub:
-            for _ in range(50):
-                await sub.update()
-        assert root._continuous_progress_value == pytest.approx(1)  # noqa: SLF001
-        mocked_progress_bar_cb.assert_called()
-        assert mocked_progress_bar_cb.call_count == 43
-        assert mocked_progress_bar_cb.call_args_list[43] == 2
+        # first step is done right away
+        await root.update()
+        assert root._current_steps == pytest.approx(1)  # noqa: SLF001
+        mocked_progress_bar_cb.assert_called_once_with(pytest.approx(1 / 3))
         mocked_progress_bar_cb.reset_mock()
-        assert root.steps == 2
-        async with root.sub_progress(steps=50) as sub:
-            for _ in range(50):
+
+        # 2nd step is a sub progress bar of 10 steps
+        async with root.sub_progress(steps=10) as sub:
+            assert sub._current_steps == pytest.approx(0)  # noqa: SLF001
+            assert root._current_steps == pytest.approx(1)  # noqa: SLF001
+            for i in range(10):
                 await sub.update()
-        assert root._continuous_progress_value == pytest.approx(2)  # noqa: SLF001
+                assert sub._current_steps == pytest.approx(float(i + 1))  # noqa: SLF001
+                assert root._current_steps == pytest.approx(  # noqa: SLF001
+                    1 + float(i + 1) / 10.0
+                )
+        assert root._current_steps == pytest.approx(2)  # noqa: SLF001
         mocked_progress_bar_cb.assert_called()
-        assert mocked_progress_bar_cb.call_count == 49
-        assert mocked_progress_bar_cb.call_args_list[49] == 2
+        assert mocked_progress_bar_cb.call_count == 10
+        assert mocked_progress_bar_cb.call_args_list[9].args[0] == pytest.approx(2 / 3)
         mocked_progress_bar_cb.reset_mock()
-        assert root.steps == 2
+
+        # 3rd step is another subprogress of 50 steps
+        async with root.sub_progress(steps=50) as sub:
+            assert sub._current_steps == pytest.approx(0)  # noqa: SLF001
+            assert root._current_steps == pytest.approx(2)  # noqa: SLF001
+            for i in range(50):
+                await sub.update()
+                assert sub._current_steps == pytest.approx(float(i + 1))  # noqa: SLF001
+                assert root._current_steps == pytest.approx(  # noqa: SLF001
+                    2 + float(i + 1) / 50.0
+                )
+        assert root._current_steps == pytest.approx(3)  # noqa: SLF001
+        mocked_progress_bar_cb.assert_called()
+        assert mocked_progress_bar_cb.call_count == 25
+        assert mocked_progress_bar_cb.call_args_list[24].args[0] == pytest.approx(1)
+        mocked_progress_bar_cb.reset_mock()
 
 
 async def test_set_progress(
     caplog: pytest.LogCaptureFixture,
 ):
-    async with ProgressBarData(steps=50) as root:
-        assert root._continuous_progress_value == pytest.approx(0)  # noqa: SLF001
-        assert root.steps == 50
+    async with ProgressBarData(num_steps=50) as root:
+        assert root._current_steps == pytest.approx(0)  # noqa: SLF001
+        assert root.num_steps == 50
         assert root.step_weights is None
-        await root.set_progress(13)
-        assert root._continuous_progress_value == pytest.approx(13)  # noqa: SLF001
-        await root.set_progress(34)
-        assert root._continuous_progress_value == pytest.approx(34)  # noqa: SLF001
-        await root.set_progress(58)
-        assert root._continuous_progress_value == pytest.approx(50)  # noqa: SLF001
+        await root.set_(13)
+        assert root._current_steps == pytest.approx(13)  # noqa: SLF001
+        await root.set_(34)
+        assert root._current_steps == pytest.approx(34)  # noqa: SLF001
+        await root.set_(58)
+        assert root._current_steps == pytest.approx(50)  # noqa: SLF001
         assert "already reached maximum" in caplog.messages[0]
         assert "TIP:" in caplog.messages[0]
 
@@ -66,23 +85,23 @@ async def test_set_progress(
 async def test_concurrent_progress_bar():
     async def do_something(root: ProgressBarData):
         async with root.sub_progress(steps=50) as sub:
-            assert sub.steps == 50
+            assert sub.num_steps == 50
             assert sub.step_weights is None
-            assert sub._continuous_progress_value == 0  # noqa: SLF001
+            assert sub._current_steps == 0  # noqa: SLF001
             for n in range(50):
                 await sub.update()
-                assert sub._continuous_progress_value == (n + 1)  # noqa: SLF001
+                assert sub._current_steps == (n + 1)  # noqa: SLF001
 
-    async with ProgressBarData(steps=12) as root:
-        assert root._continuous_progress_value == pytest.approx(0)  # noqa: SLF001
+    async with ProgressBarData(num_steps=12) as root:
+        assert root._current_steps == pytest.approx(0)  # noqa: SLF001
         assert root.step_weights is None
         await asyncio.gather(*[do_something(root) for n in range(12)])
-        assert root._continuous_progress_value == pytest.approx(12)  # noqa: SLF001
+        assert root._current_steps == pytest.approx(12)  # noqa: SLF001
 
 
 async def test_too_many_sub_progress_bars_raises():
-    async with ProgressBarData(steps=2) as root:
-        assert root.steps == 2
+    async with ProgressBarData(num_steps=2) as root:
+        assert root.num_steps == 2
         assert root.step_weights is None
         async with root.sub_progress(steps=50) as sub:
             for _ in range(50):
@@ -99,8 +118,8 @@ async def test_too_many_sub_progress_bars_raises():
 async def test_too_many_updates_does_not_raise_but_show_warning_with_stack(
     caplog: pytest.LogCaptureFixture,
 ):
-    async with ProgressBarData(steps=2) as root:
-        assert root.steps == 2
+    async with ProgressBarData(num_steps=2) as root:
+        assert root.num_steps == 2
         assert root.step_weights is None
         await root.update()
         await root.update()
@@ -111,7 +130,7 @@ async def test_too_many_updates_does_not_raise_but_show_warning_with_stack(
 
 async def test_weighted_progress_bar(mocked_progress_bar_cb: mock.Mock):
     async with ProgressBarData(
-        steps=3,
+        num_steps=3,
         step_weights=[1, 3, 1],
         progress_report_cb=mocked_progress_bar_cb,
     ) as root:
@@ -121,13 +140,13 @@ async def test_weighted_progress_bar(mocked_progress_bar_cb: mock.Mock):
         await root.update()
         mocked_progress_bar_cb.assert_called_once_with(pytest.approx(1 / 5 * 3))
         mocked_progress_bar_cb.reset_mock()
-        assert root._continuous_progress_value == pytest.approx(1)  # noqa: SLF001
+        assert root._current_steps == pytest.approx(1)  # noqa: SLF001
         await root.update()
         mocked_progress_bar_cb.assert_called_once_with(
             pytest.approx(1 / 5 * 3 + 3 / 5 * 3)
         )
         mocked_progress_bar_cb.reset_mock()
-        assert root._continuous_progress_value == pytest.approx(2)  # noqa: SLF001
+        assert root._current_steps == pytest.approx(2)  # noqa: SLF001
     mocked_progress_bar_cb.assert_called_once_with(3)
     mocked_progress_bar_cb.reset_mock()
-    assert root._continuous_progress_value == pytest.approx(3)  # noqa: SLF001
+    assert root._current_steps == pytest.approx(3)  # noqa: SLF001

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -26,6 +26,22 @@ async def test_progress_bar():
         assert root.steps == 2
 
 
+async def test_set_progress(
+    caplog: pytest.LogCaptureFixture,
+):
+    async with ProgressBarData(steps=50) as root:
+        assert root._continuous_progress_value == pytest.approx(0)  # noqa: SLF001
+        assert root.steps == 50
+        await root.set_progress(13)
+        assert root._continuous_progress_value == pytest.approx(13)  # noqa: SLF001
+        await root.set_progress(34)
+        assert root._continuous_progress_value == pytest.approx(34)  # noqa: SLF001
+        await root.set_progress(58)
+        assert root._continuous_progress_value == pytest.approx(50)  # noqa: SLF001
+        assert "already reached maximum" in caplog.messages[0]
+        assert "TIP:" in caplog.messages[0]
+
+
 async def test_concurrent_progress_bar():
     async def do_something(root: ProgressBarData):
         async with root.sub_progress(steps=50) as sub:

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -11,23 +11,38 @@ import pytest
 from pytest_mock import MockerFixture
 from servicelib.progress_bar import ProgressBarData
 
-quit
+
+@pytest.fixture
+def mocked_progress_bar_cb(mocker: MockerFixture) -> mock.Mock:
+    return mocker.Mock()
 
 
-async def test_progress_bar():
-    async with ProgressBarData(steps=2) as root:
+async def test_progress_bar(mocked_progress_bar_cb: mock.Mock):
+    async with ProgressBarData(
+        steps=2, progress_report_cb=mocked_progress_bar_cb
+    ) as root:
         assert root._continuous_progress_value == pytest.approx(0)  # noqa: SLF001
+        mocked_progress_bar_cb.assert_called_once_with(pytest.approx(0))
+        mocked_progress_bar_cb.reset_mock()
         assert root.steps == 2
         assert root.step_weights is None
         async with root.sub_progress(steps=50) as sub:
             for _ in range(50):
                 await sub.update()
         assert root._continuous_progress_value == pytest.approx(1)  # noqa: SLF001
+        mocked_progress_bar_cb.assert_called()
+        assert mocked_progress_bar_cb.call_count == 43
+        assert mocked_progress_bar_cb.call_args_list[43] == 2
+        mocked_progress_bar_cb.reset_mock()
         assert root.steps == 2
         async with root.sub_progress(steps=50) as sub:
             for _ in range(50):
                 await sub.update()
         assert root._continuous_progress_value == pytest.approx(2)  # noqa: SLF001
+        mocked_progress_bar_cb.assert_called()
+        assert mocked_progress_bar_cb.call_count == 49
+        assert mocked_progress_bar_cb.call_args_list[49] == 2
+        mocked_progress_bar_cb.reset_mock()
         assert root.steps == 2
 
 
@@ -94,17 +109,14 @@ async def test_too_many_updates_does_not_raise_but_show_warning_with_stack(
         assert "TIP:" in caplog.messages[0]
 
 
-@pytest.fixture
-def mocked_progress_bar_cb(mocker: MockerFixture) -> mock.Mock:
-    return mocker.AsyncMock()
-
-
 async def test_weighted_progress_bar(mocked_progress_bar_cb: mock.Mock):
     async with ProgressBarData(
         steps=3,
         step_weights=[1, 3, 1],
         progress_report_cb=mocked_progress_bar_cb,
     ) as root:
+        mocked_progress_bar_cb.assert_called_once_with(pytest.approx(0))
+        mocked_progress_bar_cb.reset_mock()
         assert root.step_weights == [1 / 5, 3 / 5, 1 / 5, 0]
         await root.update()
         mocked_progress_bar_cb.assert_called_once_with(pytest.approx(1 / 5 * 3))

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -5,15 +5,20 @@
 # pylint: disable=protected-access
 
 import asyncio
+from unittest import mock
 
 import pytest
+from pytest_mock import MockerFixture
 from servicelib.progress_bar import ProgressBarData
+
+quit
 
 
 async def test_progress_bar():
     async with ProgressBarData(steps=2) as root:
         assert root._continuous_progress_value == pytest.approx(0)  # noqa: SLF001
         assert root.steps == 2
+        assert root.step_weights is None
         async with root.sub_progress(steps=50) as sub:
             for _ in range(50):
                 await sub.update()
@@ -32,6 +37,7 @@ async def test_set_progress(
     async with ProgressBarData(steps=50) as root:
         assert root._continuous_progress_value == pytest.approx(0)  # noqa: SLF001
         assert root.steps == 50
+        assert root.step_weights is None
         await root.set_progress(13)
         assert root._continuous_progress_value == pytest.approx(13)  # noqa: SLF001
         await root.set_progress(34)
@@ -46,6 +52,7 @@ async def test_concurrent_progress_bar():
     async def do_something(root: ProgressBarData):
         async with root.sub_progress(steps=50) as sub:
             assert sub.steps == 50
+            assert sub.step_weights is None
             assert sub._continuous_progress_value == 0  # noqa: SLF001
             for n in range(50):
                 await sub.update()
@@ -53,7 +60,7 @@ async def test_concurrent_progress_bar():
 
     async with ProgressBarData(steps=12) as root:
         assert root._continuous_progress_value == pytest.approx(0)  # noqa: SLF001
-        assert root.steps == 12
+        assert root.step_weights is None
         await asyncio.gather(*[do_something(root) for n in range(12)])
         assert root._continuous_progress_value == pytest.approx(12)  # noqa: SLF001
 
@@ -61,6 +68,7 @@ async def test_concurrent_progress_bar():
 async def test_too_many_sub_progress_bars_raises():
     async with ProgressBarData(steps=2) as root:
         assert root.steps == 2
+        assert root.step_weights is None
         async with root.sub_progress(steps=50) as sub:
             for _ in range(50):
                 await sub.update()
@@ -78,8 +86,36 @@ async def test_too_many_updates_does_not_raise_but_show_warning_with_stack(
 ):
     async with ProgressBarData(steps=2) as root:
         assert root.steps == 2
+        assert root.step_weights is None
         await root.update()
         await root.update()
         await root.update()
         assert "already reached maximum" in caplog.messages[0]
         assert "TIP:" in caplog.messages[0]
+
+
+@pytest.fixture
+def mocked_progress_bar_cb(mocker: MockerFixture) -> mock.Mock:
+    return mocker.AsyncMock()
+
+
+async def test_weighted_progress_bar(mocked_progress_bar_cb: mock.Mock):
+    async with ProgressBarData(
+        steps=3,
+        step_weights=[1, 3, 1],
+        progress_report_cb=mocked_progress_bar_cb,
+    ) as root:
+        assert root.step_weights == [1 / 5, 3 / 5, 1 / 5, 0]
+        await root.update()
+        mocked_progress_bar_cb.assert_called_once_with(pytest.approx(1 / 5 * 3))
+        mocked_progress_bar_cb.reset_mock()
+        assert root._continuous_progress_value == pytest.approx(1)  # noqa: SLF001
+        await root.update()
+        mocked_progress_bar_cb.assert_called_once_with(
+            pytest.approx(1 / 5 * 3 + 3 / 5 * 3)
+        )
+        mocked_progress_bar_cb.reset_mock()
+        assert root._continuous_progress_value == pytest.approx(2)  # noqa: SLF001
+    mocked_progress_bar_cb.assert_called_once_with(3)
+    mocked_progress_bar_cb.reset_mock()
+    assert root._continuous_progress_value == pytest.approx(3)  # noqa: SLF001

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -63,6 +63,8 @@ async def test_progress_bar(mocked_progress_bar_cb: mock.Mock):
         assert mocked_progress_bar_cb.call_count == 25
         assert mocked_progress_bar_cb.call_args_list[24].args[0] == pytest.approx(1)
         mocked_progress_bar_cb.reset_mock()
+    # we were already done here
+    mocked_progress_bar_cb.assert_not_called()
 
 
 async def test_set_progress(

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -338,7 +338,7 @@ async def _upload_path(
     )
 
     if not progress_bar:
-        progress_bar = ProgressBarData(steps=1)
+        progress_bar = ProgressBarData(num_steps=1)
 
     is_directory: bool = isinstance(path_to_upload, Path) and path_to_upload.is_dir()
     if is_directory and not await r_clone.is_r_clone_available(r_clone_settings):

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
@@ -363,7 +363,7 @@ class Port(BaseServiceIOModel):
         await self._set(
             new_concrete_value=new_value,
             **set_kwargs,
-            progress_bar=progress_bar or ProgressBarData(steps=1),
+            progress_bar=progress_bar or ProgressBarData(num_steps=1),
         )
         await self._node_ports.save_to_db_cb(self._node_ports)
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
@@ -200,7 +200,7 @@ async def pull_file_from_store(
         local_path=local_path,
         io_log_redirect_cb=io_log_redirect_cb,
         r_clone_settings=r_clone_settings,
-        progress_bar=progress_bar or ProgressBarData(steps=1),
+        progress_bar=progress_bar or ProgressBarData(num_steps=1),
     )
     # if a file alias is present use it to rename the file accordingly
     if file_to_key_map:
@@ -273,7 +273,7 @@ async def pull_file_from_download_link(
         URL(f"{value.download_link}"),
         local_path,
         io_log_redirect_cb=io_log_redirect_cb,
-        progress_bar=progress_bar or ProgressBarData(steps=1),
+        progress_bar=progress_bar or ProgressBarData(num_steps=1),
     )
 
     # if a file alias is present use it to rename the file accordingly

--- a/packages/simcore-sdk/tests/integration/test_node_data_data_manager_.py
+++ b/packages/simcore-sdk/tests/integration/test_node_data_data_manager_.py
@@ -155,7 +155,7 @@ async def test_valid_upload_download(
     r_clone_settings: RCloneSettings,
     mock_io_log_redirect_cb: LogRedirectCB,
 ):
-    async with ProgressBarData(steps=2) as progress_bar:
+    async with ProgressBarData(num_steps=2) as progress_bar:
         await data_manager._push_directory(  # noqa: SLF001
             user_id=user_id,
             project_id=project_id,
@@ -166,9 +166,7 @@ async def test_valid_upload_download(
             r_clone_settings=r_clone_settings,
         )
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress_value == pytest.approx(  # noqa: SLF001
-            1.0
-        )
+        assert progress_bar._current_steps == pytest.approx(1.0)  # noqa: SLF001
 
         uploaded_hashes = _get_file_hashes_in_path(content_path)
 
@@ -183,9 +181,7 @@ async def test_valid_upload_download(
             r_clone_settings=r_clone_settings,
             progress_bar=progress_bar,
         )
-        assert progress_bar._continuous_progress_value == pytest.approx(  # noqa: SLF001
-            2.0
-        )
+        assert progress_bar._current_steps == pytest.approx(2.0)  # noqa: SLF001
 
     downloaded_hashes = _get_file_hashes_in_path(content_path)
 
@@ -210,7 +206,7 @@ async def test_valid_upload_download_saved_to(
     r_clone_settings: RCloneSettings,
     mock_io_log_redirect_cb: LogRedirectCB,
 ):
-    async with ProgressBarData(steps=2) as progress_bar:
+    async with ProgressBarData(num_steps=2) as progress_bar:
         await data_manager._push_directory(  # noqa: SLF001
             user_id=user_id,
             project_id=project_id,
@@ -221,9 +217,7 @@ async def test_valid_upload_download_saved_to(
             r_clone_settings=r_clone_settings,
         )
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress_value == pytest.approx(  # noqa: SLF001
-            1
-        )
+        assert progress_bar._current_steps == pytest.approx(1)  # noqa: SLF001
 
         uploaded_hashes = _get_file_hashes_in_path(content_path)
 
@@ -241,9 +235,7 @@ async def test_valid_upload_download_saved_to(
             r_clone_settings=r_clone_settings,
             progress_bar=progress_bar,
         )
-        assert progress_bar._continuous_progress_value == pytest.approx(  # noqa: SLF001
-            2
-        )
+        assert progress_bar._current_steps == pytest.approx(2)  # noqa: SLF001
 
     downloaded_hashes = _get_file_hashes_in_path(new_destination)
 
@@ -267,7 +259,7 @@ async def test_delete_legacy_archive(
     r_clone_settings: RCloneSettings,
     temp_dir: Path,
 ):
-    async with ProgressBarData(steps=2) as progress_bar:
+    async with ProgressBarData(num_steps=2) as progress_bar:
         # NOTE: legacy archives can no longer be crated
         # generating a "legacy style archive"
         archive_into_dir = temp_dir / f"legacy-archive-dir-{uuid4()}"
@@ -289,9 +281,7 @@ async def test_delete_legacy_archive(
         )
 
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress_value == pytest.approx(  # noqa: SLF001
-            1
-        )
+        assert progress_bar._current_steps == pytest.approx(1)  # noqa: SLF001
 
         assert (
             await data_manager._state_metadata_entry_exists(  # noqa: SLF001

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
@@ -74,7 +74,7 @@ async def test_valid_upload_download(
     file_path = create_file_of_size(file_size, "test.test")
 
     file_id = create_valid_file_uuid("", file_path)
-    async with ProgressBarData(steps=2) as progress_bar:
+    async with ProgressBarData(num_steps=2) as progress_bar:
         upload_result: UploadedFolder | UploadedFile = await filemanager.upload_path(
             user_id=user_id,
             store_id=s3_simcore_location,
@@ -88,9 +88,7 @@ async def test_valid_upload_download(
         assert isinstance(upload_result, UploadedFile)
         store_id, e_tag = upload_result.store_id, upload_result.etag
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress_value == pytest.approx(  # noqa: SLF001
-            1
-        )
+        assert progress_bar._current_steps == pytest.approx(1)  # noqa: SLF001
         assert store_id == s3_simcore_location
         assert e_tag
         get_store_id, get_e_tag = await filemanager.get_file_metadata(
@@ -110,9 +108,7 @@ async def test_valid_upload_download(
             r_clone_settings=optional_r_clone,
             progress_bar=progress_bar,
         )
-        assert progress_bar._continuous_progress_value == pytest.approx(
-            2
-        )  # noqa: SLF001
+        assert progress_bar._current_steps == pytest.approx(2)  # noqa: SLF001
     assert download_file_path.exists()
     assert download_file_path.name == "test.test"
     assert filecmp.cmp(download_file_path, file_path)
@@ -162,7 +158,7 @@ async def test_valid_upload_download_using_file_object(
     assert get_e_tag == e_tag
 
     download_folder = Path(tmpdir) / "downloads"
-    async with ProgressBarData(steps=1) as progress_bar:
+    async with ProgressBarData(num_steps=1) as progress_bar:
         download_file_path = await filemanager.download_path_from_s3(
             user_id=user_id,
             store_id=s3_simcore_location,
@@ -173,7 +169,7 @@ async def test_valid_upload_download_using_file_object(
             r_clone_settings=optional_r_clone,
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress_value == pytest.approx(1)  # noqa: SLF001
+    assert progress_bar._current_steps == pytest.approx(1)  # noqa: SLF001
     assert download_file_path.exists()
     assert download_file_path.name == "test.test"
     assert filecmp.cmp(download_file_path, file_path)
@@ -322,7 +318,7 @@ async def test_invalid_file_path(
 
     download_folder = Path(tmpdir) / "downloads"
     with pytest.raises(exceptions.S3InvalidPathError):  # noqa: PT012
-        async with ProgressBarData(steps=1) as progress_bar:
+        async with ProgressBarData(num_steps=1) as progress_bar:
             await filemanager.download_path_from_s3(
                 user_id=user_id,
                 store_id=store,
@@ -372,7 +368,7 @@ async def test_errors_upon_invalid_file_identifiers(
 
     download_folder = Path(tmpdir) / "downloads"
     with pytest.raises(exceptions.S3InvalidPathError):  # noqa: PT012
-        async with ProgressBarData(steps=1) as progress_bar:
+        async with ProgressBarData(num_steps=1) as progress_bar:
             invalid_s3_path = SimcoreS3FileID("")
             await filemanager.download_path_from_s3(
                 user_id=user_id,
@@ -386,7 +382,7 @@ async def test_errors_upon_invalid_file_identifiers(
             )
 
     with pytest.raises(exceptions.S3InvalidPathError):  # noqa: PT012
-        async with ProgressBarData(steps=1) as progress_bar:
+        async with ProgressBarData(num_steps=1) as progress_bar:
             await filemanager.download_path_from_s3(
                 user_id=user_id,
                 store_id=store,
@@ -424,7 +420,7 @@ async def test_invalid_store(
 
     download_folder = Path(tmpdir) / "downloads"
     with pytest.raises(exceptions.S3InvalidStore):  # noqa: PT012
-        async with ProgressBarData(steps=1) as progress_bar:
+        async with ProgressBarData(num_steps=1) as progress_bar:
             await filemanager.download_path_from_s3(
                 user_id=user_id,
                 store_id=None,
@@ -608,7 +604,7 @@ async def test_upload_path_source_is_a_folder(
     assert isinstance(upload_result, UploadedFolder)
     assert source_dir.exists()
 
-    async with ProgressBarData(steps=1) as progress_bar:
+    async with ProgressBarData(num_steps=1) as progress_bar:
         await filemanager.download_path_from_s3(
             user_id=user_id,
             store_name=None,

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
@@ -140,7 +140,7 @@ async def _upload_local_dir_to_s3(
         progress_entries.append(progress_value)
 
     async with ProgressBarData(
-        steps=1, progress_report_cb=_report_progress_upload
+        num_steps=1, progress_report_cb=_report_progress_upload
     ) as progress_bar:
         await r_clone.sync_local_to_s3(
             r_clone_settings,
@@ -164,7 +164,7 @@ async def _download_from_s3_to_local_dir(
         print(">>>|", progress_value, "| ⏬")
 
     async with ProgressBarData(
-        steps=1, progress_report_cb=_report_progress_download
+        num_steps=1, progress_report_cb=_report_progress_download
     ) as progress_bar:
         await r_clone.sync_s3_to_local(
             r_clone_settings,

--- a/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
@@ -756,7 +756,7 @@ async def test_batch_update_inputs_outputs(
     )
     await check_config_valid(PORTS, config_dict)
 
-    async with ProgressBarData(steps=2) as progress_bar:
+    async with ProgressBarData(num_steps=2) as progress_bar:
         await PORTS.set_multiple(
             {
                 PortKey(port.key): (k, None)
@@ -765,7 +765,7 @@ async def test_batch_update_inputs_outputs(
             progress_bar=progress_bar,
         )
         # pylint: disable=protected-access
-        assert progress_bar._continuous_progress_value == pytest.approx(1)
+        assert progress_bar._current_steps == pytest.approx(1)
         await PORTS.set_multiple(
             {
                 PortKey(port.key): (k, None)
@@ -773,7 +773,7 @@ async def test_batch_update_inputs_outputs(
             },
             progress_bar=progress_bar,
         )
-        assert progress_bar._continuous_progress_value == pytest.approx(2)
+        assert progress_bar._current_steps == pytest.approx(2)
 
     ports_outputs = await PORTS.outputs
     ports_inputs = await PORTS.inputs
@@ -789,9 +789,9 @@ async def test_batch_update_inputs_outputs(
 
     # test missing key raises error
     with pytest.raises(UnboundPortError):
-        async with ProgressBarData(steps=1) as progress_bar:
+        async with ProgressBarData(num_steps=1) as progress_bar:
             await PORTS.set_multiple(
                 {PortKey("missing_key_in_both"): (123132, None)},
                 progress_bar=progress_bar,
             )
-            assert progress_bar._continuous_progress_value == pytest.approx(0)
+            assert progress_bar._current_steps == pytest.approx(0)

--- a/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
+++ b/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
@@ -91,7 +91,7 @@ async def test_push_folder(
     assert len(list(test_folder.glob("**/*"))) == files_number
     for file_path in test_folder.glob("**/*"):
         assert file_path.exists()
-    async with ProgressBarData(steps=1) as progress_bar:
+    async with ProgressBarData(num_steps=1) as progress_bar:
         await data_manager._push_directory(
             user_id,
             project_id,
@@ -101,7 +101,7 @@ async def test_push_folder(
             progress_bar=progress_bar,
             r_clone_settings=r_clone_settings,
         )
-    assert progress_bar._continuous_progress_value == pytest.approx(1)
+    assert progress_bar._current_steps == pytest.approx(1)
 
     mock_filemanager.upload_path.assert_called_once_with(
         r_clone_settings=r_clone_settings,
@@ -138,7 +138,7 @@ async def test_push_file(
     assert file_path.exists()
 
     # test push file by file
-    async with ProgressBarData(steps=1) as progress_bar:
+    async with ProgressBarData(num_steps=1) as progress_bar:
         await data_manager._push_directory(
             user_id,
             project_id,
@@ -148,7 +148,7 @@ async def test_push_file(
             progress_bar=progress_bar,
             r_clone_settings=r_clone_settings,
         )
-    assert progress_bar._continuous_progress_value == pytest.approx(1)
+    assert progress_bar._current_steps == pytest.approx(1)
     mock_temporary_directory.assert_not_called()
     mock_filemanager.upload_path.assert_called_once_with(
         r_clone_settings=r_clone_settings,
@@ -212,7 +212,7 @@ async def test_pull_legacy_archive(
         test_compression_folder
     )
 
-    async with ProgressBarData(steps=1) as progress_bar:
+    async with ProgressBarData(num_steps=1) as progress_bar:
         await data_manager._pull_legacy_archive(
             user_id,
             project_id,
@@ -221,7 +221,7 @@ async def test_pull_legacy_archive(
             io_log_redirect_cb=mock_io_log_redirect_cb,
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress_value == pytest.approx(1)
+    assert progress_bar._current_steps == pytest.approx(1)
     mock_temporary_directory.assert_called_once()
     mock_filemanager.download_path_from_s3.assert_called_once_with(
         user_id=user_id,
@@ -266,7 +266,7 @@ async def test_pull_directory(
     )
     mock_filemanager.download_path_from_s3.return_value = fake_download_folder
 
-    async with ProgressBarData(steps=1) as progress_bar:
+    async with ProgressBarData(num_steps=1) as progress_bar:
         await data_manager._pull_directory(
             user_id,
             project_id,
@@ -276,7 +276,7 @@ async def test_pull_directory(
             r_clone_settings=r_clone_settings,
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress_value == pytest.approx(1)
+    assert progress_bar._current_steps == pytest.approx(1)
     mock_filemanager.download_path_from_s3.assert_called_once_with(
         local_path=fake_download_folder,
         s3_object=f"{project_id}/{node_uuid}/{fake_download_folder.name}",

--- a/packages/simcore-sdk/tests/unit/test_node_ports_common_file_io_utils.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_common_file_io_utils.py
@@ -133,7 +133,7 @@ async def test_upload_file_to_presigned_links_raises_aws_s3_400_request_time_out
         side_effect=AwsS3BadRequestRequestTimeoutError(body="nothing"),
     )
 
-    async with ProgressBarData(steps=1) as progress_bar:
+    async with ProgressBarData(num_steps=1) as progress_bar:
         with pytest.raises(AwsS3BadRequestRequestTimeoutError):
             await upload_file_to_presigned_links(
                 session=AsyncMock(),
@@ -269,7 +269,7 @@ async def test_upload_file_to_presigned_links(
     assert effective_chunk_size <= used_chunk_size
     upload_links = await create_upload_links(num_links, used_chunk_size)
     assert len(upload_links.urls) == num_links
-    async with ProgressBarData(steps=1) as progress_bar:
+    async with ProgressBarData(num_steps=1) as progress_bar:
         uploaded_parts: list[UploadedPart] = await upload_file_to_presigned_links(
             session=client_session,
             file_upload_links=upload_links,
@@ -278,5 +278,5 @@ async def test_upload_file_to_presigned_links(
             io_log_redirect_cb=None,
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress_value == pytest.approx(1)
+    assert progress_bar._current_steps == pytest.approx(1)
     assert uploaded_parts

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_nodeports_v2.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_nodeports_v2.py
@@ -130,7 +130,7 @@ async def test_node_ports_accessors(
         await node_ports.set(port.key, port.value)
 
     # test batch add
-    async with ProgressBarData(steps=1) as progress_bar:
+    async with ProgressBarData(num_steps=1) as progress_bar:
         await node_ports.set_multiple(
             {
                 port.key: (port.value, None)
@@ -139,7 +139,7 @@ async def test_node_ports_accessors(
             },
             progress_bar=progress_bar,
         )
-    assert progress_bar._continuous_progress_value == pytest.approx(1)
+    assert progress_bar._current_steps == pytest.approx(1)
 
 
 @pytest.fixture(scope="session")

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -168,7 +168,7 @@ class ComputationalSidecar:
         async with Docker() as docker_client, TaskSharedVolumes(
             Path(f"{settings.SIDECAR_COMP_SERVICES_SHARED_FOLDER}/{run_id}")
         ) as task_volumes, ProgressBarData(
-            steps=3, progress_report_cb=self.task_publishers.publish_progress
+            num_steps=3, progress_report_cb=self.task_publishers.publish_progress
         ) as progress_bar:
             # PRE-PROCESSING
             await pull_image(

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -168,7 +168,9 @@ class ComputationalSidecar:
         async with Docker() as docker_client, TaskSharedVolumes(
             Path(f"{settings.SIDECAR_COMP_SERVICES_SHARED_FOLDER}/{run_id}")
         ) as task_volumes, ProgressBarData(
-            num_steps=3, progress_report_cb=self.task_publishers.publish_progress
+            num_steps=3,
+            step_weights=[5 / 100, 90 / 100, 5 / 100],
+            progress_report_cb=self.task_publishers.publish_progress,
         ) as progress_bar:
             # PRE-PROCESSING
             await pull_image(

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
@@ -185,7 +185,7 @@ async def _parse_and_publish_logs(
         log_line, progress_regexp=progress_regexp
     )
     if progress_value is not None:
-        await progress_bar.set_progress(round(progress_value * 100.0))
+        await progress_bar.set_(round(progress_value * 100.0))
 
     task_publishers.publish_logs(
         message=log_line, log_level=guess_message_log_level(log_line)

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
@@ -34,6 +34,7 @@ from servicelib.logging_utils import (
     log_catch,
     log_context,
 )
+from servicelib.progress_bar import ProgressBarData
 from settings_library.s3 import S3Settings
 
 from ..dask_utils import TaskPublisher
@@ -178,16 +179,13 @@ async def _parse_and_publish_logs(
     *,
     task_publishers: TaskPublisher,
     progress_regexp: re.Pattern[str],
-    container_processing_progress_weight: float,
+    progress_bar: ProgressBarData,
 ) -> None:
     progress_value = await _try_parse_progress(
         log_line, progress_regexp=progress_regexp
     )
-    assert 0 < container_processing_progress_weight <= 1.0  # nosec  # noqa: PLR2004
     if progress_value is not None:
-        task_publishers.publish_progress(
-            container_processing_progress_weight * progress_value
-        )
+        await progress_bar.set_progress(round(progress_value * 100.0))
 
     task_publishers.publish_logs(
         message=log_line, log_level=guess_message_log_level(log_line)
@@ -206,7 +204,7 @@ async def _parse_container_log_file(  # noqa: PLR0913 # pylint: disable=too-many
     log_file_url: LogFileUploadURL,
     log_publishing_cb: LogPublishingCB,
     s3_settings: S3Settings | None,
-    max_monitoring_progress_value: float,
+    progress_bar: ProgressBarData,
 ) -> None:
     log_file = task_volumes.logs_folder / LEGACY_SERVICE_LOG_FILE_NAME
     with log_context(
@@ -226,7 +224,7 @@ async def _parse_container_log_file(  # noqa: PLR0913 # pylint: disable=too-many
                         line,
                         task_publishers=task_publishers,
                         progress_regexp=progress_regexp,
-                        container_processing_progress_weight=max_monitoring_progress_value,
+                        progress_bar=progress_bar,
                     )
 
             # finish reading the logs if possible
@@ -240,7 +238,7 @@ async def _parse_container_log_file(  # noqa: PLR0913 # pylint: disable=too-many
                     line,
                     task_publishers=task_publishers,
                     progress_regexp=progress_regexp,
-                    container_processing_progress_weight=max_monitoring_progress_value,
+                    progress_bar=progress_bar,
                 )
 
             # copy the log file to the log_file_url
@@ -260,7 +258,7 @@ async def _parse_container_docker_logs(
     log_file_url: LogFileUploadURL,
     log_publishing_cb: LogPublishingCB,
     s3_settings: S3Settings | None,
-    container_processing_progress_weight: float,
+    progress_bar: ProgressBarData,
 ) -> None:
     with log_context(
         logger, logging.DEBUG, "started monitoring of >=1.0 service - using docker logs"
@@ -290,7 +288,7 @@ async def _parse_container_docker_logs(
                         log_msg_without_timestamp,
                         task_publishers=task_publishers,
                         progress_regexp=progress_regexp,
-                        container_processing_progress_weight=container_processing_progress_weight,
+                        progress_bar=progress_bar,
                     )
 
             # copy the log file to the log_file_url
@@ -311,7 +309,7 @@ async def _monitor_container_logs(  # noqa: PLR0913 # pylint: disable=too-many-a
     log_file_url: LogFileUploadURL,
     log_publishing_cb: LogPublishingCB,
     s3_settings: S3Settings | None,
-    container_processing_progress_weight: float,
+    progress_bar: ProgressBarData,
 ) -> None:
     """Services running with integration version 0.0.0 are logging into a file
     that must be available in task_volumes.log / log.dat
@@ -337,7 +335,7 @@ async def _monitor_container_logs(  # noqa: PLR0913 # pylint: disable=too-many-a
                     log_file_url=log_file_url,
                     log_publishing_cb=log_publishing_cb,
                     s3_settings=s3_settings,
-                    container_processing_progress_weight=container_processing_progress_weight,
+                    progress_bar=progress_bar,
                 )
             else:
                 await _parse_container_log_file(
@@ -351,7 +349,7 @@ async def _monitor_container_logs(  # noqa: PLR0913 # pylint: disable=too-many-a
                     log_file_url=log_file_url,
                     log_publishing_cb=log_publishing_cb,
                     s3_settings=s3_settings,
-                    max_monitoring_progress_value=container_processing_progress_weight,
+                    progress_bar=progress_bar,
                 )
 
 
@@ -367,7 +365,7 @@ async def managed_monitor_container_log_task(  # noqa: PLR0913 # pylint: disable
     log_file_url: LogFileUploadURL,
     log_publishing_cb: LogPublishingCB,
     s3_settings: S3Settings | None,
-    container_processing_progress_weight: float,
+    progress_bar: ProgressBarData,
 ) -> AsyncIterator[Awaitable[None]]:
     monitoring_task = None
     try:
@@ -388,7 +386,7 @@ async def managed_monitor_container_log_task(  # noqa: PLR0913 # pylint: disable
                     log_file_url=log_file_url,
                     log_publishing_cb=log_publishing_cb,
                     s3_settings=s3_settings,
-                    container_processing_progress_weight=container_processing_progress_weight,
+                    progress_bar=progress_bar,
                 ),
                 name=f"{service_key}:{service_version}_{container.id}_monitoring_task",
             )

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/dask_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/dask_utils.py
@@ -79,6 +79,7 @@ class TaskPublisher:
                     ),
                 )
                 self._last_published_progress_value = rounded_value
+            _logger.debug("PROGRESS: %s", rounded_value)
 
     def publish_logs(
         self,

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/dask_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/dask_utils.py
@@ -68,8 +68,8 @@ class TaskPublisher:
         self.progress = distributed.Pub(TaskProgressEvent.topic_name())
         self.logs = distributed.Pub(TaskLogEvent.topic_name())
 
-    def publish_progress(self, value: float) -> None:
-        rounded_value = round(value, ndigits=2)
+    def publish_progress(self, progress_value: float) -> None:
+        rounded_value = round(progress_value, ndigits=2)
         if rounded_value > self._last_published_progress_value:
             with log_catch(logger=_logger, reraise=False):
                 publish_event(

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
@@ -241,7 +241,7 @@ async def push_file_to_remote(
                 logging.INFO,
             )
             with zipfile.ZipFile(
-                archive_file_path, mode="w", compression=zipfile.ZIP_DEFLATED
+                archive_file_path, mode="w", compression=zipfile.ZIP_STORED
             ) as zfp:
                 await asyncio.get_event_loop().run_in_executor(
                     None, zfp.write, src_path, src_path.name

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -583,12 +583,11 @@ async def test_run_computational_sidecar_dask(
         TaskProgressEvent.parse_raw(msg).progress for msg in progress_sub.buffer
     ]
     # check ordering
-    assert worker_progresses == list(
+    assert worker_progresses == sorted(
         set(worker_progresses)
     ), "ordering of progress values incorrectly sorted!"
     assert worker_progresses[0] == 0, "missing/incorrect initial progress value"
     assert worker_progresses[-1] == 1, "missing/incorrect final progress value"
-
     worker_logs = [TaskLogEvent.parse_raw(msg).log for msg in log_sub.buffer]
     print(f"<-- we got {len(worker_logs)} lines of logs")
 

--- a/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
+++ b/services/director-v2/tests/integration/02/test_dynamic_sidecar_nodeports_integration.py
@@ -639,7 +639,7 @@ async def _fetch_data_via_data_manager(
         is True
     )
 
-    async with ProgressBarData(steps=1) as progress_bar:
+    async with ProgressBarData(num_steps=1) as progress_bar:
         await data_manager._pull_directory(
             user_id=user_id,
             project_id=project_id,

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/long_running_tasks.py
@@ -348,7 +348,7 @@ async def task_restore_state(
         log_level=logging.INFO,
     )
     async with ProgressBarData(
-        steps=len(state_paths),
+        num_steps=len(state_paths),
         progress_report_cb=functools.partial(
             post_progress_message, app, ProgressType.SERVICE_STATE_PULLING
         ),
@@ -399,7 +399,7 @@ async def task_save_state(
     progress.update(message="starting state save", percent=0.0)
     state_paths = list(mounted_volumes.disk_state_paths_iter())
     async with ProgressBarData(
-        steps=len(state_paths),
+        num_steps=len(state_paths),
         progress_report_cb=functools.partial(
             post_progress_message, app, ProgressType.SERVICE_STATE_PUSHING
         ),
@@ -435,7 +435,7 @@ async def task_ports_inputs_pull(
     )
     progress.update(message="pulling inputs", percent=0.1)
     async with ProgressBarData(
-        steps=1,
+        num_steps=1,
         progress_report_cb=functools.partial(
             post_progress_message, app, ProgressType.SERVICE_INPUTS_PULLING
         ),
@@ -468,7 +468,7 @@ async def task_ports_outputs_pull(
         app, f"Pulling output for {port_keys}", log_level=logging.INFO
     )
     async with ProgressBarData(
-        steps=1,
+        num_steps=1,
         progress_report_cb=functools.partial(
             post_progress_message, app, ProgressType.SERVICE_OUTPUTS_PULLING
         ),

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
@@ -128,7 +128,7 @@ class OutputsManager:  # pylint: disable=too-many-instance-attributes
         async def _upload_ports() -> None:
             with log_context(logger, logging.INFO, f"Uploading port keys: {port_keys}"):
                 async with progress_bar.ProgressBarData(
-                    steps=1, progress_report_cb=self.task_progress_cb
+                    num_steps=1, progress_report_cb=self.task_progress_cb
                 ) as root_progress:
                     await upload_outputs(
                         outputs_path=self.outputs_context.outputs_path,

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -921,33 +921,33 @@ class SimcoreS3DataManager(BaseDataManager):
                 list_of_valid_upload_ids.append(upload_id)
 
         _logger.debug("found the following %s", f"{list_of_valid_upload_ids=}")
-        list_of_invalid_uploads = [
+        if list_of_invalid_uploads := [
             (
                 upload_id,
                 file_id,
             )
             for upload_id, file_id in current_multipart_uploads
             if upload_id not in list_of_valid_upload_ids
-        ]
-        _logger.debug(
-            "the following %s was found and will now be aborted",
-            f"{list_of_invalid_uploads=}",
-        )
-        await logged_gather(
-            *(
-                get_s3_client(self.app).abort_multipart_upload(
-                    self.simcore_bucket_name, file_id, upload_id
-                )
-                for upload_id, file_id in list_of_invalid_uploads
-            ),
-            max_concurrency=MAX_CONCURRENT_S3_TASKS,
-        )
-        _logger.warning(
-            "Dangling multipart uploads '%s', were aborted. "
-            "TIP: There were multipart uploads active on S3 with no counter-part in the file_meta_data database. "
-            "This might indicate that something went wrong in how storage handles multipart uploads!!",
-            f"{list_of_invalid_uploads}",
-        )
+        ]:
+            _logger.debug(
+                "the following %s was found and will now be aborted",
+                f"{list_of_invalid_uploads=}",
+            )
+            await logged_gather(
+                *(
+                    get_s3_client(self.app).abort_multipart_upload(
+                        self.simcore_bucket_name, file_id, upload_id
+                    )
+                    for upload_id, file_id in list_of_invalid_uploads
+                ),
+                max_concurrency=MAX_CONCURRENT_S3_TASKS,
+            )
+            _logger.warning(
+                "Dangling multipart uploads '%s', were aborted. "
+                "TIP: There were multipart uploads active on S3 with no counter-part in the file_meta_data database. "
+                "This might indicate that something went wrong in how storage handles multipart uploads!!",
+                f"{list_of_invalid_uploads}",
+            )
 
     async def clean_expired_uploads(self) -> None:
         await self._clean_expired_uploads()

--- a/services/web/server/src/simcore_service_webserver/director_v2/_core_dynamic_services.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2/_core_dynamic_services.py
@@ -213,7 +213,7 @@ async def stop_dynamic_services_in_project(
     async with AsyncExitStack() as stack:
         progress_bar = await stack.enter_async_context(
             ProgressBarData(
-                steps=len(running_dynamic_services),
+                num_steps=len(running_dynamic_services),
                 progress_report_cb=partial(
                     _post_progress_message,
                     get_rabbitmq_client(app),


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?
**This PR brings some refactoring and new features to the _ProgressBarData_ class:**
- [x] allow usage of sync and async progress reporter for more flexibility
- [x] a progress bar data may be _weighted_, i.e. some steps may have different weights (for example a progress bar of 3 steps with the 1st step being 1/10 of the progress, while the 2nd takes 8/10 and the last step again 1/10
- [x] refactoring --> adds some noise in the PR

**This PR also refactors the main dask-sidecar function:**
- [x] use _ProgressBarData_
- [x] Pulling data and docker image now represents 5% of the progress
- [x] Running the docker image now represents 90% of the progress
- [x] Pushing the data represents 5% of progress


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
