### PR TITLE
🐛Webserver: exclusive/non-exclusive RabbitMQ consumers are deleting each other, and also probably replacing each other

### DIFF
--- a/services/web/server/src/simcore_service_webserver/notifications/_constants.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_constants.py
@@ -1,3 +1,0 @@
-from typing import Final
-
-APP_RABBITMQ_CONSUMERS_KEY: Final[str] = f"{__name__}.rabbit_consumers"

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
@@ -32,10 +32,11 @@ from ..socketio.messages import (
     send_message_to_user,
 )
 from ..wallets import api as wallets_api
-from ._constants import APP_RABBITMQ_CONSUMERS_KEY
 from ._rabbitmq_consumers_common import SubcribeArgumentsTuple, subscribe_to_rabbitmq
 
 _logger = logging.getLogger(__name__)
+
+_APP_RABBITMQ_CONSUMERS_KEY: Final[str] = f"{__name__}.rabbit_consumers"
 
 
 def _convert_to_project_progress_event(
@@ -204,7 +205,7 @@ async def _unsubscribe_from_rabbitmq(app) -> None:
         await logged_gather(
             *(
                 rabbit_client.unsubscribe(queue_name)
-                for queue_name in app[APP_RABBITMQ_CONSUMERS_KEY].values()
+                for queue_name in app[_APP_RABBITMQ_CONSUMERS_KEY].values()
             ),
         )
 
@@ -212,7 +213,7 @@ async def _unsubscribe_from_rabbitmq(app) -> None:
 async def on_cleanup_ctx_rabbitmq_consumers(
     app: web.Application,
 ) -> AsyncIterator[None]:
-    app[APP_RABBITMQ_CONSUMERS_KEY] = await subscribe_to_rabbitmq(
+    app[_APP_RABBITMQ_CONSUMERS_KEY] = await subscribe_to_rabbitmq(
         app, _EXCHANGE_TO_PARSER_CONFIG
     )
     yield

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_nonexclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_nonexclusive_queue_consumers.py
@@ -15,10 +15,11 @@ from servicelib.rabbitmq import RabbitMQClient
 from servicelib.utils import logged_gather
 
 from ..rabbitmq import get_rabbitmq_client
-from ._constants import APP_RABBITMQ_CONSUMERS_KEY
 from ._rabbitmq_consumers_common import SubcribeArgumentsTuple, subscribe_to_rabbitmq
 
 _logger = logging.getLogger(__name__)
+
+_APP_RABBITMQ_CONSUMERS_KEY: Final[str] = f"{__name__}.rabbit_consumers"
 
 
 async def _instrumentation_message_parser(app: web.Application, data: bytes) -> bool:
@@ -59,7 +60,7 @@ async def _unsubscribe_from_rabbitmq(app) -> None:
         await logged_gather(
             *(
                 rabbit_client.unsubscribe_consumer(queue_name)
-                for queue_name in app[APP_RABBITMQ_CONSUMERS_KEY].values()
+                for queue_name in app[_APP_RABBITMQ_CONSUMERS_KEY].values()
             ),
         )
 
@@ -67,7 +68,7 @@ async def _unsubscribe_from_rabbitmq(app) -> None:
 async def on_cleanup_ctx_rabbitmq_consumers(
     app: web.Application,
 ) -> AsyncIterator[None]:
-    app[APP_RABBITMQ_CONSUMERS_KEY] = await subscribe_to_rabbitmq(
+    app[_APP_RABBITMQ_CONSUMERS_KEY] = await subscribe_to_rabbitmq(
         app, _EXCHANGE_TO_PARSER_CONFIG
     )
     yield

--- a/services/web/server/src/simcore_service_webserver/projects/_observer.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_observer.py
@@ -12,6 +12,7 @@ from servicelib.aiohttp.observer import (
     register_observer,
     setup_observer_registry,
 )
+from servicelib.logging_utils import log_context
 from servicelib.utils import logged_gather
 
 from ..notifications import project_logs
@@ -35,9 +36,14 @@ async def _on_user_disconnected(
 
     assert len(projects) <= 1, "At the moment, at most one project per session"  # nosec
 
-    await logged_gather(
-        *[project_logs.unsubscribe(app, ProjectID(prj)) for prj in projects]
-    )
+    with log_context(
+        _logger,
+        logging.DEBUG,
+        msg=f"user disconnects and unsubscribes from following {projects=}",
+    ):
+        await logged_gather(
+            *[project_logs.unsubscribe(app, ProjectID(prj)) for prj in projects]
+        )
 
     await logged_gather(
         *[


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)


or from https://gitmoji.dev/
-->

## What do these changes do?
After some Graylog analysis it came up that the following issue callback would happen quite often. It was found that both _rabbitmq_nonexclusive_queue_consumers and _rabbitmq_exclusive_queue_consumers were using the same ```app[APP_RABBITMQ_CONSUMERS_KEY]``` to store their respective consumers. E.G. on initialization the last one would replace the first one, and on deletion as well, thus the errors shown in Graylog. Not sure if this could also have some influence on the lost logs issues.

Another issue was also identified when a user is logging out (also visible in e2e tests), and for this an additional log output was added.

```bash
Unhandled exception:
Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.10/site-packages/aiormq/channel.py", line 182, in rpc
    result = await countdown(self.rpc_frames.get())
  File "/home/scu/.venv/lib/python3.10/site-packages/aiormq/tools.py", line 95, in __call__
    return await coro
  File "/usr/local/lib/python3.10/asyncio/queues.py", line 159, in get
    await getter
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.10/site-packages/aiormq/abc.py", line 44, in __inner
    return await self.task
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/scu/.venv/lib/python3.10/site-packages/servicelib/logging_utils.py", line 232, in log_catch
    yield
  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py", line 204, in _unsubscribe_from_rabbitmq
    await logged_gather(
  File "/home/scu/.venv/lib/python3.10/site-packages/servicelib/utils.py", line 141, in logged_gather
    raise error
  File "/home/scu/.venv/lib/python3.10/site-packages/servicelib/rabbitmq/_client.py", line 298, in unsubscribe
    queue = await channel.get_queue(queue_name)
  File "/home/scu/.venv/lib/python3.10/site-packages/aio_pika/channel.py", line 375, in get_queue
    return await self.declare_queue(name=name, passive=True)
  File "/home/scu/.venv/lib/python3.10/site-packages/aio_pika/robust_channel.py", line 233, in declare_queue
    queue: RobustQueue = await super().declare_queue(   # type: ignore
  File "/home/scu/.venv/lib/python3.10/site-packages/aio_pika/channel.py", line 350, in declare_queue
    await queue.declare(timeout=timeout)
  File "/home/scu/.venv/lib/python3.10/site-packages/aio_pika/queue.py", line 86, in declare
    self.declaration_result = await channel.queue_declare(
  File "/home/scu/.venv/lib/python3.10/site-packages/aiormq/channel.py", line 858, in queue_declare
    return await self.rpc(
  File "/home/scu/.venv/lib/python3.10/site-packages/aiormq/base.py", line 164, in wrap
    return await self.create_task(func(self, *args, **kwargs))
  File "/home/scu/.venv/lib/python3.10/site-packages/aiormq/abc.py", line 46, in __inner
    raise self._exception from e
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 650, in _wrap_awaitable
    return (yield from awaitable.__await__())
  File "/home/scu/.venv/lib/python3.10/site-packages/aiormq/abc.py", line 46, in __inner
    raise self._exception from e
  File "/home/scu/.venv/lib/python3.10/site-packages/aiormq/channel.py", line 441, in _reader
    await hook(frame)
  File "/home/scu/.venv/lib/python3.10/site-packages/aiormq/channel.py", line 410, in _on_close_frame
    raise exc
aiormq.exceptions.ChannelNotFoundEntity: NOT_FOUND - no queue 'simcore.services.instrumentation' in vhost '/'
```


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
