### PR TITLE
♻️ Adds `start_exclusive_periodic_task` derived from resource usage tracker service

### DIFF
--- a/packages/service-library/src/servicelib/redis_utils.py
+++ b/packages/service-library/src/servicelib/redis_utils.py
@@ -74,13 +74,13 @@ def start_exclusive_periodic_task(
     **kwargs,
 ) -> asyncio.Task:
     """
-    Ensures that only 1 instance of `task` is periodically ran at all times across
+    Ensures that only 1 instance of ``task`` is periodically ran at all times across
     multiple processes.
-    If one process dies out another process will run the `task`.
+    If one process dies, another process will run the ``task``.
 
-    Creates a background task that periodically tries to start the user `task`.
-    Before the `task` is scheduled for periodic background execution, it acquires a lock.
-    Subsequent calls to `start_exclusive_periodic_task` will not allow the same `task`
+    Creates a background task that periodically tries to start the user ``task``.
+    Before the ``task`` is scheduled for periodic background execution, it acquires a lock.
+    Subsequent calls to ``start_exclusive_periodic_task`` will not allow the same ``task``
     to run since the lock will prevent the scheduling.
     """
     return start_periodic_task(

--- a/packages/service-library/src/servicelib/redis_utils.py
+++ b/packages/service-library/src/servicelib/redis_utils.py
@@ -1,20 +1,22 @@
+import asyncio
 import functools
 import logging
-from typing import Optional, Union
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
 
-from .redis import RedisClientSDK
+import arrow
 
-log = logging.getLogger(__file__)
+from .background_task import start_periodic_task
+from .redis import CouldNotAcquireLockError, RedisClientSDK
+
+_logger = logging.getLogger(__file__)
 
 
 def exclusive(
-    redis: RedisClientSDK,
-    *,
-    lock_key: str,
-    lock_value: Optional[Union[bytes, str]] = None
+    redis: RedisClientSDK, *, lock_key: str, lock_value: bytes | str | None = None
 ):
     """
-    Define a method to run exclusively accross
+    Define a method to run exclusively across
     processes by leveraging a Redis Lock.
 
     parameters:
@@ -32,3 +34,62 @@ def exclusive(
         return wrapper
 
     return decorator
+
+
+async def _exclusive_task_starter(
+    redis: RedisClientSDK,
+    usr_tsk_task: Callable[..., Awaitable[None]],
+    *,
+    usr_tsk_interval: timedelta,
+    usr_tsk_task_name: str,
+    **kwargs,
+) -> None:
+    lock_key = f"lock:exclusive_task_starter:{usr_tsk_task_name}"
+    lock_value = f"locked since {arrow.utcnow().format()}"
+
+    try:
+        await exclusive(redis, lock_key=lock_key, lock_value=lock_value)(
+            start_periodic_task
+        )(
+            usr_tsk_task,
+            interval=usr_tsk_interval,
+            task_name=usr_tsk_task_name,
+            **kwargs,
+        )
+    except CouldNotAcquireLockError:
+        _logger.debug(
+            "Could not acquire lock '%s' with value '%s'", lock_key, lock_value
+        )
+    except Exception as e:
+        _logger.exception(e)  # noqa: TRY401
+        raise
+
+
+def start_exclusive_periodic_task(
+    redis: RedisClientSDK,
+    task: Callable[..., Awaitable[None]],
+    *,
+    interval: timedelta,
+    task_name: str,
+    **kwargs,
+) -> asyncio.Task:
+    """
+    Ensures that only 1 instance of `task` is periodically ran at all times across
+    multiple processes.
+    If one process dies out another process will run the `task`.
+
+    Creates a background task that periodically tries to start the user `task`.
+    Before the `task` is scheduled for periodic background execution, it acquires a lock.
+    Subsequent calls to `start_exclusive_periodic_task` will not allow the same `task`
+    to run since the lock will prevent the scheduling.
+    """
+    return start_periodic_task(
+        _exclusive_task_starter,
+        interval=interval,
+        task_name=f"exclusive_task_starter_{task_name}",
+        redis=redis,
+        usr_tsk_task=task,
+        usr_tsk_interval=timedelta(seconds=1),
+        usr_tsk_task_name=task_name,
+        **kwargs,
+    )

--- a/packages/service-library/src/servicelib/redis_utils.py
+++ b/packages/service-library/src/servicelib/redis_utils.py
@@ -74,14 +74,13 @@ def start_exclusive_periodic_task(
     **kwargs,
 ) -> asyncio.Task:
     """
-    Ensures that only 1 instance of ``task`` is periodically ran at all times across
-    multiple processes.
+    Ensures that only 1 process periodically ever runs ``task`` at all times.
     If one process dies, another process will run the ``task``.
 
     Creates a background task that periodically tries to start the user ``task``.
     Before the ``task`` is scheduled for periodic background execution, it acquires a lock.
     Subsequent calls to ``start_exclusive_periodic_task`` will not allow the same ``task``
-    to run since the lock will prevent the scheduling.
+    to start since the lock will prevent the scheduling.
 
     Q&A:
     - Why is `_exclusive_task_starter` run as a task?

--- a/packages/service-library/src/servicelib/redis_utils.py
+++ b/packages/service-library/src/servicelib/redis_utils.py
@@ -82,6 +82,13 @@ def start_exclusive_periodic_task(
     Before the ``task`` is scheduled for periodic background execution, it acquires a lock.
     Subsequent calls to ``start_exclusive_periodic_task`` will not allow the same ``task``
     to run since the lock will prevent the scheduling.
+
+    Q&A:
+    - Why is `_exclusive_task_starter` run as a task?
+        This is usually used at setup time and cannot block the setup process forever
+    - Why is `_exclusive_task_starter` task a periodic task?
+        If Redis connectivity is lost, the periodic `_exclusive_task_starter` ensures the lock is
+        reacquired
     """
     return start_periodic_task(
         _exclusive_task_starter,

--- a/packages/service-library/tests/test_redis.py
+++ b/packages/service-library/tests/test_redis.py
@@ -6,7 +6,8 @@
 
 import asyncio
 import datetime
-from typing import AsyncIterator, Final
+from collections.abc import AsyncIterator
+from typing import Final
 
 import pytest
 from faker import Faker

--- a/packages/service-library/tests/test_redis_utils.py
+++ b/packages/service-library/tests/test_redis_utils.py
@@ -1,0 +1,184 @@
+# pylint:disable=redefined-outer-name
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from itertools import chain
+from unittest.mock import Mock
+
+import arrow
+import pytest
+from faker import Faker
+from servicelib.background_task import stop_periodic_task
+from servicelib.redis import CouldNotAcquireLockError, RedisClientSDK
+from servicelib.redis_utils import exclusive, start_exclusive_periodic_task
+from servicelib.utils import logged_gather
+from settings_library.redis import RedisDatabase, RedisSettings
+from tenacity._asyncio import AsyncRetrying
+from tenacity.retry import retry_if_exception_type
+from tenacity.stop import stop_after_delay
+from tenacity.wait import wait_fixed
+
+pytest_simcore_core_services_selection = [
+    "redis",
+]
+
+
+@asynccontextmanager
+async def get_redis_client_sdk(
+    redis_service: RedisSettings,
+) -> AsyncIterator[RedisClientSDK]:
+    redis_resources_dns = redis_service.build_redis_dsn(RedisDatabase.RESOURCES)
+    client = RedisClientSDK(redis_resources_dns)
+    assert client
+    assert client.redis_dsn == redis_resources_dns
+    await client.setup()
+
+    yield client
+    # cleanup, properly close the clients
+    await client.redis.flushall()
+    await client.shutdown()
+
+
+async def _is_locked(redis_client_sdk: RedisClientSDK, lock_name: str) -> bool:
+    lock = redis_client_sdk.redis.lock(lock_name)
+    return await lock.locked()
+
+
+@pytest.fixture
+def lock_name(faker: Faker) -> str:
+    return faker.uuid4()
+
+
+async def _contained_client(
+    redis_service: RedisSettings, lock_name: str, task_duration: float
+) -> None:
+    async with get_redis_client_sdk(redis_service) as redis_client_sdk:
+        assert not await _is_locked(redis_client_sdk, lock_name)
+
+        @exclusive(redis_client_sdk, lock_key=lock_name)
+        async def _some_task() -> None:
+            assert await _is_locked(redis_client_sdk, lock_name)
+            await asyncio.sleep(task_duration)
+            assert await _is_locked(redis_client_sdk, lock_name)
+
+        await _some_task()
+
+        assert not await _is_locked(redis_client_sdk, lock_name)
+
+
+@pytest.mark.parametrize("task_duration", [0.1, 1, 2])
+async def test_exclusive_sequentially(
+    redis_service: RedisSettings,
+    lock_name: str,
+    task_duration: float,
+):
+    await _contained_client(redis_service, lock_name, task_duration)
+
+
+async def test_exclusive_parallel_lock_is_released_and_reacquired(
+    redis_service: RedisSettings, lock_name: str
+):
+    parallel_tasks = 10
+    results = await logged_gather(
+        *[
+            _contained_client(redis_service, lock_name, task_duration=0.1)
+            for _ in range(parallel_tasks)
+        ],
+        reraise=False
+    )
+    assert results.count(None) == 1
+    assert [isinstance(x, CouldNotAcquireLockError) for x in results].count(
+        True
+    ) == parallel_tasks - 1
+
+    # check lock is being released
+    async with get_redis_client_sdk(redis_service) as redis_client_sdk:
+        assert not await _is_locked(redis_client_sdk, lock_name)
+
+
+async def _sleep_task(sleep_interval: float, on_sleep_events: Mock) -> None:
+    on_sleep_events(arrow.utcnow())
+    await asyncio.sleep(sleep_interval)
+    on_sleep_events(arrow.utcnow())
+
+
+async def _assert_on_sleep_done(on_sleep_events: Mock, *, stop_after: float):
+    async for attempt in AsyncRetrying(
+        wait=wait_fixed(0.1),
+        stop=stop_after_delay(stop_after),
+        reraise=True,
+        retry=retry_if_exception_type(AssertionError),
+    ):
+        with attempt:
+            assert on_sleep_events.call_count == 2
+
+
+async def _assert_task_completes_once(
+    redis_service: RedisSettings, *, stop_after: float
+) -> tuple[float, ...]:
+    async with get_redis_client_sdk(redis_service) as redis_client_sdk:
+        sleep_events = Mock()
+
+        started_task = start_exclusive_periodic_task(
+            redis_client_sdk,
+            _sleep_task,
+            interval=timedelta(seconds=1),
+            task_name="long_running",
+            sleep_interval=1,
+            on_sleep_events=sleep_events,
+        )
+
+        await _assert_on_sleep_done(sleep_events, stop_after=stop_after)
+
+        await stop_periodic_task(started_task, timeout=5)
+
+        events_timestamps: tuple[float, ...] = tuple(
+            x.args[0].timestamp() for x in sleep_events.call_args_list
+        )
+        return events_timestamps
+
+
+async def test_start_exclusive_periodic_task_single(redis_service: RedisSettings):
+    await _assert_task_completes_once(redis_service, stop_after=2)
+
+
+def _check_elements_lower(lst: list) -> bool:
+    # False when lst[x] => lst[x+1] otherwise True
+    return all(lst[i] < lst[i + 1] for i in range(len(lst) - 1))
+
+
+def test__check_elements_lower():
+    assert _check_elements_lower([1, 2, 3, 4, 5])
+    assert not _check_elements_lower([1, 2, 3, 3, 4, 5])
+    assert not _check_elements_lower([1, 2, 3, 5, 4])
+    assert not _check_elements_lower([2, 1, 3, 4, 5])
+    assert not _check_elements_lower([1, 2, 4, 3, 5])
+
+
+async def test_start_exclusive_periodic_task_parallel_all_finish(
+    redis_service: RedisSettings,
+):
+    parallel_tasks = 10
+    results: list[tuple[float, float]] = await logged_gather(
+        *[
+            _assert_task_completes_once(redis_service, stop_after=60)
+            for _ in range(parallel_tasks)
+        ],
+        reraise=False
+    )
+
+    # check no error occurred
+    assert [isinstance(x, tuple) for x in results].count(True) == parallel_tasks
+    assert [x[0] < x[1] for x in results].count(True) == parallel_tasks
+
+    # sort by start time (task start order is not equal to the task lock acquisition order)
+    sorted_results: list[tuple[float, float]] = sorted(results, key=lambda x: x[0])
+
+    # pylint:disable=unnecessary-comprehension
+    flattened_results: list[float] = [x for x in chain(*sorted_results)]  # noqa: C416
+
+    # NOTE all entries should be in increasing order;
+    # this means that the `_sleep_task` ran sequentially
+    assert _check_elements_lower(flattened_results)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/prometheus_metrics.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/prometheus_metrics.py
@@ -113,7 +113,7 @@ class UserServicesMetrics:
             )
             self._metrics_response = MetricsResponse.from_error(e)
         except Exception as e:  # pylint: disable=broad-exception-caught
-            _logger.exception("Unexpected exception")
+            _logger.info("Unexpected exception", exc_info=True)
             self._metrics_response = MetricsResponse.from_error(e)
 
     async def _task_metrics_recovery(self) -> None:

--- a/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/resource_tracker.py
+++ b/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/resource_tracker.py
@@ -1,15 +1,13 @@
 import functools
 import logging
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timedelta, timezone
 
 from fastapi import FastAPI
 from models_library.rabbitmq_messages import RabbitResourceTrackingBaseMessage
-from servicelib.background_task import start_periodic_task, stop_periodic_task
+from servicelib.background_task import stop_periodic_task
 from servicelib.logging_utils import log_catch, log_context
 from servicelib.rabbitmq import RabbitMQClient
-from servicelib.redis import CouldNotAcquireLockError
-from servicelib.redis_utils import exclusive
+from servicelib.redis_utils import start_exclusive_periodic_task
 from settings_library.rabbit import RabbitSettings
 
 from .core.settings import ApplicationSettings
@@ -20,7 +18,6 @@ from .resource_tracker_process_messages import process_message
 
 _logger = logging.getLogger(__name__)
 
-_TASK_NAME_START_PERIODIC_TASK = "start_background_task"
 _TASK_NAME_PERIODICALY_CHECK_RUNNING_SERVICES = "periodic_check_of_running_services"
 
 _RUT_MESSAGE_TTL_IN_MS = 2 * 60 * 60 * 1000  # 2 hours
@@ -36,35 +33,6 @@ async def _subscribe_to_rabbitmq(app) -> str:
             message_ttl=_RUT_MESSAGE_TTL_IN_MS,
         )
         return subscribed_queue
-
-
-async def _start_background_task(_app: FastAPI, _interval: timedelta) -> None:
-    """With this mechanism each replica of RUT is periodically trying to start
-    'periodic_check_of_running_services_task'. When it is sucesfully started the task runs
-    exclusively what is secured with Redis Lock Mechanism. When this lock is release
-    for example when the replica dies then other replicate takes over the task."""
-
-    lock_key = f"{_app.title}:periodic_check_of_running_services_task_lock"
-    lock_value = f"locked from {datetime.now(tz=timezone.utc)}"
-
-    try:
-        await exclusive(
-            get_redis_client(_app), lock_key=lock_key, lock_value=lock_value
-        )(start_periodic_task)(
-            periodic_check_of_running_services_task,
-            interval=_interval,
-            task_name=_TASK_NAME_PERIODICALY_CHECK_RUNNING_SERVICES,
-            app=_app,
-        )
-    except CouldNotAcquireLockError:
-        _logger.debug(
-            "CouldNotAcquireLockError for lock_key: %s and lock_value: %s",
-            lock_key,
-            lock_value,
-        )
-    except Exception as e:
-        _logger.exception(e)
-        raise
 
 
 def on_app_startup(app: FastAPI) -> Callable[[], Awaitable[None]]:
@@ -86,12 +54,12 @@ def on_app_startup(app: FastAPI) -> Callable[[], Awaitable[None]]:
             )
             # Setup periodic task that will try to run "periodic_check_of_running_services_task"
             if app_settings.RESOURCE_USAGE_TRACKER_MISSED_HEARTBEAT_CHECK_ENABLED:
-                app.state.resource_tracker_background_task = start_periodic_task(
-                    _start_background_task,
+                app.state.resource_tracker_background_task = start_exclusive_periodic_task(
+                    get_redis_client(app),
+                    periodic_check_of_running_services_task,
                     interval=app_settings.RESOURCE_USAGE_TRACKER_MISSED_HEARTBEAT_INTERVAL_SEC,
-                    task_name=_TASK_NAME_START_PERIODIC_TASK,
-                    _app=app,
-                    _interval=app_settings.RESOURCE_USAGE_TRACKER_MISSED_HEARTBEAT_INTERVAL_SEC,
+                    task_name=_TASK_NAME_PERIODICALY_CHECK_RUNNING_SERVICES,
+                    app=app,
                 )
 
     return _startup


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?


Some services like `resource-usage-tracker` and `dynamic-scheduler` require to run periodic tasks that run once regardless of the number of running instances (whether this number is 1 or higher).

- ✨ added tests for `exclusive` decorator
- ♻️ refactored solution form `resource-usage-tracker` to receive a generic task to run at periodic intervals
- ♻️ `resource-usage-tracker` now uses `start_exclusive_periodic_task`


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->

- required by https://github.com/ITISFoundation/osparc-simcore/pull/5212

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
