### PR TITLE
Ensure aiohttp services use the same naming convention in prometheus

### DIFF
--- a/services/storage/src/simcore_service_storage/_meta.py
+++ b/services/storage/src/simcore_service_storage/_meta.py
@@ -12,7 +12,7 @@ VERSION: Final[Version] = info.version
 API_VERSION: Final[str] = info.__version__
 API_VTAG: Final[str] = info.api_prefix_path_tag
 SUMMARY: Final[str] = info.get_summary()
-
+APP_NAME: Final[str] = __name__.split(".")[0]
 
 ## https://patorjk.com/software/taag/#p=display&f=Standard&t=Storage
 APP_STARTED_BANNER_MSG = r"""

--- a/services/storage/src/simcore_service_storage/application.py
+++ b/services/storage/src/simcore_service_storage/application.py
@@ -12,7 +12,7 @@ from servicelib.aiohttp.dev_error_logger import setup_dev_error_logger
 from servicelib.aiohttp.monitoring import setup_monitoring
 from servicelib.aiohttp.tracing import setup_tracing
 
-from ._meta import APP_STARTED_BANNER_MSG, PROJECT_NAME, VERSION
+from ._meta import APP_NAME, APP_STARTED_BANNER_MSG, VERSION
 from .db import setup_db
 from .dsm import setup_dsm
 from .dsm_cleaner import setup_dsm_cleaner
@@ -76,7 +76,7 @@ def create(settings: Settings) -> web.Application:
         setup_dev_error_logger(app)
 
     if settings.STORAGE_MONITORING_ENABLED:
-        setup_monitoring(app, PROJECT_NAME, version=f"{VERSION}")
+        setup_monitoring(app, APP_NAME, version=f"{VERSION}")
 
     # keep mostly quiet noisy loggers
     quiet_level: int = max(

--- a/services/web/server/src/simcore_service_webserver/diagnostics/_monitoring.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics/_monitoring.py
@@ -50,14 +50,14 @@ async def exit_middleware_cb(request: web.Request, _response: web.StreamResponse
 def setup_monitoring(app: web.Application):
     service_lib_setup(
         app,
-        _meta.PROJECT_NAME,
+        _meta.APP_NAME,
         enter_middleware_cb=enter_middleware_cb,
         exit_middleware_cb=exit_middleware_cb,
         version=f"{_meta.VERSION}",
     )
 
     monitor_services.add_instrumentation(
-        app, get_collector_registry(app), _meta.PROJECT_NAME
+        app, get_collector_registry(app), _meta.APP_NAME
     )
 
     # on-the fly stats

--- a/services/web/server/src/simcore_service_webserver/diagnostics/_monitoring.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics/_monitoring.py
@@ -50,14 +50,14 @@ async def exit_middleware_cb(request: web.Request, _response: web.StreamResponse
 def setup_monitoring(app: web.Application):
     service_lib_setup(
         app,
-        _meta.APP_NAME,
+        _meta.PROJECT_NAME,
         enter_middleware_cb=enter_middleware_cb,
         exit_middleware_cb=exit_middleware_cb,
         version=f"{_meta.VERSION}",
     )
 
     monitor_services.add_instrumentation(
-        app, get_collector_registry(app), _meta.APP_NAME
+        app, get_collector_registry(app), _meta.PROJECT_NAME
     )
 
     # on-the fly stats


### PR DESCRIPTION

<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- Ensure aiohttp services use the same naming convention in their prometheus instrumentation
- Currently they don't use the same naming conventions and it makes creating grafana dashboards tricky.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
