### PR TITLE
✨Comp backend: add local prometheus in every cluster to gather metrics

### DIFF
--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -163,7 +163,7 @@ services:
       - source: prometheus-config
         target: /etc/prometheus/prometheus.yml
     volumes:
-      - prometheus_data:/prometheus
+      - prometheus-data:/prometheus
       - /var/run/docker.sock:/var/run/docker.sock:ro
     user: root # because of docker
     networks:
@@ -188,7 +188,7 @@ volumes:
   computational_shared_data:
     name: computational_shared_data
   redis-data:
-  prometheus_data:
+  prometheus-data:
 
 secrets:
   dask_tls_ca:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       placement:
         constraints:
           - "node.role==manager"
+      resources:
+        limits:
+          memory: 2048M
     secrets:
       - source: dask_tls_ca
         target: ${DASK_TLS_CA_FILE}
@@ -100,6 +103,9 @@ services:
       placement:
         constraints:
           - "node.role==manager"
+      resources:
+        limits:
+          memory: 512M
     secrets:
       - source: dask_tls_ca
         target: ${DASK_TLS_CA_FILE}
@@ -127,6 +133,10 @@ services:
       placement:
         constraints:
           - "node.role==manager"
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.5"
 
   prometheus:
     image: prom/prometheus:v2.51.0
@@ -136,6 +146,10 @@ services:
       placement:
         constraints:
           - "node.role==manager"
+      resources:
+        limits:
+          memory: 1024M
+          cpus: "1.0"
 
 volumes:
   computational_shared_data:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     deploy:
       labels:
         prometheus-job: scheduler
+        prometheus-port: 8787
       placement:
         constraints:
           - "node.role==manager"
@@ -65,6 +66,7 @@ services:
       mode: global
       labels:
         prometheus-job: sidecars
+        prometheus-port: 8787
       placement:
         constraints:
           - "node.role==worker"
@@ -112,6 +114,7 @@ services:
     deploy:
       labels:
         prometheus-job: autoscaling
+        prometheus-port: 8000
       placement:
         constraints:
           - "node.role==manager"

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -164,7 +164,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - cluster
-      - docker-access
     deploy:
       placement:
         constraints:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -128,10 +128,14 @@ services:
         constraints:
           - "node.role==manager"
 
+  prometheus:
+    image: prom/prometheus:v2.47.2
+
 volumes:
   computational_shared_data:
     name: computational_shared_data
   redis-data:
+  prometheus_data:
 
 
 secrets:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: ${DOCKER_REGISTRY:-itisfoundation}/dask-sidecar:${DOCKER_IMAGE_TAG}
     init: true
     hostname: "{{.Node.Hostname}}-{{.Task.Slot}}"
+    networks:
+      - cluster
     environment:
       DASK_TLS_CA_FILE: ${DASK_TLS_CA_FILE}
       DASK_TLS_CERT: ${DASK_TLS_CERT}
@@ -16,6 +18,8 @@ services:
       - 8786:8786 # dask-scheduler access
       - 8787:8787 # dashboard
     deploy:
+      labels:
+        prometheus-job: scheduler
       placement:
         constraints:
           - "node.role==manager"
@@ -41,6 +45,8 @@ services:
       - computational_shared_data:${SIDECAR_COMP_SERVICES_SHARED_FOLDER:-/home/scu/computational_shared_data}
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ${ETC_HOSTNAME:-/etc/hostname}:/home/scu/hostname:ro
+    networks:
+      - cluster
     environment:
       DASK_LOG_FORMAT_LOCAL_DEV_ENABLED: 1
       DASK_NPROCS: 1
@@ -57,6 +63,8 @@ services:
       SIDECAR_COMP_SERVICES_SHARED_VOLUME_NAME: computational_shared_data
     deploy:
       mode: global
+      labels:
+        prometheus-job: sidecars
       placement:
         constraints:
           - "node.role==worker"
@@ -98,8 +106,12 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    networks:
+      - cluster
     deploy:
+      labels:
+        prometheus-job: autoscaling
       placement:
         constraints:
           - "node.role==manager"
@@ -129,6 +141,8 @@ services:
       retries: 50
     volumes:
       - redis-data:/data
+    networks:
+      - cluster
     deploy:
       placement:
         constraints:
@@ -140,8 +154,16 @@ services:
 
   prometheus:
     image: prom/prometheus:v2.51.0
+    ports:
+      - 9090:9090
+    configs:
+      - source: prometheus-config
+        target: /etc/prometheus/prometheus.yml
     volumes:
       - prometheus_data:/prometheus
+    networks:
+      - cluster
+      - docker-access
     deploy:
       placement:
         constraints:
@@ -150,6 +172,37 @@ services:
         limits:
           memory: 1024M
           cpus: "1.0"
+
+  docker-api-socat:
+    image: tecnativa/docker-socket-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      NODES: 1
+      NETWORKS: 1
+      SERVICES: 1
+      TASKS: 1
+    logging:
+      # Socat logs send to black hole (we don't need them)
+      driver: none
+    networks:
+      - docker-access
+    deploy:
+      mode: global
+      resources:
+        reservations:
+          memory: 5M
+          cpus: '0.05'
+        limits:
+          memory: 10M
+          cpus: '0.1'
+      placement:
+        constraints:
+          - node.role == manager
+
+configs:
+  prometheus-config:
+    file: ./prometheus.yml
 
 volumes:
   computational_shared_data:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -161,6 +161,7 @@ services:
         target: /etc/prometheus/prometheus.yml
     volumes:
       - prometheus_data:/prometheus
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - cluster
       - docker-access
@@ -173,32 +174,8 @@ services:
           memory: 1024M
           cpus: "1.0"
 
-  docker-api-socat:
-    image: tecnativa/docker-socket-proxy
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      NODES: 1
-      NETWORKS: 1
-      SERVICES: 1
-      TASKS: 1
-    logging:
-      # Socat logs send to black hole (we don't need them)
-      driver: none
-    networks:
-      - docker-access
-    deploy:
-      mode: global
-      resources:
-        reservations:
-          memory: 5M
-          cpus: '0.05'
-        limits:
-          memory: 10M
-          cpus: '0.1'
-      placement:
-        constraints:
-          - node.role == manager
+networks:
+  cluster:
 
 configs:
   prometheus-config:
@@ -209,7 +186,6 @@ volumes:
     name: computational_shared_data
   redis-data:
   prometheus_data:
-
 
 secrets:
   dask_tls_ca:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -156,7 +156,7 @@ services:
           cpus: "0.5"
 
   prometheus:
-    image: prom/prometheus:v2.51.0
+    image: prom/prometheus:v2.51.0@sha256:5ccad477d0057e62a7cd1981ffcc43785ac10c5a35522dc207466ff7e7ec845f
     command:
       - "--storage.tsdb.retention.size=1GB"
     ports:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -129,7 +129,13 @@ services:
           - "node.role==manager"
 
   prometheus:
-    image: prom/prometheus:v2.47.2
+    image: prom/prometheus:v2.51.0
+    volumes:
+      - prometheus_data:/prometheus
+    deploy:
+      placement:
+        constraints:
+          - "node.role==manager"
 
 volumes:
   computational_shared_data:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -162,6 +162,7 @@ services:
     volumes:
       - prometheus_data:/prometheus
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    user: root # because of docker
     networks:
       - cluster
     deploy:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -157,6 +157,8 @@ services:
 
   prometheus:
     image: prom/prometheus:v2.51.0
+    command:
+      - "--storage.tsdb.retention.size=1GB"
     ports:
       - 9090:9090
     configs:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
@@ -8,7 +8,7 @@ scrape_configs:
   # Create a job for Docker Swarm containers.
   - job_name: 'docker nodes'
     dockerswarm_sd_configs:
-      - host: tcp://docker-api-socat:2375
+      - host: unix:///var/run/docker.sock
         role: nodes
     relabel_configs:
       # Fetch metrics on port 9323.
@@ -21,7 +21,7 @@ scrape_configs:
   # Create a job for Docker Swarm containers.
   - job_name: 'docker tasks'
     dockerswarm_sd_configs:
-      - host: tcp://docker-api-socat:2375
+      - host: unix:///var/run/docker.sock
         role: tasks
     relabel_configs:
       # Only keep containers that should be running.

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
@@ -47,6 +47,6 @@ scrape_configs:
       - source_labels: [__address__, __meta_dockerswarm_service_label_prometheus_port]
         separator: ':'
         target_label: __address__
-        regex: (.+)(?::\d+)?;(\d+)
+        regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
         action: replace

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
@@ -28,6 +28,10 @@ scrape_configs:
       - source_labels: [__meta_dockerswarm_task_desired_state]
         regex: running
         action: keep
+      # Only keep tasks with a `prometheus_port` label.
+      - source_labels: [__meta_dockerswarm_service_label_prometheus_port]
+        regex: .+
+        action: keep
       # Only keep containers that have a `prometheus-job` label.
       - source_labels: [__meta_dockerswarm_service_label_prometheus_job]
         regex: .+
@@ -35,3 +39,14 @@ scrape_configs:
       # Use the prometheus-job Swarm label as Prometheus job label.
       - source_labels: [__meta_dockerswarm_service_label_prometheus_job]
         target_label: job
+      # Specify the metric path if needed (optional)
+      - source_labels: [__meta_dockerswarm_service_label_prometheus_path]
+        target_label: __metrics_path__
+        regex: (.+)
+      # Use the `prometheus_port` Swarm label to set the __address__ for scraping.
+      - source_labels: [__address__, __meta_dockerswarm_service_label_prometheus_port]
+        separator: ':'
+        target_label: __address__
+        regex: (.+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        action: replace

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: "30s"
+  scrape_interval: "29s"
 scrape_configs:
   # Make Prometheus scrape itself for metrics.
   - job_name: 'prometheus'

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
@@ -1,0 +1,37 @@
+global:
+  scrape_interval: "30s"
+scrape_configs:
+  # Make Prometheus scrape itself for metrics.
+  - job_name: 'prometheus'
+    static_configs:
+    - targets: ['localhost:9090']
+  # Create a job for Docker Swarm containers.
+  - job_name: 'docker nodes'
+    dockerswarm_sd_configs:
+      - host: tcp://docker-api-socat:2375
+        role: nodes
+    relabel_configs:
+      # Fetch metrics on port 9323.
+      - source_labels: [__meta_dockerswarm_node_address]
+        target_label: __address__
+        replacement: $1:9323
+      # Set hostname as instance label
+      - source_labels: [__meta_dockerswarm_node_hostname]
+        target_label: instance
+  # Create a job for Docker Swarm containers.
+  - job_name: 'docker tasks'
+    dockerswarm_sd_configs:
+      - host: tcp://docker-api-socat:2375
+        role: tasks
+    relabel_configs:
+      # Only keep containers that should be running.
+      - source_labels: [__meta_dockerswarm_task_desired_state]
+        regex: running
+        action: keep
+      # Only keep containers that have a `prometheus-job` label.
+      - source_labels: [__meta_dockerswarm_service_label_prometheus_job]
+        regex: .+
+        action: keep
+      # Use the prometheus-job Swarm label as Prometheus job label.
+      - source_labels: [__meta_dockerswarm_service_label_prometheus_job]
+        target_label: job

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
@@ -45,7 +45,6 @@ scrape_configs:
         regex: (.+)
       # Use the `prometheus_port` Swarm label to set the __address__ for scraping.
       - source_labels: [__address__, __meta_dockerswarm_service_label_prometheus_port]
-        separator: ':'
         target_label: __address__
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/prometheus.yml
@@ -1,10 +1,6 @@
 global:
   scrape_interval: "29s"
 scrape_configs:
-  # Make Prometheus scrape itself for metrics.
-  - job_name: 'prometheus'
-    static_configs:
-    - targets: ['localhost:9090']
   # Create a job for Docker Swarm containers.
   - job_name: 'docker nodes'
     dockerswarm_sd_configs:
@@ -24,6 +20,9 @@ scrape_configs:
       - host: unix:///var/run/docker.sock
         role: tasks
     relabel_configs:
+      # Set hostname as instance label
+      - source_labels: [__meta_dockerswarm_node_hostname]
+        target_label: instance
       # Only keep containers that should be running.
       - source_labels: [__meta_dockerswarm_task_desired_state]
         regex: running

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
@@ -21,7 +21,9 @@ from ..core.settings import ApplicationSettings
 from .dask import get_scheduler_url
 
 _DOCKER_COMPOSE_FILE_NAME: Final[str] = "docker-compose.yml"
+_PROMETHEUS_FILE_NAME: Final[str] = "prometheus.yml"
 _HOST_DOCKER_COMPOSE_PATH: Final[Path] = Path(f"/{_DOCKER_COMPOSE_FILE_NAME}")
+_HOST_PROMETHEUS_PATH: Final[Path] = Path(f"/{_PROMETHEUS_FILE_NAME}")
 _HOST_CERTIFICATES_BASE_PATH: Final[Path] = Path("/.dask-sidecar-certificates")
 _HOST_TLS_CA_FILE_PATH: Final[Path] = _HOST_CERTIFICATES_BASE_PATH / "tls_dask_ca.pem"
 _HOST_TLS_CERT_FILE_PATH: Final[Path] = (
@@ -39,6 +41,12 @@ def _base_64_encode(file: Path) -> str:
 @functools.lru_cache
 def _docker_compose_yml_base64_encoded() -> str:
     file_path = PACKAGE_DATA_FOLDER / _DOCKER_COMPOSE_FILE_NAME
+    return _base_64_encode(file_path)
+
+
+@functools.lru_cache
+def _prometheus_yml_base64_encoded() -> str:
+    file_path = PACKAGE_DATA_FOLDER / _PROMETHEUS_FILE_NAME
     return _base_64_encode(file_path)
 
 
@@ -117,6 +125,7 @@ def create_startup_script(
             # NOTE: https://stackoverflow.com/questions/41203492/solving-redis-warnings-on-overcommit-memory-and-transparent-huge-pages-for-ubunt
             "sysctl vm.overcommit_memory=1",
             f"echo '{_docker_compose_yml_base64_encoded()}' | base64 -d > {_HOST_DOCKER_COMPOSE_PATH}",
+            f"echo '{_prometheus_yml_base64_encoded()}' | base64 -d > {_HOST_PROMETHEUS_PATH}",
             # NOTE: --default-addr-pool is necessary in order to prevent conflicts with AWS node IPs
             "docker swarm init --default-addr-pool 172.20.0.0/14",
             f"{' '.join(environment_variables)} docker stack deploy --with-registry-auth --compose-file={_HOST_DOCKER_COMPOSE_PATH} dask_stack",

--- a/services/clusters-keeper/tests/manual/README.md
+++ b/services/clusters-keeper/tests/manual/README.md
@@ -34,6 +34,7 @@ flowchart TD
 1. build simcore
 ```bash
 git clone https://github.com/ITISFoundation/osparc-simcore.git
+cd osparc-simcore
 make .env # generate initial .env file
 make build-devel # build for development mode or
 make build # for production mode
@@ -81,6 +82,13 @@ WORKERS_EC2_INSTANCES_SUBNET_ID=XXXXXXX
 WORKERS_EC2_INSTANCES_TIME_BEFORE_TERMINATION="00:03:00"
 WORKERS_EC2_INSTANCES_CUSTOM_TAGS='{"osparc-tag": "some fun tag value"}'
 ```
+
+4. prepare dask TLS certificates
+NOTE: the dask TLS certificates are in AWS and shall be copied into the local stack such that the director-v2 can access the clusters
+these are defined by PRIMARY_EC2_INSTANCES_SSM_TLS_DASK_CA, PRIMARY_EC2_INSTANCES_SSM_TLS_DASK_CERT and PRIMARY_EC2_INSTANCES_SSM_TLS_DASK_KEY
+  1. one need to go to the AWS Parameter Store (SSM)
+  2. find these entries then copy their contents into respectively services/dask-sidecar/.dask-certificates/dask-cert.pem and services/dask-sidecar/.dask-certificates/dask-key.pem
+
 
 5. start osparc
 ```bash


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR adds a prometheus instance to gather metrics on the computational cluster (dask, autoscaling, ...)

Here is a reminder of how a computational cluster looks like:
![ext-cluster-compose](https://github.com/ITISFoundation/osparc-simcore/assets/35365065/5a909103-f741-44a1-afa3-4a2e4322ddfe)

This PR is a first step to allow to scrape each computational clusters to monitor its status in prometheus

Added a test to monitor the size of the EC2 UserData. currently at 12.2KB (max is 16KB). 
## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
