### PR TITLE
🐛 Various issue in the study cards

### DIFF
--- a/services/static-webserver/client/source/class/osparc/auth/LoginPage.js
+++ b/services/static-webserver/client/source/class/osparc/auth/LoginPage.js
@@ -145,12 +145,21 @@ qx.Class.define("osparc.auth.LoginPage", {
     },
 
     _setBackgroundImage: function(backgroundImage) {
-      this.getContentElement().setStyles({
-        "background-image": backgroundImage,
-        "background-repeat": "no-repeat",
-        "background-size": "65% auto, 80% auto", // auto width, 85% height
-        "background-position": "left bottom, left -440px bottom -230px" // left bottom
-      });
+      if (osparc.product.Utils.getProductName().includes("s4l")) {
+        this.getContentElement().setStyles({
+          "background-image": backgroundImage,
+          "background-repeat": "no-repeat",
+          "background-size": "65% auto, 80% auto", // auto width, 85% height
+          "background-position": "left bottom, left -440px bottom -230px" // left bottom
+        });
+      } else {
+        this.getContentElement().setStyles({
+          "background-image": backgroundImage,
+          "background-repeat": "no-repeat",
+          "background-size": "50% auto", // 50% of the view width
+          "background-position": "left 10% center" // left bottom
+        });
+      }
     },
 
     _resetBackgroundImage: function() {

--- a/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
@@ -419,8 +419,7 @@ qx.Class.define("osparc.dashboard.CardBase", {
         uiModeIcon.set({
           source,
           toolTipText,
-          alignY: "bottom",
-          marginBottom: 10
+          alignY: "bottom"
         });
       }
     },

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonBase.js
@@ -65,12 +65,6 @@ qx.Class.define("osparc.dashboard.GridButtonBase", {
         row: 3,
         column: 0
       },
-      VIEWER_MODE: {
-        row: 3,
-        column: 1,
-        rowSpan: 2,
-        colSpan: 1
-      },
       FOOTER: {
         row: 4,
         column: 0,
@@ -79,30 +73,29 @@ qx.Class.define("osparc.dashboard.GridButtonBase", {
       }
     },
     FPOS: {
-      STATUS: {
+      MODIFIED: {
         row: 0,
         column: 0,
         rowSpan: 1,
-        colSpan: 4
+        colSpan: 2
       },
-      MODIFIED: {
-        row: 1,
-        column: 0,
-        rowSpan: 1,
-        colSpan: 3
+      VIEWER_MODE: {
+        row: 0,
+        column: 3,
+        colSpan: 1
       },
       UPDATES: {
-        row: 1,
+        row: 0,
         column: 4,
         colSpan: 1
       },
       TSR: {
-        row: 3,
+        row: 1,
         column: 0,
         colSpan: 2
       },
       HITS: {
-        row: 3,
+        row: 1,
         column: 2,
         colSpan: 1
       }
@@ -282,8 +275,9 @@ qx.Class.define("osparc.dashboard.GridButtonBase", {
           control = new qx.ui.basic.Image().set({
             alignY: "middle",
             textColor: "status_icon",
-            height: 12,
-            width: 12,
+            height: 13,
+            width: 13,
+            margin: [0, 1]
           });
           layout = this.getChildControl("subtitle");
           layout.set({

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonItem.js
@@ -52,10 +52,11 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
           break;
         case "workbench-mode":
           control = new qx.ui.basic.Image().set({
-            alignY: "middle"
+            alignY: "middle",
+            padding: [0, 5]
           });
-          layout = this.getChildControl("main-layout");
-          layout.add(control, osparc.dashboard.GridButtonBase.POS.VIEWER_MODE);
+          layout = this.getChildControl("footer");
+          layout.add(control, osparc.dashboard.GridButtonBase.FPOS.VIEWER_MODE);
           break;
         case "empty-workbench": {
           control = this._getEmptyWorkbenchIcon();
@@ -68,7 +69,7 @@ qx.Class.define("osparc.dashboard.GridButtonItem", {
             source: "@MaterialIcons/update/16",
             visibility: "excluded",
             alignY: "middle",
-            alignX: "center"
+            padding: [0, 5]
           });
           osparc.utils.Utils.setIdToWidget(control, "updateStudyBtn");
           layout = this.getChildControl("footer");

--- a/services/static-webserver/client/source/class/osparc/dashboard/GridButtonNew.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/GridButtonNew.js
@@ -40,7 +40,10 @@ qx.Class.define("osparc.dashboard.GridButtonNew", {
 
     if (title) {
       const titleLabel = this.getChildControl("title");
-      titleLabel.setValue(title);
+      titleLabel.set({
+        value: title,
+        rich: true
+      });
     }
 
     if (description) {


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

- Fixed the issue where the app mode button over lapped the updates button in the study card footer
![303394164-8d6f443e-a5b6-4544-9c1f-55edc3d3ab4c](https://github.com/ITISFoundation/osparc-simcore/assets/903587/302deb0d-4661-471e-9ddd-4b14a9719071)

<img width="208" alt="Screenshot 2024-04-04 at 13 27 18" src="https://github.com/ITISFoundation/osparc-simcore/assets/903587/695d8d8d-002b-4371-9036-b0ab234987fe">


- Fix the issue where the create new study failed to render rich text for sim4life lite

![images4l-lite](https://github.com/ITISFoundation/osparc-simcore/assets/903587/4348a241-da02-4c3c-ae31-3639dbc948b9)

<img width="220" alt="Screenshot 2024-04-04 at 13 26 38" src="https://github.com/ITISFoundation/osparc-simcore/assets/903587/c8a6335f-56fd-4580-9973-30ed596c5d7b">



## Related issue/s

resolves https://github.com/ITISFoundation/osparc-issues/issues/1260

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
