### PR TITLE
🎨Improving computational clusters cli monitoring tool

### DIFF
--- a/scripts/maintenance/computational-clusters/README.md
+++ b/scripts/maintenance/computational-clusters/README.md
@@ -8,9 +8,13 @@
 # example usage
 
 ```bash
-./osparc_clusters.py PATH/TO/DEPLOYX/REPO.CONFIG # this will show the current auto-scaled machines in DEPLOYX
+./osparc_clusters.py --repo-config=PATH/TO/DEPLOYX/REPO.CONFIG summary # this will show the current auto-scaled machines in DEPLOYX
 ```
 
 ```bash
-./osparc_clusters.py PATH/TO/DEPLOYX/REPO.CONFIG --ssh-key-path=PATH/TO/DEPLOYX/SSH_KEY # this will show the current auto-scaled machines in DEPLOYX AND also what is running on them
+./osparc_clusters.py --repo-config=PATH/TO/DEPLOYX/REPO.CONFIG --ssh-key-path=PATH/TO/DEPLOYX/SSH_KEY summary # this will show the current auto-scaled machines in DEPLOYX AND also what is running on them
+```
+
+```bash
+./osparc_clusters.py --repo-config=PATH/TO/DEPLOYX/REPO.CONFIG --ssh-key-path=PATH/TO/DEPLOYX/SSH_KEY summary --user-id=XX # this will show the current auto-scaled machines in DEPLOYX AND also what is running on them for user-id XX
 ```

--- a/scripts/maintenance/computational-clusters/osparc_clusters.py
+++ b/scripts/maintenance/computational-clusters/osparc_clusters.py
@@ -9,7 +9,7 @@ from collections import defaultdict, namedtuple
 from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Final, TypeAlias
+from typing import Annotated, Any, Final, Optional, TypeAlias
 
 import arrow
 import boto3
@@ -536,9 +536,7 @@ state = {
 @app.callback()
 def main(
     repo_config: Annotated[Path, typer.Option(help="path to the repo.config file")],
-    ssh_key_path: Annotated[
-        Path | None, typer.Option(help="path to the repo ssh key")
-    ] = None,
+    ssh_key_path: Annotated[Path, typer.Option(help="path to the repo ssh key")] = None,
 ):
     """Manages external clusters"""
     environment = dotenv_values(repo_config)
@@ -598,7 +596,7 @@ def summary() -> None:
 @app.command()
 def clear_jobs(
     user_id: Annotated[int, typer.Option(help="the user ID")],
-    wallet_id: Annotated[int | None, typer.Option(help="the wallet ID")] = None,
+    wallet_id: Annotated[int, typer.Option(help="the wallet ID")] = None,
 ) -> None:
     """remove any dask jobs from the cluster. Use WITH CARE!!!
 
@@ -647,3 +645,5 @@ def clear_jobs(
 
 if __name__ == "__main__":
     app()
+
+# nopycln: file

--- a/scripts/maintenance/computational-clusters/osparc_clusters.py
+++ b/scripts/maintenance/computational-clusters/osparc_clusters.py
@@ -375,13 +375,18 @@ def _print_computational_clusters(
         # now add the workers
         for worker in cluster.workers:
             table.add_row(
-                f"[bold]{_color_encode_with_state('Worker', worker.ec2_instance)}",
-                f"{worker.ec2_instance.id}\n{worker.ec2_instance.instance_type}",
-                f"Ext: {worker.ec2_instance.public_ip_address}\nInt: {worker.ec2_instance.private_ip_address}",
-                f"{worker.name}\n{_create_graylog_permalinks(environment, worker.ec2_instance)}",
-                _timedelta_formatting(
-                    time_now - arrow.get(worker.ec2_instance.launch_time)
+                f"[italic]{_color_encode_with_state('Worker', worker.ec2_instance)}[/italic]",
+                "\n".join(
+                    [
+                        worker.ec2_instance.id,
+                        worker.ec2_instance.instance_type,
+                        f"Up: {_timedelta_formatting(time_now - worker.ec2_instance.launch_time)}",
+                        f"ExtIP: {worker.ec2_instance.public_ip_address}",
+                        f"IntIP: {worker.ec2_instance.private_ip_address}",
+                        f"Name: {worker.name}",
+                    ]
                 ),
+                f"{_create_graylog_permalinks(environment, worker.ec2_instance)}",
                 "",
                 "",
                 "",

--- a/scripts/maintenance/computational-clusters/requirements.txt
+++ b/scripts/maintenance/computational-clusters/requirements.txt
@@ -1,7 +1,9 @@
 arrow
 black
 boto3
-dask[distributed]
+# NOTE: these must be in sync with osparc
+cloudpickle==2.2.1
+dask[distributed]==2023.3.2
 mypy_boto3_ec2
 types-boto3
 parse


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?
new commands to clean dask-scheduler jobs (TO USE WITH CARE).
some improvements in displaying the computational clusters.

new commands:
```bash
❯ ./osparc_clusters.py --help
                                                                                                                                                                                                                                                                                                                
 Usage: osparc_clusters.py [OPTIONS] COMMAND [ARGS]...                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                
 Manages external clusters                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ *  --repo-config               PATH  path to the repo.config file [default: None] [required]                                                                                                                                                                                                                 │
│    --ssh-key-path              PATH  path to the repo ssh key [default: None]                                                                                                                                                                                                                                │
│    --install-completion              Install completion for the current shell.                                                                                                                                                                                                                               │
│    --show-completion                 Show completion for the current shell, to copy it or customize the installation.                                                                                                                                                                                        │
│    --help                            Show this message and exit.                                                                                                                                                                                                                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ clear-jobs                                 remove any dask jobs from the cluster. Use WITH CARE!!!                                                                                                                                                                                                           │
│ summary                                    Show a summary of the current situation of autoscaled EC2 instances.                                                                                                                                                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```


## summary command
- now allows to check for specific users via ```summary --user-id=234```
## clear-job command
- allows to clean a dask-scheduler removing all jobs there. To be used when jobs are in ```erred``` state
## new display of computational clusters
- less columns more space
- more order

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
