### PR TITLE
🎨 Enhances setup to remediate accumulation of messages in socketio exchange

### DIFF
--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
@@ -112,7 +112,7 @@ async def _progress_message_parser(app: web.Application, data: bytes) -> bool:
             app,
             rabbit_message.user_id,
             message=message,
-            has_direct_connection_to_client=True,
+            ignore_queue=True,
         )
     return True
 
@@ -126,7 +126,7 @@ async def _log_message_parser(app: web.Application, data: bytes) -> bool:
             event_type=SOCKET_IO_LOG_EVENT,
             data=rabbit_message.dict(exclude={"user_id", "channel_name"}),
         ),
-        has_direct_connection_to_client=True,
+        ignore_queue=True,
     )
     return True
 
@@ -143,7 +143,7 @@ async def _events_message_parser(app: web.Application, data: bytes) -> bool:
                 "node_id": f"{rabbit_message.node_id}",
             },
         ),
-        has_direct_connection_to_client=True,
+        ignore_queue=True,
     )
     return True
 

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
@@ -105,7 +105,12 @@ async def _progress_message_parser(app: web.Application, data: bytes) -> bool:
     else:
         socket_message = _convert_to_node_progress_event(rabbit_message)
     if socket_message:
-        await send_messages_to_user(app, rabbit_message.user_id, [socket_message])
+        await send_messages_to_user(
+            app,
+            rabbit_message.user_id,
+            [socket_message],
+            has_direct_connection_to_client=True,
+        )
 
     return True
 
@@ -118,7 +123,12 @@ async def _log_message_parser(app: web.Application, data: bytes) -> bool:
             "data": rabbit_message.dict(exclude={"user_id", "channel_name"}),
         }
     ]
-    await send_messages_to_user(app, rabbit_message.user_id, socket_messages)
+    await send_messages_to_user(
+        app,
+        rabbit_message.user_id,
+        socket_messages,
+        has_direct_connection_to_client=True,
+    )
     return True
 
 
@@ -134,7 +144,12 @@ async def _events_message_parser(app: web.Application, data: bytes) -> bool:
             },
         }
     ]
-    await send_messages_to_user(app, rabbit_message.user_id, socket_messages)
+    await send_messages_to_user(
+        app,
+        rabbit_message.user_id,
+        socket_messages,
+        has_direct_connection_to_client=True,
+    )
     return True
 
 

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
@@ -29,7 +29,7 @@ from ..socketio.messages import (
     SOCKET_IO_PROJECT_PROGRESS_EVENT,
     SOCKET_IO_WALLET_OSPARC_CREDITS_UPDATED_EVENT,
     send_message_to_standard_group,
-    send_messages_to_user,
+    send_message_to_user,
 )
 from ..wallets import api as wallets_api
 from ._constants import APP_RABBITMQ_CONSUMERS_KEY
@@ -108,7 +108,7 @@ async def _progress_message_parser(app: web.Application, data: bytes) -> bool:
         message = _convert_to_node_progress_event(rabbit_message)
 
     if message:
-        await send_messages_to_user(
+        await send_message_to_user(
             app,
             rabbit_message.user_id,
             message=message,
@@ -119,7 +119,7 @@ async def _progress_message_parser(app: web.Application, data: bytes) -> bool:
 
 async def _log_message_parser(app: web.Application, data: bytes) -> bool:
     rabbit_message = LoggerRabbitMessage.parse_raw(data)
-    await send_messages_to_user(
+    await send_message_to_user(
         app,
         rabbit_message.user_id,
         message=SocketMessageDict(
@@ -133,7 +133,7 @@ async def _log_message_parser(app: web.Application, data: bytes) -> bool:
 
 async def _events_message_parser(app: web.Application, data: bytes) -> bool:
     rabbit_message = EventRabbitMessage.parse_raw(data)
-    await send_messages_to_user(
+    await send_message_to_user(
         app,
         rabbit_message.user_id,
         message=SocketMessageDict(

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
@@ -28,7 +28,7 @@ from ..socketio.messages import (
     SOCKET_IO_NODE_UPDATED_EVENT,
     SOCKET_IO_PROJECT_PROGRESS_EVENT,
     SOCKET_IO_WALLET_OSPARC_CREDITS_UPDATED_EVENT,
-    send_messages_to_group,
+    send_message_to_standard_group,
     send_messages_to_user,
 )
 from ..wallets import api as wallets_api
@@ -97,36 +97,35 @@ async def _progress_message_parser(app: web.Application, data: bytes) -> bool:
     rabbit_message: ProgressRabbitMessageNode | ProgressRabbitMessageProject = (
         parse_raw_as(ProgressRabbitMessageNode | ProgressRabbitMessageProject, data)
     )
-    socket_message: SocketMessageDict | None = None
+    message: SocketMessageDict | None = None
     if isinstance(rabbit_message, ProgressRabbitMessageProject):
-        socket_message = _convert_to_project_progress_event(rabbit_message)
+        message = _convert_to_project_progress_event(rabbit_message)
+
     elif rabbit_message.progress_type is ProgressType.COMPUTATION_RUNNING:
-        socket_message = await _convert_to_node_update_event(app, rabbit_message)
+        message = await _convert_to_node_update_event(app, rabbit_message)
+
     else:
-        socket_message = _convert_to_node_progress_event(rabbit_message)
-    if socket_message:
+        message = _convert_to_node_progress_event(rabbit_message)
+
+    if message:
         await send_messages_to_user(
             app,
             rabbit_message.user_id,
-            [socket_message],
+            message=message,
             has_direct_connection_to_client=True,
         )
-
     return True
 
 
 async def _log_message_parser(app: web.Application, data: bytes) -> bool:
     rabbit_message = LoggerRabbitMessage.parse_raw(data)
-    socket_messages: list[SocketMessageDict] = [
-        {
-            "event_type": SOCKET_IO_LOG_EVENT,
-            "data": rabbit_message.dict(exclude={"user_id", "channel_name"}),
-        }
-    ]
     await send_messages_to_user(
         app,
         rabbit_message.user_id,
-        socket_messages,
+        message=SocketMessageDict(
+            event_type=SOCKET_IO_LOG_EVENT,
+            data=rabbit_message.dict(exclude={"user_id", "channel_name"}),
+        ),
         has_direct_connection_to_client=True,
     )
     return True
@@ -134,20 +133,16 @@ async def _log_message_parser(app: web.Application, data: bytes) -> bool:
 
 async def _events_message_parser(app: web.Application, data: bytes) -> bool:
     rabbit_message = EventRabbitMessage.parse_raw(data)
-
-    socket_messages: list[SocketMessageDict] = [
-        {
-            "event_type": SOCKET_IO_EVENT,
-            "data": {
-                "action": rabbit_message.action,
-                "node_id": f"{rabbit_message.node_id}",
-            },
-        }
-    ]
     await send_messages_to_user(
         app,
         rabbit_message.user_id,
-        socket_messages,
+        message=SocketMessageDict(
+            event_type=SOCKET_IO_EVENT,
+            data={
+                "action": rabbit_message.action,
+                "node_id": f"{rabbit_message.node_id}",
+            },
+        ),
         has_direct_connection_to_client=True,
     )
     return True
@@ -155,16 +150,6 @@ async def _events_message_parser(app: web.Application, data: bytes) -> bool:
 
 async def _osparc_credits_message_parser(app: web.Application, data: bytes) -> bool:
     rabbit_message = parse_raw_as(WalletCreditsMessage, data)
-    socket_messages: list[SocketMessageDict] = [
-        {
-            "event_type": SOCKET_IO_WALLET_OSPARC_CREDITS_UPDATED_EVENT,
-            "data": {
-                "wallet_id": rabbit_message.wallet_id,
-                "osparc_credits": rabbit_message.credits,
-                "created_at": rabbit_message.created_at,
-            },
-        }
-    ]
     wallet_groups = await wallets_api.list_wallet_groups_with_read_access_by_wallet(
         app, wallet_id=rabbit_message.wallet_id
     )
@@ -172,7 +157,18 @@ async def _osparc_credits_message_parser(app: web.Application, data: bytes) -> b
         item.gid for item in wallet_groups
     )
     for room in rooms_to_notify:
-        await send_messages_to_group(app, room, socket_messages)
+        await send_message_to_standard_group(
+            app,
+            room,
+            message=SocketMessageDict(
+                event_type=SOCKET_IO_WALLET_OSPARC_CREDITS_UPDATED_EVENT,
+                data={
+                    "wallet_id": rabbit_message.wallet_id,
+                    "osparc_credits": rabbit_message.credits,
+                    "created_at": rabbit_message.created_at,
+                },
+            ),
+        )
     return True
 
 

--- a/services/web/server/src/simcore_service_webserver/payments/_socketio.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_socketio.py
@@ -29,7 +29,7 @@ async def notify_payment_completed(
             event_type=SOCKET_IO_PAYMENT_COMPLETED_EVENT,
             data=jsonable_encoder(payment, by_alias=True),
         ),
-        has_direct_connection_to_client=True,
+        ignore_queue=True,
     )
 
 
@@ -46,5 +46,5 @@ async def notify_payment_method_acked(
             event_type=SOCKET_IO_PAYMENT_METHOD_ACKED_EVENT,
             data=jsonable_encoder(payment_method_transaction, by_alias=True),
         ),
-        has_direct_connection_to_client=True,
+        ignore_queue=True,
     )

--- a/services/web/server/src/simcore_service_webserver/payments/_socketio.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_socketio.py
@@ -28,7 +28,9 @@ async def notify_payment_completed(
             "data": jsonable_encoder(payment, by_alias=True),
         }
     ]
-    await send_messages_to_user(app, user_id, messages)
+    await send_messages_to_user(
+        app, user_id, messages, has_direct_connection_to_client=True
+    )
 
 
 async def notify_payment_method_acked(
@@ -43,4 +45,6 @@ async def notify_payment_method_acked(
             "data": jsonable_encoder(payment_method_transaction, by_alias=True),
         }
     ]
-    await send_messages_to_user(app, user_id, messages)
+    await send_messages_to_user(
+        app, user_id, messages, has_direct_connection_to_client=True
+    )

--- a/services/web/server/src/simcore_service_webserver/payments/_socketio.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_socketio.py
@@ -11,7 +11,7 @@ from models_library.socketio import SocketMessageDict
 from models_library.users import UserID
 from models_library.utils.fastapi_encoders import jsonable_encoder
 
-from ..socketio.messages import send_messages_to_user
+from ..socketio.messages import send_message_to_user
 
 
 async def notify_payment_completed(
@@ -22,7 +22,7 @@ async def notify_payment_completed(
 ):
     assert payment.completed_at is not None  # nosec
 
-    await send_messages_to_user(
+    await send_message_to_user(
         app,
         user_id,
         message=SocketMessageDict(
@@ -39,7 +39,7 @@ async def notify_payment_method_acked(
     user_id: UserID,
     payment_method_transaction: PaymentMethodTransaction,
 ):
-    await send_messages_to_user(
+    await send_message_to_user(
         app,
         user_id,
         message=SocketMessageDict(

--- a/services/web/server/src/simcore_service_webserver/payments/_socketio.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_socketio.py
@@ -22,14 +22,14 @@ async def notify_payment_completed(
 ):
     assert payment.completed_at is not None  # nosec
 
-    messages: list[SocketMessageDict] = [
-        {
-            "event_type": SOCKET_IO_PAYMENT_COMPLETED_EVENT,
-            "data": jsonable_encoder(payment, by_alias=True),
-        }
-    ]
     await send_messages_to_user(
-        app, user_id, messages, has_direct_connection_to_client=True
+        app,
+        user_id,
+        message=SocketMessageDict(
+            event_type=SOCKET_IO_PAYMENT_COMPLETED_EVENT,
+            data=jsonable_encoder(payment, by_alias=True),
+        ),
+        has_direct_connection_to_client=True,
     )
 
 
@@ -39,12 +39,12 @@ async def notify_payment_method_acked(
     user_id: UserID,
     payment_method_transaction: PaymentMethodTransaction,
 ):
-    messages: list[SocketMessageDict] = [
-        {
-            "event_type": SOCKET_IO_PAYMENT_METHOD_ACKED_EVENT,
-            "data": jsonable_encoder(payment_method_transaction, by_alias=True),
-        }
-    ]
     await send_messages_to_user(
-        app, user_id, messages, has_direct_connection_to_client=True
+        app,
+        user_id,
+        message=SocketMessageDict(
+            event_type=SOCKET_IO_PAYMENT_METHOD_ACKED_EVENT,
+            data=jsonable_encoder(payment_method_transaction, by_alias=True),
+        ),
+        has_direct_connection_to_client=True,
     )

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -1441,7 +1441,7 @@ async def remove_project_dynamic_services(
 async def notify_project_state_update(
     app: web.Application,
     project: ProjectDict,
-    notify_only_user: int | None = None,
+    notify_only_user: UserID | None = None,
 ) -> None:
     if await is_project_hidden(app, ProjectID(project["uuid"])):
         return
@@ -1456,7 +1456,7 @@ async def notify_project_state_update(
     if notify_only_user:
         await send_message_to_user(
             app,
-            user_id=parse_obj_as(UserID, notify_only_user),
+            user_id=notify_only_user,
             message=message,
             has_direct_connection_to_client=True,
         )

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -1458,7 +1458,7 @@ async def notify_project_state_update(
             app,
             user_id=notify_only_user,
             message=message,
-            has_direct_connection_to_client=True,
+            ignore_queue=True,
         )
     else:
         rooms_to_notify: Generator[GroupID, None, None] = (

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -1457,7 +1457,10 @@ async def notify_project_state_update(
 
     if notify_only_user:
         await send_messages_to_user(
-            app, user_id=f"{notify_only_user}", messages=messages
+            app,
+            user_id=f"{notify_only_user}",
+            messages=messages,
+            has_direct_connection_to_client=True,
         )
     else:
         rooms_to_notify: Generator[GroupID, None, None] = (

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -97,7 +97,7 @@ from ..socketio.messages import (
     SOCKET_IO_NODE_UPDATED_EVENT,
     SOCKET_IO_PROJECT_UPDATED_EVENT,
     send_message_to_standard_group,
-    send_messages_to_user,
+    send_message_to_user,
 )
 from ..storage import api as storage_api
 from ..users.api import FullNameDict, get_user_fullname, get_user_role
@@ -1454,7 +1454,7 @@ async def notify_project_state_update(
     )
 
     if notify_only_user:
-        await send_messages_to_user(
+        await send_message_to_user(
             app,
             user_id=parse_obj_as(UserID, notify_only_user),
             message=message,

--- a/services/web/server/src/simcore_service_webserver/socketio/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/_handlers.py
@@ -22,7 +22,7 @@ from ..login.decorators import login_required
 from ..products.api import Product, get_current_product
 from ..resource_manager.user_sessions import managed_resource
 from ._utils import EnvironDict, SocketID, get_socket_server, register_socketio_handler
-from .messages import SOCKET_IO_HEARTBEAT_EVENT, send_messages_to_user
+from .messages import SOCKET_IO_HEARTBEAT_EVENT, send_message_to_user
 
 _logger = logging.getLogger(__name__)
 
@@ -138,7 +138,7 @@ async def connect(
             product_name,
         )
 
-        await send_messages_to_user(
+        await send_message_to_user(
             app,
             user_id,
             message=SocketMessageDict(

--- a/services/web/server/src/simcore_service_webserver/socketio/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/_handlers.py
@@ -145,9 +145,7 @@ async def connect(
             }
         ]
         await send_messages_to_user(
-            app,
-            user_id,
-            heart_beat_messages,
+            app, user_id, heart_beat_messages, has_direct_connection_to_client=True
         )
 
     except web.HTTPUnauthorized as exc:

--- a/services/web/server/src/simcore_service_webserver/socketio/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/_handlers.py
@@ -138,14 +138,14 @@ async def connect(
             product_name,
         )
 
-        heart_beat_messages: list[SocketMessageDict] = [
-            {
-                "event_type": SOCKET_IO_HEARTBEAT_EVENT,
-                "data": {"interval": _EMIT_INTERVAL_S},
-            }
-        ]
         await send_messages_to_user(
-            app, user_id, heart_beat_messages, has_direct_connection_to_client=True
+            app,
+            user_id,
+            message=SocketMessageDict(
+                event_type=SOCKET_IO_HEARTBEAT_EVENT,
+                data={"interval": _EMIT_INTERVAL_S},
+            ),
+            has_direct_connection_to_client=True,
         )
 
     except web.HTTPUnauthorized as exc:

--- a/services/web/server/src/simcore_service_webserver/socketio/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/_handlers.py
@@ -145,7 +145,7 @@ async def connect(
                 event_type=SOCKET_IO_HEARTBEAT_EVENT,
                 data={"interval": _EMIT_INTERVAL_S},
             ),
-            has_direct_connection_to_client=True,
+            ignore_queue=True,
         )
 
     except web.HTTPUnauthorized as exc:

--- a/services/web/server/src/simcore_service_webserver/socketio/messages.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/messages.py
@@ -72,9 +72,6 @@ async def send_message_to_user(
     Keyword Arguments:
         has_direct_connection_to_client -- set to False when this message is delivered from a server that has no direct connection to the client (default: {True})
         An example where this is value is False, is sending messages to a user in the GC
-
-    QUESTION: a user might have different tabs opened or connect with a different browser/computer. Does stickiness
-    make all these connection associated to the same server?
     """
     sio: AsyncServer = get_socket_server(app)
 

--- a/services/web/server/src/simcore_service_webserver/socketio/messages.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/messages.py
@@ -61,7 +61,7 @@ async def _safe_emit(
         )
 
 
-async def send_messages_to_user(
+async def send_message_to_user(
     app: Application,
     user_id: UserID,
     message: SocketMessageDict,
@@ -93,7 +93,7 @@ async def send_message_to_standard_group(
 ) -> None:
     """
     WARNING: please do not use primary groups here. To transmit to the
-    user use instead send_messages_to_user
+    user use instead send_message_to_user
 
     NOTE: despite the name, it can also be used for EVERYONE
     """

--- a/services/web/server/src/simcore_service_webserver/socketio/messages.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/messages.py
@@ -70,6 +70,10 @@ async def send_messages_to_user(
     """
     Keyword Arguments:
         has_direct_connection_to_client -- set to False when this message is delivered from a server that has no direct connection to the client (default: {True})
+        An example where this is value is False, is sending messages to a user in the GC
+
+    QUESTION: a user might have different tabs opened or connect with a different browser/computer. Does stickiness
+    make all these connection associated to the same server?
     """
     sio: AsyncServer = get_socket_server(app)
 
@@ -86,13 +90,7 @@ async def send_messages_to_group(
     app: Application,
     group_id: GroupID,
     messages: Sequence[SocketMessageDict],
-    *,
-    has_direct_connection_to_client: bool = True,
 ) -> None:
-    """
-    Keyword Arguments:
-        has_direct_connection_to_client -- set to False when this message is delivered from a server that has no direct connection to the client (default: {True})
-    """
     sio: AsyncServer = get_socket_server(app)
 
     await _logged_gather_emit(
@@ -100,5 +98,6 @@ async def send_messages_to_group(
         room=SocketIORoomStr.from_group_id(group_id),
         messages=messages,
         max_concurrency=10,
-        ignore_queue=has_direct_connection_to_client,
+        ignore_queue=False,  # NOTE: Except for the primary group, a group refers to different users that might be
+        # connected to different replicas
     )

--- a/services/web/server/src/simcore_service_webserver/socketio/messages.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/messages.py
@@ -32,22 +32,37 @@ SOCKET_IO_PROJECT_UPDATED_EVENT: Final[str] = "projectStateUpdated"
 SOCKET_IO_WALLET_OSPARC_CREDITS_UPDATED_EVENT: Final[str] = "walletOsparcCreditsUpdated"
 
 
-async def send_messages_to_user(
-    app: Application, user_id: UserID, messages: Sequence[SocketMessageDict]
-) -> None:
-    sio: AsyncServer = get_socket_server(app)
-
+async def _logged_gather_emit(
+    sio: AsyncServer,
+    *,
+    room: SocketIORoomStr,
+    messages: Sequence[SocketMessageDict],
+    max_concurrency: int = 100,
+):
     await logged_gather(
         *(
             sio.emit(
-                message["event_type"],
-                json_dumps(message["data"]),
-                room=SocketIORoomStr.from_user_id(user_id=user_id),
+                event=message["event_type"],
+                data=json_dumps(message["data"]),
+                room=room,
             )
             for message in messages
         ),
         reraise=False,
         log=_logger,
+        max_concurrency=max_concurrency,
+    )
+
+
+async def send_messages_to_user(
+    app: Application, user_id: UserID, messages: Sequence[SocketMessageDict]
+) -> None:
+    sio: AsyncServer = get_socket_server(app)
+
+    await _logged_gather_emit(
+        sio,
+        room=SocketIORoomStr.from_user_id(user_id),
+        messages=messages,
         max_concurrency=100,
     )
 
@@ -56,13 +71,10 @@ async def send_messages_to_group(
     app: Application, group_id: GroupID, messages: Sequence[SocketMessageDict]
 ) -> None:
     sio: AsyncServer = get_socket_server(app)
-    send_tasks = [
-        sio.emit(
-            message["event_type"],
-            json_dumps(message["data"]),
-            room=SocketIORoomStr.from_group_id(group_id),
-        )
-        for message in messages
-    ]
 
-    await logged_gather(*send_tasks, reraise=False, log=_logger, max_concurrency=10)
+    await _logged_gather_emit(
+        sio,
+        room=SocketIORoomStr.from_group_id(group_id),
+        messages=messages,
+        max_concurrency=10,
+    )

--- a/services/web/server/src/simcore_service_webserver/socketio/messages.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/messages.py
@@ -66,11 +66,11 @@ async def send_message_to_user(
     user_id: UserID,
     message: SocketMessageDict,
     *,
-    has_direct_connection_to_client: bool = True,
+    ignore_queue: bool,
 ) -> None:
     """
     Keyword Arguments:
-        has_direct_connection_to_client -- set to False when this message is delivered from a server that has no direct connection to the client (default: {True})
+        ignore_queue -- set to False when this message is delivered from a server that has no direct connection to the client (default: {True})
         An example where this is value is False, is sending messages to a user in the GC
     """
     sio: AsyncServer = get_socket_server(app)
@@ -79,7 +79,7 @@ async def send_message_to_user(
         sio,
         room=SocketIORoomStr.from_user_id(user_id),
         message=message,
-        ignore_queue=has_direct_connection_to_client,
+        ignore_queue=ignore_queue,
     )
 
 
@@ -100,7 +100,7 @@ async def send_message_to_standard_group(
         sio,
         room=SocketIORoomStr.from_group_id(group_id),
         message=message,
-        ignore_queue=False,
         # NOTE: A standard group refers to different users
         # that might be connected to different replicas
+        ignore_queue=False,
     )

--- a/services/web/server/src/simcore_service_webserver/socketio/server.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/server.py
@@ -23,7 +23,8 @@ async def _socketio_server_cleanup_ctx(app: web.Application) -> AsyncIterator[No
     )
     sio_server = AsyncServer(
         async_mode="aiohttp",
-        logger=_logger,
+        # NOTE: logger: bool|Logger
+        logger=_logger,  # type: ignore
         engineio_logger=False,
         client_manager=server_manager,
     )

--- a/services/web/server/src/simcore_service_webserver/socketio/server.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/server.py
@@ -26,7 +26,7 @@ async def _socketio_server_cleanup_ctx(app: web.Application) -> AsyncIterator[No
     )
     sio_server = AsyncServer(
         async_mode="aiohttp",
-        logger=use_logger,  # type: ignore
+        logger=use_logger,
         engineio_logger=False,
         client_manager=server_manager,
     )

--- a/services/web/server/src/simcore_service_webserver/socketio/server.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/server.py
@@ -17,14 +17,16 @@ _logger = logging.getLogger(__name__)
 
 
 async def _socketio_server_cleanup_ctx(app: web.Application) -> AsyncIterator[None]:
+    use_logger: bool | logging.Logger = _logger
+
     # SEE https://github.com/miguelgrinberg/python-socketio/blob/v4.6.1/docs/server.rst#aiohttp
     server_manager = AsyncAioPikaManager(
-        url=get_rabbitmq_settings(app).dsn, logger=_logger
+        url=get_rabbitmq_settings(app).dsn,
+        logger=use_logger,
     )
     sio_server = AsyncServer(
         async_mode="aiohttp",
-        # NOTE: logger: bool|Logger
-        logger=_logger,  # type: ignore
+        logger=use_logger,  # type: ignore
         engineio_logger=False,
         client_manager=server_manager,
     )

--- a/services/web/server/tests/integration/02/conftest.py
+++ b/services/web/server/tests/integration/02/conftest.py
@@ -3,8 +3,8 @@
 # pylint:disable=redefined-outer-name
 
 import json
+from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import AsyncIterator
 from uuid import uuid4
 
 import pytest

--- a/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
+++ b/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
@@ -246,7 +246,7 @@ async def test_log_workflow_only_receives_messages_if_subscribed(
 
     """
     mocked_send_messages = mocker.patch(
-        "simcore_service_webserver.notifications._rabbitmq_exclusive_queue_consumers.send_messages_to_user",
+        "simcore_service_webserver.notifications._rabbitmq_exclusive_queue_consumers.send_message_to_user",
         autospec=True,
     )
 

--- a/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
+++ b/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
@@ -5,8 +5,9 @@
 
 import asyncio
 import json
+from collections.abc import Awaitable, Callable
 from random import choice
-from typing import Any, Awaitable, Callable
+from typing import Any
 from unittest import mock
 
 import aiopg
@@ -79,7 +80,7 @@ _STABLE_DELAY_S = 2
 
 
 async def _assert_handler_not_called(handler: mock.Mock) -> None:
-    with pytest.raises(RetryError):
+    with pytest.raises(RetryError):  # noqa: PT012
         async for attempt in AsyncRetrying(
             retry=retry_always,
             stop=stop_after_delay(_STABLE_DELAY_S),
@@ -175,25 +176,52 @@ async def rabbitmq_publisher(
     return create_rabbitmq_client("pytest_publisher")
 
 
+@pytest.fixture
+def random_node_id_in_user_project(user_project: ProjectDict) -> NodeID:
+    workbench = list(user_project["workbench"])
+    return NodeID(choice(workbench))  # noqa: S311
+
+
+@pytest.fixture
+def user_project_id(user_project: ProjectDict) -> ProjectID:
+    return ProjectID(user_project["uuid"])
+
+
+@pytest.fixture
+def user_id(logged_user: UserInfoDict) -> UserID:
+    return UserID(logged_user["id"])
+
+
+@pytest.fixture
+def sender_user_id(user_id: UserID, sender_same_user_id: bool, faker: Faker) -> UserID:
+    if sender_same_user_id is False:
+        return UserID(faker.pyint(min_value=user_id + 1))
+    return user_id
+
+
 @pytest.mark.parametrize("user_role", [UserRole.GUEST], ids=str)
 @pytest.mark.parametrize(
-    "sender_same_user_id", [True, False], ids=lambda id: f"same_sender_id={id}"
+    "sender_same_user_id", [True, False], ids=lambda id_: f"same_sender_id={id_}"
 )
 @pytest.mark.parametrize(
-    "subscribe_to_logs", [True, False], ids=lambda id: f"subscribed={id}"
+    "subscribe_to_logs", [True, False], ids=lambda id_: f"subscribed={id_}"
 )
 async def test_log_workflow(
     client: TestClient,
     rabbitmq_publisher: RabbitMQClient,
-    logged_user: UserInfoDict,
-    user_project: ProjectDict,
-    faker: Faker,
+    subscribe_to_logs: bool,
     socketio_client_factory: Callable[
         [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
     ],
-    mocker: MockerFixture,
+    # user
     sender_same_user_id: bool,
-    subscribe_to_logs: bool,
+    sender_user_id: UserID,
+    # project
+    random_node_id_in_user_project: NodeID,
+    user_project_id: ProjectID,
+    #
+    faker: Faker,
+    mocker: MockerFixture,
 ):
     """
     RabbitMQ (TOPIC) --> Webserver --> Redis --> webclient (socketio)
@@ -204,20 +232,14 @@ async def test_log_workflow(
     mock_log_handler = mocker.MagicMock()
     socket_io_conn.on(SOCKET_IO_LOG_EVENT, handler=mock_log_handler)
 
-    project_id = ProjectID(user_project["uuid"])
-    random_node_id_in_project = NodeID(choice(list(user_project["workbench"])))
-    sender_user_id = UserID(logged_user["id"])
-    if sender_same_user_id is False:
-        sender_user_id = UserID(faker.pyint(min_value=logged_user["id"] + 1))
-
     if subscribe_to_logs:
         assert client.app
-        await project_logs.subscribe(client.app, project_id)
+        await project_logs.subscribe(client.app, user_project_id)
 
     log_message = LoggerRabbitMessage(
         user_id=sender_user_id,
-        project_id=project_id,
-        node_id=random_node_id_in_project,
+        project_id=user_project_id,
+        node_id=random_node_id_in_user_project,
         messages=[faker.text() for _ in range(10)],
     )
     await rabbitmq_publisher.publish(log_message.channel_name, log_message)
@@ -236,8 +258,12 @@ async def test_log_workflow(
 async def test_log_workflow_only_receives_messages_if_subscribed(
     client: TestClient,
     rabbitmq_publisher: RabbitMQClient,
-    logged_user: UserInfoDict,
-    user_project: ProjectDict,
+    # user
+    user_id: UserID,
+    # project
+    random_node_id_in_user_project: NodeID,
+    user_project_id: ProjectID,
+    #
     faker: Faker,
     mocker: MockerFixture,
 ):
@@ -250,17 +276,13 @@ async def test_log_workflow_only_receives_messages_if_subscribed(
         autospec=True,
     )
 
-    project_id = ProjectID(user_project["uuid"])
-    random_node_id_in_project = NodeID(choice(list(user_project["workbench"])))
-    sender_user_id = UserID(logged_user["id"])
-
     assert client.app
-    await project_logs.subscribe(client.app, project_id)
+    await project_logs.subscribe(client.app, user_project_id)
 
     log_message = LoggerRabbitMessage(
-        user_id=sender_user_id,
-        project_id=project_id,
-        node_id=random_node_id_in_project,
+        user_id=user_id,
+        project_id=user_project_id,
+        node_id=random_node_id_in_user_project,
         messages=[faker.text() for _ in range(10)],
     )
     await rabbitmq_publisher.publish(log_message.channel_name, log_message)
@@ -269,18 +291,17 @@ async def test_log_workflow_only_receives_messages_if_subscribed(
         mock.call(
             client.app,
             log_message.user_id,
-            [
-                {
-                    "event_type": SOCKET_IO_LOG_EVENT,
-                    "data": log_message.dict(exclude={"user_id", "channel_name"}),
-                }
-            ],
+            message={
+                "event_type": SOCKET_IO_LOG_EVENT,
+                "data": log_message.dict(exclude={"user_id", "channel_name"}),
+            },
+            ignore_queue=True,
         ),
     )
     mocked_send_messages.reset_mock()
 
     # when unsubscribed, we do not receive the messages anymore
-    await project_logs.unsubscribe(client.app, project_id)
+    await project_logs.unsubscribe(client.app, user_project_id)
     await rabbitmq_publisher.publish(log_message.channel_name, log_message)
     await _assert_handler_not_called(mocked_send_messages)
 
@@ -292,24 +313,27 @@ async def test_log_workflow_only_receives_messages_if_subscribed(
     ids=str,
 )
 @pytest.mark.parametrize(
-    "sender_same_user_id", [True, False], ids=lambda id: f"same_sender_id={id}"
+    "sender_same_user_id", [True, False], ids=lambda id_: f"same_sender_id={id_}"
 )
 @pytest.mark.parametrize(
-    "subscribe_to_logs", [True, False], ids=lambda id: f"subscribed={id}"
+    "subscribe_to_logs", [True, False], ids=lambda id_: f"subscribed={id_}"
 )
 async def test_progress_non_computational_workflow(
     client: TestClient,
     rabbitmq_publisher: RabbitMQClient,
-    logged_user: UserInfoDict,
-    user_project: ProjectDict,
-    faker: Faker,
     socketio_client_factory: Callable[
         [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
     ],
-    mocker: MockerFixture,
-    progress_type: ProgressType,
-    sender_same_user_id: bool,
     subscribe_to_logs: bool,
+    progress_type: ProgressType,
+    # user
+    sender_same_user_id: bool,
+    sender_user_id: UserID,
+    # project
+    random_node_id_in_user_project: NodeID,
+    user_project_id: ProjectID,
+    #
+    mocker: MockerFixture,
 ):
     """
     RabbitMQ (TOPIC) --> Webserver -->  Redis --> webclient (socketio)
@@ -320,18 +344,14 @@ async def test_progress_non_computational_workflow(
     mock_progress_handler = mocker.MagicMock()
     socket_io_conn.on(SOCKET_IO_NODE_PROGRESS_EVENT, handler=mock_progress_handler)
 
-    random_node_id_in_project = NodeID(choice(list(user_project["workbench"])))
-    sender_user_id = UserID(logged_user["id"])
-    project_id = ProjectID(user_project["uuid"])
-    if sender_same_user_id is False:
-        sender_user_id = UserID(faker.pyint(min_value=logged_user["id"] + 1))
     if subscribe_to_logs:
         assert client.app
-        await project_logs.subscribe(client.app, project_id)
+        await project_logs.subscribe(client.app, user_project_id)
+
     progress_message = ProgressRabbitMessageNode(
         user_id=sender_user_id,
-        project_id=ProjectID(user_project["uuid"]),
-        node_id=random_node_id_in_project,
+        project_id=user_project_id,
+        node_id=random_node_id_in_user_project,
         progress=0.3,
         progress_type=progress_type,
     )
@@ -347,24 +367,27 @@ async def test_progress_non_computational_workflow(
 
 @pytest.mark.parametrize("user_role", [UserRole.GUEST], ids=str)
 @pytest.mark.parametrize(
-    "sender_same_user_id", [True, False], ids=lambda id: f"same_sender_id={id}"
+    "sender_same_user_id", [True, False], ids=lambda id_: f"same_sender_id={id_}"
 )
 @pytest.mark.parametrize(
-    "subscribe_to_logs", [True, False], ids=lambda id: f"subscribed={id}"
+    "subscribe_to_logs", [True, False], ids=lambda id_: f"subscribed={id_}"
 )
 async def test_progress_computational_workflow(
     client: TestClient,
     rabbitmq_publisher: RabbitMQClient,
-    logged_user: UserInfoDict,
     user_project: ProjectDict,
     socketio_client_factory: Callable[
         [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
     ],
     mocker: MockerFixture,
     aiopg_engine: aiopg.sa.Engine,
-    sender_same_user_id: bool,
-    faker: Faker,
     subscribe_to_logs: bool,
+    # user
+    sender_same_user_id: bool,
+    sender_user_id: UserID,
+    # project
+    random_node_id_in_user_project: NodeID,
+    user_project_id: ProjectID,
 ):
     """
     RabbitMQ (TOPIC) --> Webserver -->  DB (get project)
@@ -375,18 +398,14 @@ async def test_progress_computational_workflow(
 
     mock_progress_handler = mocker.MagicMock()
     socket_io_conn.on(SOCKET_IO_NODE_UPDATED_EVENT, handler=mock_progress_handler)
-    random_node_id_in_project = NodeID(choice(list(user_project["workbench"])))
-    sender_user_id = UserID(logged_user["id"])
-    project_id = ProjectID(user_project["uuid"])
-    if sender_same_user_id is False:
-        sender_user_id = UserID(faker.pyint(min_value=logged_user["id"] + 1))
+
     if subscribe_to_logs:
         assert client.app
-        await project_logs.subscribe(client.app, project_id)
+        await project_logs.subscribe(client.app, user_project_id)
     progress_message = ProgressRabbitMessageNode(
         user_id=sender_user_id,
-        project_id=ProjectID(user_project["uuid"]),
-        node_id=random_node_id_in_project,
+        project_id=user_project_id,
+        node_id=random_node_id_in_user_project,
         progress=0.3,
         progress_type=ProgressType.COMPUTATION_RUNNING,
     )
@@ -398,7 +417,7 @@ async def test_progress_computational_workflow(
             progress_message, include={"node_id", "project_id"}
         )
         expected_call |= {
-            "data": user_project["workbench"][f"{random_node_id_in_project}"]
+            "data": user_project["workbench"][f"{random_node_id_in_user_project}"]
         }
         expected_call["data"]["progress"] = int(progress_message.progress * 100)
         await _assert_handler_called_with_json(mock_progress_handler, expected_call)
@@ -409,14 +428,17 @@ async def test_progress_computational_workflow(
     async with aiopg_engine.acquire() as conn:
         result = await conn.execute(
             sa.select(projects.c.workbench).where(
-                projects.c.uuid == user_project["uuid"]
+                projects.c.uuid == str(user_project_id)
             )
         )
         row = await result.fetchone()
         assert row
         project_workbench = dict(row[projects.c.workbench])
         # NOTE: the progress might still be present but is not used anymore
-        assert project_workbench[f"{random_node_id_in_project}"].get("progress", 0) == 0
+        assert (
+            project_workbench[f"{random_node_id_in_user_project}"].get("progress", 0)
+            == 0
+        )
 
 
 @pytest.mark.parametrize("user_role", [UserRole.GUEST], ids=str)
@@ -424,11 +446,14 @@ async def test_progress_computational_workflow(
 async def test_instrumentation_workflow(
     client: TestClient,
     rabbitmq_publisher: RabbitMQClient,
-    logged_user: UserInfoDict,
-    user_project: ProjectDict,
     mocker: MockerFixture,
     faker: Faker,
     metrics_name: str,
+    # user
+    user_id: UserID,
+    # project
+    random_node_id_in_user_project: NodeID,
+    user_project_id: ProjectID,
 ):
     """
     RabbitMQ --> Webserver -->  Prometheus metrics
@@ -439,11 +464,10 @@ async def test_instrumentation_workflow(
         f"simcore_service_webserver.notifications._rabbitmq_nonexclusive_queue_consumers.{metrics_name}"
     )
 
-    random_node_id_in_project = NodeID(choice(list(user_project["workbench"])))
     rabbit_message = InstrumentationRabbitMessage(
-        user_id=UserID(logged_user["id"]),
-        project_id=ProjectID(user_project["uuid"]),
-        node_id=random_node_id_in_project,
+        user_id=user_id,
+        project_id=user_project_id,
+        node_id=random_node_id_in_user_project,
         metrics=metrics_name,
         service_uuid=faker.uuid4(),
         service_key=faker.pystr(),
@@ -468,19 +492,21 @@ async def test_instrumentation_workflow(
 
 @pytest.mark.parametrize("user_role", [UserRole.GUEST], ids=str)
 @pytest.mark.parametrize(
-    "sender_same_user_id", [True, False], ids=lambda id: f"same_sender_id={id}"
+    "sender_same_user_id", [True, False], ids=lambda id_: f"same_sender_id={id_}"
 )
 async def test_event_workflow(
+    mocker: MockerFixture,
     client: TestClient,
     rabbitmq_publisher: RabbitMQClient,
-    logged_user: UserInfoDict,
-    user_project: ProjectDict,
     socketio_client_factory: Callable[
         [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
     ],
-    mocker: MockerFixture,
+    # user
     sender_same_user_id: bool,
-    faker: Faker,
+    sender_user_id: UserID,
+    # project
+    random_node_id_in_user_project: NodeID,
+    user_project_id: ProjectID,
 ):
     """
     RabbitMQ --> Webserver --> Redis --> webclient (socketio)
@@ -490,14 +516,10 @@ async def test_event_workflow(
     mock_event_handler = mocker.MagicMock()
     socket_io_conn.on(SOCKET_IO_EVENT, handler=mock_event_handler)
 
-    sender_user_id = UserID(logged_user["id"])
-    if sender_same_user_id is False:
-        sender_user_id = UserID(faker.pyint(min_value=logged_user["id"] + 1))
-    random_node_id_in_project = NodeID(choice(list(user_project["workbench"])))
     rabbit_message = EventRabbitMessage(
         user_id=sender_user_id,
-        project_id=ProjectID(user_project["uuid"]),
-        node_id=random_node_id_in_project,
+        project_id=user_project_id,
+        node_id=random_node_id_in_user_project,
         action=RabbitEventMessageType.RELOAD_IFRAME,
     )
 

--- a/services/web/server/tests/unit/isolated/notifications/test_rabbitmq_consumers.py
+++ b/services/web/server/tests/unit/isolated/notifications/test_rabbitmq_consumers.py
@@ -52,14 +52,14 @@ async def test_regression_progress_message_parser(
     mocker: MockerFixture, raw_data: bytes, class_type: type[BaseModel]
 ):
     send_messages_to_user_mock = mocker.patch(
-        "simcore_service_webserver.notifications._rabbitmq_exclusive_queue_consumers.send_messages_to_user",
+        "simcore_service_webserver.notifications._rabbitmq_exclusive_queue_consumers.send_message_to_user",
         autospec=True,
     )
 
     app = AsyncMock()
     assert await _progress_message_parser(app, raw_data)
 
-    # tests how send_messages_to_user is called
+    # tests how send_message_to_user is called
     assert send_messages_to_user_mock.call_count == 1
     message = send_messages_to_user_mock.call_args.kwargs["message"]
 

--- a/services/web/server/tests/unit/isolated/notifications/test_rabbitmq_consumers.py
+++ b/services/web/server/tests/unit/isolated/notifications/test_rabbitmq_consumers.py
@@ -1,5 +1,8 @@
-# pylint: disable=redefined-outer-name
 # pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
 
 from unittest.mock import AsyncMock
 
@@ -12,25 +15,11 @@ from models_library.rabbitmq_messages import (
 )
 from pydantic import BaseModel
 from pytest_mock import MockerFixture
-from simcore_service_webserver.notifications import _rabbitmq_exclusive_queue_consumers
+from simcore_service_webserver.notifications._rabbitmq_exclusive_queue_consumers import (
+    _progress_message_parser,
+)
 
 _faker = Faker()
-
-
-@pytest.fixture
-def mock_send_messages(mocker: MockerFixture) -> dict:
-    reference = {}
-
-    async def mock_send_message(*args) -> None:
-        reference["args"] = args
-
-    mocker.patch.object(
-        _rabbitmq_exclusive_queue_consumers,
-        "send_messages_to_user",
-        side_effect=mock_send_message,
-    )
-
-    return reference
 
 
 @pytest.mark.parametrize(
@@ -38,25 +27,21 @@ def mock_send_messages(mocker: MockerFixture) -> dict:
     [
         pytest.param(
             ProgressRabbitMessageNode(
-                **{
-                    "project_id": _faker.uuid4(cast_to=None),
-                    "user_id": _faker.uuid4(cast_to=None),
-                    "node_id": _faker.uuid4(cast_to=None),
-                    "progress_type": ProgressType.SERVICE_OUTPUTS_PULLING,
-                    "progress": 0.4,
-                }
+                project_id=_faker.uuid4(cast_to=None),
+                user_id=_faker.uuid4(cast_to=None),
+                node_id=_faker.uuid4(cast_to=None),
+                progress_type=ProgressType.SERVICE_OUTPUTS_PULLING,
+                progress=0.4,
             ).json(),
             ProgressRabbitMessageNode,
             id="node_progress",
         ),
         pytest.param(
             ProgressRabbitMessageProject(
-                **{
-                    "project_id": _faker.uuid4(cast_to=None),
-                    "user_id": _faker.uuid4(cast_to=None),
-                    "progress_type": ProgressType.PROJECT_CLOSING,
-                    "progress": 0.4,
-                }
+                project_id=_faker.uuid4(cast_to=None),
+                user_id=_faker.uuid4(cast_to=None),
+                progress_type=ProgressType.PROJECT_CLOSING,
+                progress=0.4,
             ).json(),
             ProgressRabbitMessageProject,
             id="project_progress",
@@ -64,11 +49,19 @@ def mock_send_messages(mocker: MockerFixture) -> dict:
     ],
 )
 async def test_regression_progress_message_parser(
-    mock_send_messages: dict, raw_data: bytes, class_type: type[BaseModel]
+    mocker: MockerFixture, raw_data: bytes, class_type: type[BaseModel]
 ):
-    await _rabbitmq_exclusive_queue_consumers._progress_message_parser(
-        AsyncMock(), raw_data
+    mock = mocker.patch(
+        "simcore_service_webserver.notifications._rabbitmq_exclusive_queue_consumers.send_messages_to_user",
+        autospec=True,
     )
-    serialized_sent_data = mock_send_messages["args"][2][0]["data"]
+
+    app = AsyncMock()
+    assert await _progress_message_parser(app, raw_data)
+
+    # tests how send_messages_to_user is called
+    assert mock.call_count == 1
+    message = mock.call_args.kwargs["message"]
+
     # check that all fields are sent as expected
-    assert class_type.parse_obj(serialized_sent_data)
+    assert class_type.parse_obj(message["data"])

--- a/services/web/server/tests/unit/isolated/notifications/test_rabbitmq_consumers.py
+++ b/services/web/server/tests/unit/isolated/notifications/test_rabbitmq_consumers.py
@@ -51,7 +51,7 @@ _faker = Faker()
 async def test_regression_progress_message_parser(
     mocker: MockerFixture, raw_data: bytes, class_type: type[BaseModel]
 ):
-    mock = mocker.patch(
+    send_messages_to_user_mock = mocker.patch(
         "simcore_service_webserver.notifications._rabbitmq_exclusive_queue_consumers.send_messages_to_user",
         autospec=True,
     )
@@ -60,8 +60,8 @@ async def test_regression_progress_message_parser(
     assert await _progress_message_parser(app, raw_data)
 
     # tests how send_messages_to_user is called
-    assert mock.call_count == 1
-    message = mock.call_args.kwargs["message"]
+    assert send_messages_to_user_mock.call_count == 1
+    message = send_messages_to_user_mock.call_args.kwargs["message"]
 
     # check that all fields are sent as expected
     assert class_type.parse_obj(message["data"])

--- a/services/web/server/tests/unit/with_dbs/03/wallets/payments/test_payments.py
+++ b/services/web/server/tests/unit/with_dbs/03/wallets/payments/test_payments.py
@@ -75,7 +75,7 @@ async def test_one_time_payment_worfklow(
     assert settings.PAYMENTS_FAKE_COMPLETION is False
 
     send_message = mocker.patch(
-        "simcore_service_webserver.payments._socketio.send_messages_to_user",
+        "simcore_service_webserver.payments._socketio.send_message_to_user",
         autospec=True,
     )
     mock_rut_add_credits_to_wallet = mocker.patch(
@@ -152,7 +152,7 @@ async def test_multiple_payments(
     assert settings.PAYMENTS_FAKE_COMPLETION is False
 
     send_message = mocker.patch(
-        "simcore_service_webserver.payments._socketio.send_messages_to_user",
+        "simcore_service_webserver.payments._socketio.send_message_to_user",
         autospec=True,
     )
     mocker.patch(
@@ -249,7 +249,7 @@ async def test_complete_payment_errors(
 ):
     assert client.app
     send_message = mocker.patch(
-        "simcore_service_webserver.payments._socketio.send_messages_to_user",
+        "simcore_service_webserver.payments._socketio.send_message_to_user",
         autospec=True,
     )
 

--- a/services/web/server/tests/unit/with_dbs/03/wallets/payments/test_payments_methods.py
+++ b/services/web/server/tests/unit/with_dbs/03/wallets/payments/test_payments_methods.py
@@ -52,7 +52,7 @@ async def test_payment_method_worfklow(
     assert settings.PAYMENTS_FAKE_COMPLETION is False
 
     send_message = mocker.patch(
-        "simcore_service_webserver.payments._socketio.send_messages_to_user",
+        "simcore_service_webserver.payments._socketio.send_message_to_user",
         autospec=True,
     )
 
@@ -342,7 +342,7 @@ async def test_one_time_payment_with_payment_method(
     assert client.app
 
     send_message = mocker.patch(
-        "simcore_service_webserver.payments._socketio.send_messages_to_user",
+        "simcore_service_webserver.payments._socketio.send_message_to_user",
         autospec=True,
     )
     mock_rut_add_credits_to_wallet = mocker.patch(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

The problem reported in **incident 48** (see related issues) indicate that the `socketio` exchange is overloaded with messages that are not attended. Those seem to be produced by those queued from the web-server's `emit` call. Most of those calls do not actually need to be queued because the client is directly connected to that server!


- 🎨 [Disabled queue](https://github.com/miguelgrinberg/python-socketio/blob/main/src/socketio/async_server.py#L155-L161) when message was directly delivered to the client to avoid filling `socketio` exchange with messages going to and back to the server
- 🎨stopped `gathering` the `emit` coroutines since the latter is not [designed to run concurrently](https://github.com/miguelgrinberg/python-socketio/blob/main/src/socketio/async_server.py#L163-L167). Signature now only excepts one message at a time.
- ♻️ Unified common code under `_safe_emit`
- ♻️ Simplified test mocks

## Related issue/s

- Follows up from https://github.com/ITISFoundation/osparc-simcore/pull/5331


## How to test

- Manual exploratory testing shows no more accumulation in my local deploy

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
