### PR TITLE
🎨Ensure pulling s4l returns smooth increment of progress (Part 1)

### DIFF
--- a/packages/notifications-library/tests/conftest.py
+++ b/packages/notifications-library/tests/conftest.py
@@ -13,6 +13,7 @@ from models_library.products import ProductName
 from notifications_library._models import ProductData, UserData
 from notifications_library.payments import PaymentData
 from pydantic import EmailStr, parse_obj_as
+from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_postgres_database.models.products import Vendor
 
 pytest_plugins = [
@@ -53,6 +54,14 @@ def pytest_addoption(parser: pytest.Parser):
         default=None,
         help="Overrides `support_email` fixture",
     )
+
+
+@pytest.fixture(scope="session")
+def external_environment(external_environment: EnvVarsDict) -> EnvVarsDict:
+    if external_environment:
+        assert "PAYMENTS_GATEWAY_API_SECRET" in external_environment
+        assert "PAYMENTS_GATEWAY_URL" in external_environment
+    return external_environment
 
 
 @pytest.fixture(scope="session")

--- a/packages/notifications-library/tests/conftest.py
+++ b/packages/notifications-library/tests/conftest.py
@@ -13,8 +13,6 @@ from models_library.products import ProductName
 from notifications_library._models import ProductData, UserData
 from notifications_library.payments import PaymentData
 from pydantic import EmailStr, parse_obj_as
-from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.utils_envs import load_dotenv
 from simcore_postgres_database.models.products import Vendor
 
 pytest_plugins = [
@@ -39,15 +37,7 @@ def package_dir() -> Path:
 
 def pytest_addoption(parser: pytest.Parser):
     group = parser.getgroup(
-        "external_environment",
-        description="Replaces mocked services with real ones by passing actual environs and connecting directly to external services",
-    )
-    group.addoption(
-        "--external-envfile",
-        action="store",
-        type=Path,
-        default=None,
-        help="Path to an env file. Consider passing a link to repo configs, i.e. `ln -s /path/to/osparc-ops-config/repo.config`",
+        "simcore",
     )
     group.addoption(
         "--external-user-email",
@@ -63,29 +53,6 @@ def pytest_addoption(parser: pytest.Parser):
         default=None,
         help="Overrides `support_email` fixture",
     )
-
-
-@pytest.fixture(scope="session")
-def external_environment(request: pytest.FixtureRequest) -> EnvVarsDict:
-    """
-    If a file under test folder prefixed with `.env-secret` is present,
-    then this fixture captures it.
-
-    This technique allows reusing the same tests to check against
-    external development/production servers
-    """
-    envs = {}
-    if envfile := request.config.getoption("--external-envfile"):
-        print("🚨 EXTERNAL `envfile` option detected. Loading", envfile, "...")
-
-        assert isinstance(envfile, Path)
-        assert envfile.is_file()
-
-        envs = load_dotenv(envfile)
-        assert "PAYMENTS_GATEWAY_API_SECRET" in envs
-        assert "PAYMENTS_GATEWAY_URL" in envs
-
-    return envs
 
 
 @pytest.fixture(scope="session")

--- a/packages/pytest-simcore/src/pytest_simcore/__init__.py
+++ b/packages/pytest-simcore/src/pytest_simcore/__init__.py
@@ -1,5 +1,6 @@
 # Collection of tests fixtures for integration testing
 from importlib.metadata import version
+from pathlib import Path
 
 import pytest
 
@@ -7,12 +8,22 @@ __version__: str = version("pytest-simcore")
 
 
 def pytest_addoption(parser):
-    group = parser.getgroup("simcore")
-    group.addoption(
+    simcore_group = parser.getgroup(
+        "simcore", description="options related to pytest simcore"
+    )
+    simcore_group.addoption(
         "--keep-docker-up",
         action="store_true",
         default=False,
         help="Keep stack/registry up after fixtures closes",
+    )
+
+    simcore_group.addoption(
+        "--external-envfile",
+        action="store",
+        type=Path,
+        default=None,
+        help="Path to an env file. Consider passing a link to repo configs, i.e. `ln -s /path/to/osparc-ops-config/repo.config`",
     )
 
     # DUMMY

--- a/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
+++ b/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
@@ -36,3 +36,24 @@ def all_env_devel_undefined(
     when some script was accidentaly injecting the entire .env-devel in the environment
     """
     delenvs_from_dict(monkeypatch, env_devel_dict, raising=False)
+
+
+@pytest.fixture(scope="session")
+def external_environment(request: pytest.FixtureRequest) -> EnvVarsDict:
+    """
+    If a file under test folder prefixed with `.env-secret` is present,
+    then this fixture captures it.
+
+    This technique allows reusing the same tests to check against
+    external development/production servers
+    """
+    envs = {}
+    if envfile := request.config.getoption("--external-envfile"):
+        print("🚨 EXTERNAL `envfile` option detected. Loading", envfile, "...")
+
+        assert isinstance(envfile, Path)
+        assert envfile.is_file()
+
+        envs = load_dotenv(envfile)
+
+    return envs

--- a/packages/service-library/src/servicelib/fastapi/docker_utils.py
+++ b/packages/service-library/src/servicelib/fastapi/docker_utils.py
@@ -139,6 +139,8 @@ async def pull_images(
         for image, image_layer_info in zip(
             images, images_layer_information, strict=True
         ):
+            # TODO: use gather call here to pull faster
+            # problem with progress in concurrent calls
             await pull_image(
                 image,
                 registry_settings,
@@ -148,15 +150,3 @@ async def pull_images(
                 if isinstance(image_layer_info, DockerImageManifestsV2)
                 else None,
             )
-
-        # await asyncio.gather(
-        #     *(
-        #         _pull_image(
-        #             image,
-        #             registry_settings=registry_settings,
-        #             pbar=pbar,
-        #             log_cb=log_cb,
-        #         )
-        #         for image in images
-        #     )
-        # )

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -124,12 +124,11 @@ class ProgressBarData:
 
     def _compute_progress(self, steps: float) -> float:
         if not self.step_weights:
-            return round(steps / self.num_steps, ndigits=2)
+            return steps / self.num_steps
         weight_index = int(steps)
-        return round(
+        return (
             sum(self.step_weights[:weight_index])
-            + steps % 1 * self.step_weights[weight_index],
-            ndigits=2,
+            + steps % 1 * self.step_weights[weight_index]
         )
 
     async def update(self, steps: float = 1) -> None:
@@ -152,9 +151,7 @@ class ProgressBarData:
             new_progress_value = self._compute_progress(new_steps_value)
             if self._current_steps != _INITIAL_VALUE:
                 old_progress_value = self._compute_progress(self._current_steps)
-                parent_update_value = round(
-                    new_progress_value - old_progress_value, ndigits=2
-                )
+                parent_update_value = new_progress_value - old_progress_value
             self._current_steps = new_steps_value
 
         if parent_update_value:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -124,11 +124,12 @@ class ProgressBarData:
 
     def _compute_progress(self, steps: float) -> float:
         if not self.step_weights:
-            return steps / self.num_steps
+            return round(steps / self.num_steps, ndigits=2)
         weight_index = int(steps)
-        return (
+        return round(
             sum(self.step_weights[:weight_index])
-            + steps % 1 * self.step_weights[weight_index]
+            + steps % 1 * self.step_weights[weight_index],
+            ndigits=2,
         )
 
     async def update(self, steps: float = 1) -> None:
@@ -151,7 +152,9 @@ class ProgressBarData:
             new_progress_value = self._compute_progress(new_steps_value)
             if self._current_steps != _INITIAL_VALUE:
                 old_progress_value = self._compute_progress(self._current_steps)
-                parent_update_value = new_progress_value - old_progress_value
+                parent_update_value = round(
+                    new_progress_value - old_progress_value, ndigits=2
+                )
             self._current_steps = new_steps_value
 
         if parent_update_value:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -6,7 +6,7 @@ from typing import Final, Optional, Protocol, runtime_checkable
 
 from .logging_utils import log_catch
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 _MIN_PROGRESS_UPDATE_PERCENT: Final[float] = 0.01
 _INITIAL_VALUE: Final[float] = -1.0
 _FINAL_VALUE: Final[float] = 1.0
@@ -105,7 +105,7 @@ class ProgressBarData:
         if not self.progress_report_cb:
             return
 
-        with log_catch(logger, reraise=False):
+        with log_catch(_logger, reraise=False):
             # NOTE: only report if at least a percent was increased
             if (
                 (force and value != self._last_report_value)
@@ -136,7 +136,7 @@ class ProgressBarData:
             if new_steps_value > self.num_steps:
                 new_steps_value = round(new_steps_value)
             if new_steps_value > self.num_steps:
-                logger.warning(
+                _logger.warning(
                     "%s",
                     f"Progress already reached maximum of {self.num_steps=}, "
                     f"cause: {self._current_steps=} is updated by {steps=}"
@@ -145,6 +145,9 @@ class ProgressBarData:
                 )
 
                 new_steps_value = self.num_steps
+
+            if new_steps_value == self._current_steps:
+                return
 
             new_progress_value = self._compute_progress(new_steps_value)
             if self._current_steps != _INITIAL_VALUE:
@@ -161,6 +164,7 @@ class ProgressBarData:
         await self.update(update_value)
 
     async def finish(self) -> None:
+        _logger.debug("finishing %s", f"{self.num_steps} progress")
         await self.set_(self.num_steps)
 
     def sub_progress(

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -8,6 +8,7 @@ from .logging_utils import log_catch
 
 logger = logging.getLogger(__name__)
 _MIN_PROGRESS_UPDATE_PERCENT: Final[float] = 0.01
+_INITIAL_VALUE: Final[float] = -1.0
 _FINAL_VALUE: Final[float] = 1.0
 
 
@@ -28,9 +29,6 @@ def _normalize_weights(steps: int, weights: list[float]) -> list[float]:
     if total == 0:
         return [1] * steps
     return [weight / total for weight in weights]
-
-
-_INITIAL_VALUE: Final[float] = -1
 
 
 @dataclass(slots=True, kw_only=True)
@@ -159,8 +157,8 @@ class ProgressBarData:
         await self._report_external(new_progress_value)
 
     async def set_(self, new_value: float) -> None:
-        if update_value := round(new_value - self._current_steps):
-            await self.update(update_value)
+        update_value = new_value - self._current_steps
+        await self.update(update_value)
 
     async def finish(self) -> None:
         await self.set_(self.num_steps)

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -160,8 +160,7 @@ class ProgressBarData:
         await self._report_external(new_progress_value)
 
     async def set_(self, new_value: float) -> None:
-        update_value = new_value - self._current_steps
-        await self.update(update_value)
+        await self.update(new_value - self._current_steps)
 
     async def finish(self) -> None:
         _logger.debug("finishing %s", f"{self.num_steps} progress")

--- a/packages/service-library/tests/conftest.py
+++ b/packages/service-library/tests/conftest.py
@@ -10,13 +10,12 @@ from typing import Any
 import pytest
 import servicelib
 from faker import Faker
-from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.utils_envs import load_dotenv
 
 pytest_plugins = [
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
+    "pytest_simcore.environment_configs",
     "pytest_simcore.file_extra",
     "pytest_simcore.pytest_global_environs",
     "pytest_simcore.rabbit_service",
@@ -61,38 +60,3 @@ def fake_data_dict(faker: Faker) -> dict[str, Any]:
     }
     data["object"] = deepcopy(data)
     return data
-
-
-def pytest_addoption(parser: pytest.Parser):
-    group = parser.getgroup(
-        "external_environment",
-        description="Replaces mocked services with real ones by passing actual environs and connecting directly to external services",
-    )
-    group.addoption(
-        "--external-envfile",
-        action="store",
-        type=Path,
-        default=None,
-        help="Path to an env file. Consider passing a link to repo configs, i.e. `ln -s /path/to/osparc-ops-config/repo.config`",
-    )
-
-
-@pytest.fixture(scope="session")
-def external_environment(request: pytest.FixtureRequest) -> EnvVarsDict:
-    """
-    If a file under test folder prefixed with `.env-secret` is present,
-    then this fixture captures it.
-
-    This technique allows reusing the same tests to check against
-    external development/production servers
-    """
-    envs = {}
-    if envfile := request.config.getoption("--external-envfile"):
-        print("🚨 EXTERNAL `envfile` option detected. Loading", envfile, "...")
-
-        assert isinstance(envfile, Path)
-        assert envfile.is_file()
-
-        envs = load_dotenv(envfile)
-
-    return envs

--- a/packages/service-library/tests/conftest.py
+++ b/packages/service-library/tests/conftest.py
@@ -10,6 +10,8 @@ from typing import Any
 import pytest
 import servicelib
 from faker import Faker
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from pytest_simcore.helpers.utils_envs import load_dotenv
 
 pytest_plugins = [
     "pytest_simcore.docker_compose",
@@ -59,3 +61,38 @@ def fake_data_dict(faker: Faker) -> dict[str, Any]:
     }
     data["object"] = deepcopy(data)
     return data
+
+
+def pytest_addoption(parser: pytest.Parser):
+    group = parser.getgroup(
+        "external_environment",
+        description="Replaces mocked services with real ones by passing actual environs and connecting directly to external services",
+    )
+    group.addoption(
+        "--external-envfile",
+        action="store",
+        type=Path,
+        default=None,
+        help="Path to an env file. Consider passing a link to repo configs, i.e. `ln -s /path/to/osparc-ops-config/repo.config`",
+    )
+
+
+@pytest.fixture(scope="session")
+def external_environment(request: pytest.FixtureRequest) -> EnvVarsDict:
+    """
+    If a file under test folder prefixed with `.env-secret` is present,
+    then this fixture captures it.
+
+    This technique allows reusing the same tests to check against
+    external development/production servers
+    """
+    envs = {}
+    if envfile := request.config.getoption("--external-envfile"):
+        print("🚨 EXTERNAL `envfile` option detected. Loading", envfile, "...")
+
+        assert isinstance(envfile, Path)
+        assert envfile.is_file()
+
+        envs = load_dotenv(envfile)
+
+    return envs

--- a/packages/service-library/tests/fastapi/test_docker_utils.py
+++ b/packages/service-library/tests/fastapi/test_docker_utils.py
@@ -7,7 +7,6 @@ import pytest
 from models_library.docker import DockerGenericTag
 from pydantic import parse_obj_as
 from pytest_mock import MockerFixture
-from pytest_simcore.helpers.typing_env import EnvVarsDict
 from servicelib import progress_bar
 from servicelib.docker_utils import pull_image
 from servicelib.fastapi.docker_utils import (
@@ -124,30 +123,6 @@ async def test_pull_image(
     # check there were no warnings
     for record in caplog.records:
         assert record.levelname != "WARNING", record.message
-
-
-@pytest.fixture
-def external_registry_settings(
-    external_environment: EnvVarsDict,
-) -> RegistrySettings | None:
-    if external_environment:
-        config = {
-            field: external_environment.get(field, None)
-            for field in RegistrySettings.__fields__
-        }
-        return RegistrySettings.parse_obj(config)
-    return None
-
-
-@pytest.fixture
-def registry_settings(
-    registry_settings: RegistrySettings,
-    external_registry_settings: RegistrySettings | None,
-) -> RegistrySettings:
-    """overrides original registry settings to be able to use real data from deployments"""
-    if external_registry_settings:
-        return external_registry_settings
-    return registry_settings
 
 
 @pytest.mark.parametrize(

--- a/packages/service-library/tests/fastapi/test_docker_utils.py
+++ b/packages/service-library/tests/fastapi/test_docker_utils.py
@@ -129,12 +129,12 @@ async def test_pull_image(
     "images_set",
     [
         {"itisfoundation/sleeper:1.0.0", "nginx:latest", "busybox:latest"},
-        {
-            "${REGISYTR_URL}/simcore/services/dynamic/s4l-core-8-0-0-dy:3.2.7",
-            "${REGISYTR_URL}/simcore/services/dynamic/sym-server-8-0-0-dy:3.2.7",
-            "${REGISYTR_URL}/simcore/services/dynamic/sim4life-8-0-0-dy:3.2.7",
-            "${REGISYTR_URL}/simcore/services/dynamic/s4l-stream-8-0-0-dy:3.2.7",
-        },
+        # {
+        #     "${REGISYTR_URL}/simcore/services/dynamic/s4l-core-8-0-0-dy:3.2.7",
+        #     "${REGISYTR_URL}/simcore/services/dynamic/sym-server-8-0-0-dy:3.2.7",
+        #     "${REGISYTR_URL}/simcore/services/dynamic/sim4life-8-0-0-dy:3.2.7",
+        #     "${REGISYTR_URL}/simcore/services/dynamic/s4l-stream-8-0-0-dy:3.2.7",
+        # },
     ],
 )
 async def test_pull_images(

--- a/packages/service-library/tests/fastapi/test_docker_utils.py
+++ b/packages/service-library/tests/fastapi/test_docker_utils.py
@@ -141,7 +141,10 @@ async def test_pull_images(
     async def _log_cb(*args, **kwargs) -> None:
         print(f"received log: {args}, {kwargs}")
 
-    fake_progress_report_cb = mocker.AsyncMock()
+    async def _progress_cb(*args, **kwargs) -> None:
+        print(f"received progress: {args}, {kwargs}")
+
+    fake_progress_report_cb = mocker.AsyncMock(side_effect=_progress_cb)
     fake_log_cb = mocker.AsyncMock(side_effect=_log_cb)
     await pull_images(
         images_set, registry_settings, fake_progress_report_cb, fake_log_cb

--- a/packages/service-library/tests/fastapi/test_docker_utils.py
+++ b/packages/service-library/tests/fastapi/test_docker_utils.py
@@ -129,12 +129,6 @@ async def test_pull_image(
     "images_set",
     [
         {"itisfoundation/sleeper:1.0.0", "nginx:latest", "busybox:latest"},
-        # {
-        #     "${REGISYTR_URL}/simcore/services/dynamic/s4l-core-8-0-0-dy:3.2.7",
-        #     "${REGISYTR_URL}/simcore/services/dynamic/sym-server-8-0-0-dy:3.2.7",
-        #     "${REGISYTR_URL}/simcore/services/dynamic/sim4life-8-0-0-dy:3.2.7",
-        #     "${REGISYTR_URL}/simcore/services/dynamic/s4l-stream-8-0-0-dy:3.2.7",
-        # },
     ],
 )
 async def test_pull_images(

--- a/packages/service-library/tests/fastapi/test_docker_utils.py
+++ b/packages/service-library/tests/fastapi/test_docker_utils.py
@@ -164,5 +164,4 @@ async def test_pull_images(
 
     # check there were no warnings
     # NOTE: this would pop up in case docker changes its pulling statuses
-    for record in caplog.records:
-        assert record.levelname != "WARNING", record.message
+    assert not [r.message for r in caplog.records if r.levelname == "WARNING"]

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -79,8 +79,6 @@ async def test_progress_bar(
         assert mocked_cb.call_count == 25
         assert mocked_cb.call_args_list[24].args[0] == pytest.approx(1)
         mocked_cb.reset_mock()
-    # we were not exactly at 1 here so it will get called now
-    mocked_cb.assert_called_once_with(_FINAL_VALUE)
 
 
 async def test_progress_bar_always_reports_0_on_creation_and_1_on_finish(

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
@@ -35,6 +35,13 @@ from .reserved_space import setup as setup_reserved_space
 from .settings import ApplicationSettings
 from .utils import volumes_fix_permissions
 
+_LOG_LEVEL_STEP = logging.CRITICAL - logging.ERROR
+_NOISY_LOGGERS = (
+    "aio_pika",
+    "aiormq",
+    "httpcore",
+)
+
 logger = logging.getLogger(__name__)
 
 #
@@ -111,6 +118,13 @@ def setup_logger(settings: ApplicationSettings):
 
 
 def create_base_app() -> FastAPI:
+    # keep mostly quiet noisy loggers
+    quiet_level: int = max(
+        min(logging.root.level + _LOG_LEVEL_STEP, logging.CRITICAL), logging.WARNING
+    )
+    for name in _NOISY_LOGGERS:
+        logging.getLogger(name).setLevel(quiet_level)
+
     # settings
     settings = ApplicationSettings.create_from_envs()
     setup_logger(settings)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_compose_utils.py
@@ -12,10 +12,11 @@ from typing import Final
 from fastapi import FastAPI
 from models_library.rabbitmq_messages import ProgressType
 from servicelib.async_utils import run_sequentially_in_context
+from servicelib.fastapi.docker_utils import pull_images
 from servicelib.logging_utils import LogLevelInt, LogMessageStr
 from settings_library.basic_types import LogLevel
 
-from .docker_utils import get_docker_service_images, pull_images
+from .docker_utils import get_docker_service_images
 from .rabbitmq import post_progress_message, post_sidecar_log_message
 from .settings import ApplicationSettings
 from .utils import CommandResult, async_command

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
@@ -11,15 +11,13 @@ from aiodocker.containers import DockerContainer
 from faker import Faker
 from models_library.generated_models.docker_rest_api import ContainerState
 from models_library.services import RunID
-from pydantic import PositiveInt, SecretStr
-from settings_library.docker_registry import RegistrySettings
+from pydantic import PositiveInt
 from simcore_service_dynamic_sidecar.core.docker_utils import (
     _get_containers_inspect_from_names,
     get_container_states,
     get_containers_count_from_names,
     get_docker_service_images,
     get_volume_by_label,
-    pull_images,
 )
 from simcore_service_dynamic_sidecar.core.errors import VolumeNotFoundError
 
@@ -167,27 +165,3 @@ def test_get_docker_service_images(compose_spec_yaml: str):
         "nginx:latest",
         "simcore/services/dynamic/jupyter-math:2.1.3",
     }
-
-
-@pytest.mark.parametrize("repeat", ["first-pull", "repeat-pull"])
-async def test_pull_image(repeat: str):
-    async def _print_progress(progress_value: float):
-        print("progress ->", f"{progress_value=}")
-
-    async def _print_log(msg, log_level):
-        assert "alpine" in msg
-        print(f"log: {log_level=}: {msg}")
-
-    await pull_images(
-        images={
-            "alpine:latest",
-        },
-        registry_settings=RegistrySettings(
-            REGISTRY_AUTH=False,
-            REGISTRY_USER="",
-            REGISTRY_PW=SecretStr(""),
-            REGISTRY_SSL=False,
-        ),
-        progress_cb=_print_progress,
-        log_cb=_print_log,
-    )

--- a/services/payments/tests/conftest.py
+++ b/services/payments/tests/conftest.py
@@ -67,6 +67,14 @@ def pytest_addoption(parser: pytest.Parser):
     )
 
 
+@pytest.fixture(scope="session")
+def external_environment(external_environment: EnvVarsDict) -> EnvVarsDict:
+    if external_environment:
+        assert "PAYMENTS_GATEWAY_API_SECRET" in external_environment
+        assert "PAYMENTS_GATEWAY_URL" in external_environment
+    return external_environment
+
+
 @pytest.fixture
 def env_devel_dict(
     env_devel_dict: EnvVarsDict, external_environment: EnvVarsDict

--- a/services/payments/tests/conftest.py
+++ b/services/payments/tests/conftest.py
@@ -14,7 +14,7 @@ from faker import Faker
 from models_library.users import GroupID
 from pydantic import parse_obj_as
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.utils_envs import load_dotenv, setenvs_from_dict
+from pytest_simcore.helpers.utils_envs import setenvs_from_dict
 from servicelib.utils_secrets import generate_token_secret_key
 
 pytest_plugins = [
@@ -56,17 +56,8 @@ def secret_key() -> str:
 
 
 def pytest_addoption(parser: pytest.Parser):
-    group = parser.getgroup(
-        "external_environment",
-        description="Replaces mocked services with real ones by passing actual environs and connecting directly to external services",
-    )
-    group.addoption(
-        "--external-envfile",
-        action="store",
-        type=Path,
-        default=None,
-        help="Path to an env file. Consider passing a link to repo configs, i.e. `ln -s /path/to/osparc-ops-config/repo.config`",
-    )
+    group = parser.getgroup("simcore")
+
     group.addoption(
         "--external-email",
         action="store",
@@ -74,26 +65,6 @@ def pytest_addoption(parser: pytest.Parser):
         default=None,
         help="An email for test_services_notifier_email",
     )
-
-
-@pytest.fixture(scope="session")
-def external_environment(request: pytest.FixtureRequest) -> EnvVarsDict:
-    """
-    If a file under test folder prefixed with `.env-secret` is present,
-    then this fixture captures it.
-
-    This technique allows reusing the same tests to check against
-    external development/production servers
-    """
-    envs = {}
-    if envfile := request.config.getoption("--external-envfile"):
-        assert isinstance(envfile, Path)
-        print("🚨 EXTERNAL: external envs detected. Loading", envfile, "...")
-        envs = load_dotenv(envfile)
-        assert "PAYMENTS_GATEWAY_API_SECRET" in envs
-        assert "PAYMENTS_GATEWAY_URL" in envs
-
-    return envs
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- moved code to pull a set of docker images out of the dynamic-sidecar inside servicelib
- added tests around the pull of the images

### Main changes
Progress bar wise, the pulling of images was divided like so:
```100% / NUM_IMAGES then for each image the progress goes like IMAGE_SIZE * 3 / (DOWNLOADED_SIZE + 2* EXTRACTED_SIZE```
Since services such as s4l are composed of 5 images, where 1 image is about 30GiB, the even distribution of the progress is problematic.

Using a "weighted" progress bar fixes this, by giving part of the progress a higher weight. The downside is that some concurrent code cannot be run concurrently for now, until the progress bar with weights becomes compatible.



## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
