### PR TITLE
🎨 Enh/storage s3 timeout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     rev: v0.2.1
     hooks:
       - id: ruff
-        args: [ --fix, --exit-non-zero-on-fix ]
+        args: [ --fix--only, --exit-non-zero-on-fix ]
       - id: ruff-format
   - repo: https://github.com/psf/black
     rev: 22.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,6 @@ repos:
       - id: pycln
         args: [--all, --expand-stars]
         name: prune imports
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-        name: sort imports
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,13 +34,12 @@ repos:
       - id: pycln
         args: [--all, --expand-stars]
         name: prune imports
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
     hooks:
-      - id: ruff
-        args: [ --fix, --exit-non-zero-on-fix ]
-      - id: ruff-format
-        exclude: ^scripts
+      - id: isort
+        args: ["--profile", "black"]
+        name: sort imports
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,11 +34,17 @@ repos:
       - id: pycln
         args: [--all, --expand-stars]
         name: prune imports
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+        name: sort imports
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.1
     hooks:
       - id: ruff
-        args: [ --fix ]
+        args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff-format
   - repo: https://github.com/psf/black
     rev: 22.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,12 @@ repos:
       - id: pycln
         args: [--all, --expand-stars]
         name: prune imports
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1
     hooks:
-      - id: isort
-        args: ["--profile", "black"]
-        name: sort imports
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,8 +38,9 @@ repos:
     rev: v0.2.1
     hooks:
       - id: ruff
-        args: [ --fix--only, --exit-non-zero-on-fix ]
+        args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff-format
+        exclude: ^scripts
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,5 @@
 
-select = [
+lint.select = [
   "A",     # [https://pypi.org/project/flake8-builtins/]
   "ARG",   # [https://pypi.org/project/flake8-unused-arguments/]
   "ASYNC", # [https://pypi.org/project/flake8-async/]
@@ -40,7 +40,7 @@ select = [
   "W",     # [https://pypi.org/project/pycodestyle/] warnings
   "YTT",   # [https://pypi.org/project/flake8-2020/]
 ]
-ignore = [
+lint.ignore = [
   "E501",   # line too long, handled by black
   "S101",   # use of `assert` detected hanbled by pylance, does not support noseq
   "TID252", # [*] Relative imports from parent modules are banned
@@ -50,7 +50,7 @@ ignore = [
 target-version = "py310"
 
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "**/{tests,pytest_simcore}/**" = [
   "T201",    # print found
   "ARG001",  # unused function argument
@@ -64,10 +64,10 @@ target-version = "py310"
   "FBT001",  # Boolean positional arg in function definition
 ]
 
-[flake8-pytest-style]
+[lint.flake8-pytest-style]
 fixture-parentheses = false
 parametrize-names-type = "csv"
 
 
-[pylint]
+[lint.pylint]
 max-args = 10

--- a/packages/pytest-simcore/src/pytest_simcore/repository_paths.py
+++ b/packages/pytest-simcore/src/pytest_simcore/repository_paths.py
@@ -97,7 +97,8 @@ def pylintrc(osparc_simcore_root_dir: Path) -> Path:
 
 @pytest.fixture(scope="session")
 def project_slug_dir() -> Path:
-    raise NotImplementedError("Override fixture in project's tests/conftest.py")
+    msg = "Override fixture in project's tests/conftest.py"
+    raise NotImplementedError(msg)
     #
     # Implementation example
     #   folder = CURRENT_DIR.parent

--- a/services/storage/src/simcore_service_storage/application.py
+++ b/services/storage/src/simcore_service_storage/application.py
@@ -103,3 +103,10 @@ def run(settings: Settings, app: web.Application | None = None):
         port=settings.STORAGE_PORT,
         access_log_format=_ACCESS_LOG_FORMAT,
     )
+
+
+def get_application_settings(app: web.Application) -> Settings:
+    settings = app[APP_CONFIG_KEY]
+    assert settings  # nosec
+    assert isinstance(settings, Settings)  # nosec
+    return settings

--- a/services/storage/src/simcore_service_storage/exceptions.py
+++ b/services/storage/src/simcore_service_storage/exceptions.py
@@ -1,3 +1,4 @@
+import botocore.exceptions
 from pydantic.errors import PydanticErrorMixin
 
 
@@ -40,6 +41,11 @@ class LinkAlreadyExistsError(DatabaseAccessError):
 class S3AccessError(StorageRuntimeError):
     code = "s3_access.error"
     msg_template: str = "Unexpected error while accessing S3 backend"
+
+
+class S3ReadTimeoutError(S3AccessError):
+    msg_template = "S3 {error}, rq={error.request}, rsp={error.response}"
+    error: botocore.exceptions.ReadTimeoutError
 
 
 class S3BucketInvalidError(S3AccessError):

--- a/services/storage/src/simcore_service_storage/s3_client.py
+++ b/services/storage/src/simcore_service_storage/s3_client.py
@@ -92,6 +92,10 @@ class StorageS3Client:  # pylint: disable=too-many-public-methods
     _client: S3Client
     transfer_max_concurrency: int
 
+    @property
+    def inner(self) -> S3Client:
+        return self._client
+
     @classmethod
     async def create(
         cls, exit_stack: AsyncExitStack, settings: S3Settings, s3_max_concurrency: int

--- a/services/storage/src/simcore_service_storage/s3_client.py
+++ b/services/storage/src/simcore_service_storage/s3_client.py
@@ -20,7 +20,6 @@ from pydantic import AnyUrl, ByteSize, NonNegativeInt, parse_obj_as
 from servicelib.logging_utils import log_context
 from servicelib.utils import logged_gather
 from settings_library.s3 import S3Settings
-from simcore_service_storage.exceptions import S3KeyNotFoundError
 from types_aiobotocore_s3 import S3Client
 from types_aiobotocore_s3.type_defs import (
     ListObjectsV2OutputTypeDef,
@@ -356,12 +355,7 @@ class StorageS3Client:  # pylint: disable=too-many-public-methods
         dst_file: SimcoreS3FileID,
         bytes_transfered_cb: Callable[[int], None] | None,
     ) -> None:
-        """copy a file in S3 using aioboto3 transfer manager (e.g. works >5Gb and creates multiple threads)
-
-        :type bucket: S3BucketName
-        :type src_file: SimcoreS3FileID
-        :type dst_file: SimcoreS3FileID
-        """
+        """Copies a file in S3 using aioboto3 transfer manager (e.g. works >5Gb and creates multiple threads)"""
         copy_options = {
             "CopySource": {"Bucket": bucket, "Key": src_file},
             "Bucket": bucket,
@@ -413,12 +407,7 @@ class StorageS3Client:  # pylint: disable=too-many-public-methods
         file_id: SimcoreS3FileID,
         bytes_transfered_cb: Callable[[int], None] | None,
     ) -> None:
-        """upload a file using aioboto3 transfer manager (e.g. works >5Gb and create multiple threads)
-
-        :type bucket: S3BucketName
-        :type file: Path
-        :type file_id: SimcoreS3FileID
-        """
+        """Uploads a file using aioboto3 transfer manager (e.g. works >5Gb and create multiple threads)"""
         upload_options = {
             "Bucket": bucket,
             "Key": file_id,

--- a/services/storage/src/simcore_service_storage/s3_client.py
+++ b/services/storage/src/simcore_service_storage/s3_client.py
@@ -88,7 +88,7 @@ async def _list_objects_v2_paginated_gen(
 
 @dataclass
 class StorageS3Client:  # pylint: disable=too-many-public-methods
-    session: aioboto3.Session
+    _session: aioboto3.Session
     _client: S3Client
     transfer_max_concurrency: int
 
@@ -113,7 +113,11 @@ class StorageS3Client:  # pylint: disable=too-many-public-methods
         # NOTE: this triggers a botocore.exception.ClientError in case the connection is not made to the S3 backend
         await client.list_buckets()
 
-        return cls(session, client, s3_max_concurrency)
+        return cls(
+            _session=session,
+            _client=client,
+            transfer_max_concurrency=s3_max_concurrency,
+        )
 
     @s3_exception_handler(_logger)
     async def create_bucket(self, bucket: S3BucketName) -> None:

--- a/services/storage/src/simcore_service_storage/s3_client.py
+++ b/services/storage/src/simcore_service_storage/s3_client.py
@@ -117,8 +117,8 @@ class StorageS3Client:  # pylint: disable=too-many-public-methods
             config=Config(
                 signature_version="s3v4",
                 retries={
-                    "mode": "standard",
-                    "total_max_attempts": 4,
+                    "mode": "adaptive",
+                    "total_max_attempts": 2,
                 },
             ),
         )
@@ -459,6 +459,8 @@ class StorageS3Client:  # pylint: disable=too-many-public-methods
                     )
                     total_size += obj["Size"]
                     total_count += 1
+
+                    print(f"{total_size=}", f"{total_count=}")
 
                 except Exception:
                     _logger.exception("%s failed to copy to -> %s", obj, dst)

--- a/services/storage/src/simcore_service_storage/s3_client.py
+++ b/services/storage/src/simcore_service_storage/s3_client.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Final, TypeAlias, cast
 
 import aioboto3
+import arrow
 from aiobotocore.session import ClientCreatorContext
 from boto3.s3.transfer import TransferConfig
 from botocore.client import Config
@@ -114,13 +115,7 @@ class StorageS3Client:  # pylint: disable=too-many-public-methods
             aws_session_token=settings.S3_ACCESS_TOKEN,
             region_name=settings.S3_REGION,
             # FIXME: retries should be reconfigurable via settings
-            config=Config(
-                signature_version="s3v4",
-                retries={
-                    "mode": "adaptive",
-                    "total_max_attempts": 2,
-                },
-            ),
+            config=Config(signature_version="s3v4"),
         )
         assert isinstance(session_client, ClientCreatorContext)  # nosec
         client = cast(S3Client, await exit_stack.enter_async_context(session_client))
@@ -460,7 +455,11 @@ class StorageS3Client:  # pylint: disable=too-many-public-methods
                     total_size += obj["Size"]
                     total_count += 1
 
-                    print(f"{total_size=}", f"{total_count=}")
+                    print(
+                        f"{arrow.now().isoformat()=}",
+                        f"{total_size=}",
+                        f"{total_count=}",
+                    )
 
                 except Exception:
                     _logger.exception("%s failed to copy to -> %s", obj, dst)

--- a/services/storage/src/simcore_service_storage/s3_client.py
+++ b/services/storage/src/simcore_service_storage/s3_client.py
@@ -113,6 +113,8 @@ class StorageS3Client:  # pylint: disable=too-many-public-methods
         # NOTE: this triggers a botocore.exception.ClientError in case the connection is not made to the S3 backend
         await client.list_buckets()
 
+        _logger.debug("AWS S3 %s", f"{client.meta.config=}")
+
         return cls(
             _session=session,
             _client=client,

--- a/services/storage/src/simcore_service_storage/s3_utils.py
+++ b/services/storage/src/simcore_service_storage/s3_utils.py
@@ -16,7 +16,6 @@ from tenacity.before_sleep import before_sleep_log
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_random_exponential
-from types_aiobotocore_s3.client import Exceptions as BotocoreClientErrorsDef
 
 from .exceptions import (
     S3AccessError,
@@ -99,7 +98,7 @@ def s3_exception_handler(log: logging.Logger):
             try:
                 response = await member_func(self, *args, **kwargs)
 
-            except BotocoreClientErrorsDef.NoSuchBucket as err:
+            except self.wrapped_client.exceptions.NoSuchBucket as err:
                 raise S3BucketInvalidError(
                     bucket=err.response.get("Error", {}).get("BucketName", "undefined")
                 ) from err

--- a/services/storage/src/simcore_service_storage/s3_utils.py
+++ b/services/storage/src/simcore_service_storage/s3_utils.py
@@ -1,19 +1,36 @@
 import functools
 import logging
 from dataclasses import dataclass
-from typing import Final, Optional
+from typing import Final
 
-from botocore import exceptions as botocore_exc
+import botocore.exceptions
+import tenacity
 from pydantic import ByteSize, parse_obj_as
 from servicelib.aiohttp.long_running_tasks.server import (
     ProgressMessage,
     ProgressPercent,
     TaskProgress,
 )
+from tenacity.before_sleep import before_sleep_log
+from tenacity.retry import retry_if_exception_type
+from tenacity.stop import stop_after_attempt
+from tenacity.wait import wait_exponential
 
-from .exceptions import S3AccessError, S3BucketInvalidError, S3KeyNotFoundError
+from .exceptions import (
+    S3AccessError,
+    S3BucketInvalidError,
+    S3KeyNotFoundError,
+    S3ReadTimeoutError,
+)
 
-logger = logging.getLogger(__name__)
+#
+# Retry policies
+#
+# NOTE: these are retries on the S3* exceptions mapped in s3_exception_handler
+#
+
+
+_logger = logging.getLogger(__name__)
 
 # this is artifically defined, if possible we keep a maximum number of requests for parallel
 # uploading. If that is not possible then we create as many upload part as the max part size allows
@@ -42,63 +59,83 @@ def compute_num_file_chunks(file_size: ByteSize) -> tuple[int, ByteSize]:
         num_upload_links = int(file_size / chunk) + (1 if file_size % chunk > 0 else 0)
         if num_upload_links < _MULTIPART_MAX_NUMBER_OF_PARTS:
             return (num_upload_links, chunk)
+    msg = f"Could not determine number of upload links for {file_size=}"
     raise ValueError(
-        f"Could not determine number of upload links for {file_size=}",
+        msg,
     )
 
 
 def s3_exception_handler(log: logging.Logger):
-    """converts typical aiobotocore/boto exceptions to storage exceptions
+    """Converts typical aiobotocore/boto exceptions to storage exceptions
     NOTE: this is a work in progress as more exceptions might arise in different
     use-cases
+
+    SEE https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
     """
 
-    def decorator(func):
+    def _decorator(func):
         @functools.wraps(func)
-        async def wrapper(self, *args, **kwargs):
+        async def _wrapper(self, *args, **kwargs):
+
             try:
                 response = await func(self, *args, **kwargs)
-            except self.client.exceptions.NoSuchBucket as exc:
-                raise S3BucketInvalidError(
-                    bucket=exc.response.get("Error", {}).get("BucketName", "undefined")
-                ) from exc
-            except botocore_exc.ClientError as exc:
-                if exc.response.get("Error", {}).get("Code") == "404":
-                    if exc.operation_name == "HeadObject":
-                        raise S3KeyNotFoundError(bucket=args[0], key=args[1]) from exc
-                    if exc.operation_name == "HeadBucket":
-                        raise S3BucketInvalidError(bucket=args[0]) from exc
-                if exc.response.get("Error", {}).get("Code") == "403":
-                    if exc.operation_name == "HeadBucket":
-                        raise S3BucketInvalidError(bucket=args[0]) from exc
-                raise S3AccessError from exc
-            except botocore_exc.EndpointConnectionError as exc:
-                raise S3AccessError from exc
 
-            except botocore_exc.BotoCoreError as exc:
+            except self.client.exceptions.NoSuchBucket as err:
+                raise S3BucketInvalidError(
+                    bucket=err.response.get("Error", {}).get("BucketName", "undefined")
+                ) from err
+
+            except botocore.exceptions.ReadTimeoutError as err:
+                raise S3ReadTimeoutError(error=err) from err
+
+            except botocore.exceptions.ClientError as err:
+                # AWS services error responses
+                error_code: str | None = err.response.get("Error", {}).get("Code", None)
+                if error_code == "404":
+                    if err.operation_name == "HeadObject":
+                        raise S3KeyNotFoundError(bucket=args[0], key=args[1]) from err
+                    if err.operation_name == "HeadBucket":
+                        raise S3BucketInvalidError(bucket=args[0]) from err
+                if error_code == "403" and err.operation_name == "HeadBucket":
+                    raise S3BucketInvalidError(bucket=args[0]) from err
+                raise S3AccessError from err
+
+            except botocore.exceptions.EndpointConnectionError as err:
+                raise S3AccessError from err
+
+            except botocore.exceptions.BotoCoreError as err:
                 log.exception("Unexpected error in s3 client: ")
-                raise S3AccessError from exc
+                raise S3AccessError from err
 
             return response
 
-        return wrapper
+        return _wrapper
 
-    return decorator
+    return _decorator
+
+
+on_timeout_retry_with_exponential_backoff = tenacity.retry(
+    retry=retry_if_exception_type(S3ReadTimeoutError),
+    reraise=True,
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=1, min=4, max=60),
+    before_sleep=before_sleep_log(_logger, logging.WARNING),
+)
 
 
 def update_task_progress(
-    task_progress: Optional[TaskProgress],
-    message: Optional[ProgressMessage] = None,
-    progress: Optional[ProgressPercent] = None,
+    task_progress: TaskProgress | None,
+    message: ProgressMessage | None = None,
+    progress: ProgressPercent | None = None,
 ) -> None:
-    logger.debug("%s [%s]", message or "", progress or "n/a")
+    _logger.debug("%s [%s]", message or "", progress or "n/a")
     if task_progress:
         task_progress.update(message=message, percent=progress)
 
 
 @dataclass
 class S3TransferDataCB:
-    task_progress: Optional[TaskProgress]
+    task_progress: TaskProgress | None
     total_bytes_to_transfer: ByteSize
     task_progress_message_prefix: str = ""
     _total_bytes_copied: int = 0

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -68,11 +68,7 @@ from .models import (
 )
 from .s3 import get_s3_client
 from .s3_client import S3MetaData, StorageS3Client
-from .s3_utils import (
-    S3TransferDataCB,
-    on_timeout_retry_with_exponential_backoff,
-    update_task_progress,
-)
+from .s3_utils import S3TransferDataCB, update_task_progress
 from .settings import Settings
 from .simcore_s3_dsm_utils import (
     expand_directory,
@@ -1124,32 +1120,15 @@ class SimcoreS3DataManager(BaseDataManager):
             await transaction.commit()
 
             s3_client: StorageS3Client = get_s3_client(self.app)
-            _copy_file = on_timeout_retry_with_exponential_backoff(s3_client.copy_file)
-
             if src_fmd.is_directory:
-                # FIXME: create a first empty file and remove at the end if everything went well
-
-                async for page in s3_client.iter_pages(
+                await s3_client.copy_directory(
                     self.simcore_bucket_name,
-                    prefix=src_fmd.object_name,
-                ):
-                    s3_objects_map: dict[str, str] = {
-                        s3_obj["Key"]: f"{new_fmd.object_name}"
-                        + s3_obj["Key"].removeprefix(f"{src_fmd.object_name}")
-                        for s3_obj in page
-                    }
-
-                    for src, new in s3_objects_map.items():
-                        # NOTE: copy_file cannot be called concurrently or it will hang.
-                        # test this with copying multiple 1GB files if you do not believe me
-                        await _copy_file(
-                            self.simcore_bucket_name,
-                            cast(SimcoreS3FileID, src),
-                            cast(SimcoreS3FileID, new),
-                            bytes_transfered_cb=bytes_transfered_cb,
-                        )
+                    src_prefix=src_fmd.object_name,
+                    dst_prefix=new_fmd.object_name,
+                    bytes_transfered_cb=bytes_transfered_cb,
+                )
             else:
-                await _copy_file(
+                await s3_client.copy_file(
                     self.simcore_bucket_name,
                     src_fmd.object_name,
                     new_fmd.object_name,

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -39,6 +39,7 @@ from models_library.projects_nodes_io import LocationID, SimcoreS3FileID
 from models_library.users import UserID
 from models_library.utils.fastapi_encoders import jsonable_encoder
 from pydantic import ByteSize, parse_obj_as
+from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_assert import assert_status
 from servicelib.aiohttp import status
 from simcore_postgres_database.storage_models import file_meta_data, projects, users
@@ -85,22 +86,14 @@ def here() -> Path:
 
 
 @pytest.fixture(scope="session")
-def package_dir(here) -> Path:
+def package_dir(here: Path) -> Path:
     dirpath = Path(simcore_service_storage.__file__).parent
     assert dirpath.exists()
     return dirpath
 
 
 @pytest.fixture(scope="session")
-def osparc_simcore_root_dir(here) -> Path:
-    root_dir = here.parent.parent.parent
-    assert root_dir.exists()
-    assert any(root_dir.glob("services")), "Is this service within osparc-simcore repo?"
-    return root_dir
-
-
-@pytest.fixture(scope="session")
-def osparc_api_specs_dir(osparc_simcore_root_dir) -> Path:
+def osparc_api_specs_dir(osparc_simcore_root_dir: Path) -> Path:
     dirpath = osparc_simcore_root_dir / "api" / "specs"
     assert dirpath.exists()
     return dirpath
@@ -119,8 +112,7 @@ def project_slug_dir(osparc_simcore_root_dir) -> Path:
 def project_env_devel_dict(project_slug_dir: Path) -> dict:
     env_devel_file = project_slug_dir / ".env-devel"
     assert env_devel_file.exists()
-    environ = dotenv.dotenv_values(env_devel_file, verbose=True, interpolate=True)
-    return environ
+    return dotenv.dotenv_values(env_devel_file, verbose=True, interpolate=True)
 
 
 @pytest.fixture
@@ -182,7 +174,7 @@ async def storage_s3_bucket(app_settings: Settings) -> str:
 def mock_config(
     aiopg_engine: Engine,
     postgres_host_config: dict[str, str],
-    mocked_s3_server_envs,
+    mocked_s3_server_envs: EnvVarsDict,
     datcore_adapter_service_mock: aioresponses.aioresponses,
 ):
     # NOTE: this can be overriden in tests that do not need all dependencies up
@@ -385,6 +377,7 @@ def upload_file(
         file_size: ByteSize,
         file_name: str,
         file_id: SimcoreS3FileID | None = None,
+        *,
         wait_for_completion: bool = True,
         sha256_checksum: SHA256Str | None = None,
     ) -> tuple[Path, SimcoreS3FileID]:

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -80,6 +80,20 @@ CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve(
 sys.path.append(str(CURRENT_DIR / "helpers"))
 
 
+def pytest_addoption(parser: pytest.Parser):
+    group = parser.getgroup(
+        "external_environment",
+        description="External parameters used to replace some fixture by external environments",
+    )
+    group.addoption(
+        "--external-envfile",
+        action="store",
+        type=Path,
+        default=None,
+        help="Path to an env file. Consider passing a link to repo configs, i.e. `ln -s /path/to/osparc-ops-config/repo.config`",
+    )
+
+
 @pytest.fixture(scope="session")
 def here() -> Path:
     return CURRENT_DIR
@@ -149,7 +163,7 @@ async def cleanup_user_projects_file_metadata(aiopg_engine: Engine):
 
 
 @pytest.fixture
-def simcore_s3_dsm(client) -> SimcoreS3DataManager:
+def simcore_s3_dsm(client: TestClient) -> SimcoreS3DataManager:
     return cast(
         SimcoreS3DataManager,
         get_dsm_provider(client.app).get(SimcoreS3DataManager.get_location_id()),

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -176,13 +176,13 @@ def mock_config(
     postgres_host_config: dict[str, str],
     mocked_s3_server_envs: EnvVarsDict,
     datcore_adapter_service_mock: aioresponses.aioresponses,
-):
+) -> None:
     # NOTE: this can be overriden in tests that do not need all dependencies up
     ...
 
 
 @pytest.fixture
-def app_settings(mock_config) -> Settings:
+def app_settings(mock_config: None) -> Settings:
     test_app_settings = Settings.create_from_envs()
     print(f"{test_app_settings.json(indent=2)=}")
     return test_app_settings

--- a/services/storage/tests/unit/conftest.py
+++ b/services/storage/tests/unit/conftest.py
@@ -1,6 +1,9 @@
+# pylint: disable=protected-access
 # pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
+
 
 import asyncio
 import urllib.parse

--- a/services/storage/tests/unit/conftest.py
+++ b/services/storage/tests/unit/conftest.py
@@ -210,7 +210,7 @@ async def directory_with_files(
 async def with_versioning_enabled(
     storage_s3_client: StorageS3Client, storage_s3_bucket: str
 ) -> None:
-    await storage_s3_client.client.put_bucket_versioning(
+    await storage_s3_client._client.put_bucket_versioning(
         Bucket=storage_s3_bucket,
         VersioningConfiguration={"MFADelete": "Disabled", "Status": "Enabled"},
     )

--- a/services/storage/tests/unit/test_dsm.py
+++ b/services/storage/tests/unit/test_dsm.py
@@ -1,6 +1,8 @@
-# pylint: disable=unused-variable
-# pylint: disable=unused-argument
+# pylint: disable=protected-access
 # pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
 
 import asyncio
 from collections.abc import Awaitable, Callable

--- a/services/storage/tests/unit/test_dsm.py
+++ b/services/storage/tests/unit/test_dsm.py
@@ -3,8 +3,8 @@
 # pylint: disable=redefined-outer-name
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Awaitable, Callable, Optional
 
 import pytest
 from faker import Faker
@@ -25,7 +25,7 @@ async def dsm_mockup_complete_db(
     simcore_s3_dsm: SimcoreS3DataManager,
     user_id: UserID,
     upload_file: Callable[
-        [ByteSize, str, Optional[SimcoreS3FileID]],
+        [ByteSize, str, SimcoreS3FileID | None],
         Awaitable[tuple[Path, SimcoreS3FileID]],
     ],
     cleanup_user_projects_file_metadata: None,
@@ -58,7 +58,7 @@ async def test_sync_table_meta_data(
     # now remove the files
     for file_entry in dsm_mockup_complete_db:
         s3_key = f"{file_entry.project_id}/{file_entry.node_id}/{file_entry.file_name}"
-        await storage_s3_client.client.delete_object(
+        await storage_s3_client._client.delete_object(
             Bucket=storage_s3_bucket, Key=s3_key
         )
         expected_removed_files.append(s3_key)

--- a/services/storage/tests/unit/test_handlers_files.py
+++ b/services/storage/tests/unit/test_handlers_files.py
@@ -655,7 +655,7 @@ async def test_upload_of_single_presigned_link_lazily_update_database_on_get(
     assert file_upload_link
     # let's use the storage s3 internal client to upload
     with file.open("rb") as fp:
-        response = await storage_s3_client.client.put_object(
+        response = await storage_s3_client._client.put_object(
             Bucket=storage_s3_bucket, Key=simcore_file_id, Body=fp
         )
         assert "ETag" in response
@@ -697,7 +697,7 @@ async def test_upload_real_file_with_s3_client(
     )
     # let's use the storage s3 internal client to upload
     with file.open("rb") as fp:
-        response = await storage_s3_client.client.put_object(
+        response = await storage_s3_client._client.put_object(
             Bucket=storage_s3_bucket, Key=simcore_file_id, Body=fp
         )
         assert "ETag" in response

--- a/services/storage/tests/unit/test_handlers_files.py
+++ b/services/storage/tests/unit/test_handlers_files.py
@@ -1,8 +1,9 @@
-# pylint:disable=unused-variable
-# pylint:disable=unused-argument
-# pylint:disable=redefined-outer-name
-# pylint:disable=too-many-arguments
-# pylint:disable=no-name-in-module
+# pylint: disable=no-name-in-module
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
 
 
 import asyncio

--- a/services/storage/tests/unit/test_handlers_health.py
+++ b/services/storage/tests/unit/test_handlers_health.py
@@ -64,7 +64,7 @@ async def test_bad_health_status_if_bucket_missing(
     app_status_check = AppStatusCheck.parse_obj(data)
     assert app_status_check.services["s3"]["healthy"] == "connected"
     # now delete the bucket
-    await storage_s3_client.client.delete_bucket(Bucket=storage_s3_bucket)
+    await storage_s3_client._client.delete_bucket(Bucket=storage_s3_bucket)
     # check again the health
     response = await client.get(f"{url}")
     data, error = await assert_status(response, status.HTTP_200_OK)

--- a/services/storage/tests/unit/test_s3.py
+++ b/services/storage/tests/unit/test_s3.py
@@ -32,7 +32,7 @@ async def test_s3_client(enable_s3: bool, app_settings: Settings, client: TestCl
         s3_client = get_s3_client(client.app)
         assert s3_client
 
-        response = await s3_client.client.list_buckets()
+        response = await s3_client._client.list_buckets()
         assert response
         assert "Buckets" in response
         assert len(response["Buckets"]) == 1

--- a/services/storage/tests/unit/test_s3.py
+++ b/services/storage/tests/unit/test_s3.py
@@ -1,4 +1,6 @@
+# pylint: disable=protected-access
 # pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 

--- a/services/storage/tests/unit/test_s3_client.py
+++ b/services/storage/tests/unit/test_s3_client.py
@@ -55,7 +55,8 @@ _DEFAULT_EXPIRATION_SECS: Final[int] = 10
 
 @pytest.fixture
 def mock_config(
-    mocked_s3_server_envs: EnvVarsDict, monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
+    mocked_s3_server_envs: EnvVarsDict,
 ) -> None:
     # NOTE: override services/storage/tests/conftest.py::mock_config
     monkeypatch.setenv("STORAGE_POSTGRES", "null")

--- a/services/storage/tests/unit/test_s3_client.py
+++ b/services/storage/tests/unit/test_s3_client.py
@@ -51,7 +51,7 @@ from tests.helpers.file_utils import (
     upload_file_to_presigned_link,
 )
 
-DEFAULT_EXPIRATION_SECS: Final[int] = 10
+_DEFAULT_EXPIRATION_SECS: Final[int] = 10
 
 
 @pytest.fixture
@@ -140,7 +140,7 @@ async def test_create_single_presigned_upload_link(
     file = create_file_of_size(parse_obj_as(ByteSize, "1Mib"))
     file_id = create_simcore_file_id(uuid4(), uuid4(), file.name)
     presigned_url = await storage_s3_client.create_single_presigned_upload_link(
-        storage_s3_bucket, file_id, expiration_secs=DEFAULT_EXPIRATION_SECS
+        storage_s3_bucket, file_id, expiration_secs=_DEFAULT_EXPIRATION_SECS
     )
     assert presigned_url
 
@@ -173,7 +173,7 @@ async def test_create_single_presigned_upload_link_invalid_raises(
         await storage_s3_client.create_single_presigned_upload_link(
             S3BucketName("pytestinvalidbucket"),
             file_id,
-            expiration_secs=DEFAULT_EXPIRATION_SECS,
+            expiration_secs=_DEFAULT_EXPIRATION_SECS,
         )
 
 
@@ -385,7 +385,7 @@ def upload_file_single_presigned_link(
         if not file_id:
             file_id = SimcoreS3FileID(file.name)
         presigned_url = await storage_s3_client.create_single_presigned_upload_link(
-            storage_s3_bucket, file_id, expiration_secs=DEFAULT_EXPIRATION_SECS
+            storage_s3_bucket, file_id, expiration_secs=_DEFAULT_EXPIRATION_SECS
         )
         assert presigned_url
 
@@ -429,7 +429,7 @@ def upload_file_multipart_presigned_link_without_completion(
             storage_s3_bucket,
             file_id,
             ByteSize(file.stat().st_size),
-            expiration_secs=DEFAULT_EXPIRATION_SECS,
+            expiration_secs=_DEFAULT_EXPIRATION_SECS,
             sha256_checksum=parse_obj_as(SHA256Str, faker.sha256()),
         )
         assert upload_links
@@ -668,7 +668,7 @@ async def test_create_single_presigned_download_link(
     file_id = await upload_file_single_presigned_link()
 
     presigned_url = await storage_s3_client.create_single_presigned_download_link(
-        storage_s3_bucket, file_id, expiration_secs=DEFAULT_EXPIRATION_SECS
+        storage_s3_bucket, file_id, expiration_secs=_DEFAULT_EXPIRATION_SECS
     )
 
     assert presigned_url
@@ -701,12 +701,12 @@ async def test_create_single_presigned_download_link_invalid_raises(
         await storage_s3_client.create_single_presigned_download_link(
             S3BucketName("invalidpytestbucket"),
             file_id,
-            expiration_secs=DEFAULT_EXPIRATION_SECS,
+            expiration_secs=_DEFAULT_EXPIRATION_SECS,
         )
     wrong_file_id = create_simcore_file_id(uuid4(), uuid4(), faker.file_name())
     with pytest.raises(S3KeyNotFoundError):
         await storage_s3_client.create_single_presigned_download_link(
-            storage_s3_bucket, wrong_file_id, expiration_secs=DEFAULT_EXPIRATION_SECS
+            storage_s3_bucket, wrong_file_id, expiration_secs=_DEFAULT_EXPIRATION_SECS
         )
 
 

--- a/services/storage/tests/unit/test_s3_client.py
+++ b/services/storage/tests/unit/test_s3_client.py
@@ -12,12 +12,12 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from random import choice
-from typing import Final
+from typing import Final, cast
 from uuid import uuid4
 
 import botocore.exceptions
 import pytest
-from aiohttp import ClientSession
+from aiohttp import ClientSession, web
 from faker import Faker
 from models_library.api_schemas_storage import UploadedPart
 from models_library.basic_types import SHA256Str
@@ -25,15 +25,21 @@ from models_library.projects import ProjectID
 from models_library.projects_nodes import NodeID
 from models_library.projects_nodes_io import SimcoreS3FileID
 from pydantic import ByteSize, parse_obj_as
-from pytest_mock import MockFixture
+from pytest_mock import MockerFixture, MockFixture
 from pytest_simcore.helpers.utils_envs import EnvVarsDict
 from pytest_simcore.helpers.utils_parametrizations import byte_size_ids
 from simcore_service_storage.exceptions import (
     S3AccessError,
     S3BucketInvalidError,
     S3KeyNotFoundError,
+    S3ReadTimeoutError,
 )
-from simcore_service_storage.models import MultiPartUploadLinks, S3BucketName
+from simcore_service_storage.models import (
+    FileMetaDataAtDB,
+    MultiPartUploadLinks,
+    S3BucketName,
+)
+from simcore_service_storage.s3 import get_s3_client
 from simcore_service_storage.s3_client import (
     StorageS3Client,
     _list_objects_v2_paginated_gen,
@@ -962,7 +968,7 @@ async def test_list_objects_v2_paginated_and_list_all_objects_gen(
 
     # fetch all items using the generator make sure it does not break
     generator_query = []
-    async for s3_objects in storage_s3_client.list_all_objects_gen(
+    async for s3_objects in storage_s3_client.iter_pages(
         storage_s3_bucket,
         prefix="",
     ):
@@ -994,3 +1000,81 @@ async def test_file_exists(
         )
         is False
     )
+
+
+##############################################################
+
+
+@pytest.mark.skip()
+async def test__copy_path_s3_s3(
+    mocker: MockerFixture,
+    app: web.Application,
+    simcore_bucket_name: S3BucketName,
+    src_fmd: FileMetaDataAtDB,
+    new_fmd: FileMetaDataAtDB,
+):
+
+    bytes_transfered_cb = mocker.MagicMock()
+
+    s3_client = get_s3_client(app)
+
+    async for s3_objects in s3_client.iter_pages(
+        simcore_bucket_name,
+        prefix=src_fmd.object_name,
+    ):
+        s3_objects_src_to_new: dict[str, str] = {
+            x["Key"]: x["Key"].replace(
+                f"{src_fmd.object_name}", f"{new_fmd.object_name}"
+            )
+            for x in s3_objects
+            if "Key" in x
+        }
+
+        for src, new in s3_objects_src_to_new.items():
+            # NOTE: copy_file cannot be called concurrently or it will hang.
+            # test this with copying multiple 1GB files if you do not believe me
+            await s3_client.copy_file(
+                simcore_bucket_name,
+                cast(SimcoreS3FileID, src),
+                cast(SimcoreS3FileID, new),
+                bytes_transfered_cb=bytes_transfered_cb,
+            )
+
+            assert bytes_transfered_cb.called
+
+
+async def test_it():
+    import botocore.exceptions
+    from simcore_service_storage.exceptions import S3ReadTimeoutError
+    from simcore_service_storage.s3_utils import (
+        on_timeout_retry_with_exponential_backoff,
+    )
+
+    for key, value in sorted(botocore.exceptions.__dict__.items()):
+        if isinstance(value, type):
+            print(key)
+
+    with pytest.raises(S3ReadTimeoutError) as err_info:
+        raise S3ReadTimeoutError(
+            error=botocore.exceptions.ReadTimeoutError(
+                endpoint_url="https://foo.endpoint.com", request="foo", response="bar"
+            )
+        )
+
+    print(err_info.value)
+    assert isinstance(err_info.value.error, botocore.exceptions.ReadTimeoutError)
+
+    async def foo():
+        raise S3ReadTimeoutError(
+            error=botocore.exceptions.ReadTimeoutError(
+                endpoint_url="https://failing.point.com", request="foo", response="bar"
+            )
+        )
+
+    foo_with_retry = on_timeout_retry_with_exponential_backoff(foo)
+
+    with pytest.raises(S3ReadTimeoutError):
+        await foo_with_retry()
+
+    print(foo_with_retry.retry.statistics)
+    assert foo_with_retry.retry.statistics["attempt_number"] == 5

--- a/services/storage/tests/unit/test_s3_client_copy.py
+++ b/services/storage/tests/unit/test_s3_client_copy.py
@@ -1,0 +1,145 @@
+# pylint: disable=no-name-in-module
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from pathlib import Path
+
+import pytest
+from aiohttp.test_utils import TestClient
+from pytest_mock import MockerFixture
+from pytest_simcore.helpers.utils_envs import (
+    EnvVarsDict,
+    load_dotenv,
+    setenvs_from_dict,
+)
+from simcore_service_storage.application import get_application_settings
+from simcore_service_storage.models import S3BucketName
+from simcore_service_storage.s3 import get_s3_client
+from simcore_service_storage.settings import S3Settings
+
+
+@pytest.fixture(scope="session")
+def external_environment(request: pytest.FixtureRequest) -> EnvVarsDict:
+    """
+    If a file under test folder prefixed with `.env-secret` is present,
+    then this fixture captures it.
+
+    This technique allows reusing the same tests to check against
+    external development/production servers
+    """
+    envs = {}
+    if envfile := request.config.getoption("--external-envfile"):
+        assert isinstance(envfile, Path)
+        print("🚨 EXTERNAL: external envs detected. Loading", envfile, "...")
+        envs = load_dotenv(envfile)
+        assert "S3_ACCESS_KEY" in envs
+        assert "S3_BUCKET_NAME" in envs
+    return envs
+
+
+@pytest.fixture
+def mock_config(
+    monkeypatch: pytest.MonkeyPatch,
+    mocked_s3_server_envs: EnvVarsDict,
+    external_environment: EnvVarsDict,
+) -> None:
+    # NOTE: override services/storage/tests/conftest.py::mock_config
+
+    if external_environment:
+        print("WARNING: be careful with running tests that")
+
+    setenvs_from_dict(monkeypatch, {"STORAGE_POSTGRES": "null", **external_environment})
+    print(
+        "Tests below will be using the following S3 settings:",
+        S3Settings.create_from_envs().json(indent=1),
+    )
+
+
+@pytest.fixture
+def simcore_bucket_name(client: TestClient) -> str:
+    assert client.app
+    settings = get_application_settings(client.app)
+    assert settings.STORAGE_S3
+    return settings.STORAGE_S3.S3_BUCKET_NAME
+
+
+async def test__copy_path_s3_s3(
+    mocker: MockerFixture,
+    client: TestClient,
+    simcore_bucket_name: S3BucketName,
+):
+    bytes_transfered_cb = mocker.MagicMock()
+
+    src_fmd_object_name = "502fd316-8a9e-11ee-a81b-02420a0b173b"
+    new_fmd_object_name = "destination"
+    assert client.app
+    s3_client = get_s3_client(client.app)
+
+    start = 1
+    async for page in s3_client.iter_pages(
+        simcore_bucket_name,
+        prefix=src_fmd_object_name,
+    ):
+        objects_names_map: dict[str, str] = {
+            s3_obj[
+                "Key"
+            ]: f"{new_fmd_object_name}{s3_obj['Key'].removeprefix(src_fmd_object_name)}"
+            for s3_obj in page
+        }
+        for s3_obj in page:
+            print(s3_obj)
+
+        n = 0
+        for n, (src, new) in enumerate(objects_names_map.items(), start=start):
+            print(n, "copy_file", src, "->", new)
+        start += n + 1
+        #     # NOTE: copy_file cannot be called concurrently or it will hang.
+        #     # test this with copying multiple 1GB files if you do not believe me
+        #     await s3_client.copy_file(
+        #         simcore_bucket_name,
+        #         cast(SimcoreS3FileID, src),
+        #         cast(SimcoreS3FileID, new),
+        #         bytes_transfered_cb=bytes_transfered_cb,
+        #     )
+
+        #     assert bytes_transfered_cb.called
+
+
+async def test_it():
+    import botocore.exceptions
+    from simcore_service_storage.exceptions import S3ReadTimeoutError
+    from simcore_service_storage.s3_utils import (
+        on_timeout_retry_with_exponential_backoff,
+    )
+
+    for key, value in sorted(botocore.exceptions.__dict__.items()):
+        if isinstance(value, type):
+            print(key)
+
+    with pytest.raises(S3ReadTimeoutError) as err_info:
+        raise S3ReadTimeoutError(
+            error=botocore.exceptions.ReadTimeoutError(
+                endpoint_url="https://foo.endpoint.com", request="foo", response="bar"
+            )
+        )
+
+    print(err_info.value)
+    assert isinstance(err_info.value.error, botocore.exceptions.ReadTimeoutError)
+
+    async def foo():
+        raise S3ReadTimeoutError(
+            error=botocore.exceptions.ReadTimeoutError(
+                endpoint_url="https://failing.point.com", request="foo", response="bar"
+            )
+        )
+
+    foo_with_retry = on_timeout_retry_with_exponential_backoff(foo)
+
+    with pytest.raises(S3ReadTimeoutError):
+        await foo_with_retry()
+
+    print(foo_with_retry.retry.statistics)
+    assert foo_with_retry.retry.statistics["attempt_number"] == 5

--- a/services/storage/tests/unit/test_s3_client_copy.py
+++ b/services/storage/tests/unit/test_s3_client_copy.py
@@ -106,7 +106,7 @@ async def _garbage_collect_failed_copies(s3_client, bucket, prefix, threshold_ho
         print("No marker found. No cleanup needed.")
 
 
-async def test__copy_path_s3_s3(
+async def test_copy_directory_from_s3_to_s3(
     mocker: MockerFixture,
     client: TestClient,
     simcore_bucket_name: S3BucketName,
@@ -116,10 +116,10 @@ async def test__copy_path_s3_s3(
     src_fmd_object_name = (
         "d2504240-cf63-11ee-bf70-02420a0b0228"  # andreas example (s4lio)
     )
-    src_fmd_object_name = (
-        "502fd316-8a9e-11ee-a81b-02420a0b173b"  # taylor example (NIH prod)
-    )
-    src_fmd_object_name = "d0be75f0-ca9a-11ee-9b42-02420a000206"  # MY example (master)
+    # src_fmd_object_name = (
+    #    "502fd316-8a9e-11ee-a81b-02420a0b173b"  # taylor example (NIH prod)
+    # )
+    # src_fmd_object_name = "d0be75f0-ca9a-11ee-9b42-02420a000206"  # MY example (master)
     new_fmd_object_name = "pytest_destination"
     assert client.app
     s3_client = get_s3_client(client.app)
@@ -136,15 +136,18 @@ async def test__copy_path_s3_s3(
         "Copied",
         src_fmd_object_name,
         f"{copied_count=}",
+        f"{sum(copied_count)=}",
         f"{copied_size=}",
+        f"{sum(copied_size)=}",
         f"{elapsed=:3.2f}",
         "secs",
     )
 
-    # 1002 58.541385
-    # 1002 100.254
+    # 0be75f0-ca9a-11ee-9b42-02420a000206 copied_count=1004 copied_size=1048579839 elapsed=72.92 secs
+    #
+
     assert bytes_transfered_cb.called
-    assert bytes_transfered_cb.call_count == 2 * copied_count
+    assert bytes_transfered_cb.call_count == 2 * sum(copied_count)
 
 
 @pytest.mark.skip(reason="UNDER DEVE")

--- a/services/storage/tests/unit/test_s3_client_copy.py
+++ b/services/storage/tests/unit/test_s3_client_copy.py
@@ -113,27 +113,41 @@ async def test__copy_path_s3_s3(
 ):
     bytes_transfered_cb = mocker.MagicMock()
 
-    src_fmd_object_name = "502fd316-8a9e-11ee-a81b-02420a0b173b"
-    src_fmd_object_name = "d0be75f0-ca9a-11ee-9b42-02420a000206"
+    src_fmd_object_name = (
+        "d2504240-cf63-11ee-bf70-02420a0b0228"  # andreas example (s4lio)
+    )
+    src_fmd_object_name = (
+        "502fd316-8a9e-11ee-a81b-02420a0b173b"  # taylor example (NIH prod)
+    )
+    src_fmd_object_name = "d0be75f0-ca9a-11ee-9b42-02420a000206"  # MY example (master)
     new_fmd_object_name = "pytest_destination"
     assert client.app
     s3_client = get_s3_client(client.app)
 
     tic = time.time()
-    copied_count = await s3_client.copy_directory(
+    copied_count, copied_size = await s3_client.copy_directory(
         bucket=simcore_bucket_name,
         src_prefix=src_fmd_object_name,
         dst_prefix=new_fmd_object_name,
         bytes_transfered_cb=bytes_transfered_cb,
     )
-    toc = time.time() - tic
-    print(copied_count, f"{toc:3.2f}", "secs")
+    elapsed = time.time() - tic
+    print(
+        "Copied",
+        src_fmd_object_name,
+        f"{copied_count=}",
+        f"{copied_size=}",
+        f"{elapsed=:3.2f}",
+        "secs",
+    )
+
     # 1002 58.541385
     # 1002 100.254
     assert bytes_transfered_cb.called
     assert bytes_transfered_cb.call_count == 2 * copied_count
 
 
+@pytest.mark.skip(reason="UNDER DEVE")
 async def test_it():
     import botocore.exceptions
     from simcore_service_storage.exceptions import S3ReadTimeoutError

--- a/services/storage/tests/unit/test_s3_client_copy.py
+++ b/services/storage/tests/unit/test_s3_client_copy.py
@@ -5,6 +5,7 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -113,18 +114,24 @@ async def test__copy_path_s3_s3(
     bytes_transfered_cb = mocker.MagicMock()
 
     src_fmd_object_name = "502fd316-8a9e-11ee-a81b-02420a0b173b"
-    new_fmd_object_name = "destination"
+    src_fmd_object_name = "d0be75f0-ca9a-11ee-9b42-02420a000206"
+    new_fmd_object_name = "pytest_destination"
     assert client.app
     s3_client = get_s3_client(client.app)
 
+    tic = time.time()
     copied_count = await s3_client.copy_directory(
         bucket=simcore_bucket_name,
         src_prefix=src_fmd_object_name,
         dst_prefix=new_fmd_object_name,
         bytes_transfered_cb=bytes_transfered_cb,
     )
-    print(copied_count)
+    toc = time.time() - tic
+    print(copied_count, f"{toc:3.2f}", "secs")
+    # 1002 58.541385
+    # 1002 100.254
     assert bytes_transfered_cb.called
+    assert bytes_transfered_cb.call_count == 2 * copied_count
 
 
 async def test_it():

--- a/services/storage/tests/unit/test_s3_client_copy.py
+++ b/services/storage/tests/unit/test_s3_client_copy.py
@@ -136,9 +136,7 @@ async def test_copy_directory_from_s3_to_s3(
         "Copied",
         src_fmd_object_name,
         f"{copied_count=}",
-        f"{sum(copied_count)=}",
         f"{copied_size=}",
-        f"{sum(copied_size)=}",
         f"{elapsed=:3.2f}",
         "secs",
     )
@@ -147,7 +145,7 @@ async def test_copy_directory_from_s3_to_s3(
     #
 
     assert bytes_transfered_cb.called
-    assert bytes_transfered_cb.call_count == 2 * sum(copied_count)
+    assert bytes_transfered_cb.call_count == 2 * copied_count
 
 
 @pytest.mark.skip(reason="UNDER DEVE")


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

- Handles timeout
- Creates a single instance of paginator
- Overcall cleanup of files while analysing the code

## Related issue/s

- Problem experienced while copying taylor's large template


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
