### PR TITLE
🔨  Ensures all active users have at least a product's group (🗃️)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@ Makefile                                  @pcrespov @sanderegg
 /ci/                                      @sanderegg @pcrespov
 /docs/                                    @pcrespov
 /packages/models-library/                 @sanderegg @pcrespov @matusdrobuliak66
+/packages/postgres-database/              @matusdrobuliak66
 /packages/pytest-simcore/                 @pcrespov @sanderegg
 /packages/service-integration/            @pcrespov @sanderegg @GitHK
 /packages/service-library/                @pcrespov

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/392a86f2e446_all_users_must_have_a_product.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/392a86f2e446_all_users_must_have_a_product.py
@@ -1,0 +1,50 @@
+"""all users must have a product
+
+Revision ID: 392a86f2e446
+Revises: 0ad000429e3d
+Create Date: 2024-01-09 15:14:11.504329+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "392a86f2e446"
+down_revision = "0ad000429e3d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # If a user has NO associated product groups, assign them a default product
+    migration_query = sa.text(
+        """
+        INSERT INTO users_to_groups (uid, gid)
+        SELECT u.uid, (
+            SELECT p.group_id
+            FROM products p
+            WHERE p.group_id IS NOT NULL
+            ORDER BY p.priority ASC
+            LIMIT 1
+        ) AS default_group_id
+        FROM users u
+        WHERE u.uid NOT IN (
+            SELECT utg.uid
+            FROM users_to_groups utg
+            WHERE utg.gid IN (
+                SELECT p.group_id
+                FROM products p
+            )
+        )
+        AND u.state = 'ACTIVE';
+    """
+    )
+
+    # Execute the migration query
+    conn = op.get_bind()
+    conn.execute(migration_query)
+
+
+def downgrade():
+    # Define the downgrade logic if needed
+    pass

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/392a86f2e446_all_users_must_have_a_product.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/392a86f2e446_all_users_must_have_a_product.py
@@ -19,8 +19,8 @@ def upgrade():
     # If a user has NO associated product groups, assign them a default product
     migration_query = sa.text(
         """
-        INSERT INTO users_to_groups (uid, gid)
-        SELECT u.uid, (
+        INSERT INTO user_to_groups (uid, gid)
+        SELECT u.id, (
             SELECT p.group_id
             FROM products p
             WHERE p.group_id IS NOT NULL
@@ -28,15 +28,15 @@ def upgrade():
             LIMIT 1
         ) AS default_group_id
         FROM users u
-        WHERE u.uid NOT IN (
+        WHERE u.id NOT IN (
             SELECT utg.uid
-            FROM users_to_groups utg
+            FROM user_to_groups utg
             WHERE utg.gid IN (
                 SELECT p.group_id
                 FROM products p
             )
         )
-        AND u.state = 'ACTIVE';
+        AND u.status = 'ACTIVE';
     """
     )
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

This PR adds a migration script that will assign the default product on all `ACTIVE` users that have no product associated. This will guarantee that all ACTIVE users have at least an associated product

- This is a pre-condition for the product-based login #5117 
- This scenario is encountered on users created **before** the product feature was created. Currently all new users are automatically added to a product (see invitation workflow)



## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

Before the migration some active users might not have at least a product group. After the migration all users should have a product group. 

To see the default product run ... and check the first
```sql
SELECT p.group_id, p.name
FROM products p
WHERE p.group_id IS NOT NULL
ORDER BY p.priority ASC
```            

Run this query **before** (should list users to update) and **after** migration (should have none)
```sql
SELECT u.id, u.email
FROM users u
WHERE u.id NOT IN (
	SELECT utg.uid
	FROM user_to_groups utg
	WHERE utg.gid IN (
		SELECT p.group_id
		FROM products p
	)
)
AND u.status = 'ACTIVE';
```

- [x] tested against postgres data in `master` deploy





## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps

- 🗃️ `users` table is affected