### PR TITLE
✨ PO Pre-registration UI Step

### DIFF
--- a/api/specs/web-server/_products.py
+++ b/api/specs/web-server/_products.py
@@ -41,6 +41,9 @@ async def get_current_product_price():
 @router.get(
     "/products/{product_name}",
     response_model=Envelope[GetProduct],
+    tags=[
+        "po",
+    ],
 )
 async def get_product(_params: Annotated[_ProductsRequestParams, Depends()]):
     ...
@@ -49,6 +52,9 @@ async def get_product(_params: Annotated[_ProductsRequestParams, Depends()]):
 @router.put(
     "/products/{product_name}/templates/{template_id}",
     status_code=status.HTTP_204_NO_CONTENT,
+    tags=[
+        "po",
+    ],
 )
 async def update_product_template(
     _params: Annotated[_ProductTemplateParams, Depends()], _body: UpdateProductTemplate
@@ -59,6 +65,9 @@ async def update_product_template(
 @router.post(
     "/invitation:generate",
     response_model=Envelope[InvitationGenerated],
+    tags=[
+        "po",
+    ],
 )
 async def generate_invitation(_body: GenerateInvitation):
     ...

--- a/api/specs/web-server/_users.py
+++ b/api/specs/web-server/_users.py
@@ -128,12 +128,24 @@ async def list_user_permissions():
     ...
 
 
-@router.get("/users:search", response_model=Envelope[list[UserProfile]])
+@router.get(
+    "/users:search",
+    response_model=Envelope[list[UserProfile]],
+    tags=[
+        "po",
+    ],
+)
 async def search_users(_params: Annotated[_SearchQueryParams, Depends()]):
     # NOTE: see `Search` in `Common Custom Methods` in https://cloud.google.com/apis/design/custom_methods
     ...
 
 
-@router.post("/users:pre-register", response_model=Envelope[UserProfile])
+@router.post(
+    "/users:pre-register",
+    response_model=Envelope[UserProfile],
+    tags=[
+        "po",
+    ],
+)
 async def pre_register_user(_body: PreUserProfile):
     ...

--- a/services/static-webserver/client/source/class/osparc/data/Permissions.js
+++ b/services/static-webserver/client/source/class/osparc/data/Permissions.js
@@ -142,7 +142,8 @@ qx.Class.define("osparc.data.Permissions", {
         ],
         "product_owner": [
           "user.invitation.generate",
-          "user.users.search"
+          "user.users.search",
+          "user.users.pre-register"
         ],
         "admin": []
       };

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -737,6 +737,10 @@ qx.Class.define("osparc.data.Resources", {
           search: {
             method: "GET",
             url: statics.API + "/users:search?email={email}"
+          },
+          preRegister: {
+            method: "POST",
+            url: statics.API + "/users:pre-register"
           }
         }
       },

--- a/services/static-webserver/client/source/class/osparc/po/POCenter.js
+++ b/services/static-webserver/client/source/class/osparc/po/POCenter.js
@@ -39,6 +39,9 @@ qx.Class.define("osparc.po.POCenter", {
     const usersPage = this.__getUsersPage();
     tabViews.add(usersPage);
 
+    const preRegistration = this.__getPreRegistrationPage();
+    tabViews.add(preRegistration);
+
     const invitationsPage = this.__getInvitationsPage();
     tabViews.add(invitationsPage);
 
@@ -64,6 +67,17 @@ qx.Class.define("osparc.po.POCenter", {
       return page;
     },
 
+    __getPreRegistrationPage: function() {
+      const title = this.tr("PreRegistration");
+      const iconSrc = "@FontAwesome5Solid/address-card/22";
+      const page = new osparc.desktop.preferences.pages.BasePage(title, iconSrc);
+      const preRegistration = new osparc.po.PreRegistration();
+      preRegistration.set({
+        margin: 10
+      });
+      page.add(preRegistration);
+      return page;
+    },
 
     __getInvitationsPage: function() {
       const title = this.tr("Invitations");

--- a/services/static-webserver/client/source/class/osparc/po/PreRegistration.js
+++ b/services/static-webserver/client/source/class/osparc/po/PreRegistration.js
@@ -64,12 +64,12 @@ qx.Class.define("osparc.po.PreRegistration", {
     },
 
     __searchPreRegistration: function() {
-      const _group_box = this.self().createGroupBox(this.tr("Pre-Registration"));
-      const _form = this.__preRegistrationForm();
-      const _formRenderer = new qx.ui.form.renderer.Single(_form);
-      _group_box.add(_formRenderer);
+      const groupBox = this.self().createGroupBox(this.tr("Pre-Registration"));
+      const form = this.__preRegistrationForm();
+      const formRenderer = new qx.ui.form.renderer.Single(form);
+      groupBox.add(formRenderer);
 
-      return _group_box;
+      return groupBox;
     },
 
     __preRegistrationForm: function() {
@@ -101,8 +101,8 @@ qx.Class.define("osparc.po.PreRegistration", {
           submitBtn.setFetching(true);
           osparc.data.Resources.fetch("users", "preRegister", params)
             .then(data => {
-              const _layout = this.__preRegistrationLayout = this.__createPreRegistrationLayout(data);
-              this._add(_layout);
+              const layout = this.__preRegistrationLayout = this.__createPreRegistrationLayout(data);
+              this._add(layout);
             })
             .catch(err => {
               console.error(err);

--- a/services/static-webserver/client/source/class/osparc/po/PreRegistration.js
+++ b/services/static-webserver/client/source/class/osparc/po/PreRegistration.js
@@ -74,10 +74,10 @@ qx.Class.define("osparc.po.PreRegistration", {
 
     __preRegistrationForm: function() {
       const form = new qx.ui.form.Form();
-      const requestAccountData = new qx.ui.form.TextAream().set({
+      const requestAccountData = new qx.ui.form.TextArea().set({
         required: true,
-        minHeight: 100,
-        placeholder: this.tr("Copy&paste the Request Account Form in JSON format here ...")
+        minHeight: 200,
+        placeholder: this.tr("Copy&Paste the Request Account Form in JSON format here ...")
       });
       form.add(requestAccountData, this.tr("Request Form"));
 
@@ -96,7 +96,7 @@ qx.Class.define("osparc.po.PreRegistration", {
           }
 
           const params = {
-            data: requestAccountData.getValue()
+            data: JSON.parse(requestAccountData.getValue())
           };
           submitBtn.setFetching(true);
           osparc.data.Resources.fetch("users", "preRegister", params)

--- a/services/static-webserver/client/source/class/osparc/po/PreRegistration.js
+++ b/services/static-webserver/client/source/class/osparc/po/PreRegistration.js
@@ -124,7 +124,7 @@ qx.Class.define("osparc.po.PreRegistration", {
       }));
       vBox.add(hBox);
 
-      const respLabel = new qx.ui.basic.Label(this.tr("Pre-Registration"));
+      const respLabel = new qx.ui.basic.Label(this.tr("Pre-Registered as:"));
       vBox.add(respLabel);
 
       const preregistrationRespViewer = new osparc.ui.basic.JsonTreeWidget(respData, "preregistration-data");

--- a/services/static-webserver/client/source/class/osparc/po/PreRegistration.js
+++ b/services/static-webserver/client/source/class/osparc/po/PreRegistration.js
@@ -1,0 +1,138 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2024 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Pedro Crespo-Valero (pcrespov)
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+qx.Class.define("osparc.po.PreRegistration", {
+  extend: qx.ui.core.Widget,
+
+  construct: function() {
+    this.base(arguments);
+
+    this._setLayout(new qx.ui.layout.VBox(10));
+
+    this.__buildLayout();
+  },
+
+  statics: {
+    createGroupBox: function(title) {
+      const box = new qx.ui.groupbox.GroupBox(title).set({
+        appearance: "settings-groupbox",
+        layout: new qx.ui.layout.VBox(5),
+        alignX: "center"
+      });
+      box.getChildControl("legend").set({
+        font: "text-14"
+      });
+      box.getChildControl("frame").set({
+        backgroundColor: "transparent"
+      });
+      return box;
+    },
+
+  },
+
+  members: {
+    __preRegistrationLayout: null,
+
+    _createChildControlImpl: function(id) {
+      let control;
+      switch (id) {
+        case "search-preregistration":
+          control = this.__searchPreRegistration();
+          this._add(control);
+          break;
+      }
+      return control || this.base(arguments, id);
+    },
+
+    __buildLayout: function() {
+      this._createChildControlImpl("search-preregistration");
+    },
+
+    __searchPreRegistration: function() {
+      const _group_box = this.self().createGroupBox(this.tr("Pre-Registration"));
+      const _form = this.__preRegistrationForm();
+      const _formRenderer = new qx.ui.form.renderer.Single(_form);
+      _group_box.add(_formRenderer);
+
+      return _group_box;
+    },
+
+    __preRegistrationForm: function() {
+      const form = new qx.ui.form.Form();
+      const requestAccountData = new qx.ui.form.TextAream().set({
+        required: true,
+        minHeight: 100,
+        placeholder: this.tr("Copy&paste the Request Account Form in JSON format here ...")
+      });
+      form.add(requestAccountData, this.tr("Request Form"));
+
+      const submitBtn = new osparc.ui.form.FetchButton(this.tr("Submit"));
+      submitBtn.set({
+        appearance: "form-button"
+      });
+
+      submitBtn.addListener("execute", () => {
+        if (!osparc.data.Permissions.getInstance().canDo("user.users.pre-register", true)) {
+          return;
+        }
+        if (form.validate()) {
+          if (this.__preRegistrationLayout) {
+            this._remove(this.__preRegistrationLayout);
+          }
+
+          const params = {
+            data: requestAccountData.getValue()
+          };
+          submitBtn.setFetching(true);
+          osparc.data.Resources.fetch("users", "preRegister", params)
+            .then(data => {
+              const _layout = this.__preRegistrationLayout = this.__createPreRegistrationLayout(data);
+              this._add(_layout);
+            })
+            .catch(err => {
+              console.error(err);
+              osparc.FlashMessenger.logAs(err.message, "ERROR");
+            })
+            .finally(() => submitBtn.setFetching(false));
+        }
+      }, this);
+      form.addButton(submitBtn);
+
+      return form;
+    },
+
+    __createPreRegistrationLayout: function(respData) {
+      const vBox = new qx.ui.container.Composite(new qx.ui.layout.VBox(2));
+
+      const hBox = new qx.ui.container.Composite(new qx.ui.layout.HBox(10).set({
+        alignY: "middle"
+      }));
+      vBox.add(hBox);
+
+      const respLabel = new qx.ui.basic.Label(this.tr("Pre-Registration"));
+      vBox.add(respLabel);
+
+      const preregistrationRespViewer = new osparc.ui.basic.JsonTreeWidget(respData, "preregistration-data");
+      const container = new qx.ui.container.Scroll();
+      container.add(preregistrationRespViewer);
+      vBox.add(container);
+
+      return vBox;
+    }
+  }
+});

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -1807,6 +1807,7 @@ paths:
     get:
       tags:
       - products
+      - po
       summary: Get Product
       operationId: get_product
       parameters:
@@ -1833,6 +1834,7 @@ paths:
     put:
       tags:
       - products
+      - po
       summary: Update Product Template
       operationId: update_product_template
       parameters:
@@ -1869,6 +1871,7 @@ paths:
     post:
       tags:
       - products
+      - po
       summary: Generate Invitation
       operationId: generate_invitation
       requestBody:
@@ -4088,12 +4091,14 @@ paths:
     get:
       tags:
       - user
+      - po
       summary: Search Users
       operationId: search_users
       parameters:
       - required: true
         schema:
           title: Email
+          maxLength: 200
           minLength: 3
           type: string
         name: email
@@ -4109,6 +4114,7 @@ paths:
     post:
       tags:
       - user
+      - po
       summary: Pre Register User
       operationId: pre_register_user
       requestBody:
@@ -8406,7 +8412,7 @@ components:
           title: Pricingunits
           type: array
           items:
-            $ref: '#/components/schemas/PricingUnitAdminGet'
+            $ref: '#/components/schemas/PricingUnitGet'
         isActive:
           title: Isactive
           type: boolean
@@ -10776,7 +10782,7 @@ components:
           title: Products
           type: array
           items:
-            type: object
+            type: string
           description: List of products this users is included or None if fields is
             unset
     UserStatus:

--- a/services/web/server/src/simcore_service_webserver/security/_authz_access_roles.py
+++ b/services/web/server/src/simcore_service_webserver/security/_authz_access_roles.py
@@ -89,6 +89,7 @@ ROLES_PERMISSIONS: dict[UserRole, PermissionDict] = {
         inherits=[UserRole.USER],
     ),
     UserRole.PRODUCT_OWNER: PermissionDict(
+        # NOTE: do not forget to add tags=["po"] to this entrypoint
         can=[
             "product.details.*",
             "product.invitations.create",

--- a/services/web/server/src/simcore_service_webserver/security/_authz_access_roles.py
+++ b/services/web/server/src/simcore_service_webserver/security/_authz_access_roles.py
@@ -89,7 +89,7 @@ ROLES_PERMISSIONS: dict[UserRole, PermissionDict] = {
         inherits=[UserRole.USER],
     ),
     UserRole.PRODUCT_OWNER: PermissionDict(
-        # NOTE: do not forget to add tags=["po"] to this entrypoint
+        # NOTE: Add `tags=["po"]` to entrypoints with this access requirements
         can=[
             "product.details.*",
             "product.invitations.create",
@@ -98,7 +98,11 @@ ROLES_PERMISSIONS: dict[UserRole, PermissionDict] = {
         inherits=[UserRole.TESTER],
     ),
     UserRole.ADMIN: PermissionDict(
-        can=["admin.*", "storage.files.sync", "resource-usage.write"],
+        can=[
+            "admin.*",
+            "storage.files.sync",
+            "resource-usage.write",
+        ],
         inherits=[UserRole.TESTER],
     ),
 }

--- a/services/web/server/tests/unit/with_dbs/03/test_users.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_users.py
@@ -343,7 +343,7 @@ async def test_search_and_pre_registration(
         "universityName",
     ],
 )
-def test_parse_model_from_request_form_data(
+def test_preuserprofile_parse_model_from_request_form_data(
     account_request_form: dict[str, Any],
     institution_key: str,
 ):
@@ -371,7 +371,9 @@ def test_parse_model_from_request_form_data(
     assert pre_user_profile.extras["comment"] == "extra comment"
 
 
-def test_parse_model_without_extras(account_request_form: dict[str, Any]):
+def test_preuserprofile_parse_model_without_extras(
+    account_request_form: dict[str, Any]
+):
     required = {
         f.alias or f.name for f in PreUserProfile.__fields__.values() if f.required
     }
@@ -379,8 +381,24 @@ def test_parse_model_without_extras(account_request_form: dict[str, Any]):
     assert not PreUserProfile(**data).extras
 
 
-def test_max_bytes_size_extras_limits(faker: Faker):
+def test_preuserprofile_max_bytes_size_extras_limits(faker: Faker):
     data = random_pre_registration_details(faker)
     data_size = sys.getsizeof(data["extras"])
 
     assert data_size < MAX_BYTES_SIZE_EXTRAS
+
+
+@pytest.mark.parametrize(
+    "given_name", ["PEDrO-luis", "pedro luis", "   pedro  LUiS   ", "pedro  lUiS   "]
+)
+def test_preuserprofile_pre_given_names(
+    given_name: str,
+    account_request_form: dict[str, Any],
+):
+    account_request_form["firstName"] = given_name
+    account_request_form["lastName"] = given_name
+
+    pre_user_profile = PreUserProfile(**account_request_form)
+    print(pre_user_profile.json(indent=1))
+    assert pre_user_profile.first_name in ["Pedro-Luis", "Pedro Luis"]
+    assert pre_user_profile.first_name == pre_user_profile.last_name


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

PO can now pre-register a user by copy&pasting the request form (JSON) in the Pre-registration page of the PO-center.

- 🎨 normalizes values from the request form (e.g. capitalization, spaces, country names etc) so pre-registration data is as clean as possible
- 🎨 tags OAS entrypoints with PO exclusive access as `po`. This way swagger renders them in the same group

## Related issue/s

- Pre-registration part in #5507

## How to test

![image](https://github.com/ITISFoundation/osparc-simcore/assets/32402063/03bef487-c8ab-4e5a-b795-dd25800bdf9f)

- Get the JSON from a fogbugz case
- Open PO center -> **Pre-Registration** 
- Add input & **submit**
- If successful, open PO center -> **Users**
- add the email & press **search**

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))
