### PR TITLE
🐛Fixes `TypeError: issubclass() arg 1 must be a class` while building BaseCustomSettings classes

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
+++ b/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from .helpers.typing_env import EnvVarsDict
-from .helpers.utils_envs import load_dotenv, setenvs_from_dict
+from .helpers.utils_envs import delenvs_from_dict, load_dotenv, setenvs_from_dict
 
 
 @pytest.fixture(scope="session")
@@ -23,3 +23,16 @@ def mock_env_devel_environment(
     env_devel_dict: EnvVarsDict, monkeypatch: pytest.MonkeyPatch
 ) -> EnvVarsDict:
     return setenvs_from_dict(monkeypatch, env_devel_dict)
+
+
+@pytest.fixture
+def all_env_devel_undefined(
+    monkeypatch: pytest.MonkeyPatch, env_devel_dict: EnvVarsDict
+):
+    """Ensures that all env vars in .env-devel are undefined in the test environment
+
+    NOTE: this is useful to have a clean starting point and avoid
+    the environment to influence your test. I found this situation
+    when some script was accidentaly injecting the entire .env-devel in the environment
+    """
+    delenvs_from_dict(monkeypatch, env_devel_dict, raising=False)

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/typing_env.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/typing_env.py
@@ -1,7 +1,8 @@
+from collections.abc import Iterable
 from typing import TypeAlias
 
 EnvVarsDict: TypeAlias = dict[str, str]
-EnvVarsList: TypeAlias = list[str]
+EnvVarsList: TypeAlias = Iterable[str]
 
 
 # SEE packages/pytest-simcore/tests/test_helpers_utils_envs.py

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/typing_env.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/typing_env.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable
 from typing import TypeAlias
 
 EnvVarsDict: TypeAlias = dict[str, str]
-EnvVarsList: TypeAlias = Iterable[str]
+EnvVarsIterable: TypeAlias = Iterable[str]
 
 
 # SEE packages/pytest-simcore/tests/test_helpers_utils_envs.py

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/utils_envs.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/utils_envs.py
@@ -17,13 +17,6 @@ from .typing_env import EnvVarsDict, EnvVarsList
 #
 
 
-def delenvs_from_dict(monkeypatch: pytest.MonkeyPatch, envs: EnvVarsList):
-    for var in envs:
-        assert isinstance(var, str)
-        assert var is not None  # None keys cannot be is defined w/o value
-        monkeypatch.delenv(var)
-
-
 def setenvs_from_dict(
     monkeypatch: pytest.MonkeyPatch, envs: EnvVarsDict
 ) -> EnvVarsDict:
@@ -57,6 +50,18 @@ def load_dotenv(envfile_content_or_path: Path | str, **options) -> EnvVarsDict:
     return {k: v or "" for k, v in dotenv.dotenv_values(**kwargs).items()}
 
 
+def delenvs_from_dict(
+    monkeypatch: pytest.MonkeyPatch,
+    envs: EnvVarsList,
+    *,
+    raising: bool = True,
+) -> None:
+    for key in envs:
+        assert isinstance(key, str)
+        assert key is not None  # None keys cannot be is defined w/o value
+        monkeypatch.delenv(key, raising)
+
+
 #
 # monkeypath using envfiles ('.env' and also denoted as dotfiles)
 #
@@ -76,7 +81,8 @@ def setenvs_from_envfile(
 def delenvs_from_envfile(
     monkeypatch: pytest.MonkeyPatch,
     content_or_path: str | Path,
-    raising: bool,
+    *,
+    raising: bool = True,
     **dotenv_kwags,
 ) -> EnvVarsDict:
     """Batch monkeypatch.delenv(...) on all env vars in an envfile"""

--- a/packages/settings-library/src/settings_library/base.py
+++ b/packages/settings-library/src/settings_library/base.py
@@ -90,9 +90,8 @@ class BaseCustomSettings(BaseSettings):
             if args := get_args(field_type):
                 field_type = next(a for a in args if a != type(None))
 
-            if auto_default_from_env:
-                if issubclass(field_type, BaseCustomSettings):
-
+            if issubclass(field_type, BaseCustomSettings):
+                if auto_default_from_env:
                     assert field.field_info.default is Undefined
                     assert field.field_info.default_factory is None
 
@@ -100,13 +99,14 @@ class BaseCustomSettings(BaseSettings):
                     field.default_factory = create_settings_from_env(field)
                     field.default = None
                     field.required = False  # has a default now
-                else:
-                    msg = f"auto_default_from_env=True can only be used in BaseCustomSettings subclassesbut field {cls}.{field.name} is {field_type} "
-                    raise ValueError(msg)
 
-                if issubclass(field_type, BaseSettings):
-                    msg = f"{cls}.{field.name} of type {field_type} must inherit from BaseCustomSettings"
-                    raise ValueError(msg)
+            elif issubclass(field_type, BaseSettings):
+                msg = f"{cls}.{field.name} of type {field_type} must inherit from BaseCustomSettings"
+                raise ValueError(msg)
+
+            elif auto_default_from_env:
+                msg = f"auto_default_from_env=True can only be used in BaseCustomSettings subclassesbut field {cls}.{field.name} is {field_type} "
+                raise ValueError(msg)
 
     @classmethod
     def create_from_envs(cls, **overrides):

--- a/packages/settings-library/src/settings_library/base.py
+++ b/packages/settings-library/src/settings_library/base.py
@@ -3,7 +3,14 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import Final, get_args, get_origin
 
-from pydantic import BaseConfig, BaseSettings, Extra, ValidationError, validator
+from pydantic import (
+    BaseConfig,
+    BaseSettings,
+    ConfigError,
+    Extra,
+    ValidationError,
+    validator,
+)
 from pydantic.error_wrappers import ErrorList, ErrorWrapper
 from pydantic.fields import ModelField, Undefined
 
@@ -107,11 +114,11 @@ class BaseCustomSettings(BaseSettings):
 
             elif is_not_composed and issubclass(field_type, BaseSettings):
                 msg = f"{cls}.{field.name} of type {field_type} must inherit from BaseCustomSettings"
-                raise ValueError(msg)
+                raise ConfigError(msg)
 
             elif auto_default_from_env:
                 msg = f"auto_default_from_env=True can only be used in BaseCustomSettings subclassesbut field {cls}.{field.name} is {field_type} "
-                raise ValueError(msg)
+                raise ConfigError(msg)
 
     @classmethod
     def create_from_envs(cls, **overrides):

--- a/packages/settings-library/src/settings_library/base.py
+++ b/packages/settings-library/src/settings_library/base.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Sequence
 from functools import cached_property
-from typing import Final, get_args
+from typing import Final, get_args, get_origin
 
 from pydantic import BaseConfig, BaseSettings, Extra, ValidationError, validator
 from pydantic.error_wrappers import ErrorList, ErrorWrapper
@@ -90,7 +90,12 @@ class BaseCustomSettings(BaseSettings):
             if args := get_args(field_type):
                 field_type = next(a for a in args if a != type(None))
 
-            if issubclass(field_type, BaseCustomSettings):
+            # Avoids issubclass raising TypeError. SEE test_issubclass_type_error_with_pydantic_models
+            is_not_composed = (
+                get_origin(field_type) is None
+            )  # is not composed as dict[str, Any] or Generic[Base]
+
+            if is_not_composed and issubclass(field_type, BaseCustomSettings):
                 if auto_default_from_env:
                     assert field.field_info.default is Undefined
                     assert field.field_info.default_factory is None
@@ -100,7 +105,7 @@ class BaseCustomSettings(BaseSettings):
                     field.default = None
                     field.required = False  # has a default now
 
-            elif issubclass(field_type, BaseSettings):
+            elif is_not_composed and issubclass(field_type, BaseSettings):
                 msg = f"{cls}.{field.name} of type {field_type} must inherit from BaseCustomSettings"
                 raise ValueError(msg)
 

--- a/packages/settings-library/src/settings_library/base.py
+++ b/packages/settings-library/src/settings_library/base.py
@@ -90,8 +90,9 @@ class BaseCustomSettings(BaseSettings):
             if args := get_args(field_type):
                 field_type = next(a for a in args if a != type(None))
 
-            if issubclass(field_type, BaseCustomSettings):
-                if auto_default_from_env:
+            if auto_default_from_env:
+                if issubclass(field_type, BaseCustomSettings):
+
                     assert field.field_info.default is Undefined
                     assert field.field_info.default_factory is None
 
@@ -99,14 +100,13 @@ class BaseCustomSettings(BaseSettings):
                     field.default_factory = create_settings_from_env(field)
                     field.default = None
                     field.required = False  # has a default now
+                else:
+                    msg = f"auto_default_from_env=True can only be used in BaseCustomSettings subclassesbut field {cls}.{field.name} is {field_type} "
+                    raise ValueError(msg)
 
-            elif issubclass(field_type, BaseSettings):
-                msg = f"{cls}.{field.name} of type {field_type} must inherit from BaseCustomSettings"
-                raise ValueError(msg)
-
-            elif auto_default_from_env:
-                msg = f"auto_default_from_env=True can only be used in BaseCustomSettings subclassesbut field {cls}.{field.name} is {field_type} "
-                raise ValueError(msg)
+                if issubclass(field_type, BaseSettings):
+                    msg = f"{cls}.{field.name} of type {field_type} must inherit from BaseCustomSettings"
+                    raise ValueError(msg)
 
     @classmethod
     def create_from_envs(cls, **overrides):

--- a/packages/settings-library/tests/conftest.py
+++ b/packages/settings-library/tests/conftest.py
@@ -4,13 +4,13 @@
 
 import sys
 from pathlib import Path
-from typing import Optional
 
 import pytest
 import settings_library
 from dotenv import dotenv_values
 from pydantic.fields import Field
 from pytest_simcore.helpers.typing_env import EnvVarsDict
+from pytest_simcore.helpers.utils_envs import delenvs_from_dict
 from settings_library.base import BaseCustomSettings
 from settings_library.basic_types import PortInt
 from settings_library.postgres import PostgresSettings
@@ -46,6 +46,14 @@ def project_tests_data_folder(project_tests_dir: Path) -> Path:
     dir_path = project_tests_dir / "data"
     assert dir_path.exists()
     return dir_path
+
+
+@pytest.fixture
+def all_env_devel_undefined(
+    monkeypatch: pytest.MonkeyPatch, env_devel_dict: EnvVarsDict
+):
+    """Ensures that all env vars in .env-devel are undefined in the environment"""
+    delenvs_from_dict(monkeypatch, env_devel_dict, raising=False)
 
 
 @pytest.fixture
@@ -97,13 +105,9 @@ def fake_settings_class() -> type[BaseCustomSettings]:
 
         # NOTE: by convention, an addon is disabled when APP_ADDON=None, so we make this
         # entry nullable as well
-        APP_OPTIONAL_ADDON: Optional[_ModuleSettings] = Field(
-            auto_default_from_env=True
-        )
+        APP_OPTIONAL_ADDON: _ModuleSettings | None = Field(auto_default_from_env=True)
 
         # NOTE: example of a group that cannot be disabled (not nullable)
-        APP_REQUIRED_PLUGIN: Optional[PostgresSettings] = Field(
-            auto_default_from_env=True
-        )
+        APP_REQUIRED_PLUGIN: PostgresSettings | None = Field(auto_default_from_env=True)
 
     return _ApplicationSettings

--- a/packages/settings-library/tests/conftest.py
+++ b/packages/settings-library/tests/conftest.py
@@ -10,7 +10,6 @@ import settings_library
 from dotenv import dotenv_values
 from pydantic.fields import Field
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.utils_envs import delenvs_from_dict
 from settings_library.base import BaseCustomSettings
 from settings_library.basic_types import PortInt
 from settings_library.postgres import PostgresSettings
@@ -46,14 +45,6 @@ def project_tests_data_folder(project_tests_dir: Path) -> Path:
     dir_path = project_tests_dir / "data"
     assert dir_path.exists()
     return dir_path
-
-
-@pytest.fixture
-def all_env_devel_undefined(
-    monkeypatch: pytest.MonkeyPatch, env_devel_dict: EnvVarsDict
-):
-    """Ensures that all env vars in .env-devel are undefined in the environment"""
-    delenvs_from_dict(monkeypatch, env_devel_dict, raising=False)
 
 
 @pytest.fixture

--- a/packages/settings-library/tests/test_base.py
+++ b/packages/settings-library/tests/test_base.py
@@ -309,8 +309,7 @@ def test_issubclass_type_error_with_pydantic_models():
     # TypeError: issubclass() arg 1 must be a class
     #
 
-    assert not inspect.isclass(dict, BaseSettings)
-
+    assert inspect.isclass(dict[str, str])
     assert not issubclass(dict, BaseSettings)
 
     # NOTE: this should fail when fixed!
@@ -319,8 +318,8 @@ def test_issubclass_type_error_with_pydantic_models():
 
     # here reproduces the problem with our settings
     # that occurred to ANE and PC
-    class SomeSettings(BaseCustomSettings):
+    class SettingsClassThatFailed(BaseCustomSettings):
         FOO: dict[str, str] | None = Field(default=None)
 
-    SomeSettings(FOO={})
-    assert SomeSettings(FOO=None) == SomeSettings()
+    SettingsClassThatFailed(FOO={})
+    assert SettingsClassThatFailed(FOO=None) == SettingsClassThatFailed()

--- a/packages/settings-library/tests/test_base.py
+++ b/packages/settings-library/tests/test_base.py
@@ -312,12 +312,11 @@ def test_issubclass_type_error_with_pydantic_models():
     assert inspect.isclass(dict[str, str])
     assert not issubclass(dict, BaseSettings)
 
-    # NOTE: this should fail when fixed!
+    # NOTE: this should be fixed by pydantic at some point. When this happens, this test will fail
     with pytest.raises(TypeError):
         issubclass(dict[str, str], BaseSettings)
 
-    # here reproduces the problem with our settings
-    # that occurred to ANE and PC
+    # here reproduces the problem with our settings that ANE and PC had
     class SettingsClassThatFailed(BaseCustomSettings):
         FOO: dict[str, str] | None = Field(default=None)
 

--- a/packages/settings-library/tests/test_email.py
+++ b/packages/settings-library/tests/test_email.py
@@ -1,3 +1,8 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+# pylint: disable=too-many-arguments
+
 from typing import Any
 
 import pytest
@@ -46,15 +51,25 @@ from settings_library.email import EmailProtocol, SMTPSettings
         },
     ],
 )
-def test_smtp_configuration_ok(cfg: dict[str, Any]):
+def test_smtp_configuration_ok(cfg: dict[str, Any], all_env_devel_undefined: None):
     assert SMTPSettings.parse_obj(cfg)
 
 
 @pytest.mark.parametrize(
     "cfg",
     [
-        {"SMTP_HOST": "test", "SMTP_PORT": 113, "SMTP_USERNAME": "test"},
-        {"SMTP_HOST": "test", "SMTP_PORT": 113, "SMTP_PASSWORD": "test"},
+        {
+            "SMTP_HOST": "test",
+            "SMTP_PORT": 111,
+            "SMTP_USERNAME": "test",
+            # password required if username provided
+        },
+        {
+            "SMTP_HOST": "test",
+            "SMTP_PORT": 112,
+            "SMTP_PASSWORD": "test",
+            # username required if password provided
+        },
         {
             "SMTP_HOST": "test",
             "SMTP_PORT": 113,
@@ -63,26 +78,26 @@ def test_smtp_configuration_ok(cfg: dict[str, Any]):
         },
         {
             "SMTP_HOST": "test",
-            "SMTP_PORT": 113,
+            "SMTP_PORT": 114,
             "SMTP_PROTOCOL": EmailProtocol.STARTTLS,
             "SMTP_USERNAME": "test",
         },
         {
             "SMTP_HOST": "test",
-            "SMTP_PORT": 113,
+            "SMTP_PORT": 115,
             "SMTP_USERNAME": "",
             "SMTP_PASSWORD": "test",
             "SMTP_PROTOCOL": EmailProtocol.STARTTLS,
         },
         {
             "SMTP_HOST": "test",
-            "SMTP_PORT": 113,
+            "SMTP_PORT": 116,
             "SMTP_USERNAME": "",
             "SMTP_PASSWORD": "test",
             "SMTP_PROTOCOL": EmailProtocol.TLS,
         },
     ],
 )
-def test_smtp_configuration_fails(cfg: dict[str, Any]):
+def test_smtp_configuration_fails(cfg: dict[str, Any], all_env_devel_undefined: None):
     with pytest.raises(ValidationError):
-        assert SMTPSettings.parse_obj(cfg)
+        SMTPSettings(**cfg)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

Some configurations with  `BaseCustomSettings` subclasses raised `TypeError: issubclass() arg 1 must be a class`. 

This is raised by `issubclass` when using pydantic subclasses (e.g. `BaseCustomSettings` inherits from `BaseSettings`) in combination with "composed" types as `dict[str, str]`.
```cmd
>>> issubclass(dict[str, str], dict)
False
 >> issubclass(dict[str, str], BaseSettings)
    Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/home/crespo/.pyenv/versions/3.10.13/lib/python3.10/abc.py", line 123, in __subclasscheck__
        return _abc_subclasscheck(cls, subclass)
    TypeError: issubclass() arg 1 must be a class
```
Some more information and references to pydantic issues are provided in the code's tests

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

Tests that reproduces the bug in 

```cmd
cd packages/settings-library
pytest -vv -k test_issubclass_type_error_with_pydantic_models
```

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
