### PR TITLE
🎨 Send email on successful payment w/ payment-method

### DIFF
--- a/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
+++ b/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
@@ -19,13 +19,10 @@ from pydantic import EmailStr
 from servicelib.logging_utils import get_log_record_extra, log_context
 from servicelib.rabbitmq import RPCRouter
 
-from services.payments.src.simcore_service_payments.services.notifier import (
-    NotifierService,
-)
-
 from ...db.payments_methods_repo import PaymentsMethodsRepo
 from ...db.payments_transactions_repo import PaymentsTransactionsRepo
 from ...services import payments, payments_methods
+from ...services.notifier import NotifierService
 from ...services.payments_gateway import PaymentsGatewayApi
 from ...services.resource_usage_tracker import ResourceUsageTrackerApi
 

--- a/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
+++ b/services/payments/src/simcore_service_payments/api/rpc/_payments_methods.py
@@ -19,6 +19,10 @@ from pydantic import EmailStr
 from servicelib.logging_utils import get_log_record_extra, log_context
 from servicelib.rabbitmq import RPCRouter
 
+from services.payments.src.simcore_service_payments.services.notifier import (
+    NotifierService,
+)
+
 from ...db.payments_methods_repo import PaymentsMethodsRepo
 from ...db.payments_transactions_repo import PaymentsTransactionsRepo
 from ...services import payments, payments_methods
@@ -176,6 +180,7 @@ async def pay_with_payment_method(  # noqa: PLR0913 # pylint: disable=too-many-a
             rut=ResourceUsageTrackerApi.get_from_app_state(app),
             repo_transactions=PaymentsTransactionsRepo(db_engine=app.state.engine),
             repo_methods=PaymentsMethodsRepo(db_engine=app.state.engine),
+            notifier=NotifierService.get_from_app_state(app),
             payment_method_id=payment_method_id,
             amount_dollars=amount_dollars,
             target_credits=target_credits,

--- a/services/payments/src/simcore_service_payments/services/auto_recharge_process_message.py
+++ b/services/payments/src/simcore_service_payments/services/auto_recharge_process_message.py
@@ -25,6 +25,10 @@ from simcore_service_payments.services.resource_usage_tracker import (
     ResourceUsageTrackerApi,
 )
 
+from services.payments.src.simcore_service_payments.services.notifier import (
+    NotifierService,
+)
+
 from ..core.settings import ApplicationSettings
 from .auto_recharge import get_wallet_auto_recharge
 from .payments import pay_with_payment_method
@@ -150,11 +154,17 @@ async def _perform_auto_recharge(
     payments_transactions_repo = PaymentsTransactionsRepo(db_engine=app.state.engine)
     rut_api = ResourceUsageTrackerApi.get_from_app_state(app)
 
+    # FIXME: how can I get these?
+    # wallet_name =
+    # user_name =
+    # user_eamil =
+
     await pay_with_payment_method(
         gateway=payments_gateway,
         rut=rut_api,
         repo_transactions=payments_transactions_repo,
         repo_methods=PaymentsMethodsRepo(db_engine=app.state.engine),
+        notifier=NotifierService.get_from_app_state(app),
         payment_method_id=cast(PaymentMethodID, wallet_auto_recharge.payment_method_id),
         amount_dollars=wallet_auto_recharge.top_up_amount_in_usd,
         target_credits=credit_result.credit_amount,

--- a/services/payments/src/simcore_service_payments/services/auto_recharge_process_message.py
+++ b/services/payments/src/simcore_service_payments/services/auto_recharge_process_message.py
@@ -150,21 +150,18 @@ async def _perform_auto_recharge(
     )
     credit_result = parse_obj_as(CreditResultGet, result)
 
-    payments_gateway = PaymentsGatewayApi.get_from_app_state(app)
-    payments_transactions_repo = PaymentsTransactionsRepo(db_engine=app.state.engine)
-    rut_api = ResourceUsageTrackerApi.get_from_app_state(app)
-
     # FIXME: how can I get these?
     # wallet_name =
     # user_name =
     # user_eamil =
 
     await pay_with_payment_method(
-        gateway=payments_gateway,
-        rut=rut_api,
-        repo_transactions=payments_transactions_repo,
+        gateway=PaymentsGatewayApi.get_from_app_state(app),
+        rut=ResourceUsageTrackerApi.get_from_app_state(app),
+        repo_transactions=PaymentsTransactionsRepo(db_engine=app.state.engine),
         repo_methods=PaymentsMethodsRepo(db_engine=app.state.engine),
         notifier=NotifierService.get_from_app_state(app),
+        #
         payment_method_id=cast(PaymentMethodID, wallet_auto_recharge.payment_method_id),
         amount_dollars=wallet_auto_recharge.top_up_amount_in_usd,
         target_credits=credit_result.credit_amount,

--- a/services/payments/src/simcore_service_payments/services/auto_recharge_process_message.py
+++ b/services/payments/src/simcore_service_payments/services/auto_recharge_process_message.py
@@ -25,12 +25,9 @@ from simcore_service_payments.services.resource_usage_tracker import (
     ResourceUsageTrackerApi,
 )
 
-from services.payments.src.simcore_service_payments.services.notifier import (
-    NotifierService,
-)
-
 from ..core.settings import ApplicationSettings
 from .auto_recharge import get_wallet_auto_recharge
+from .notifier import NotifierService
 from .payments import pay_with_payment_method
 from .payments_gateway import PaymentsGatewayApi
 from .rabbitmq import get_rabbitmq_rpc_client

--- a/services/payments/src/simcore_service_payments/services/auto_recharge_process_message.py
+++ b/services/payments/src/simcore_service_payments/services/auto_recharge_process_message.py
@@ -147,11 +147,6 @@ async def _perform_auto_recharge(
     )
     credit_result = parse_obj_as(CreditResultGet, result)
 
-    # FIXME: how can I get these?
-    # wallet_name =
-    # user_name =
-    # user_eamil =
-
     await pay_with_payment_method(
         gateway=PaymentsGatewayApi.get_from_app_state(app),
         rut=ResourceUsageTrackerApi.get_from_app_state(app),

--- a/services/payments/src/simcore_service_payments/services/notifier_abc.py
+++ b/services/payments/src/simcore_service_payments/services/notifier_abc.py
@@ -26,3 +26,7 @@ class NotificationProvider(ABC):
         payment_method: PaymentMethodTransaction,
     ):
         ...
+
+    @classmethod
+    def get_name(cls):
+        return cls.__name__

--- a/services/payments/src/simcore_service_payments/services/payments.py
+++ b/services/payments/src/simcore_service_payments/services/payments.py
@@ -41,6 +41,7 @@ from ..models.payments_gateway import InitPayment, PaymentInitiated
 from ..models.schemas.acknowledgements import AckPayment, AckPaymentWithPaymentMethod
 from ..services.resource_usage_tracker import ResourceUsageTrackerApi
 from .notifier import NotifierService
+from .notifier_ws import WebSocketProvider
 from .payments_gateway import PaymentsGatewayApi
 
 _logger = logging.getLogger()
@@ -259,7 +260,7 @@ async def pay_with_payment_method(  # noqa: PLR0913
 
     # NOTE: notifications here are done as background-task after responding `POST /wallets/{wallet_id}/payments-methods/{payment_method_id}:pay`
     await on_payment_completed(
-        transaction, rut, notifier=notifier, exclude={"WebSocketProvider"}
+        transaction, rut, notifier=notifier, exclude={WebSocketProvider.get_name()}
     )
 
     return to_payments_api_model(transaction)

--- a/services/payments/src/simcore_service_payments/services/payments.py
+++ b/services/payments/src/simcore_service_payments/services/payments.py
@@ -182,12 +182,11 @@ async def on_payment_completed(
             f"{credit_transaction_id=}",
         )
 
-    if notifier:
-        await notifier.notify_payment_completed(
-            user_id=transaction.user_id,
-            payment=to_payments_api_model(transaction),
-            exclude=exclude,
-        )
+    await notifier.notify_payment_completed(
+        user_id=transaction.user_id,
+        payment=to_payments_api_model(transaction),
+        exclude=exclude,
+    )
 
 
 async def pay_with_payment_method(  # noqa: PLR0913

--- a/services/payments/tests/unit/test_services_payments.py
+++ b/services/payments/tests/unit/test_services_payments.py
@@ -1,10 +1,13 @@
+# pylint: disable=protected-access
 # pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
-# pylint: disable=too-many-arguments
 
 
+import asyncio
 from collections.abc import Awaitable, Callable
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -24,6 +27,8 @@ from simcore_service_payments.db.payments_transactions_repo import (
 from simcore_service_payments.models.db import PaymentsMethodsDB
 from simcore_service_payments.services import payments
 from simcore_service_payments.services.notifier import NotifierService
+from simcore_service_payments.services.notifier_email import EmailProvider
+from simcore_service_payments.services.notifier_ws import WebSocketProvider
 from simcore_service_payments.services.payments_gateway import PaymentsGatewayApi
 from simcore_service_payments.services.resource_usage_tracker import (
     ResourceUsageTrackerApi,
@@ -59,6 +64,20 @@ def app_environment(
     )
 
 
+@pytest.fixture
+def mock_email_provider(mocker: MockerFixture) -> MagicMock:
+    mock = mocker.MagicMock(EmailProvider)
+    mock.get_name.return_value = EmailProvider.get_name()
+    return mock
+
+
+@pytest.fixture
+def mock_ws_provider(mocker: MockerFixture) -> MagicMock:
+    mock = mocker.MagicMock(WebSocketProvider)
+    mock.get_name.return_value = WebSocketProvider.get_name()
+    return mock
+
+
 async def test_fails_to_pay_with_payment_method_without_funds(
     app: FastAPI,
     create_fake_payment_method_in_db: Callable[
@@ -73,6 +92,8 @@ async def test_fails_to_pay_with_payment_method_without_funds(
     user_email: EmailStr,
     payments_clean_db: None,
     mocker: MockerFixture,
+    mock_email_provider: MagicMock,
+    mock_ws_provider: MagicMock,
 ):
     if mock_payments_gateway_service_or_none is None:
         pytest.skip(
@@ -87,7 +108,9 @@ async def test_fails_to_pay_with_payment_method_without_funds(
 
     rut = ResourceUsageTrackerApi.get_from_app_state(app)
     rut_create_credit_transaction = mocker.spy(rut, "create_credit_transaction")
-    notifier = NotifierService.get_from_app_state(app)
+
+    # Mocker providers
+    notifier = NotifierService(mock_email_provider, mock_ws_provider)
 
     payment = await payments.pay_with_payment_method(
         gateway=PaymentsGatewayApi.get_from_app_state(app),
@@ -108,9 +131,28 @@ async def test_fails_to_pay_with_payment_method_without_funds(
         comment="test_failure_in_pay_with_payment_method",
     )
 
+    # should not add credits
     assert not rut_create_credit_transaction.called
 
+    # check resulting payment
     assert payment.completed_at is not None
     assert payment.created_at < payment.completed_at
     assert payment.state == "FAILED"
     assert payment.state_message, "expected reason of failure"
+
+    # check notifications triggered as background tasks
+    await asyncio.sleep(0.1)
+    assert len(notifier._background_tasks) == 0  # noqa: SLF001
+
+    assert mock_email_provider.notify_payment_completed.called
+    assert (
+        mock_email_provider.notify_payment_completed.call_args.kwargs["user_id"]
+        == user_id
+    )
+    assert (
+        mock_email_provider.notify_payment_completed.call_args.kwargs["payment"]
+        == payment
+    )
+
+    # Websockets notification should be in the exclude list
+    assert not mock_ws_provider.notify_payment_completed.called

--- a/services/payments/tests/unit/test_services_payments.py
+++ b/services/payments/tests/unit/test_services_payments.py
@@ -23,6 +23,7 @@ from simcore_service_payments.db.payments_transactions_repo import (
 )
 from simcore_service_payments.models.db import PaymentsMethodsDB
 from simcore_service_payments.services import payments
+from simcore_service_payments.services.notifier import NotifierService
 from simcore_service_payments.services.payments_gateway import PaymentsGatewayApi
 from simcore_service_payments.services.resource_usage_tracker import (
     ResourceUsageTrackerApi,
@@ -86,12 +87,15 @@ async def test_fails_to_pay_with_payment_method_without_funds(
 
     rut = ResourceUsageTrackerApi.get_from_app_state(app)
     rut_create_credit_transaction = mocker.spy(rut, "create_credit_transaction")
+    notifier = NotifierService.get_from_app_state(app)
 
     payment = await payments.pay_with_payment_method(
         gateway=PaymentsGatewayApi.get_from_app_state(app),
         rut=rut,
         repo_transactions=PaymentsTransactionsRepo(db_engine=app.state.engine),
         repo_methods=PaymentsMethodsRepo(db_engine=app.state.engine),
+        notifier=notifier,
+        #
         payment_method_id=payment_method_without_funds.payment_method_id,
         amount_dollars=100,
         target_credits=100,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?

This PR sends also send an email to the user for a succesful payment using a saved payment method (e.g. when auto-recharge mechanism is enabled). 


### Highlights
   - `NotifierService` uses  fire&forget to notify
   - `pay_with_payment_method` incorporates `notifier` but excludes websocket notifications
   - email notifications currently upon success payment only (not websockets notify also failures)

## Related issue/s

- Follows up from https://github.com/ITISFoundation/osparc-simcore/pull/5310
- All emails notifications in payments for #5227


## How to test
- Tested in master by payment w/ payment-method
- Tested in master by payment with auto-recharge
- Driving tests `test_services_payments`

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist

None
