### PR TITLE
🐛 Fix: increase credits limit in invitations to 1000

### DIFF
--- a/services/static-webserver/client/source/class/osparc/po/Invitations.js
+++ b/services/static-webserver/client/source/class/osparc/po/Invitations.js
@@ -101,7 +101,7 @@ qx.Class.define("osparc.po.Invitations", {
 
       const extraCreditsInUsd = new qx.ui.form.Spinner().set({
         minimum: 0,
-        maximum: 199,
+        maximum: 1000,
         value: 100
       });
       form.add(extraCreditsInUsd, this.tr("Welcome Credits (US$)"));


### PR DESCRIPTION
## What do these changes do?

Fix: increase credits limit in invitations to 1000

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
