### PR TITLE
♻️ do not send heartbeat as soon as the service is started

### DIFF
--- a/packages/service-library/src/servicelib/background_task.py
+++ b/packages/service-library/src/servicelib/background_task.py
@@ -12,7 +12,7 @@ from tenacity._asyncio import AsyncRetrying
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 _DEFAULT_STOP_TIMEOUT_S: Final[int] = 5
@@ -28,16 +28,24 @@ async def _periodic_scheduled_task(
     *,
     interval: datetime.timedelta,
     task_name: str,
+    wait_before_running: bool,
     **task_kwargs,
 ) -> None:
+    wait_interval: float = interval.total_seconds()
+    if wait_before_running:
+        with log_context(
+            _logger, logging.DEBUG, f"waiting {wait_interval} seconds before running"
+        ):
+            await asyncio.sleep(wait_interval)
+
     # NOTE: This retries forever unless cancelled
-    async for attempt in AsyncRetrying(wait=wait_fixed(interval.total_seconds())):
+    async for attempt in AsyncRetrying(wait=wait_fixed(wait_interval)):
         with attempt:
             with log_context(
-                logger,
+                _logger,
                 logging.INFO,
                 msg=f"iteration {attempt.retry_state.attempt_number} of '{task_name}'",
-            ), log_catch(logger):
+            ), log_catch(_logger):
                 await task(**task_kwargs)
 
             raise TryAgain
@@ -48,16 +56,18 @@ def start_periodic_task(
     *,
     interval: datetime.timedelta,
     task_name: str,
+    wait_before_running: bool = False,
     **kwargs,
 ) -> asyncio.Task:
     with log_context(
-        logger, logging.DEBUG, msg=f"create periodic background task '{task_name}'"
+        _logger, logging.DEBUG, msg=f"create periodic background task '{task_name}'"
     ):
         return asyncio.create_task(
             _periodic_scheduled_task(
                 task,
                 interval=interval,
                 task_name=task_name,
+                wait_before_running=wait_before_running,
                 **kwargs,
             ),
             name=task_name,
@@ -87,7 +97,7 @@ async def cancel_task(
             _, pending = await asyncio.wait((task,), timeout=timeout)
             if pending:
                 task_name = task.get_name()
-                logger.info(
+                _logger.info(
                     "tried to cancel '%s' but timed-out! %s", task_name, pending
                 )
                 raise PeriodicTaskCancellationError(task_name=task_name)
@@ -97,7 +107,7 @@ async def stop_periodic_task(
     asyncio_task: asyncio.Task, *, timeout: float | None = None
 ) -> None:
     with log_context(
-        logger,
+        _logger,
         logging.DEBUG,
         msg=f"cancel periodic background task '{asyncio_task.get_name()}'",
     ):

--- a/packages/service-library/src/servicelib/background_task.py
+++ b/packages/service-library/src/servicelib/background_task.py
@@ -12,7 +12,7 @@ from tenacity._asyncio import AsyncRetrying
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
 
-_logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 _DEFAULT_STOP_TIMEOUT_S: Final[int] = 5
@@ -34,7 +34,7 @@ async def _periodic_scheduled_task(
     wait_interval: float = interval.total_seconds()
     if wait_before_running:
         with log_context(
-            _logger, logging.DEBUG, f"waiting {wait_interval} seconds before running"
+            logger, logging.DEBUG, f"waiting {wait_interval} seconds before running"
         ):
             await asyncio.sleep(wait_interval)
 
@@ -42,10 +42,10 @@ async def _periodic_scheduled_task(
     async for attempt in AsyncRetrying(wait=wait_fixed(wait_interval)):
         with attempt:
             with log_context(
-                _logger,
+                logger,
                 logging.INFO,
                 msg=f"iteration {attempt.retry_state.attempt_number} of '{task_name}'",
-            ), log_catch(_logger):
+            ), log_catch(logger):
                 await task(**task_kwargs)
 
             raise TryAgain
@@ -60,7 +60,7 @@ def start_periodic_task(
     **kwargs,
 ) -> asyncio.Task:
     with log_context(
-        _logger, logging.DEBUG, msg=f"create periodic background task '{task_name}'"
+        logger, logging.DEBUG, msg=f"create periodic background task '{task_name}'"
     ):
         return asyncio.create_task(
             _periodic_scheduled_task(
@@ -97,7 +97,7 @@ async def cancel_task(
             _, pending = await asyncio.wait((task,), timeout=timeout)
             if pending:
                 task_name = task.get_name()
-                _logger.info(
+                logger.info(
                     "tried to cancel '%s' but timed-out! %s", task_name, pending
                 )
                 raise PeriodicTaskCancellationError(task_name=task_name)
@@ -107,7 +107,7 @@ async def stop_periodic_task(
     asyncio_task: asyncio.Task, *, timeout: float | None = None
 ) -> None:
     with log_context(
-        _logger,
+        logger,
         logging.DEBUG,
         msg=f"cancel periodic background task '{asyncio_task.get_name()}'",
     ):

--- a/packages/service-library/src/servicelib/background_task.py
+++ b/packages/service-library/src/servicelib/background_task.py
@@ -57,15 +57,15 @@ def start_periodic_task(
         logger, logging.DEBUG, msg=f"create periodic background task '{task_name}'"
     ):
         delayed_periodic_scheduled_task = async_delayed(wait_before_running)(
-            _periodic_scheduled_task(
+            _periodic_scheduled_task
+        )
+        return asyncio.create_task(
+            delayed_periodic_scheduled_task(
                 task,
                 interval=interval,
                 task_name=task_name,
                 **kwargs,
-            )
-        )
-        return asyncio.create_task(
-            delayed_periodic_scheduled_task(),
+            ),
             name=task_name,
         )
 

--- a/packages/service-library/src/servicelib/decorators.py
+++ b/packages/service-library/src/servicelib/decorators.py
@@ -4,14 +4,18 @@ IMPORTANT: lowest level module
    I order to avoid cyclic dependences, please
    DO NOT IMPORT ANYTHING from .
 """
+import asyncio
+import datetime
 import logging
+from collections.abc import Callable
 from copy import deepcopy
 from functools import wraps
+from typing import Any, Coroutine
 
 log = logging.getLogger(__name__)
 
 
-def safe_return(if_fails_return=False, catch=None, logger=None):
+def safe_return(if_fails_return=False, catch=None, logger=None):  # noqa: FBT002
     # defaults
     if catch is None:
         catch = (RuntimeError,)
@@ -20,16 +24,29 @@ def safe_return(if_fails_return=False, catch=None, logger=None):
 
     def decorate(func):
         @wraps(func)
-        def safe_func(*args, **kargs):
+        def safe_func(*args, **kwargs):
             try:
-                res = func(*args, **kargs)
-                return res
+                return func(*args, **kwargs)
             except catch as err:
                 logger.info("%s failed:  %s", func.__name__, str(err))
             except Exception:  # pylint: disable=broad-except
                 logger.info("%s failed unexpectedly", func.__name__, exc_info=True)
-            return deepcopy(if_fails_return)  # avoid issues with default mutables
+            return deepcopy(if_fails_return)  # avoid issues with default mutable
 
         return safe_func
 
     return decorate
+
+
+def async_delayed(
+    interval: datetime.timedelta,
+) -> Callable[..., Callable[..., Coroutine]]:
+    def decorator(func) -> Callable[..., Coroutine]:
+        @wraps(func)
+        async def wrapper(*args, **kwargs) -> Any:
+            await asyncio.sleep(interval.total_seconds())
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/packages/service-library/src/servicelib/decorators.py
+++ b/packages/service-library/src/servicelib/decorators.py
@@ -7,10 +7,10 @@ IMPORTANT: lowest level module
 import asyncio
 import datetime
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from copy import deepcopy
 from functools import wraps
-from typing import Any, Coroutine
+from typing import Any
 
 log = logging.getLogger(__name__)
 

--- a/packages/service-library/src/servicelib/decorators.py
+++ b/packages/service-library/src/servicelib/decorators.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 from functools import wraps
 from typing import Any
 
-log = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 def safe_return(if_fails_return=False, catch=None, logger=None):  # noqa: FBT002
@@ -20,7 +20,7 @@ def safe_return(if_fails_return=False, catch=None, logger=None):  # noqa: FBT002
     if catch is None:
         catch = (RuntimeError,)
     if logger is None:
-        logger = log
+        logger = _logger
 
     def decorate(func):
         @wraps(func)

--- a/packages/service-library/tests/test_decorators.py
+++ b/packages/service-library/tests/test_decorators.py
@@ -32,14 +32,16 @@ def test_safe_return_mutables():
 
 async def test_async_delayed():
     @async_delayed(timedelta(seconds=0.2))
-    async def decorated_function() -> int:
+    async def decorated_awaitable() -> int:
         return 42
 
-    assert await decorated_function() == 42
+    assert await decorated_awaitable() == 42
 
-    async def a_function() -> int:
+    async def another_awaitable() -> int:
         return 42
 
-    decorated_function = async_delayed(timedelta(seconds=0.2))(a_function)
+    decorated_another_awaitable = async_delayed(timedelta(seconds=0.2))(
+        another_awaitable
+    )
 
-    assert await decorated_function() == 42
+    assert await decorated_another_awaitable() == 42

--- a/packages/service-library/tests/test_decorators.py
+++ b/packages/service-library/tests/test_decorators.py
@@ -2,16 +2,18 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-from servicelib.decorators import safe_return
+from datetime import timedelta
+
+from servicelib.decorators import async_delayed, safe_return
 
 
 def test_safe_return_decorator():
-    class MyException(Exception):
+    class AnError(Exception):
         pass
 
-    @safe_return(if_fails_return=False, catch=(MyException,), logger=None)
+    @safe_return(if_fails_return=False, catch=(AnError,), logger=None)
     def raise_my_exception():
-        raise MyException()
+        raise AnError
 
     assert not raise_my_exception()
 
@@ -19,9 +21,25 @@ def test_safe_return_decorator():
 def test_safe_return_mutables():
     some_mutable_return = ["some", "defaults"]
 
-    @safe_return(if_fails_return=some_mutable_return)
+    @safe_return(if_fails_return=some_mutable_return)  # type: ignore
     def return_mutable():
-        raise RuntimeError("Runtime is default")
+        msg = "Runtime is default"
+        raise RuntimeError(msg)
 
     assert return_mutable() == some_mutable_return  # contains the same
-    assert not (return_mutable() is some_mutable_return)  # but is not the same
+    assert return_mutable() is not some_mutable_return  # but is not the same
+
+
+async def test_async_delayed():
+    @async_delayed(timedelta(seconds=0.2))
+    async def decorated_function() -> int:
+        return 42
+
+    assert await decorated_function() == 42
+
+    async def a_function() -> int:
+        return 42
+
+    decorated_function = async_delayed(timedelta(seconds=0.2))(a_function)
+
+    assert await decorated_function() == 42

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/resource_tracking/_core.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/resource_tracking/_core.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Final
 
@@ -42,6 +43,16 @@ async def _start_heart_beat_task(app: FastAPI) -> None:
     if resource_tracking.heart_beat_task is not None:
         msg = f"Unexpected task={resource_tracking.heart_beat_task} already running!"
         raise RuntimeError(msg)
+
+    sleep_interval: float = (
+        resource_tracking_settings.RESOURCE_TRACKING_HEARTBEAT_INTERVAL.total_seconds()
+    )
+    with log_context(
+        _logger,
+        logging.DEBUG,
+        f"sleeping {sleep_interval} seconds before starting heart beat task",
+    ):
+        await asyncio.sleep(sleep_interval)
 
     with log_context(_logger, logging.DEBUG, "starting heart beat task"):
         resource_tracking.heart_beat_task = start_periodic_task(

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/resource_tracking/_core.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/resource_tracking/_core.py
@@ -49,7 +49,7 @@ async def _start_heart_beat_task(app: FastAPI) -> None:
             app=app,
             interval=resource_tracking_settings.RESOURCE_TRACKING_HEARTBEAT_INTERVAL,
             task_name="resource_tracking_heart_beat",
-            wait_before_running=True,
+            wait_before_running=resource_tracking_settings.RESOURCE_TRACKING_HEARTBEAT_INTERVAL,
         )
 
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/resource_tracking/_core.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/resource_tracking/_core.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import Final
 
@@ -44,22 +43,13 @@ async def _start_heart_beat_task(app: FastAPI) -> None:
         msg = f"Unexpected task={resource_tracking.heart_beat_task} already running!"
         raise RuntimeError(msg)
 
-    sleep_interval: float = (
-        resource_tracking_settings.RESOURCE_TRACKING_HEARTBEAT_INTERVAL.total_seconds()
-    )
-    with log_context(
-        _logger,
-        logging.DEBUG,
-        f"sleeping {sleep_interval} seconds before starting heart beat task",
-    ):
-        await asyncio.sleep(sleep_interval)
-
     with log_context(_logger, logging.DEBUG, "starting heart beat task"):
         resource_tracking.heart_beat_task = start_periodic_task(
             _heart_beat_task,
             app=app,
             interval=resource_tracking_settings.RESOURCE_TRACKING_HEARTBEAT_INTERVAL,
             task_name="resource_tracking_heart_beat",
+            wait_before_running=True,
         )
 
 

--- a/services/dynamic-sidecar/tests/unit/test_api_workflow_service_metrics.py
+++ b/services/dynamic-sidecar/tests/unit/test_api_workflow_service_metrics.py
@@ -300,6 +300,9 @@ async def test_user_services_fail_to_stop_or_save_data(
 
     await _wait_for_containers_to_be_running(app)
 
+    # let a few heartbeats pass
+    await asyncio.sleep(_BASE_HEART_BEAT_INTERVAL * 2)
+
     # in case of manual intervention multiple stops will be sent
     _EXPECTED_STOP_MESSAGES = 4
     for _ in range(_EXPECTED_STOP_MESSAGES):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

The heart beat was sent as soon as the service was started. Since the order of events is not guaranteed, it can arrive before the start event.

With @matusdrobuliak66 we have decided to skip the first heartbeat event.


Bonus:
- fixes flaky tests in `tests/unit/test_modules_dynamic_sidecar_client_api_base.py`: `test_connection_error` and possibly flaky `test_retry_on_errors_by_error_type` 

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


- https://github.com/ITISFoundation/osparc-simcore/issues/5169

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
