### PR TITLE
🐛Correctly handle file type of on-demand clusters

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_clients_pool.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_clients_pool.py
@@ -80,7 +80,7 @@ class DaskClientsPool:
                         tasks_file_link_type = (
                             self.settings.COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_FILE_LINK_TYPE
                         )
-                    if cluster.type is ClusterTypeInModel.ON_DEMAND:
+                    if cluster.type == ClusterTypeInModel.ON_DEMAND.value:
                         tasks_file_link_type = (
                             self.settings.COMPUTATIONAL_BACKEND_ON_DEMAND_CLUSTERS_FILE_LINK_TYPE
                         )

--- a/services/storage/src/simcore_service_storage/exceptions.py
+++ b/services/storage/src/simcore_service_storage/exceptions.py
@@ -44,7 +44,7 @@ class S3AccessError(StorageRuntimeError):
 
 class S3BucketInvalidError(S3AccessError):
     code = "s3_bucket.invalid_error"
-    msg_template: str = "The {bucket} is invalid"
+    msg_template: str = "The bucket '{bucket}' is invalid"
 
 
 class S3KeyNotFoundError(S3AccessError):

--- a/services/storage/src/simcore_service_storage/handlers_files.py
+++ b/services/storage/src/simcore_service_storage/handlers_files.py
@@ -192,9 +192,9 @@ async def upload_file(request: web.Request) -> web.Response:
     )
     if query_params.file_size is None and not query_params.is_directory:
         # return v1 response
+        assert len(links.urls) == 1  # nosec
         response = {"data": {"link": jsonable_encoder(links.urls[0], by_alias=True)}}
         log.debug("Returning v1 response: %s", response)
-        assert len(links.urls) == 1  # nosec
         return web.json_response(response, dumps=json_dumps)
 
     # v2 response

--- a/services/storage/src/simcore_service_storage/handlers_files.py
+++ b/services/storage/src/simcore_service_storage/handlers_files.py
@@ -192,11 +192,10 @@ async def upload_file(request: web.Request) -> web.Response:
     )
     if query_params.file_size is None and not query_params.is_directory:
         # return v1 response
+        response = {"data": {"link": jsonable_encoder(links.urls[0], by_alias=True)}}
+        log.debug("Returning v1 response: %s", response)
         assert len(links.urls) == 1  # nosec
-        return web.json_response(
-            {"data": {"link": jsonable_encoder(links.urls[0], by_alias=True)}},
-            dumps=json_dumps,
-        )
+        return web.json_response(response, dumps=json_dumps)
 
     # v2 response
     abort_url = request.url.join(
@@ -226,7 +225,7 @@ async def upload_file(request: web.Request) -> web.Response:
             ),
         ),
     )
-
+    log.debug("returning v2 response: %s", response)
     return jsonable_encoder(response, by_alias=True)
 
 

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -805,12 +805,13 @@ class SimcoreS3DataManager(BaseDataManager):
             list_of_expired_uploads = await db_file_meta_data.list_fmds(
                 conn, expired_after=now
             )
+
+        if not list_of_expired_uploads:
+            return
         _logger.debug(
             "found following pending uploads: [%s]",
             [fmd.file_id for fmd in list_of_expired_uploads],
         )
-        if not list_of_expired_uploads:
-            return
 
         # try first to upload these from S3 (conservative)
         updated_fmds = await logged_gather(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

This PR fixes the issue where using on-demand clusters would not properly use S3 file types but instead were locked on presigned links.
This had the consequence of limiting uploads to max 5Gib, but is also the sad fact that we still do not properly fixed it by using the public API from the dask-sidecars.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test
Use a python runner and run the following script:
```python
import os


def generate_large_file(file_path, size_gb):
    with open(file_path, "wb") as f:
        # Generate random data
        chunk_size = 1024 * 1024  # 1 MB chunks
        for _ in range(size_gb * 1024):
            data = os.urandom(chunk_size)
            f.write(data)


def create_file():
    # Example usage:
    desired_file_path = "/outputs/large_file.txt"
    desired_size_gb = 6  # Adjust this to your desired size in gigabytes

    generate_large_file(desired_file_path, desired_size_gb)

    print(f"Large file created: {desired_file_path}")


if __name__ == "__main__":
    create_file()

```
<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
- hotfix to sim4life.io
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
