### PR TITLE
 ♻️ Remove a method to replace an empty dict with None in the Envelop model

### DIFF
--- a/packages/models-library/src/models_library/generics.py
+++ b/packages/models-library/src/models_library/generics.py
@@ -1,7 +1,6 @@
 from collections.abc import ItemsView, Iterable, Iterator, KeysView, ValuesView
 from typing import Any, Generic, TypeVar
 
-from pydantic import validator
 from pydantic.generics import GenericModel
 
 DictKey = TypeVar("DictKey")
@@ -65,10 +64,3 @@ class Envelope(GenericModel, Generic[DataT]):
     @classmethod
     def parse_data(cls, obj):
         return cls.parse_obj({"data": obj})
-
-    @validator("data", pre=True)
-    @classmethod
-    def empty_dict_is_none(cls, v):
-        if v == {}:
-            return None
-        return v


### PR DESCRIPTION
## What do these changes do?

When the Envelop model sees an empty dict, it returns a None instead. This can cause unintuitive behavior when e.g. a study has no inputs, and instead of return an empty dict, we get None back. 
Making this change doesn't seem to make tests fail. We might have to check if it has more important consequence, that's why for now this is a draft PR.

## Related issue/s


## How to test

Run all existing tests.

## Dev-ops checklist

- [ x ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))