### PR TITLE
🎨 Frontend: Data tab only visible in oSparc product

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
@@ -120,7 +120,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
           buildLayout: this.__createServiceBrowser
         });
       }
-      if (permissions.canDo("dashboard.data.read")) {
+      if (permissions.canDo("dashboard.data.read") && osparc.product.Utils.isProduct("osparc")) {
         tabs.push({
           id: "dataTabBtn",
           label: this.tr("DATA"),

--- a/services/static-webserver/client/source/class/osparc/data/Permissions.js
+++ b/services/static-webserver/client/source/class/osparc/data/Permissions.js
@@ -158,10 +158,9 @@ qx.Class.define("osparc.data.Permissions", {
           "study.slides.stop"
         ];
       } else if (osparc.product.Utils.isProduct("s4llite")) {
-        // "services" and "data" tabs only for testers
+        // "services" tabs only for testers
         fromUserToTester = [
-          "dashboard.services.read",
-          "dashboard.data.read"
+          "dashboard.services.read"
         ];
       }
       fromUserToTester.forEach(onlyTester => {


### PR DESCRIPTION
## What do these changes do?

Data tab only visible in oSparc product

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
