### PR TITLE
  🐛 Fix bug that throws error when capturing api responses in dev mode

### DIFF
--- a/services/api-server/src/simcore_service_api_server/core/settings.py
+++ b/services/api-server/src/simcore_service_api_server/core/settings.py
@@ -1,6 +1,7 @@
+from collections.abc import Mapping
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 from models_library.basic_types import BootModeEnum, LogLevel
 from pydantic import Field, NonNegativeInt, SecretStr, parse_obj_as
@@ -161,11 +162,12 @@ class ApplicationSettings(BasicSettings):
             if (
                 values
                 and (boot_mode := values.get("SC_BOOT_MODE"))
-                and boot_mode.is_devel_mode()
+                and not boot_mode.is_devel_mode()
             ):
-                raise ValueError(
+                error_message = (
                     "API_SERVER_DEV_HTTP_CALLS_LOGS_PATH only allowed in devel mode"
                 )
+                raise ValueError(error_message)
 
         return v
 


### PR DESCRIPTION
## What do these changes do?

It fixes a bug that only affects the api server capture mode. It was supposed to only work in dev mode, but the code actually only threw an exception about that 'in debug mode'

## Related issue/s

## How to test

Enable api server capture mode, run osparc in dev mode, api server should start without crashing

## Dev Checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

## DevOps Checklist
<!--

Some checks that might help your code run stable on production, and help devops assess criticality.

Modified from https://oschvr.com/posts/what-id-like-as-sre/


- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
