### PR TITLE
🎨Autoscaling metrics: define namespace and subsystem

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -12,7 +12,7 @@ from ..core.errors import ConfigurationError
 from ..core.settings import get_application_settings
 from ..models import AssociatedInstance, Cluster, NonAssociatedInstance
 
-METRICS_NAMESPACE: Final[str] = APP_NAME
+METRICS_NAMESPACE: Final[str] = APP_NAME.replace("-", "_")
 EC2_INSTANCE_LABELS: Final[tuple[str]] = ("instance_type",)
 
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -7,10 +7,12 @@ from servicelib.fastapi.prometheus_instrumentation import (
     setup_prometheus_instrumentation as setup_rest_instrumentation,
 )
 
+from .._meta import APP_NAME
 from ..core.errors import ConfigurationError
 from ..core.settings import get_application_settings
 from ..models import AssociatedInstance, Cluster, NonAssociatedInstance
 
+METRICS_NAMESPACE: Final[str] = APP_NAME
 EC2_INSTANCE_LABELS: Final[tuple[str]] = ("instance_type",)
 
 
@@ -27,6 +29,7 @@ def _update_gauge(
 @dataclass(slots=True, kw_only=True)
 class AutoscalingInstrumentation:
     registry: CollectorRegistry
+    subsystem: str
     _active_nodes: Gauge = field(init=False)
     _pending_nodes: Gauge = field(init=False)
     _drained_nodes: Gauge = field(init=False)
@@ -41,40 +44,56 @@ class AutoscalingInstrumentation:
             "active_nodes",
             "Number of EC2-backed docker nodes which are active and ready to run tasks",
             labelnames=EC2_INSTANCE_LABELS,
+            namespace=METRICS_NAMESPACE,
+            subsystem=self.subsystem,
         )
         self._pending_nodes = Gauge(
             "pending_nodes",
             "Number of EC2-backed docker nodes which are active and NOT ready to run tasks",
             labelnames=EC2_INSTANCE_LABELS,
+            namespace=METRICS_NAMESPACE,
+            subsystem=self.subsystem,
         )
         self._drained_nodes = Gauge(
             "drained_nodes",
             "Number of EC2-backed docker nodes which are drained",
             labelnames=EC2_INSTANCE_LABELS,
+            namespace=METRICS_NAMESPACE,
+            subsystem=self.subsystem,
         )
         self._buffer_drained_nodes = Gauge(
             "buffer_drained_nodes",
             "Number of EC2-backed docker nodes which are drained and in buffer/reserve",
             labelnames=EC2_INSTANCE_LABELS,
+            namespace=METRICS_NAMESPACE,
+            subsystem=self.subsystem,
         )
         self._pending_ec2s = Gauge(
             "pending_ec2s",
             "Number of EC2 instance not yet part of the cluster",
             labelnames=EC2_INSTANCE_LABELS,
+            namespace=METRICS_NAMESPACE,
+            subsystem=self.subsystem,
         )
         self._disconnected_nodes = Gauge(
             "disconnected_nodes",
             "Number of docker node not backed by a running EC2 instance",
+            namespace=METRICS_NAMESPACE,
+            subsystem=self.subsystem,
         )
         self._started_instances = Counter(
             "started_instances_total",
             "Number of EC2 instances that were started",
             labelnames=EC2_INSTANCE_LABELS,
+            namespace=METRICS_NAMESPACE,
+            subsystem=self.subsystem,
         )
         self._terminated_instances = Counter(
             "terminated_ec2_instances_total",
             "Number of EC2 instances that were terminated",
             labelnames=EC2_INSTANCE_LABELS,
+            namespace=METRICS_NAMESPACE,
+            subsystem=self.subsystem,
         )
 
     def update_from_cluster(self, cluster: Cluster) -> None:
@@ -101,8 +120,11 @@ def setup(app: FastAPI) -> None:
     instrumentator = setup_rest_instrumentation(app)
 
     async def on_startup() -> None:
+        metrics_subsystem = (
+            "dynamic" if app_settings.AUTOSCALING_NODES_MONITORING else "computational"
+        )
         app.state.instrumentation = AutoscalingInstrumentation(
-            registry=instrumentator.registry
+            registry=instrumentator.registry, subsystem=metrics_subsystem
         )
 
     async def on_shutdown() -> None:

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -27,7 +27,7 @@ def _update_gauge(
 
 
 @dataclass(slots=True, kw_only=True)
-class AutoscalingInstrumentation:
+class AutoscalingInstrumentation:  # pylint: disable=too-many-instance-attributes
     registry: CollectorRegistry
     subsystem: str
     _active_nodes: Gauge = field(init=False)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This PR changes the names of the metrics generated by the autoscaling application to use
- a namespace defined as the ```APP_NAME == simcore_service_autoscaling```
- a subsystem defined either as ```dynamic``` or ```computational```

that means that the metrics created are prefixed with ```namespace_subsystem```

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
