### PR TITLE
🐛Dask-Sidecar: improper detection of GPUs on multi-GPU machines if log-driver is improperly set

### DIFF
--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils.py
@@ -27,6 +27,7 @@ def _nvidia_smi_docker_config(cmd: list[str]) -> dict[str, Any]:
         "HostConfig": {
             "Init": True,
             "AutoRemove": False,  # NOTE: this cannot be True as we need the logs of the container before removing it
+            "LogConfig": {"Type": "json-file"},
         },  # NOTE: The Init parameter shows a weird behavior: no exception thrown when the container fails
     }
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?
This PR changes slightly how the dask-sidecar detects the number of GPUs by imposing Docker default log-driver to use.
After testing it came as a surprise that the number of GPUs on a multi-gpu machine was reported wrong!

The machine was setup as such:
  ```bash
   cat /etc/docker/daemon.json
{
  "metrics-addr": "0.0.0.0:9323",
  "experimental": true,
  "default-runtime": "nvidia",
  "runtimes": {
    "nvidia": {
      "path": "/usr/bin/nvidia-container-runtime",
      "runtimeArgs": []
    }
  },
  "log-driver": "gelf",
  "log-opts": {
    "gelf-address": "udp://0.0.0.0:12201"
  },
  "data-root": "/mnt/docker/data",
  "exec-root": "/mnt/docker/exec",
  "default-address-pools": [
    {
      "base": "172.17.0.0/12",
      "size": 20
    },
    {
      "base": "192.168.0.0/16",
      "size": 24
    }
  ]
}
```
Note that the log-driver is set to _gelf_ and probably the url is wrong in this case.
--> running ```docker run -it nvidia/cuda:12.2.0-base-ubuntu22.04 nvidia-smi --list-gpus``` would output the correct number of GPUs
--> **BUT** running ```docker logs CONTAINER_ID``` (where CONTAINER_ID is the id of the container run just above) would show only half that number!!! [this might be an explanation to the problem](https://docs.docker.com/config/containers/logging/dual-logging/#limitations)

reverting the log-driver to json-file would fix that.

Therefore the change is done now to be independent of any kind of log-driver.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
