### PR TITLE
✨ api-server: Adds job outputs

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -47,7 +47,7 @@
       "type": "debugpy",
       "request": "attach",
       "connect": {
-        "port": 3015,
+        "port": 3006,
         "host": "127.0.0.1"
       },
       "pathMappings": [

--- a/services/api-server/src/simcore_service_api_server/services/study_job_models_converters.py
+++ b/services/api-server/src/simcore_service_api_server/services/study_job_models_converters.py
@@ -2,7 +2,6 @@
     Helper functions to convert models used in
     services/api-server/src/simcore_service_api_server/api/routes/studies_jobs.py
 """
-import collections.abc
 from typing import Any, NamedTuple
 from uuid import UUID
 
@@ -13,11 +12,12 @@ from models_library.api_schemas_webserver.projects_ports import (
 )
 from models_library.projects import DateTimeStr
 from models_library.projects_nodes import InputID, NodeID
-from models_library.projects_nodes_io import SimcoreS3FileID
+from models_library.projects_nodes_io import LinkToFileTypes, SimcoreS3FileID
+from pydantic import parse_obj_as
 
 from ..models.domain.projects import InputTypes, SimCoreFileLink
 from ..models.schemas.files import File
-from ..models.schemas.jobs import ArgumentTypes, Job, JobInputs, JobOutputs
+from ..models.schemas.jobs import Job, JobInputs, JobOutputs
 from ..models.schemas.studies import Study, StudyID
 from .storage import to_file_api_model
 
@@ -71,7 +71,7 @@ def create_job_from_study(
 
     job_name = Job.compose_resource_name(parent_name=study_name, job_id=project.uuid)
 
-    new_job = Job(
+    return Job(
         id=project.uuid,
         name=job_name,
         inputs_checksum=job_inputs.compute_checksum(),
@@ -82,8 +82,6 @@ def create_job_from_study(
         outputs_url=None,
     )
 
-    return new_job
-
 
 async def create_job_outputs_from_project_outputs(
     job_id: StudyID,
@@ -91,24 +89,34 @@ async def create_job_outputs_from_project_outputs(
     user_id,
     storage_client,
 ) -> JobOutputs:
-    results: dict[str, ArgumentTypes] = {}
+    """
+
+    Raises:
+        ValidationError: when on invalid project_outputs
+
+    """
+    results: dict[str, Any] = {}
 
     for node_dict in project_outputs.values():
         name = node_dict["label"]
         value = node_dict["value"]
+
         if (
-            value and isinstance(value, collections.abc.Mapping) and "store" in value
-        ):  # TODO make this more robust
+            value
+            and isinstance(value, dict)
+            and {"store", "path"}.issubset(value.keys())
+        ):
+            assert parse_obj_as(LinkToFileTypes, value) is not None  # nosec
+
             path = value["path"]
             file_id: UUID = File.create_id(*path.split("/"))
 
-            found = await storage_client.search_files(
+            if found := await storage_client.search_files(
                 user_id=user_id,
                 file_id=file_id,
                 sha256_checksum=None,
                 access_right="read",
-            )
-            if found:
+            ):
                 assert len(found) == 1  # nosec
                 results[name] = to_file_api_model(found[0])
             else:
@@ -118,5 +126,5 @@ async def create_job_outputs_from_project_outputs(
                 results[name] = api_file
         else:
             results[name] = value
-    job_outputs = JobOutputs(job_id=job_id, results=results)
-    return job_outputs
+
+    return JobOutputs(job_id=job_id, results=results)

--- a/services/api-server/src/simcore_service_api_server/services/study_job_models_converters.py
+++ b/services/api-server/src/simcore_service_api_server/services/study_job_models_converters.py
@@ -93,7 +93,7 @@ async def create_job_outputs_from_project_outputs(
 ) -> JobOutputs:
     results: dict[str, ArgumentTypes] = {}
 
-    for _, node_dict in project_outputs.items():
+    for node_dict in project_outputs.values():
         name = node_dict["label"]
         value = node_dict["value"]
         if (

--- a/services/api-server/src/simcore_service_api_server/services/webserver.py
+++ b/services/api-server/src/simcore_service_api_server/services/webserver.py
@@ -462,9 +462,8 @@ class AuthSession:
 
         response.raise_for_status()
         data = Envelope[dict[NodeID, dict[str, Any]]].parse_raw(response.text).data
-        assert data is not None  # nosec
 
-        return data
+        return data or {}
 
     @_exception_mapper({})
     async def update_node_outputs(

--- a/services/api-server/src/simcore_service_api_server/services/webserver.py
+++ b/services/api-server/src/simcore_service_api_server/services/webserver.py
@@ -451,6 +451,21 @@ class AuthSession:
         )
         return {} if data is None else data
 
+    @_exception_mapper({status.HTTP_404_NOT_FOUND: (status.HTTP_404_NOT_FOUND, None)})
+    async def get_project_outputs(
+        self, project_id: ProjectID
+    ) -> dict[NodeID, dict[str, Any]]:
+        response = await self.client.get(
+            f"/projects/{project_id}/outputs",
+            cookies=self.session_cookies,
+        )
+
+        response.raise_for_status()
+        data = Envelope[dict[NodeID, dict[str, Any]]].parse_raw(response.text).data
+        assert data is not None  # nosec
+
+        return data
+
     @_exception_mapper({})
     async def update_node_outputs(
         self, project_id: UUID, node_id: UUID, new_node_outputs: NodeOutputs

--- a/services/api-server/tests/unit/conftest.py
+++ b/services/api-server/tests/unit/conftest.py
@@ -19,6 +19,7 @@ from asgi_lifespan import LifespanManager
 from cryptography.fernet import Fernet
 from faker import Faker
 from fastapi import FastAPI, status
+from httpx import ASGITransport
 from models_library.api_schemas_long_running_tasks.tasks import (
     TaskGet,
     TaskProgress,
@@ -107,9 +108,9 @@ async def client(app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
 
     # LifespanManager will trigger app's startup&shutown event handlers
     async with LifespanManager(app), httpx.AsyncClient(
-        app=app,
         base_url="http://api.testserver.io",
         headers={"Content-Type": "application/json"},
+        transport=ASGITransport(app=app),
     ) as httpx_async_client:
         yield httpx_async_client
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

- ✨ Moves and adapts `POST /v0/studies/{study_id}/jobs/{job_id}/outputs` implementation from https://github.com/wvangeit/osparc-simcore/tree/studies_api
- ♻️ Fixes `httpx` deprecation
```
DeprecationWarning: The 'app' shortcut is now deprecated. 
Use the explicit style 'transport=ASGITransport(app=...)' instead.
```  

This is just a PR to move the implementation. I will follow up with more improvements in a separate PR 


## Related issue/s

- https://github.com/ITISFoundation/osparc-issues/issues/1291

## How to test

Minimal test (for now)
```
cd services/api-server
make install-dev
pytest -vv --pdb tests/unit -k test_get_study_job_outputs
```

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))
