### PR TITLE
🎨 Add extra tests for no registered subscriber when using `RabbitMQClient.subscribe`

### DIFF
--- a/packages/service-library/src/servicelib/rabbitmq/_client.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client.py
@@ -151,6 +151,9 @@ class RabbitMQClient(RabbitMQClientBase):
         - exclusive_queue: False means that only one instance of this application will
             reveice the incoming message
 
+        NOTE: ``message_ttl` is also a soft timeout: if the handler does not finish processing
+        the message before this is reached the message will be redelivered!
+
         specifying a topic will make the client declare a TOPIC type of RabbitMQ Exchange
         instead of FANOUT
         - a FANOUT exchange transmit messages to any connected queue regardless of

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq.py
@@ -125,13 +125,13 @@ async def _setup_publisher_and_subscriber(
         unexpected_error_retry_delay_s=_ON_ERROR_DELAY_S,
     )
 
-    if topics is not None:
+    if topics is None:
+        message = random_rabbit_message()
+        await publisher.publish(exchange_name, message)
+    else:
         for topic in topics:
             message = random_rabbit_message(topic=topic)
             await publisher.publish(exchange_name, message)
-    else:
-        message = random_rabbit_message()
-        await publisher.publish(exchange_name, message)
 
     topics_count: int = 1 if topics is None else len(topics)
     return topics_count
@@ -322,13 +322,14 @@ async def test_publish_with_no_registered_subscriber(
     topics_count: int = 1 if topics is None else len(topics)
 
     async def _publish_random_message():
-        if topics is not None:
+        if topics is None:
+            message = random_rabbit_message()
+            await publisher.publish(exchange_name, message)
+
+        else:
             for topic in topics:
                 message = random_rabbit_message(topic=topic)
                 await publisher.publish(exchange_name, message)
-        else:
-            message = random_rabbit_message()
-            await publisher.publish(exchange_name, message)
 
     async def _subscribe_consumer_to_queue():
         await consumer.subscribe(

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq.py
@@ -303,6 +303,71 @@ async def test_subscribe_always_returns_fails_stops(
     }
 
 
+@pytest.mark.parametrize("topics", _TOPICS)
+@pytest.mark.no_cleanup_check_rabbitmq_server_has_no_errors()
+async def test_publish_with_no_registered_subscriber(
+    on_message_spy: mock.Mock,
+    create_rabbitmq_client: Callable[[str], RabbitMQClient],
+    random_exchange_name: Callable[[], str],
+    random_rabbit_message: Callable[..., PytestRabbitMessage],
+    mocked_message_parser: mock.AsyncMock,
+    topics: list[str] | None,
+):
+    publisher = create_rabbitmq_client("publisher")
+    consumer = create_rabbitmq_client("consumer")
+
+    exchange_name = f"{random_exchange_name()}"
+
+    ttl_s: float = 0.1
+    topics_count: int = 1 if topics is None else len(topics)
+
+    async def _publish_random_message():
+        if topics is not None:
+            for topic in topics:
+                message = random_rabbit_message(topic=topic)
+                await publisher.publish(exchange_name, message)
+        else:
+            message = random_rabbit_message()
+            await publisher.publish(exchange_name, message)
+
+    async def _subscribe_consumer_to_queue():
+        await consumer.subscribe(
+            exchange_name,
+            mocked_message_parser,
+            topics=topics,
+            exclusive_queue=False,
+            message_ttl=int(ttl_s * 1000),
+            unexpected_error_max_attempts=_DEFAULT_UNEXPECTED_ERROR_MAX_ATTEMPTS,
+            unexpected_error_retry_delay_s=ttl_s,
+        )
+
+    async def _unsubscribe_consumer():
+        await consumer.unsubscribe_consumer(exchange_name)
+
+    # CASE 1
+
+    await _subscribe_consumer_to_queue()
+    await _unsubscribe_consumer()
+    await _publish_random_message()
+    # reconnect immediately
+    await _subscribe_consumer_to_queue()
+    # expected to receive a message (one per topic)
+    await _assert_wait_for_messages(on_message_spy, 1 * topics_count)
+
+    # CASE 2
+    on_message_spy.reset_mock()
+
+    await _unsubscribe_consumer()
+    await _publish_random_message()
+    # wait for message to expire (will be dropped)
+    await asyncio.sleep(ttl_s * 2)
+    await _subscribe_consumer_to_queue()
+    # wait for a message to be possibly delivered
+    await asyncio.sleep(ttl_s * 2)
+    # nothing changed from before
+    await _assert_wait_for_messages(on_message_spy, 0)
+
+
 async def test_rabbit_client_pub_sub_message_is_lost_if_no_consumer_present(
     create_rabbitmq_client: Callable[[str], RabbitMQClient],
     random_exchange_name: Callable[[], str],

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq.py
@@ -344,7 +344,7 @@ async def test_publish_with_no_registered_subscriber(
     async def _unsubscribe_consumer():
         await consumer.unsubscribe_consumer(exchange_name)
 
-    # CASE 1
+    # CASE 1 (subscribe immediately after publishing message)
 
     await _subscribe_consumer_to_queue()
     await _unsubscribe_consumer()
@@ -354,7 +354,7 @@ async def test_publish_with_no_registered_subscriber(
     # expected to receive a message (one per topic)
     await _assert_wait_for_messages(on_message_spy, 1 * topics_count)
 
-    # CASE 2
+    # CASE 2 (no subscriber attached when publishing)
     on_message_spy.reset_mock()
 
     await _unsubscribe_consumer()


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

There was a double that having no subscribers attached could send the message in an infinite loop between the delay queue and the main queue. This does not happen.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
