### PR TITLE
🎨 Reduces response time of catalog/services listing entrypoint

### DIFF
--- a/scripts/mypy/requirements.txt
+++ b/scripts/mypy/requirements.txt
@@ -3,6 +3,7 @@ pydantic[email]~=1.10  # plugin for primary lib: keep in sync. SEE https://docs.
 sqlalchemy[mypy]~=1.4  # plugin for primary lib: keep in sync. SEE https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html#installation
 types-aiofiles
 types-attrs
+types-cachetools
 types-PyYAML
 types-redis
 types-requests

--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -31,6 +31,7 @@ aiohttp-swagger[performance]
 aiopg[sa] # db
 aiosmtplib # email
 asyncpg # db
+cachetools # caching for sync functions
 cryptography # security
 faker # Only used in dev-mode for proof-of-concepts
 gunicorn[setproctitle]

--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -18,7 +18,6 @@
 --requirement ../../../../packages/service-library/requirements/_aiohttp.in
 
 
-
 aio-pika # RabbitMQ client
 aiocache
 aiodebug # asyncio debug
@@ -38,6 +37,7 @@ gunicorn[setproctitle]
 jinja_app_loader # email
 json2html
 jsondiff
+msgpack
 openpyxl # excel
 orjson  # json
 packaging

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -253,6 +253,8 @@ markupsafe==2.1.1
     #   mako
 mdurl==0.1.2
     # via markdown-it-py
+msgpack==1.0.7
+    # via -r requirements/_base.in
 multidict==6.0.2
     # via
     #   aiohttp

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -11,7 +11,9 @@ aio-pika==9.1.2
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
 aiocache==0.11.1
-    # via -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
+    # via
+    #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
+    #   -r requirements/_base.in
 aiodebug==2.3.0
     # via
     #   -c requirements/../../../../packages/service-library/requirements/./_base.in
@@ -110,6 +112,8 @@ attrs==21.4.0
     #   openapi-core
 bidict==0.22.0
     # via python-socketio
+cachetools==5.3.2
+    # via -r requirements/_base.in
 certifi==2023.7.22
     # via
     #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt

--- a/services/web/server/requirements/_test.in
+++ b/services/web/server/requirements/_test.in
@@ -21,6 +21,7 @@ jsonschema
 openapi-spec-validator
 pytest
 pytest-aiohttp
+pytest-benchmark
 pytest-cov
 pytest-docker
 pytest-icdiff

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -128,6 +128,8 @@ pluggy==1.3.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
+py-cpuinfo==9.0.0
+    # via pytest-benchmark
 pyrsistent==0.18.1
     # via
     #   -c requirements/_base.txt
@@ -137,6 +139,7 @@ pytest==7.4.3
     #   -r requirements/_test.in
     #   pytest-aiohttp
     #   pytest-asyncio
+    #   pytest-benchmark
     #   pytest-cov
     #   pytest-docker
     #   pytest-icdiff
@@ -148,6 +151,8 @@ pytest-aiohttp==1.0.5
     # via -r requirements/_test.in
 pytest-asyncio==0.21.1
     # via pytest-aiohttp
+pytest-benchmark==4.0.0
+    # via -r requirements/_test.in
 pytest-cov==4.1.0
     # via -r requirements/_test.in
 pytest-docker==2.0.1

--- a/services/web/server/requirements/_tools.in
+++ b/services/web/server/requirements/_tools.in
@@ -4,5 +4,5 @@
 
 --requirement ../../../../requirements/devenv.txt
 
-# for gunicorn reloading mechanism
-inotify
+inotify # for gunicorn reloading mechanism
+types-cachetools

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -126,6 +126,8 @@ tomli==2.0.1
     #   pyproject-hooks
 tomlkit==0.12.3
     # via pylint
+types-cachetools==5.3.0.7
+    # via -r requirements/_tools.in
 typing-extensions==4.3.0
     # via
     #   -c requirements/_base.txt

--- a/services/web/server/src/simcore_service_webserver/catalog/_api.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_api.py
@@ -61,6 +61,7 @@ class CatalogRequestContext(BaseModel):
 
 async def list_services(
     app: web.Application,
+    *,
     user_id: UserID,
     product_name: str,
     unit_registry: UnitRegistry,

--- a/services/web/server/src/simcore_service_webserver/catalog/_models.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_models.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Final
 
+import cachetools
 from models_library.api_schemas_webserver.catalog import (
     ServiceInputGet,
     ServiceInputKey,
@@ -51,8 +52,25 @@ def get_html_formatted_unit(
 #
 
 
+# Caching:  https://cachetools.readthedocs.io/en/latest/index.html#cachetools.TTLCache
+# - the least recently used items will be discarded first to make space when necessary.
+#
+
+_CACHE_MAXSIZE: Final = (
+    100  # number of items  i.e. ServiceInputGet/ServiceOutputGet insteances
+)
+_CACHE_TTL: Final = 60  # secs
+
+
+def _hash_inputs(service: dict[str, Any], input_key: str, ureg):
+    return f"{service['key']}/{service['version']}/{input_key}"
+
+
 class ServiceInputGetFactory:
     @staticmethod
+    @cachetools.cached(
+        cachetools.TTLCache(ttl=_CACHE_TTL, maxsize=_CACHE_MAXSIZE), key=_hash_inputs
+    )
     def from_catalog_service_api_model(
         service: dict[str, Any],
         input_key: ServiceInputKey,
@@ -73,8 +91,15 @@ class ServiceInputGetFactory:
         return port
 
 
+def _hash_outputs(service: dict[str, Any], output_key: str, ureg):
+    return f"{service['key']}/{service['version']}/{output_key}"
+
+
 class ServiceOutputGetFactory:
     @staticmethod
+    @cachetools.cached(
+        cachetools.TTLCache(ttl=_CACHE_TTL, maxsize=_CACHE_MAXSIZE), key=_hash_outputs
+    )
     def from_catalog_service_api_model(
         service: dict[str, Any],
         output_key: ServiceOutputKey,

--- a/services/web/server/src/simcore_service_webserver/catalog/_models.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_models.py
@@ -63,6 +63,7 @@ _CACHE_TTL: Final = 60  # secs
 
 
 def _hash_inputs(service: dict[str, Any], input_key: str, ureg):
+    assert ureg  # nosec
     return f"{service['key']}/{service['version']}/{input_key}"
 
 
@@ -92,6 +93,7 @@ class ServiceInputGetFactory:
 
 
 def _hash_outputs(service: dict[str, Any], output_key: str, ureg):
+    assert ureg  # nosec
     return f"{service['key']}/{service['version']}/{output_key}"
 
 

--- a/services/web/server/src/simcore_service_webserver/catalog/client.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/client.py
@@ -95,7 +95,7 @@ async def get_services_for_user_in_product(
             url,
             headers={X_PRODUCT_NAME_HEADER: product_name},
         ) as response:
-            if response.status >= 400:
+            if not response.ok:
                 _logger.warning(
                     "Error while retrieving services for user %s. Returning an empty list",
                     user_id,

--- a/services/web/server/tests/unit/isolated/test_catalog_models.py
+++ b/services/web/server/tests/unit/isolated/test_catalog_models.py
@@ -76,23 +76,38 @@ def test_from_catalog_to_webapi_service(
         )
         return s
 
-    webapi_service = benchmark(_run)
+    result = benchmark(_run)
 
-    print(json.dumps(webapi_service, indent=1))
+    # check result
+    got = json.dumps(result, indent=1)
 
     # If units are defined, I want unitShort and unitLong
-    assert webapi_service["outputs"]["outFile"]["unit"] == "sec"
-    assert webapi_service["outputs"]["outFile"]["unitShort"] == "s"
-    assert webapi_service["outputs"]["outFile"]["unitLong"] == "second"
+    assert result["outputs"]["outFile"]["unit"] == "sec", f"{got=}\n"
+    assert result["outputs"]["outFile"]["unitShort"] == "s", f"{got=}\n"
+    assert result["outputs"]["outFile"]["unitLong"] == "second", f"{got=}\n"
 
     # if units are NOT defined => must NOT set Long/Short units
-    fields = set(webapi_service["inputs"]["uno"].keys())
+    fields = set(result["inputs"]["uno"].keys())
     assert not fields.intersection({"unit", "unitShort", "unitLong"})
 
     # Trimmed!
-    assert "defaultValue" not in webapi_service["outputs"]["outFile"]
+    assert "defaultValue" not in result["outputs"]["outFile"], f"{got=}\n"
 
     # All None are trimmed
     for field, value in catalog_service["outputs"]["outFile"].items():
         if field != "defaultValue":
-            assert webapi_service["outputs"]["outFile"][field] == value
+            assert result["outputs"]["outFile"][field] == value, f"{got=}\n"
+
+    # Check whether cache was effective
+    meta = benchmark.stats
+
+    # The coefficient of variation provides a measure of relative variability
+    # in relation to the mean. It allows you to assess the degree of variability
+    # in a dataset while considering the scale of the data.
+    # A higher CV indicates greater relative variability, while a lower CV
+    # suggests lower relative variability.
+    ref_mean = 30e-6
+    ref_std = 2e-6
+    assert (meta.stats.stddev / meta.stats.mean) < (
+        ref_std / ref_mean
+    ), f"benchmark stats: {json.dumps(meta.stats.as_dict(), indent=1)}\n"

--- a/services/web/server/tests/unit/isolated/test_catalog_models.py
+++ b/services/web/server/tests/unit/isolated/test_catalog_models.py
@@ -97,17 +97,3 @@ def test_from_catalog_to_webapi_service(
     for field, value in catalog_service["outputs"]["outFile"].items():
         if field != "defaultValue":
             assert result["outputs"]["outFile"][field] == value, f"{got=}\n"
-
-    # Check whether cache was effective
-    meta = benchmark.stats
-
-    # The coefficient of variation provides a measure of relative variability
-    # in relation to the mean. It allows you to assess the degree of variability
-    # in a dataset while considering the scale of the data.
-    # A higher CV indicates greater relative variability, while a lower CV
-    # suggests lower relative variability.
-    ref_mean = 30e-6
-    ref_std = 2e-6
-    assert (meta.stats.stddev / meta.stats.mean) < (
-        ref_std / ref_mean
-    ), f"benchmark stats: {json.dumps(meta.stats.as_dict(), indent=1)}\n"


### PR DESCRIPTION
## What do these changes do?

This PR analyses and provides a temporary solution for the incident #5267 that reports very long delays in `GET /catalog/services` entrypoint. In addition the front-end can at time spawn up to 17 parallel calls to this entrypoint point (probably due to some retry mechanism)

![image](https://github.com/ITISFoundation/osparc-simcore/assets/32402063/4f96433c-c7fb-4f2e-9ce1-3034e65da636)

We are well aware that the original design does not scale with the amount of services. A proper resolution of this issue therefore requires a redesign that should incorporate at least _pagination_ and lighter item objects with bounded fields.

For the moment we decided to go with a strategic TTL cache that will reduce the overhead of postprocessing **every service item** in the webserver. Note that the webserver does not just forward the service object provided by the `catalog` service but also computes and adds some extra information (e.g. units) to it. Using a profiler reveals that `replace_service_inputs` incurs a considerable computation overhead. Therefore, with the last increase in the number of services this has caused the large delays reported in #5267. 

This is the benchark results and profiler before the cache was added
![image](https://github.com/ITISFoundation/osparc-simcore/assets/32402063/736aeb1c-80b8-4fd7-8655-9a59722c1e4e)
and this is after
![image](https://github.com/ITISFoundation/osparc-simcore/assets/32402063/90caa334-f3bd-4414-88d9-d9e2a8ef6a2e)
Finally here we can see several calls to the entrypoint. After the first, subsequent calls take much less time

![image](https://github.com/ITISFoundation/osparc-simcore/assets/32402063/c8468d40-5286-46a9-89b9-8dcca7cb6d30)

Regarding the empty lists, I also noticed that this comes directly in the response of the catalog service (and not from the webserver). Probably is due to an issue of the caches on the multiple replicas there. Nonetheless this point has not been addressed here

![image](https://github.com/ITISFoundation/osparc-simcore/assets/32402063/9ec17b27-b4a3-4cab-a1dc-494cef173e26)

### Details

- ⬆️  New `cachetools` to cache sync functions (we have `aiocache` to cache async functions` 
- ⬆️ Adds `pytest-benchmark` to benchmark the `replace_service_inputs`
- ⬆️ Adds `msgpack` mainly to remove log warning message of some libraries (e.g. aiocache) that uses this as a default if it is available. 

## Related issue/s

 - Analyses and provides a fix for #5267

## How to test
Driving test `services/web/server/tests/unit/isolated/test_catalog_models.py`

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps
