### PR TITLE
🐛 Autoscaling: issues with labelled drained nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ leave: ## Forces to stop all services, networks, etc by the node leaving the swa
 .PHONY: .init-swarm
 .init-swarm:
 	# Ensures swarm is initialized
-	$(if $(SWARM_HOSTS),,docker swarm init --advertise-addr=$(get_my_ip))
+	$(if $(SWARM_HOSTS),,docker swarm init --advertise-addr=$(get_my_ip) --default-addr-pool 192.168.0.1/16)
 
 
 ## DOCKER TAGS  -------------------------------

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -159,6 +159,7 @@ fastapi==0.99.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
+    #   prometheus-fastapi-instrumentator
 frozenlist==1.4.0
     # via
     #   aiohttp
@@ -273,6 +274,12 @@ partd==1.4.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
+prometheus-client==0.20.0
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   prometheus-fastapi-instrumentator
+prometheus-fastapi-instrumentator==6.1.0
+    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 psutil==5.9.5
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
@@ -452,6 +459,8 @@ types-aiobotocore==2.7.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 types-aiobotocore-ec2==2.7.0
     # via types-aiobotocore
+types-aiobotocore-s3==2.7.0
+    # via types-aiobotocore
 types-awscrt==0.19.8
     # via botocore-stubs
 types-python-dateutil==2.8.19.14
@@ -465,6 +474,7 @@ typing-extensions==4.8.0
     #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
+    #   types-aiobotocore-s3
     #   uvicorn
 urllib3==1.26.16
     # via

--- a/services/autoscaling/src/simcore_service_autoscaling/core/application.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/application.py
@@ -25,10 +25,25 @@ from ..modules.redis import setup as setup_redis
 from ..modules.remote_debug import setup_remote_debugging
 from .settings import ApplicationSettings
 
+_LOG_LEVEL_STEP = logging.CRITICAL - logging.ERROR
+_NOISY_LOGGERS = (
+    "aiobotocore",
+    "aio_pika",
+    "aiormq",
+    "botocore",
+)
+
 logger = logging.getLogger(__name__)
 
 
 def create_app(settings: ApplicationSettings) -> FastAPI:
+    # keep mostly quiet noisy loggers
+    quiet_level: int = max(
+        min(logging.root.level + _LOG_LEVEL_STEP, logging.CRITICAL), logging.WARNING
+    )
+    for name in _NOISY_LOGGERS:
+        logging.getLogger(name).setLevel(quiet_level)
+
     logger.info("app settings: %s", settings.json(indent=1))
 
     app = FastAPI(

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Final, cast
 
+import arrow
 import yaml
 from aws_library.ec2.models import EC2InstanceData, Resources
 from models_library.docker import (
@@ -110,7 +111,7 @@ async def remove_nodes(
 def _is_task_waiting_for_resources(task: Task) -> bool:
     # NOTE: https://docs.docker.com/engine/swarm/how-swarm-mode-works/swarm-task-states/
     with log_context(
-        logger, level=logging.DEBUG, msg=f"_is_task_waiting_for_resources: {task}"
+        logger, level=logging.DEBUG, msg=f"_is_task_waiting_for_resources: {task.ID}"
     ):
         if (
             not task.Status
@@ -550,7 +551,10 @@ def is_node_ready_and_available(node: Node, *, availability: Availability) -> bo
 
 
 _OSPARC_SERVICE_READY_LABEL_KEY: Final[DockerLabelKey] = parse_obj_as(
-    DockerLabelKey, "osparc-services-ready"
+    DockerLabelKey, "io.simcore.osparc-services-ready"
+)
+_OSPARC_SERVICES_READY_DATETIME_LABEL_KEY: Final[DockerLabelKey] = parse_obj_as(
+    DockerLabelKey, f"{_OSPARC_SERVICE_READY_LABEL_KEY}-last-changed"
 )
 
 
@@ -575,6 +579,7 @@ async def set_node_osparc_ready(
     assert node.Spec  # nosec
     new_tags = deepcopy(cast(dict[DockerLabelKey, str], node.Spec.Labels))
     new_tags[_OSPARC_SERVICE_READY_LABEL_KEY] = "true" if ready else "false"
+    new_tags[_OSPARC_SERVICES_READY_DATETIME_LABEL_KEY] = arrow.utcnow().isoformat()
     # NOTE: docker drain sometimes impeed on performance when undraining see https://github.com/ITISFoundation/osparc-simcore/issues/5339
     available = app_settings.AUTOSCALING_DRAIN_NODES_WITH_LABELS or ready
     return await tag_node(
@@ -583,6 +588,14 @@ async def set_node_osparc_ready(
         tags=new_tags,
         available=available,
     )
+
+
+def get_node_last_readyness_update(node: Node) -> datetime.datetime:
+    assert node.Spec  # nosec
+    assert node.Spec.Labels  # nosec
+    return arrow.get(
+        node.Spec.Labels[_OSPARC_SERVICES_READY_DATETIME_LABEL_KEY]
+    ).datetime
 
 
 async def attach_node(
@@ -595,6 +608,7 @@ async def attach_node(
     assert node.Spec  # nosec
     current_tags = cast(dict[DockerLabelKey, str], node.Spec.Labels or {})
     new_tags = current_tags | tags | {_OSPARC_SERVICE_READY_LABEL_KEY: "false"}
+    new_tags[_OSPARC_SERVICES_READY_DATETIME_LABEL_KEY] = arrow.utcnow().isoformat()
     return await tag_node(
         docker_client,
         node,

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -593,9 +593,10 @@ async def set_node_osparc_ready(
 def get_node_last_readyness_update(node: Node) -> datetime.datetime:
     assert node.Spec  # nosec
     assert node.Spec.Labels  # nosec
-    return arrow.get(
-        node.Spec.Labels[_OSPARC_SERVICES_READY_DATETIME_LABEL_KEY]
-    ).datetime
+    return cast(
+        datetime.datetime,
+        arrow.get(node.Spec.Labels[_OSPARC_SERVICES_READY_DATETIME_LABEL_KEY]).datetime,
+    )  # mypy
 
 
 async def attach_node(

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
@@ -15,6 +15,7 @@ from typing import Any
 from unittest import mock
 
 import aiodocker
+import arrow
 import pytest
 from aws_library.ec2.models import EC2InstanceData, Resources
 from faker import Faker
@@ -54,6 +55,7 @@ from simcore_service_autoscaling.modules.docker import (
 )
 from simcore_service_autoscaling.utils.utils_docker import (
     _OSPARC_SERVICE_READY_LABEL_KEY,
+    _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY,
 )
 from types_aiobotocore_ec2.client import EC2Client
 from types_aiobotocore_ec2.literals import InstanceTypeType
@@ -521,11 +523,67 @@ async def test_cluster_scaling_up_and_down(  # noqa: PLR0915
         _OSPARC_SERVICE_READY_LABEL_KEY: "false"
     }
 
+    # the node is tagged and made active right away since we still have the pending task
+    mock_find_node_with_name.assert_called_once()
+    mock_find_node_with_name.reset_mock()
+
+    assert mock_docker_tag_node.call_count == 2
+    assert fake_node.Spec
+    assert fake_node.Spec.Labels
+    # check attach call
+    assert mock_docker_tag_node.call_args_list[0] == mock.call(
+        get_docker_client(initialized_app),
+        fake_node,
+        tags=fake_node.Spec.Labels
+        | expected_docker_node_tags
+        | {
+            _OSPARC_SERVICE_READY_LABEL_KEY: "false",
+            _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY: mock.ANY,
+        },
+        available=with_drain_nodes_labelled,
+    )
+    # update our fake node
+    fake_attached_node.Spec.Labels[
+        _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY
+    ] = mock_docker_tag_node.call_args_list[0][1]["tags"][
+        _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY
+    ]
+    # check the activate time is later than attach time
+    assert arrow.get(
+        mock_docker_tag_node.call_args_list[1][1]["tags"][
+            _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY
+        ]
+    ) > arrow.get(
+        mock_docker_tag_node.call_args_list[0][1]["tags"][
+            _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY
+        ]
+    )
     mock_compute_node_used_resources.assert_called_once_with(
         get_docker_client(initialized_app),
         fake_attached_node,
     )
     mock_compute_node_used_resources.reset_mock()
+    # check activate call
+    assert mock_docker_tag_node.call_args_list[1] == mock.call(
+        get_docker_client(initialized_app),
+        fake_attached_node,
+        tags=fake_node.Spec.Labels
+        | expected_docker_node_tags
+        | {
+            _OSPARC_SERVICE_READY_LABEL_KEY: "true",
+            _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY: mock.ANY,
+        },
+        available=True,
+    )
+    # update our fake node
+    fake_attached_node.Spec.Labels[
+        _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY
+    ] = mock_docker_tag_node.call_args_list[1][1]["tags"][
+        _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY
+    ]
+    mock_docker_tag_node.reset_mock()
+    mock_docker_set_node_availability.assert_not_called()
+
     # check the number of instances did not change and is still running
     internal_dns_names = await _assert_ec2_instances(
         ec2_client,
@@ -536,38 +594,6 @@ async def test_cluster_scaling_up_and_down(  # noqa: PLR0915
     )
     assert len(internal_dns_names) == 1
     internal_dns_name = internal_dns_names[0].removesuffix(".ec2.internal")
-
-    # the node is tagged and made active right away since we still have the pending task
-    mock_find_node_with_name.assert_called_once()
-    mock_find_node_with_name.reset_mock()
-
-    assert mock_docker_tag_node.call_count == 2
-    assert fake_node.Spec
-    assert fake_node.Spec.Labels
-
-    mock_docker_tag_node.assert_has_calls(
-        (
-            # attach node call
-            mock.call(
-                get_docker_client(initialized_app),
-                fake_node,
-                tags=fake_node.Spec.Labels
-                | expected_docker_node_tags
-                | {_OSPARC_SERVICE_READY_LABEL_KEY: "false"},
-                available=with_drain_nodes_labelled,
-            ),
-            mock.call(
-                get_docker_client(initialized_app),
-                fake_attached_node,
-                tags=fake_node.Spec.Labels
-                | expected_docker_node_tags
-                | {_OSPARC_SERVICE_READY_LABEL_KEY: "true"},
-                available=True,
-            ),
-        )
-    )
-    mock_docker_tag_node.reset_mock()
-    mock_docker_set_node_availability.assert_not_called()
 
     # check rabbit messages were sent, we do have worker
     assert fake_attached_node.Description
@@ -653,8 +679,19 @@ async def test_cluster_scaling_up_and_down(  # noqa: PLR0915
         get_docker_client(initialized_app),
         fake_attached_node,
         tags=fake_attached_node.Spec.Labels
-        | {_OSPARC_SERVICE_READY_LABEL_KEY: "false"},
+        | {
+            _OSPARC_SERVICE_READY_LABEL_KEY: "false",
+            _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY: mock.ANY,
+        },
         available=with_drain_nodes_labelled,
+    )
+    # check the datetime was updated
+    assert arrow.get(
+        mock_docker_tag_node.call_args_list[0][1]["tags"][
+            _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY
+        ]
+    ) > arrow.get(
+        fake_attached_node.Spec.Labels[_OSPARC_SERVICES_READY_DATETIME_LABEL_KEY]
     )
     mock_docker_tag_node.reset_mock()
 
@@ -665,7 +702,10 @@ async def test_cluster_scaling_up_and_down(  # noqa: PLR0915
         get_docker_client(initialized_app),
         fake_attached_node,
         tags=fake_attached_node.Spec.Labels
-        | {_OSPARC_SERVICE_READY_LABEL_KEY: "false"},
+        | {
+            _OSPARC_SERVICE_READY_LABEL_KEY: "false",
+            _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY: mock.ANY,
+        },
         available=with_drain_nodes_labelled,
     )
     mock_docker_tag_node.reset_mock()
@@ -681,9 +721,10 @@ async def test_cluster_scaling_up_and_down(  # noqa: PLR0915
     # we artifically set the node to drain
     fake_attached_node.Spec.Availability = Availability.drain
     fake_attached_node.Spec.Labels[_OSPARC_SERVICE_READY_LABEL_KEY] = "false"
-    fake_attached_node.UpdatedAt = datetime.datetime.now(
-        tz=datetime.timezone.utc
-    ).isoformat()
+    fake_attached_node.Spec.Labels[
+        _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY
+    ] = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+
     # the node will be not be terminated before the timeout triggers
     assert app_settings.AUTOSCALING_EC2_INSTANCES
     assert (
@@ -706,7 +747,7 @@ async def test_cluster_scaling_up_and_down(  # noqa: PLR0915
     )
 
     # now changing the last update timepoint will trigger the node removal and shutdown the ec2 instance
-    fake_attached_node.UpdatedAt = (
+    fake_attached_node.Spec.Labels[_OSPARC_SERVICES_READY_DATETIME_LABEL_KEY] = (
         datetime.datetime.now(tz=datetime.timezone.utc)
         - app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
         - datetime.timedelta(seconds=1)
@@ -856,10 +897,16 @@ async def test__deactivate_empty_nodes(
     assert not updated_cluster.active_nodes
     assert len(updated_cluster.drained_nodes) == len(active_cluster.active_nodes)
     mock_docker_set_node_availability.assert_not_called()
+    assert host_node.Spec
+    assert host_node.Spec.Labels
     mock_docker_tag_node.assert_called_once_with(
         mock.ANY,
         host_node,
-        tags={_OSPARC_SERVICE_READY_LABEL_KEY: "false"},
+        tags=host_node.Spec.Labels
+        | {
+            _OSPARC_SERVICE_READY_LABEL_KEY: "false",
+            _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY: mock.ANY,
+        },
         available=with_drain_nodes_labelled,
     )
 
@@ -898,10 +945,16 @@ async def test__deactivate_empty_nodes_to_drain_when_services_running_are_missin
     assert not updated_cluster.active_nodes
     assert len(updated_cluster.drained_nodes) == len(active_cluster.active_nodes)
     mock_docker_set_node_availability.assert_not_called()
+    assert host_node.Spec
+    assert host_node.Spec.Labels
     mock_docker_tag_node.assert_called_once_with(
         mock.ANY,
         host_node,
-        tags={_OSPARC_SERVICE_READY_LABEL_KEY: "false"},
+        tags=host_node.Spec.Labels
+        | {
+            _OSPARC_SERVICE_READY_LABEL_KEY: "false",
+            _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY: mock.ANY,
+        },
         available=with_drain_nodes_labelled,
     )
 
@@ -1174,6 +1227,9 @@ async def test__activate_drained_nodes_with_drained_node(
     mock_docker_tag_node.assert_called_once_with(
         mock.ANY,
         drained_host_node,
-        tags={_OSPARC_SERVICE_READY_LABEL_KEY: "true"},
+        tags={
+            _OSPARC_SERVICE_READY_LABEL_KEY: "true",
+            _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY: mock.ANY,
+        },
         available=True,
     )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

https://github.com/ITISFoundation/osparc-simcore/pull/5340 introduced a big change on how nodes are treated.
A few issues were found that this PR should fix:
- terminating node was relying on the docker node _UpdatedAt_ field which is not changed anymore the same way as when the node was drained/activated via docker facilities
- the label for osparc readyness was changed to follow inverse URL notations

NOTE: these changes are compatible with both modes.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
