### PR TITLE
🎨Image pulling progress: use overall size (Part 2)

### DIFF
--- a/packages/service-library/src/servicelib/docker_utils.py
+++ b/packages/service-library/src/servicelib/docker_utils.py
@@ -187,9 +187,6 @@ async def pull_image(
                         "pulling fs layer",
                         "waiting",
                         "digest: ",
-                        "status: downloaded newer image for ",
-                        "status: image is up to date for ",
-                        "already exists",
                     ]
                 ):
                     # nothing to do here
@@ -218,6 +215,17 @@ async def pull_image(
                     layer_id_to_size[parsed_progress.id].extracted = layer_id_to_size[
                         parsed_progress.id
                     ].size
+                case progress_status if any(
+                    msg in progress_status
+                    for msg in [
+                        "status: downloaded newer image for ",
+                        "status: image is up to date for ",
+                        "already exists",
+                    ]
+                ):
+                    for layer_pull_status in layer_id_to_size.values():
+                        layer_pull_status.downloaded = layer_pull_status.size
+                        layer_pull_status.extracted = layer_pull_status.size
                 case _:
                     _logger.warning(
                         "unknown pull state: %s. Please check", f"{parsed_progress=}"

--- a/packages/service-library/src/servicelib/docker_utils.py
+++ b/packages/service-library/src/servicelib/docker_utils.py
@@ -174,7 +174,7 @@ async def pull_image(
 
         client = await exit_stack.enter_async_context(aiodocker.Docker())
 
-        reported_progress = 0
+        reported_progress = 0.0
         async for pull_progress in client.images.pull(
             image, stream=True, auth=registry_auth
         ):

--- a/packages/service-library/src/servicelib/docker_utils.py
+++ b/packages/service-library/src/servicelib/docker_utils.py
@@ -195,26 +195,28 @@ async def pull_image(
                     assert parsed_progress.id  # nosec
                     assert parsed_progress.progress_detail  # nosec
                     assert parsed_progress.progress_detail.current  # nosec
-                    layer_id_to_size[
-                        parsed_progress.id
-                    ].downloaded = parsed_progress.progress_detail.current
+
+                    layer_id_to_size.setdefault(
+                        parsed_progress.id,
+                        _PulledStatus(parsed_progress.progress_detail.total or 0),
+                    ).downloaded = parsed_progress.progress_detail.current
                 case "verifying checksum" | "download complete":
                     assert parsed_progress.id  # nosec
-                    layer_id_to_size[parsed_progress.id].downloaded = layer_id_to_size[
-                        parsed_progress.id
-                    ].size
+                    layer_id_to_size.setdefault(
+                        parsed_progress.id, _PulledStatus(0)
+                    ).downloaded = layer_id_to_size[parsed_progress.id].size
                 case "extracting":
                     assert parsed_progress.id  # nosec
                     assert parsed_progress.progress_detail  # nosec
                     assert parsed_progress.progress_detail.current  # nosec
-                    layer_id_to_size[
-                        parsed_progress.id
-                    ].extracted = parsed_progress.progress_detail.current
+                    layer_id_to_size.setdefault(
+                        parsed_progress.id, _PulledStatus(0)
+                    ).extracted = parsed_progress.progress_detail.current
                 case "pull complete":
                     assert parsed_progress.id  # nosec
-                    layer_id_to_size[parsed_progress.id].extracted = layer_id_to_size[
-                        parsed_progress.id
-                    ].size
+                    layer_id_to_size.setdefault(
+                        parsed_progress.id, _PulledStatus(0)
+                    ).extracted = layer_id_to_size[parsed_progress.id].size
                 case progress_status if any(
                     msg in progress_status
                     for msg in [

--- a/packages/service-library/src/servicelib/fastapi/docker_utils.py
+++ b/packages/service-library/src/servicelib/fastapi/docker_utils.py
@@ -114,31 +114,31 @@ async def pull_images(
             for image in images
         ]
     )
-    progress_step_weights = [
-        float(i.layers_total_size) if i else float(_DEFAULT_MIN_IMAGE_SIZE)
+    images_total_size = sum(
+        i.layers_total_size if i else _DEFAULT_MIN_IMAGE_SIZE
         for i in images_layer_information
-    ]
-    _logger.debug("images to pull sizes: %s", progress_step_weights)
+    )
 
     async with ProgressBarData(
-        num_steps=len(images),
-        step_weights=progress_step_weights,
+        num_steps=images_total_size,
         progress_report_cb=progress_cb,
     ) as pbar:
-        for image, image_layer_info in zip(
-            images, images_layer_information, strict=True
-        ):
-            # NOTE: use gather call here to pull faster
-            # problem with progress in concurrent calls, needs to fix the progress bar
 
-            await pull_image(
-                image,
-                registry_settings,
-                pbar,
-                log_cb,
-                (
-                    image_layer_info
-                    if isinstance(image_layer_info, DockerImageManifestsV2)
-                    else None
-                ),
-            )
+        await asyncio.gather(
+            *[
+                pull_image(
+                    image,
+                    registry_settings,
+                    pbar,
+                    log_cb,
+                    (
+                        image_layer_info
+                        if isinstance(image_layer_info, DockerImageManifestsV2)
+                        else None
+                    ),
+                )
+                for image, image_layer_info in zip(
+                    images, images_layer_information, strict=True
+                )
+            ]
+        )

--- a/packages/service-library/tests/aiohttp/test_docker_utils.py
+++ b/packages/service-library/tests/aiohttp/test_docker_utils.py
@@ -82,20 +82,25 @@ async def test_pull_image(
     # clean first
     await remove_images_from_host([image])
     layer_information = await retrieve_image_layer_information(image, registry_settings)
+    assert layer_information
 
     async def _log_cb(*args, **kwargs) -> None:
         print(f"received log: {args}, {kwargs}")
 
     fake_progress_report_cb = mocker.AsyncMock()
     async with progress_bar.ProgressBarData(
-        num_steps=1, progress_report_cb=fake_progress_report_cb
+        num_steps=layer_information.layers_total_size,
+        progress_report_cb=fake_progress_report_cb,
     ) as main_progress_bar:
         fake_log_cb = mocker.AsyncMock(side_effect=_log_cb)
         await pull_image(
             image, registry_settings, main_progress_bar, fake_log_cb, layer_information
         )
         fake_log_cb.assert_called()
-        assert main_progress_bar._current_steps == 1  # noqa: SLF001
+        assert (
+            main_progress_bar._current_steps  # noqa: SLF001
+            == layer_information.layers_total_size
+        )
     assert fake_progress_report_cb.call_args_list[0] == call(0.0)
     fake_progress_report_cb.assert_called_with(1.0)
 
@@ -106,14 +111,18 @@ async def test_pull_image(
 
     # pull a second time should, the image is already there
     async with progress_bar.ProgressBarData(
-        num_steps=1, progress_report_cb=fake_progress_report_cb
+        num_steps=layer_information.layers_total_size,
+        progress_report_cb=fake_progress_report_cb,
     ) as main_progress_bar:
         fake_log_cb = mocker.AsyncMock(side_effect=_log_cb)
         await pull_image(
             image, registry_settings, main_progress_bar, fake_log_cb, layer_information
         )
         fake_log_cb.assert_called()
-        assert main_progress_bar._current_steps == 1  # noqa: SLF001
+        assert (
+            main_progress_bar._current_steps  # noqa: SLF001
+            == layer_information.layers_total_size
+        )
     assert fake_progress_report_cb.call_args_list[0] == call(0.0)
     fake_progress_report_cb.assert_called_with(1.0)
     # check there were no warnings


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- using the overall size of all images, this brings back the old behavior of parallelized pulling of images (improved performance when pulling multiple images)
- ensure progress reporting kind of works in case where it is not possible to retrieve docker image layer information prior to pulling
- tests consistency
- test when no layer information is available

@odeimaiz next PR will bring the current size/total size

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
