### PR TITLE
🐛Clusters-keeper: calling >100 times for the same new cluster now returns cached information

### DIFF
--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/clusters_keeper/clusters.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/clusters_keeper/clusters.py
@@ -1,13 +1,24 @@
+from typing import Final
+
+from aiocache import cached
 from models_library.api_schemas_clusters_keeper import CLUSTERS_KEEPER_RPC_NAMESPACE
 from models_library.api_schemas_clusters_keeper.clusters import OnDemandCluster
 from models_library.rabbitmq_basic_types import RPCMethodName
 from models_library.users import UserID
 from models_library.wallets import WalletID
+from servicelib.async_utils import run_sequentially_in_context
 
 from ..._client_rpc import RabbitMQRPCClient
 from ..._constants import RPC_REMOTE_METHOD_TIMEOUT_S
 
+_TTL_CACHE_ON_CLUSTERS_S: Final[int] = 15
 
+
+@run_sequentially_in_context(target_args=["user_id", "wallet_id"])
+@cached(
+    ttl=_TTL_CACHE_ON_CLUSTERS_S,
+    key_builder=lambda f, *_args, **kwargs: f"{f.__name__}_{kwargs['user_id']}_{kwargs['wallet_id']}",
+)
 async def get_or_create_cluster(
     client: RabbitMQRPCClient, *, user_id: UserID, wallet_id: WalletID | None
 ) -> OnDemandCluster:
@@ -16,6 +27,9 @@ async def get_or_create_cluster(
     Raises:
         RPCServerError -- if anything happens remotely
     """
+    # NOTE: we tend to have burst of calls for the same cluster
+    # the 1st decorator ensure all of these go 1 by 1
+    # the 2nd decorator ensure that many calls in a short time will return quickly the same value
     on_demand_cluster: OnDemandCluster = await client.request(
         CLUSTERS_KEEPER_RPC_NAMESPACE,
         RPCMethodName("get_or_create_cluster"),

--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/clusters_keeper/clusters.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/clusters_keeper/clusters.py
@@ -11,7 +11,7 @@ from servicelib.async_utils import run_sequentially_in_context
 from ..._client_rpc import RabbitMQRPCClient
 from ..._constants import RPC_REMOTE_METHOD_TIMEOUT_S
 
-_TTL_CACHE_ON_CLUSTERS_S: Final[int] = 15
+_TTL_CACHE_ON_CLUSTERS_S: Final[int] = 5
 
 
 @run_sequentially_in_context(target_args=["user_id", "wallet_id"])

--- a/services/clusters-keeper/tests/unit/conftest.py
+++ b/services/clusters-keeper/tests/unit/conftest.py
@@ -45,6 +45,7 @@ pytest_plugins = [
     "pytest_simcore.environment_configs",
     "pytest_simcore.rabbit_service",
     "pytest_simcore.repository_paths",
+    "pytest_simcore.simcore_service_library_fixtures",
     "pytest_simcore.tmp_path_extra",
 ]
 

--- a/services/clusters-keeper/tests/unit/test_rpc_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_rpc_clusters.py
@@ -49,6 +49,7 @@ def _base_configuration(
     mocked_ec2_server_envs: EnvVarsDict,
     mocked_primary_ec2_instances_envs: EnvVarsDict,
     initialized_app: FastAPI,
+    ensure_run_in_sequence_context_is_empty: None,
 ) -> None:
     ...
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?
when running many jobs through the public API, we actually create as many projects as jobs for 1 same user.
When starting them all at the same time, we actually need to _get_or_create_ the very same cluster at the same time which means there are as many very same call to the clusters-keeper via RPC, then locking a distributed lock, then calling into AWS.

This PR ensures that:
- the call for the very same cluster are sent in sequence instead of concurrently
- the call for the very same cluster are cached 5 seconds

In effect, this prevents calls from going more often than once every 5 seconds for the same user_id/wallet_id combination


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
