### PR TITLE
🐛 🚑️ Fixes internal server error in port matching

### DIFF
--- a/services/api-server/src/simcore_service_api_server/services/catalog.py
+++ b/services/api-server/src/simcore_service_api_server/services/catalog.py
@@ -94,7 +94,7 @@ class CatalogApi(BaseServiceClientApi):
                     if predicate is None or predicate(solver):
                         solvers.append(solver)
 
-            except ValidationError as err:
+            except ValidationError as err:  # noqa: PERF203
                 # NOTE: For the moment, this is necessary because there are no guarantees
                 #       at the image registry. Therefore we exclude and warn
                 #       invalid items instead of returning error

--- a/services/web/server/src/simcore_service_webserver/catalog/_api.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_api.py
@@ -215,7 +215,7 @@ async def list_service_outputs(
     outputs = []
     for output_key in service["outputs"]:
         service_output = ServiceOutputGetFactory.from_catalog_service_api_model(
-            service, output_key
+            service, output_key, None
         )
         outputs.append(service_output)
     return outputs

--- a/services/web/server/src/simcore_service_webserver/catalog/_models.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_models.py
@@ -63,7 +63,10 @@ _CACHE_TTL: Final = 60  # secs
 
 
 def _hash_inputs(
-    service: dict[str, Any], input_key: str, *args, **kwargs  # noqa: ARG001
+    service: dict[str, Any],
+    input_key: str,
+    *args,  # noqa: ARG001 # pylint: disable=unused-argument
+    **kwargs,  # noqa: ARG001 # pylint: disable=unused-argument
 ):
     return f"{service['key']}/{service['version']}/{input_key}"
 
@@ -94,7 +97,10 @@ class ServiceInputGetFactory:
 
 
 def _hash_outputs(
-    service: dict[str, Any], output_key: str, *args, **kwargs  # noqa: ARG001
+    service: dict[str, Any],
+    output_key: str,
+    *args,  # noqa: ARG001 # pylint: disable=unused-argument
+    **kwargs,  # noqa: ARG001 # pylint: disable=unused-argument
 ):
     return f"{service['key']}/{service['version']}/{output_key}"
 

--- a/services/web/server/src/simcore_service_webserver/catalog/_models.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_models.py
@@ -62,8 +62,7 @@ _CACHE_MAXSIZE: Final = (
 _CACHE_TTL: Final = 60  # secs
 
 
-def _hash_inputs(service: dict[str, Any], input_key: str, ureg):
-    assert ureg  # nosec
+def _hash_inputs(service: dict[str, Any], input_key: str):
     return f"{service['key']}/{service['version']}/{input_key}"
 
 
@@ -92,8 +91,7 @@ class ServiceInputGetFactory:
         return port
 
 
-def _hash_outputs(service: dict[str, Any], output_key: str, ureg):
-    assert ureg  # nosec
+def _hash_outputs(service: dict[str, Any], output_key: str):
     return f"{service['key']}/{service['version']}/{output_key}"
 
 

--- a/services/web/server/src/simcore_service_webserver/catalog/_models.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_models.py
@@ -62,7 +62,9 @@ _CACHE_MAXSIZE: Final = (
 _CACHE_TTL: Final = 60  # secs
 
 
-def _hash_inputs(service: dict[str, Any], input_key: str):
+def _hash_inputs(
+    service: dict[str, Any], input_key: str, *args, **kwargs  # noqa: ARG001
+):
     return f"{service['key']}/{service['version']}/{input_key}"
 
 
@@ -91,7 +93,9 @@ class ServiceInputGetFactory:
         return port
 
 
-def _hash_outputs(service: dict[str, Any], output_key: str):
+def _hash_outputs(
+    service: dict[str, Any], output_key: str, *args, **kwargs  # noqa: ARG001
+):
     return f"{service['key']}/{service['version']}/{output_key}"
 
 


### PR DESCRIPTION
## What do these changes do?

- 🐛 Fixes missing outputs in hash key generator. In the logs, we found that a request like `GET /v0/catalog/services/simcore/services/dynamic/jupyter-smash/3.0.7/inputs:match` responds 500 due to
```log
  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_webserver/catalog/_handlers.py", line 199, in get_compatible_inputs_given_source_output
    data = await _api.get_compatible_inputs_given_source_output(
  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_webserver/catalog/_api.py", line 180, in get_compatible_inputs_given_source_output
    service_output = await get_service_output(
  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_webserver/catalog/_api.py", line 234, in get_service_output
    ServiceOutputGetFactory.from_catalog_service_api_model(service, output_key)
  File "/home/scu/.venv/lib/python3.10/site-packages/cachetools/__init__.py", line 732, in wrapper
    k = key(*args, **kwargs)
TypeError: _hash_outputs() missing 1 required positional argument: 'ureg'
```
NOTE: that this is the functionality used to interconnect ports. i.e. right now we cannot connect services.
- ⚗️ Increasing test coverage to avoid these errors in the future.
- 🚑️  Should get into staging ASAP

## Related issue/s

- bug introduced by https://github.com/ITISFoundation/osparc-simcore/pull/5273

## How to test

- increased coverage of construction of api-model: `services/web/server/tests/unit/isolated/test_catalog_models.py`

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
