### PR TITLE
🐛⚗️Computational backend: tasks in UNKNOWN state are sometimes only temporarily in that state

### DIFF
--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1555,11 +1555,16 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: "pip"
           cache-dependency-path: "services/web/server/requirements/ci.txt"
-      - name: download docker images
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249
+      - name: download docker images with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner.temp }}/build
+          action: actions/download-artifact@v4
+          with: |
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            path: /${{ runner.temp }}/build
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: load docker images
         run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
@@ -1609,11 +1614,16 @@ jobs:
           cache-dependency-path: "services/web/server/requirements/ci.txt"
       - name: expose github runtime for buildx
         uses: crazy-max/ghaction-github-runtime@v3
-      - name: download docker images
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249
+      - name: download docker images with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner.temp }}/build
+          action: actions/download-artifact@v4
+          with: |
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            path: /${{ runner.temp }}/build
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: load docker images
         run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
@@ -1663,11 +1673,16 @@ jobs:
           cache-dependency-path: "services/director-v2/requirements/ci.txt"
       - name: expose github runtime for buildx
         uses: crazy-max/ghaction-github-runtime@v3
-      - name: download docker images
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249
+      - name: download docker images with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner.temp }}/build
+          action: actions/download-artifact@v4
+          with: |
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            path: /${{ runner.temp }}/build
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: load docker images
         run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
@@ -1719,11 +1734,16 @@ jobs:
           cache-dependency-path: "services/director-v2/requirements/ci.txt"
       - name: expose github runtime for buildx
         uses: crazy-max/ghaction-github-runtime@v3
-      - name: download docker images
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249
+      - name: download docker images with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner.temp }}/build
+          action: actions/download-artifact@v4
+          with: |
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            path: /${{ runner.temp }}/build
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: load docker images
         run: make load-images local-src=/${{ runner.temp }}/build
       - name: install rclone
@@ -1775,11 +1795,16 @@ jobs:
           cache-dependency-path: "services/dynamic-sidecar/requirements/ci.txt"
       - name: expose github runtime for buildx
         uses: crazy-max/ghaction-github-runtime@v3
-      - name: download docker images
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249
+      - name: download docker images with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner.temp }}/build
+          action: actions/download-artifact@v4
+          with: |
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            path: /${{ runner.temp }}/build
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: load docker images
         run: make load-images local-src=/${{ runner.temp }}/build
       - name: install rclone
@@ -1832,11 +1857,16 @@ jobs:
           cache-dependency-path: "services/osparc-gateway-server/requirements/ci.txt"
       - name: expose github runtime for buildx
         uses: crazy-max/ghaction-github-runtime@v3
-      - name: download docker images
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249
+      - name: download docker images with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner.temp }}/build
+          action: actions/download-artifact@v4
+          with: |
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            path: /${{ runner.temp }}/build
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: load docker images
         run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
@@ -1900,11 +1930,16 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: "pip"
           cache-dependency-path: "packages/simcore-sdk/requirements/ci.txt"
-      - name: download docker images
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249
+      - name: download docker images with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner.temp }}/build
+          action: actions/download-artifact@v4
+          with: |
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            path: /${{ runner.temp }}/build
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: load docker images
         run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
@@ -1978,11 +2013,16 @@ jobs:
           cache-dependency-path: "tests/public-api/requirements/ci.txt"
       - name: expose github runtime for buildx
         uses: crazy-max/ghaction-github-runtime@v3
-      - name: download docker images
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249
+      - name: download docker images with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner.temp }}/build
+          action: actions/download-artifact@v4
+          with: |
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            path: /${{ runner.temp }}/build
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: load docker images
         run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
@@ -2031,11 +2071,16 @@ jobs:
           cache-dependency-path: "tests/swarm-deploy/requirements/ci.txt"
       - name: expose github runtime for buildx
         uses: crazy-max/ghaction-github-runtime@v3
-      - name: download docker images
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249
+      - name: download docker images with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner.temp }}/build
+          action: actions/download-artifact@v4
+          with: |
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            path: /${{ runner.temp }}/build
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: load docker images
         run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
@@ -2095,11 +2140,16 @@ jobs:
           cache-dependency-path: "tests/e2e/package-lock.json"
       - name: expose github runtime for buildx
         uses: crazy-max/ghaction-github-runtime@v3
-      - name: download docker images
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249
+      - name: download docker images with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner.temp }}/build
+          action: actions/download-artifact@v4
+          with: |
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            path: /${{ runner.temp }}/build
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: load docker images
         run: make load-images local-src=/${{ runner.temp }}/build
       - name: show system version
@@ -2213,11 +2263,16 @@ jobs:
         with:
           version: ${{ matrix.docker_buildx }}
           driver: docker-container
-      - name: download docker images
-        uses: actions/download-artifact@v4
+      # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249
+      - name: download docker images with retry
+        uses: Wandalen/wretry.action@master
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
-          path: /${{ runner.temp }}/build
+          action: actions/download-artifact@v4
+          with: |
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            path: /${{ runner.temp }}/build
+          attempt_limit: 5
+          attempt_delay: 1000
       - name: load docker images
         run: |
           make load-images local-src=/${{ runner.temp }}/build

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
@@ -598,7 +598,7 @@ class BaseCompScheduler(ABC):
         )
         dag: nx.DiGraph = nx.DiGraph()
         try:
-            dag: nx.DiGraph = await self._get_pipeline_dag(project_id)
+            dag = await self._get_pipeline_dag(project_id)
             # 1. Update our list of tasks with data from backend (state, results)
             await self._update_states_from_comp_backend(
                 user_id, project_id, iteration, dag, pipeline_params=pipeline_params

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
@@ -670,6 +670,8 @@ class BaseCompScheduler(ABC):
                 user_id, project_id, iteration, RunningState.ABORTED
             )
             self.scheduled_pipelines.pop((user_id, project_id, iteration), None)
+        except ComputationalBackendNotConnectedError:
+            _logger.exception("Computational backend is not connected!")
 
     async def _schedule_tasks_to_stop(
         self,

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/base_scheduler.py
@@ -532,18 +532,16 @@ class BaseCompScheduler(ABC):
                 run_metadata=pipeline_params.run_metadata,
             )
 
-        if sorted_tasks.completed:
+        if sorted_tasks.completed or sorted_tasks.potentially_lost:
             await self._process_completed_tasks(
                 user_id,
-                sorted_tasks.completed,
+                sorted_tasks.completed + sorted_tasks.potentially_lost,
                 iteration,
                 pipeline_params=pipeline_params,
             )
 
-        if sorted_tasks.waiting or sorted_tasks.potentially_lost:
-            await self._process_waiting_tasks(
-                sorted_tasks.waiting + sorted_tasks.potentially_lost
-            )
+        if sorted_tasks.waiting:
+            await self._process_waiting_tasks(sorted_tasks.waiting)
 
     @abstractmethod
     async def _start_tasks(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
@@ -115,7 +115,9 @@ class DaskScheduler(BaseCompScheduler):
                 RunningState.PENDING,
             )
             # each task is started independently
-            results: list[list[tuple[NodeID, str]] | Exception] = await asyncio.gather(
+            results: list[
+                list[tuple[NodeID, str]] | BaseException
+            ] = await asyncio.gather(
                 *(
                     client.send_computation_tasks(
                         user_id=user_id,
@@ -138,7 +140,7 @@ class DaskScheduler(BaseCompScheduler):
                         project_id, tasks_sent[0][0], tasks_sent[0][1]
                     )
                     for tasks_sent in results
-                    if not isinstance(tasks_sent, Exception)
+                    if not isinstance(tasks_sent, BaseException)
                 ]
             )
             return results

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
@@ -23,6 +23,7 @@ from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
 from servicelib.logging_utils import log_catch
 
 from ...core.errors import (
+    ComputationalBackendNotConnectedError,
     ComputationalBackendOnDemandNotReadyError,
     TaskSchedulingError,
 )
@@ -281,6 +282,8 @@ class DaskScheduler(BaseCompScheduler):
                                 "type": "runtime",
                             }
                         )
+                        if isinstance(result, ComputationalBackendNotConnectedError):
+                            simcore_platform_status = SimcorePlatformStatus.BAD
                     # we need to remove any invalid files in the storage
                     await clean_task_output_and_log_files_if_invalid(
                         self.db_engine, user_id, project_id, node_id

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/dask_scheduler.py
@@ -235,7 +235,7 @@ class DaskScheduler(BaseCompScheduler):
     async def _process_task_result(
         self,
         task: CompTaskAtDB,
-        result: Exception | TaskOutputData,
+        result: BaseException | TaskOutputData,
         run_metadata: RunMetadataDict,
         iteration: Iteration,
     ) -> None:

--- a/services/director-v2/src/simcore_service_director_v2/utils/comp_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/comp_scheduler.py
@@ -47,7 +47,6 @@ COMPLETED_STATES: set[RunningState] = {
     RunningState.ABORTED,
     RunningState.SUCCESS,
     RunningState.FAILED,
-    RunningState.UNKNOWN,
 }
 
 

--- a/services/director-v2/src/simcore_service_director_v2/utils/comp_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/comp_scheduler.py
@@ -11,7 +11,8 @@ from models_library.services_resources import (
 )
 from models_library.users import UserID
 from pydantic import PositiveInt
-from simcore_service_director_v2.models.comp_tasks import CompTaskAtDB
+
+from ..models.comp_tasks import CompTaskAtDB
 
 SCHEDULED_STATES: set[RunningState] = {
     RunningState.PUBLISHED,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

This PR tries to fix/improve the issue where:
- a task is submitted to an external cluster (the cluster gets created), task is in WAITING_FOR_CLUSTER state
- at some point the cluster primary (with dask-scheduler) comes up and the dask client submits the job
- it seems that under load when the director-v2 asks for the task the dask-scheduler does not know *yet* of the task and then it is correctly reported as UNKNOWN
- the director-v2 then wrongly triage that task to be STARTED and at the same time COMPLETED, and sends a *start event* over the wire to ResourcesUsageTracker (RUT) (that is the wrong one)
- during the time when the task is waiting, no *heartbeat event* is sent to RUT, which considers the task as FAILED
- later the task appears in the dask-scheduler, and is eventually processed by a dask-worker (-> thus another *start event* is triggered (the real one) - RUT correctly complains
- the director-v2 then sends *heartbeat events*

Different issues were identified:
- when a dask-scheduler does not "know" about a job it returns a status _RunningState.UNKNOWN_ (this makes sense)
- when the director-v2 receives such a state, it is considering the task as being COMPLETED, in a way if the task is unknown, that means the task is gone/lost. Therefore from a higher level POV the task is considered as FAILED, which also makes sense.
- What does not make sense is to send the *start event* when this happens and the task did not even start. it makes no sense to bill that.

This PR tries to correct that by removing the UNKNOWN state from the COMPLETED states. The UNKNOWN state is treated separately:
- the start event is not sent anymore
- but the pipeline is still stopped, which is what is expected in case the dask-scheduler was restarted or deleted

Bonuses:
- in case a dask-scheduler is restarted, it would restart the whole computational scheduler, this is fixed
- in case a dask-scheduler is gone and the director-v2 cannot connect to it, it would restart the whole computational scheduler, this is fixed
- workaround for https://github.com/actions/download-artifact/issues/249 by re-using https://github.com/sue445/plant_erd/pull/238, thanks!


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
