### PR TITLE
🎨 Fixes flaky `test_studies_dispatcher_studies_access`

### DIFF
--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_errors.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_errors.py
@@ -26,3 +26,7 @@ class InvalidRedirectionParams(PydanticErrorMixin, StudyDispatcherError):
         "The link you provided is invalid because it doesn't contain any information related to data or a service."
         " Please check the link and make sure it is correct."
     )
+
+
+class GuestUsersLimitError(PydanticErrorMixin, StudyDispatcherError):
+    msg_template = "Maximum number of guests was reached. Please login with a registered user or try again later"

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_studies_access.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_studies_access.py
@@ -40,7 +40,7 @@ from ._constants import (
     MSG_TOO_MANY_GUESTS,
     MSG_UNEXPECTED_ERROR,
 )
-from ._users import create_temporary_guest_user, get_authorized_user
+from ._users import MaxGuestUsersError, create_temporary_guest_user, get_authorized_user
 
 _logger = logging.getLogger(__name__)
 
@@ -288,16 +288,15 @@ async def get_redirection_to_study_page(request: web.Request) -> web.Response:
             user = await create_temporary_guest_user(request)
             is_anonymous_user = True
 
-        except Exception as exc:
-            # NOTE: when lock times out it is because a user cannot
-            # be create in less that 3 seconds. That shows that the system
-            # is really busy and we rather stop creating GUEST users. For that
+        except MaxGuestUsersError as exc:
+            #
+            # NOTE: Creation of guest users is limited. For that
             # reason we respond with 429 and inform the user that temporarily
             # we cannot accept any more users.
             #
             error_code = create_error_code(exc)
             _logger.exception(
-                "Failed to create guest user. Responded with 429 Too Many Requests[%s]",
+                "Failed to create guest user. Responded with 429 Too Many Requests [%s]",
                 f"{error_code}",
                 extra={"error_code": error_code},
             )

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_studies_access.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_studies_access.py
@@ -40,7 +40,8 @@ from ._constants import (
     MSG_TOO_MANY_GUESTS,
     MSG_UNEXPECTED_ERROR,
 )
-from ._users import MaxGuestUsersError, create_temporary_guest_user, get_authorized_user
+from ._errors import GuestUsersLimitError
+from ._users import create_temporary_guest_user, get_authorized_user
 
 _logger = logging.getLogger(__name__)
 
@@ -288,7 +289,7 @@ async def get_redirection_to_study_page(request: web.Request) -> web.Response:
             user = await create_temporary_guest_user(request)
             is_anonymous_user = True
 
-        except MaxGuestUsersError as exc:
+        except GuestUsersLimitError as exc:
             #
             # NOTE: Creation of guest users is limited. For that
             # reason we respond with 429 and inform the user that temporarily

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
@@ -134,7 +134,9 @@ async def create_temporary_guest_user(request: web.Request):
             ).acquire()
 
     except LockNotOwnedError as err:
-        #   NOTE: when lock times out it is because a user cannot
+        # NOTE: The policy on number of GUETS users allowed is bound to the
+        # load of the system.
+        # If the lock times-out it is because a user cannot
         # be create in less that MAX_DELAY_TO_CREATE_USER seconds.
         # That shows that the system is really loaded and we rather
         # stop creating GUEST users.

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_users.py
@@ -13,9 +13,9 @@ from datetime import datetime
 
 import redis.asyncio as aioredis
 from aiohttp import web
-from aioredis.exceptions import LockNotOwnedError
 from models_library.emails import LowerCaseEmailStr
 from pydantic import BaseModel, parse_obj_as
+from redis.exceptions import LockNotOwnedError
 from servicelib.aiohttp.application_keys import APP_FIRE_AND_FORGET_TASKS_KEY
 from servicelib.logging_utils import log_decorator
 from servicelib.utils import fire_and_forget_task


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

This PR aims to remove a recent "flaky" test in master
```
FAILED tests/unit/with_dbs/01/studies_dispatcher/test_studies_dispatcher_studies_access.py::test_guest_user_is_not_garbage_collected[64] - AssertionError: Expected /study/uuid, got /error?message=We+have+reached+the+maximum+of+anonymous+users+allowed+the+platform.+Please+try+later+or+login+with+a+registered+account.&status_code=429
```

It enhances error handling and cleanup during creation of guest users in the `studies_dispatcher` plugin.


## Related issue/s
Part of
- https://github.com/ITISFoundation/osparc-simcore/issues/3421
- https://github.com/ITISFoundation/osparc-simcore/issues/3977


## How to test


## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
None