### PR TITLE
 🐛 Remove quotes around "/data" in MINIO_VOLUMES var

### DIFF
--- a/services/docker-compose-ops.yml
+++ b/services/docker-compose-ops.yml
@@ -48,7 +48,7 @@ services:
     environment:
       - MINIO_ROOT_USER=${S3_ACCESS_KEY:?access_key_required}
       - MINIO_ROOT_PASSWORD=${S3_SECRET_KEY:?secret_key_required}
-      - MINIO_VOLUMES="/data"
+      - MINIO_VOLUMES=/data
     ports:
       - "9001:9000"
       - "9090:9090"


### PR DESCRIPTION
Leaving quotes around this path, makes docker compose translate this into '"/data"', which generates a path with quotes in it, and makes minio store data in its container instead of the minio volume

## What do these changes do?

Remove the quotes around "/data" in docker compose

## How to test
(at least for Docker Compose version v2.24.5)
Enable minio in a local deployment. Run: 
make up-prod
Put some data in the minio store, but for example uploading some file to a local osparc study. Run:
make down; make leave; make down;
Next time when run make up-prod, the data in Minio is gone.

One can also attach to the minio container with portainer, and verify the location of the data. After the fix it should be in /data, before the fix the data will be in a directory called '"' in the /

## Dev Checklist

- [ X ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
