### PR TITLE
🐛 Fixes error upon registration of pending email confirmation

### DIFF
--- a/packages/postgres-database/src/simcore_postgres_database/errors.py
+++ b/packages/postgres-database/src/simcore_postgres_database/errors.py
@@ -32,22 +32,12 @@ from psycopg2 import (
 from psycopg2.errors import (
     CheckViolation,
     ForeignKeyViolation,
+    InvalidTextRepresentation,
     NotNullViolation,
     UniqueViolation,
 )
 
 assert issubclass(UniqueViolation, IntegrityError)  # nosec
-
-# TODO: see https://stackoverflow.com/questions/58740043/how-do-i-catch-a-psycopg2-errors-uniqueviolation-error-in-a-python-flask-app
-# from sqlalchemy.exc import IntegrityError
-#
-# from psycopg2.errors import UniqueViolation
-#
-#    try:
-#        s.commit()
-#   except IntegrityError as e:
-#        assert isinstance(e.orig, UniqueViolation)
-
 
 __all__: tuple[str, ...] = (
     "CheckViolation",
@@ -58,6 +48,7 @@ __all__: tuple[str, ...] = (
     "IntegrityError",
     "InterfaceError",
     "InternalError",
+    "InvalidTextRepresentation",
     "NotNullViolation",
     "NotSupportedError",
     "OperationalError",

--- a/packages/postgres-database/src/simcore_postgres_database/models/users.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/users.py
@@ -51,15 +51,15 @@ class UserRole(Enum):
 
 
 class UserStatus(str, Enum):
-    # user registered but not confirmed
+    # This is a transition state. The user is registered but not confirmed. NOTE that state is optional depending on LOGIN_REGISTRATION_CONFIRMATION_REQUIRED
     CONFIRMATION_PENDING = "CONFIRMATION_PENDING"
-    # user is confirmed and can use the platform
+    # This user can now operate the platform
     ACTIVE = "ACTIVE"
-    # user is not authorized because it expired after a trial period
+    # This user is inactive because it expired after a trial period
     EXPIRED = "EXPIRED"
-    # user is not authorized
+    # This user is inactive because he has been a bad boy
     BANNED = "BANNED"
-    # this account is marked for deletion
+    # This user is inactive because it was marked for deletion
     DELETED = "DELETED"
 
 

--- a/packages/postgres-database/src/simcore_postgres_database/models/users.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/users.py
@@ -50,19 +50,16 @@ class UserRole(Enum):
         return NotImplemented
 
 
-class UserStatus(Enum):
-    """
-    pending: user registered but not confirmed
-    active: user is confirmed and can use the platform
-    expired: user is not authorized because it expired after a trial period
-    banned: user is not authorized
-    deleted: this account is marked for deletion
-    """
-
-    CONFIRMATION_PENDING = "PENDING"
+class UserStatus(str, Enum):
+    # user registered but not confirmed
+    CONFIRMATION_PENDING = "CONFIRMATION_PENDING"
+    # user is confirmed and can use the platform
     ACTIVE = "ACTIVE"
+    # user is not authorized because it expired after a trial period
     EXPIRED = "EXPIRED"
+    # user is not authorized
     BANNED = "BANNED"
+    # this account is marked for deletion
     DELETED = "DELETED"
 
 

--- a/packages/postgres-database/tests/conftest.py
+++ b/packages/postgres-database/tests/conftest.py
@@ -32,8 +32,8 @@ from simcore_postgres_database.webserver_models import (
 )
 
 pytest_plugins = [
-    "pytest_simcore.repository_paths",
     "pytest_simcore.pytest_global_environs",
+    "pytest_simcore.repository_paths",
 ]
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

If a user is `CONFIRMATION_PENDING` and tries to register, the webserver responds 500 because `UserStatus` constructor raises `ValuerError`
![image](https://github.com/ITISFoundation/osparc-simcore/assets/32402063/b1bfab6d-20a5-497a-a141-2c1a9ffe849a)

NOTE that the values stored in the database for `UserStatus.CONFIRMATION_PENDING` before this change were not "PENDING" but `CONFIRMATION_PENDING`. Therefore this change does not require a database migration script.

## Related issue/s

- Error while manual exploratory testing of registration of @NielsKuster 
- Better handling of 500 error messages in https://github.com/ITISFoundation/osparc-simcore/pull/5487

## How to test

```cmd
cd packages/postgres-database
pytest tests/test_users.py
```

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))
