### PR TITLE
  ⬆️ Upgrade to `pip~=24.0`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -456,7 +456,7 @@ push-version: tag-version
 	python3 -m venv $@
 	## upgrading tools to latest version in $(shell python3 --version)
 	$@/bin/pip3 --quiet install --upgrade \
-		pip~=23.1 \
+		pip~=24.0 \
 		wheel \
 		setuptools
 	@$@/bin/pip3 list --verbose

--- a/api/specs/web-server/_admin.py
+++ b/api/specs/web-server/_admin.py
@@ -9,7 +9,11 @@ from typing import Union
 from fastapi import APIRouter, Header
 from models_library.generics import Envelope
 from simcore_service_webserver._meta import API_VTAG
-from simcore_service_webserver.email._handlers import TestEmail, TestFailed, TestPassed
+from simcore_service_webserver.email._handlers import (
+    EmailTestFailed,
+    EmailTestPassed,
+    TestEmail,
+)
 
 router = APIRouter(
     prefix=f"/{API_VTAG}",
@@ -21,7 +25,7 @@ router = APIRouter(
 
 @router.post(
     "/email:test",
-    response_model=Envelope[Union[TestFailed, TestPassed]],
+    response_model=Envelope[Union[EmailTestFailed, EmailTestPassed]],
 )
 async def test_email(
     _test: TestEmail, x_simcore_products_name: str | None = Header(default=None)

--- a/ci/helpers/ensure_python_pip.bash
+++ b/ci/helpers/ensure_python_pip.bash
@@ -11,7 +11,7 @@ set -o pipefail # don't hide errors within pipes
 IFS=$'\n\t'
 
 # Pin pip version to a compatible release https://www.python.org/dev/peps/pep-0440/#compatible-release
-PIP_VERSION=23.1
+PIP_VERSION=24.0
 
 echo "INFO:" "$(python --version)" "@" "$(command -v python)"
 

--- a/packages/postgres-database/docker/Dockerfile
+++ b/packages/postgres-database/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/packages/postgres-database/scripts/erd/Dockerfile
+++ b/packages/postgres-database/scripts/erd/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/packages/service-integration/Dockerfile
+++ b/packages/service-integration/Dockerfile
@@ -54,7 +54,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/requirements/tools/Dockerfile
+++ b/requirements/tools/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
 # SEE bug with pip==22.1 https://github.com/jazzband/pip-tools/issues/1617
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/scripts/erd/Dockerfile
+++ b/scripts/erd/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/scripts/openapi/oas_resolver/Dockerfile
+++ b/scripts/openapi/oas_resolver/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /src
 # update pip
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/scripts/pydeps-docker/Dockerfile
+++ b/scripts/pydeps-docker/Dockerfile
@@ -29,7 +29,7 @@ COPY .pydeps ${HOME_DIR}/.pydeps
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -80,7 +80,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/api-server/Dockerfile
+++ b/services/api-server/Dockerfile
@@ -76,7 +76,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/autoscaling/Dockerfile
+++ b/services/autoscaling/Dockerfile
@@ -96,7 +96,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -76,7 +76,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/clusters-keeper/Dockerfile
+++ b/services/clusters-keeper/Dockerfile
@@ -96,7 +96,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -86,7 +86,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/datcore-adapter/Dockerfile
+++ b/services/datcore-adapter/Dockerfile
@@ -77,7 +77,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/director-v2/Dockerfile
+++ b/services/director-v2/Dockerfile
@@ -77,7 +77,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/dynamic-scheduler/Dockerfile
+++ b/services/dynamic-scheduler/Dockerfile
@@ -76,7 +76,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -107,7 +107,7 @@ RUN python -m venv "${VIRTUAL_ENV}" \
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/invitations/Dockerfile
+++ b/services/invitations/Dockerfile
@@ -76,7 +76,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/migration/Dockerfile
+++ b/services/migration/Dockerfile
@@ -49,7 +49,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/osparc-gateway-server/Dockerfile
+++ b/services/osparc-gateway-server/Dockerfile
@@ -77,7 +77,7 @@ RUN  --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
 RUN python -m venv "${VIRTUAL_ENV}"
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -76,7 +76,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/resource-usage-tracker/Dockerfile
+++ b/services/resource-usage-tracker/Dockerfile
@@ -77,7 +77,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/storage/Dockerfile
+++ b/services/storage/Dockerfile
@@ -85,7 +85,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -88,7 +88,7 @@ RUN python -m venv "${VIRTUAL_ENV}"
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
   pip install --upgrade  \
-  pip~=23.1  \
+  pip~=24.0  \
   wheel \
   setuptools
 

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -53,7 +53,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Envelope_Union_TestFailed__TestPassed__'
+                $ref: '#/components/schemas/Envelope_Union_EmailTestFailed__EmailTestPassed__'
   /v0/announcements:
     get:
       tags:
@@ -5407,6 +5407,40 @@ components:
       additionalProperties: false
       description: I/O port type to hold a generic download link to a file (e.g. S3
         pre-signed link, etc)
+    EmailTestFailed:
+      title: EmailTestFailed
+      required:
+      - test_name
+      - error_type
+      - error_message
+      - traceback
+      type: object
+      properties:
+        test_name:
+          title: Test Name
+          type: string
+        error_type:
+          title: Error Type
+          type: string
+        error_message:
+          title: Error Message
+          type: string
+        traceback:
+          title: Traceback
+          type: string
+    EmailTestPassed:
+      title: EmailTestPassed
+      required:
+      - fixtures
+      - info
+      type: object
+      properties:
+        fixtures:
+          title: Fixtures
+          type: object
+        info:
+          title: Info
+          type: object
     EmptyModel:
       title: EmptyModel
       type: object
@@ -5776,6 +5810,17 @@ components:
           $ref: '#/components/schemas/ThirdPartyToken'
         error:
           title: Error
+    Envelope_Union_EmailTestFailed__EmailTestPassed__:
+      title: Envelope[Union[EmailTestFailed, EmailTestPassed]]
+      type: object
+      properties:
+        data:
+          title: Data
+          anyOf:
+          - $ref: '#/components/schemas/EmailTestFailed'
+          - $ref: '#/components/schemas/EmailTestPassed'
+        error:
+          title: Error
     Envelope_Union_NodeGetIdle__NodeGetUnknown__RunningDynamicServiceDetails__NodeGet__:
       title: Envelope[Union[NodeGetIdle, NodeGetUnknown, RunningDynamicServiceDetails,
         NodeGet]]
@@ -5796,17 +5841,6 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/PricingUnitGet'
-        error:
-          title: Error
-    Envelope_Union_TestFailed__TestPassed__:
-      title: Envelope[Union[TestFailed, TestPassed]]
-      type: object
-      properties:
-        data:
-          title: Data
-          anyOf:
-          - $ref: '#/components/schemas/TestFailed'
-          - $ref: '#/components/schemas/TestPassed'
         error:
           title: Error
     Envelope_Union_WalletGet__NoneType__:
@@ -9805,40 +9839,6 @@ components:
           title: Template Context
           type: object
           default: {}
-    TestFailed:
-      title: TestFailed
-      required:
-      - test_name
-      - error_type
-      - error_message
-      - traceback
-      type: object
-      properties:
-        test_name:
-          title: Test Name
-          type: string
-        error_type:
-          title: Error Type
-          type: string
-        error_message:
-          title: Error Message
-          type: string
-        traceback:
-          title: Traceback
-          type: string
-    TestPassed:
-      title: TestPassed
-      required:
-      - fixtures
-      - info
-      type: object
-      properties:
-        fixtures:
-          title: Fixtures
-          type: object
-        info:
-          title: Info
-          type: object
     TextArea:
       title: TextArea
       required:

--- a/services/web/server/src/simcore_service_webserver/email/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/email/_handlers.py
@@ -37,7 +37,7 @@ class TestEmail(BaseModel):
     template_context: dict[str, Any] = {}
 
 
-class TestFailed(BaseModel):
+class EmailTestFailed(BaseModel):
     test_name: str
     error_type: str
     error_message: str
@@ -53,7 +53,7 @@ class TestFailed(BaseModel):
         )
 
 
-class TestPassed(BaseModel):
+class EmailTestPassed(BaseModel):
     fixtures: dict[str, Any]
     info: dict[str, Any]
 
@@ -98,7 +98,7 @@ async def test_email(request: web.Request):
         )
 
         return envelope_json_response(
-            TestPassed(
+            EmailTestPassed(
                 fixtures=body.dict(),
                 info={
                     "email-server": info,
@@ -113,5 +113,5 @@ async def test_email(request: web.Request):
             f"{settings.json(indent=1)}",
         )
         return envelope_json_response(
-            TestFailed.create_from_exception(error=err, test_name="test_email")
+            EmailTestFailed.create_from_exception(error=err, test_name="test_email")
         )

--- a/services/web/server/tests/unit/with_dbs/03/test_email.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_email.py
@@ -23,7 +23,7 @@ from settings_library.email import EmailProtocol, SMTPSettings
 from simcore_service_webserver._meta import API_VTAG
 from simcore_service_webserver._resources import webserver_resources
 from simcore_service_webserver.email._core import _remove_comments, _render_template
-from simcore_service_webserver.email._handlers import TestFailed, TestPassed
+from simcore_service_webserver.email._handlers import EmailTestFailed, EmailTestPassed
 from simcore_service_webserver.email.plugin import setup_email
 
 
@@ -122,9 +122,9 @@ async def test_email_handlers(
         assert error is None
 
         with pytest.raises(ValidationError):
-            TestFailed.parse_obj(data)
+            EmailTestFailed.parse_obj(data)
 
-        passed = TestPassed.parse_obj(data)
+        passed = EmailTestPassed.parse_obj(data)
         print(passed.json(indent=1))
 
 


### PR DESCRIPTION


## What do these changes do?

- Repo-wide update to `pip~=24.0` (i.e.  `24.*` ). SEE https://pip.pypa.io/en/stable/cli/
- _Extra_: Fixes warning 

```log
PytestCollectionWarning: cannot collect test class 'TestFailed' because it has a __init__ constructor (from: tests/unit/with_dbs/03/test_email.py)
    class TestFailed(BaseModel):
```

## Related issue/s



## How to test


## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
