### PR TITLE
🎨 UI/UX: Notifications bell tapping

### DIFF
--- a/services/static-webserver/client/source/class/osparc/notification/NotificationsButton.js
+++ b/services/static-webserver/client/source/class/osparc/notification/NotificationsButton.js
@@ -46,7 +46,7 @@ qx.Class.define("osparc.notification.NotificationsButton", {
 
   members: {
     __notificationsContainer: null,
-    __isNotificationsContainerVisible: null,
+    __tappedOut: null,
 
     _createChildControlImpl: function(id) {
       let control;
@@ -104,14 +104,18 @@ qx.Class.define("osparc.notification.NotificationsButton", {
     },
 
     __buttonTapped: function() {
-      this.__isNotificationsContainerVisible ? this.__hideNotifications() : this.__showNotifications();
+      if (this.__tappedOut) {
+        this.__tappedOut = false;
+        return;
+      }
+      this.__showNotifications();
     },
 
     __showNotifications: function() {
       const tapListener = event => {
-        const notificationsContainer = this.__notificationsContainer;
-        if (osparc.utils.Utils.isMouseOnElement(notificationsContainer, event)) {
-          return;
+        // If the user tapped on the bell we don't want to show it again
+        if (osparc.utils.Utils.isMouseOnElement(this, event)) {
+          this.__tappedOut = true;
         }
         this.__hideNotifications();
         document.removeEventListener("mousedown", tapListener, this);

--- a/services/static-webserver/client/source/class/osparc/notification/NotificationsButton.js
+++ b/services/static-webserver/client/source/class/osparc/notification/NotificationsButton.js
@@ -41,7 +41,7 @@ qx.Class.define("osparc.notification.NotificationsButton", {
     this.__notificationsContainer = new osparc.notification.NotificationsContainer();
     this.__notificationsContainer.exclude();
 
-    this.addListener("tap", () => this.__buttonTapped(), this);
+    this.addListener("tap", this.__buttonTapped, this);
   },
 
   members: {
@@ -104,21 +104,17 @@ qx.Class.define("osparc.notification.NotificationsButton", {
     },
 
     __buttonTapped: function() {
-      console.log("tapped on");
       this.__isNotificationsContainerVisible ? this.__hideNotifications() : this.__showNotifications();
     },
 
     __showNotifications: function() {
-      const that = this;
       const tapListener = event => {
         const notificationsContainer = this.__notificationsContainer;
         if (osparc.utils.Utils.isMouseOnElement(notificationsContainer, event)) {
           return;
         }
-        console.log("tapped out");
-        // eslint-disable-next-line no-underscore-dangle
-        that.__hideNotifications();
-        document.removeEventListener("mousedown", tapListener);
+        this.__hideNotifications();
+        document.removeEventListener("mousedown", tapListener, this);
       };
 
       const bounds = this.getBounds();
@@ -133,16 +129,12 @@ qx.Class.define("osparc.notification.NotificationsButton", {
       }
       this.__notificationsContainer.setPosition(bounds.left+bounds.width-2, bounds.top+bounds.height-2);
       this.__notificationsContainer.show();
-      console.log("show");
-      this.__isNotificationsContainerVisible = true;
 
-      document.addEventListener("mousedown", tapListener);
+      document.addEventListener("mousedown", tapListener, this);
     },
 
     __hideNotifications: function() {
       this.__notificationsContainer.exclude();
-      console.log("hide 1");
-      this.__isNotificationsContainerVisible = false;
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/notification/NotificationsButton.js
+++ b/services/static-webserver/client/source/class/osparc/notification/NotificationsButton.js
@@ -41,11 +41,12 @@ qx.Class.define("osparc.notification.NotificationsButton", {
     this.__notificationsContainer = new osparc.notification.NotificationsContainer();
     this.__notificationsContainer.exclude();
 
-    this.addListener("tap", () => this.__showNotifications(), this);
+    this.addListener("tap", () => this.__buttonTapped(), this);
   },
 
   members: {
     __notificationsContainer: null,
+    __isNotificationsContainerVisible: null,
 
     _createChildControlImpl: function(id) {
       let control;
@@ -102,6 +103,10 @@ qx.Class.define("osparc.notification.NotificationsButton", {
       });
     },
 
+    __buttonTapped: function() {
+      this.__isNotificationsContainerVisible ? this.__hideNotifications() : this.__showNotifications();
+    },
+
     __showNotifications: function() {
       const that = this;
       const tapListener = event => {
@@ -126,12 +131,14 @@ qx.Class.define("osparc.notification.NotificationsButton", {
       }
       this.__notificationsContainer.setPosition(bounds.left+bounds.width-2, bounds.top+bounds.height-2);
       this.__notificationsContainer.show();
+      this.__isNotificationsContainerVisible = true;
 
       document.addEventListener("mousedown", tapListener);
     },
 
     __hideNotifications: function() {
       this.__notificationsContainer.exclude();
+      this.__isNotificationsContainerVisible = false;
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/notification/NotificationsButton.js
+++ b/services/static-webserver/client/source/class/osparc/notification/NotificationsButton.js
@@ -113,6 +113,7 @@ qx.Class.define("osparc.notification.NotificationsButton", {
 
     __showNotifications: function() {
       const tapListener = event => {
+        // I somehow can't stop the propagation of the event so workaround:
         // If the user tapped on the bell we don't want to show it again
         if (osparc.utils.Utils.isMouseOnElement(this, event)) {
           this.__tappedOut = true;

--- a/services/static-webserver/client/source/class/osparc/notification/NotificationsButton.js
+++ b/services/static-webserver/client/source/class/osparc/notification/NotificationsButton.js
@@ -104,6 +104,7 @@ qx.Class.define("osparc.notification.NotificationsButton", {
     },
 
     __buttonTapped: function() {
+      console.log("tapped on");
       this.__isNotificationsContainerVisible ? this.__hideNotifications() : this.__showNotifications();
     },
 
@@ -114,6 +115,7 @@ qx.Class.define("osparc.notification.NotificationsButton", {
         if (osparc.utils.Utils.isMouseOnElement(notificationsContainer, event)) {
           return;
         }
+        console.log("tapped out");
         // eslint-disable-next-line no-underscore-dangle
         that.__hideNotifications();
         document.removeEventListener("mousedown", tapListener);
@@ -131,6 +133,7 @@ qx.Class.define("osparc.notification.NotificationsButton", {
       }
       this.__notificationsContainer.setPosition(bounds.left+bounds.width-2, bounds.top+bounds.height-2);
       this.__notificationsContainer.show();
+      console.log("show");
       this.__isNotificationsContainerVisible = true;
 
       document.addEventListener("mousedown", tapListener);
@@ -138,6 +141,7 @@ qx.Class.define("osparc.notification.NotificationsButton", {
 
     __hideNotifications: function() {
       this.__notificationsContainer.exclude();
+      console.log("hide 1");
       this.__isNotificationsContainerVisible = false;
     }
   }


### PR DESCRIPTION
## What do these changes do?

Tapping the notifications bell when the notifications are visible, hides them.

Before:
![TapBellBefore](https://github.com/ITISFoundation/osparc-simcore/assets/33152403/442c09ec-6f13-43b3-88f3-f172348950d8)

After:
![TapBell](https://github.com/ITISFoundation/osparc-simcore/assets/33152403/1ca9598d-5366-44d6-b8ad-f6272440410a)


## Related issue/s

related to https://z43.manuscript.com/f/cases/190690/New-feedback-Project-Shared-covers-task


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
