### PR TITLE
🐛 Fix: drops phone check

### DIFF
--- a/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
@@ -348,7 +348,6 @@ async def register_phone(request: web.Request):
     settings: LoginSettingsForProduct = get_plugin_settings(
         request.app, product_name=product.name
     )
-    db: AsyncpgStorage = get_plugin_storage(request.app)
 
     if not settings.LOGIN_2FA_REQUIRED:
         raise web.HTTPServiceUnavailable(
@@ -379,10 +378,6 @@ async def register_phone(request: web.Request):
             first_name=get_user_name_from_email(registration.email),
         )
 
-        message = MSG_2FA_CODE_SENT.format(
-            phone_number=mask_phone_number(registration.phone)
-        )
-
         return envelope_response(
             # RegisterPhoneNextPage
             data={
@@ -390,7 +385,9 @@ async def register_phone(request: web.Request):
                 "parameters": {
                     "retry_2fa_after": settings.LOGIN_2FA_CODE_EXPIRATION_SEC,
                 },
-                "message": message,
+                "message": MSG_2FA_CODE_SENT.format(
+                    phone_number=mask_phone_number(registration.phone)
+                ),
                 "level": "INFO",
                 "logger": "user",
             },

--- a/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
+++ b/services/web/server/src/simcore_service_webserver/login/handlers_registration.py
@@ -365,12 +365,6 @@ async def register_phone(request: web.Request):
             msg = f"Messaging SID is not configured in {product}. Update product's twilio_messaging_sid in database."
             raise ValueError(msg)
 
-        if await db.get_user({"phone": registration.phone}):
-            raise web.HTTPUnauthorized(  # noqa: TRY301
-                reason="Cannot register this phone number because it is already assigned to an active user",
-                content_type=MIMETYPE_APPLICATION_JSON,
-            )
-
         code = await create_2fa_code(
             app=request.app,
             user_email=registration.email,

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_2fa.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_2fa.py
@@ -243,7 +243,7 @@ async def test_workflow_register_and_login_with_2fa(
     assert user["status"] == UserStatus.ACTIVE.value
 
 
-async def test_register_phone_allows_with_used_number(
+async def test_can_register_same_phone_in_different_accounts(
     client: TestClient,
     fake_user_email: str,
     fake_user_password: str,
@@ -252,9 +252,8 @@ async def test_register_phone_allows_with_used_number(
     cleanup_db_tables: None,
 ):
     """
-    Changed policy about reusing phone https://github.com/ITISFoundation/osparc-simcore/pull/5460
-    Tests https://github.com/ITISFoundation/osparc-simcore/issues/3304
-
+    - Changed policy about user phone constraint in  https://github.com/ITISFoundation/osparc-simcore/pull/5460
+    - Tests https://github.com/ITISFoundation/osparc-simcore/issues/3304
     """
     assert client.app
 

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_2fa.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_2fa.py
@@ -28,7 +28,10 @@ from simcore_service_webserver.login._2fa import (
     get_redis_validation_code_client,
     send_email_code,
 )
-from simcore_service_webserver.login._constants import MSG_2FA_UNAVAILABLE_OEC
+from simcore_service_webserver.login._constants import (
+    CODE_2FA_CODE_REQUIRED,
+    MSG_2FA_UNAVAILABLE_OEC,
+)
 from simcore_service_webserver.login.storage import AsyncpgStorage
 from simcore_service_webserver.products.api import Product, get_current_product
 from twilio.base.exceptions import TwilioRestException
@@ -296,6 +299,7 @@ async def test_register_phone_allows_with_used_number(
         data, error = await assert_status(response, status.HTTP_202_ACCEPTED)
         assert data
         assert "Code" in data["message"]
+        assert data["name"] == CODE_2FA_CODE_REQUIRED
         assert not error
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Removes check on existing phone number

## Related issue/s

- Follows up with https://github.com/ITISFoundation/osparc-simcore/pull/5460

## How to test

Driving test
```
cd services/web/server
make install-dev
pytest -vv tests/unit/with_db -k test_can_register_same_phone_in_different_accounts
```

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))
