### PR TITLE
🔨  Adds logs in e2e with timestamps

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/playwright_utils.py
+++ b/packages/pytest-simcore/src/pytest_simcore/playwright_utils.py
@@ -1,9 +1,11 @@
 import json
 import logging
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum, unique
-from typing import Any, Final, Iterator, TypeAlias
+from types import SimpleNamespace
+from typing import Any, Final, TypeAlias
 
 from playwright.sync_api import WebSocket
 
@@ -11,22 +13,56 @@ SECOND: Final[int] = 1000
 MINUTE: Final[int] = 60 * SECOND
 
 
-_logger = logging.getLogger(__name__)
+class DynamicIndentFormatter(logging.Formatter):
+    indent_char = "\t"
+    _indent_level = 0
+
+    def __init__(self, fmt=None, datefmt=None, style="%"):
+        dynamic_fmt = fmt or "%(asctime)s %(levelname)s %(message)s"
+        assert "message" in dynamic_fmt
+        super().__init__(dynamic_fmt, datefmt, style)
+
+    def format(self, record):
+        original_message = record.msg
+        record.msg = f"{self.indent_char * self._indent_level}{original_message}"
+        result = super().format(record)
+        record.msg = original_message
+        return result
+
+    @classmethod
+    def increase_indent(cls):
+        cls._indent_level += 1
+
+    @classmethod
+    def decrease_indent(cls):
+        cls._indent_level = max(0, cls._indent_level - 1)
+
+    @classmethod
+    def setup(cls, logger: logging.Logger):
+        _formatter = DynamicIndentFormatter()
+        _handler = logging.StreamHandler()
+        _handler.setFormatter(_formatter)
+        logger.addHandler(_handler)
+        logger.setLevel(logging.INFO)
 
 
-LogLevelInt: TypeAlias = int
-LogMessageStr: TypeAlias = str
+test_logger = logging.getLogger(__name__)
+DynamicIndentFormatter.setup(test_logger)
 
 
 @dataclass
 class ContextMessages:
     start: str
     ok: str
-    failed: str | None = field(default=None)
+    failed: str = field(default="")
 
     def __post_init__(self):
-        if self.failed is None:
+        if not self.failed:
             self.failed = f"{self.ok} [with error]"
+
+
+LogLevelInt: TypeAlias = int
+LogMessageStr: TypeAlias = str
 
 
 @contextmanager
@@ -34,17 +70,17 @@ def log_context(
     level: LogLevelInt,
     msg: LogMessageStr | tuple | ContextMessages,
     *args,
-    logger: logging.Logger = _logger,
+    logger: logging.Logger = test_logger,
     **kwargs,
-) -> Iterator[ContextMessages]:
+) -> Iterator[SimpleNamespace]:
     # NOTE: Preserves original signature of a logger https://docs.python.org/3/library/logging.html#logging.Logger.log
     # NOTE: To add more info to the logs e.g. times, user_id etc prefer using formatting instead of adding more here
 
     if isinstance(msg, str):
         ctx_msg = ContextMessages(
-            start=f"---> Starting {msg} ...",
-            ok=f"<--- Finished {msg}",
-            failed=f"<--- Errored {msg}",
+            start=f"> {msg} starting ...",
+            ok=f"< {msg} done",
+            failed=f"< {msg} errored",
         )
     elif isinstance(msg, tuple):
         ctx_msg = ContextMessages(*msg)
@@ -52,15 +88,20 @@ def log_context(
         ctx_msg = msg
 
     try:
+        DynamicIndentFormatter.increase_indent()
+
         logger.log(level, ctx_msg.start, *args, **kwargs)
 
-        yield ctx_msg  # can change finsh messages
+        yield SimpleNamespace(logger=logger, messages=ctx_msg)
 
         logger.log(level, ctx_msg.ok, *args, **kwargs)
 
     except:
         logger.log(logging.ERROR, ctx_msg.failed, *args, **kwargs)
         raise
+
+    finally:
+        DynamicIndentFormatter.decrease_indent()
 
 
 @unique

--- a/packages/pytest-simcore/src/pytest_simcore/playwright_utils.py
+++ b/packages/pytest-simcore/src/pytest_simcore/playwright_utils.py
@@ -52,13 +52,13 @@ DynamicIndentFormatter.setup(test_logger)
 
 @dataclass
 class ContextMessages:
-    start: str
-    ok: str
-    failed: str = field(default="")
+    starting: str
+    done: str
+    raised: str = field(default="")
 
     def __post_init__(self):
-        if not self.failed:
-            self.failed = f"{self.ok} [with error]"
+        if not self.raised:
+            self.raised = f"{self.done} [with error]"
 
 
 LogLevelInt: TypeAlias = int
@@ -78,9 +78,9 @@ def log_context(
 
     if isinstance(msg, str):
         ctx_msg = ContextMessages(
-            start=f"> {msg} starting ...",
-            ok=f"< {msg} done",
-            failed=f"< {msg} errored",
+            starting=f"-> {msg} starting ...",
+            done=f"<- {msg} done",
+            raised=f"! {msg} raised",
         )
     elif isinstance(msg, tuple):
         ctx_msg = ContextMessages(*msg)
@@ -90,14 +90,14 @@ def log_context(
     try:
         DynamicIndentFormatter.increase_indent()
 
-        logger.log(level, ctx_msg.start, *args, **kwargs)
+        logger.log(level, ctx_msg.starting, *args, **kwargs)
 
         yield SimpleNamespace(logger=logger, messages=ctx_msg)
 
-        logger.log(level, ctx_msg.ok, *args, **kwargs)
+        logger.log(level, ctx_msg.done, *args, **kwargs)
 
     except:
-        logger.log(logging.ERROR, ctx_msg.failed, *args, **kwargs)
+        logger.log(logging.ERROR, ctx_msg.raised, *args, **kwargs)
         raise
 
     finally:

--- a/packages/pytest-simcore/src/pytest_simcore/playwright_utils.py
+++ b/packages/pytest-simcore/src/pytest_simcore/playwright_utils.py
@@ -22,7 +22,7 @@ class DynamicIndentFormatter(logging.Formatter):
         assert "message" in dynamic_fmt
         super().__init__(dynamic_fmt, datefmt, style)
 
-    def format(self, record):
+    def format(self, record):  # noqa: A003
         original_message = record.msg
         record.msg = f"{self.indent_char * self._indent_level}{original_message}"
         result = super().format(record)
@@ -199,12 +199,12 @@ def wait_for_pipeline_state(
     return current_state
 
 
-def on_web_socket(ws) -> None:
+def on_web_socket_default_handler(ws) -> None:
     """Usage
 
-    from pytest_simcore.playwright_utils import on_web_socket
+    from pytest_simcore.playwright_utils import on_web_socket_default_handler
 
-    page.on("websocket", on_web_socket)
+    page.on("websocket", on_web_socket_default_handler)
 
     """
     stack = ExitStack()

--- a/packages/pytest-simcore/src/pytest_simcore/playwright_utils.py
+++ b/packages/pytest-simcore/src/pytest_simcore/playwright_utils.py
@@ -14,8 +14,8 @@ MINUTE: Final[int] = 60 * SECOND
 
 
 class DynamicIndentFormatter(logging.Formatter):
-    indent_char = "\t"
-    _indent_level = 0
+    indent_char: str = "\t"
+    _indent_level: int = 0
 
     def __init__(self, fmt=None, datefmt=None, style="%"):
         dynamic_fmt = fmt or "%(asctime)s %(levelname)s %(message)s"

--- a/tests/e2e-playwright/tests/conftest.py
+++ b/tests/e2e-playwright/tests/conftest.py
@@ -5,6 +5,7 @@
 # pylint: disable=too-many-statements
 # pylint: disable=no-name-in-module
 
+import logging
 import os
 import random
 import re
@@ -19,6 +20,7 @@ from pytest_simcore.playwright_utils import (
     SocketIOEvent,
     SocketIOProjectStateUpdatedWaiter,
     decode_socketio_42_message,
+    log_context,
 )
 
 
@@ -151,24 +153,25 @@ def register(
     user_password: str,
 ) -> Callable[[], AutoRegisteredUser]:
     def _do() -> AutoRegisteredUser:
-        print(
-            f"------> Registering in {product_url=} using {user_name=}/{user_password=}"
-        )
-        response = page.goto(f"{product_url}")
-        assert response
-        assert response.ok, response.body()
-        page.get_by_test_id("loginCreateAccountBtn").click()
-        user_email_box = page.get_by_test_id("registrationEmailFld")
-        user_email_box.click()
-        user_email_box.fill(user_name)
-        for pass_id in ["registrationPass1Fld", "registrationPass2Fld"]:
-            user_password_box = page.get_by_test_id(pass_id)
-            user_password_box.click()
-            user_password_box.fill(user_password)
-        with page.expect_response(re.compile(r"/auth/register")) as response_info:
-            page.get_by_test_id("registrationSubmitBtn").click()
-        assert response_info.value.ok, response_info.value.json()
-        return AutoRegisteredUser(user_email=user_name, password=user_password)
+        with log_context(
+            logging.INFO,
+            f"------> Registering in {product_url=} using {user_name=}/{user_password=}",
+        ):
+            response = page.goto(f"{product_url}")
+            assert response
+            assert response.ok, response.body()
+            page.get_by_test_id("loginCreateAccountBtn").click()
+            user_email_box = page.get_by_test_id("registrationEmailFld")
+            user_email_box.click()
+            user_email_box.fill(user_name)
+            for pass_id in ["registrationPass1Fld", "registrationPass2Fld"]:
+                user_password_box = page.get_by_test_id(pass_id)
+                user_password_box.click()
+                user_password_box.fill(user_password)
+            with page.expect_response(re.compile(r"/auth/register")) as response_info:
+                page.get_by_test_id("registrationSubmitBtn").click()
+            assert response_info.value.ok, response_info.value.json()
+            return AutoRegisteredUser(user_email=user_name, password=user_password)
 
     return _do
 
@@ -182,13 +185,16 @@ def log_in_and_out(
     auto_register: bool,
     register: Callable[[], AutoRegisteredUser],
 ) -> Iterator[WebSocket]:
-    print(
-        f"------> Opening {product_url=} using {user_name=}/{user_password=}/{auto_register=}"
-    )
-    response = page.goto(f"{product_url}")
-    assert response
-    assert response.ok, response.body()
-    print(f"-----> Opened {product_url=} successfully")
+    with log_context(
+        logging.INFO,
+        (
+            f"------> Opening {product_url=} using {user_name=}/{user_password=}/{auto_register=}",
+            f"-----> Opened {product_url=} successfully",
+        ),
+    ):
+        response = page.goto(f"{product_url}")
+        assert response
+        assert response.ok, response.body()
 
     # In case the accept cookies or new release window shows up, we accept
     page.wait_for_timeout(2000)
@@ -204,18 +210,20 @@ def log_in_and_out(
         if auto_register:
             register()
         else:
-            print(
-                f"------> Logging in {product_url=} using {user_name=}/{user_password=}"
-            )
-            _user_email_box = page.get_by_test_id("loginUserEmailFld")
-            _user_email_box.click()
-            _user_email_box.fill(user_name)
-            _user_password_box = page.get_by_test_id("loginPasswordFld")
-            _user_password_box.click()
-            _user_password_box.fill(user_password)
-            with page.expect_response(re.compile(r"/login")) as response_info:
-                page.get_by_test_id("loginSubmitBtn").click()
-            assert response_info.value.ok, f"{response_info.value.json()}"
+            with log_context(
+                logging.INFO,
+                f"------> Logging in {product_url=} using {user_name=}/{user_password=}",
+            ):
+                _user_email_box = page.get_by_test_id("loginUserEmailFld")
+                _user_email_box.click()
+                _user_email_box.fill(user_name)
+                _user_password_box = page.get_by_test_id("loginPasswordFld")
+                _user_password_box.click()
+                _user_password_box.fill(user_password)
+                with page.expect_response(re.compile(r"/login")) as response_info:
+                    page.get_by_test_id("loginSubmitBtn").click()
+                assert response_info.value.ok, f"{response_info.value.json()}"
+
     ws = ws_info.value
     assert not ws.is_closed()
 
@@ -236,19 +244,25 @@ def log_in_and_out(
 
     yield ws
 
-    print(f"<------ Logging out of {product_url=} using {user_name=}/{user_password=}")
-    # click anywher to remove modal windows
-    page.click(
-        "body",
-        position={"x": 0, "y": 0},
-    )
-    page.get_by_test_id("userMenuBtn").click()
-    with page.expect_response(re.compile(r"/auth/logout")) as response_info:
-        page.get_by_test_id("userMenuLogoutBtn").click()
-    assert response_info.value.ok, f"{response_info.value.json()}"
-    # so we see the logout page
-    page.wait_for_timeout(500)
-    print(f"<------ Logged out of {product_url=} using {user_name=}/{user_password=}")
+    with log_context(
+        logging.INFO,
+        (
+            "<------ Logging out of %s",
+            "<------ Logged out of %s",
+        ),
+        f"{product_url=} using {user_name=}/{user_password=}",
+    ):
+        # click anywher to remove modal windows
+        page.click(
+            "body",
+            position={"x": 0, "y": 0},
+        )
+        page.get_by_test_id("userMenuBtn").click()
+        with page.expect_response(re.compile(r"/auth/logout")) as response_info:
+            page.get_by_test_id("userMenuLogoutBtn").click()
+        assert response_info.value.ok, f"{response_info.value.json()}"
+        # so we see the logout page
+        page.wait_for_timeout(500)
 
 
 @pytest.fixture
@@ -263,35 +277,45 @@ def create_new_project_and_delete(
     created_project_uuids = []
 
     def _do(auto_delete: bool) -> None:
-        print(f"------> Opening project in {product_url=} as {product_billable=}")
-        waiter = SocketIOProjectStateUpdatedWaiter(expected_states=("NOT_STARTED",))
-        with log_in_and_out.expect_event("framereceived", waiter), page.expect_response(
-            re.compile(r"/projects/[^:]+:open")
-        ) as response_info:
-            # Project detail view pop-ups shows
-            page.get_by_test_id("openResource").click()
-            if product_billable:
-                # Open project with default resources
-                page.get_by_test_id("openWithResources").click()
-        project_data = response_info.value.json()
-        assert project_data
-        project_uuid = project_data["data"]["uuid"]
-        print(
-            f"------> Opened project with {project_uuid=} in {product_url=} as {product_billable=}"
-        )
-        if auto_delete:
-            created_project_uuids.append(project_uuid)
+
+        with log_context(
+            logging.INFO,
+            f"------> Opening project in {product_url=} as {product_billable=}",
+        ) as ctx:
+            waiter = SocketIOProjectStateUpdatedWaiter(expected_states=("NOT_STARTED",))
+            with log_in_and_out.expect_event(
+                "framereceived", waiter
+            ), page.expect_response(
+                re.compile(r"/projects/[^:]+:open")
+            ) as response_info:
+                # Project detail view pop-ups shows
+                page.get_by_test_id("openResource").click()
+                if product_billable:
+                    # Open project with default resources
+                    page.get_by_test_id("openWithResources").click()
+            project_data = response_info.value.json()
+            assert project_data
+            project_uuid = project_data["data"]["uuid"]
+
+            ctx.messages.done = (
+                f"------> Opened project with {project_uuid=} in {product_url=} as {product_billable=}",
+            )
+            if auto_delete:
+                created_project_uuids.append(project_uuid)
 
     yield _do
 
     for project_uuid in created_project_uuids:
-        print(
-            f"<------ Deleting project with {project_uuid=} in {product_url=} as {product_billable=}"
-        )
-        api_request_context.delete(f"{product_url}v0/projects/{project_uuid}")
-        print(
-            f"<------ Deleted project with {project_uuid=} in {product_url=} as {product_billable=}"
-        )
+        with log_context(
+            logging.INFO,
+            (
+                "<------ Deleting project with %s",
+                "<------ Deleted project with %s",
+            ),
+            f"{project_uuid=} in {product_url=} as {product_billable=}",
+        ):
+
+            api_request_context.delete(f"{product_url}v0/projects/{project_uuid}")
 
 
 @pytest.fixture
@@ -304,38 +328,52 @@ def start_and_stop_pipeline(
     started_pipeline_ids = []
 
     def _do() -> SocketIOEvent:
-        print(f"------> Starting computation in {product_url=}...")
-        waiter = SocketIOProjectStateUpdatedWaiter(
-            expected_states=(
-                "PUBLISHED",
-                "PENDING",
-                "WAITING_FOR_CLUSTER",
-                "WAITING_FOR_RESOURCES",
-                "STARTED",
+        with log_context(
+            logging.INFO,
+            f"------> Starting computation in {product_url=}...",
+        ) as ctx:
+            waiter = SocketIOProjectStateUpdatedWaiter(
+                expected_states=(
+                    "PUBLISHED",
+                    "PENDING",
+                    "WAITING_FOR_CLUSTER",
+                    "WAITING_FOR_RESOURCES",
+                    "STARTED",
+                )
             )
-        )
-        with page.expect_request(
-            lambda request: re.search(r"/computations", request.url)
-            and request.method.upper() == "POST"  # type: ignore
-        ) as request_info, log_in_and_out.expect_event(
-            "framereceived", waiter
-        ) as event:
-            page.get_by_test_id("runStudyBtn").click()
-        response = request_info.value.response()
-        assert response
-        assert response.ok, f"{response.json()}"
-        response_body = response.json()
-        assert "data" in response_body
-        assert "pipeline_id" in response_body["data"]
-        pipeline_id = response_body["data"]["pipeline_id"]
-        started_pipeline_ids.append(pipeline_id)
-        print(f"------> Started computation with {pipeline_id=} in {product_url=}...")
-        return decode_socketio_42_message(event.value)
+            with page.expect_request(
+                lambda request: re.search(r"/computations", request.url)
+                and request.method.upper() == "POST"  # type: ignore
+            ) as request_info, log_in_and_out.expect_event(
+                "framereceived", waiter
+            ) as event:
+                page.get_by_test_id("runStudyBtn").click()
+            response = request_info.value.response()
+            assert response
+            assert response.ok, f"{response.json()}"
+            response_body = response.json()
+            assert "data" in response_body
+            assert "pipeline_id" in response_body["data"]
+
+            pipeline_id = response_body["data"]["pipeline_id"]
+            started_pipeline_ids.append(pipeline_id)
+
+            ctx.messages.done = (
+                f"------> Started computation with {pipeline_id=} in {product_url=}..."
+            )
+
+            return decode_socketio_42_message(event.value)
 
     yield _do
 
     # ensure all the pipelines are stopped properly
     for pipeline_id in started_pipeline_ids:
-        print(f"------> Stopping computation with {pipeline_id=} in {product_url=}...")
-        api_request_context.post(f"{product_url}v0/computations/{pipeline_id}:stop")
-        print(f"------> Stopped computation with {pipeline_id=} in {product_url=}...")
+        with log_context(
+            logging.INFO,
+            (
+                "<------ Stopping computation with %s",
+                "<------ Stopped computation with %s",
+            ),
+            f"{pipeline_id=} in {product_url=}...",
+        ):
+            api_request_context.post(f"{product_url}v0/computations/{pipeline_id}:stop")

--- a/tests/e2e-playwright/tests/jupyterlab.py
+++ b/tests/e2e-playwright/tests/jupyterlab.py
@@ -11,6 +11,7 @@ from typing import Final
 
 from playwright.sync_api import APIRequestContext, Page
 from pydantic import AnyUrl
+from pytest_simcore.playwright_utils import on_web_socket, test_logger
 from tenacity import Retrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_attempt
@@ -19,13 +20,6 @@ from tenacity.wait import wait_fixed
 projects_uuid_pattern: Final[re.Pattern] = re.compile(
     r"/projects/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 )
-
-
-def on_web_socket(ws) -> None:
-    print(f"WebSocket opened: {ws.url}")
-    ws.on("framesent", lambda payload: print("⬇️", payload))
-    ws.on("framereceived", lambda payload: print("⬆️", payload))
-    ws.on("close", lambda payload: print("WebSocket closed"))
 
 
 def test_jupyterlab(
@@ -56,7 +50,7 @@ def test_jupyterlab(
         page.wait_for_timeout(1000)
 
     # Get project uuid, will be used to delete this project in the end
-    print(f"projects uuid endpoint captured: {response_info.value.url}")
+    test_logger.info(f"projects uuid endpoint captured: {response_info.value.url}")
     match = projects_uuid_pattern.search(response_info.value.url)
     assert match
     extracted_uuid = match.group(1)
@@ -84,7 +78,8 @@ def test_jupyterlab(
         _jupyterlab_ui.fill("print('test')")
         _jupyterlab_ui.press("Shift+Enter")
     else:
-        raise ValueError("Not supported service key")
+        msg = "Not supported service key"
+        raise ValueError(msg)
     page.wait_for_timeout(1000)
 
     # Going back to dashboard

--- a/tests/e2e-playwright/tests/jupyterlab.py
+++ b/tests/e2e-playwright/tests/jupyterlab.py
@@ -11,7 +11,7 @@ from typing import Final
 
 from playwright.sync_api import APIRequestContext, Page
 from pydantic import AnyUrl
-from pytest_simcore.playwright_utils import on_web_socket, test_logger
+from pytest_simcore.playwright_utils import on_web_socket_default_handler, test_logger
 from tenacity import Retrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_attempt
@@ -32,7 +32,7 @@ def test_jupyterlab(
     service_test_id: str,
 ):
     # connect and listen to websocket
-    page.on("websocket", on_web_socket)
+    page.on("websocket", on_web_socket_default_handler)
 
     # open services tab and filter for the service
     page.get_by_test_id("servicesTabBtn").click()

--- a/tests/e2e-playwright/tests/resource_usage_tracker.py
+++ b/tests/e2e-playwright/tests/resource_usage_tracker.py
@@ -1,9 +1,10 @@
+# pylint: disable=logging-fstring-interpolation
 # pylint: disable=redefined-outer-name
-# pylint: disable=unused-argument
-# pylint: disable=unused-variable
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-statements
 # pylint: disable=unnecessary-lambda
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
 
 import os
 from collections.abc import Iterator
@@ -13,6 +14,7 @@ from http import HTTPStatus
 import pytest
 from playwright.sync_api import APIRequestContext
 from pydantic import AnyUrl
+from pytest_simcore.playwright_utils import test_logger
 from tenacity import Retrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
@@ -47,7 +49,7 @@ def test_resource_usage_tracker(
     service_run_ids_before = set()
     for service_run in service_runs_before:
         service_run_ids_before.add(service_run["service_run_id"])
-    print(f"Service runs before: {service_run_ids_before}")
+    test_logger.info(f"Service runs before: {service_run_ids_before}")
 
     # 2. Start computations
     data = {"subgraph": [], "force_restart": True}
@@ -64,7 +66,7 @@ def test_resource_usage_tracker(
         reraise=True,
     ):
         with attempt:
-            print(
+            test_logger.info(
                 f"====================={datetime.now(tz=timezone.utc)}============================="
             )
             output = api_request_context.get(f"{product_url}v0/projects/{STUDY_ID}")
@@ -75,7 +77,7 @@ def test_resource_usage_tracker(
             for node in list(workbench.keys()):
                 node_label = workbench[node]["label"]
                 node_current_status = workbench[node]["state"]["currentStatus"]
-                print((node_label, node_current_status, node))
+                test_logger.info("%s", (node_label, node_current_status, node))
                 status_check.add(node_current_status)
 
             assert len(status_check.union({"SUCCESS", "FAILED"})) == 2
@@ -89,7 +91,7 @@ def test_resource_usage_tracker(
     service_run_ids_after = set()
     for service_run in service_runs_after:
         service_run_ids_after.add(service_run["service_run_id"])
-    print(f"Service runs after: {service_run_ids_after}")
+    test_logger.info(f"Service runs after: {service_run_ids_after}")
 
     # If there is an intersection with old service run id, that means that
     # RUT didn't created a new service run id

--- a/tests/e2e-playwright/tests/sim4life.py
+++ b/tests/e2e-playwright/tests/sim4life.py
@@ -1,9 +1,11 @@
+# pylint: disable=logging-fstring-interpolation
 # pylint: disable=redefined-outer-name
-# pylint: disable=unused-argument
-# pylint: disable=unused-variable
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-statements
 # pylint: disable=unnecessary-lambda
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
 
 import re
 from http import HTTPStatus
@@ -50,7 +52,7 @@ def test_sim4life(
         page.wait_for_timeout(1000)
 
     # Get project uuid, will be used to delete this project in the end
-    test_logger.info(f"projects uuid endpoint captured: %s", response_info.value.url)
+    test_logger.info("projects uuid endpoint captured: %s", response_info.value.url)
     match = projects_uuid_pattern.search(response_info.value.url)
     assert match
     extracted_uuid = match.group(1)

--- a/tests/e2e-playwright/tests/sim4life.py
+++ b/tests/e2e-playwright/tests/sim4life.py
@@ -5,15 +5,13 @@
 # pylint: disable=too-many-statements
 # pylint: disable=unnecessary-lambda
 
-import logging
 import re
-from contextlib import ExitStack
 from http import HTTPStatus
 from typing import Final
 
 from playwright.sync_api import APIRequestContext, Page
 from pydantic import AnyUrl
-from pytest_simcore.playwright_utils import log_context, test_logger
+from pytest_simcore.playwright_utils import on_web_socket, test_logger
 from tenacity import Retrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_attempt
@@ -22,23 +20,6 @@ from tenacity.wait import wait_fixed
 projects_uuid_pattern: Final[re.Pattern] = re.compile(
     r"/projects/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 )
-
-
-def on_web_socket(ws) -> None:
-    stack = ExitStack()
-    ctx = stack.enter_context(
-        log_context(
-            logging.INFO,
-            (
-                f"WebSocket opened: {ws.url}",
-                "WebSocket closed",
-            ),
-        )
-    )
-
-    ws.on("framesent", lambda payload: ctx.logger.info(payload))
-    ws.on("framereceived", lambda payload: ctx.logger.info(payload))
-    ws.on("close", lambda payload: stack.close())
 
 
 def test_sim4life(

--- a/tests/e2e-playwright/tests/sim4life.py
+++ b/tests/e2e-playwright/tests/sim4life.py
@@ -13,7 +13,7 @@ from typing import Final
 
 from playwright.sync_api import APIRequestContext, Page
 from pydantic import AnyUrl
-from pytest_simcore.playwright_utils import on_web_socket, test_logger
+from pytest_simcore.playwright_utils import on_web_socket_default_handler, test_logger
 from tenacity import Retrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_attempt
@@ -34,7 +34,7 @@ def test_sim4life(
     service_test_id: str,
 ):
     # connect and listen to websocket
-    page.on("websocket", on_web_socket)
+    page.on("websocket", on_web_socket_default_handler)
 
     # open services tab and filter for sim4life service
     page.get_by_test_id("servicesTabBtn").click()

--- a/tests/e2e-playwright/tests/sleepers/conftest.py
+++ b/tests/e2e-playwright/tests/sleepers/conftest.py
@@ -31,4 +31,4 @@ def num_sleepers(request: pytest.FixtureRequest) -> int:
 
 @pytest.fixture
 def input_sleep_time(request: pytest.FixtureRequest) -> int | None:
-    return request.config.getoption("--input-sleep-time")
+    return request.config.getoption("--input-sleep-time", default=None)

--- a/tests/e2e-playwright/tests/sleepers/sleepers.py
+++ b/tests/e2e-playwright/tests/sleepers/sleepers.py
@@ -1,10 +1,11 @@
-# pylint:disable=unused-variable
-# pylint:disable=unused-argument
-# pylint:disable=redefined-outer-name
-# pylint:disable=protected-access
+# pylint: disable=logging-fstring-interpolation
 # pylint:disable=no-value-for-parameter
+# pylint:disable=protected-access
+# pylint:disable=redefined-outer-name
 # pylint:disable=too-many-arguments
 # pylint:disable=too-many-statements
+# pylint:disable=unused-argument
+# pylint:disable=unused-variable
 
 
 import datetime
@@ -168,9 +169,7 @@ def test_sleepers(
         logging.INFO,
         (
             f"---> Looking for {expected_file_names=} in all {num_sleepers} sleeper services...",
-            "------------------------------------------------------"
-            "---> All good, we're done here! This was really great!"
-            "------------------------------------------------------",
+            "---> All good, we're done here! This was really great!",
         ),
     ) as ctx:
         for index, sleeper in enumerate(page.get_by_test_id("nodeTreeItem").all()[1:]):
@@ -182,7 +181,8 @@ def test_sleepers(
                 page.get_by_test_id("nodeOutputFilesBtn").click()
                 output_file_names_found = _get_file_names(page)
 
-            msg = f"<--- found {output_file_names_found=} in sleeper {index} service outputs."
-            ctx.logger.info(msg)
+            ctx.logger.info(
+                f"<--- found {output_file_names_found=} in sleeper {index} service outputs."
+            )  # noqa: G004
             assert output_file_names_found == expected_file_names
             page.get_by_test_id("nodeDataManagerCloseBtn").click()


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

After reviewing the e2e with @sanderegg we thought _it might be handy to have timestamps to measure how long it take a particular section of the the test_. 

The standard way to solve this is to use a proper logger instead of `print`. In addition, this PR implements some extra convenience utilities to simplify logging scopes/sections. For that we have a *log context* and a separate *formatter class* to include indentation in the messages as the context managers get nested. 

A dedicated `pytest_simcore.playwritght_utils.test_logger` in setup with that formatter. Note that indentation mechanism is therefore optional. You just have to use another logger.

To demo this utility I first enabled the [live log](https://docs.pytest.org/en/7.1.x/how-to/logging.html#live-logs) with timestamps and some options in `pytest.ini` and then run 
```python
import logging
import time

from pytest_simcore.playwright_utils import log_context


def test_it():

    with log_context(logging.INFO, "thing 1"):
        time.sleep(2)

        with log_context(logging.WARNING, ("%s started", "%s finished"), "thing 2"):
            time.sleep(1)
            with log_context(logging.WARNING, ("%s started", "%s finished"), "thing 3"):
                time.sleep(1)

    with log_context(logging.INFO, "thing 4") as ctx:
        time.sleep(3)
        ctx.logger.warning("thing4 started")
        ctx.messages.raised = "thing 4 WRONG MESSAGE CHANGED!!"

    with log_context(logging.INFO, "thing 5"):
        time.sleep(2)
        raise ValueError(3)
```
This is how it would display in the command
![image](https://github.com/ITISFoundation/osparc-simcore/assets/32402063/fe1f7d77-36db-4d0d-bff1-612074c9298c)

Notice that when it errors, the new formatter is captured in the stderr (3). This is because pytest adds another formatter (the one coloured) to the same logger for the live. 

## Related issue/s
- e2e 

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
