### PR TITLE
🐛Autoscaling: Ensure buffer machine type remains the same over the app session

### DIFF
--- a/scripts/maintenance/computational-clusters/osparc_clusters.py
+++ b/scripts/maintenance/computational-clusters/osparc_clusters.py
@@ -533,7 +533,7 @@ def _dask_list_tasks(dask_client: distributed.Client) -> dict[TaskState, list[Ta
             if task.state in task_state_to_tasks:
                 task_state_to_tasks[task.state].append(task.key)
             else:
-                task_state_to_tasks[task.state] = task.key
+                task_state_to_tasks[task.state] = [task.key]
 
         return dict(task_state_to_tasks)
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -55,10 +55,18 @@ def _node_not_ready(node: Node) -> bool:
     return bool(node.Status.State != NodeState.ready)
 
 
+def _get_machine_buffer_type(
+    available_ec2_types: list[EC2InstanceType],
+) -> EC2InstanceType:
+    assert len(available_ec2_types) > 0  # nosec
+    return available_ec2_types[0]
+
+
 def _sort_drained_nodes(
     app_settings: ApplicationSettings,
     all_drained_nodes: list[AssociatedInstance],
 ) -> tuple[list[AssociatedInstance], list[AssociatedInstance]]:
+    assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
     return (
         all_drained_nodes[
             app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER :
@@ -508,7 +516,7 @@ async def _find_needed_instances(
             app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
             - len(cluster.reserve_drained_nodes)
         ):
-            default_instance_type = available_ec2_types[0]
+            default_instance_type = _get_machine_buffer_type(available_ec2_types)
             num_instances_per_type[default_instance_type] += num_missing_nodes
 
     return num_instances_per_type

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -99,15 +99,14 @@ async def _analyze_current_cluster(
         else:
             pending_nodes.append(instance)
 
+    desired_number_buffer_machines = (
+        app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
+    )
     cluster = Cluster(
         active_nodes=active_nodes,
         pending_nodes=pending_nodes,
-        drained_nodes=all_drained_nodes[
-            app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER :
-        ],
-        reserve_drained_nodes=all_drained_nodes[
-            : app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
-        ],
+        drained_nodes=all_drained_nodes[desired_number_buffer_machines:],
+        reserve_drained_nodes=all_drained_nodes[:desired_number_buffer_machines],
         pending_ec2s=[NonAssociatedInstance(ec2_instance=i) for i in pending_ec2s],
         terminated_instances=terminated_ec2_instances,
         disconnected_nodes=[n for n in docker_nodes if _node_not_ready(n)],
@@ -189,14 +188,13 @@ async def _try_attach_pending_ec2s(
     all_drained_nodes = (
         cluster.drained_nodes + cluster.reserve_drained_nodes + new_found_instances
     )
+    desired_number_buffer_machines = (
+        app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
+    )
     return dataclasses.replace(
         cluster,
-        drained_nodes=all_drained_nodes[
-            app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER :
-        ],
-        reserve_drained_nodes=all_drained_nodes[
-            : app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
-        ],
+        drained_nodes=all_drained_nodes[desired_number_buffer_machines:],
+        reserve_drained_nodes=all_drained_nodes[:desired_number_buffer_machines],
         pending_ec2s=still_pending_ec2s,
     )
 

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
@@ -148,3 +148,34 @@ def find_selected_instance_type_for_task(
         raise Ec2InstanceInvalidError(msg=msg)
 
     return selected_instance
+
+
+def get_machine_buffer_type(
+    available_ec2_types: list[EC2InstanceType],
+) -> EC2InstanceType:
+    return available_ec2_types[0]
+
+
+DRAINED_NODES = list[AssociatedInstance]
+BUFFER_DRAINED_NODES = list[AssociatedInstance]
+
+
+def sort_drained_nodes(
+    app_settings: ApplicationSettings,
+    all_drained_nodes: list[AssociatedInstance],
+    available_ec2_types: list[EC2InstanceType],
+) -> tuple[DRAINED_NODES, BUFFER_DRAINED_NODES]:
+    assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
+    # we need to keep in reserve only the drained nodes of the right type
+    machine_buffer_type = get_machine_buffer_type(available_ec2_types)
+    # NOTE: we keep only in buffer the drained nodes with the right EC2 type
+    buffer_drained_nodes = [
+        node
+        for node in all_drained_nodes
+        if node.ec2_instance.type == machine_buffer_type.name
+    ][: app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER]
+    # all the others are "normal" drained nodes and may be terminated at some point
+    other_drained_nodes = [
+        node for node in all_drained_nodes if node not in buffer_drained_nodes
+    ]
+    return (other_drained_nodes, buffer_drained_nodes)

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
@@ -169,7 +169,7 @@ def sort_drained_nodes(
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
     # we need to keep in reserve only the drained nodes of the right type
     machine_buffer_type = get_machine_buffer_type(available_ec2_types)
-    # NOTE: we keep only in buffer the drained nodes with the right EC2 type
+    # NOTE: we keep only in buffer the drained nodes with the right EC2 type, AND the right amount
     buffer_drained_nodes = [
         node
         for node in all_drained_nodes

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
@@ -153,18 +153,19 @@ def find_selected_instance_type_for_task(
 def get_machine_buffer_type(
     available_ec2_types: list[EC2InstanceType],
 ) -> EC2InstanceType:
+    assert len(available_ec2_types) > 0  # nosec
     return available_ec2_types[0]
 
 
-DRAINED_NODES = list[AssociatedInstance]
-BUFFER_DRAINED_NODES = list[AssociatedInstance]
+DrainedNodes = list[AssociatedInstance]
+BufferDrainedNodes = list[AssociatedInstance]
 
 
 def sort_drained_nodes(
     app_settings: ApplicationSettings,
     all_drained_nodes: list[AssociatedInstance],
     available_ec2_types: list[EC2InstanceType],
-) -> tuple[DRAINED_NODES, BUFFER_DRAINED_NODES]:
+) -> tuple[DrainedNodes, BufferDrainedNodes]:
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
     # we need to keep in reserve only the drained nodes of the right type
     machine_buffer_type = get_machine_buffer_type(available_ec2_types)

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -21,7 +21,12 @@ import psutil
 import pytest
 import simcore_service_autoscaling
 from asgi_lifespan import LifespanManager
-from aws_library.ec2.models import EC2InstanceBootSpecific, EC2InstanceData
+from aws_library.ec2.models import (
+    EC2InstanceBootSpecific,
+    EC2InstanceData,
+    EC2InstanceType,
+    Resources,
+)
 from deepdiff import DeepDiff
 from faker import Faker
 from fakeredis.aioredis import FakeRedis
@@ -49,7 +54,11 @@ from simcore_service_autoscaling.core.settings import (
     ApplicationSettings,
     EC2Settings,
 )
-from simcore_service_autoscaling.models import Cluster, DaskTaskResources
+from simcore_service_autoscaling.models import (
+    AssociatedInstance,
+    Cluster,
+    DaskTaskResources,
+)
 from simcore_service_autoscaling.modules.docker import AutoscalingDocker
 from simcore_service_autoscaling.modules.ec2 import SimcoreEC2API
 from simcore_service_autoscaling.utils.utils_docker import (
@@ -767,3 +776,65 @@ def patch_ec2_client_start_aws_instances_min_number_of_instances(
         autospec=True,
         side_effect=_change_parameters,
     )
+
+
+@pytest.fixture
+def random_fake_available_instances(faker: Faker) -> list[EC2InstanceType]:
+    list_of_instances = [
+        EC2InstanceType(
+            name=faker.pystr(),
+            resources=Resources(cpus=n, ram=ByteSize(n)),
+        )
+        for n in range(1, 30)
+    ]
+    random.shuffle(list_of_instances)
+    return list_of_instances
+
+
+@pytest.fixture
+def create_associated_instance(
+    fake_ec2_instance_data: Callable[..., EC2InstanceData],
+    app_settings: ApplicationSettings,
+    faker: Faker,
+    host_cpu_count: int,
+    host_memory_total: ByteSize,
+) -> Callable[[DockerNode, bool, dict[str, Any]], AssociatedInstance]:
+    def _creator(
+        node: DockerNode,
+        terminateable_time: bool,
+        fake_ec2_instance_data_override: dict[str, Any],
+    ) -> AssociatedInstance:
+        assert app_settings.AUTOSCALING_EC2_INSTANCES
+        assert (
+            datetime.timedelta(seconds=10)
+            < app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
+        ), "this tests relies on the fact that the time before termination is above 10 seconds"
+        assert app_settings.AUTOSCALING_EC2_INSTANCES
+        seconds_delta = (
+            -datetime.timedelta(seconds=10)
+            if terminateable_time
+            else datetime.timedelta(seconds=10)
+        )
+        return AssociatedInstance(
+            node=node,
+            ec2_instance=fake_ec2_instance_data(
+                launch_time=datetime.datetime.now(datetime.timezone.utc)
+                - app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
+                - datetime.timedelta(
+                    days=faker.pyint(min_value=0, max_value=100),
+                    hours=faker.pyint(min_value=0, max_value=100),
+                )
+                + seconds_delta,
+                resources=Resources(cpus=host_cpu_count, ram=host_memory_total),
+                **fake_ec2_instance_data_override,
+            ),
+        )
+
+    return _creator
+
+
+@pytest.fixture
+def mock_machines_buffer(monkeypatch: pytest.MonkeyPatch) -> int:
+    num_machines_in_buffer = 5
+    monkeypatch.setenv("EC2_INSTANCES_MACHINES_BUFFER", f"{num_machines_in_buffer}")
+    return num_machines_in_buffer

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -802,7 +802,7 @@ def create_associated_instance(
     def _creator(
         node: DockerNode,
         terminateable_time: bool,
-        fake_ec2_instance_data_override: dict[str, Any],
+        fake_ec2_instance_data_override: dict[str, Any] | None = None,
     ) -> AssociatedInstance:
         assert app_settings.AUTOSCALING_EC2_INSTANCES
         assert (
@@ -815,6 +815,10 @@ def create_associated_instance(
             if terminateable_time
             else datetime.timedelta(seconds=10)
         )
+
+        if fake_ec2_instance_data_override is None:
+            fake_ec2_instance_data_override = {}
+
         return AssociatedInstance(
             node=node,
             ec2_instance=fake_ec2_instance_data(

--- a/services/autoscaling/tests/unit/test_utils_auto_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_utils_auto_scaling_core.py
@@ -8,21 +8,26 @@ import datetime
 import json
 import re
 from collections.abc import Callable
+from random import choice, shuffle
 
 import pytest
+from aws_library.ec2.models import EC2InstanceType
 from faker import Faker
 from models_library.docker import DockerGenericTag
 from models_library.generated_models.docker_rest_api import Node
+from models_library.generated_models.docker_rest_api import Node as DockerNode
 from pydantic import parse_obj_as
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict
 from simcore_service_autoscaling.core.errors import Ec2InvalidDnsNameError
 from simcore_service_autoscaling.core.settings import ApplicationSettings
-from simcore_service_autoscaling.models import EC2InstanceData
+from simcore_service_autoscaling.models import AssociatedInstance, EC2InstanceData
 from simcore_service_autoscaling.utils.auto_scaling_core import (
     associate_ec2_instances_with_nodes,
     ec2_startup_script,
+    get_machine_buffer_type,
     node_host_name_from_ec2_private_dns,
+    sort_drained_nodes,
 )
 
 
@@ -80,9 +85,11 @@ async def test_associate_ec2_instances_with_nodes_with_no_correspondence(
 ):
     nodes = [node() for _ in range(10)]
     ec2_instances = [
-        fake_ec2_instance_data(aws_private_dns=f"ip-10-12-32-{n+1}.internal-data")
-        if valid_ec2_dns
-        else fake_ec2_instance_data()
+        (
+            fake_ec2_instance_data(aws_private_dns=f"ip-10-12-32-{n+1}.internal-data")
+            if valid_ec2_dns
+            else fake_ec2_instance_data()
+        )
         for n in range(10)
     ]
 
@@ -288,4 +295,83 @@ async def test_ec2_startup_script_with_pre_pulling_but_no_registry(
     assert len(startup_script.split("&&")) == 1
     assert re.fullmatch(
         r"^docker swarm join --availability=drain --token .*$", startup_script
+    )
+
+
+def test_get_machine_buffer_type(
+    random_fake_available_instances: list[EC2InstanceType],
+):
+    assert (
+        get_machine_buffer_type(random_fake_available_instances)
+        == random_fake_available_instances[0]
+    )
+
+
+def test_sort_empty_drained_nodes(
+    minimal_configuration: None,
+    app_settings: ApplicationSettings,
+    random_fake_available_instances: list[EC2InstanceType],
+):
+    assert sort_drained_nodes(app_settings, [], random_fake_available_instances) == (
+        [],
+        [],
+    )
+
+
+def test_sort_drained_nodes(
+    mock_machines_buffer: int,
+    minimal_configuration: None,
+    app_settings: ApplicationSettings,
+    random_fake_available_instances: list[EC2InstanceType],
+    create_fake_node: Callable[..., DockerNode],
+    create_associated_instance: Callable[..., AssociatedInstance],
+):
+    machine_buffer_type = get_machine_buffer_type(random_fake_available_instances)
+    _NUM_DRAINED_NODES = 20
+    _NUM_NODE_WITH_TYPE_BUFFER = 3 * mock_machines_buffer
+    fake_drained_nodes = []
+    for _ in range(_NUM_DRAINED_NODES):
+        fake_node = create_fake_node()
+        fake_associated_instance = create_associated_instance(
+            fake_node,
+            terminateable_time=False,
+            fake_ec2_instance_data_override={
+                "type": choice(  # noqa: S311
+                    [
+                        i
+                        for i in random_fake_available_instances
+                        if i != machine_buffer_type
+                    ]
+                ).name
+            },
+        )
+        fake_drained_nodes.append(fake_associated_instance)
+
+    for _ in range(_NUM_NODE_WITH_TYPE_BUFFER):
+        fake_node = create_fake_node()
+        fake_associated_instance = create_associated_instance(
+            fake_node,
+            terminateable_time=False,
+            fake_ec2_instance_data_override={"type": machine_buffer_type.name},
+        )
+        fake_drained_nodes.append(fake_associated_instance)
+    shuffle(fake_drained_nodes)
+
+    assert len(fake_drained_nodes) == _NUM_DRAINED_NODES + _NUM_NODE_WITH_TYPE_BUFFER
+    sorted_drained_nodes, sorted_buffer_drained_nodes = sort_drained_nodes(
+        app_settings, fake_drained_nodes, random_fake_available_instances
+    )
+    assert app_settings.AUTOSCALING_EC2_INSTANCES
+    assert (
+        mock_machines_buffer
+        == app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
+    )
+    assert (
+        len(sorted_drained_nodes)
+        == len(fake_drained_nodes)
+        - app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
+    )
+    assert (
+        len(sorted_buffer_drained_nodes)
+        == app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
     )

--- a/services/autoscaling/tests/unit/test_utils_auto_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_utils_auto_scaling_core.py
@@ -14,7 +14,6 @@ import pytest
 from aws_library.ec2.models import EC2InstanceType
 from faker import Faker
 from models_library.docker import DockerGenericTag
-from models_library.generated_models.docker_rest_api import Node
 from models_library.generated_models.docker_rest_api import Node as DockerNode
 from pydantic import parse_obj_as
 from pytest_simcore.helpers.typing_env import EnvVarsDict
@@ -32,9 +31,9 @@ from simcore_service_autoscaling.utils.auto_scaling_core import (
 
 
 @pytest.fixture
-def node(faker: Faker) -> Callable[..., Node]:
-    def _creator(**overrides) -> Node:
-        return Node(
+def node(faker: Faker) -> Callable[..., DockerNode]:
+    def _creator(**overrides) -> DockerNode:
+        return DockerNode(
             **(
                 {
                     "ID": faker.uuid4(),
@@ -80,7 +79,7 @@ def test_node_host_name_from_ec2_private_dns_raises_with_invalid_name(
 @pytest.mark.parametrize("valid_ec2_dns", [True, False])
 async def test_associate_ec2_instances_with_nodes_with_no_correspondence(
     fake_ec2_instance_data: Callable[..., EC2InstanceData],
-    node: Callable[..., Node],
+    node: Callable[..., DockerNode],
     valid_ec2_dns: bool,
 ):
     nodes = [node() for _ in range(10)]
@@ -105,7 +104,7 @@ async def test_associate_ec2_instances_with_nodes_with_no_correspondence(
 
 async def test_associate_ec2_instances_with_corresponding_nodes(
     fake_ec2_instance_data: Callable[..., EC2InstanceData],
-    node: Callable[..., Node],
+    node: Callable[..., DockerNode],
 ):
     nodes = []
     ec2_instances = []

--- a/services/autoscaling/tests/unit/test_utils_ec2.py
+++ b/services/autoscaling/tests/unit/test_utils_ec2.py
@@ -3,8 +3,6 @@
 # pylint: disable=unused-variable
 
 
-import random
-
 import pytest
 from aws_library.ec2.models import EC2InstanceType, Resources
 from faker import Faker
@@ -27,19 +25,6 @@ async def test_find_best_fitting_ec2_instance_with_no_instances_raises():
             allowed_ec2_instances=[],
             resources=Resources(cpus=0, ram=ByteSize(0)),
         )
-
-
-@pytest.fixture
-def random_fake_available_instances(faker: Faker) -> list[EC2InstanceType]:
-    list_of_instances = [
-        EC2InstanceType(
-            name=faker.pystr(),
-            resources=Resources(cpus=n, ram=ByteSize(n)),
-        )
-        for n in range(1, 30)
-    ]
-    random.shuffle(list_of_instances)
-    return list_of_instances
 
 
 async def test_find_best_fitting_ec2_instance_closest_instance_policy_with_resource_0_raises(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR fixes the issue where a different machine type could replace the intended buffer machine type.
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/5453
@mguidon this should allow setting multiple machine types, and still keeping the correct type of buffer machines (iSeg use-case)
## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
