### PR TITLE
🐛Dynamic scheduler is using the wrong information for hardware info

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events.py
@@ -64,7 +64,6 @@ from ._events_utils import (
     attempt_pod_removal_and_data_saving,
     get_allow_metrics_collection,
     get_director_v0_client,
-    get_hardware_info,
     parse_containers_inspect,
     prepare_services_environment,
     wait_for_sidecar_api,
@@ -182,8 +181,6 @@ class CreateSidecars(DynamicSchedulerEvent):
         swarm_network_id: NetworkId = swarm_network["Id"]
         swarm_network_name: str = swarm_network["Name"]
 
-        hardware_info = await get_hardware_info(app, scheduler_data)
-
         metrics_collection_allowed: bool = await get_allow_metrics_collection(
             app,
             user_id=scheduler_data.user_id,
@@ -205,7 +202,7 @@ class CreateSidecars(DynamicSchedulerEvent):
             swarm_network_id=swarm_network_id,
             settings=settings,
             app_settings=app.state.settings,
-            hardware_info=hardware_info,
+            hardware_info=scheduler_data.hardware_info,
             has_quota_support=dynamic_services_scheduler_settings.DYNAMIC_SIDECAR_ENABLE_VOLUME_LIMITS,
             allow_internet_access=allow_internet_access,
             metrics_collection_allowed=metrics_collection_allowed,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
@@ -10,7 +10,6 @@ from models_library.projects_networks import ProjectsNetworks
 from models_library.projects_nodes import NodeID
 from models_library.projects_nodes_io import NodeIDStr
 from models_library.rabbitmq_messages import InstrumentationRabbitMessage
-from models_library.resource_tracker import HardwareInfo
 from models_library.service_settings_labels import SimcoreServiceLabels
 from models_library.services import ServiceKeyVersion
 from models_library.shared_user_preferences import (
@@ -38,14 +37,12 @@ from tenacity.wait import wait_fixed
 from .....core.dynamic_services_settings.scheduler import (
     DynamicServicesSchedulerSettings,
 )
-from .....core.errors import PricingPlanUnitNotFoundError
 from .....core.settings import AppSettings
 from .....models.dynamic_services_scheduler import (
     DockerContainerInspect,
     DockerStatus,
     SchedulerData,
 )
-from .....modules.resource_usage_tracker_client import ResourceUsageTrackerClient
 from .....utils.db import get_repository
 from ....api_keys_manager import safe_remove
 from ....db.repositories.projects import ProjectsRepository
@@ -468,21 +465,6 @@ async def prepare_services_environment(
     )
 
     scheduler_data.dynamic_sidecar.is_service_environment_ready = True
-
-
-async def get_hardware_info(
-    app: FastAPI, scheduler_data: SchedulerData
-) -> HardwareInfo | None:
-    rut_client = ResourceUsageTrackerClient.get_from_state(app)
-    try:
-        result = await rut_client.get_default_pricing_and_hardware_info(
-            product_name=scheduler_data.product_name,
-            service_key=scheduler_data.key,
-            service_version=scheduler_data.version,
-        )
-        return HardwareInfo(aws_ec2_instances=result.aws_ec2_instances)
-    except PricingPlanUnitNotFoundError:
-        return None
 
 
 async def get_allow_metrics_collection(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

The director-v2 was asking for the default pricing info for some unknown reason??
it is already passed by the webserver.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
