### PR TITLE
✨Frontend: Do not auto start TIP

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -659,7 +659,7 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
         });
         page.addToContent(servicesBootOpts);
 
-        if (osparc.utils.Resources.isStudy(resourceData)) {
+        if (osparc.utils.Resources.isStudy(resourceData) || osparc.utils.Resources.isTemplate(resourceData)) {
           if (osparc.product.Utils.showDisableServiceAutoStart()) {
             const study = new osparc.data.model.Study(resourceData);
             const autoStartButton = osparc.info.StudyUtils.createDisableServiceAutoStart(study);

--- a/services/static-webserver/client/source/class/osparc/desktop/SlideshowView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/SlideshowView.js
@@ -314,6 +314,14 @@ qx.Class.define("osparc.desktop.SlideshowView", {
             flex: 1
           });
           this.__nodeView = view;
+
+          // Automatically try to start the dynamic service when the user gets to this step
+          if (node.isDynamic()) {
+            const status = node.getStatus().getInteractive();
+            if (["idle", "failed"].includes(status)) {
+              node.requestStartNode();
+            }
+          }
         }
 
         const upstreamDependencies = this.__getUpstreamCompDependencies(node);

--- a/services/static-webserver/client/source/class/osparc/desktop/SlideshowView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/SlideshowView.js
@@ -315,12 +315,9 @@ qx.Class.define("osparc.desktop.SlideshowView", {
           });
           this.__nodeView = view;
 
-          // Automatically try to start the dynamic service when the user gets to this step
+          // Automatically request to start the dynamic service when the user gets to this step
           if (node.isDynamic()) {
-            const status = node.getStatus().getInteractive();
-            if (["idle", "failed"].includes(status)) {
-              node.requestStartNode();
-            }
+            node.requestStartNode();
           }
         }
 
@@ -387,6 +384,12 @@ qx.Class.define("osparc.desktop.SlideshowView", {
         this.__moveToNode(currentNodeId);
       } else {
         this.__openFirstNode();
+      }
+
+      const node = this.__nodeView.getNode();
+      if (node.isDynamic()) {
+        // Start it. First wait a second because the function depends on the node's state which might not be available yet
+        setTimeout(() => node.requestStartNode(), 1000);
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/node/NodeView.js
+++ b/services/static-webserver/client/source/class/osparc/node/NodeView.js
@@ -86,6 +86,14 @@ qx.Class.define("osparc.node.NodeView", {
       this._mainView.add(this._iFrameLayout, {
         flex: 1
       });
+
+      // Automatically try to start the service when the user gets to this step
+      this.addListener("appear", () => {
+        const status = this.getNode().getStatus().getInteractive();
+        if (["idle", "failed"].includes(status)) {
+          this.getNode().requestStartNode();
+        }
+      });
     },
 
     // overridden

--- a/services/static-webserver/client/source/class/osparc/node/NodeView.js
+++ b/services/static-webserver/client/source/class/osparc/node/NodeView.js
@@ -86,14 +86,6 @@ qx.Class.define("osparc.node.NodeView", {
       this._mainView.add(this._iFrameLayout, {
         flex: 1
       });
-
-      // Automatically try to start the service when the user gets to this step
-      this.addListener("appear", () => {
-        const status = this.getNode().getStatus().getInteractive();
-        if (["idle", "failed"].includes(status)) {
-          this.getNode().requestStartNode();
-        }
-      });
     },
 
     // overridden

--- a/services/static-webserver/client/source/class/osparc/product/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/product/Utils.js
@@ -205,7 +205,7 @@ qx.Class.define("osparc.product.Utils", {
     },
 
     showDisableServiceAutoStart: function() {
-      if (this.isProduct("s4llite") || this.isProduct("tis")) {
+      if (this.isProduct("s4llite")) {
         return false;
       }
       return true;


### PR DESCRIPTION
## What do these changes do?

In order to save resources in the new TIP deployment in AWS, it was decided not to autostart the three (or two) steps in the TIP pipeline. For that, we simply need to set the Disable Auto Start checkbox to true in the TIP templates (exposing this feature to TIP and templates was needed). So that the UX doesn't change too much, when the users get to a step in the pipeline, the frontend will automatically request the current dynamic service to start.

- [x] Expose disable auto start option in TIP
- [x] Auto start service when the user gets to the step
- [ ] ~~20" after leaving the step stop it~~ It only makes sense if all services have persistency. At the moment, only S4L-PostPro has it

![DisableAutoStart](https://github.com/ITISFoundation/osparc-simcore/assets/33152403/0deef0c9-9a10-4381-ad0b-738dcc270962)


## Related issue/s

closes https://github.com/ITISFoundation/osparc-issues/issues/1396

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
