### PR TITLE
♻️Move python version test to devenv dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,11 +85,6 @@ export DOCKER_IMAGE_TAG ?= latest
 export DOCKER_REGISTRY  ?= itisfoundation
 
 
-# Check Python version, throw error if compilation would fail with the installed version
-PYTHON_VERSION_TEST := $(shell python ./scripts/test_python_version.py 2>&1)
-ifneq ($(.SHELLSTATUS), 0)
-$(error "Python version test failed: ${PYTHON_VERSION_TEST}")
-endif
 
 get_my_ip := $(shell hostname --all-ip-addresses | cut --delimiter=" " --fields=1)
 
@@ -134,6 +129,8 @@ else
 	@awk --posix 'BEGIN {FS = ":.*?## "} /^[[:alpha:][:space:]_-]+:.*?## / {printf "%-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 endif
 
+test_python_version: ## Check Python version, throw error if compilation would fail with the installed version
+	python ./scripts/test_python_version.py
 
 
 ## DOCKER BUILD -------------------------------
@@ -481,7 +478,7 @@ push-version: tag-version
 		uv
 	@uv pip list
 
-devenv: .venv .vscode/settings.json .vscode/launch.json ## create a development environment (configs, virtual-env, hooks, ...)
+devenv: test_python_version .venv .vscode/settings.json .vscode/launch.json ## create a development environment (configs, virtual-env, hooks, ...)
 	@uv pip --quiet install -r requirements/devenv.txt
 	# Installing pre-commit hooks in current .git repo
 	@$</bin/pre-commit install

--- a/Makefile
+++ b/Makefile
@@ -478,7 +478,7 @@ push-version: tag-version
 		uv
 	@uv pip list
 
-devenv: test_python_version .venv .vscode/settings.json .vscode/launch.json ## create a development environment (configs, virtual-env, hooks, ...)
+devenv: .venv test_python_version .vscode/settings.json .vscode/launch.json ## create a development environment (configs, virtual-env, hooks, ...)
 	@uv pip --quiet install -r requirements/devenv.txt
 	# Installing pre-commit hooks in current .git repo
 	@$</bin/pre-commit install


### PR DESCRIPTION
## What do these changes do?

Since we don't want to enforce non-python developers on the same minimum python requirement, the python version test is moved to a dependency of devenv

## Related issue/s
https://github.com/ITISFoundation/osparc-simcore/pull/5504

## How to test

Run make devenv on system with old/correct python version, make devenv should fail/succeed respectively.

## Dev-ops checklist

- [ x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
