### PR TITLE
♻️ Remove WSL-related Makefile integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,13 +84,6 @@ export SWARM_STACK_NAME_NO_HYPHEN = $(subst -,_,$(SWARM_STACK_NAME))
 export DOCKER_IMAGE_TAG ?= latest
 export DOCKER_REGISTRY  ?= itisfoundation
 
-# NOTE: this is only for WSL1 as /etc/hostname is not accessible there
-ifeq ($(IS_WSL),WSL)
-ETC_HOSTNAME = $(CURDIR)/.fake_hostname_file
-export ETC_HOSTNAME
-host := $(shell echo $$(hostname) > $(ETC_HOSTNAME))
-endif
-
 get_my_ip := $(shell hostname --all-ip-addresses | cut --delimiter=" " --fields=1)
 
 # NOTE: this is only for WSL2 as the WSL2 subsystem IP is changing on each reboot


### PR DESCRIPTION
We dont support WSL at all, but especially not WSL1. Let's remove the legacy code related to it.