### PR TITLE
♻️ Aligned default timeout with the old client

### DIFF
--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/dynamic_scheduler/services.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/dynamic_scheduler/services.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Final
 
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler import DYNAMIC_SCHEDULER_RPC_NAMESPACE
@@ -8,11 +9,15 @@ from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects_nodes_io import NodeID
 from models_library.rabbitmq_basic_types import RPCMethodName
-from pydantic import parse_obj_as
+from pydantic import NonNegativeFloat, parse_obj_as
 from servicelib.logging_utils import log_decorator
 from servicelib.rabbitmq import RabbitMQRPCClient
 
 _logger = logging.getLogger(__name__)
+
+# To avoid any side effects using the same timeout as the
+# aiohttp client that was calling into director-v2 from webserver
+_DEFAULT_LEGACY_TIMEOUT_S: Final[NonNegativeFloat] = 20
 
 
 @log_decorator(_logger, level=logging.DEBUG)
@@ -23,6 +28,7 @@ async def get_service_status(
         DYNAMIC_SCHEDULER_RPC_NAMESPACE,
         parse_obj_as(RPCMethodName, "get_service_status"),
         node_id=node_id,
+        timeout_s=_DEFAULT_LEGACY_TIMEOUT_S,
     )
     assert isinstance(result, NodeGetIdle | DynamicServiceGet | NodeGet)  # nosec
     return result
@@ -38,6 +44,7 @@ async def run_dynamic_service(
         DYNAMIC_SCHEDULER_RPC_NAMESPACE,
         parse_obj_as(RPCMethodName, "run_dynamic_service"),
         rpc_dynamic_service_create=rpc_dynamic_service_create,
+        timeout_s=_DEFAULT_LEGACY_TIMEOUT_S,
     )
     assert isinstance(result, DynamicServiceGet | NodeGet)  # nosec
     return result

--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/dynamic_scheduler/services.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/dynamic_scheduler/services.py
@@ -9,7 +9,7 @@ from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects_nodes_io import NodeID
 from models_library.rabbitmq_basic_types import RPCMethodName
-from pydantic import NonNegativeFloat, parse_obj_as
+from pydantic import NonNegativeInt, parse_obj_as
 from servicelib.logging_utils import log_decorator
 from servicelib.rabbitmq import RabbitMQRPCClient
 
@@ -17,7 +17,7 @@ _logger = logging.getLogger(__name__)
 
 # To avoid any side effects using the same timeout as the
 # aiohttp client that was calling into director-v2 from webserver
-_DEFAULT_LEGACY_TIMEOUT_S: Final[NonNegativeFloat] = 20
+_DEFAULT_LEGACY_TIMEOUT_S: Final[NonNegativeInt] = 20
 
 
 @log_decorator(_logger, level=logging.DEBUG)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

To avoid possible regressions, bump timeout of the client from 5 to 20 seconds. This timeout comes form the aiohttp client used inside the webserver to comunicate with the director-v2.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
