### PR TITLE
⬆️Maintenance: Upgrade of dask-based services and libs

### DIFF
--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -67,7 +67,7 @@ multidict==6.0.5
 orjson==3.10.0
 pamqp==3.3.0
     # via aiormq
-pydantic==1.10.14
+pydantic==1.10.15
 pygments==2.17.2
     # via rich
 pyinstrument==4.6.2
@@ -104,10 +104,10 @@ typer-slim==0.12.0
     # via
     #   typer
     #   typer-cli
-types-aiobotocore==2.12.1
-types-aiobotocore-ec2==2.12.1
+types-aiobotocore==2.12.2
+types-aiobotocore-ec2==2.12.2
     # via types-aiobotocore
-types-aiobotocore-s3==2.12.1
+types-aiobotocore-s3==2.12.2
     # via types-aiobotocore
 types-awscrt==0.20.5
     # via botocore-stubs

--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -36,7 +36,7 @@ botocore==1.34.34
 botocore-stubs==1.34.69
     # via types-aiobotocore
 click==8.1.7
-    # via typer-slim
+    # via typer
 dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
@@ -82,7 +82,7 @@ referencing==0.29.3
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via typer-slim
+    # via typer
 rpds-py==0.18.0
     # via
     #   jsonschema
@@ -91,19 +91,13 @@ s3transfer==0.10.1
     # via boto3
 sh==2.0.6
 shellingham==1.5.4
-    # via typer-slim
+    # via typer
 six==1.16.0
     # via python-dateutil
 tenacity==8.2.3
 toolz==0.12.1
 tqdm==4.66.2
-typer==0.12.0
-typer-cli==0.12.0
-    # via typer
-typer-slim==0.12.0
-    # via
-    #   typer
-    #   typer-cli
+typer==0.12.1
 types-aiobotocore==2.12.2
 types-aiobotocore-ec2==2.12.2
     # via types-aiobotocore
@@ -113,12 +107,12 @@ types-awscrt==0.20.5
     # via botocore-stubs
 types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   aiodebug
     #   aiodocker
     #   pydantic
-    #   typer-slim
+    #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
     #   types-aiobotocore-s3

--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -1,18 +1,18 @@
-aio-pika==9.3.0
-aioboto3==12.0.0
-aiobotocore==2.7.0
+aio-pika==9.4.1
+aioboto3==12.3.0
+aiobotocore==2.11.2
     # via aioboto3
 aiocache==0.12.2
 aiodebug==2.3.0
 aiodocker==0.21.0
 aiofiles==23.2.1
-aiohttp==3.8.6
+aiohttp==3.9.3
     # via
     #   aiobotocore
     #   aiodocker
 aioitertools==0.11.0
     # via aiobotocore
-aiormq==6.7.7
+aiormq==6.8.0
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
@@ -21,33 +21,31 @@ async-timeout==4.0.3
     # via
     #   aiohttp
     #   redis
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.28.64
+boto3==1.34.34
     # via aiobotocore
-botocore==1.31.64
+botocore==1.34.34
     # via
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.31.85
+botocore-stubs==1.34.69
     # via types-aiobotocore
-charset-normalizer==3.3.2
-    # via aiohttp
 click==8.1.7
-    # via typer
-dnspython==2.4.2
+    # via typer-slim
+dnspython==2.6.1
     # via email-validator
-email-validator==2.1.0.post1
+email-validator==2.1.1
     # via pydantic
-frozenlist==1.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-idna==3.4
+idna==3.6
     # via
     #   email-validator
     #   yarl
@@ -55,63 +53,72 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.19.2
+jsonschema==4.21.1
 jsonschema-specifications==2023.7.1
     # via jsonschema
 markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
 orjson==3.10.0
-pamqp==3.2.1
+pamqp==3.3.0
     # via aiormq
-pydantic==1.10.13
-pygments==2.16.1
+pydantic==1.10.14
+pygments==2.17.2
     # via rich
-pyinstrument==4.6.1
-python-dateutil==2.8.2
+pyinstrument==4.6.2
+python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   botocore
 pyyaml==6.0.1
-redis==5.0.1
+redis==5.0.3
 referencing==0.29.3
     # via
     #   jsonschema
     #   jsonschema-specifications
-rich==13.6.0
-rpds-py==0.12.0
+rich==13.7.1
+    # via typer-slim
+rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.7.0
+s3transfer==0.10.1
     # via boto3
 sh==2.0.6
+shellingham==1.5.4
+    # via typer-slim
 six==1.16.0
     # via python-dateutil
 tenacity==8.2.3
-toolz==0.12.0
-tqdm==4.66.1
-typer==0.9.0
-types-aiobotocore==2.7.0
-types-aiobotocore-ec2==2.7.0
+toolz==0.12.1
+tqdm==4.66.2
+typer==0.12.0
+typer-cli==0.12.0
+    # via typer
+typer-slim==0.12.0
+    # via
+    #   typer
+    #   typer-cli
+types-aiobotocore==2.12.1
+types-aiobotocore-ec2==2.12.1
     # via types-aiobotocore
-types-aiobotocore-s3==2.7.0
+types-aiobotocore-s3==2.12.1
     # via types-aiobotocore
-types-awscrt==0.19.10
+types-awscrt==0.20.5
     # via botocore-stubs
-types-python-dateutil==2.8.19.14
+types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.8.0
+typing-extensions==4.10.0
     # via
     #   aiodebug
     #   aiodocker
     #   pydantic
-    #   typer
+    #   typer-slim
     #   types-aiobotocore
     #   types-aiobotocore-ec2
     #   types-aiobotocore-s3
@@ -119,7 +126,7 @@ urllib3==2.0.7
     # via botocore
 wrapt==1.16.0
     # via aiobotocore
-yarl==1.9.2
+yarl==1.9.4
     # via
     #   aio-pika
     #   aiohttp

--- a/packages/aws-library/requirements/_test.txt
+++ b/packages/aws-library/requirements/_test.txt
@@ -1,53 +1,49 @@
-attrs==23.1.0
+antlr4-python3-runtime==4.13.1
+    # via moto
+attrs==23.2.0
     # via
     #   jschema-to-python
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.82.0
+aws-sam-translator==1.86.0
     # via cfn-lint
-aws-xray-sdk==2.12.1
+aws-xray-sdk==2.13.0
     # via moto
 blinker==1.7.0
     # via flask
-boto3==1.28.64
+boto3==1.34.34
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.31.64
+botocore==1.34.34
     # via
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
-certifi==2023.11.17
+certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.83.6
+cfn-lint==0.86.1
     # via moto
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via flask
-coverage==7.3.3
+coverage==7.4.4
     # via pytest-cov
-cryptography==41.0.7
+cryptography==42.0.5
     # via
+    #   joserfc
     #   moto
-    #   python-jose
-    #   sshpubkeys
 docker==7.0.0
     # via moto
-ecdsa==0.18.0
-    # via
-    #   moto
-    #   python-jose
-    #   sshpubkeys
 exceptiongroup==1.2.0
     # via pytest
-faker==21.0.0
-flask==3.0.0
+faker==24.4.0
+flask==3.0.2
     # via
     #   flask-cors
     #   moto
@@ -57,13 +53,13 @@ graphql-core==3.2.3
     # via moto
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.4
+idna==3.6
     # via requests
 iniconfig==2.0.0
     # via pytest
 itsdangerous==2.1.2
     # via flask
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   flask
     #   moto
@@ -71,17 +67,21 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+joserfc==0.9.0
+    # via moto
 jschema-to-python==1.2.3
     # via cfn-lint
 jsondiff==2.0.0
     # via moto
 jsonpatch==1.33
     # via cfn-lint
-jsonpickle==3.0.2
+jsonpath-ng==1.6.1
+    # via moto
+jsonpickle==3.0.3
     # via jschema-to-python
 jsonpointer==2.4
     # via jsonpatch
-jsonschema==4.19.2
+jsonschema==4.21.1
     # via
     #   aws-sam-translator
     #   cfn-lint
@@ -95,13 +95,13 @@ jsonschema-specifications==2023.7.1
     #   openapi-schema-validator
 junit-xml==1.9
     # via cfn-lint
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.10.0
     # via openapi-spec-validator
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   jinja2
     #   werkzeug
-moto==4.2.11
+moto==5.0.4
 mpmath==1.3.0
     # via sympy
 networkx==3.2.1
@@ -110,7 +110,7 @@ openapi-schema-validator==0.6.2
     # via openapi-spec-validator
 openapi-spec-validator==0.7.1
     # via moto
-packaging==23.2
+packaging==24.0
     # via
     #   docker
     #   pytest
@@ -122,23 +122,21 @@ pbr==6.0.0
     #   jschema-to-python
     #   sarif-om
 pint==0.23
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
+ply==3.11
+    # via jsonpath-ng
 pprintpp==0.4.0
     # via pytest-icdiff
-py-partiql-parser==0.4.2
+py-partiql-parser==0.5.2
     # via moto
-pyasn1==0.5.1
-    # via
-    #   python-jose
-    #   rsa
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pydantic==1.10.13
+pydantic==1.10.14
     # via aws-sam-translator
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via moto
-pytest==7.4.3
+pytest==8.1.1
     # via
     #   pytest-asyncio
     #   pytest-cov
@@ -147,20 +145,18 @@ pytest==7.4.3
     #   pytest-mock
     #   pytest-sugar
 pytest-asyncio==0.21.1
-pytest-cov==4.1.0
+pytest-cov==5.0.0
 pytest-icdiff==0.9
 pytest-instafail==0.5.0
-pytest-mock==3.12.0
+pytest-mock==3.14.0
 pytest-runner==6.0.1
-pytest-sugar==0.9.7
-python-dateutil==2.8.2
+pytest-sugar==1.0.0
+python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   faker
     #   moto
-python-dotenv==1.0.0
-python-jose==3.3.0
-    # via moto
+python-dotenv==1.0.1
 pyyaml==6.0.1
     # via
     #   cfn-lint
@@ -172,7 +168,7 @@ referencing==0.29.3
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-regex==2023.10.3
+regex==2023.12.25
     # via cfn-lint
 requests==2.31.0
     # via
@@ -180,17 +176,15 @@ requests==2.31.0
     #   jsonschema-path
     #   moto
     #   responses
-responses==0.24.1
+responses==0.25.0
     # via moto
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.12.0
+rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via python-jose
-s3transfer==0.7.0
+s3transfer==0.10.1
     # via boto3
 sarif-om==1.0.4
     # via cfn-lint
@@ -198,12 +192,9 @@ setuptools==69.2.0
     # via moto
 six==1.16.0
     # via
-    #   ecdsa
     #   junit-xml
     #   python-dateutil
     #   rfc3339-validator
-sshpubkeys==3.3.1
-    # via moto
 sympy==1.12
     # via cfn-lint
 termcolor==2.4.0
@@ -212,7 +203,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.8.0
+typing-extensions==4.10.0
     # via
     #   aws-sam-translator
     #   pint
@@ -223,7 +214,7 @@ urllib3==2.0.7
     #   docker
     #   requests
     #   responses
-werkzeug==3.0.1
+werkzeug==3.0.2
     # via
     #   flask
     #   moto

--- a/packages/aws-library/requirements/_test.txt
+++ b/packages/aws-library/requirements/_test.txt
@@ -6,7 +6,7 @@ attrs==23.2.0
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.86.0
+aws-sam-translator==1.87.0
     # via cfn-lint
 aws-xray-sdk==2.13.0
     # via moto
@@ -26,7 +26,7 @@ certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.86.1
+cfn-lint==0.86.2
     # via moto
 charset-normalizer==3.3.2
     # via requests
@@ -42,8 +42,8 @@ docker==7.0.0
     # via moto
 exceptiongroup==1.2.0
     # via pytest
-faker==24.4.0
-flask==3.0.2
+faker==24.7.1
+flask==3.0.3
     # via
     #   flask-cors
     #   moto
@@ -101,10 +101,10 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   werkzeug
-moto==5.0.4
+moto==5.0.5
 mpmath==1.3.0
     # via sympy
-networkx==3.2.1
+networkx==3.3
     # via cfn-lint
 openapi-schema-validator==0.6.2
     # via openapi-spec-validator
@@ -128,7 +128,7 @@ ply==3.11
     # via jsonpath-ng
 pprintpp==0.4.0
     # via pytest-icdiff
-py-partiql-parser==0.5.2
+py-partiql-parser==0.5.4
     # via moto
 pycparser==2.22
     # via cffi
@@ -203,7 +203,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   aws-sam-translator
     #   pint

--- a/packages/aws-library/requirements/_test.txt
+++ b/packages/aws-library/requirements/_test.txt
@@ -132,7 +132,7 @@ py-partiql-parser==0.5.2
     # via moto
 pycparser==2.22
     # via cffi
-pydantic==1.10.14
+pydantic==1.10.15
     # via aws-sam-translator
 pyparsing==3.1.2
     # via moto

--- a/packages/aws-library/requirements/_tools.txt
+++ b/packages/aws-library/requirements/_tools.txt
@@ -1,52 +1,32 @@
-aiohttp==3.8.6
-    # via black
-aiosignal==1.3.1
-    # via aiohttp
-astroid==3.0.2
+astroid==3.1.0
     # via pylint
-async-timeout==4.0.3
-    # via aiohttp
-attrs==23.1.0
-    # via aiohttp
-black==23.12.0
-build==1.0.3
+black==24.3.0
+build==1.2.1
     # via pip-tools
 bump2version==1.0.1
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.3.2
-    # via aiohttp
 click==8.1.7
     # via
     #   black
     #   pip-tools
-dill==0.3.7
+dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.1
+filelock==3.13.3
     # via virtualenv
-frozenlist==1.4.0
-    # via
-    #   aiohttp
-    #   aiosignal
-identify==2.5.33
+identify==2.5.35
     # via pre-commit
-idna==3.4
-    # via yarl
 isort==5.13.2
     # via pylint
 mccabe==0.7.0
     # via pylint
-multidict==6.0.4
-    # via
-    #   aiohttp
-    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.2
+packaging==24.0
     # via
     #   black
     #   build
@@ -54,19 +34,21 @@ pathspec==0.12.1
     # via black
 pip==24.0
     # via pip-tools
-pip-tools==7.3.0
-platformdirs==4.1.0
+pip-tools==7.4.1
+platformdirs==4.2.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.6.0
-pylint==3.0.3
+pre-commit==3.7.0
+pylint==3.1.0
 pyproject-hooks==1.0.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 pyyaml==6.0.1
     # via pre-commit
-ruff==0.1.8
+ruff==0.3.5
 setuptools==69.2.0
     # via
     #   nodeenv
@@ -78,15 +60,13 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via pylint
-typing-extensions==4.8.0
+typing-extensions==4.10.0
     # via
     #   astroid
     #   black
-virtualenv==20.25.0
+virtualenv==20.25.1
     # via pre-commit
-wheel==0.42.0
+wheel==0.43.0
     # via pip-tools
-yarl==1.9.2
-    # via aiohttp

--- a/packages/aws-library/requirements/_tools.txt
+++ b/packages/aws-library/requirements/_tools.txt
@@ -62,7 +62,7 @@ tomli==2.0.1
     #   pyproject-hooks
 tomlkit==0.12.4
     # via pylint
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   astroid
     #   black

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -1,5 +1,5 @@
 arrow==1.3.0
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
@@ -7,29 +7,29 @@ click==8.1.7
     # via
     #   dask
     #   distributed
-    #   typer
+    #   typer-slim
 cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-dask==2023.12.0
+dask==2024.4.0
     # via distributed
-distributed==2023.12.0
+distributed==2024.4.0
     # via dask
-dnspython==2.4.2
+dnspython==2.6.1
     # via email-validator
-email-validator==2.1.0.post1
+email-validator==2.1.1
     # via pydantic
-fsspec==2023.12.2
+fsspec==2024.3.1
     # via dask
 idna==3.6
     # via email-validator
-importlib-metadata==7.0.0
+importlib-metadata==7.1.0
     # via dask
-jinja2==3.1.2
+jinja2==3.1.3
     # via distributed
-jsonschema==4.20.0
-jsonschema-specifications==2023.11.2
+jsonschema==4.21.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 locket==1.0.0
     # via
@@ -37,62 +37,71 @@ locket==1.0.0
     #   partd
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-msgpack==1.0.7
+msgpack==1.0.8
     # via distributed
 orjson==3.10.0
-packaging==23.2
+packaging==24.0
     # via
     #   dask
     #   distributed
 partd==1.4.1
     # via dask
-psutil==5.9.6
+psutil==5.9.8
     # via distributed
-pydantic==1.10.13
+pydantic==1.10.14
 pygments==2.17.2
     # via rich
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via arrow
 pyyaml==6.0.1
     # via
     #   dask
     #   distributed
-referencing==0.32.0
+referencing==0.34.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-rich==13.7.0
-rpds-py==0.13.2
+rich==13.7.1
+    # via typer-slim
+rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
+shellingham==1.5.4
+    # via typer-slim
 six==1.16.0
     # via python-dateutil
 sortedcontainers==2.4.0
     # via distributed
 tblib==3.0.0
     # via distributed
-toolz==0.12.0
+toolz==0.12.1
     # via
     #   dask
     #   distributed
     #   partd
 tornado==6.4
     # via distributed
-typer==0.9.0
-types-python-dateutil==2.8.19.14
+typer==0.12.0
+typer-cli==0.12.0
+    # via typer
+typer-slim==0.12.0
+    # via
+    #   typer
+    #   typer-cli
+types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   pydantic
-    #   typer
-urllib3==2.1.0
+    #   typer-slim
+urllib3==2.2.1
     # via distributed
 zict==3.0.0
     # via distributed
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -7,14 +7,14 @@ click==8.1.7
     # via
     #   dask
     #   distributed
-    #   typer-slim
+    #   typer
 cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-dask==2024.4.0
+dask==2024.4.1
     # via distributed
-distributed==2024.4.0
+distributed==2024.4.1
     # via dask
 dnspython==2.6.1
     # via email-validator
@@ -66,13 +66,13 @@ referencing==0.34.0
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via typer-slim
+    # via typer
 rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
 shellingham==1.5.4
-    # via typer-slim
+    # via typer
 six==1.16.0
     # via python-dateutil
 sortedcontainers==2.4.0
@@ -86,19 +86,13 @@ toolz==0.12.1
     #   partd
 tornado==6.4
     # via distributed
-typer==0.12.0
-typer-cli==0.12.0
-    # via typer
-typer-slim==0.12.0
-    # via
-    #   typer
-    #   typer-cli
+typer==0.12.1
 types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   pydantic
-    #   typer-slim
+    #   typer
 urllib3==2.2.1
     # via distributed
 zict==3.0.0

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -52,7 +52,7 @@ partd==1.4.1
     # via dask
 psutil==5.9.8
     # via distributed
-pydantic==1.10.14
+pydantic==1.10.15
 pygments==2.17.2
     # via rich
 python-dateutil==2.9.0.post0

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -2,7 +2,7 @@ coverage==7.4.4
     # via pytest-cov
 exceptiongroup==1.2.0
     # via pytest
-faker==24.4.0
+faker==24.7.1
 icdiff==2.0.7
     # via pytest-icdiff
 iniconfig==2.0.0
@@ -42,5 +42,5 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via pint

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -1,22 +1,22 @@
-coverage==7.3.3
+coverage==7.4.4
     # via pytest-cov
 exceptiongroup==1.2.0
     # via pytest
-faker==21.0.0
+faker==24.4.0
 icdiff==2.0.7
     # via pytest-icdiff
 iniconfig==2.0.0
     # via pytest
-packaging==23.2
+packaging==24.0
     # via
     #   pytest
     #   pytest-sugar
 pint==0.23
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-pytest==7.4.3
+pytest==8.1.1
     # via
     #   pytest-asyncio
     #   pytest-cov
@@ -25,13 +25,13 @@ pytest==7.4.3
     #   pytest-mock
     #   pytest-sugar
 pytest-asyncio==0.21.1
-pytest-cov==4.1.0
+pytest-cov==5.0.0
 pytest-icdiff==0.9
 pytest-instafail==0.5.0
-pytest-mock==3.12.0
+pytest-mock==3.14.0
 pytest-runner==6.0.1
-pytest-sugar==0.9.7
-python-dateutil==2.8.2
+pytest-sugar==1.0.0
+python-dateutil==2.9.0.post0
     # via faker
 pyyaml==6.0.1
 six==1.16.0
@@ -42,5 +42,5 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via pint

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -62,7 +62,7 @@ tomli==2.0.1
     #   pyproject-hooks
 tomlkit==0.12.4
     # via pylint
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   astroid
     #   black

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -1,15 +1,7 @@
-aiohttp==3.9.1
-    # via black
-aiosignal==1.3.1
-    # via aiohttp
-astroid==3.0.2
+astroid==3.1.0
     # via pylint
-async-timeout==4.0.3
-    # via aiohttp
-attrs==23.1.0
-    # via aiohttp
-black==23.12.0
-build==1.0.3
+black==24.3.0
+build==1.2.1
     # via pip-tools
 bump2version==1.0.1
 cfgv==3.4.0
@@ -18,33 +10,23 @@ click==8.1.7
     # via
     #   black
     #   pip-tools
-dill==0.3.7
+dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.1
+filelock==3.13.3
     # via virtualenv
-frozenlist==1.4.0
-    # via
-    #   aiohttp
-    #   aiosignal
-identify==2.5.33
+identify==2.5.35
     # via pre-commit
-idna==3.6
-    # via yarl
 isort==5.13.2
     # via pylint
 mccabe==0.7.0
     # via pylint
-multidict==6.0.4
-    # via
-    #   aiohttp
-    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.2
+packaging==24.0
     # via
     #   black
     #   build
@@ -52,19 +34,21 @@ pathspec==0.12.1
     # via black
 pip==24.0
     # via pip-tools
-pip-tools==7.3.0
-platformdirs==4.1.0
+pip-tools==7.4.1
+platformdirs==4.2.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.6.0
-pylint==3.0.3
+pre-commit==3.7.0
+pylint==3.1.0
 pyproject-hooks==1.0.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 pyyaml==6.0.1
     # via pre-commit
-ruff==0.1.8
+ruff==0.3.5
 setuptools==69.2.0
     # via
     #   nodeenv
@@ -76,15 +60,13 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via pylint
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   astroid
     #   black
-virtualenv==20.25.0
+virtualenv==20.25.1
     # via pre-commit
-wheel==0.42.0
+wheel==0.43.0
     # via pip-tools
-yarl==1.9.4
-    # via aiohttp

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -90,12 +90,3 @@ pennsieve>=999999999
 
 # User alternative e.g. parametrized fixture or request.getfixturevalue(.)
 pytest-lazy-fixture>=999999999
-
-# From 3.9.0 the follwong test fails: `tests/unit/test_modules_system_monitor__notifier.py::test_notifier_publish_message`
-# the room disconnect event is no longer propagated
-# Issue triggered by:
-# - this change: https://github.com/ttsia/aiohttp/commit/70b3536e3eef1627bbb425e71faea2f8ce1c6f9b
-# - and it's PR: https://github.com/aio-libs/aiohttp/pull/7680
-# - this is the breaking change (1 line) https://github.com/ttsia/aiohttp/commit/70b3536e3eef1627bbb425e71faea2f8ce1c6f9b#diff-5eda97b86ffb5b1e8b797dbacc03e6d75767caada5d09956c1035b5684711965R204
-# submitted issue https://github.com/miguelgrinberg/python-socketio/issues/1319
-aiohttp<3.9.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -90,3 +90,12 @@ pennsieve>=999999999
 
 # User alternative e.g. parametrized fixture or request.getfixturevalue(.)
 pytest-lazy-fixture>=999999999
+
+# From 3.9.0 the follwong test fails: `tests/unit/test_modules_system_monitor__notifier.py::test_notifier_publish_message`
+# the room disconnect event is no longer propagated
+# Issue triggered by:
+# - this change: https://github.com/ttsia/aiohttp/commit/70b3536e3eef1627bbb425e71faea2f8ce1c6f9b
+# - and it's PR: https://github.com/aio-libs/aiohttp/pull/7680
+# - this is the breaking change (1 line) https://github.com/ttsia/aiohttp/commit/70b3536e3eef1627bbb425e71faea2f8ce1c6f9b#diff-5eda97b86ffb5b1e8b797dbacc03e6d75767caada5d09956c1035b5684711965R204
+# submitted issue https://github.com/miguelgrinberg/python-socketio/issues/1319
+aiohttp<3.9.0

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -47,7 +47,7 @@ click==8.1.7
     # via
     #   dask
     #   distributed
-    #   typer-slim
+    #   typer
     #   uvicorn
 cloudpickle==3.0.0
     # via
@@ -144,7 +144,7 @@ referencing==0.29.3
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via typer-slim
+    # via typer
 rpds-py==0.18.0
     # via
     #   jsonschema
@@ -153,7 +153,7 @@ s3transfer==0.10.1
     # via boto3
 sh==2.0.6
 shellingham==1.5.4
-    # via typer-slim
+    # via typer
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.1
@@ -175,13 +175,7 @@ toolz==0.12.1
 tornado==6.4
     # via distributed
 tqdm==4.66.2
-typer==0.12.0
-typer-cli==0.12.0
-    # via typer
-typer-slim==0.12.0
-    # via
-    #   typer
-    #   typer-cli
+typer==0.12.1
 types-aiobotocore==2.12.2
 types-aiobotocore-ec2==2.12.2
     # via types-aiobotocore
@@ -191,14 +185,14 @@ types-awscrt==0.20.5
     # via botocore-stubs
 types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   aiodebug
     #   aiodocker
     #   anyio
     #   fastapi
     #   pydantic
-    #   typer-slim
+    #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
     #   types-aiobotocore-s3

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -125,7 +125,7 @@ prometheus-client==0.20.0
 prometheus-fastapi-instrumentator==6.1.0
 psutil==5.9.8
     # via distributed
-pydantic==1.10.14
+pydantic==1.10.15
     # via fastapi
 pygments==2.17.2
     # via rich
@@ -182,10 +182,10 @@ typer-slim==0.12.0
     # via
     #   typer
     #   typer-cli
-types-aiobotocore==2.12.1
-types-aiobotocore-ec2==2.12.1
+types-aiobotocore==2.12.2
+types-aiobotocore-ec2==2.12.2
     # via types-aiobotocore
-types-aiobotocore-s3==2.12.1
+types-aiobotocore-s3==2.12.2
     # via types-aiobotocore
 types-awscrt==0.20.5
     # via botocore-stubs

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -47,9 +47,9 @@ click==8.1.7
     # via
     #   dask
     #   distributed
-    #   typer
+    #   typer-slim
     #   uvicorn
-cloudpickle==2.2.1
+cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
@@ -69,13 +69,13 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.6.0
+fsspec==2024.3.1
     # via dask
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.4
+httpcore==1.0.5
     # via httpx
 httpx==0.27.0
 idna==3.6
@@ -84,9 +84,9 @@ idna==3.6
     #   email-validator
     #   httpx
     #   yarl
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via dask
-jinja2==3.1.2
+jinja2==3.1.3
     # via distributed
 jmespath==1.0.1
     # via
@@ -101,29 +101,29 @@ locket==1.0.0
     #   partd
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-msgpack==1.0.5
+msgpack==1.0.8
     # via distributed
 multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
 orjson==3.10.0
-packaging==23.1
+packaging==24.0
     # via
     #   dask
     #   distributed
 pamqp==3.3.0
     # via aiormq
-partd==1.4.0
+partd==1.4.1
     # via dask
 prometheus-client==0.20.0
     # via prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
-psutil==5.9.5
+psutil==5.9.8
     # via distributed
 pydantic==1.10.14
     # via fastapi
@@ -144,6 +144,7 @@ referencing==0.29.3
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
+    # via typer-slim
 rpds-py==0.18.0
     # via
     #   jsonschema
@@ -151,6 +152,8 @@ rpds-py==0.18.0
 s3transfer==0.10.1
     # via boto3
 sh==2.0.6
+shellingham==1.5.4
+    # via typer-slim
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.1
@@ -161,18 +164,24 @@ sortedcontainers==2.4.0
     # via distributed
 starlette==0.27.0
     # via fastapi
-tblib==2.0.0
+tblib==3.0.0
     # via distributed
 tenacity==8.2.3
-toolz==0.12.0
+toolz==0.12.1
     # via
     #   dask
     #   distributed
     #   partd
-tornado==6.3.3
+tornado==6.4
     # via distributed
 tqdm==4.66.2
-typer==0.10.0
+typer==0.12.0
+typer-cli==0.12.0
+    # via typer
+typer-slim==0.12.0
+    # via
+    #   typer
+    #   typer-cli
 types-aiobotocore==2.12.1
 types-aiobotocore-ec2==2.12.1
     # via types-aiobotocore
@@ -189,12 +198,12 @@ typing-extensions==4.10.0
     #   anyio
     #   fastapi
     #   pydantic
-    #   typer
+    #   typer-slim
     #   types-aiobotocore
     #   types-aiobotocore-ec2
     #   types-aiobotocore-s3
     #   uvicorn
-urllib3==1.26.16
+urllib3==2.0.7
     # via
     #   botocore
     #   distributed
@@ -208,5 +217,5 @@ yarl==1.9.4
     #   aiormq
 zict==3.0.0
     # via distributed
-zipp==3.16.2
+zipp==3.18.1
     # via importlib-metadata

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -156,7 +156,7 @@ py-partiql-parser==0.5.2
     # via moto
 pycparser==2.22
     # via cffi
-pydantic==1.10.14
+pydantic==1.10.15
     # via aws-sam-translator
 pyparsing==3.1.2
     # via moto

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -11,7 +11,7 @@ attrs==23.2.0
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.86.0
+aws-sam-translator==1.87.0
     # via cfn-lint
 aws-xray-sdk==2.13.0
     # via moto
@@ -34,7 +34,7 @@ certifi==2024.2.2
     #   requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.86.1
+cfn-lint==0.86.2
     # via moto
 charset-normalizer==3.3.2
     # via requests
@@ -46,16 +46,16 @@ cryptography==42.0.5
     # via
     #   joserfc
     #   moto
-deepdiff==6.7.1
+deepdiff==7.0.0
 docker==7.0.0
     # via moto
 exceptiongroup==1.2.0
     # via
     #   anyio
     #   pytest
-faker==24.4.0
+faker==24.7.1
 fakeredis==2.21.3
-flask==3.0.2
+flask==3.0.3
     # via
     #   flask-cors
     #   moto
@@ -124,10 +124,10 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   werkzeug
-moto==5.0.4
+moto==5.0.5
 mpmath==1.3.0
     # via sympy
-networkx==3.2.1
+networkx==3.3
     # via cfn-lint
 openapi-schema-validator==0.6.2
     # via openapi-spec-validator
@@ -152,7 +152,7 @@ ply==3.11
 pprintpp==0.4.0
     # via pytest-icdiff
 psutil==5.9.8
-py-partiql-parser==0.5.2
+py-partiql-parser==0.5.4
     # via moto
 pycparser==2.22
     # via cffi
@@ -231,7 +231,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   anyio
     #   aws-sam-translator

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -1,3 +1,5 @@
+antlr4-python3-runtime==4.13.1
+    # via moto
 anyio==4.3.0
     # via httpx
 asgi-lifespan==2.1.0
@@ -51,7 +53,7 @@ exceptiongroup==1.2.0
     # via
     #   anyio
     #   pytest
-faker==24.3.0
+faker==24.4.0
 fakeredis==2.21.3
 flask==3.0.2
     # via
@@ -63,7 +65,7 @@ graphql-core==3.2.3
     # via moto
 h11==0.14.0
     # via httpcore
-httpcore==1.0.4
+httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via respx
@@ -78,7 +80,7 @@ iniconfig==2.0.0
     # via pytest
 itsdangerous==2.1.2
     # via flask
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   flask
     #   moto
@@ -94,6 +96,8 @@ jsondiff==2.0.0
     # via moto
 jsonpatch==1.33
     # via cfn-lint
+jsonpath-ng==1.6.1
+    # via moto
 jsonpickle==3.0.3
     # via jschema-to-python
 jsonpointer==2.4
@@ -116,11 +120,11 @@ lazy-object-proxy==1.10.0
     # via openapi-spec-validator
 lupa==2.1
     # via fakeredis
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   jinja2
     #   werkzeug
-moto==5.0.3
+moto==5.0.4
 mpmath==1.3.0
     # via sympy
 networkx==3.2.1
@@ -131,7 +135,7 @@ openapi-spec-validator==0.7.1
     # via moto
 ordered-set==4.1.0
     # via deepdiff
-packaging==23.1
+packaging==24.0
     # via
     #   docker
     #   pytest
@@ -143,12 +147,14 @@ pbr==6.0.0
     #   sarif-om
 pluggy==1.4.0
     # via pytest
+ply==3.11
+    # via jsonpath-ng
 pprintpp==0.4.0
     # via pytest-icdiff
-psutil==5.9.5
-py-partiql-parser==0.5.1
+psutil==5.9.8
+py-partiql-parser==0.5.2
     # via moto
-pycparser==2.21
+pycparser==2.22
     # via cffi
 pydantic==1.10.14
     # via aws-sam-translator
@@ -194,7 +200,7 @@ requests==2.31.0
     #   responses
 responses==0.25.0
     # via moto
-respx==0.21.0
+respx==0.21.1
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rpds-py==0.18.0
@@ -230,13 +236,13 @@ typing-extensions==4.10.0
     #   anyio
     #   aws-sam-translator
     #   pydantic
-urllib3==1.26.16
+urllib3==2.0.7
     # via
     #   botocore
     #   docker
     #   requests
     #   responses
-werkzeug==3.0.1
+werkzeug==3.0.2
     # via
     #   flask
     #   moto

--- a/services/autoscaling/requirements/_tools.txt
+++ b/services/autoscaling/requirements/_tools.txt
@@ -64,7 +64,7 @@ tomli==2.0.1
     #   pyproject-hooks
 tomlkit==0.12.4
     # via pylint
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   astroid
     #   black

--- a/services/autoscaling/requirements/_tools.txt
+++ b/services/autoscaling/requirements/_tools.txt
@@ -1,15 +1,7 @@
-aiohttp==3.9.3
-    # via black
-aiosignal==1.3.1
-    # via aiohttp
-astroid==3.0.2
+astroid==3.1.0
     # via pylint
-async-timeout==4.0.3
-    # via aiohttp
-attrs==23.2.0
-    # via aiohttp
-black==23.12.0
-build==1.0.3
+black==24.3.0
+build==1.2.1
     # via pip-tools
 bump2version==1.0.1
 cfgv==3.4.0
@@ -18,33 +10,23 @@ click==8.1.7
     # via
     #   black
     #   pip-tools
-dill==0.3.7
+dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.1
+filelock==3.13.3
     # via virtualenv
-frozenlist==1.4.1
-    # via
-    #   aiohttp
-    #   aiosignal
-identify==2.5.33
+identify==2.5.35
     # via pre-commit
-idna==3.6
-    # via yarl
 isort==5.13.2
     # via pylint
 mccabe==0.7.0
     # via pylint
-multidict==6.0.5
-    # via
-    #   aiohttp
-    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==24.0
     # via
     #   black
     #   build
@@ -52,21 +34,23 @@ pathspec==0.12.1
     # via black
 pip==24.0
     # via pip-tools
-pip-tools==7.3.0
-platformdirs==4.1.0
+pip-tools==7.4.1
+platformdirs==4.2.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.6.0
-pylint==3.0.3
+pre-commit==3.7.0
+pylint==3.1.0
 pyproject-hooks==1.0.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 pyyaml==6.0.1
     # via
     #   pre-commit
     #   watchdog
-ruff==0.1.8
+ruff==0.3.5
 setuptools==69.2.0
     # via
     #   nodeenv
@@ -78,16 +62,14 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via pylint
 typing-extensions==4.10.0
     # via
     #   astroid
     #   black
-virtualenv==20.25.0
+virtualenv==20.25.1
     # via pre-commit
-watchdog==3.0.0
-wheel==0.42.0
+watchdog==4.0.0
+wheel==0.43.0
     # via pip-tools
-yarl==1.9.4
-    # via aiohttp

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -47,7 +47,7 @@ click==8.1.7
     # via
     #   dask
     #   distributed
-    #   typer-slim
+    #   typer
     #   uvicorn
 cloudpickle==3.0.0
     # via
@@ -144,7 +144,7 @@ referencing==0.29.3
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via typer-slim
+    # via typer
 rpds-py==0.18.0
     # via
     #   jsonschema
@@ -153,7 +153,7 @@ s3transfer==0.10.1
     # via boto3
 sh==2.0.6
 shellingham==1.5.4
-    # via typer-slim
+    # via typer
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.1
@@ -175,13 +175,7 @@ toolz==0.12.1
 tornado==6.4
     # via distributed
 tqdm==4.66.2
-typer==0.12.0
-typer-cli==0.12.0
-    # via typer
-typer-slim==0.12.0
-    # via
-    #   typer
-    #   typer-cli
+typer==0.12.1
 types-aiobotocore==2.12.2
 types-aiobotocore-ec2==2.12.2
     # via types-aiobotocore
@@ -191,14 +185,14 @@ types-awscrt==0.20.5
     # via botocore-stubs
 types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   aiodebug
     #   aiodocker
     #   anyio
     #   fastapi
     #   pydantic
-    #   typer-slim
+    #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
     #   types-aiobotocore-s3

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -125,7 +125,7 @@ prometheus-client==0.20.0
 prometheus-fastapi-instrumentator==6.1.0
 psutil==5.9.8
     # via distributed
-pydantic==1.10.14
+pydantic==1.10.15
     # via fastapi
 pygments==2.17.2
     # via rich
@@ -182,10 +182,10 @@ typer-slim==0.12.0
     # via
     #   typer
     #   typer-cli
-types-aiobotocore==2.12.1
-types-aiobotocore-ec2==2.12.1
+types-aiobotocore==2.12.2
+types-aiobotocore-ec2==2.12.2
     # via types-aiobotocore
-types-aiobotocore-s3==2.12.1
+types-aiobotocore-s3==2.12.2
     # via types-aiobotocore
 types-awscrt==0.20.5
     # via botocore-stubs

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -47,9 +47,9 @@ click==8.1.7
     # via
     #   dask
     #   distributed
-    #   typer
+    #   typer-slim
     #   uvicorn
-cloudpickle==2.2.1
+cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
@@ -69,13 +69,13 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.6.0
+fsspec==2024.3.1
     # via dask
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.4
+httpcore==1.0.5
     # via httpx
 httpx==0.27.0
 idna==3.6
@@ -84,9 +84,9 @@ idna==3.6
     #   email-validator
     #   httpx
     #   yarl
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via dask
-jinja2==3.1.2
+jinja2==3.1.3
     # via distributed
 jmespath==1.0.1
     # via
@@ -101,29 +101,29 @@ locket==1.0.0
     #   partd
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-msgpack==1.0.5
+msgpack==1.0.8
     # via distributed
 multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
 orjson==3.10.0
-packaging==23.1
+packaging==24.0
     # via
     #   dask
     #   distributed
 pamqp==3.3.0
     # via aiormq
-partd==1.4.0
+partd==1.4.1
     # via dask
 prometheus-client==0.20.0
     # via prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
-psutil==5.9.5
+psutil==5.9.8
     # via distributed
 pydantic==1.10.14
     # via fastapi
@@ -144,6 +144,7 @@ referencing==0.29.3
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
+    # via typer-slim
 rpds-py==0.18.0
     # via
     #   jsonschema
@@ -151,6 +152,8 @@ rpds-py==0.18.0
 s3transfer==0.10.1
     # via boto3
 sh==2.0.6
+shellingham==1.5.4
+    # via typer-slim
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.1
@@ -161,18 +164,24 @@ sortedcontainers==2.4.0
     # via distributed
 starlette==0.27.0
     # via fastapi
-tblib==2.0.0
+tblib==3.0.0
     # via distributed
 tenacity==8.2.3
-toolz==0.12.0
+toolz==0.12.1
     # via
     #   dask
     #   distributed
     #   partd
-tornado==6.3.3
+tornado==6.4
     # via distributed
 tqdm==4.66.2
-typer==0.10.0
+typer==0.12.0
+typer-cli==0.12.0
+    # via typer
+typer-slim==0.12.0
+    # via
+    #   typer
+    #   typer-cli
 types-aiobotocore==2.12.1
 types-aiobotocore-ec2==2.12.1
     # via types-aiobotocore
@@ -189,12 +198,12 @@ typing-extensions==4.10.0
     #   anyio
     #   fastapi
     #   pydantic
-    #   typer
+    #   typer-slim
     #   types-aiobotocore
     #   types-aiobotocore-ec2
     #   types-aiobotocore-s3
     #   uvicorn
-urllib3==1.26.16
+urllib3==2.0.7
     # via
     #   botocore
     #   distributed
@@ -208,5 +217,5 @@ yarl==1.9.4
     #   aiormq
 zict==3.0.0
     # via distributed
-zipp==3.16.2
+zipp==3.18.1
     # via importlib-metadata

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -3,6 +3,8 @@ aiohttp==3.9.3
     # via aiodocker
 aiosignal==1.3.1
     # via aiohttp
+antlr4-python3-runtime==4.13.1
+    # via moto
 anyio==4.3.0
     # via httpx
 asgi-lifespan==2.1.0
@@ -60,7 +62,7 @@ exceptiongroup==1.2.0
     # via
     #   anyio
     #   pytest
-faker==24.3.0
+faker==24.4.0
 fakeredis==2.21.3
 flask==3.0.2
     # via
@@ -76,7 +78,7 @@ graphql-core==3.2.3
     # via moto
 h11==0.14.0
     # via httpcore
-httpcore==1.0.4
+httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via respx
@@ -90,7 +92,7 @@ iniconfig==2.0.0
     # via pytest
 itsdangerous==2.1.2
     # via flask
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   flask
     #   moto
@@ -106,6 +108,8 @@ jsondiff==2.0.0
     # via moto
 jsonpatch==1.33
     # via cfn-lint
+jsonpath-ng==1.6.1
+    # via moto
 jsonpickle==3.0.3
     # via jschema-to-python
 jsonpointer==2.4
@@ -128,11 +132,11 @@ lazy-object-proxy==1.10.0
     # via openapi-spec-validator
 lupa==2.1
     # via fakeredis
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   jinja2
     #   werkzeug
-moto==5.0.3
+moto==5.0.4
 mpmath==1.3.0
     # via sympy
 multidict==6.0.5
@@ -147,7 +151,7 @@ openapi-spec-validator==0.7.1
     # via moto
 ordered-set==4.1.0
     # via deepdiff
-packaging==23.1
+packaging==24.0
     # via
     #   docker
     #   pytest
@@ -160,10 +164,12 @@ pbr==6.0.0
     #   sarif-om
 pluggy==1.4.0
     # via pytest
-psutil==5.9.5
-py-partiql-parser==0.5.1
+ply==3.11
+    # via jsonpath-ng
+psutil==5.9.8
+py-partiql-parser==0.5.2
     # via moto
-pycparser==2.21
+pycparser==2.22
     # via cffi
 pydantic==1.10.14
     # via aws-sam-translator
@@ -207,7 +213,7 @@ requests==2.31.0
     #   responses
 responses==0.25.0
     # via moto
-respx==0.21.0
+respx==0.21.1
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rpds-py==0.18.0
@@ -244,13 +250,13 @@ typing-extensions==4.10.0
     #   anyio
     #   aws-sam-translator
     #   pydantic
-urllib3==1.26.16
+urllib3==2.0.7
     # via
     #   botocore
     #   docker
     #   requests
     #   responses
-werkzeug==3.0.1
+werkzeug==3.0.2
     # via
     #   flask
     #   moto

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -19,7 +19,7 @@ attrs==23.2.0
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.86.0
+aws-sam-translator==1.87.0
     # via cfn-lint
 aws-xray-sdk==2.13.0
     # via moto
@@ -42,7 +42,7 @@ certifi==2024.2.2
     #   requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.86.1
+cfn-lint==0.86.2
     # via moto
 charset-normalizer==3.3.2
     # via requests
@@ -55,16 +55,16 @@ cryptography==42.0.5
     #   joserfc
     #   moto
 debugpy==1.8.1
-deepdiff==6.7.1
+deepdiff==7.0.0
 docker==7.0.0
     # via moto
 exceptiongroup==1.2.0
     # via
     #   anyio
     #   pytest
-faker==24.4.0
+faker==24.7.1
 fakeredis==2.21.3
-flask==3.0.2
+flask==3.0.3
     # via
     #   flask-cors
     #   moto
@@ -136,14 +136,14 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   werkzeug
-moto==5.0.4
+moto==5.0.5
 mpmath==1.3.0
     # via sympy
 multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-networkx==3.2.1
+networkx==3.3
     # via cfn-lint
 openapi-schema-validator==0.6.2
     # via openapi-spec-validator
@@ -167,7 +167,7 @@ pluggy==1.4.0
 ply==3.11
     # via jsonpath-ng
 psutil==5.9.8
-py-partiql-parser==0.5.2
+py-partiql-parser==0.5.4
     # via moto
 pycparser==2.22
     # via cffi
@@ -244,7 +244,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   aiodocker
     #   anyio

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -171,7 +171,7 @@ py-partiql-parser==0.5.2
     # via moto
 pycparser==2.22
     # via cffi
-pydantic==1.10.14
+pydantic==1.10.15
     # via aws-sam-translator
 pyparsing==3.1.2
     # via moto

--- a/services/clusters-keeper/requirements/_tools.txt
+++ b/services/clusters-keeper/requirements/_tools.txt
@@ -64,7 +64,7 @@ tomli==2.0.1
     #   pyproject-hooks
 tomlkit==0.12.4
     # via pylint
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   astroid
     #   black

--- a/services/clusters-keeper/requirements/_tools.txt
+++ b/services/clusters-keeper/requirements/_tools.txt
@@ -1,7 +1,7 @@
 astroid==3.1.0
     # via pylint
 black==24.3.0
-build==1.1.1
+build==1.2.1
     # via pip-tools
 bump2version==1.0.1
 cfgv==3.4.0
@@ -14,7 +14,7 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.2
+filelock==3.13.3
     # via virtualenv
 identify==2.5.35
     # via pre-commit
@@ -26,7 +26,7 @@ mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==24.0
     # via
     #   black
     #   build
@@ -50,7 +50,7 @@ pyyaml==6.0.1
     # via
     #   pre-commit
     #   watchdog
-ruff==0.3.4
+ruff==0.3.5
 setuptools==69.2.0
     # via
     #   nodeenv

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -113,7 +113,7 @@ pillow==10.3.0
 prometheus-client==0.20.0
 psutil==5.9.8
     # via distributed
-pydantic==1.10.14
+pydantic==1.10.15
 pygments==2.17.2
     # via rich
 pyinstrument==4.6.2

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -37,7 +37,7 @@ click==8.1.7
     #   dask
     #   dask-gateway
     #   distributed
-    #   typer-slim
+    #   typer
 cloudpickle==3.0.0
     # via
     #   dask
@@ -135,7 +135,7 @@ referencing==0.29.3
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via typer-slim
+    # via typer
 rpds-py==0.18.0
     # via
     #   jsonschema
@@ -143,7 +143,7 @@ rpds-py==0.18.0
 s3fs==2024.3.1
     # via fsspec
 shellingham==1.5.4
-    # via typer-slim
+    # via typer
 six==1.16.0
     # via python-dateutil
 sortedcontainers==2.4.0
@@ -162,22 +162,16 @@ tornado==6.4
     #   dask-gateway
     #   distributed
 tqdm==4.66.2
-typer==0.12.0
-typer-cli==0.12.0
-    # via typer
-typer-slim==0.12.0
-    # via
-    #   typer
-    #   typer-cli
+typer==0.12.1
 types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   aiodebug
     #   aiodocker
     #   bokeh
     #   pydantic
-    #   typer-slim
+    #   typer
 urllib3==2.0.7
     # via
     #   botocore

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -1,10 +1,10 @@
-aio-pika==9.2.2
-aiobotocore==2.5.4
+aio-pika==9.4.1
+aiobotocore==2.12.2
     # via s3fs
 aiodebug==2.3.0
 aiodocker==0.21.0
 aiofiles==23.2.1
-aiohttp==3.8.5
+aiohttp==3.9.3
     # via
     #   aiobotocore
     #   aiodocker
@@ -13,16 +13,16 @@ aiohttp==3.8.5
     #   s3fs
 aioitertools==0.11.0
     # via aiobotocore
-aiormq==6.7.7
+aiormq==6.8.0
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
-arrow==1.2.3
+arrow==1.3.0
 async-timeout==4.0.3
     # via
     #   aiohttp
     #   redis
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   aiohttp
     #   jsonschema
@@ -30,21 +30,15 @@ attrs==23.1.0
 blosc==1.11.1
 bokeh==2.4.3
     # via dask
-botocore==1.31.17
+botocore==1.34.51
     # via aiobotocore
-certifi==2023.7.22
-    # via requests
-charset-normalizer==3.2.0
-    # via
-    #   aiohttp
-    #   requests
 click==8.1.7
     # via
     #   dask
     #   dask-gateway
     #   distributed
-    #   typer
-cloudpickle==2.2.1
+    #   typer-slim
+cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
@@ -52,83 +46,82 @@ dask==2023.3.2
     # via
     #   dask-gateway
     #   distributed
-dask-gateway==2023.1.1
+dask-gateway==2024.1.0
 distributed==2023.3.2
     # via
     #   dask
     #   dask-gateway
-dnspython==2.4.2
+dnspython==2.6.1
     # via email-validator
-email-validator==2.0.0.post2
+email-validator==2.1.1
     # via pydantic
-frozenlist==1.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.6.0
+fsspec==2024.3.1
     # via
     #   dask
     #   s3fs
-idna==3.4
+idna==3.6
     # via
     #   email-validator
-    #   requests
     #   yarl
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via dask
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   bokeh
     #   dask
     #   distributed
 jmespath==1.0.1
     # via botocore
-jsonschema==4.19.0
+jsonschema==4.21.1
 jsonschema-specifications==2023.7.1
     # via jsonschema
 locket==1.0.0
     # via
     #   distributed
     #   partd
-lz4==4.3.2
+lz4==4.3.3
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-msgpack==1.0.5
+msgpack==1.0.8
     # via distributed
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-numpy==1.25.2
+numpy==1.26.4
     # via bokeh
 orjson==3.10.0
-packaging==23.1
+packaging==24.0
     # via
     #   bokeh
     #   dask
     #   distributed
-pamqp==3.2.1
+pamqp==3.3.0
     # via aiormq
-partd==1.4.0
+partd==1.4.1
     # via dask
-pillow==10.0.0
+pillow==10.3.0
     # via bokeh
-prometheus-client==0.19.0
-psutil==5.9.5
+prometheus-client==0.20.0
+psutil==5.9.8
     # via distributed
-pydantic==1.10.12
-pygments==2.16.1
+pydantic==1.10.14
+pygments==2.17.2
     # via rich
-pyinstrument==4.5.1
-python-dateutil==2.8.2
+pyinstrument==4.6.2
+python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   botocore
-python-dotenv==1.0.0
+python-dotenv==1.0.1
     # via pydantic
 pyyaml==6.0.1
     # via
@@ -136,59 +129,67 @@ pyyaml==6.0.1
     #   dask
     #   dask-gateway
     #   distributed
-redis==5.0.0
+redis==5.0.3
 referencing==0.29.3
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.31.0
-    # via fsspec
-rich==13.5.2
-rpds-py==0.9.2
+rich==13.7.1
+    # via typer-slim
+rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-s3fs==2023.6.0
+s3fs==2024.3.1
     # via fsspec
+shellingham==1.5.4
+    # via typer-slim
 six==1.16.0
     # via python-dateutil
 sortedcontainers==2.4.0
     # via distributed
-tblib==2.0.0
+tblib==3.0.0
     # via distributed
 tenacity==8.2.3
-toolz==0.12.0
+toolz==0.12.1
     # via
     #   dask
     #   distributed
     #   partd
-tornado==6.3.3
+tornado==6.4
     # via
     #   bokeh
     #   dask-gateway
     #   distributed
-tqdm==4.66.1
-typer==0.9.0
-typing-extensions==4.7.1
+tqdm==4.66.2
+typer==0.12.0
+typer-cli==0.12.0
+    # via typer
+typer-slim==0.12.0
+    # via
+    #   typer
+    #   typer-cli
+types-python-dateutil==2.9.0.20240316
+    # via arrow
+typing-extensions==4.10.0
     # via
     #   aiodebug
     #   aiodocker
     #   bokeh
     #   pydantic
-    #   typer
-urllib3==1.26.16
+    #   typer-slim
+urllib3==2.0.7
     # via
     #   botocore
     #   distributed
-    #   requests
-wrapt==1.15.0
+wrapt==1.16.0
     # via aiobotocore
-yarl==1.9.2
+yarl==1.9.4
     # via
     #   aio-pika
     #   aiohttp
     #   aiormq
 zict==3.0.0
     # via distributed
-zipp==3.16.2
+zipp==3.18.1
     # via importlib-metadata

--- a/services/dask-sidecar/requirements/_dask-distributed.txt
+++ b/services/dask-sidecar/requirements/_dask-distributed.txt
@@ -3,7 +3,7 @@ click==8.1.7
     # via
     #   dask
     #   distributed
-cloudpickle==2.2.1
+cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
@@ -11,29 +11,29 @@ dask==2023.3.2
     # via distributed
 distributed==2023.3.2
     # via dask
-fsspec==2023.6.0
+fsspec==2024.3.1
     # via dask
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via dask
-jinja2==3.1.2
+jinja2==3.1.3
     # via distributed
 locket==1.0.0
     # via
     #   distributed
     #   partd
-lz4==4.3.2
-markupsafe==2.1.3
+lz4==4.3.3
+markupsafe==2.1.5
     # via jinja2
-msgpack==1.0.5
+msgpack==1.0.8
     # via distributed
-numpy==1.25.2
-packaging==23.1
+numpy==1.26.4
+packaging==24.0
     # via
     #   dask
     #   distributed
-partd==1.4.0
+partd==1.4.1
     # via dask
-psutil==5.9.5
+psutil==5.9.8
     # via distributed
 pyyaml==6.0.1
     # via
@@ -41,18 +41,18 @@ pyyaml==6.0.1
     #   distributed
 sortedcontainers==2.4.0
     # via distributed
-tblib==2.0.0
+tblib==3.0.0
     # via distributed
-toolz==0.12.0
+toolz==0.12.1
     # via
     #   dask
     #   distributed
     #   partd
-tornado==6.3.3
+tornado==6.4
     # via distributed
-urllib3==1.26.16
+urllib3==2.0.7
     # via distributed
 zict==3.0.0
     # via distributed
-zipp==3.16.2
+zipp==3.18.1
     # via importlib-metadata

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -6,7 +6,7 @@ attrs==23.2.0
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.86.0
+aws-sam-translator==1.87.0
     # via cfn-lint
 aws-xray-sdk==2.13.0
     # via moto
@@ -26,7 +26,7 @@ certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.86.1
+cfn-lint==0.86.2
     # via moto
 charset-normalizer==3.3.2
     # via requests
@@ -43,8 +43,8 @@ docker==7.0.0
     # via moto
 exceptiongroup==1.2.0
     # via pytest
-faker==24.4.0
-flask==3.0.2
+faker==24.7.1
+flask==3.0.3
     # via
     #   flask-cors
     #   moto
@@ -102,10 +102,10 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   werkzeug
-moto==5.0.4
+moto==5.0.5
 mpmath==1.3.0
     # via sympy
-networkx==3.2.1
+networkx==3.3
     # via cfn-lint
 openapi-schema-validator==0.6.2
     # via openapi-spec-validator
@@ -128,7 +128,7 @@ ply==3.11
     # via jsonpath-ng
 pprintpp==0.4.0
     # via pytest-icdiff
-py-partiql-parser==0.5.2
+py-partiql-parser==0.5.4
     # via moto
 pycparser==2.22
     # via cffi
@@ -208,7 +208,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   aws-sam-translator
     #   pydantic

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -1,54 +1,50 @@
-attrs==23.1.0
+antlr4-python3-runtime==4.13.1
+    # via moto
+attrs==23.2.0
     # via
     #   jschema-to-python
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.79.0
+aws-sam-translator==1.86.0
     # via cfn-lint
-aws-xray-sdk==2.12.1
+aws-xray-sdk==2.13.0
     # via moto
 blinker==1.7.0
     # via flask
-boto3==1.28.17
+boto3==1.34.51
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.31.17
+botocore==1.34.51
     # via
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
-certifi==2023.7.22
+certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.83.1
+cfn-lint==0.86.1
     # via moto
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via flask
-coverage==7.3.2
+coverage==7.4.4
     # via pytest-cov
-cryptography==41.0.7
+cryptography==42.0.5
     # via
+    #   joserfc
     #   moto
     #   pyopenssl
-    #   python-jose
-    #   sshpubkeys
-docker==6.1.3
+docker==7.0.0
     # via moto
-ecdsa==0.18.0
-    # via
-    #   moto
-    #   python-jose
-    #   sshpubkeys
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
-faker==19.13.0
-flask==3.0.0
+faker==24.4.0
+flask==3.0.2
     # via
     #   flask-cors
     #   moto
@@ -58,13 +54,13 @@ graphql-core==3.2.3
     # via moto
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.4
+idna==3.6
     # via requests
 iniconfig==2.0.0
     # via pytest
 itsdangerous==2.1.2
     # via flask
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   flask
     #   moto
@@ -72,23 +68,27 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+joserfc==0.9.0
+    # via moto
 jschema-to-python==1.2.3
     # via cfn-lint
 jsondiff==2.0.0
     # via moto
 jsonpatch==1.33
     # via cfn-lint
-jsonpickle==3.0.2
+jsonpath-ng==1.6.1
+    # via moto
+jsonpickle==3.0.3
     # via jschema-to-python
 jsonpointer==2.4
     # via jsonpatch
-jsonschema==4.19.0
+jsonschema==4.21.1
     # via
     #   aws-sam-translator
     #   cfn-lint
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.1
+jsonschema-path==0.3.2
     # via openapi-spec-validator
 jsonschema-specifications==2023.7.1
     # via
@@ -96,53 +96,51 @@ jsonschema-specifications==2023.7.1
     #   openapi-schema-validator
 junit-xml==1.9
     # via cfn-lint
-lazy-object-proxy==1.9.0
+lazy-object-proxy==1.10.0
     # via openapi-spec-validator
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   jinja2
     #   werkzeug
-moto==4.2.7
+moto==5.0.4
 mpmath==1.3.0
     # via sympy
 networkx==3.2.1
     # via cfn-lint
-openapi-schema-validator==0.6.0
+openapi-schema-validator==0.6.2
     # via openapi-spec-validator
 openapi-spec-validator==0.7.1
     # via moto
-packaging==23.1
+packaging==24.0
     # via
     #   docker
     #   pytest
     #   pytest-sugar
 pathable==0.4.3
     # via jsonschema-path
-pbr==5.11.1
+pbr==6.0.0
     # via
     #   jschema-to-python
     #   sarif-om
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
+ply==3.11
+    # via jsonpath-ng
 pprintpp==0.4.0
     # via pytest-icdiff
-py-partiql-parser==0.4.1
+py-partiql-parser==0.5.2
     # via moto
-pyasn1==0.5.0
-    # via
-    #   python-jose
-    #   rsa
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pydantic==1.10.12
+pydantic==1.10.14
     # via aws-sam-translator
 pyftpdlib==1.5.9
     # via pytest-localftpserver
-pyopenssl==23.3.0
+pyopenssl==24.1.0
     # via pytest-localftpserver
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via moto
-pytest==7.4.3
+pytest==8.1.1
     # via
     #   pytest-asyncio
     #   pytest-cov
@@ -152,20 +150,18 @@ pytest==7.4.3
     #   pytest-mock
     #   pytest-sugar
 pytest-asyncio==0.21.1
-pytest-cov==4.1.0
-pytest-icdiff==0.8
+pytest-cov==5.0.0
+pytest-icdiff==0.9
 pytest-instafail==0.5.0
 pytest-localftpserver==1.2.0
-pytest-mock==3.12.0
-pytest-sugar==0.9.7
-python-dateutil==2.8.2
+pytest-mock==3.14.0
+pytest-sugar==1.0.0
+python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   faker
     #   moto
-python-dotenv==1.0.0
-python-jose==3.3.0
-    # via moto
+python-dotenv==1.0.1
 pyyaml==6.0.1
     # via
     #   cfn-lint
@@ -177,7 +173,7 @@ referencing==0.29.3
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-regex==2023.10.3
+regex==2023.12.25
     # via cfn-lint
 requests==2.31.0
     # via
@@ -185,17 +181,15 @@ requests==2.31.0
     #   jsonschema-path
     #   moto
     #   responses
-responses==0.23.3
+responses==0.25.0
     # via moto
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.9.2
+rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-rsa==4.9
-    # via python-jose
-s3transfer==0.6.2
+s3transfer==0.10.1
     # via boto3
 sarif-om==1.0.4
     # via cfn-lint
@@ -203,39 +197,32 @@ setuptools==69.2.0
     # via moto
 six==1.16.0
     # via
-    #   ecdsa
     #   junit-xml
     #   python-dateutil
     #   rfc3339-validator
-sshpubkeys==3.3.1
-    # via moto
 sympy==1.12
     # via cfn-lint
-termcolor==2.3.0
+termcolor==2.4.0
     # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
-types-pyyaml==6.0.12.12
-    # via responses
-typing-extensions==4.7.1
+typing-extensions==4.10.0
     # via
     #   aws-sam-translator
     #   pydantic
-urllib3==1.26.16
+urllib3==2.0.7
     # via
     #   botocore
     #   docker
     #   requests
     #   responses
-websocket-client==1.6.4
-    # via docker
-werkzeug==3.0.1
+werkzeug==3.0.2
     # via
     #   flask
     #   moto
-wrapt==1.15.0
+wrapt==1.16.0
     # via aws-xray-sdk
 xmltodict==0.13.0
     # via moto

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -132,7 +132,7 @@ py-partiql-parser==0.5.2
     # via moto
 pycparser==2.22
     # via cffi
-pydantic==1.10.14
+pydantic==1.10.15
     # via aws-sam-translator
 pyftpdlib==1.5.9
     # via pytest-localftpserver

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -64,7 +64,7 @@ tomli==2.0.1
     #   pyproject-hooks
 tomlkit==0.12.4
     # via pylint
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   astroid
     #   black

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -1,52 +1,32 @@
-aiohttp==3.8.5
-    # via black
-aiosignal==1.3.1
-    # via aiohttp
-astroid==3.0.2
+astroid==3.1.0
     # via pylint
-async-timeout==4.0.3
-    # via aiohttp
-attrs==23.1.0
-    # via aiohttp
-black==23.12.0
-build==1.0.3
+black==24.3.0
+build==1.2.1
     # via pip-tools
 bump2version==1.0.1
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.2.0
-    # via aiohttp
 click==8.1.7
     # via
     #   black
     #   pip-tools
-dill==0.3.7
+dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.1
+filelock==3.13.3
     # via virtualenv
-frozenlist==1.4.0
-    # via
-    #   aiohttp
-    #   aiosignal
-identify==2.5.33
+identify==2.5.35
     # via pre-commit
-idna==3.4
-    # via yarl
 isort==5.13.2
     # via pylint
 mccabe==0.7.0
     # via pylint
-multidict==6.0.4
-    # via
-    #   aiohttp
-    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==24.0
     # via
     #   black
     #   build
@@ -54,21 +34,23 @@ pathspec==0.12.1
     # via black
 pip==24.0
     # via pip-tools
-pip-tools==7.3.0
-platformdirs==4.1.0
+pip-tools==7.4.1
+platformdirs==4.2.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.6.0
-pylint==3.0.3
+pre-commit==3.7.0
+pylint==3.1.0
 pyproject-hooks==1.0.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 pyyaml==6.0.1
     # via
     #   pre-commit
     #   watchdog
-ruff==0.1.8
+ruff==0.3.5
 setuptools==69.2.0
     # via
     #   nodeenv
@@ -80,16 +62,14 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via pylint
-typing-extensions==4.7.1
+typing-extensions==4.10.0
     # via
     #   astroid
     #   black
-virtualenv==20.25.0
+virtualenv==20.25.1
     # via pre-commit
-watchdog==3.0.0
-wheel==0.42.0
+watchdog==4.0.0
+wheel==0.43.0
     # via pip-tools
-yarl==1.9.2
-    # via aiohttp

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -3,7 +3,7 @@ aiocache==0.12.2
 aiodebug==2.3.0
 aiodocker==0.21.0
 aiofiles==23.2.1
-aiohttp==3.9.3
+aiohttp==3.8.6
     # via
     #   aiodocker
     #   dask-gateway
@@ -39,6 +39,8 @@ certifi==2024.2.2
     # via
     #   httpcore
     #   httpx
+charset-normalizer==3.3.2
+    # via aiohttp
 click==8.1.7
     # via
     #   dask

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -1,32 +1,33 @@
-aio-pika==9.1.2
-aiocache==0.12.1
+aio-pika==9.4.1
+aiocache==0.12.2
 aiodebug==2.3.0
 aiodocker==0.21.0
-aiofiles==23.1.0
-aiohttp==3.8.5
+aiofiles==23.2.1
+aiohttp==3.9.3
     # via
     #   aiodocker
     #   dask-gateway
 aiopg==1.4.0
-aiormq==6.7.6
+aiormq==6.8.0
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
-alembic==1.11.1
-anyio==3.7.1
+alembic==1.13.1
+anyio==4.3.0
     # via
-    #   httpcore
+    #   httpx
     #   starlette
     #   watchfiles
-arrow==1.2.3
-async-timeout==4.0.2
+arrow==1.3.0
+async-timeout==4.0.3
     # via
     #   aiohttp
     #   aiopg
+    #   asyncpg
     #   redis
-asyncpg==0.28.0
+asyncpg==0.29.0
     # via sqlalchemy
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   aiohttp
     #   jsonschema
@@ -34,20 +35,18 @@ attrs==23.1.0
 bidict==0.23.1
     # via python-socketio
 blosc==1.11.1
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   httpcore
     #   httpx
-charset-normalizer==3.2.0
-    # via aiohttp
 click==8.1.7
     # via
     #   dask
     #   dask-gateway
     #   distributed
-    #   typer
+    #   typer-slim
     #   uvicorn
-cloudpickle==2.2.1
+cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
@@ -55,113 +54,111 @@ dask==2023.3.2
     # via
     #   dask-gateway
     #   distributed
-dask-gateway==2023.1.1
+dask-gateway==2024.1.0
 distributed==2023.3.2
     # via
     #   dask
     #   dask-gateway
-dnspython==2.4.0
+dnspython==2.6.1
     # via email-validator
-email-validator==2.0.0.post2
+email-validator==2.1.1
     # via
     #   fastapi
     #   pydantic
-exceptiongroup==1.1.2
+exceptiongroup==1.2.0
     # via anyio
 fastapi==0.99.1
     # via prometheus-fastapi-instrumentator
-frozenlist==1.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.6.0
+fsspec==2024.3.1
     # via dask
-greenlet==2.0.2
+greenlet==3.0.3
     # via sqlalchemy
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
     #   wsproto
-httpcore==0.17.3
-    # via
-    #   dnspython
-    #   httpx
-httptools==0.6.0
+httpcore==1.0.5
+    # via httpx
+httptools==0.6.1
     # via uvicorn
-httpx==0.24.1
+httpx==0.27.0
     # via fastapi
-idna==3.4
+idna==3.6
     # via
     #   anyio
     #   email-validator
     #   httpx
     #   yarl
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via dask
 itsdangerous==2.1.2
     # via fastapi
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   distributed
     #   fastapi
-jsonschema==4.18.4
+jsonschema==4.21.1
 jsonschema-specifications==2023.7.1
     # via jsonschema
 locket==1.0.0
     # via
     #   distributed
     #   partd
-lz4==4.3.2
-mako==1.2.4
+lz4==4.3.3
+mako==1.3.2
     # via alembic
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   jinja2
     #   mako
 mdurl==0.1.2
     # via markdown-it-py
-msgpack==1.0.5
+msgpack==1.0.8
     # via
     #   aiocache
     #   distributed
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-networkx==3.1
-numpy==1.25.2
+networkx==3.2.1
+numpy==1.26.4
 ordered-set==4.1.0
 orjson==3.10.0
     # via fastapi
-packaging==23.1
+packaging==24.0
     # via
     #   dask
     #   distributed
-pamqp==3.2.1
+pamqp==3.3.0
     # via aiormq
-partd==1.4.0
+partd==1.4.1
     # via dask
-pint==0.22
+pint==0.23
 prometheus-client==0.20.0
     # via prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
-psutil==5.9.5
+psutil==5.9.8
     # via distributed
-psycopg2-binary==2.9.6
+psycopg2-binary==2.9.9
     # via
     #   aiopg
     #   sqlalchemy
-pydantic==1.10.11
+pydantic==1.10.14
     # via fastapi
-pygments==2.15.1
+pygments==2.17.2
     # via rich
-pyinstrument==4.5.1
-python-dateutil==2.8.2
+pyinstrument==4.6.2
+python-dateutil==2.9.0.post0
     # via arrow
-python-dotenv==1.0.0
+python-dotenv==1.0.1
     # via
     #   pydantic
     #   uvicorn
@@ -169,7 +166,7 @@ python-engineio==4.9.0
     # via python-socketio
 python-multipart==0.0.9
     # via fastapi
-python-socketio==5.11.1
+python-socketio==5.11.2
 pyyaml==6.0.1
     # via
     #   dask
@@ -177,79 +174,89 @@ pyyaml==6.0.1
     #   distributed
     #   fastapi
     #   uvicorn
-redis==4.6.0
+redis==5.0.3
     # via aiocache
 referencing==0.29.3
     # via
     #   jsonschema
     #   jsonschema-specifications
-rich==13.4.2
-rpds-py==0.9.2
+rich==13.7.1
+    # via typer-slim
+rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
+shellingham==1.5.4
+    # via typer-slim
 simple-websocket==1.0.0
     # via python-engineio
 six==1.16.0
     # via python-dateutil
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
-    #   dnspython
-    #   httpcore
     #   httpx
 sortedcontainers==2.4.0
     # via distributed
-sqlalchemy==1.4.49
+sqlalchemy==1.4.52
     # via
     #   aiopg
     #   alembic
 starlette==0.27.0
     # via fastapi
-tblib==2.0.0
+tblib==3.0.0
     # via distributed
-tenacity==8.2.2
-toolz==0.12.0
+tenacity==8.2.3
+toolz==0.12.1
     # via
     #   dask
     #   distributed
     #   partd
-tornado==6.3.3
+tornado==6.4
     # via
     #   dask-gateway
     #   distributed
-tqdm==4.65.0
-typer==0.9.0
-typing-extensions==4.7.1
+tqdm==4.66.2
+typer==0.12.0
+typer-cli==0.12.0
+    # via typer
+typer-slim==0.12.0
+    # via
+    #   typer
+    #   typer-cli
+types-python-dateutil==2.9.0.20240316
+    # via arrow
+typing-extensions==4.10.0
     # via
     #   aiodebug
     #   aiodocker
     #   alembic
+    #   anyio
     #   fastapi
     #   pint
     #   pydantic
-    #   typer
+    #   typer-slim
     #   uvicorn
-ujson==5.8.0
+ujson==5.9.0
     # via fastapi
-urllib3==1.26.16
+urllib3==2.0.7
     # via distributed
-uvicorn==0.23.1
+uvicorn==0.29.0
     # via fastapi
-uvloop==0.17.0
+uvloop==0.19.0
     # via uvicorn
-watchfiles==0.19.0
+watchfiles==0.21.0
     # via uvicorn
-websockets==11.0.3
+websockets==12.0
     # via uvicorn
 wsproto==1.2.0
     # via simple-websocket
-yarl==1.9.2
+yarl==1.9.4
     # via
     #   aio-pika
     #   aiohttp
     #   aiormq
 zict==3.0.0
     # via distributed
-zipp==3.16.2
+zipp==3.18.1
     # via importlib-metadata

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -151,7 +151,7 @@ psycopg2-binary==2.9.9
     # via
     #   aiopg
     #   sqlalchemy
-pydantic==1.10.14
+pydantic==1.10.15
     # via fastapi
 pygments==2.17.2
     # via rich

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -3,7 +3,7 @@ aiocache==0.12.2
 aiodebug==2.3.0
 aiodocker==0.21.0
 aiofiles==23.2.1
-aiohttp==3.8.6
+aiohttp==3.9.3
     # via
     #   aiodocker
     #   dask-gateway
@@ -39,14 +39,12 @@ certifi==2024.2.2
     # via
     #   httpcore
     #   httpx
-charset-normalizer==3.3.2
-    # via aiohttp
 click==8.1.7
     # via
     #   dask
     #   dask-gateway
     #   distributed
-    #   typer-slim
+    #   typer
     #   uvicorn
 cloudpickle==3.0.0
     # via
@@ -130,7 +128,7 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-networkx==3.2.1
+networkx==3.3
 numpy==1.26.4
 ordered-set==4.1.0
 orjson==3.10.0
@@ -183,13 +181,13 @@ referencing==0.29.3
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via typer-slim
+    # via typer
 rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
 shellingham==1.5.4
-    # via typer-slim
+    # via typer
 simple-websocket==1.0.0
     # via python-engineio
 six==1.16.0
@@ -219,16 +217,10 @@ tornado==6.4
     #   dask-gateway
     #   distributed
 tqdm==4.66.2
-typer==0.12.0
-typer-cli==0.12.0
-    # via typer
-typer-slim==0.12.0
-    # via
-    #   typer
-    #   typer-cli
+typer==0.12.1
 types-python-dateutil==2.9.0.20240316
     # via arrow
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   aiodebug
     #   aiodocker
@@ -237,7 +229,7 @@ typing-extensions==4.10.0
     #   fastapi
     #   pint
     #   pydantic
-    #   typer-slim
+    #   typer
     #   uvicorn
 ujson==5.9.0
     # via fastapi

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -2,7 +2,7 @@ aio-pika==9.4.1
 aioboto3==12.3.0
 aiobotocore==2.11.2
     # via aioboto3
-aiohttp==3.8.6
+aiohttp==3.9.3
     # via
     #   aiobotocore
     #   dask-gateway-server
@@ -40,9 +40,7 @@ certifi==2024.2.2
 cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 click==8.1.7
     # via
     #   dask
@@ -67,9 +65,9 @@ exceptiongroup==1.2.0
     # via
     #   anyio
     #   pytest
-execnet==2.0.2
+execnet==2.1.1
     # via pytest-xdist
-faker==24.4.0
+faker==24.7.1
 flaky==3.8.1
 frozenlist==1.4.1
     # via
@@ -214,7 +212,7 @@ tornado==6.4
     #   distributed
 traitlets==5.14.2
     # via dask-gateway-server
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   alembic
     #   anyio

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -2,7 +2,7 @@ aio-pika==9.4.1
 aioboto3==12.3.0
 aiobotocore==2.11.2
     # via aioboto3
-aiohttp==3.9.3
+aiohttp==3.8.6
     # via
     #   aiobotocore
     #   dask-gateway-server
@@ -40,7 +40,9 @@ certifi==2024.2.2
 cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   aiohttp
+    #   requests
 click==8.1.7
     # via
     #   dask

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -1,103 +1,101 @@
-aio-pika==9.1.2
-aioboto3==12.0.0
-aiobotocore==2.7.0
+aio-pika==9.4.1
+aioboto3==12.3.0
+aiobotocore==2.11.2
     # via aioboto3
-aiohttp==3.8.5
+aiohttp==3.9.3
     # via
     #   aiobotocore
     #   dask-gateway-server
 aioitertools==0.11.0
     # via aiobotocore
-aiormq==6.7.6
+aiormq==6.8.0
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
-alembic==1.11.1
-anyio==3.7.1
-    # via httpcore
+alembic==1.13.1
+anyio==4.3.0
+    # via httpx
 asgi-lifespan==2.1.0
 async-asgi-testclient==1.4.11
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via aiohttp
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   aiohttp
     #   pytest-docker
 bokeh==2.4.3
     # via dask
-boto3==1.28.64
+boto3==1.34.34
     # via aiobotocore
-botocore==1.31.64
+botocore==1.34.34
     # via
     #   aiobotocore
     #   boto3
     #   s3transfer
-certifi==2023.7.22
+certifi==2024.2.2
     # via
     #   httpcore
     #   httpx
     #   requests
 cffi==1.16.0
     # via cryptography
-charset-normalizer==3.2.0
-    # via
-    #   aiohttp
-    #   requests
+charset-normalizer==3.3.2
+    # via requests
 click==8.1.7
     # via
     #   dask
     #   distributed
-cloudpickle==2.2.1
+cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-colorlog==6.7.0
+colorlog==6.8.2
     # via dask-gateway-server
-coverage==7.3.2
+coverage==7.4.4
     # via pytest-cov
-cryptography==41.0.7
+cryptography==42.0.5
     # via dask-gateway-server
 dask==2023.3.2
     # via distributed
 dask-gateway-server==2023.1.1
 distributed==2023.3.2
     # via dask
-docker==6.1.3
-exceptiongroup==1.1.2
+docker==7.0.0
+exceptiongroup==1.2.0
     # via
     #   anyio
     #   pytest
 execnet==2.0.2
     # via pytest-xdist
-faker==19.13.0
-flaky==3.7.0
-frozenlist==1.4.0
+faker==24.4.0
+flaky==3.8.1
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.6.0
+fsspec==2024.3.1
     # via dask
-greenlet==2.0.2
+greenlet==3.0.3
     # via sqlalchemy
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==1.0.5
     # via httpx
-httpx==0.24.1
+httpx==0.27.0
     # via respx
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.4
+idna==3.6
     # via
     #   anyio
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via dask
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   bokeh
     #   dask
@@ -110,47 +108,47 @@ locket==1.0.0
     # via
     #   distributed
     #   partd
-mako==1.2.4
+mako==1.3.2
     # via alembic
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   jinja2
     #   mako
-msgpack==1.0.5
+msgpack==1.0.8
     # via distributed
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   async-asgi-testclient
     #   yarl
-mypy==1.6.1
+mypy==1.9.0
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
-numpy==1.25.2
+numpy==1.26.4
     # via bokeh
-packaging==23.1
+packaging==24.0
     # via
     #   bokeh
     #   dask
     #   distributed
     #   docker
     #   pytest
-pamqp==3.2.1
+pamqp==3.3.0
     # via aiormq
-partd==1.4.0
+partd==1.4.1
     # via dask
-pillow==10.1.0
+pillow==10.3.0
     # via bokeh
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-psutil==5.9.5
+psutil==5.9.8
     # via distributed
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pytest==7.4.3
+pytest==8.1.1
     # via
     #   pytest-asyncio
     #   pytest-cov
@@ -159,13 +157,13 @@ pytest==7.4.3
     #   pytest-mock
     #   pytest-xdist
 pytest-asyncio==0.21.1
-pytest-cov==4.1.0
-pytest-docker==2.0.1
-pytest-icdiff==0.8
-pytest-mock==3.12.0
-pytest-runner==6.0.0
-pytest-xdist==3.3.1
-python-dateutil==2.8.2
+pytest-cov==5.0.0
+pytest-docker==3.1.1
+pytest-icdiff==0.9
+pytest-mock==3.14.0
+pytest-runner==6.0.1
+pytest-xdist==3.5.0
+python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   faker
@@ -178,65 +176,63 @@ requests==2.31.0
     # via
     #   async-asgi-testclient
     #   docker
-respx==0.20.2
-s3transfer==0.7.0
+respx==0.21.1
+s3transfer==0.10.1
     # via boto3
 six==1.16.0
     # via python-dateutil
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
     #   asgi-lifespan
-    #   httpcore
     #   httpx
 sortedcontainers==2.4.0
     # via distributed
-sqlalchemy==1.4.49
+sqlalchemy==1.4.52
     # via
     #   alembic
     #   dask-gateway-server
-sqlalchemy2-stubs==0.0.2a36
+sqlalchemy2-stubs==0.0.2a38
     # via sqlalchemy
-tblib==2.0.0
+tblib==3.0.0
     # via distributed
 tomli==2.0.1
     # via
     #   coverage
     #   mypy
     #   pytest
-toolz==0.12.0
+toolz==0.12.1
     # via
     #   dask
     #   distributed
     #   partd
-tornado==6.3.3
+tornado==6.4
     # via
     #   bokeh
     #   distributed
-traitlets==5.13.0
+traitlets==5.14.2
     # via dask-gateway-server
-typing-extensions==4.7.1
+typing-extensions==4.10.0
     # via
     #   alembic
+    #   anyio
     #   bokeh
     #   mypy
     #   sqlalchemy2-stubs
-urllib3==1.26.16
+urllib3==2.0.7
     # via
     #   botocore
     #   distributed
     #   docker
     #   requests
-websocket-client==1.6.4
-    # via docker
-wrapt==1.15.0
+wrapt==1.16.0
     # via aiobotocore
-yarl==1.9.2
+yarl==1.9.4
     # via
     #   aio-pika
     #   aiohttp
     #   aiormq
 zict==3.0.0
     # via distributed
-zipp==3.16.2
+zipp==3.18.1
     # via importlib-metadata

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -1,52 +1,32 @@
-aiohttp==3.8.5
-    # via black
-aiosignal==1.3.1
-    # via aiohttp
-astroid==3.0.2
+astroid==3.1.0
     # via pylint
-async-timeout==4.0.2
-    # via aiohttp
-attrs==23.1.0
-    # via aiohttp
-black==23.12.0
-build==1.0.3
+black==24.3.0
+build==1.2.1
     # via pip-tools
 bump2version==1.0.1
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.2.0
-    # via aiohttp
 click==8.1.7
     # via
     #   black
     #   pip-tools
-dill==0.3.7
+dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.1
+filelock==3.13.3
     # via virtualenv
-frozenlist==1.4.0
-    # via
-    #   aiohttp
-    #   aiosignal
-identify==2.5.33
+identify==2.5.35
     # via pre-commit
-idna==3.4
-    # via yarl
 isort==5.13.2
     # via pylint
 mccabe==0.7.0
     # via pylint
-multidict==6.0.4
-    # via
-    #   aiohttp
-    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==24.0
     # via
     #   black
     #   build
@@ -54,21 +34,23 @@ pathspec==0.12.1
     # via black
 pip==24.0
     # via pip-tools
-pip-tools==7.3.0
-platformdirs==4.1.0
+pip-tools==7.4.1
+platformdirs==4.2.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.6.0
-pylint==3.0.3
+pre-commit==3.7.0
+pylint==3.1.0
 pyproject-hooks==1.0.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 pyyaml==6.0.1
     # via
     #   pre-commit
     #   watchdog
-ruff==0.1.8
+ruff==0.3.5
 setuptools==69.2.0
     # via
     #   nodeenv
@@ -80,16 +62,14 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via pylint
-typing-extensions==4.7.1
+typing-extensions==4.10.0
     # via
     #   astroid
     #   black
-virtualenv==20.25.0
+virtualenv==20.25.1
     # via pre-commit
-watchdog==3.0.0
-wheel==0.42.0
+watchdog==4.0.0
+wheel==0.43.0
     # via pip-tools
-yarl==1.9.2
-    # via aiohttp

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -64,7 +64,7 @@ tomli==2.0.1
     #   pyproject-hooks
 tomlkit==0.12.4
     # via pylint
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   astroid
     #   black

--- a/services/director-v2/requirements/constraints.txt
+++ b/services/director-v2/requirements/constraints.txt
@@ -1,0 +1,8 @@
+# From 3.9.0 the follwong test fails: `services/director-v2/tests/unit/test_modules_notifier.py::test_notifier_publish_message`
+# the room disconnect event is no longer propagated
+# Issue triggered by:
+# - this change: https://github.com/ttsia/aiohttp/commit/70b3536e3eef1627bbb425e71faea2f8ce1c6f9b
+# - and it's PR: https://github.com/aio-libs/aiohttp/pull/7680
+# - this is the breaking change (1 line) https://github.com/ttsia/aiohttp/commit/70b3536e3eef1627bbb425e71faea2f8ce1c6f9b#diff-5eda97b86ffb5b1e8b797dbacc03e6d75767caada5d09956c1035b5684711965R204
+# submitted issue https://github.com/miguelgrinberg/python-socketio/issues/1319
+aiohttp<3.9.0

--- a/services/director-v2/requirements/constraints.txt
+++ b/services/director-v2/requirements/constraints.txt
@@ -1,8 +1,0 @@
-# From 3.9.0 the follwong test fails: `services/director-v2/tests/unit/test_modules_notifier.py::test_notifier_publish_message`
-# the room disconnect event is no longer propagated
-# Issue triggered by:
-# - this change: https://github.com/ttsia/aiohttp/commit/70b3536e3eef1627bbb425e71faea2f8ce1c6f9b
-# - and it's PR: https://github.com/aio-libs/aiohttp/pull/7680
-# - this is the breaking change (1 line) https://github.com/ttsia/aiohttp/commit/70b3536e3eef1627bbb425e71faea2f8ce1c6f9b#diff-5eda97b86ffb5b1e8b797dbacc03e6d75767caada5d09956c1035b5684711965R204
-# submitted issue https://github.com/miguelgrinberg/python-socketio/issues/1319
-aiohttp<3.9.0

--- a/services/director-v2/tests/integration/conftest.py
+++ b/services/director-v2/tests/integration/conftest.py
@@ -113,7 +113,7 @@ async def create_pipeline(
             for user_id, task in created_comp_tasks
         )
     )
-    assert all(r.raise_for_status() is None for r in responses)
+    assert all(isinstance(r.raise_for_status(), httpx.Response) for r in responses)
 
 
 @pytest.fixture

--- a/services/osparc-gateway-server/requirements/_base.txt
+++ b/services/osparc-gateway-server/requirements/_base.txt
@@ -1,69 +1,51 @@
 aiodocker==0.21.0
-aiohttp==3.8.5
+aiohttp==3.9.3
     # via
     #   aiodocker
     #   dask-gateway-server
 aiosignal==1.3.1
     # via aiohttp
-anyio==3.7.1
-    # via httpcore
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via aiohttp
-attrs==23.1.0
+attrs==23.2.0
     # via aiohttp
-certifi==2023.7.22
-    # via httpcore
-cffi==1.15.1
+cffi==1.16.0
     # via cryptography
-charset-normalizer==3.2.0
-    # via aiohttp
-colorlog==6.7.0
+colorlog==6.8.2
     # via dask-gateway-server
-cryptography==41.0.7
+cryptography==42.0.5
     # via dask-gateway-server
 dask-gateway-server==2023.1.1
-dnspython==2.4.0
+dnspython==2.6.1
     # via email-validator
-email-validator==2.0.0.post2
+email-validator==2.1.1
     # via pydantic
-exceptiongroup==1.1.2
-    # via anyio
-frozenlist==1.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-greenlet==2.0.2
+greenlet==3.0.3
     # via sqlalchemy
-h11==0.14.0
-    # via httpcore
-httpcore==0.17.3
-    # via dnspython
-idna==3.4
+idna==3.6
     # via
-    #   anyio
     #   email-validator
     #   yarl
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pydantic==1.10.11
-python-dotenv==1.0.0
+pydantic==1.10.14
+python-dotenv==1.0.1
     # via pydantic
-sniffio==1.3.0
-    # via
-    #   anyio
-    #   dnspython
-    #   httpcore
-sqlalchemy==1.4.49
+sqlalchemy==1.4.52
     # via dask-gateway-server
-traitlets==5.9.0
+traitlets==5.14.2
     # via dask-gateway-server
-typing-extensions==4.7.1
+typing-extensions==4.10.0
     # via
     #   aiodocker
     #   pydantic
-yarl==1.9.2
+yarl==1.9.4
     # via aiohttp

--- a/services/osparc-gateway-server/requirements/_base.txt
+++ b/services/osparc-gateway-server/requirements/_base.txt
@@ -43,7 +43,7 @@ sqlalchemy==1.4.52
     # via dask-gateway-server
 traitlets==5.14.2
     # via dask-gateway-server
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   aiodocker
     #   pydantic

--- a/services/osparc-gateway-server/requirements/_base.txt
+++ b/services/osparc-gateway-server/requirements/_base.txt
@@ -36,7 +36,7 @@ multidict==6.0.5
     #   yarl
 pycparser==2.22
     # via cffi
-pydantic==1.10.14
+pydantic==1.10.15
 python-dotenv==1.0.1
     # via pydantic
 sqlalchemy==1.4.52

--- a/services/osparc-gateway-server/requirements/_test.txt
+++ b/services/osparc-gateway-server/requirements/_test.txt
@@ -32,7 +32,7 @@ distributed==2023.3.2
 docker==7.0.0
 exceptiongroup==1.2.0
     # via pytest
-faker==24.4.0
+faker==24.7.1
 frozenlist==1.4.1
     # via
     #   aiohttp
@@ -133,7 +133,7 @@ tornado==6.4
     # via
     #   dask-gateway
     #   distributed
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   mypy
     #   sqlalchemy2-stubs

--- a/services/osparc-gateway-server/requirements/_test.txt
+++ b/services/osparc-gateway-server/requirements/_test.txt
@@ -1,92 +1,90 @@
-aiohttp==3.8.5
+aiohttp==3.9.3
     # via dask-gateway
 aiosignal==1.3.1
     # via aiohttp
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via aiohttp
-attrs==23.1.0
+attrs==23.2.0
     # via aiohttp
-certifi==2023.7.22
+certifi==2024.2.2
     # via requests
-charset-normalizer==3.2.0
-    # via
-    #   aiohttp
-    #   requests
+charset-normalizer==3.3.2
+    # via requests
 click==8.1.7
     # via
     #   dask
     #   dask-gateway
     #   distributed
-cloudpickle==2.2.1
+cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-coverage==7.3.2
+coverage==7.4.4
     # via pytest-cov
 dask==2023.3.2
     # via
     #   dask-gateway
     #   distributed
-dask-gateway==2023.9.0
-debugpy==1.8.0
+dask-gateway==2024.1.0
+debugpy==1.8.1
 distributed==2023.3.2
     # via dask-gateway
-docker==6.1.3
-exceptiongroup==1.1.2
+docker==7.0.0
+exceptiongroup==1.2.0
     # via pytest
-faker==19.13.0
-frozenlist==1.4.0
+faker==24.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.6.0
+fsspec==2024.3.1
     # via dask
-greenlet==2.0.2
+greenlet==3.0.3
     # via sqlalchemy
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.4
+idna==3.6
     # via
     #   requests
     #   yarl
-importlib-metadata==6.8.0
+importlib-metadata==7.1.0
     # via dask
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.2
+jinja2==3.1.3
     # via distributed
 locket==1.0.0
     # via
     #   distributed
     #   partd
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
-msgpack==1.0.5
+msgpack==1.0.8
     # via distributed
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-mypy==1.6.1
+mypy==1.9.0
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
-packaging==23.1
+packaging==24.0
     # via
     #   dask
     #   distributed
     #   docker
     #   pytest
     #   pytest-sugar
-partd==1.4.0
+partd==1.4.1
     # via dask
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-psutil==5.9.5
+psutil==5.9.8
     # via distributed
-pytest==7.4.3
+pytest==8.1.1
     # via
     #   pytest-asyncio
     #   pytest-cov
@@ -95,12 +93,12 @@ pytest==7.4.3
     #   pytest-mock
     #   pytest-sugar
 pytest-asyncio==0.21.1
-pytest-cov==4.1.0
-pytest-icdiff==0.8
+pytest-cov==5.0.0
+pytest-icdiff==0.9
 pytest-instafail==0.5.0
-pytest-mock==3.12.0
-pytest-sugar==0.9.7
-python-dateutil==2.8.2
+pytest-mock==3.14.0
+pytest-sugar==1.0.0
+python-dateutil==2.9.0.post0
     # via faker
 pyyaml==6.0.1
     # via
@@ -113,42 +111,40 @@ six==1.16.0
     # via python-dateutil
 sortedcontainers==2.4.0
     # via distributed
-sqlalchemy==1.4.49
-sqlalchemy2-stubs==0.0.2a36
+sqlalchemy==1.4.52
+sqlalchemy2-stubs==0.0.2a38
     # via sqlalchemy
-tblib==2.0.0
+tblib==3.0.0
     # via distributed
 tenacity==8.2.3
-termcolor==2.3.0
+termcolor==2.4.0
     # via pytest-sugar
 tomli==2.0.1
     # via
     #   coverage
     #   mypy
     #   pytest
-toolz==0.12.0
+toolz==0.12.1
     # via
     #   dask
     #   distributed
     #   partd
-tornado==6.3.3
+tornado==6.4
     # via
     #   dask-gateway
     #   distributed
-typing-extensions==4.7.1
+typing-extensions==4.10.0
     # via
     #   mypy
     #   sqlalchemy2-stubs
-urllib3==1.26.16
+urllib3==2.0.7
     # via
     #   distributed
     #   docker
     #   requests
-websocket-client==1.6.4
-    # via docker
-yarl==1.9.2
+yarl==1.9.4
     # via aiohttp
 zict==3.0.0
     # via distributed
-zipp==3.16.2
+zipp==3.18.1
     # via importlib-metadata

--- a/services/osparc-gateway-server/requirements/_tools.txt
+++ b/services/osparc-gateway-server/requirements/_tools.txt
@@ -1,52 +1,32 @@
-aiohttp==3.8.5
-    # via black
-aiosignal==1.3.1
-    # via aiohttp
-astroid==3.0.2
+astroid==3.1.0
     # via pylint
-async-timeout==4.0.2
-    # via aiohttp
-attrs==23.1.0
-    # via aiohttp
-black==23.12.0
-build==1.0.3
+black==24.3.0
+build==1.2.1
     # via pip-tools
 bump2version==1.0.1
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.2.0
-    # via aiohttp
 click==8.1.7
     # via
     #   black
     #   pip-tools
-dill==0.3.7
+dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.1
+filelock==3.13.3
     # via virtualenv
-frozenlist==1.4.0
-    # via
-    #   aiohttp
-    #   aiosignal
-identify==2.5.33
+identify==2.5.35
     # via pre-commit
-idna==3.4
-    # via yarl
 isort==5.13.2
     # via pylint
 mccabe==0.7.0
     # via pylint
-multidict==6.0.4
-    # via
-    #   aiohttp
-    #   yarl
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==24.0
     # via
     #   black
     #   build
@@ -54,21 +34,23 @@ pathspec==0.12.1
     # via black
 pip==24.0
     # via pip-tools
-pip-tools==7.3.0
-platformdirs==4.1.0
+pip-tools==7.4.1
+platformdirs==4.2.0
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.6.0
-pylint==3.0.3
+pre-commit==3.7.0
+pylint==3.1.0
 pyproject-hooks==1.0.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 pyyaml==6.0.1
     # via
     #   pre-commit
     #   watchdog
-ruff==0.1.8
+ruff==0.3.5
 setuptools==69.2.0
     # via
     #   nodeenv
@@ -80,16 +62,14 @@ tomli==2.0.1
     #   pip-tools
     #   pylint
     #   pyproject-hooks
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via pylint
-typing-extensions==4.7.1
+typing-extensions==4.10.0
     # via
     #   astroid
     #   black
-virtualenv==20.25.0
+virtualenv==20.25.1
     # via pre-commit
-watchdog==3.0.0
-wheel==0.42.0
+watchdog==4.0.0
+wheel==0.43.0
     # via pip-tools
-yarl==1.9.2
-    # via aiohttp

--- a/services/osparc-gateway-server/requirements/_tools.txt
+++ b/services/osparc-gateway-server/requirements/_tools.txt
@@ -64,7 +64,7 @@ tomli==2.0.1
     #   pyproject-hooks
 tomlkit==0.12.4
     # via pylint
-typing-extensions==4.10.0
+typing-extensions==4.11.0
     # via
     #   astroid
     #   black


### PR DESCRIPTION
###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 154
- #packages after ~ 148

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.3.0, 9.2.2, 9.1.2 | 9.4.1      | *minor*    | 4 | aws-library🧪</br>dask-sidecar⬆️</br>director-v2⬆️🧪 |
|   2 | aioboto3                  | 12.0.0          | 12.3.0     | *minor*    | 2 | aws-library🧪</br>director-v2🧪 |
|   3 | aiobotocore               | 2.7.0, 2.5.4    | 2.12.2,2.11.2 | *minor*    | 3 | aws-library🧪</br>dask-sidecar⬆️</br>director-v2🧪 |
|   4 | aiocache                  | 0.12.1          | 0.12.2     |            | 1 | director-v2⬆️ |
|   5 | aiofiles                  | 23.1.0          | 23.2.1     | *minor*    | 1 | director-v2⬆️ |
|   6 | aiohttp                   | 3.9.3, 3.8.5, 3.8.6, 3.9.1 | 3.9.3      |            | 12 | autoscaling🔧</br>aws-library🧪🔧</br>dask-sidecar⬆️🔧</br>dask-task-models-library🔧</br>director-v2⬆️🧪🔧</br>osparc-gateway-server⬆️🧪🔧 |
|   7 | aiormq                    | 6.7.6, 6.7.7    | 6.8.0      | *minor*    | 4 | aws-library🧪</br>dask-sidecar⬆️</br>director-v2⬆️🧪 |
|   8 | aiosignal                 | 1.3.1           | 🗑️ removed |  | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|   9 | alembic                   | 1.11.1          | 1.13.1     | *minor*    | 2 | director-v2⬆️🧪 |
|  10 | anyio                     | 3.7.1           | 4.3.0      | **MAJOR**  | 3 | director-v2⬆️🧪</br>osparc-gateway-server⬆️ |
|  11 | arrow                     | 1.2.3           | 1.3.0      | *minor*    | 2 | dask-sidecar⬆️</br>director-v2⬆️ |
|  12 | astroid                   | 3.0.2           | 3.1.0      | *minor*    | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  13 | async-timeout             | 4.0.2, 4.0.3    | 4.0.3      |            | 10 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2⬆️🧪🔧</br>osparc-gateway-server⬆️🧪🔧 |
|  14 | asyncpg                   | 0.28.0          | 0.29.0     | *minor*    | 1 | director-v2⬆️ |
|  15 | attrs                     | 23.1.0, 23.2.0  | 23.2.0     |            | 15 | autoscaling🔧</br>aws-library🧪🧪🔧</br>dask-sidecar⬆️🧪🔧</br>dask-task-models-library🧪🔧</br>director-v2⬆️🧪🔧</br>osparc-gateway-server⬆️🧪🔧 |
|  16 | aws-sam-translator        | 1.82.0, 1.86.0, 1.79.0 | 1.87.0     | *minor*    | 4 | autoscaling🧪</br>aws-library🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|  17 | aws-xray-sdk              | 2.12.1          | 2.13.0     | *minor*    | 2 | aws-library🧪</br>dask-sidecar🧪 |
|  18 | black                     | 23.12.0         | 24.3.0     | **MAJOR**  | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  19 | boto3                     | 1.28.64, 1.28.17 | 1.34.34,1.34.51 | *minor*    | 4 | aws-library🧪🧪</br>dask-sidecar🧪</br>director-v2🧪 |
|  20 | botocore                  | 1.31.64, 1.31.17 | 1.34.34,1.34.51 | *minor*    | 5 | aws-library🧪🧪</br>dask-sidecar⬆️🧪</br>director-v2🧪 |
|  21 | botocore-stubs            | 1.31.85         | 1.34.69    | *minor*    | 1 | aws-library🧪 |
|  22 | build                     | 1.0.3, 1.1.1    | 1.2.1      | *minor*    | 7 | autoscaling🔧</br>aws-library🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  23 | certifi                   | 2023.7.22, 2023.11.17 | 2024.2.2   | **MAJOR**  | 7 | aws-library🧪</br>dask-sidecar⬆️🧪</br>director-v2⬆️🧪</br>osparc-gateway-server⬆️🧪 |
|  24 | cffi                      | 1.15.1          | 1.16.0     | *minor*    | 1 | osparc-gateway-server⬆️ |
|  25 | cfn-lint                  | 0.83.6, 0.86.1, 0.83.1 | 0.86.2     |            | 4 | autoscaling🧪</br>aws-library🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|  26 | charset-normalizer        | 3.3.2, 3.2.0    | 3.3.2      |            | 11 | aws-library🧪🔧</br>dask-sidecar⬆️🧪🔧</br>director-v2⬆️🧪🔧</br>osparc-gateway-server⬆️🧪🔧 |
|  27 | cloudpickle               | 2.2.1           | 3.0.0      | **MAJOR**  | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  28 | colorlog                  | 6.7.0           | 6.8.2      | *minor*    | 2 | director-v2🧪</br>osparc-gateway-server⬆️ |
|  29 | coverage                  | 7.3.2, 7.3.3    | 7.4.4      | *minor*    | 5 | aws-library🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>director-v2🧪</br>osparc-gateway-server🧪 |
|  30 | cryptography              | 41.0.7          | 42.0.5     | **MAJOR**  | 4 | aws-library🧪</br>dask-sidecar🧪</br>director-v2🧪</br>osparc-gateway-server⬆️ |
|  31 | dask                      | 2023.12.0       | 2024.4.1   | **MAJOR**  | 1 | dask-task-models-library🧪 |
|  32 | dask-gateway              | 2023.1.1, 2023.9.0 | 2024.1.0   | **MAJOR**  | 3 | dask-sidecar⬆️</br>director-v2⬆️</br>osparc-gateway-server🧪 |
|  33 | debugpy                   | 1.8.0           | 1.8.1      |            | 1 | osparc-gateway-server🧪 |
|  34 | deepdiff                  | 6.7.1           | 7.0.0      | **MAJOR**  | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  35 | dill                      | 0.3.7           | 0.3.8      |            | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  36 | distributed               | 2023.12.0       | 2024.4.1   | **MAJOR**  | 1 | dask-task-models-library🧪 |
|  37 | dnspython                 | 2.4.2, 2.4.0    | 2.6.1      | *minor*    | 5 | aws-library🧪</br>dask-sidecar⬆️</br>dask-task-models-library🧪</br>director-v2⬆️</br>osparc-gateway-server⬆️ |
|  38 | docker                    | 6.1.3           | 7.0.0      | **MAJOR**  | 3 | dask-sidecar🧪</br>director-v2🧪</br>osparc-gateway-server🧪 |
|  39 | ecdsa                     | 0.18.0          | 🗑️ removed |  | 2 | aws-library🧪</br>dask-sidecar🧪 |
|  40 | email-validator           | 2.1.0.post1, 2.0.0.post2 | 2.1.1      |            | 5 | aws-library🧪</br>dask-sidecar⬆️</br>dask-task-models-library🧪</br>director-v2⬆️</br>osparc-gateway-server⬆️ |
|  41 | exceptiongroup            | 1.1.2, 1.1.3    | 1.2.0      | *minor*    | 5 | dask-sidecar🧪</br>director-v2⬆️🧪</br>osparc-gateway-server⬆️🧪 |
|  42 | execnet                   | 2.0.2           | 2.1.1      | *minor*    | 1 | director-v2🧪 |
|  43 | faker                     | 24.3.0, 21.0.0, 24.7.1, 19.13.0 | 24.4.0,24.7.1 |            | 8 | autoscaling🧪</br>aws-library🧪</br>clusters-keeper🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>director-v2🧪</br>dynamic-sidecar🧪</br>osparc-gateway-server🧪 |
|  44 | filelock                  | 3.13.2, 3.13.1  | 3.13.3     |            | 7 | autoscaling🔧</br>aws-library🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  45 | flaky                     | 3.7.0           | 3.8.1      | *minor*    | 1 | director-v2🧪 |
|  46 | flask                     | 3.0.2, 3.0.0    | 3.0.3      |            | 4 | autoscaling🧪</br>aws-library🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|  47 | frozenlist                | 1.4.0, 1.4.1    | 1.4.1      |            | 12 | autoscaling🔧</br>aws-library🧪🔧</br>dask-sidecar⬆️🔧</br>dask-task-models-library🔧</br>director-v2⬆️🧪🔧</br>osparc-gateway-server⬆️🧪🔧 |
|  48 | fsspec                    | 2023.6.0, 2023.12.2 | 2024.3.1   | **MAJOR**  | 8 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  49 | greenlet                  | 2.0.2           | 3.0.3      | **MAJOR**  | 4 | director-v2⬆️🧪</br>osparc-gateway-server⬆️🧪 |
|  50 | h11                       | 0.14.0          | 🗑️ removed |  | 1 | osparc-gateway-server⬆️ |
|  51 | httpcore                  | 0.17.3, 1.0.4   | 1.0.5      |            | 7 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>director-v2⬆️🧪</br>osparc-gateway-server⬆️ |
|  52 | httptools                 | 0.6.0           | 0.6.1      |            | 1 | director-v2⬆️ |
|  53 | httpx                     | 0.24.1          | 0.27.0     | *minor*    | 2 | director-v2⬆️🧪 |
|  54 | identify                  | 2.5.33          | 2.5.35     |            | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  55 | idna                      | 3.4, 3.6        | 3.6        |            | 14 | autoscaling🔧</br>aws-library🧪🧪🔧</br>dask-sidecar⬆️🧪🔧</br>dask-task-models-library🔧</br>director-v2⬆️🧪🔧</br>osparc-gateway-server⬆️🧪🔧 |
|  56 | importlib-metadata        | 6.8.0, 7.0.0    | 7.1.0      | *minor*    | 8 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  57 | jinja2                    | 3.1.2           | 3.1.3      |            | 12 | autoscaling⬆️🧪</br>aws-library🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️⬆️🧪</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  58 | jsonpickle                | 3.0.2           | 3.0.3      |            | 2 | aws-library🧪</br>dask-sidecar🧪 |
|  59 | jsonschema                | 4.18.4, 4.20.0, 4.19.0, 4.19.2 | 4.21.1     | *minor*    | 6 | aws-library🧪🧪</br>dask-sidecar⬆️🧪</br>dask-task-models-library🧪</br>director-v2⬆️ |
|  60 | jsonschema-path           | 0.3.1           | 0.3.2      |            | 1 | dask-sidecar🧪 |
|  61 | jsonschema-specifications | 2023.11.2       | 2023.12.1  | *minor*    | 1 | dask-task-models-library🧪 |
|  62 | lazy-object-proxy         | 1.9.0           | 1.10.0     | *minor*    | 2 | aws-library🧪</br>dask-sidecar🧪 |
|  63 | lz4                       | 4.3.2           | 4.3.3      |            | 3 | dask-sidecar⬆️⬆️</br>director-v2⬆️ |
|  64 | mako                      | 1.2.4           | 1.3.2      | *minor*    | 2 | director-v2⬆️🧪 |
|  65 | markupsafe                | 2.1.3           | 2.1.5      |            | 12 | autoscaling⬆️🧪</br>aws-library🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️⬆️🧪</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  66 | moto                      | 4.2.7, 5.0.3, 4.2.11 | 5.0.5      |            | 4 | autoscaling🧪</br>aws-library🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|  67 | msgpack                   | 1.0.7, 1.0.5    | 1.0.8      |            | 8 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  68 | multidict                 | 6.0.5, 6.0.4    | 6.0.5      |            | 12 | autoscaling🔧</br>aws-library🧪🔧</br>dask-sidecar⬆️🔧</br>dask-task-models-library🔧</br>director-v2⬆️🧪🔧</br>osparc-gateway-server⬆️🧪🔧 |
|  69 | mypy                      | 1.6.1           | 1.9.0      | *minor*    | 2 | director-v2🧪</br>osparc-gateway-server🧪 |
|  70 | networkx                  | 3.1, 3.2.1      | 3.3        | *minor*    | 5 | autoscaling🧪</br>aws-library🧪</br>clusters-keeper🧪</br>dask-sidecar🧪</br>director-v2⬆️ |
|  71 | numpy                     | 1.25.2          | 1.26.4     | *minor*    | 4 | dask-sidecar⬆️⬆️</br>director-v2⬆️🧪 |
|  72 | openapi-schema-validator  | 0.6.0           | 0.6.2      |            | 1 | dask-sidecar🧪 |
|  73 | orjson                    | 3.10.0          | 3.7.2,3.9.15,3.9.7,3.9.10 | 🔥 downgrade | 12 | agent⬆️</br>catalog⬆️</br>invitations⬆️</br>models-library🧪</br>notifications-library🧪</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-integration🧪</br>service-library🧪</br>simcore-sdk🧪</br>swarm-deploy🧪</br>web⬆️ |
|  74 | packaging                 | 23.1, 23.2      | 24.0       | **MAJOR**  | 20 | autoscaling⬆️🧪🔧</br>aws-library🧪🔧</br>clusters-keeper⬆️🧪🔧</br>dask-sidecar⬆️⬆️🧪🔧</br>dask-task-models-library🧪🧪🔧</br>director-v2⬆️🧪🔧</br>osparc-gateway-server🧪🔧 |
|  75 | pamqp                     | 3.2.1           | 3.3.0      | *minor*    | 4 | aws-library🧪</br>dask-sidecar⬆️</br>director-v2⬆️🧪 |
|  76 | partd                     | 1.4.0           | 1.4.1      |            | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  77 | pbr                       | 5.11.1          | 6.0.0      | **MAJOR**  | 1 | dask-sidecar🧪 |
|  78 | pillow                    | 10.0.0, 10.1.0  | 10.3.0     | *minor*    | 2 | dask-sidecar⬆️</br>director-v2🧪 |
|  79 | pint                      | 0.22            | 0.23       | *minor*    | 1 | director-v2⬆️ |
|  80 | pip-tools                 | 7.3.0           | 7.4.1      | *minor*    | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  81 | platformdirs              | 4.1.0           | 4.2.0      | *minor*    | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  82 | pluggy                    | 1.3.0           | 1.4.0      | *minor*    | 5 | aws-library🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>director-v2🧪</br>osparc-gateway-server🧪 |
|  83 | pre-commit                | 3.6.0           | 3.7.0      | *minor*    | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  84 | prometheus-client         | 0.19.0          | 0.20.0     | *minor*    | 1 | dask-sidecar⬆️ |
|  85 | psutil                    | 5.9.5, 5.9.6    | 5.9.8      |            | 10 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  86 | psycopg2-binary           | 2.9.6           | 2.9.9      |            | 1 | director-v2⬆️ |
|  87 | py-partiql-parser         | 0.4.1, 0.4.2, 0.5.1 | 0.5.4      |            | 4 | autoscaling🧪</br>aws-library🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|  88 | pyasn1                    | 0.5.1, 0.5.0    | 🗑️ removed |  | 2 | aws-library🧪</br>dask-sidecar🧪 |
|  89 | pycparser                 | 2.21            | 2.22       | *minor*    | 6 | autoscaling🧪</br>aws-library🧪</br>clusters-keeper🧪</br>dask-sidecar🧪</br>director-v2🧪</br>osparc-gateway-server⬆️ |
|  90 | pydantic                  | 1.10.13, 1.10.11, 1.10.12, 1.10.14 | 1.10.15    |            | 11 | autoscaling⬆️🧪</br>aws-library🧪🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️🧪</br>dask-task-models-library🧪</br>director-v2⬆️</br>osparc-gateway-server⬆️ |
|  91 | pygments                  | 2.15.1, 2.16.1  | 2.17.2     | *minor*    | 3 | aws-library🧪</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  92 | pyinstrument              | 4.5.1, 4.6.1    | 4.6.2      |            | 3 | aws-library🧪</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  93 | pylint                    | 3.0.3           | 3.1.0      | *minor*    | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  94 | pyopenssl                 | 23.3.0          | 24.1.0     | **MAJOR**  | 1 | dask-sidecar🧪 |
|  95 | pyparsing                 | 3.1.1           | 3.1.2      |            | 2 | aws-library🧪</br>dask-sidecar🧪 |
|  96 | pytest                    | 7.4.3           | 8.1.1      | **MAJOR**  | 5 | aws-library🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>director-v2🧪</br>osparc-gateway-server🧪 |
|  97 | pytest-cov                | 4.1.0           | 5.0.0      | **MAJOR**  | 5 | aws-library🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>director-v2🧪</br>osparc-gateway-server🧪 |
|  98 | pytest-docker             | 2.0.1           | 3.1.1      | **MAJOR**  | 1 | director-v2🧪 |
|  99 | pytest-icdiff             | 0.8             | 0.9        | *minor*    | 3 | dask-sidecar🧪</br>director-v2🧪</br>osparc-gateway-server🧪 |
| 100 | pytest-mock               | 3.12.0          | 3.14.0     | *minor*    | 5 | aws-library🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>director-v2🧪</br>osparc-gateway-server🧪 |
| 101 | pytest-runner             | 6.0.0           | 6.0.1      |            | 1 | director-v2🧪 |
| 102 | pytest-sugar              | 0.9.7           | 1.0.0      | **MAJOR**  | 4 | aws-library🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>osparc-gateway-server🧪 |
| 103 | pytest-xdist              | 3.3.1           | 3.5.0      | *minor*    | 1 | director-v2🧪 |
| 104 | python-dateutil           | 2.8.2           | 2.9.0.post0 | *minor*    | 9 | aws-library🧪🧪</br>dask-sidecar⬆️🧪</br>dask-task-models-library🧪🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
| 105 | python-dotenv             | 1.0.0           | 1.0.1      |            | 5 | aws-library🧪</br>dask-sidecar⬆️🧪</br>director-v2⬆️</br>osparc-gateway-server⬆️ |
| 106 | python-jose               | 3.3.0           | 🗑️ removed |  | 2 | aws-library🧪</br>dask-sidecar🧪 |
| 107 | python-socketio           | 5.11.1          | 5.11.2     |            | 1 | director-v2⬆️ |
| 108 | redis                     | 5.0.1, 4.6.0, 5.0.0 | 5.0.3      |            | 3 | aws-library🧪</br>dask-sidecar⬆️</br>director-v2⬆️ |
| 109 | referencing               | 0.32.0          | 0.34.0     | *minor*    | 1 | dask-task-models-library🧪 |
| 110 | regex                     | 2023.10.3       | 2023.12.25 | *minor*    | 2 | aws-library🧪</br>dask-sidecar🧪 |
| 111 | requests                  | 2.31.0          | 🗑️ removed |  | 1 | dask-sidecar⬆️ |
| 112 | responses                 | 0.23.3, 0.24.1  | 0.25.0     | *minor*    | 2 | aws-library🧪</br>dask-sidecar🧪 |
| 113 | respx                     | 0.20.2, 0.21.0  | 0.21.1     |            | 3 | autoscaling🧪</br>clusters-keeper🧪</br>director-v2🧪 |
| 114 | rich                      | 13.5.2, 13.4.2, 13.7.0, 13.6.0 | 13.7.1     |            | 4 | aws-library🧪</br>dask-sidecar⬆️</br>dask-task-models-library🧪</br>director-v2⬆️ |
| 115 | rpds-py                   | 0.12.0, 0.13.2, 0.9.2 | 0.18.0     | *minor*    | 6 | aws-library🧪🧪</br>dask-sidecar⬆️🧪</br>dask-task-models-library🧪</br>director-v2⬆️ |
| 116 | rsa                       | 4.9             | 🗑️ removed |  | 2 | aws-library🧪</br>dask-sidecar🧪 |
| 117 | ruff                      | 0.1.8, 0.3.4    | 0.3.5      |            | 7 | autoscaling🔧</br>aws-library🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
| 118 | s3fs                      | 2023.6.0        | 2024.3.1   | **MAJOR**  | 1 | dask-sidecar⬆️ |
| 119 | s3transfer                | 0.7.0, 0.6.2    | 0.10.1     | *minor*    | 4 | aws-library🧪🧪</br>dask-sidecar🧪</br>director-v2🧪 |
| 120 | setuptools                | 69.2.0          | 🗑️ removed |  | 1 | agent⬆️ |
| 121 | sniffio                   | 1.3.0           | 1.3.1      |            | 3 | director-v2⬆️🧪</br>osparc-gateway-server⬆️ |
| 122 | sqlalchemy                | 1.4.49          | 1.4.52     |            | 4 | director-v2⬆️🧪</br>osparc-gateway-server⬆️🧪 |
| 123 | sshpubkeys                | 3.3.1           | 🗑️ removed |  | 2 | aws-library🧪</br>dask-sidecar🧪 |
| 124 | tblib                     | 2.0.0           | 3.0.0      | **MAJOR**  | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
| 125 | tenacity                  | 8.2.2           | 8.2.3      |            | 1 | director-v2⬆️ |
| 126 | termcolor                 | 2.3.0           | 2.4.0      | *minor*    | 2 | dask-sidecar🧪</br>osparc-gateway-server🧪 |
| 127 | tomlkit                   | 0.12.3          | 0.12.4     |            | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
| 128 | toolz                     | 0.12.0          | 0.12.1     |            | 9 | autoscaling⬆️</br>aws-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
| 129 | tornado                   | 6.3.3           | 6.4        | *minor*    | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
| 130 | tqdm                      | 4.66.1, 4.65.0  | 4.66.2     |            | 3 | aws-library🧪</br>dask-sidecar⬆️</br>director-v2⬆️ |
| 131 | traitlets                 | 5.13.0, 5.9.0   | 5.14.2     | *minor*    | 2 | director-v2🧪</br>osparc-gateway-server⬆️ |
| 132 | typer                     | 0.10.0, 0.9.0   | 0.12.1     | *minor*    | 6 | autoscaling⬆️</br>aws-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>dask-task-models-library🧪</br>director-v2⬆️ |
| 133 | types-aiobotocore         | 2.7.0, 2.12.1   | 2.12.2     |            | 3 | autoscaling⬆️</br>aws-library🧪</br>clusters-keeper⬆️ |
| 134 | types-aiobotocore-ec2     | 2.7.0, 2.12.1   | 2.12.2     |            | 3 | autoscaling⬆️</br>aws-library🧪</br>clusters-keeper⬆️ |
| 135 | types-aiobotocore-s3      | 2.7.0, 2.12.1   | 2.12.2     |            | 3 | autoscaling⬆️</br>aws-library🧪</br>clusters-keeper⬆️ |
| 136 | types-awscrt              | 0.19.10         | 0.20.5     | *minor*    | 1 | aws-library🧪 |
| 137 | types-python-dateutil     | 2.8.19.14       | 2.9.0.20240316 | *minor*    | 2 | aws-library🧪</br>dask-task-models-library🧪 |
| 138 | types-pyyaml              | 6.0.12.12       | 🗑️ removed |  | 1 | dask-sidecar🧪 |
| 139 | typing-extensions         | 4.9.0, 4.7.1, 4.8.0, 4.10.0 | 4.11.0     | *minor*    | 21 | autoscaling⬆️🧪🔧</br>aws-library🧪🧪🔧</br>clusters-keeper⬆️🧪🔧</br>dask-sidecar⬆️🧪🔧</br>dask-task-models-library🧪🧪🔧</br>director-v2⬆️🧪🔧</br>osparc-gateway-server⬆️🧪🔧 |
| 140 | ujson                     | 5.8.0           | 5.9.0      | *minor*    | 1 | director-v2⬆️ |
| 141 | urllib3                   | 1.26.16, 2.1.0  | 2.2.1,2.0.7 | *minor*    | 11 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️⬆️🧪</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
| 142 | uvicorn                   | 0.23.1          | 0.29.0     | *minor*    | 1 | director-v2⬆️ |
| 143 | uvloop                    | 0.17.0          | 0.19.0     | *minor*    | 1 | director-v2⬆️ |
| 144 | virtualenv                | 20.25.0         | 20.25.1    |            | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
| 145 | watchdog                  | 3.0.0           | 4.0.0      | **MAJOR**  | 4 | autoscaling🔧</br>dask-sidecar🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
| 146 | watchfiles                | 0.19.0          | 0.21.0     | *minor*    | 1 | director-v2⬆️ |
| 147 | websocket-client          | 1.6.4           | 🗑️ removed |  | 3 | dask-sidecar🧪</br>director-v2🧪</br>osparc-gateway-server🧪 |
| 148 | websockets                | 11.0.3          | 12.0       | **MAJOR**  | 1 | director-v2⬆️ |
| 149 | werkzeug                  | 3.0.1           | 3.0.2      |            | 4 | autoscaling🧪</br>aws-library🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
| 150 | wheel                     | 0.42.0          | 0.43.0     | *minor*    | 6 | autoscaling🔧</br>aws-library🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
| 151 | wrapt                     | 1.15.0          | 1.16.0     | *minor*    | 3 | dask-sidecar⬆️🧪</br>director-v2🧪 |
| 152 | yarl                      | 1.9.2, 1.9.4    | 1.9.4      |            | 12 | autoscaling🔧</br>aws-library🧪🔧</br>dask-sidecar⬆️🔧</br>dask-task-models-library🔧</br>director-v2⬆️🧪🔧</br>osparc-gateway-server⬆️🧪🔧 |
| 153 | zipp                      | 3.16.2, 3.17.0  | 3.18.1     | *minor*    | 8 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 94

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.1.2, 9.3.0, 9.4.1       | 9.3.0, 9.4.1              |                           |
|   2 | aioboto3                  | 12.3.0                    | 9.6.0, 12.3.0             |                           |
|   3 | aiobotocore               | 2.11.2, 2.12.2            | 2.3.0, 2.11.2             |                           |
|   4 | aiocache                  | 0.11.1, 0.12.2            | 0.12.2                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.21.0                    | 0.21.0                    |                           |
|   7 | aiofiles                  | 0.8.0, 23.2.1             | 23.2.1                    |                           |
|   8 | aiohttp                   | 3.8.5, 3.8.6, 3.9.3       | 3.8.5, 3.8.6, 3.9.3       | 3.8.5, 3.8.6, 3.9.1       |
|   9 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  10 | aiohttp-security          | 0.4.0                     |                           |                           |
|  11 | aiohttp-session           | 2.11.0                    |                           |                           |
|  12 | aiohttp-swagger           | 1.0.16                    |                           |                           |
|  13 | aioitertools              | 0.11.0                    | 0.11.0                    |                           |
|  14 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  15 | aioprocessing             | 2.0.1                     |                           |                           |
|  16 | aioresponses              |                           | 0.7.6                     |                           |
|  17 | aiormq                    | 6.7.6, 6.7.7, 6.8.0       | 6.7.7, 6.8.0              |                           |
|  18 | aiosignal                 | 1.2.0, 1.3.1              | 1.2.0, 1.3.1              | 1.2.0, 1.3.1              |
|  19 | aiosmtplib                | 1.1.6, 3.0.1              |                           |                           |
|  20 | aiozipkin                 | 1.1.1                     |                           |                           |
|  21 | alembic                   | 1.8.1, 1.12.1, 1.13.1     | 1.8.1, 1.12.1, 1.13.1     |                           |
|  22 | annotated-types           |                           | 0.6.0                     |                           |
|  23 | antlr4-python3-runtime    |                           | 4.13.1                    |                           |
|  24 | anyio                     | 3.6.2, 4.3.0              | 3.6.2, 4.0.0, 4.3.0       |                           |
|  25 | arrow                     | 1.2.3, 1.3.0              | 1.3.0                     |                           |
|  26 | asgi-lifespan             |                           | 2.1.0                     |                           |
|  27 | astroid                   |                           |                           | 3.0.2, 3.1.0              |
|  28 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  29 | async-timeout             | 4.0.2, 4.0.3              | 4.0.2, 4.0.3              | 4.0.2, 4.0.3              |
|  30 | asyncpg                   | 0.27.0, 0.28.0, 0.29.0    | 0.28.0                    |                           |
|  31 | attrs                     | 21.4.0, 23.1.0, 23.2.0    | 21.4.0, 23.1.0, 23.2.0    | 21.4.0, 23.1.0            |
|  32 | aws-sam-translator        |                           | 1.55.0, 1.79.0, 1.86.0, 1.87.0 |                           |
|  33 | aws-xray-sdk              |                           | 2.12.1, 2.13.0            |                           |
|  34 | bidict                    | 0.22.0, 0.23.1            | 0.23.1                    |                           |
|  35 | black                     |                           |                           | 23.12.0, 24.2.0, 24.3.0   |
|  36 | blinker                   |                           | 1.7.0                     |                           |
|  37 | blosc                     | 1.11.1                    |                           |                           |
|  38 | bokeh                     | 2.4.3                     | 2.4.3                     |                           |
|  39 | boto3                     | 1.34.34, 1.34.75          | 1.21.21, 1.34.34, 1.34.51, 1.34.76 |                           |
|  40 | boto3-stubs               |                           | 1.34.76                   |                           |
|  41 | botocore                  | 1.34.34, 1.34.51, 1.34.75 | 1.24.21, 1.34.34, 1.34.51, 1.34.76 |                           |
|  42 | botocore-stubs            | 1.34.69                   | 1.33.6, 1.34.69           |                           |
|  43 | build                     |                           |                           | 1.0.3, 1.1.1, 1.2.1       |
|  44 | bump2version              |                           |                           | 1.0.1                     |
|  45 | cachetools                | 5.3.2                     |                           |                           |
|  46 | certifi                   | 2023.7.22, 2023.11.17, 2024.2.2 | 2023.7.22, 2023.11.17, 2024.2.2 |                           |
|  47 | cffi                      | 1.15.0, 1.16.0            | 1.16.0                    |                           |
|  48 | cfgv                      |                           |                           | 3.4.0                     |
|  49 | cfn-lint                  |                           | 0.72.0, 0.83.1, 0.86.1, 0.86.2 |                           |
|  50 | change-case               |                           |                           | 0.5.2                     |
|  51 | charset-normalizer        | 2.0.12, 2.1.1, 3.3.2      | 2.0.12, 2.1.1, 3.3.2      | 2.0.12, 2.1.1, 3.3.2      |
|  52 | click                     | 8.1.3, 8.1.7              | 8.1.3, 8.1.7              | 8.1.3, 8.1.7              |
|  53 | cloudpickle               | 3.0.0                     | 2.2.1, 3.0.0              |                           |
|  54 | colorama                  | 0.4.6                     |                           |                           |
|  55 | colorlog                  | 6.8.2                     | 6.8.2                     |                           |
|  56 | contourpy                 | 1.2.0                     |                           |                           |
|  57 | coverage                  |                           | 7.3.2, 7.4.3, 7.4.4       |                           |
|  58 | cryptography              | 41.0.7, 42.0.5            | 41.0.7, 42.0.5            |                           |
|  59 | cycler                    | 0.12.1                    |                           |                           |
|  60 | dask                      | 2023.3.2, 2024.4.1        | 2023.3.2                  |                           |
|  61 | dask-gateway              | 2024.1.0                  | 2023.9.0, 2024.1.0        |                           |
|  62 | dask-gateway-server       | 2023.1.1                  | 2023.1.1                  |                           |
|  63 | dateparser                | 1.2.0                     |                           |                           |
|  64 | debugpy                   |                           | 1.8.1                     |                           |
|  65 | deepdiff                  |                           | 7.0.0                     |                           |
|  66 | dill                      |                           |                           | 0.3.7, 0.3.8              |
|  67 | distlib                   |                           |                           | 0.3.8                     |
|  68 | distributed               | 2023.3.2, 2024.4.1        | 2023.3.2                  |                           |
|  69 | dnspython                 | 2.2.1, 2.4.2, 2.6.1       | 2.4.2                     |                           |
|  70 | docker                    | 6.1.3                     | 6.1.3, 7.0.0              |                           |
|  71 | ecdsa                     | 0.18.0                    | 0.18.0                    |                           |
|  72 | email-validator           | 1.2.1, 1.3.0, 2.1.0.post1, 2.1.1 | 2.1.0.post1               |                           |
|  73 | et-xmlfile                | 1.1.0                     |                           |                           |
|  74 | exceptiongroup            | 1.1.3, 1.2.0              | 1.1.3, 1.2.0              |                           |
|  75 | execnet                   |                           | 2.0.2, 2.1.1              |                           |
|  76 | faker                     | 19.6.1                    | 19.6.1, 19.13.0, 21.0.0, 23.2.1, 24.0.0, 24.4.0, 24.7.1 |                           |
|  77 | fakeredis                 |                           | 2.21.3                    |                           |
|  78 | fastapi                   | 0.96.0, 0.99.1            |                           |                           |
|  79 | fastapi-pagination        | 0.12.17, 0.12.21          |                           |                           |
|  80 | filelock                  |                           |                           | 3.13.1, 3.13.3            |
|  81 | flaky                     |                           | 3.7.0, 3.8.1              |                           |
|  82 | flask                     |                           | 2.1.3, 3.0.0, 3.0.2, 3.0.3 |                           |
|  83 | flask-cors                |                           | 4.0.0                     |                           |
|  84 | fonttools                 | 4.50.0                    |                           |                           |
|  85 | frozenlist                | 1.3.0, 1.3.1, 1.4.0, 1.4.1 | 1.3.0, 1.3.1, 1.4.0, 1.4.1 | 1.3.0, 1.3.1, 1.4.0, 1.4.1 |
|  86 | fsspec                    | 2024.3.1                  | 2023.6.0, 2024.3.1        |                           |
|  87 | graphql-core              |                           | 3.2.3                     |                           |
|  88 | greenlet                  | 2.0.2, 3.0.1, 3.0.3       | 2.0.2, 3.0.1, 3.0.3       |                           |
|  89 | gunicorn                  | 20.1.0                    |                           |                           |
|  90 | h11                       | 0.14.0                    | 0.14.0                    |                           |
|  91 | h2                        | 4.1.0                     |                           |                           |
|  92 | hpack                     | 4.0.0                     |                           |                           |
|  93 | httmock                   | 1.4.0                     |                           |                           |
|  94 | httpcore                  | 1.0.2, 1.0.4, 1.0.5       | 0.18.0, 1.0.2, 1.0.4, 1.0.5 |                           |
|  95 | httptools                 | 0.6.1                     |                           |                           |
|  96 | httpx                     | 0.26.0, 0.27.0            | 0.25.0, 0.26.0, 0.27.0    |                           |
|  97 | hyperframe                | 6.0.1                     |                           |                           |
|  98 | hypothesis                |                           | 6.88.1, 6.99.13           |                           |
|  99 | icdiff                    |                           | 2.0.7                     |                           |
| 100 | identify                  |                           |                           | 2.5.33, 2.5.35            |
| 101 | idna                      | 3.3, 3.4, 3.6             | 3.3, 3.4, 3.6             | 3.3, 3.4, 3.6             |
| 102 | importlib-metadata        | 7.1.0                     | 6.8.0, 7.1.0              |                           |
| 103 | iniconfig                 | 2.0.0                     | 2.0.0                     |                           |
| 104 | inotify                   |                           |                           | 0.2.10                    |
| 105 | isodate                   | 0.6.1                     |                           |                           |
| 106 | isort                     |                           |                           | 5.13.2                    |
| 107 | itsdangerous              | 2.1.2                     | 2.1.2                     |                           |
| 108 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 109 | jinja2                    | 3.1.2, 3.1.3              | 3.1.2, 3.1.3              | 3.1.3                     |
| 110 | jmespath                  | 1.0.1                     | 1.0.1                     |                           |
| 111 | joserfc                   |                           | 0.9.0                     |                           |
| 112 | jschema-to-python         |                           | 1.2.3                     |                           |
| 113 | json2html                 | 1.3.0                     |                           |                           |
| 114 | jsondiff                  | 2.0.0                     | 2.0.0                     |                           |
| 115 | jsonpatch                 |                           | 1.33                      |                           |
| 116 | jsonpath-ng               |                           | 1.6.1                     |                           |
| 117 | jsonpickle                |                           | 3.0.2, 3.0.3              |                           |
| 118 | jsonpointer               |                           | 2.4                       |                           |
| 119 | jsonref                   |                           | 1.1.0                     |                           |
| 120 | jsonschema                | 3.2.0, 4.19.2, 4.21.1     | 3.2.0, 4.19.2, 4.21.1     |                           |
| 121 | jsonschema-path           | 0.3.2                     | 0.3.1, 0.3.2              |                           |
| 122 | jsonschema-specifications | 2023.7.1, 2023.12.1       | 2023.7.1, 2023.12.1       |                           |
| 123 | junit-xml                 |                           | 1.9                       |                           |
| 124 | kiwisolver                | 1.4.5                     |                           |                           |
| 125 | lazy-object-proxy         | 1.7.1, 1.10.0             | 1.9.0, 1.10.0             |                           |
| 126 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 127 | lupa                      |                           | 2.1                       |                           |
| 128 | lz4                       | 4.3.3                     | 4.3.2                     |                           |
| 129 | mako                      | 1.2.2, 1.2.4, 1.3.2       | 1.2.2, 1.2.4, 1.3.2       |                           |
| 130 | markdown-it-py            | 3.0.0                     | 3.0.0                     |                           |
| 131 | markupsafe                | 2.1.1, 2.1.3, 2.1.5       | 2.1.1, 2.1.3, 2.1.5       | 2.1.5                     |
| 132 | matplotlib                | 3.8.3                     |                           |                           |
| 133 | mccabe                    |                           |                           | 0.7.0                     |
| 134 | mdurl                     | 0.1.2                     | 0.1.2                     |                           |
| 135 | more-itertools            | 10.2.0                    |                           |                           |
| 136 | moto                      |                           | 4.0.1, 4.2.6, 4.2.7, 5.0.3, 5.0.4, 5.0.5 |                           |
| 137 | mpmath                    |                           | 1.3.0                     |                           |
| 138 | msgpack                   | 1.0.7, 1.0.8              | 1.0.5, 1.0.8              |                           |
| 139 | multidict                 | 6.0.2, 6.0.4, 6.0.5       | 6.0.2, 6.0.4, 6.0.5       | 6.0.2, 6.0.4, 6.0.5       |
| 140 | mypy                      |                           | 1.6.1, 1.9.0              |                           |
| 141 | mypy-extensions           |                           | 1.0.0                     | 1.0.0                     |
| 142 | nest-asyncio              | 1.6.0                     |                           |                           |
| 143 | networkx                  | 3.3                       | 2.8.8, 3.2.1, 3.3         |                           |
| 144 | nodeenv                   |                           |                           | 1.8.0                     |
| 145 | nose                      |                           |                           | 1.3.7                     |
| 146 | numpy                     | 1.26.4                    | 1.25.2, 1.26.4            |                           |
| 147 | openapi-core              | 0.12.0, 0.19.0            |                           |                           |
| 148 | openapi-schema-validator  | 0.2.3, 0.6.2              | 0.2.3, 0.6.2              |                           |
| 149 | openapi-spec-validator    | 0.4.0, 0.7.1              | 0.4.0, 0.7.1              |                           |
| 150 | openpyxl                  | 3.0.9                     |                           |                           |
| 151 | ordered-set               | 4.1.0                     | 4.1.0                     |                           |
| 152 | orjson                    | 3.7.2, 3.9.7, 3.9.10, 3.9.15, 3.10.0 | 3.9.10                    |                           |
| 153 | osparc                    | 0.6.5                     |                           |                           |
| 154 | osparc-client             | 0.6.5                     |                           |                           |
| 155 | packaging                 | 23.1, 23.2, 24.0          | 23.1, 23.2, 24.0          | 23.1, 23.2, 24.0          |
| 156 | pamqp                     | 3.2.1, 3.3.0              | 3.2.1, 3.3.0              |                           |
| 157 | pandas                    | 2.2.1                     | 2.2.1                     |                           |
| 158 | parse                     | 1.20.1                    | 1.20.1                    |                           |
| 159 | partd                     | 1.4.1                     | 1.4.0, 1.4.1              |                           |
| 160 | passlib                   | 1.7.4                     |                           |                           |
| 161 | pathable                  | 0.4.3                     | 0.4.3                     |                           |
| 162 | pathspec                  |                           |                           | 0.12.1                    |
| 163 | pbr                       |                           | 5.11.1, 6.0.0             |                           |
| 164 | pillow                    | 10.2.0, 10.3.0            | 10.3.0                    |                           |
| 165 | pint                      | 0.19.2, 0.22, 0.23        | 0.22, 0.23                |                           |
| 166 | pip                       |                           |                           | 24.0                      |
| 167 | pip-tools                 |                           |                           | 7.3.0, 7.4.0, 7.4.1       |
| 168 | platformdirs              |                           |                           | 4.1.0, 4.2.0              |
| 169 | playwright                |                           | 1.40.0                    |                           |
| 170 | pluggy                    | 1.3.0                     | 1.3.0, 1.4.0              |                           |
| 171 | ply                       |                           | 3.11                      |                           |
| 172 | pprintpp                  |                           | 0.4.0                     |                           |
| 173 | pre-commit                |                           |                           | 3.6.0, 3.6.2, 3.7.0       |
| 174 | prometheus-api-client     | 0.5.5                     |                           |                           |
| 175 | prometheus-client         | 0.14.1, 0.19.0, 0.20.0    |                           |                           |
| 176 | prometheus-fastapi-instrumentator | 6.1.0                     |                           |                           |
| 177 | psutil                    | 5.9.8                     | 5.9.5, 5.9.8              |                           |
| 178 | psycopg2-binary           | 2.9.6, 2.9.9              | 2.9.9                     |                           |
| 179 | ptvsd                     |                           | 4.3.2                     |                           |
| 180 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 181 | py-partiql-parser         |                           | 0.4.0, 0.4.1, 0.5.1, 0.5.2, 0.5.4 |                           |
| 182 | pyasn1                    | 0.5.1                     | 0.5.0, 0.6.0              |                           |
| 183 | pycountry                 | 23.12.11                  |                           |                           |
| 184 | pycparser                 | 2.21, 2.22                | 2.21, 2.22                |                           |
| 185 | pydantic                  | 1.9.0, 1.10.2, 1.10.13, 1.10.14, 1.10.15 | 1.10.2, 1.10.13, 1.10.14, 1.10.15, 2.5.2 |                           |
| 186 | pydantic-core             |                           | 2.14.5                    |                           |
| 187 | pyee                      |                           | 11.0.1                    |                           |
| 188 | pyftpdlib                 |                           | 1.5.9                     |                           |
| 189 | pygments                  | 2.15.1, 2.16.1, 2.17.2    | 2.16.1                    |                           |
| 190 | pyinstrument              | 4.6.1, 4.6.2              | 4.6.1, 4.6.2              |                           |
| 191 | pyjwt                     | 2.4.0                     |                           |                           |
| 192 | pylint                    |                           |                           | 3.0.3, 3.1.0              |
| 193 | pyopenssl                 |                           | 24.1.0                    |                           |
| 194 | pyparsing                 | 3.1.2                     | 3.1.1, 3.1.2              |                           |
| 195 | pyproject-hooks           |                           |                           | 1.0.0                     |
| 196 | pyrsistent                | 0.18.1, 0.19.2, 0.20.0    | 0.18.1, 0.19.2, 0.20.0    |                           |
| 197 | pytest                    | 7.4.3                     | 7.4.3, 8.0.2, 8.1.1       |                           |
| 198 | pytest-aiohttp            |                           | 1.0.5                     |                           |
| 199 | pytest-asyncio            |                           | 0.21.1                    |                           |
| 200 | pytest-base-url           |                           | 2.0.0                     |                           |
| 201 | pytest-benchmark          |                           | 4.0.0                     |                           |
| 202 | pytest-cov                |                           | 4.1.0, 5.0.0              |                           |
| 203 | pytest-docker             |                           | 2.0.1, 3.1.1              |                           |
| 204 | pytest-html               |                           | 4.1.1                     |                           |
| 205 | pytest-icdiff             |                           | 0.8, 0.9                  |                           |
| 206 | pytest-instafail          |                           | 0.5.0                     |                           |
| 207 | pytest-localftpserver     |                           | 1.2.0                     |                           |
| 208 | pytest-metadata           |                           | 3.0.0                     |                           |
| 209 | pytest-mock               |                           | 3.12.0, 3.14.0            |                           |
| 210 | pytest-playwright         |                           | 0.4.3                     |                           |
| 211 | pytest-runner             |                           | 6.0.0, 6.0.1              |                           |
| 212 | pytest-sugar              |                           | 0.9.7, 1.0.0              |                           |
| 213 | pytest-xdist              |                           | 3.3.1, 3.5.0              |                           |
| 214 | python-dateutil           | 2.8.2, 2.9.0.post0        | 2.8.2, 2.9.0.post0        |                           |
| 215 | python-dotenv             | 1.0.0, 1.0.1              | 1.0.0, 1.0.1              |                           |
| 216 | python-engineio           | 4.3.4, 4.9.0              | 4.9.0                     |                           |
| 217 | python-jose               | 3.3.0                     | 3.3.0                     |                           |
| 218 | python-magic              | 0.4.25, 0.4.27            |                           |                           |
| 219 | python-multipart          | 0.0.9                     |                           |                           |
| 220 | python-slugify            |                           | 8.0.1                     |                           |
| 221 | python-socketio           | 5.8.0, 5.11.2             | 5.11.2                    |                           |
| 222 | pytz                      | 2022.1, 2024.1            | 2024.1                    |                           |
| 223 | pyyaml                    | 6.0.1                     | 6.0.1                     | 6.0.1                     |
| 224 | redis                     | 4.5.4, 5.0.1, 5.0.3       | 4.5.4, 5.0.1, 5.0.3       |                           |
| 225 | referencing               | 0.29.3, 0.30.2, 0.33.0, 0.34.0 | 0.29.3, 0.30.2, 0.33.0    |                           |
| 226 | regex                     | 2023.12.25                | 2023.10.3, 2023.12.25     |                           |
| 227 | requests                  | 2.31.0                    | 2.31.0                    |                           |
| 228 | requests-mock             |                           | 1.11.0                    |                           |
| 229 | responses                 |                           | 0.23.3, 0.25.0            |                           |
| 230 | respx                     |                           | 0.20.2, 0.21.0, 0.21.1    |                           |
| 231 | rfc3339-validator         | 0.1.4                     | 0.1.4                     |                           |
| 232 | rich                      | 13.4.2, 13.6.0, 13.7.1    | 13.6.0                    |                           |
| 233 | rpds-py                   | 0.10.6, 0.18.0            | 0.10.6, 0.18.0            |                           |
| 234 | rsa                       | 4.9                       | 4.9                       |                           |
| 235 | ruff                      |                           |                           | 0.1.8, 0.2.2, 0.3.1, 0.3.4, 0.3.5 |
| 236 | s3fs                      | 2024.3.1                  |                           |                           |
| 237 | s3transfer                | 0.10.1                    | 0.5.2, 0.10.1             |                           |
| 238 | sarif-om                  |                           | 1.0.4                     |                           |
| 239 | setproctitle              | 1.2.3                     |                           |                           |
| 240 | setuptools                | 69.1.1, 69.2.0            | 69.1.1, 69.2.0            | 69.1.1, 69.2.0            |
| 241 | sh                        | 2.0.6                     |                           |                           |
| 242 | shellingham               | 1.5.4                     |                           |                           |
| 243 | shortuuid                 | 1.0.13                    |                           |                           |
| 244 | simple-websocket          | 1.0.0                     | 1.0.0                     |                           |
| 245 | six                       | 1.16.0                    | 1.16.0                    |                           |
| 246 | sniffio                   | 1.3.0, 1.3.1              | 1.3.0, 1.3.1              |                           |
| 247 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 248 | sqlalchemy                | 1.4.47, 1.4.50, 1.4.52    | 1.4.47, 1.4.50, 1.4.52    |                           |
| 249 | sqlalchemy2-stubs         |                           | 0.0.2a36, 0.0.2a38        |                           |
| 250 | sshpubkeys                |                           | 3.3.1                     |                           |
| 251 | starlette                 | 0.27.0                    |                           |                           |
| 252 | strict-rfc3339            | 0.7                       |                           |                           |
| 253 | sympy                     |                           | 1.12                      |                           |
| 254 | tblib                     | 3.0.0                     | 2.0.0, 3.0.0              |                           |
| 255 | tenacity                  | 8.0.1, 8.2.3              | 8.0.1, 8.2.3              |                           |
| 256 | termcolor                 |                           | 2.3.0, 2.4.0              |                           |
| 257 | text-unidecode            |                           | 1.3                       |                           |
| 258 | tomli                     | 2.0.1                     | 2.0.1                     | 2.0.1                     |
| 259 | tomlkit                   |                           |                           | 0.12.3, 0.12.4            |
| 260 | toolz                     | 0.12.0, 0.12.1            | 0.12.0, 0.12.1            |                           |
| 261 | tornado                   | 6.4                       | 6.3.3, 6.4                |                           |
| 262 | tqdm                      | 4.64.0, 4.66.1, 4.66.2    | 4.66.1                    |                           |
| 263 | traitlets                 | 5.14.2                    | 5.14.2                    |                           |
| 264 | twilio                    | 7.12.0                    |                           |                           |
| 265 | typer                     | 0.4.1, 0.6.1, 0.9.0, 0.10.0, 0.12.0, 0.12.1 | 0.9.0                     | 0.9.0                     |
| 266 | typer-cli                 | 0.12.0                    |                           |                           |
| 267 | typer-slim                | 0.12.0                    |                           |                           |
| 268 | types-aiobotocore         | 2.12.1, 2.12.2            | 2.8.0                     |                           |
| 269 | types-aiobotocore-ec2     | 2.12.1, 2.12.2            |                           |                           |
| 270 | types-aiobotocore-s3      | 2.12.1, 2.12.2            | 2.8.0, 2.12.2             |                           |
| 271 | types-aiofiles            |                           | 23.2.0.20240403           |                           |
| 272 | types-awscrt              | 0.20.5                    | 0.19.19, 0.20.5           |                           |
| 273 | types-boto3               |                           | 1.0.2                     |                           |
| 274 | types-cachetools          |                           |                           | 5.3.0.7                   |
| 275 | types-pkg-resources       |                           | 0.1.3                     |                           |
| 276 | types-python-dateutil     | 2.8.19.14, 2.8.19.20240106, 2.9.0.20240316 | 2.8.19.14, 2.8.19.20240106 |                           |
| 277 | types-pyyaml              |                           | 6.0.12.12, 6.0.12.20240311 |                           |
| 278 | types-s3transfer          |                           | 0.10.0                    |                           |
| 279 | typing-extensions         | 4.3.0, 4.4.0, 4.8.0, 4.10.0, 4.11.0 | 4.3.0, 4.4.0, 4.8.0, 4.9.0, 4.10.0, 4.11.0 | 4.3.0, 4.4.0, 4.8.0, 4.9.0, 4.10.0, 4.11.0 |
| 280 | tzdata                    | 2024.1                    | 2024.1                    |                           |
| 281 | tzlocal                   | 5.2                       |                           |                           |
| 282 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 283 | ujson                     | 5.5.0, 5.9.0              |                           |                           |
| 284 | urllib3                   | 1.26.11, 2.0.7, 2.2.1     | 1.26.11, 1.26.16, 1.26.18, 2.0.7, 2.1.0, 2.2.1 |                           |
| 285 | uvicorn                   | 0.19.0, 0.29.0            |                           |                           |
| 286 | uvloop                    | 0.19.0                    |                           |                           |
| 287 | virtualenv                |                           |                           | 20.25.0, 20.25.1          |
| 288 | watchdog                  | 4.0.0                     |                           | 3.0.0, 4.0.0              |
| 289 | watchfiles                | 0.21.0                    |                           |                           |
| 290 | websocket-client          | 1.6.4                     | 1.6.4                     |                           |
| 291 | websockets                | 12.0                      | 12.0                      |                           |
| 292 | werkzeug                  | 2.1.2, 3.0.2              | 2.1.2, 3.0.1, 3.0.2       |                           |
| 293 | wheel                     |                           |                           | 0.42.0, 0.43.0            |
| 294 | wrapt                     | 1.16.0                    | 1.15.0, 1.16.0            |                           |
| 295 | wsproto                   | 1.2.0                     | 1.2.0                     |                           |
| 296 | xmltodict                 |                           | 0.13.0                    |                           |
| 297 | yarl                      | 1.5.1, 1.9.2, 1.9.4       | 1.5.1, 1.9.2, 1.9.4       | 1.5.1, 1.9.2, 1.9.4       |
| 298 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 299 | zipp                      | 3.18.1                    | 3.16.2, 3.18.1            |                           |
