### PR TITLE
🎨 Improve exception when clusters-keeper is not running in billable products

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_utils.py
@@ -305,7 +305,11 @@ async def _update_project_node_resources_from_hardware_info(
             " TIP: adjust product configuration"
         )
         raise ConfigurationError(msg) from exc
-    except (RemoteMethodNotRegisteredError, RPCServerError) as exc:
+    except (
+        RemoteMethodNotRegisteredError,
+        RPCServerError,
+        asyncio.TimeoutError,
+    ) as exc:
         raise ClustersKeeperNotAvailableError from exc
 
 
@@ -377,14 +381,15 @@ async def generate_tasks_list_from_project(
             node_version=node.version,
         )
         assert rabbitmq_rpc_client  # nosec
-        await _update_project_node_resources_from_hardware_info(
-            connection,
-            is_wallet=is_wallet,
-            project_id=project.uuid,
-            node_id=NodeID(node_id),
-            hardware_info=hardware_info,
-            rabbitmq_rpc_client=rabbitmq_rpc_client,
-        )
+        if to_node_class(node.key) == NodeClass.COMPUTATIONAL:
+            await _update_project_node_resources_from_hardware_info(
+                connection,
+                is_wallet=is_wallet,
+                project_id=project.uuid,
+                node_id=NodeID(node_id),
+                hardware_info=hardware_info,
+                rabbitmq_rpc_client=rabbitmq_rpc_client,
+            )
 
         image = await _generate_task_image(
             catalog_client=catalog_client,

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_utils.py
@@ -381,15 +381,14 @@ async def generate_tasks_list_from_project(
             node_version=node.version,
         )
         assert rabbitmq_rpc_client  # nosec
-        if to_node_class(node.key) == NodeClass.COMPUTATIONAL:
-            await _update_project_node_resources_from_hardware_info(
-                connection,
-                is_wallet=is_wallet,
-                project_id=project.uuid,
-                node_id=NodeID(node_id),
-                hardware_info=hardware_info,
-                rabbitmq_rpc_client=rabbitmq_rpc_client,
-            )
+        await _update_project_node_resources_from_hardware_info(
+            connection,
+            is_wallet=is_wallet,
+            project_id=project.uuid,
+            node_id=NodeID(node_id),
+            hardware_info=hardware_info,
+            rabbitmq_rpc_client=rabbitmq_rpc_client,
+        )
 
         image = await _generate_task_image(
             catalog_client=catalog_client,

--- a/services/web/server/src/simcore_service_webserver/projects/_nodes_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_nodes_handlers.py
@@ -51,13 +51,13 @@ from servicelib.rabbitmq.rpc_interfaces.dynamic_scheduler.errors import (
     ServiceWasNotFoundError,
 )
 from simcore_postgres_database.models.users import UserRole
-from simcore_service_webserver.groups.exceptions import GroupNotFoundError
 
 from .._meta import API_VTAG as VTAG
 from ..catalog import client as catalog_client
 from ..director_v2 import api as director_v2_api
 from ..dynamic_scheduler import api as dynamic_scheduler_api
 from ..groups.api import get_group_from_gid, list_user_groups
+from ..groups.exceptions import GroupNotFoundError
 from ..login.decorators import login_required
 from ..security.decorators import permission_required
 from ..users.api import get_user_id_from_gid, get_user_role
@@ -69,6 +69,7 @@ from ._common_models import ProjectPathParams, RequestContext
 from ._nodes_api import NodeScreenshot, get_node_screenshots
 from .db import ProjectDBAPI
 from .exceptions import (
+    ClustersKeeperNotAvailableError,
     DefaultPricingUnitNotFoundError,
     NodeNotFoundError,
     ProjectNodeResourcesInsufficientRightsError,
@@ -288,6 +289,8 @@ async def start_node(request: web.Request) -> web.Response:
 
     except ProjectStartsTooManyDynamicNodesError as exc:
         raise web.HTTPConflict(reason=f"{exc}") from exc
+    except ClustersKeeperNotAvailableError as exc:
+        raise web.HTTPServiceUnavailable(reason=f"{exc}") from exc
 
 
 async def _stop_dynamic_service_task(

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -386,7 +386,11 @@ async def update_project_node_resources_from_hardware_info(
     except KeyError as exc:
         msg = "Sub service is missing RAM/CPU resource keys!"
         raise ProjectNodeResourcesInvalidError(msg) from exc
-    except (RemoteMethodNotRegisteredError, RPCServerError) as exc:
+    except (
+        RemoteMethodNotRegisteredError,
+        RPCServerError,
+        asyncio.TimeoutError,
+    ) as exc:
         raise ClustersKeeperNotAvailableError from exc
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

When the clusters-keeper application is down, paused or not accessible, then it is impossible to start a dynamic service and/or start a computation for the following reasons:
- the clusters-keeper provides an interface to the AWS EC2 API to get the EC2 resources (CPU, RAM),
- if the clusters-keeper is not accessible or shutdown for whatever reason, then this interface is not available,
- therefore it is not possible to set the service resources to run dynamic services and computational services which makes  sense

This PR improves the situation by returning a 503 when a dynamic service cannot start due to that fact.
Basically for billable products, starting a service depends on the clusters-keeper being up and running.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
