### PR TITLE
⬆️ tools repo-wide upgrade

### DIFF
--- a/packages/aws-library/requirements/_test.txt
+++ b/packages/aws-library/requirements/_test.txt
@@ -25,7 +25,7 @@ attrs==23.1.0
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.79.0
+aws-sam-translator==1.82.0
     # via cfn-lint
 aws-xray-sdk==2.12.1
     # via moto
@@ -43,13 +43,13 @@ botocore==1.31.64
     #   boto3
     #   moto
     #   s3transfer
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.83.2
+cfn-lint==0.83.6
     # via moto
 charset-normalizer==3.3.2
     # via
@@ -60,26 +60,26 @@ click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   flask
-coverage==7.3.2
+coverage==7.3.3
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   moto
     #   python-jose
     #   sshpubkeys
-docker==6.1.3
+docker==7.0.0
     # via moto
 ecdsa==0.18.0
     # via
     #   moto
     #   python-jose
     #   sshpubkeys
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
-faker==20.0.0
+faker==21.0.0
     # via -r requirements/_test.in
 flask==3.0.0
     # via
@@ -132,7 +132,7 @@ jsonschema==4.19.2
     #   cfn-lint
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.1
+jsonschema-path==0.3.2
     # via openapi-spec-validator
 jsonschema-specifications==2023.7.1
     # via
@@ -147,7 +147,7 @@ markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
-moto==4.2.8
+moto==4.2.11
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
@@ -173,7 +173,7 @@ pbr==6.0.0
     # via
     #   jschema-to-python
     #   sarif-om
-pint==0.22
+pint==0.23
     # via -r requirements/_test.in
 pluggy==1.3.0
     # via pytest
@@ -181,7 +181,7 @@ pprintpp==0.4.0
     # via pytest-icdiff
 py-partiql-parser==0.4.2
     # via moto
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via
     #   python-jose
     #   rsa
@@ -206,17 +206,17 @@ pytest==7.4.3
     #   pytest-sugar
 pytest-aiohttp==1.0.5
     # via -r requirements/_test.in
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.2
     # via pytest-aiohttp
 pytest-cov==4.1.0
     # via -r requirements/_test.in
-pytest-icdiff==0.8
+pytest-icdiff==0.9
     # via -r requirements/_test.in
 pytest-instafail==0.5.0
     # via -r requirements/_test.in
 pytest-mock==3.12.0
     # via -r requirements/_test.in
-pytest-runner==6.0.0
+pytest-runner==6.0.1
     # via -r requirements/_test.in
 pytest-sugar==0.9.7
     # via -r requirements/_test.in
@@ -255,7 +255,7 @@ requests==2.31.0
     #   jsonschema-path
     #   moto
     #   responses
-responses==0.24.0
+responses==0.24.1
     # via moto
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
@@ -285,7 +285,7 @@ sshpubkeys==3.3.1
     # via moto
 sympy==1.12
     # via cfn-lint
-termcolor==2.3.0
+termcolor==2.4.0
     # via pytest-sugar
 tomli==2.0.1
     # via
@@ -305,8 +305,6 @@ urllib3==2.0.7
     #   docker
     #   requests
     #   responses
-websocket-client==1.6.4
-    # via docker
 werkzeug==3.0.1
     # via
     #   flask

--- a/packages/aws-library/requirements/_tools.txt
+++ b/packages/aws-library/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.11.0
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +35,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_base.txt
@@ -22,18 +48,35 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -43,18 +86,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -64,7 +107,7 @@ pyyaml==6.0.1
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.1.5
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -74,7 +117,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
@@ -82,10 +125,15 @@ typing-extensions==4.8.0
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -14,41 +14,47 @@ click==8.1.7
     # via
     #   dask
     #   distributed
+    #   typer
 cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-dask==2023.10.1
+dask==2023.12.0
     # via
     #   -r requirements/_base.in
     #   distributed
-distributed==2023.10.1
+distributed==2023.12.0
     # via dask
 dnspython==2.4.2
     # via email-validator
 email-validator==2.1.0.post1
     # via pydantic
-fsspec==2023.10.0
+fsspec==2023.12.2
     # via dask
-idna==3.4
+idna==3.6
     # via email-validator
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via dask
 jinja2==3.1.2
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   distributed
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via -r requirements/../../../packages/models-library/requirements/_base.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.2
     # via jsonschema
 locket==1.0.0
     # via
     #   distributed
     #   partd
+markdown-it-py==3.0.0
+    # via rich
 markupsafe==2.1.3
     # via jinja2
+mdurl==0.1.2
+    # via markdown-it-py
 msgpack==1.0.7
     # via distributed
 orjson==3.9.10
@@ -64,22 +70,29 @@ psutil==5.9.6
 pydantic==1.10.13
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
+pygments==2.17.2
+    # via rich
 python-dateutil==2.8.2
     # via arrow
 pyyaml==6.0.1
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   dask
     #   distributed
-referencing==0.30.2
+referencing==0.32.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.10.6
+rich==13.7.0
+    # via -r requirements/../../../packages/settings-library/requirements/_base.in
+rpds-py==0.13.2
     # via
     #   jsonschema
     #   referencing
@@ -94,15 +107,20 @@ toolz==0.12.0
     #   dask
     #   distributed
     #   partd
-tornado==6.3.3
+tornado==6.4
     # via distributed
+typer==0.9.0
+    # via -r requirements/../../../packages/settings-library/requirements/_base.in
 types-python-dateutil==2.8.19.14
     # via arrow
-typing-extensions==4.8.0
-    # via pydantic
-urllib3==2.0.7
+typing-extensions==4.9.0
+    # via
+    #   pydantic
+    #   typer
+urllib3==2.1.0
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   distributed
 zict==3.0.0

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/_test.txt --strip-extras requirements/_test.in
 #
-aiohttp==3.8.6
+aiohttp==3.9.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   pytest-aiohttp
@@ -16,15 +16,13 @@ attrs==23.1.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-charset-normalizer==3.3.2
-    # via aiohttp
-coverage==7.3.2
+coverage==7.3.3
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
-faker==19.13.0
+faker==21.0.0
     # via -r requirements/_test.in
 frozenlist==1.4.0
     # via
@@ -32,7 +30,7 @@ frozenlist==1.4.0
     #   aiosignal
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.4
+idna==3.6
     # via
     #   -c requirements/_base.txt
     #   yarl
@@ -47,7 +45,7 @@ packaging==23.2
     #   -c requirements/_base.txt
     #   pytest
     #   pytest-sugar
-pint==0.22
+pint==0.23
     # via -r requirements/_test.in
 pluggy==1.3.0
     # via pytest
@@ -65,17 +63,17 @@ pytest==7.4.3
     #   pytest-sugar
 pytest-aiohttp==1.0.5
     # via -r requirements/_test.in
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.2
     # via pytest-aiohttp
 pytest-cov==4.1.0
     # via -r requirements/_test.in
-pytest-icdiff==0.8
+pytest-icdiff==0.9
     # via -r requirements/_test.in
 pytest-instafail==0.5.0
     # via -r requirements/_test.in
 pytest-mock==3.12.0
     # via -r requirements/_test.in
-pytest-runner==6.0.0
+pytest-runner==6.0.1
     # via -r requirements/_test.in
 pytest-sugar==0.9.7
     # via -r requirements/_test.in
@@ -92,15 +90,15 @@ six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil
-termcolor==2.3.0
+termcolor==2.4.0
     # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c requirements/_base.txt
     #   pint
-yarl==1.9.2
+yarl==1.9.4
     # via aiohttp

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -4,9 +4,27 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.9.1
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -21,18 +39,33 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.6
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -43,18 +76,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -64,7 +97,7 @@ pyyaml==6.0.1
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -74,18 +107,22 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.4
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/packages/models-library/requirements/_tools.txt
+++ b/packages/models-library/requirements/_tools.txt
@@ -4,9 +4,27 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +32,10 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   black
@@ -21,18 +43,33 @@ click==8.1.7
     #   typer
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -42,18 +79,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -62,7 +99,7 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -72,7 +109,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typer==0.9.0
     # via -r requirements/_tools.in
@@ -83,10 +120,14 @@ typing-extensions==4.8.0
     #   astroid
     #   black
     #   typer
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/packages/postgres-database/requirements/_tools.txt
+++ b/packages/postgres-database/requirements/_tools.txt
@@ -4,9 +4,26 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,24 +31,44 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   black
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements/_test.txt
@@ -43,18 +80,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -63,7 +100,7 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -73,7 +110,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
@@ -81,10 +118,15 @@ typing-extensions==4.8.0
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/packages/service-integration/requirements/_tools.txt
+++ b/packages/service-integration/requirements/_tools.txt
@@ -4,9 +4,21 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.9.1
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   black
+aiosignal==1.3.1
+    # via aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -21,18 +33,30 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -43,18 +67,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -63,7 +87,7 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -74,17 +98,19 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.4
+    # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/packages/service-library/requirements/_tools.txt
+++ b/packages/service-library/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +35,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_base.txt
@@ -21,18 +47,35 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -42,18 +85,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -63,7 +106,7 @@ pyyaml==6.0.1
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -73,17 +116,22 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/packages/settings-library/requirements/_tools.txt
+++ b/packages/settings-library/requirements/_tools.txt
@@ -4,9 +4,19 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.9.1
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   black
+aiosignal==1.3.1
+    # via aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via aiohttp
+attrs==23.1.0
+    # via aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -21,18 +31,28 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.6
+    # via yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -42,18 +62,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -61,7 +81,7 @@ pyyaml==6.0.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -71,17 +91,19 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.4
+    # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/packages/simcore-sdk/requirements/_tools.txt
+++ b/packages/simcore-sdk/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +35,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_base.txt
@@ -22,18 +48,35 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -44,18 +87,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -65,7 +108,7 @@ pyyaml==6.0.1
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -75,7 +118,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
@@ -83,10 +126,15 @@ typing-extensions==4.8.0
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/agent/requirements/_tools.txt
+++ b/services/agent/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.2.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==21.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   -r requirements/_tools.in
@@ -16,6 +37,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==2.1.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.3
     # via
     #   -c requirements/_base.txt
@@ -24,19 +50,36 @@ click==8.1.3
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   -r requirements/_tools.in
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -47,18 +90,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -69,7 +112,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -79,7 +122,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.4.0
     # via
@@ -87,12 +130,17 @@ typing-extensions==4.4.0
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/api-server/requirements/_tools.txt
+++ b/services/api-server/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==21.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -16,6 +37,11 @@ cfgv==3.4.0
     # via pre-commit
 change-case==0.5.2
     # via -r requirements/_tools.in
+charset-normalizer==3.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.3
     # via
     #   -c requirements/_base.txt
@@ -24,13 +50,24 @@ click==8.1.3
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.3.3
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
@@ -47,6 +84,12 @@ markupsafe==2.1.3
     #   jinja2
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements/_test.txt
@@ -59,18 +102,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -81,7 +124,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -91,7 +134,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.6.3
     # via
@@ -99,12 +142,17 @@ typing-extensions==4.6.3
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -21,7 +21,7 @@ attrs==23.1.0
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.79.0
+aws-sam-translator==1.82.0
     # via cfn-lint
 aws-xray-sdk==2.12.1
     # via moto
@@ -48,7 +48,7 @@ certifi==2023.7.22
     #   requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.83.1
+cfn-lint==0.83.6
     # via moto
 charset-normalizer==3.3.2
     # via
@@ -58,19 +58,19 @@ click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   flask
-coverage==7.3.2
+coverage==7.3.3
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-cryptography==41.0.5
+cryptography==41.0.7
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   moto
     #   python-jose
     #   sshpubkeys
-deepdiff==6.6.1
+deepdiff==6.7.1
     # via -r requirements/_test.in
-docker==6.1.3
+docker==7.0.0
     # via
     #   -r requirements/_test.in
     #   moto
@@ -84,9 +84,9 @@ exceptiongroup==1.1.3
     #   -c requirements/_base.txt
     #   anyio
     #   pytest
-faker==19.13.0
+faker==21.0.0
     # via -r requirements/_test.in
-fakeredis==2.20.0
+fakeredis==2.20.1
     # via -r requirements/_test.in
 flask==3.0.0
     # via
@@ -150,7 +150,7 @@ jsonschema==4.19.2
     #   cfn-lint
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.1
+jsonschema-path==0.3.2
     # via openapi-spec-validator
 jsonschema-specifications==2023.7.1
     # via
@@ -168,7 +168,7 @@ markupsafe==2.1.3
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==4.2.7
+moto==4.2.11
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
@@ -187,7 +187,7 @@ packaging==23.1
     #   pytest
 pathable==0.4.3
     # via jsonschema-path
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   jschema-to-python
     #   sarif-om
@@ -199,9 +199,9 @@ psutil==5.9.5
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-py-partiql-parser==0.4.1
+py-partiql-parser==0.4.2
     # via moto
-pyasn1==0.5.0
+pyasn1==0.5.1
     # via
     #   python-jose
     #   rsa
@@ -221,15 +221,15 @@ pytest==7.4.3
     #   pytest-cov
     #   pytest-icdiff
     #   pytest-mock
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.2
     # via -r requirements/_test.in
 pytest-cov==4.1.0
     # via -r requirements/_test.in
-pytest-icdiff==0.8
+pytest-icdiff==0.9
     # via -r requirements/_test.in
 pytest-mock==3.12.0
     # via -r requirements/_test.in
-pytest-runner==6.0.0
+pytest-runner==6.0.1
     # via -r requirements/_test.in
 python-dateutil==2.8.2
     # via
@@ -270,7 +270,7 @@ requests==2.31.0
     #   jsonschema-path
     #   moto
     #   responses
-responses==0.23.3
+responses==0.24.1
     # via moto
 respx==0.20.2
     # via -r requirements/_test.in
@@ -317,8 +317,6 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-types-pyyaml==6.0.12.12
-    # via responses
 typing-extensions==4.8.0
     # via
     #   -c requirements/_base.txt
@@ -332,8 +330,6 @@ urllib3==1.26.16
     #   docker
     #   requests
     #   responses
-websocket-client==1.6.4
-    # via docker
 werkzeug==3.0.1
     # via
     #   flask

--- a/services/autoscaling/requirements/_tools.txt
+++ b/services/autoscaling/requirements/_tools.txt
@@ -4,9 +4,28 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +33,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_base.txt
@@ -22,18 +46,33 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -44,18 +83,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -66,7 +105,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -76,7 +115,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
@@ -84,12 +123,16 @@ typing-extensions==4.8.0
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/catalog/requirements/_tools.txt
+++ b/services/catalog/requirements/_tools.txt
@@ -4,9 +4,29 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.5
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==21.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +34,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==2.0.12
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.3
     # via
     #   -c requirements/_base.txt
@@ -22,18 +47,35 @@ click==8.1.3
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.3.3
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==2.10
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements/_test.txt
@@ -46,18 +88,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -66,7 +108,7 @@ pyyaml==6.0.1
     #   -c requirements/_base.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -76,7 +118,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.3.0
     # via
@@ -84,12 +126,17 @@ typing-extensions==4.3.0
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/clusters-keeper/requirements/_tools.txt
+++ b/services/clusters-keeper/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.11.0
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +35,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_base.txt
@@ -22,18 +48,35 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -44,18 +87,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -66,7 +109,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.4
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -76,7 +119,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
@@ -84,12 +127,17 @@ typing-extensions==4.8.0
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +35,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.2.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_base.txt
@@ -22,18 +48,35 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -44,18 +87,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -66,7 +109,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -76,7 +119,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.7.1
     # via
@@ -84,12 +127,17 @@ typing-extensions==4.7.1
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/datcore-adapter/requirements/_tools.txt
+++ b/services/datcore-adapter/requirements/_tools.txt
@@ -4,9 +4,26 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+attrs==21.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +31,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.3
     # via
     #   -c requirements/_base.txt
@@ -21,18 +43,33 @@ click==8.1.3
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.3.3
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.3
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -42,18 +79,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -63,7 +100,7 @@ pyyaml==6.0.1
     #   -c requirements/_base.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -73,19 +110,23 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.4.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +35,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.2.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_base.txt
@@ -22,18 +48,35 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements/_test.txt
@@ -46,18 +89,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -68,7 +111,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -78,7 +121,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.7.1
     # via
@@ -86,12 +129,17 @@ typing-extensions==4.7.1
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/dynamic-scheduler/requirements/_tools.txt
+++ b/services/dynamic-scheduler/requirements/_tools.txt
@@ -4,9 +4,26 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +31,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_base.txt
@@ -21,18 +43,33 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -43,18 +80,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -63,7 +100,7 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -73,17 +110,21 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/dynamic-sidecar/requirements/_tools.txt
+++ b/services/dynamic-sidecar/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +35,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.2.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.6
     # via
     #   -c requirements/_base.txt
@@ -21,18 +47,35 @@ click==8.1.6
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements/_test.txt
@@ -45,18 +88,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -65,7 +108,7 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -75,7 +118,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.7.1
     # via
@@ -83,10 +126,15 @@ typing-extensions==4.7.1
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/invitations/requirements/_tools.txt
+++ b/services/invitations/requirements/_tools.txt
@@ -4,9 +4,27 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +32,10 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_base.txt
@@ -21,18 +43,33 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -43,18 +80,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -64,7 +101,7 @@ pyyaml==6.0.1
     #   -c requirements/_base.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -74,19 +111,23 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/migration/requirements/_tools.txt
+++ b/services/migration/requirements/_tools.txt
@@ -4,9 +4,21 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.9.1
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   black
+aiosignal==1.3.1
+    # via aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -20,18 +32,30 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements/_test.txt
@@ -43,18 +67,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -64,7 +88,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -74,19 +98,21 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.4
+    # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/osparc-gateway-server/requirements/_tools.txt
+++ b/services/osparc-gateway-server/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +35,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.2.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_test.txt
@@ -21,18 +47,35 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements/_test.txt
@@ -44,18 +87,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -65,7 +108,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -75,7 +118,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.7.1
     # via
@@ -83,12 +126,17 @@ typing-extensions==4.7.1
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/osparc-gateway-server/tests/system/requirements/_tools.txt
+++ b/services/osparc-gateway-server/tests/system/requirements/_tools.txt
@@ -4,9 +4,26 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../../../requirements/constraints.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +31,10 @@ bump2version==1.0.1
     # via -r requirements/../../../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_test.txt
@@ -21,18 +42,32 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -42,18 +77,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -62,7 +97,7 @@ pyyaml==6.0.1
     #   -c requirements/../../../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -72,17 +107,21 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/payments/requirements/_tools.txt
+++ b/services/payments/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +35,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_base.txt
@@ -21,18 +47,35 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -43,18 +86,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -63,7 +106,7 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -73,17 +116,22 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
     #   -c requirements/_base.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/resource-usage-tracker/requirements/_tools.txt
+++ b/services/resource-usage-tracker/requirements/_tools.txt
@@ -4,9 +4,27 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==21.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +32,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.3
     # via
     #   -c requirements/_base.txt
@@ -21,18 +44,33 @@ click==8.1.3
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.3.3
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements/_test.txt
@@ -45,18 +83,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -66,7 +104,7 @@ pyyaml==6.0.1
     #   -c requirements/_base.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -76,7 +114,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.5.0
     # via
@@ -84,12 +122,16 @@ typing-extensions==4.5.0
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/storage/requirements/_tools.txt
+++ b/services/storage/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.11.0
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +35,11 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_base.txt
@@ -22,18 +48,35 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements/_test.txt
@@ -45,18 +88,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -67,7 +110,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.4
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -77,7 +120,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
@@ -85,12 +128,17 @@ typing-extensions==4.8.0
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -4,9 +4,30 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.5
+    # via
+    #   -c requirements/../../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.2.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==21.4.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +35,11 @@ bump2version==1.0.1
     # via -r requirements/../../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==2.0.12
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.3
     # via
     #   -c requirements/_base.txt
@@ -22,20 +48,37 @@ click==8.1.3
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.3.0
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
+idna==3.3
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   yarl
 inotify==0.2.10
     # via -r requirements/_tools.in
-isort==5.12.0
+isort==5.13.2
     # via
     #   -r requirements/../../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.2
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via
     #   -c requirements/_test.txt
@@ -50,18 +93,18 @@ packaging==23.1
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -71,7 +114,7 @@ pyyaml==6.0.1
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -81,7 +124,7 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.3.0
     # via
@@ -89,10 +132,15 @@ typing-extensions==4.3.0
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.5.1
+    # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/tests/public-api/requirements/_tools.txt
+++ b/tests/public-api/requirements/_tools.txt
@@ -4,9 +4,26 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,24 +31,42 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   black
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -41,18 +76,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -61,7 +96,7 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -71,16 +106,20 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
-typing-extensions==4.8.0
+typing-extensions==4.9.0
     # via
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/tests/swarm-deploy/requirements/_tools.txt
+++ b/tests/swarm-deploy/requirements/_tools.txt
@@ -4,9 +4,26 @@
 #
 #    pip-compile --output-file=requirements/_tools.txt --strip-extras requirements/_tools.in
 #
-astroid==3.0.1
+aiohttp==3.8.6
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_test.txt
+    #   black
+aiosignal==1.3.1
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+astroid==3.0.2
     # via pylint
-black==23.10.1
+async-timeout==4.0.3
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+attrs==23.1.0
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+black==23.12.0
     # via -r requirements/../../../requirements/devenv.txt
 build==1.0.3
     # via pip-tools
@@ -14,6 +31,10 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
 click==8.1.7
     # via
     #   -c requirements/_test.txt
@@ -21,18 +42,32 @@ click==8.1.7
     #   pip-tools
 dill==0.3.7
     # via pylint
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
 filelock==3.13.1
     # via virtualenv
-identify==2.5.31
+frozenlist==1.4.0
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   aiosignal
+identify==2.5.33
     # via pre-commit
-isort==5.12.0
+idna==3.4
+    # via
+    #   -c requirements/_test.txt
+    #   yarl
+isort==5.13.2
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
 mccabe==0.7.0
     # via pylint
+multidict==6.0.4
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
@@ -42,18 +77,18 @@ packaging==23.2
     #   -c requirements/_test.txt
     #   black
     #   build
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.5.0
+pre-commit==3.6.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.0.2
+pylint==3.0.3
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.0.0
     # via build
@@ -63,7 +98,7 @@ pyyaml==6.0.1
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.1.3
+ruff==0.1.8
     # via -r requirements/../../../requirements/devenv.txt
 tomli==2.0.1
     # via
@@ -73,19 +108,23 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.1
+tomlkit==0.12.3
     # via pylint
 typing-extensions==4.8.0
     # via
     #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.24.6
+virtualenv==20.25.0
     # via pre-commit
 watchdog==3.0.0
     # via -r requirements/_tools.in
-wheel==0.41.3
+wheel==0.42.0
     # via pip-tools
+yarl==1.9.2
+    # via
+    #   -c requirements/_test.txt
+    #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
###  Highlights on updated libraries (only updated libraries are included)

- #packages before: 51
- #packages after : 59

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aiohttp                   | 3.8.6           | 3.8.6,3.8.5,3.9.1 | *minor*    | 1 | dask-task-models-library🧪 |
|   2 | astroid                   | 3.0.1           | 3.0.2      |            | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|   3 | aws-sam-translator        | 1.79.0          | 1.82.0     | *minor*    | 2 | autoscaling🧪</br>aws-library🧪 |
|   4 | black                     | 23.10.1, 23.11.0 | 23.12.0    | *minor*    | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|   5 | certifi                   | 2023.7.22       | 2023.11.17 | *minor*    | 1 | aws-library🧪 |
|   6 | cfn-lint                  | 0.83.1, 0.83.2  | 0.83.6     |            | 2 | autoscaling🧪</br>aws-library🧪 |
|   7 | charset-normalizer        | 3.3.2           | 3.2.0,3.1.0,3.3.2,2.0.12,2.1.1 |            | 1 | dask-task-models-library🧪 |
|   8 | coverage                  | 7.3.2           | 7.3.3      |            | 3 | autoscaling🧪</br>aws-library🧪</br>dask-task-models-library🧪 |
|   9 | cryptography              | 41.0.5          | 41.0.7     |            | 2 | autoscaling🧪</br>aws-library🧪 |
|  10 | dask                      | 2023.10.1       | 2023.12.0  | *minor*    | 1 | dask-task-models-library🧪 |
|  11 | deepdiff                  | 6.6.1           | 6.7.1      | *minor*    | 1 | autoscaling🧪 |
|  12 | distlib                   | 0.3.7           | 0.3.8      |            | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  13 | distributed               | 2023.10.1       | 2023.12.0  | *minor*    | 1 | dask-task-models-library🧪 |
|  14 | docker                    | 6.1.3           | 7.0.0      | **MAJOR**  | 2 | autoscaling🧪</br>aws-library🧪 |
|  15 | exceptiongroup            | 1.1.3           | 1.2.0      | *minor*    | 2 | aws-library🧪</br>dask-task-models-library🧪 |
|  16 | faker                     | 19.13.0, 20.0.0 | 21.0.0     | **MAJOR**  | 3 | autoscaling🧪</br>aws-library🧪</br>dask-task-models-library🧪 |
|  17 | fakeredis                 | 2.20.0          | 2.20.1     |            | 1 | autoscaling🧪 |
|  18 | fsspec                    | 2023.10.0       | 2023.12.2  | *minor*    | 1 | dask-task-models-library🧪 |
|  19 | identify                  | 2.5.31          | 2.5.33     |            | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  20 | idna                      | 3.4             | 3.4,2.10,3.3,3.6 | *minor*    | 2 | dask-task-models-library🧪🧪 |
|  21 | importlib-metadata        | 6.8.0           | 7.0.0      | **MAJOR**  | 1 | dask-task-models-library🧪 |
|  22 | isort                     | 5.12.0          | 5.13.2     | *minor*    | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  23 | jsonschema                | 4.19.2          | 4.20.0     | *minor*    | 1 | dask-task-models-library🧪 |
|  24 | jsonschema-path           | 0.3.1           | 0.3.2      |            | 2 | autoscaling🧪</br>aws-library🧪 |
|  25 | jsonschema-specifications | 2023.7.1        | 2023.11.2  | *minor*    | 1 | dask-task-models-library🧪 |
|  26 | moto                      | 4.2.8, 4.2.7    | 4.2.11     |            | 2 | autoscaling🧪</br>aws-library🧪 |
|  27 | pathspec                  | 0.11.2          | 0.12.1     | *minor*    | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  28 | pbr                       | 5.11.1          | 6.0.0      | **MAJOR**  | 1 | autoscaling🧪 |
|  29 | pint                      | 0.22            | 0.23       | *minor*    | 2 | aws-library🧪</br>dask-task-models-library🧪 |
|  30 | platformdirs              | 3.11.0          | 4.1.0      | **MAJOR**  | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  31 | pre-commit                | 3.5.0           | 3.6.0      | *minor*    | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  32 | py-partiql-parser         | 0.4.1           | 0.4.2      |            | 1 | autoscaling🧪 |
|  33 | pyasn1                    | 0.5.0           | 0.5.1      |            | 2 | autoscaling🧪</br>aws-library🧪 |
|  34 | pylint                    | 3.0.2           | 3.0.3      |            | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  35 | pytest-asyncio            | 0.21.1          | 0.23.2     | *minor*    | 3 | autoscaling🧪</br>aws-library🧪</br>dask-task-models-library🧪 |
|  36 | pytest-icdiff             | 0.8             | 0.9        | *minor*    | 3 | autoscaling🧪</br>aws-library🧪</br>dask-task-models-library🧪 |
|  37 | pytest-runner             | 6.0.0           | 6.0.1      |            | 3 | autoscaling🧪</br>aws-library🧪</br>dask-task-models-library🧪 |
|  38 | referencing               | 0.30.2          | 0.32.0     | *minor*    | 1 | dask-task-models-library🧪 |
|  39 | responses                 | 0.23.3, 0.24.0  | 0.24.1     |            | 2 | autoscaling🧪</br>aws-library🧪 |
|  40 | rpds-py                   | 0.10.6          | 0.13.2     | *minor*    | 1 | dask-task-models-library🧪 |
|  41 | ruff                      | 0.1.5, 0.1.3, 0.1.4 | 0.1.8      |            | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  42 | termcolor                 | 2.3.0           | 2.4.0      | *minor*    | 2 | aws-library🧪</br>dask-task-models-library🧪 |
|  43 | tomlkit                   | 0.12.1, 0.12.2  | 0.12.3     |            | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  44 | tornado                   | 6.3.3           | 6.4        | *minor*    | 1 | dask-task-models-library🧪 |
|  45 | types-pyyaml              | 6.0.12.12       | 🗑️ removed |  | 1 | autoscaling🧪 |
|  46 | typing-extensions         | 4.8.0           | 4.9.0      | *minor*    | 4 | dask-task-models-library🧪🧪🔧</br>public-api🧪 |
|  47 | urllib3                   | 2.0.7           | 2.1.0      | *minor*    | 1 | dask-task-models-library🧪 |
|  48 | virtualenv                | 20.24.6         | 20.25.0    | *minor*    | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  49 | websocket-client          | 1.6.4           | 🗑️ removed |  | 2 | autoscaling🧪</br>aws-library🧪 |
|  50 | wheel                     | 0.41.3          | 0.42.0     | *minor*    | 28 | agent🔧</br>api-server🔧</br>autoscaling🔧</br>aws-library🔧</br>catalog🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>datcore-adapter🔧</br>director-v2🔧</br>dynamic-scheduler🔧</br>dynamic-sidecar🔧</br>invitations🔧</br>migration🔧</br>models-library🔧</br>osparc-gateway-server🔧🧪</br>payments🔧</br>postgres-database🔧</br>public-api🧪</br>resource-usage-tracker🔧</br>service-integration🔧</br>service-library🔧</br>settings-library🔧</br>simcore-sdk🔧</br>storage🔧</br>swarm-deploy🧪</br>web🔧 |
|  51 | yarl                      | 1.9.2           | 1.5.1,1.9.4,1.9.2 |            | 1 | dask-task-models-library🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 89

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.1.2, 9.2.2, 9.3.0       | 9.1.2, 9.3.0              |                           |
|   2 | aioboto3                  | 12.0.0                    | 9.6.0, 12.0.0             |                           |
|   3 | aiobotocore               | 2.5.4, 2.7.0              | 2.3.0, 2.7.0              |                           |
|   4 | aiocache                  | 0.11.1, 0.12.1, 0.12.2    | 0.12.2                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.21.0                    | 0.21.0                    |                           |
|   7 | aiofiles                  | 0.8.0, 22.1.0, 23.1.0, 23.2.1 | 23.2.1                    |                           |
|   8 | aiohttp                   | 3.8.5, 3.8.6              | 3.8.5, 3.8.6, 3.9.1       | 3.8.5, 3.8.6, 3.9.1       |
|   9 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  10 | aiohttp-security          | 0.4.0                     |                           |                           |
|  11 | aiohttp-session           | 2.11.0                    |                           |                           |
|  12 | aiohttp-swagger           | 1.0.16                    |                           |                           |
|  13 | aioitertools              | 0.11.0                    | 0.11.0                    |                           |
|  14 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  15 | aioprocessing             | 2.0.1                     |                           |                           |
|  16 | aioredis                  | 2.0.1                     |                           |                           |
|  17 | aioresponses              |                           | 0.7.4, 0.7.5              |                           |
|  18 | aiormq                    | 6.7.6, 6.7.7              | 6.7.6, 6.7.7              |                           |
|  19 | aiosignal                 | 1.2.0, 1.3.1              | 1.2.0, 1.3.1              | 1.2.0, 1.3.1              |
|  20 | aiosmtplib                | 1.1.6                     |                           |                           |
|  21 | aiozipkin                 | 1.1.1                     |                           |                           |
|  22 | alembic                   | 1.8.1, 1.11.1, 1.12.1     | 1.8.1, 1.11.1, 1.12.1     |                           |
|  23 | anyio                     | 3.6.2, 3.7.0, 3.7.1, 4.0.0 | 3.6.2, 3.7.0, 3.7.1, 4.0.0 |                           |
|  24 | arrow                     | 1.2.3, 1.3.0              | 1.3.0                     |                           |
|  25 | asgi-lifespan             |                           | 2.1.0                     |                           |
|  26 | asgiref                   | 3.5.2, 3.7.2              |                           |                           |
|  27 | astroid                   |                           |                           | 3.0.2                     |
|  28 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  29 | async-timeout             | 4.0.2, 4.0.3              | 4.0.2, 4.0.3              | 4.0.2, 4.0.3              |
|  30 | asyncpg                   | 0.27.0, 0.28.0, 0.29.0    | 0.28.0                    |                           |
|  31 | attrs                     | 21.4.0, 23.1.0            | 21.4.0, 23.1.0            | 21.4.0, 23.1.0            |
|  32 | aws-sam-translator        |                           | 1.55.0, 1.79.0, 1.82.0    |                           |
|  33 | aws-xray-sdk              |                           | 2.12.1                    |                           |
|  34 | bidict                    | 0.22.0, 0.22.1            | 0.22.1                    |                           |
|  35 | black                     |                           |                           | 23.12.0                   |
|  36 | blinker                   |                           | 1.7.0                     |                           |
|  37 | blosc                     | 1.11.1                    |                           |                           |
|  38 | bokeh                     | 2.4.3                     | 2.4.3                     |                           |
|  39 | boto3                     | 1.24.96, 1.28.64          | 1.21.21, 1.28.17, 1.28.64, 1.29.2 |                           |
|  40 | boto3-stubs               |                           | 1.29.2                    |                           |
|  41 | botocore                  | 1.27.96, 1.31.17, 1.31.64 | 1.24.21, 1.31.17, 1.31.64, 1.32.2 |                           |
|  42 | botocore-stubs            | 1.31.77, 1.31.80, 1.31.85 | 1.32.2, 1.33.6            |                           |
|  43 | build                     |                           |                           | 1.0.3                     |
|  44 | bump2version              |                           |                           | 1.0.1                     |
|  45 | certifi                   | 2023.7.22                 | 2023.7.22, 2023.11.17     |                           |
|  46 | cffi                      | 1.15.0, 1.15.1, 1.16.0    | 1.15.1, 1.16.0            |                           |
|  47 | cfgv                      |                           |                           | 3.4.0                     |
|  48 | cfn-lint                  |                           | 0.72.0, 0.83.1, 0.83.6    |                           |
|  49 | change-case               |                           |                           | 0.5.2                     |
|  50 | charset-normalizer        | 2.0.12, 2.1.1, 3.1.0, 3.2.0, 3.3.2 | 2.0.12, 2.1.1, 3.1.0, 3.2.0, 3.3.2 | 2.0.12, 2.1.1, 3.1.0, 3.2.0, 3.3.2 |
|  51 | click                     | 8.1.3, 8.1.6, 8.1.7       | 8.1.3, 8.1.7              | 8.1.3, 8.1.6, 8.1.7       |
|  52 | cloudpickle               | 2.2.1, 3.0.0              | 2.2.1                     |                           |
|  53 | colorama                  | 0.4.6                     |                           |                           |
|  54 | colorlog                  | 6.7.0                     | 6.7.0                     |                           |
|  55 | contourpy                 | 1.0.7                     |                           |                           |
|  56 | coverage                  |                           | 7.3.2, 7.3.3              |                           |
|  57 | cryptography              | 41.0.3, 41.0.5            | 41.0.3, 41.0.5, 41.0.7    |                           |
|  58 | cycler                    | 0.11.0                    |                           |                           |
|  59 | dask                      | 2023.3.2, 2023.12.0       | 2023.3.2                  |                           |
|  60 | dask-gateway              | 2023.1.1                  | 2023.9.0                  |                           |
|  61 | dask-gateway-server       | 2023.1.1                  | 2023.1.1                  |                           |
|  62 | dateparser                | 1.1.8                     |                           |                           |
|  63 | debugpy                   |                           | 1.8.0                     |                           |
|  64 | deepdiff                  |                           | 6.7.0, 6.7.1              |                           |
|  65 | dill                      |                           |                           | 0.3.7                     |
|  66 | distlib                   |                           |                           | 0.3.8                     |
|  67 | distributed               | 2023.3.2, 2023.12.0       | 2023.3.2                  |                           |
|  68 | dnspython                 | 2.1.0, 2.2.1, 2.3.0, 2.4.0, 2.4.1, 2.4.2 | 2.4.2                     |                           |
|  69 | docker                    | 6.1.3                     | 6.1.3, 7.0.0              |                           |
|  70 | ecdsa                     | 0.18.0                    | 0.18.0                    |                           |
|  71 | email-validator           | 1.2.1, 1.3.0, 2.0.0.post2, 2.1.0.post1 | 2.1.0.post1               |                           |
|  72 | et-xmlfile                | 1.1.0                     |                           |                           |
|  73 | exceptiongroup            | 1.1.1, 1.1.2, 1.1.3       | 1.1.1, 1.1.2, 1.1.3, 1.2.0 |                           |
|  74 | execnet                   |                           | 2.0.2                     |                           |
|  75 | expiringdict              | 1.2.1                     |                           |                           |
|  76 | faker                     | 19.6.1                    | 19.6.1, 19.13.0, 20.0.3, 21.0.0 |                           |
|  77 | fakeredis                 |                           | 2.20.0, 2.20.1            |                           |
|  78 | fastapi                   | 0.96.0, 0.98.0, 0.99.1    |                           |                           |
|  79 | fastapi-pagination        | 0.10.0, 0.12.5            |                           |                           |
|  80 | filelock                  |                           |                           | 3.13.1                    |
|  81 | flaky                     |                           | 3.7.0                     |                           |
|  82 | flask                     |                           | 2.1.3, 3.0.0              |                           |
|  83 | flask-cors                |                           | 4.0.0                     |                           |
|  84 | fonttools                 | 4.39.4                    |                           |                           |
|  85 | frozenlist                | 1.3.0, 1.3.1, 1.3.3, 1.4.0 | 1.3.0, 1.3.1, 1.3.3, 1.4.0 | 1.3.0, 1.3.1, 1.3.3, 1.4.0 |
|  86 | fsspec                    | 2023.6.0, 2023.12.2       | 2023.6.0                  |                           |
|  87 | graphql-core              |                           | 3.2.3                     |                           |
|  88 | greenlet                  | 2.0.2, 3.0.1              | 2.0.2, 3.0.0, 3.0.1       |                           |
|  89 | gunicorn                  | 20.1.0                    |                           |                           |
|  90 | h11                       | 0.12.0, 0.14.0            | 0.12.0, 0.14.0            |                           |
|  91 | h2                        | 4.1.0                     |                           |                           |
|  92 | hpack                     | 4.0.0                     |                           |                           |
|  93 | httmock                   | 1.4.0                     |                           |                           |
|  94 | httpcore                  | 0.15.0, 0.17.1, 0.17.2, 0.17.3, 0.18.0, 1.0.1 | 0.15.0, 0.17.1, 0.17.2, 0.17.3, 0.18.0, 1.0.1 |                           |
|  95 | httptools                 | 0.2.0, 0.5.0, 0.6.0, 0.6.1 |                           |                           |
|  96 | httpx                     | 0.24.0, 0.24.1, 0.25.0, 0.25.1 | 0.24.0, 0.24.1, 0.25.0, 0.25.1 |                           |
|  97 | hyperframe                | 6.0.1                     |                           |                           |
|  98 | hypothesis                |                           | 6.88.1, 6.88.3            |                           |
|  99 | icdiff                    |                           | 2.0.7                     |                           |
| 100 | identify                  |                           |                           | 2.5.33                    |
| 101 | idna                      | 2.10, 3.3, 3.4, 3.6       | 2.10, 3.3, 3.4, 3.6       | 2.10, 3.3, 3.4, 3.6       |
| 102 | importlib-metadata        | 6.8.0, 7.0.0              | 6.8.0                     |                           |
| 103 | iniconfig                 | 2.0.0                     | 2.0.0                     |                           |
| 104 | inotify                   |                           |                           | 0.2.10                    |
| 105 | isodate                   | 0.6.1                     |                           |                           |
| 106 | isort                     |                           |                           | 5.13.2                    |
| 107 | itsdangerous              | 1.1.0, 2.1.2              | 2.1.2                     |                           |
| 108 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 109 | jinja2                    | 3.1.2                     | 3.1.2                     | 3.1.2                     |
| 110 | jmespath                  | 1.0.1                     | 1.0.1                     |                           |
| 111 | jschema-to-python         |                           | 1.2.3                     |                           |
| 112 | json2html                 | 1.3.0                     |                           |                           |
| 113 | jsondiff                  | 2.0.0                     | 2.0.0                     |                           |
| 114 | jsonpatch                 |                           | 1.33                      |                           |
| 115 | jsonpickle                |                           | 3.0.2                     |                           |
| 116 | jsonpointer               |                           | 2.4                       |                           |
| 117 | jsonref                   |                           | 1.1.0                     |                           |
| 118 | jsonschema                | 3.2.0, 4.18.4, 4.19.0, 4.19.2, 4.20.0 | 3.2.0, 4.19.0, 4.19.2     |                           |
| 119 | jsonschema-path           | 0.3.1                     | 0.3.1, 0.3.2              |                           |
| 120 | jsonschema-spec           | 0.2.4                     | 0.2.4                     |                           |
| 121 | jsonschema-specifications | 2023.7.1, 2023.11.2       | 2023.7.1                  |                           |
| 122 | junit-xml                 |                           | 1.9                       |                           |
| 123 | kiwisolver                | 1.4.4                     |                           |                           |
| 124 | lazy-object-proxy         | 1.7.1, 1.9.0              | 1.9.0                     |                           |
| 125 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 126 | lupa                      |                           | 2.0                       |                           |
| 127 | lz4                       | 4.3.2                     | 4.3.2                     |                           |
| 128 | mako                      | 1.2.2, 1.2.4              | 1.2.2, 1.2.4              |                           |
| 129 | markdown-it-py            | 2.2.0, 3.0.0              | 3.0.0                     |                           |
| 130 | markupsafe                | 2.1.1, 2.1.3              | 2.1.1, 2.1.3              | 2.1.3                     |
| 131 | matplotlib                | 3.7.1                     |                           |                           |
| 132 | mccabe                    |                           |                           | 0.7.0                     |
| 133 | mdurl                     | 0.1.2                     | 0.1.2                     |                           |
| 134 | more-itertools            | 10.1.0                    |                           |                           |
| 135 | moto                      |                           | 4.0.1, 4.2.6, 4.2.7, 4.2.11 |                           |
| 136 | mpmath                    |                           | 1.3.0                     |                           |
| 137 | msgpack                   | 1.0.3, 1.0.5, 1.0.7       | 1.0.5                     |                           |
| 138 | multidict                 | 6.0.2, 6.0.3, 6.0.4       | 6.0.2, 6.0.4              | 6.0.2, 6.0.3, 6.0.4       |
| 139 | mypy                      |                           | 1.6.1, 1.7.0              |                           |
| 140 | mypy-extensions           |                           | 1.0.0                     | 1.0.0                     |
| 141 | networkx                  | 3.1                       | 2.8.8, 3.2.1              |                           |
| 142 | nodeenv                   |                           |                           | 1.8.0                     |
| 143 | nose                      |                           |                           | 1.3.7                     |
| 144 | numpy                     | 1.24.3, 1.25.2            | 1.25.2, 1.26.1            |                           |
| 145 | openapi-core              | 0.12.0, 0.18.2            |                           |                           |
| 146 | openapi-schema-validator  | 0.2.3, 0.6.2              | 0.2.3, 0.6.0, 0.6.2       |                           |
| 147 | openapi-spec-validator    | 0.4.0, 0.7.1              | 0.4.0, 0.6.0, 0.7.1       |                           |
| 148 | openpyxl                  | 3.0.9                     |                           |                           |
| 149 | ordered-set               | 4.1.0                     | 4.1.0                     |                           |
| 150 | orjson                    | 3.7.2, 3.9.1, 3.9.2, 3.9.7, 3.9.10 | 3.9.10                    |                           |
| 151 | packaging                 | 23.1, 23.2                | 23.1, 23.2                | 23.1, 23.2                |
| 152 | pamqp                     | 3.2.1                     | 3.2.1                     |                           |
| 153 | pandas                    | 2.0.1                     | 2.1.2                     |                           |
| 154 | parse                     | 1.19.1                    | 1.19.1                    |                           |
| 155 | partd                     | 1.4.0, 1.4.1              | 1.4.0                     |                           |
| 156 | passlib                   | 1.7.4                     |                           |                           |
| 157 | pathable                  | 0.4.3                     | 0.4.3                     |                           |
| 158 | pathspec                  |                           |                           | 0.12.1                    |
| 159 | pbr                       |                           | 5.11.1, 6.0.0             |                           |
| 160 | pillow                    | 9.5.0, 10.0.0             | 10.1.0                    |                           |
| 161 | pint                      | 0.19.2, 0.22              | 0.22, 0.23                |                           |
| 162 | pip-tools                 |                           |                           | 7.3.0                     |
| 163 | platformdirs              |                           |                           | 4.1.0                     |
| 164 | playwright                |                           | 1.39.0                    |                           |
| 165 | pluggy                    | 1.3.0                     | 1.3.0                     |                           |
| 166 | pprintpp                  |                           | 0.4.0                     |                           |
| 167 | pre-commit                |                           |                           | 3.6.0                     |
| 168 | prometheus-api-client     | 0.5.3                     |                           |                           |
| 169 | prometheus-client         | 0.14.1, 0.18.0            |                           |                           |
| 170 | psutil                    | 5.9.5, 5.9.6              | 5.9.5                     |                           |
| 171 | psycopg2-binary           | 2.9.6, 2.9.9              | 2.9.9                     |                           |
| 172 | ptvsd                     |                           | 4.3.2                     |                           |
| 173 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 174 | py-partiql-parser         |                           | 0.4.0, 0.4.1, 0.4.2       |                           |
| 175 | pyasn1                    | 0.5.0                     | 0.5.0, 0.5.1              |                           |
| 176 | pycparser                 | 2.21                      | 2.21                      |                           |
| 177 | pydantic                  | 1.9.0, 1.10.2, 1.10.7, 1.10.9, 1.10.11, 1.10.12, 1.10.13 | 1.10.2, 1.10.12, 1.10.13  |                           |
| 178 | pyee                      |                           | 11.0.1                    |                           |
| 179 | pyftpdlib                 |                           | 1.5.9                     |                           |
| 180 | pygments                  | 2.15.1, 2.16.1, 2.17.2    | 2.16.1                    |                           |
| 181 | pyinstrument              | 3.4.2, 4.1.1, 4.3.0, 4.4.0, 4.5.0, 4.5.1, 4.6.0, 4.6.1 | 4.5.0, 4.6.0              |                           |
| 182 | pyinstrument-cext         | 0.2.4                     |                           |                           |
| 183 | pyjwt                     | 2.4.0                     |                           |                           |
| 184 | pylint                    |                           |                           | 3.0.3                     |
| 185 | pyopenssl                 |                           | 23.3.0                    |                           |
| 186 | pyparsing                 | 3.0.9                     | 3.1.1                     |                           |
| 187 | pyproject-hooks           |                           |                           | 1.0.0                     |
| 188 | pyrsistent                | 0.18.1, 0.19.2, 0.19.3    | 0.18.1, 0.19.2, 0.19.3    |                           |
| 189 | pytest                    | 7.4.3                     | 7.4.3                     |                           |
| 190 | pytest-aiohttp            |                           | 1.0.5                     |                           |
| 191 | pytest-asyncio            |                           | 0.21.1, 0.23.2            |                           |
| 192 | pytest-base-url           |                           | 2.0.0                     |                           |
| 193 | pytest-benchmark          |                           | 4.0.0                     |                           |
| 194 | pytest-cov                |                           | 4.1.0                     |                           |
| 195 | pytest-docker             |                           | 2.0.1                     |                           |
| 196 | pytest-html               |                           | 4.1.1                     |                           |
| 197 | pytest-icdiff             |                           | 0.8, 0.9                  |                           |
| 198 | pytest-instafail          |                           | 0.5.0                     |                           |
| 199 | pytest-lazy-fixture       |                           | 0.6.3                     |                           |
| 200 | pytest-localftpserver     |                           | 1.2.0                     |                           |
| 201 | pytest-metadata           |                           | 3.0.0                     |                           |
| 202 | pytest-mock               |                           | 3.12.0                    |                           |
| 203 | pytest-playwright         |                           | 0.4.3                     |                           |
| 204 | pytest-runner             |                           | 6.0.0, 6.0.1              |                           |
| 205 | pytest-sugar              |                           | 0.9.7                     |                           |
| 206 | pytest-xdist              |                           | 3.3.1                     |                           |
| 207 | python-dateutil           | 2.8.2                     | 2.8.2                     |                           |
| 208 | python-dotenv             | 0.20.0, 0.21.0, 1.0.0     | 1.0.0                     |                           |
| 209 | python-engineio           | 4.3.4, 4.8.0              | 4.8.0                     |                           |
| 210 | python-jose               | 3.3.0                     | 3.3.0                     |                           |
| 211 | python-magic              | 0.4.25, 0.4.27            |                           |                           |
| 212 | python-multipart          | 0.0.5, 0.0.6              |                           |                           |
| 213 | python-slugify            |                           | 8.0.1                     |                           |
| 214 | python-socketio           | 5.8.0, 5.10.0             | 5.10.0                    |                           |
| 215 | pytz                      | 2022.1, 2023.3            | 2023.3.post1              |                           |
| 216 | pyyaml                    | 6.0.1                     | 6.0.1                     | 6.0.1                     |
| 217 | redis                     | 4.5.4, 4.5.5, 4.6.0, 5.0.0, 5.0.1 | 4.5.4, 4.5.5, 5.0.1       |                           |
| 218 | referencing               | 0.29.3, 0.30.2, 0.32.0    | 0.29.3, 0.30.2            |                           |
| 219 | regex                     | 2023.5.5                  | 2023.10.3                 |                           |
| 220 | requests                  | 2.30.0, 2.31.0            | 2.30.0, 2.31.0            |                           |
| 221 | requests-mock             |                           | 1.11.0                    |                           |
| 222 | responses                 |                           | 0.23.3, 0.24.0, 0.24.1    |                           |
| 223 | respx                     |                           | 0.20.2                    |                           |
| 224 | rfc3339-validator         | 0.1.4                     | 0.1.4                     |                           |
| 225 | rich                      | 13.3.5, 13.4.2, 13.5.2, 13.6.0, 13.7.0 | 13.6.0                    |                           |
| 226 | rpds-py                   | 0.9.2, 0.10.6, 0.12.0, 0.13.2 | 0.9.2, 0.10.6, 0.12.0     |                           |
| 227 | rsa                       | 4.9                       | 4.9                       |                           |
| 228 | ruff                      |                           |                           | 0.1.8                     |
| 229 | s3fs                      | 2023.6.0                  |                           |                           |
| 230 | s3transfer                | 0.6.0, 0.7.0              | 0.5.2, 0.6.2, 0.7.0       |                           |
| 231 | sarif-om                  |                           | 1.0.4                     |                           |
| 232 | semantic-version          | 2.10.0                    |                           |                           |
| 233 | setproctitle              | 1.2.3                     |                           |                           |
| 234 | sh                        | 2.0.6                     |                           |                           |
| 235 | shellingham               | 1.5.0.post1, 1.5.4        |                           |                           |
| 236 | simple-websocket          | 1.0.0                     | 1.0.0                     |                           |
| 237 | six                       | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            |                           |
| 238 | sniffio                   | 1.2.0, 1.3.0              | 1.2.0, 1.3.0              |                           |
| 239 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 240 | sqlalchemy                | 1.4.47, 1.4.48, 1.4.49, 1.4.50 | 1.4.47, 1.4.48, 1.4.49, 1.4.50 |                           |
| 241 | sqlalchemy2-stubs         |                           | 0.0.2a36, 0.0.2a37        |                           |
| 242 | sshpubkeys                |                           | 3.3.1                     |                           |
| 243 | starlette                 | 0.27.0                    |                           |                           |
| 244 | strict-rfc3339            | 0.7                       |                           |                           |
| 245 | sympy                     |                           | 1.12                      |                           |
| 246 | tblib                     | 2.0.0, 3.0.0              | 2.0.0                     |                           |
| 247 | tenacity                  | 8.0.1, 8.1.0, 8.2.2, 8.2.3 | 8.0.1, 8.2.3              |                           |
| 248 | termcolor                 |                           | 2.3.0, 2.4.0              |                           |
| 249 | text-unidecode            |                           | 1.3                       |                           |
| 250 | tomli                     | 2.0.1                     | 2.0.1                     | 2.0.1                     |
| 251 | tomlkit                   |                           |                           | 0.12.3                    |
| 252 | toolz                     | 0.12.0                    | 0.12.0                    |                           |
| 253 | tornado                   | 6.3.3, 6.4                | 6.3.3                     |                           |
| 254 | tqdm                      | 4.64.0, 4.64.1, 4.65.0, 4.66.1 | 4.66.1                    |                           |
| 255 | traitlets                 | 5.9.0                     | 5.13.0                    |                           |
| 256 | twilio                    | 7.12.0                    |                           |                           |
| 257 | typer                     | 0.4.1, 0.6.1, 0.9.0       | 0.9.0                     | 0.9.0                     |
| 258 | types-aiobotocore         | 2.7.0                     | 2.8.0                     |                           |
| 259 | types-aiobotocore-ec2     | 2.7.0                     |                           |                           |
| 260 | types-aiobotocore-s3      | 2.7.0                     | 2.7.0, 2.8.0              |                           |
| 261 | types-aiofiles            |                           | 23.2.0.0                  |                           |
| 262 | types-awscrt              | 0.19.8, 0.19.10           | 0.19.12, 0.19.19          |                           |
| 263 | types-boto3               |                           | 1.0.2                     |                           |
| 264 | types-pkg-resources       |                           | 0.1.3                     |                           |
| 265 | types-python-dateutil     | 2.8.19.14                 | 2.8.19.14                 |                           |
| 266 | types-pyyaml              |                           | 6.0.12.12                 |                           |
| 267 | types-s3transfer          |                           | 0.7.0                     |                           |
| 268 | typing-extensions         | 4.3.0, 4.4.0, 4.5.0, 4.6.3, 4.7.1, 4.8.0, 4.9.0 | 4.3.0, 4.4.0, 4.5.0, 4.6.3, 4.7.1, 4.8.0, 4.9.0 | 4.3.0, 4.4.0, 4.5.0, 4.6.3, 4.7.1, 4.8.0, 4.9.0 |
| 269 | tzdata                    | 2023.3                    | 2023.3                    |                           |
| 270 | tzlocal                   | 5.0.1                     |                           |                           |
| 271 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 272 | ujson                     | 5.5.0, 5.8.0              |                           |                           |
| 273 | urllib3                   | 1.26.11, 1.26.12, 1.26.16, 2.0.2, 2.0.7, 2.1.0 | 1.26.11, 1.26.12, 1.26.16, 1.26.18, 2.0.2, 2.0.7, 2.1.0 |                           |
| 274 | uvicorn                   | 0.15.0, 0.19.0, 0.22.0, 0.23.1, 0.23.2, 0.24.0.post1 |                           |                           |
| 275 | uvloop                    | 0.16.0, 0.17.0, 0.19.0    |                           |                           |
| 276 | virtualenv                |                           |                           | 20.25.0                   |
| 277 | watchdog                  | 3.0.0                     |                           | 3.0.0                     |
| 278 | watchfiles                | 0.18.0, 0.19.0, 0.21.0    |                           |                           |
| 279 | watchgod                  | 0.8.2                     |                           |                           |
| 280 | websocket-client          | 1.6.4                     | 1.6.4                     |                           |
| 281 | websockets                | 10.1, 10.3, 11.0.3, 12.0  | 12.0                      |                           |
| 282 | werkzeug                  | 2.1.2, 3.0.1              | 2.1.2, 3.0.1              |                           |
| 283 | wheel                     |                           |                           | 0.42.0                    |
| 284 | wrapt                     | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            |                           |
| 285 | wsproto                   | 1.2.0                     | 1.2.0                     |                           |
| 286 | xmltodict                 |                           | 0.13.0                    |                           |
| 287 | yarl                      | 1.5.1, 1.9.2              | 1.5.1, 1.9.2, 1.9.4       | 1.5.1, 1.9.2, 1.9.4       |
| 288 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 289 | zipp                      | 3.16.2, 3.17.0            | 3.16.2                    |                           |
