### PR TITLE
⬆️ Maintenance: Dask upgrade to 2024.5.1 and upgrades of autoscaling/clusters-keeper/director-v2/dask-sidecar/osparc-gateway 🚨

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ ifneq ($(wildcard .stack-*), )
 	-@rm $(wildcard .stack-*)
 endif
 	# Removing local registry if any
-	-@docker ps --all --quiet --filter "name=$(LOCAL_REGISTRY_HOSTNAME)" | xargs --no-run-if-empty docker rm
+	-@docker ps --all --quiet --filter "name=$(LOCAL_REGISTRY_HOSTNAME)" | xargs --no-run-if-empty docker rm --force
 
 leave: ## Forces to stop all services, networks, etc by the node leaving the swarm
 	-docker swarm leave -f

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -12,9 +12,9 @@ cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-dask==2024.5.0
+dask==2024.4.2
     # via distributed
-distributed==2024.5.0
+distributed==2024.4.2
     # via dask
 dnspython==2.6.1
     # via email-validator
@@ -43,7 +43,7 @@ mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.0.8
     # via distributed
-orjson==3.10.3
+orjson==3.10.1
 packaging==24.0
     # via
     #   dask
@@ -61,7 +61,7 @@ pyyaml==6.0.1
     # via
     #   dask
     #   distributed
-referencing==0.35.1
+referencing==0.35.0
     # via
     #   jsonschema
     #   jsonschema-specifications

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -1,4 +1,5 @@
 arrow==1.3.0
+    # via -r requirements/../../../packages/models-library/requirements/_base.in
 attrs==23.2.0
     # via
     #   jsonschema
@@ -12,23 +13,30 @@ cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-dask==2024.4.2
-    # via distributed
-distributed==2024.4.2
+dask==2024.5.1
+    # via
+    #   -r requirements/_base.in
+    #   distributed
+distributed==2024.5.1
     # via dask
 dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-fsspec==2024.3.1
+fsspec==2024.5.0
     # via dask
 idna==3.7
     # via email-validator
 importlib-metadata==7.1.0
     # via dask
 jinja2==3.1.4
-    # via distributed
+    # via
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   distributed
 jsonschema==4.22.0
+    # via -r requirements/../../../packages/models-library/requirements/_base.in
 jsonschema-specifications==2023.12.1
     # via jsonschema
 locket==1.0.0
@@ -43,31 +51,48 @@ mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.0.8
     # via distributed
-orjson==3.10.1
+orjson==3.10.3
+    # via
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
 packaging==24.0
     # via
     #   dask
     #   distributed
-partd==1.4.1
+partd==1.4.2
     # via dask
 psutil==5.9.8
     # via distributed
 pydantic==1.10.15
+    # via
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/_base.in
 pygments==2.18.0
     # via rich
 python-dateutil==2.9.0.post0
     # via arrow
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   dask
     #   distributed
-referencing==0.35.0
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via typer
-rpds-py==0.18.0
+    # via
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   typer
+rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
@@ -87,6 +112,7 @@ toolz==0.12.1
 tornado==6.4
     # via distributed
 typer==0.12.3
+    # via -r requirements/../../../packages/settings-library/requirements/_base.in
 types-python-dateutil==2.9.0.20240316
     # via arrow
 typing-extensions==4.11.0
@@ -94,8 +120,12 @@ typing-extensions==4.11.0
     #   pydantic
     #   typer
 urllib3==2.2.1
-    # via distributed
+    # via
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   distributed
 zict==3.0.0
     # via distributed
-zipp==3.18.1
+zipp==3.18.2
     # via importlib-metadata

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -1,23 +1,29 @@
-coverage==7.5.0
-    # via pytest-cov
+coverage==7.5.1
+    # via
+    #   -r requirements/_test.in
+    #   pytest-cov
 exceptiongroup==1.2.1
     # via pytest
-faker==24.11.0
+faker==25.2.0
+    # via -r requirements/_test.in
 icdiff==2.0.7
     # via pytest-icdiff
 iniconfig==2.0.0
     # via pytest
 packaging==24.0
     # via
+    #   -c requirements/_base.txt
     #   pytest
     #   pytest-sugar
 pint==0.23
+    # via -r requirements/_test.in
 pluggy==1.5.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-pytest==8.2.0
+pytest==8.2.1
     # via
+    #   -r requirements/_test.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-icdiff
@@ -25,17 +31,34 @@ pytest==8.2.0
     #   pytest-mock
     #   pytest-sugar
 pytest-asyncio==0.21.2
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/_test.in
 pytest-cov==5.0.0
+    # via -r requirements/_test.in
 pytest-icdiff==0.9
+    # via -r requirements/_test.in
 pytest-instafail==0.5.0
+    # via -r requirements/_test.in
 pytest-mock==3.14.0
+    # via -r requirements/_test.in
 pytest-runner==6.0.1
+    # via -r requirements/_test.in
 pytest-sugar==1.0.0
+    # via -r requirements/_test.in
 python-dateutil==2.9.0.post0
-    # via faker
+    # via
+    #   -c requirements/_base.txt
+    #   faker
 pyyaml==6.0.1
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
 six==1.16.0
-    # via python-dateutil
+    # via
+    #   -c requirements/_base.txt
+    #   python-dateutil
 termcolor==2.4.0
     # via pytest-sugar
 tomli==2.0.1
@@ -43,4 +66,6 @@ tomli==2.0.1
     #   coverage
     #   pytest
 typing-extensions==4.11.0
-    # via pint
+    # via
+    #   -c requirements/_base.txt
+    #   pint

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -1,8 +1,8 @@
-coverage==7.5.1
+coverage==7.5.0
     # via pytest-cov
 exceptiongroup==1.2.1
     # via pytest
-faker==25.0.1
+faker==24.11.0
 icdiff==2.0.7
     # via pytest-icdiff
 iniconfig==2.0.0

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -1,25 +1,30 @@
-astroid==3.1.0
+astroid==3.2.2
     # via pylint
-black==24.4.1
+black==24.4.2
+    # via -r requirements/../../../requirements/devenv.txt
 build==1.2.1
     # via pip-tools
 bump2version==1.0.1
+    # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
 click==8.1.7
     # via
+    #   -c requirements/_base.txt
     #   black
     #   pip-tools
 dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.4
+filelock==3.14.0
     # via virtualenv
 identify==2.5.36
     # via pre-commit
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements/../../../requirements/devenv.txt
+    #   pylint
 mccabe==0.7.0
     # via pylint
 mypy-extensions==1.0.0
@@ -28,6 +33,8 @@ nodeenv==1.8.0
     # via pre-commit
 packaging==24.0
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   black
     #   build
 pathspec==0.12.1
@@ -35,37 +42,48 @@ pathspec==0.12.1
 pip==24.0
     # via pip-tools
 pip-tools==7.4.1
-platformdirs==4.2.1
+    # via -r requirements/../../../requirements/devenv.txt
+platformdirs==4.2.2
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.7.0
-pylint==3.1.0
+pre-commit==3.7.1
+    # via -r requirements/../../../requirements/devenv.txt
+pylint==3.2.2
+    # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
 pyyaml==6.0.1
-    # via pre-commit
-ruff==0.4.1
-setuptools==69.5.1
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
+    #   pre-commit
+ruff==0.4.4
+    # via -r requirements/../../../requirements/devenv.txt
+setuptools==70.0.0
     # via
     #   nodeenv
     #   pip-tools
 tomli==2.0.1
     # via
+    #   -c requirements/_test.txt
     #   black
     #   build
     #   pip-tools
     #   pylint
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via pylint
 typing-extensions==4.11.0
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.26.0
+virtualenv==20.26.2
     # via pre-commit
 wheel==0.43.0
     # via pip-tools

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -1,6 +1,6 @@
 astroid==3.1.0
     # via pylint
-black==24.4.2
+black==24.4.1
 build==1.2.1
     # via pip-tools
 bump2version==1.0.1
@@ -14,7 +14,7 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-filelock==3.14.0
+filelock==3.13.4
     # via virtualenv
 identify==2.5.36
     # via pre-commit
@@ -48,7 +48,7 @@ pyproject-hooks==1.1.0
     #   pip-tools
 pyyaml==6.0.1
     # via pre-commit
-ruff==0.4.3
+ruff==0.4.1
 setuptools==69.5.1
     # via
     #   nodeenv
@@ -65,7 +65,7 @@ typing-extensions==4.11.0
     # via
     #   astroid
     #   black
-virtualenv==20.26.1
+virtualenv==20.26.0
     # via pre-commit
 wheel==0.43.0
     # via pip-tools

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -90,3 +90,6 @@ pennsieve>=999999999
 
 # User alternative e.g. parametrized fixture or request.getfixturevalue(.)
 pytest-lazy-fixture>=999999999
+
+# skip requests https://github.com/ansible-collections/community.docker/issues/860
+requests!=2.32.*

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -92,4 +92,5 @@ pennsieve>=999999999
 pytest-lazy-fixture>=999999999
 
 # skip requests https://github.com/ansible-collections/community.docker/issues/860
-requests!=2.32.*
+# remove once docker fixes https://github.com/docker/docker-py/issues/3256
+requests<2.32.0

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -1,13 +1,46 @@
 aio-pika==9.4.1
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 aioboto3==12.4.0
+    # via -r requirements/../../../packages/aws-library/requirements/_base.in
 aiobotocore==2.12.3
     # via aioboto3
 aiocache==0.12.2
-aiodebug==2.3.0
-aiodocker==0.21.0
-aiofiles==23.2.1
-aiohttp==3.9.3
     # via
+    #   -r requirements/../../../packages/aws-library/requirements/_base.in
+    #   -r requirements/_base.in
+aiodebug==2.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aiodocker==0.21.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
+aiofiles==23.2.1
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aiohttp==3.9.5
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   aiobotocore
     #   aiodocker
 aioitertools==0.11.0
@@ -23,6 +56,15 @@ anyio==4.3.0
     #   httpx
     #   starlette
 arrow==1.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 async-timeout==4.0.3
     # via
     #   aiohttp
@@ -39,43 +81,83 @@ botocore==1.34.69
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.34.69
+botocore-stubs==1.34.94
     # via types-aiobotocore
 certifi==2024.2.2
     # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   httpcore
     #   httpx
 click==8.1.7
     # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
     #   typer
     #   uvicorn
 cloudpickle==3.0.0
     # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-dask==2024.4.2
-    # via distributed
-distributed==2024.4.2
-    # via dask
+dask==2024.5.1
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   -r requirements/_base.in
+    #   distributed
+distributed==2024.5.1
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
 dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via anyio
 fast-depends==2.4.2
     # via faststream
 fastapi==0.99.1
-    # via prometheus-fastapi-instrumentator
-faststream==0.5.2
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   -r requirements/_base.in
+    #   prometheus-fastapi-instrumentator
+faststream==0.5.7
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.3.1
-    # via dask
+fsspec==2024.5.0
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
 h11==0.14.0
     # via
     #   httpcore
@@ -83,82 +165,221 @@ h11==0.14.0
 httpcore==1.0.5
     # via httpx
 httpx==0.27.0
-idna==3.6
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+idna==3.7
     # via
     #   anyio
     #   email-validator
     #   httpx
     #   yarl
 importlib-metadata==7.1.0
-    # via dask
-jinja2==3.1.3
-    # via distributed
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
+jinja2==3.1.4
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.21.1
+jsonschema==4.22.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
 jsonschema-specifications==2023.7.1
     # via jsonschema
 locket==1.0.0
     # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
     #   partd
 markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.0.8
-    # via distributed
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-orjson==3.10.0
+orjson==3.10.3
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
 packaging==24.0
     # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   -r requirements/_base.in
     #   dask
     #   distributed
 pamqp==3.3.0
     # via aiormq
-partd==1.4.1
-    # via dask
+partd==1.4.2
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
 prometheus-client==0.20.0
-    # via prometheus-fastapi-instrumentator
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
+    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 psutil==5.9.8
-    # via distributed
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 pydantic==1.10.15
     # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   fast-depends
     #   fastapi
-pygments==2.17.2
+pygments==2.18.0
     # via rich
 pyinstrument==4.6.2
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   botocore
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
-redis==5.0.3
+redis==5.0.4
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 referencing==0.29.3
     # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/./constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via typer
-rpds-py==0.18.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   typer
+rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
 s3transfer==0.10.1
     # via boto3
 sh==2.0.6
+    # via -r requirements/../../../packages/aws-library/requirements/_base.in
 shellingham==1.5.4
     # via typer
 six==1.16.0
@@ -168,28 +389,66 @@ sniffio==1.3.1
     #   anyio
     #   httpx
 sortedcontainers==2.4.0
-    # via distributed
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 starlette==0.27.0
-    # via fastapi
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 tblib==3.0.0
-    # via distributed
-tenacity==8.2.3
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
+tenacity==8.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 toolz==0.12.1
     # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
     #   partd
 tornado==6.4
-    # via distributed
-tqdm==4.66.2
-typer==0.12.1
-    # via faststream
-types-aiobotocore==2.12.2
-types-aiobotocore-ec2==2.12.2
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
+tqdm==4.66.4
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+typer==0.12.3
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   faststream
+types-aiobotocore==2.13.0
+    # via -r requirements/../../../packages/aws-library/requirements/_base.in
+types-aiobotocore-ec2==2.13.0
     # via types-aiobotocore
-types-aiobotocore-s3==2.12.2
+types-aiobotocore-s3==2.13.0
     # via types-aiobotocore
-types-awscrt==0.20.5
+types-awscrt==0.20.9
     # via botocore-stubs
 types-python-dateutil==2.9.0.20240316
     # via arrow
@@ -208,9 +467,23 @@ typing-extensions==4.11.0
     #   uvicorn
 urllib3==2.2.1
     # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   botocore
     #   distributed
 uvicorn==0.29.0
+    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 wrapt==1.16.0
     # via aiobotocore
 yarl==1.9.4
@@ -219,6 +492,10 @@ yarl==1.9.4
     #   aiohttp
     #   aiormq
 zict==3.0.0
-    # via distributed
-zipp==3.18.1
-    # via importlib-metadata
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
+zipp==3.18.2
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   importlib-metadata

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -1,6 +1,6 @@
 aio-pika==9.4.1
-aioboto3==12.3.0
-aiobotocore==2.11.2
+aioboto3==12.4.0
+aiobotocore==2.12.3
     # via aioboto3
 aiocache==0.12.2
 aiodebug==2.3.0
@@ -32,9 +32,9 @@ attrs==23.2.0
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.34.34
+boto3==1.34.69
     # via aiobotocore
-botocore==1.34.34
+botocore==1.34.69
     # via
     #   aiobotocore
     #   boto3
@@ -55,9 +55,9 @@ cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-dask==2023.3.2
+dask==2024.4.2
     # via distributed
-distributed==2023.3.2
+distributed==2024.4.2
     # via dask
 dnspython==2.6.1
     # via email-validator
@@ -206,7 +206,7 @@ typing-extensions==4.11.0
     #   types-aiobotocore-ec2
     #   types-aiobotocore-s3
     #   uvicorn
-urllib3==2.0.7
+urllib3==2.2.1
     # via
     #   botocore
     #   distributed

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -1,60 +1,81 @@
 antlr4-python3-runtime==4.13.1
     # via moto
 anyio==4.3.0
-    # via httpx
+    # via
+    #   -c requirements/_base.txt
+    #   httpx
 asgi-lifespan==2.1.0
+    # via -r requirements/_test.in
 async-timeout==4.0.3
-    # via redis
+    # via
+    #   -c requirements/_base.txt
+    #   redis
 attrs==23.2.0
     # via
+    #   -c requirements/_base.txt
     #   jschema-to-python
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.87.0
+aws-sam-translator==1.89.0
     # via cfn-lint
-aws-xray-sdk==2.13.0
+aws-xray-sdk==2.13.1
     # via moto
-blinker==1.8.1
+blinker==1.8.2
     # via flask
 boto3==1.34.69
     # via
+    #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
 botocore==1.34.69
     # via
+    #   -c requirements/_base.txt
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
 certifi==2024.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   httpcore
     #   httpx
     #   requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.87.1
+cfn-lint==0.87.3
     # via moto
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via flask
-coverage==7.5.1
-    # via pytest-cov
-cryptography==42.0.6
     # via
+    #   -c requirements/_base.txt
+    #   flask
+coverage==7.5.1
+    # via
+    #   -r requirements/_test.in
+    #   pytest-cov
+cryptography==42.0.7
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   joserfc
     #   moto
 deepdiff==7.0.1
+    # via -r requirements/_test.in
 docker==7.0.0
-    # via moto
-exceptiongroup==1.2.0
     # via
+    #   -r requirements/_test.in
+    #   moto
+exceptiongroup==1.2.1
+    # via
+    #   -c requirements/_base.txt
     #   anyio
     #   pytest
-faker==25.0.1
-fakeredis==2.22.0
+faker==25.2.0
+    # via -r requirements/_test.in
+fakeredis==2.23.2
+    # via -r requirements/_test.in
 flask==3.0.3
     # via
     #   flask-cors
@@ -64,15 +85,24 @@ flask-cors==4.0.1
 graphql-core==3.2.3
     # via moto
 h11==0.14.0
-    # via httpcore
+    # via
+    #   -c requirements/_base.txt
+    #   httpcore
 httpcore==1.0.5
-    # via httpx
+    # via
+    #   -c requirements/_base.txt
+    #   httpx
 httpx==0.27.0
-    # via respx
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
+    #   respx
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.6
+idna==3.7
     # via
+    #   -c requirements/_base.txt
     #   anyio
     #   httpx
     #   requests
@@ -80,15 +110,18 @@ iniconfig==2.0.0
     # via pytest
 itsdangerous==2.2.0
     # via flask
-jinja2==3.1.3
+jinja2==3.1.4
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   flask
     #   moto
 jmespath==1.0.1
     # via
+    #   -c requirements/_base.txt
     #   boto3
     #   botocore
-joserfc==0.9.0
+joserfc==0.10.0
     # via moto
 jschema-to-python==1.2.3
     # via cfn-lint
@@ -102,8 +135,9 @@ jsonpickle==3.0.4
     # via jschema-to-python
 jsonpointer==2.4
     # via jsonpatch
-jsonschema==4.21.1
+jsonschema==4.22.0
     # via
+    #   -c requirements/_base.txt
     #   aws-sam-translator
     #   cfn-lint
     #   openapi-schema-validator
@@ -112,6 +146,7 @@ jsonschema-path==0.3.2
     # via openapi-spec-validator
 jsonschema-specifications==2023.7.1
     # via
+    #   -c requirements/_base.txt
     #   jsonschema
     #   openapi-schema-validator
 junit-xml==1.9
@@ -122,9 +157,11 @@ lupa==2.1
     # via fakeredis
 markupsafe==2.1.5
     # via
+    #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.0.6
+moto==5.0.7
+    # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
 networkx==3.3
@@ -137,6 +174,7 @@ ordered-set==4.1.0
     # via deepdiff
 packaging==24.0
     # via
+    #   -c requirements/_base.txt
     #   docker
     #   pytest
 pathable==0.4.3
@@ -152,47 +190,69 @@ ply==3.11
 pprintpp==0.4.0
     # via pytest-icdiff
 psutil==5.9.8
-py-partiql-parser==0.5.4
+    # via
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
+py-partiql-parser==0.5.5
     # via moto
 pycparser==2.22
     # via cffi
 pydantic==1.10.15
-    # via aws-sam-translator
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   aws-sam-translator
 pyparsing==3.1.2
     # via moto
-pytest==8.2.0
+pytest==8.2.1
     # via
+    #   -r requirements/_test.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-icdiff
     #   pytest-mock
 pytest-asyncio==0.21.2
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/_test.in
 pytest-cov==5.0.0
+    # via -r requirements/_test.in
 pytest-icdiff==0.9
+    # via -r requirements/_test.in
 pytest-mock==3.14.0
+    # via -r requirements/_test.in
 pytest-runner==6.0.1
+    # via -r requirements/_test.in
 python-dateutil==2.9.0.post0
     # via
+    #   -c requirements/_base.txt
     #   botocore
     #   faker
     #   moto
 python-dotenv==1.0.1
+    # via -r requirements/_test.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   cfn-lint
     #   jsonschema-path
     #   moto
     #   responses
-redis==5.0.3
-    # via fakeredis
+redis==5.0.4
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   fakeredis
 referencing==0.29.3
     # via
+    #   -c requirements/_base.txt
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-regex==2024.4.28
+regex==2024.5.15
     # via cfn-lint
-requests==2.31.0
+requests==2.32.1
     # via
     #   docker
     #   jsonschema-path
@@ -201,30 +261,38 @@ requests==2.31.0
 responses==0.25.0
     # via moto
 respx==0.21.1
+    # via -r requirements/_test.in
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.18.0
+rpds-py==0.18.1
     # via
+    #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
 s3transfer==0.10.1
-    # via boto3
+    # via
+    #   -c requirements/_base.txt
+    #   boto3
 sarif-om==1.0.4
     # via cfn-lint
-setuptools==69.5.1
+setuptools==70.0.0
     # via moto
 six==1.16.0
     # via
+    #   -c requirements/_base.txt
     #   junit-xml
     #   python-dateutil
     #   rfc3339-validator
 sniffio==1.3.1
     # via
+    #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
     #   httpx
 sortedcontainers==2.4.0
-    # via fakeredis
+    # via
+    #   -c requirements/_base.txt
+    #   fakeredis
 sympy==1.12
     # via cfn-lint
 tomli==2.0.1
@@ -233,11 +301,15 @@ tomli==2.0.1
     #   pytest
 typing-extensions==4.11.0
     # via
+    #   -c requirements/_base.txt
     #   anyio
     #   aws-sam-translator
+    #   fakeredis
     #   pydantic
 urllib3==2.2.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   botocore
     #   docker
     #   requests
@@ -247,6 +319,8 @@ werkzeug==3.0.3
     #   flask
     #   moto
 wrapt==1.16.0
-    # via aws-xray-sdk
+    # via
+    #   -c requirements/_base.txt
+    #   aws-xray-sdk
 xmltodict==0.13.0
     # via moto

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -17,11 +17,11 @@ aws-xray-sdk==2.13.0
     # via moto
 blinker==1.8.1
     # via flask
-boto3==1.34.34
+boto3==1.34.69
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.34.34
+botocore==1.34.69
     # via
     #   aws-xray-sdk
     #   boto3
@@ -236,7 +236,7 @@ typing-extensions==4.11.0
     #   anyio
     #   aws-sam-translator
     #   pydantic
-urllib3==2.0.7
+urllib3==2.2.1
     # via
     #   botocore
     #   docker

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -252,8 +252,9 @@ referencing==0.29.3
     #   jsonschema-specifications
 regex==2024.5.15
     # via cfn-lint
-requests==2.32.1
+requests==2.31.0
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   docker
     #   jsonschema-path
     #   moto

--- a/services/autoscaling/requirements/_tools.txt
+++ b/services/autoscaling/requirements/_tools.txt
@@ -1,13 +1,17 @@
-astroid==3.1.0
+astroid==3.2.2
     # via pylint
 black==24.4.2
+    # via -r requirements/../../../requirements/devenv.txt
 build==1.2.1
     # via pip-tools
 bump2version==1.0.1
+    # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
 click==8.1.7
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   black
     #   pip-tools
 dill==0.3.8
@@ -19,7 +23,9 @@ filelock==3.14.0
 identify==2.5.36
     # via pre-commit
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements/../../../requirements/devenv.txt
+    #   pylint
 mccabe==0.7.0
     # via pylint
 mypy-extensions==1.0.0
@@ -28,6 +34,8 @@ nodeenv==1.8.0
     # via pre-commit
 packaging==24.0
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   black
     #   build
 pathspec==0.12.1
@@ -35,40 +43,52 @@ pathspec==0.12.1
 pip==24.0
     # via pip-tools
 pip-tools==7.4.1
-platformdirs==4.2.1
+    # via -r requirements/../../../requirements/devenv.txt
+platformdirs==4.2.2
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.7.0
-pylint==3.1.0
+pre-commit==3.7.1
+    # via -r requirements/../../../requirements/devenv.txt
+pylint==3.2.2
+    # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.4.3
-setuptools==69.5.1
+ruff==0.4.4
+    # via -r requirements/../../../requirements/devenv.txt
+setuptools==70.0.0
     # via
+    #   -c requirements/_test.txt
     #   nodeenv
     #   pip-tools
 tomli==2.0.1
     # via
+    #   -c requirements/_test.txt
     #   black
     #   build
     #   pip-tools
     #   pylint
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via pylint
 typing-extensions==4.11.0
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via pre-commit
 watchdog==4.0.0
+    # via -r requirements/_tools.in
 wheel==0.43.0
     # via pip-tools

--- a/services/autoscaling/tests/unit/test_modules_dask.py
+++ b/services/autoscaling/tests/unit/test_modules_dask.py
@@ -148,7 +148,9 @@ async def test_list_processing_tasks(
         scheduler_url, scheduler_authentication
     ) == {
         next(iter(dask_spec_cluster_client.scheduler_info()["workers"])): [
-            DaskTask(task_id=DaskTaskId(future_queued_task.key), required_resources={})
+            DaskTask(
+                task_id=DaskTaskId(future_queued_task.key), required_resources=None
+            )
         ]
     }
 

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -1,13 +1,43 @@
 aio-pika==9.4.1
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 aioboto3==12.4.0
+    # via -r requirements/../../../packages/aws-library/requirements/_base.in
 aiobotocore==2.12.3
     # via aioboto3
 aiocache==0.12.2
+    # via -r requirements/../../../packages/aws-library/requirements/_base.in
 aiodebug==2.3.0
-aiodocker==0.21.0
-aiofiles==23.2.1
-aiohttp==3.9.3
     # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aiodocker==0.21.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aiofiles==23.2.1
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+aiohttp==3.9.5
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   aiobotocore
     #   aiodocker
 aioitertools==0.11.0
@@ -23,6 +53,15 @@ anyio==4.3.0
     #   httpx
     #   starlette
 arrow==1.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 async-timeout==4.0.3
     # via
     #   aiohttp
@@ -39,43 +78,83 @@ botocore==1.34.69
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.34.69
+botocore-stubs==1.34.94
     # via types-aiobotocore
 certifi==2024.2.2
     # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   httpcore
     #   httpx
 click==8.1.7
     # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
     #   typer
     #   uvicorn
 cloudpickle==3.0.0
     # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-dask==2024.4.2
-    # via distributed
-distributed==2024.4.2
-    # via dask
+dask==2024.5.1
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   -r requirements/_base.in
+    #   distributed
+distributed==2024.5.1
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
 dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via anyio
 fast-depends==2.4.2
     # via faststream
 fastapi==0.99.1
-    # via prometheus-fastapi-instrumentator
-faststream==0.5.2
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   -r requirements/_base.in
+    #   prometheus-fastapi-instrumentator
+faststream==0.5.7
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.3.1
-    # via dask
+fsspec==2024.5.0
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
 h11==0.14.0
     # via
     #   httpcore
@@ -83,82 +162,221 @@ h11==0.14.0
 httpcore==1.0.5
     # via httpx
 httpx==0.27.0
-idna==3.6
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+idna==3.7
     # via
     #   anyio
     #   email-validator
     #   httpx
     #   yarl
 importlib-metadata==7.1.0
-    # via dask
-jinja2==3.1.3
-    # via distributed
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
+jinja2==3.1.4
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.21.1
+jsonschema==4.22.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
 jsonschema-specifications==2023.7.1
     # via jsonschema
 locket==1.0.0
     # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
     #   partd
 markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   jinja2
 mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.0.8
-    # via distributed
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-orjson==3.10.0
+orjson==3.10.3
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
 packaging==24.0
     # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   -r requirements/_base.in
     #   dask
     #   distributed
 pamqp==3.3.0
     # via aiormq
-partd==1.4.1
-    # via dask
+partd==1.4.2
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
 prometheus-client==0.20.0
-    # via prometheus-fastapi-instrumentator
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
+    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 psutil==5.9.8
-    # via distributed
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 pydantic==1.10.15
     # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   fast-depends
     #   fastapi
-pygments==2.17.2
+pygments==2.18.0
     # via rich
 pyinstrument==4.6.2
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   botocore
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
-redis==5.0.3
+redis==5.0.4
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 referencing==0.29.3
     # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/./constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via typer
-rpds-py==0.18.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   typer
+rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
 s3transfer==0.10.1
     # via boto3
 sh==2.0.6
+    # via -r requirements/../../../packages/aws-library/requirements/_base.in
 shellingham==1.5.4
     # via typer
 six==1.16.0
@@ -168,28 +386,66 @@ sniffio==1.3.1
     #   anyio
     #   httpx
 sortedcontainers==2.4.0
-    # via distributed
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 starlette==0.27.0
-    # via fastapi
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 tblib==3.0.0
-    # via distributed
-tenacity==8.2.3
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
+tenacity==8.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 toolz==0.12.1
     # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
     #   partd
 tornado==6.4
-    # via distributed
-tqdm==4.66.2
-typer==0.12.1
-    # via faststream
-types-aiobotocore==2.12.2
-types-aiobotocore-ec2==2.12.2
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
+tqdm==4.66.4
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+typer==0.12.3
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   faststream
+types-aiobotocore==2.13.0
+    # via -r requirements/../../../packages/aws-library/requirements/_base.in
+types-aiobotocore-ec2==2.13.0
     # via types-aiobotocore
-types-aiobotocore-s3==2.12.2
+types-aiobotocore-s3==2.13.0
     # via types-aiobotocore
-types-awscrt==0.20.5
+types-awscrt==0.20.9
     # via botocore-stubs
 types-python-dateutil==2.9.0.20240316
     # via arrow
@@ -208,9 +464,23 @@ typing-extensions==4.11.0
     #   uvicorn
 urllib3==2.2.1
     # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   botocore
     #   distributed
 uvicorn==0.29.0
+    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 wrapt==1.16.0
     # via aiobotocore
 yarl==1.9.4
@@ -219,6 +489,10 @@ yarl==1.9.4
     #   aiohttp
     #   aiormq
 zict==3.0.0
-    # via distributed
-zipp==3.18.1
-    # via importlib-metadata
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
+zipp==3.18.2
+    # via
+    #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   importlib-metadata

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -1,6 +1,6 @@
 aio-pika==9.4.1
-aioboto3==12.3.0
-aiobotocore==2.11.2
+aioboto3==12.4.0
+aiobotocore==2.12.3
     # via aioboto3
 aiocache==0.12.2
 aiodebug==2.3.0
@@ -32,9 +32,9 @@ attrs==23.2.0
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.34.34
+boto3==1.34.69
     # via aiobotocore
-botocore==1.34.34
+botocore==1.34.69
     # via
     #   aiobotocore
     #   boto3
@@ -55,9 +55,9 @@ cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-dask==2023.3.2
+dask==2024.4.2
     # via distributed
-distributed==2023.3.2
+distributed==2024.4.2
     # via dask
 dnspython==2.6.1
     # via email-validator
@@ -206,7 +206,7 @@ typing-extensions==4.11.0
     #   types-aiobotocore-ec2
     #   types-aiobotocore-s3
     #   uvicorn
-urllib3==2.0.7
+urllib3==2.2.1
     # via
     #   botocore
     #   distributed

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -275,8 +275,9 @@ referencing==0.29.3
     #   jsonschema-specifications
 regex==2024.5.15
     # via cfn-lint
-requests==2.32.1
+requests==2.31.0
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   docker
     #   jsonschema-path
     #   moto

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -25,11 +25,11 @@ aws-xray-sdk==2.13.0
     # via moto
 blinker==1.8.1
     # via flask
-boto3==1.34.34
+boto3==1.34.69
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.34.34
+botocore==1.34.69
     # via
     #   aws-xray-sdk
     #   boto3
@@ -250,7 +250,7 @@ typing-extensions==4.11.0
     #   anyio
     #   aws-sam-translator
     #   pydantic
-urllib3==2.0.7
+urllib3==2.2.1
     # via
     #   botocore
     #   docker

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -1,69 +1,98 @@
 aiodocker==0.21.0
-aiohttp==3.9.3
-    # via aiodocker
+    # via
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
+aiohttp==3.9.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   aiodocker
 aiosignal==1.3.1
-    # via aiohttp
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 antlr4-python3-runtime==4.13.1
     # via moto
 anyio==4.3.0
-    # via httpx
+    # via
+    #   -c requirements/_base.txt
+    #   httpx
 asgi-lifespan==2.1.0
+    # via -r requirements/_test.in
 async-timeout==4.0.3
     # via
+    #   -c requirements/_base.txt
     #   aiohttp
     #   redis
 attrs==23.2.0
     # via
+    #   -c requirements/_base.txt
     #   aiohttp
     #   jschema-to-python
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.87.0
+aws-sam-translator==1.89.0
     # via cfn-lint
-aws-xray-sdk==2.13.0
+aws-xray-sdk==2.13.1
     # via moto
-blinker==1.8.1
+blinker==1.8.2
     # via flask
 boto3==1.34.69
     # via
+    #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
 botocore==1.34.69
     # via
+    #   -c requirements/_base.txt
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
 certifi==2024.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   httpcore
     #   httpx
     #   requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.87.1
+cfn-lint==0.87.3
     # via moto
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via flask
-coverage==7.5.1
-    # via pytest-cov
-cryptography==42.0.6
     # via
+    #   -c requirements/_base.txt
+    #   flask
+coverage==7.5.1
+    # via
+    #   -r requirements/_test.in
+    #   pytest-cov
+cryptography==42.0.7
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   joserfc
     #   moto
 debugpy==1.8.1
+    # via -r requirements/_test.in
 deepdiff==7.0.1
+    # via -r requirements/_test.in
 docker==7.0.0
-    # via moto
-exceptiongroup==1.2.0
     # via
+    #   -r requirements/_test.in
+    #   moto
+exceptiongroup==1.2.1
+    # via
+    #   -c requirements/_base.txt
     #   anyio
     #   pytest
-faker==25.0.1
-fakeredis==2.22.0
+faker==25.2.0
+    # via -r requirements/_test.in
+fakeredis==2.23.2
+    # via -r requirements/_test.in
 flask==3.0.3
     # via
     #   flask-cors
@@ -72,18 +101,28 @@ flask-cors==4.0.1
     # via moto
 frozenlist==1.4.1
     # via
+    #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
 graphql-core==3.2.3
     # via moto
 h11==0.14.0
-    # via httpcore
-httpcore==1.0.5
-    # via httpx
-httpx==0.27.0
-    # via respx
-idna==3.6
     # via
+    #   -c requirements/_base.txt
+    #   httpcore
+httpcore==1.0.5
+    # via
+    #   -c requirements/_base.txt
+    #   httpx
+httpx==0.27.0
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
+    #   respx
+idna==3.7
+    # via
+    #   -c requirements/_base.txt
     #   anyio
     #   httpx
     #   requests
@@ -92,15 +131,18 @@ iniconfig==2.0.0
     # via pytest
 itsdangerous==2.2.0
     # via flask
-jinja2==3.1.3
+jinja2==3.1.4
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   flask
     #   moto
 jmespath==1.0.1
     # via
+    #   -c requirements/_base.txt
     #   boto3
     #   botocore
-joserfc==0.9.0
+joserfc==0.10.0
     # via moto
 jschema-to-python==1.2.3
     # via cfn-lint
@@ -114,8 +156,9 @@ jsonpickle==3.0.4
     # via jschema-to-python
 jsonpointer==2.4
     # via jsonpatch
-jsonschema==4.21.1
+jsonschema==4.22.0
     # via
+    #   -c requirements/_base.txt
     #   aws-sam-translator
     #   cfn-lint
     #   openapi-schema-validator
@@ -124,6 +167,7 @@ jsonschema-path==0.3.2
     # via openapi-spec-validator
 jsonschema-specifications==2023.7.1
     # via
+    #   -c requirements/_base.txt
     #   jsonschema
     #   openapi-schema-validator
 junit-xml==1.9
@@ -134,13 +178,16 @@ lupa==2.1
     # via fakeredis
 markupsafe==2.1.5
     # via
+    #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.0.6
+moto==5.0.7
+    # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
 multidict==6.0.5
     # via
+    #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
 networkx==3.3
@@ -153,9 +200,11 @@ ordered-set==4.1.0
     # via deepdiff
 packaging==24.0
     # via
+    #   -c requirements/_base.txt
     #   docker
     #   pytest
 parse==1.20.1
+    # via -r requirements/_test.in
 pathable==0.4.3
     # via jsonschema-path
 pbr==6.0.0
@@ -167,45 +216,66 @@ pluggy==1.5.0
 ply==3.11
     # via jsonpath-ng
 psutil==5.9.8
-py-partiql-parser==0.5.4
+    # via
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
+py-partiql-parser==0.5.5
     # via moto
 pycparser==2.22
     # via cffi
 pydantic==1.10.15
-    # via aws-sam-translator
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   aws-sam-translator
 pyparsing==3.1.2
     # via moto
-pytest==8.2.0
+pytest==8.2.1
     # via
+    #   -r requirements/_test.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
 pytest-asyncio==0.21.2
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/_test.in
 pytest-cov==5.0.0
+    # via -r requirements/_test.in
 pytest-mock==3.14.0
+    # via -r requirements/_test.in
 pytest-runner==6.0.1
+    # via -r requirements/_test.in
 python-dateutil==2.9.0.post0
     # via
+    #   -c requirements/_base.txt
     #   botocore
     #   faker
     #   moto
 python-dotenv==1.0.1
+    # via -r requirements/_test.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   cfn-lint
     #   jsonschema-path
     #   moto
     #   responses
-redis==5.0.3
-    # via fakeredis
+redis==5.0.4
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   fakeredis
 referencing==0.29.3
     # via
+    #   -c requirements/_base.txt
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-regex==2024.4.28
+regex==2024.5.15
     # via cfn-lint
-requests==2.31.0
+requests==2.32.1
     # via
     #   docker
     #   jsonschema-path
@@ -214,30 +284,38 @@ requests==2.31.0
 responses==0.25.0
     # via moto
 respx==0.21.1
+    # via -r requirements/_test.in
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.18.0
+rpds-py==0.18.1
     # via
+    #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
 s3transfer==0.10.1
-    # via boto3
+    # via
+    #   -c requirements/_base.txt
+    #   boto3
 sarif-om==1.0.4
     # via cfn-lint
-setuptools==69.5.1
+setuptools==70.0.0
     # via moto
 six==1.16.0
     # via
+    #   -c requirements/_base.txt
     #   junit-xml
     #   python-dateutil
     #   rfc3339-validator
 sniffio==1.3.1
     # via
+    #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
     #   httpx
 sortedcontainers==2.4.0
-    # via fakeredis
+    # via
+    #   -c requirements/_base.txt
+    #   fakeredis
 sympy==1.12
     # via cfn-lint
 tomli==2.0.1
@@ -246,12 +324,16 @@ tomli==2.0.1
     #   pytest
 typing-extensions==4.11.0
     # via
+    #   -c requirements/_base.txt
     #   aiodocker
     #   anyio
     #   aws-sam-translator
+    #   fakeredis
     #   pydantic
 urllib3==2.2.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   botocore
     #   docker
     #   requests
@@ -261,8 +343,12 @@ werkzeug==3.0.3
     #   flask
     #   moto
 wrapt==1.16.0
-    # via aws-xray-sdk
+    # via
+    #   -c requirements/_base.txt
+    #   aws-xray-sdk
 xmltodict==0.13.0
     # via moto
 yarl==1.9.4
-    # via aiohttp
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp

--- a/services/clusters-keeper/requirements/_tools.txt
+++ b/services/clusters-keeper/requirements/_tools.txt
@@ -1,13 +1,17 @@
-astroid==3.1.0
+astroid==3.2.2
     # via pylint
 black==24.4.2
+    # via -r requirements/../../../requirements/devenv.txt
 build==1.2.1
     # via pip-tools
 bump2version==1.0.1
+    # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
 click==8.1.7
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   black
     #   pip-tools
 dill==0.3.8
@@ -19,7 +23,9 @@ filelock==3.14.0
 identify==2.5.36
     # via pre-commit
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements/../../../requirements/devenv.txt
+    #   pylint
 mccabe==0.7.0
     # via pylint
 mypy-extensions==1.0.0
@@ -28,6 +34,8 @@ nodeenv==1.8.0
     # via pre-commit
 packaging==24.0
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   black
     #   build
 pathspec==0.12.1
@@ -35,40 +43,52 @@ pathspec==0.12.1
 pip==24.0
     # via pip-tools
 pip-tools==7.4.1
-platformdirs==4.2.1
+    # via -r requirements/../../../requirements/devenv.txt
+platformdirs==4.2.2
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.7.0
-pylint==3.1.0
+pre-commit==3.7.1
+    # via -r requirements/../../../requirements/devenv.txt
+pylint==3.2.2
+    # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.4.3
-setuptools==69.5.1
+ruff==0.4.4
+    # via -r requirements/../../../requirements/devenv.txt
+setuptools==70.0.0
     # via
+    #   -c requirements/_test.txt
     #   nodeenv
     #   pip-tools
 tomli==2.0.1
     # via
+    #   -c requirements/_test.txt
     #   black
     #   build
     #   pip-tools
     #   pylint
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via pylint
 typing-extensions==4.11.0
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via pre-commit
 watchdog==4.0.0
+    # via -r requirements/_tools.in
 wheel==0.43.0
     # via pip-tools

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -1,11 +1,28 @@
 aio-pika==9.4.1
-aiobotocore==2.12.3
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+aiobotocore==2.13.0
     # via s3fs
 aiodebug==2.3.0
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiodocker==0.21.0
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
 aiofiles==23.2.1
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
 aiohttp==3.9.5
     # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   aiobotocore
     #   aiodocker
     #   dask-gateway
@@ -22,6 +39,11 @@ anyio==4.3.0
     #   fast-depends
     #   faststream
 arrow==1.3.0
+    # via
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 async-timeout==4.0.3
     # via
     #   aiohttp
@@ -32,9 +54,10 @@ attrs==23.2.0
     #   jsonschema
     #   referencing
 blosc==1.11.1
+    # via -r requirements/_base.in
 bokeh==3.4.1
     # via dask
-botocore==1.34.69
+botocore==1.34.106
     # via aiobotocore
 click==8.1.7
     # via
@@ -48,12 +71,16 @@ cloudpickle==3.0.0
     #   distributed
 contourpy==1.2.1
     # via bokeh
-dask==2024.4.2
+dask==2024.5.1
     # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
+    #   -r requirements/_base.in
     #   dask-gateway
     #   distributed
 dask-gateway==2024.1.0
-distributed==2024.4.2
+    # via -r requirements/_base.in
+distributed==2024.5.1
     # via
     #   dask
     #   dask-gateway
@@ -65,13 +92,15 @@ exceptiongroup==1.2.1
     # via anyio
 fast-depends==2.4.2
     # via faststream
-faststream==0.5.3
+faststream==0.5.7
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.3.1
+fsspec==2024.5.0
     # via
+    #   -r requirements/_base.in
     #   dask
     #   s3fs
 idna==3.7
@@ -81,14 +110,27 @@ idna==3.7
     #   yarl
 importlib-metadata==7.1.0
     # via dask
-jinja2==3.1.3
+jinja2==3.1.4
     # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   bokeh
     #   dask
     #   distributed
 jmespath==1.0.1
     # via botocore
-jsonschema==4.21.1
+jsonschema==4.22.0
+    # via
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
 jsonschema-specifications==2023.7.1
     # via jsonschema
 locket==1.0.0
@@ -96,6 +138,7 @@ locket==1.0.0
     #   distributed
     #   partd
 lz4==4.3.3
+    # via -r requirements/_base.in
 markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
@@ -113,7 +156,20 @@ numpy==1.26.4
     #   bokeh
     #   contourpy
     #   pandas
-orjson==3.10.1
+orjson==3.10.3
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
 packaging==24.0
     # via
     #   bokeh
@@ -123,18 +179,39 @@ pamqp==3.3.0
     # via aiormq
 pandas==2.2.2
     # via bokeh
-partd==1.4.1
+partd==1.4.2
     # via dask
 pillow==10.3.0
     # via bokeh
 prometheus-client==0.20.0
+    # via -r requirements/_base.in
 psutil==5.9.8
     # via distributed
 pydantic==1.10.15
-    # via fast-depends
-pygments==2.17.2
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/_base.in
+    #   fast-depends
+pygments==2.18.0
     # via rich
 pyinstrument==4.6.2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via
     #   arrow
@@ -146,22 +223,48 @@ pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   bokeh
     #   dask
     #   dask-gateway
     #   distributed
 redis==5.0.4
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 referencing==0.29.3
     # via
+    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via typer
-rpds-py==0.18.0
+    # via
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   typer
+rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
-s3fs==2024.3.1
+s3fs==2024.5.0
     # via fsspec
 shellingham==1.5.4
     # via typer
@@ -173,9 +276,11 @@ sortedcontainers==2.4.0
     # via distributed
 tblib==3.0.0
     # via distributed
-tenacity==8.2.3
+tenacity==8.3.0
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 toolz==0.12.1
     # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
     #   partd
@@ -184,9 +289,14 @@ tornado==6.4
     #   bokeh
     #   dask-gateway
     #   distributed
-tqdm==4.66.2
+tqdm==4.66.4
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 typer==0.12.3
-    # via faststream
+    # via
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   faststream
 types-python-dateutil==2.9.0.20240316
     # via arrow
 typing-extensions==4.11.0
@@ -201,6 +311,15 @@ tzdata==2024.1
     # via pandas
 urllib3==2.2.1
     # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   botocore
     #   distributed
 wrapt==1.16.0
@@ -214,5 +333,5 @@ yarl==1.9.4
     #   aiormq
 zict==3.0.0
     # via distributed
-zipp==3.18.1
+zipp==3.18.2
     # via importlib-metadata

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -1,10 +1,10 @@
 aio-pika==9.4.1
-aiobotocore==2.12.2
+aiobotocore==2.12.3
     # via s3fs
 aiodebug==2.3.0
 aiodocker==0.21.0
 aiofiles==23.2.1
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   aiobotocore
     #   aiodocker
@@ -32,9 +32,9 @@ attrs==23.2.0
     #   jsonschema
     #   referencing
 blosc==1.11.1
-bokeh==2.4.3
+bokeh==3.4.1
     # via dask
-botocore==1.34.51
+botocore==1.34.69
     # via aiobotocore
 click==8.1.7
     # via
@@ -46,12 +46,14 @@ cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-dask==2023.3.2
+contourpy==1.2.1
+    # via bokeh
+dask==2024.4.2
     # via
     #   dask-gateway
     #   distributed
 dask-gateway==2024.1.0
-distributed==2023.3.2
+distributed==2024.4.2
     # via
     #   dask
     #   dask-gateway
@@ -63,7 +65,7 @@ exceptiongroup==1.2.1
     # via anyio
 fast-depends==2.4.2
     # via faststream
-faststream==0.5.2
+faststream==0.5.3
 frozenlist==1.4.1
     # via
     #   aiohttp
@@ -72,7 +74,7 @@ fsspec==2024.3.1
     # via
     #   dask
     #   s3fs
-idna==3.6
+idna==3.7
     # via
     #   anyio
     #   email-validator
@@ -107,8 +109,11 @@ multidict==6.0.5
     #   aiohttp
     #   yarl
 numpy==1.26.4
-    # via bokeh
-orjson==3.10.0
+    # via
+    #   bokeh
+    #   contourpy
+    #   pandas
+orjson==3.10.1
 packaging==24.0
     # via
     #   bokeh
@@ -116,6 +121,8 @@ packaging==24.0
     #   distributed
 pamqp==3.3.0
     # via aiormq
+pandas==2.2.2
+    # via bokeh
 partd==1.4.1
     # via dask
 pillow==10.3.0
@@ -132,15 +139,18 @@ python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   botocore
+    #   pandas
 python-dotenv==1.0.1
     # via pydantic
+pytz==2024.1
+    # via pandas
 pyyaml==6.0.1
     # via
     #   bokeh
     #   dask
     #   dask-gateway
     #   distributed
-redis==5.0.3
+redis==5.0.4
 referencing==0.29.3
     # via
     #   jsonschema
@@ -175,7 +185,7 @@ tornado==6.4
     #   dask-gateway
     #   distributed
 tqdm==4.66.2
-typer==0.12.1
+typer==0.12.3
     # via faststream
 types-python-dateutil==2.9.0.20240316
     # via arrow
@@ -184,16 +194,19 @@ typing-extensions==4.11.0
     #   aiodebug
     #   aiodocker
     #   anyio
-    #   bokeh
     #   faststream
     #   pydantic
     #   typer
-urllib3==2.0.7
+tzdata==2024.1
+    # via pandas
+urllib3==2.2.1
     # via
     #   botocore
     #   distributed
 wrapt==1.16.0
     # via aiobotocore
+xyzservices==2024.4.0
+    # via bokeh
 yarl==1.9.4
     # via
     #   aio-pika

--- a/services/dask-sidecar/requirements/_dask-distributed.txt
+++ b/services/dask-sidecar/requirements/_dask-distributed.txt
@@ -7,9 +7,9 @@ cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-dask==2023.3.2
+dask==2024.4.2
     # via distributed
-distributed==2023.3.2
+distributed==2024.4.2
     # via dask
 fsspec==2024.3.1
     # via dask
@@ -50,7 +50,7 @@ toolz==0.12.1
     #   partd
 tornado==6.4
     # via distributed
-urllib3==2.0.7
+urllib3==2.2.1
     # via distributed
 zict==3.0.0
     # via distributed

--- a/services/dask-sidecar/requirements/_dask-distributed.txt
+++ b/services/dask-sidecar/requirements/_dask-distributed.txt
@@ -1,58 +1,104 @@
 blosc==1.11.1
+    # via
+    #   -c requirements/./_base.txt
+    #   -r requirements/_dask-distributed.in
 click==8.1.7
     # via
+    #   -c requirements/./_base.txt
     #   dask
     #   distributed
 cloudpickle==3.0.0
     # via
+    #   -c requirements/./_base.txt
     #   dask
     #   distributed
-dask==2024.4.2
-    # via distributed
-distributed==2024.4.2
-    # via dask
-fsspec==2024.3.1
-    # via dask
+dask==2024.5.1
+    # via
+    #   -c requirements/./_base.txt
+    #   -r requirements/_dask-distributed.in
+    #   distributed
+distributed==2024.5.1
+    # via
+    #   -c requirements/./_base.txt
+    #   dask
+fsspec==2024.5.0
+    # via
+    #   -c requirements/./_base.txt
+    #   dask
 importlib-metadata==7.1.0
-    # via dask
-jinja2==3.1.3
-    # via distributed
+    # via
+    #   -c requirements/./_base.txt
+    #   dask
+jinja2==3.1.4
+    # via
+    #   -c requirements/./_base.txt
+    #   distributed
 locket==1.0.0
     # via
+    #   -c requirements/./_base.txt
     #   distributed
     #   partd
 lz4==4.3.3
+    # via
+    #   -c requirements/./_base.txt
+    #   -r requirements/_dask-distributed.in
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements/./_base.txt
+    #   jinja2
 msgpack==1.0.8
-    # via distributed
+    # via
+    #   -c requirements/./_base.txt
+    #   distributed
 numpy==1.26.4
+    # via
+    #   -c requirements/./_base.txt
+    #   -r requirements/_dask-distributed.in
 packaging==24.0
     # via
+    #   -c requirements/./_base.txt
     #   dask
     #   distributed
-partd==1.4.1
-    # via dask
+partd==1.4.2
+    # via
+    #   -c requirements/./_base.txt
+    #   dask
 psutil==5.9.8
-    # via distributed
+    # via
+    #   -c requirements/./_base.txt
+    #   distributed
 pyyaml==6.0.1
     # via
+    #   -c requirements/./_base.txt
     #   dask
     #   distributed
 sortedcontainers==2.4.0
-    # via distributed
+    # via
+    #   -c requirements/./_base.txt
+    #   distributed
 tblib==3.0.0
-    # via distributed
+    # via
+    #   -c requirements/./_base.txt
+    #   distributed
 toolz==0.12.1
     # via
+    #   -c requirements/./_base.txt
     #   dask
     #   distributed
     #   partd
 tornado==6.4
-    # via distributed
+    # via
+    #   -c requirements/./_base.txt
+    #   distributed
 urllib3==2.2.1
-    # via distributed
+    # via
+    #   -c requirements/./_base.txt
+    #   distributed
 zict==3.0.0
-    # via distributed
-zipp==3.18.1
-    # via importlib-metadata
+    # via
+    #   -c requirements/./_base.txt
+    #   distributed
+zipp==3.18.2
+    # via
+    #   -c requirements/./_base.txt
+    #   importlib-metadata

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -219,8 +219,9 @@ referencing==0.29.3
     #   jsonschema-specifications
 regex==2024.5.15
     # via cfn-lint
-requests==2.32.1
+requests==2.31.0
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   docker
     #   jsonschema-path
     #   moto

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -2,48 +2,62 @@ antlr4-python3-runtime==4.13.1
     # via moto
 attrs==23.2.0
     # via
+    #   -c requirements/_base.txt
     #   jschema-to-python
     #   jsonschema
     #   referencing
     #   sarif-om
-aws-sam-translator==1.87.0
+aws-sam-translator==1.89.0
     # via cfn-lint
-aws-xray-sdk==2.13.0
+aws-xray-sdk==2.13.1
     # via moto
-blinker==1.8.1
+blinker==1.8.2
     # via flask
-boto3==1.34.69
+boto3==1.34.106
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.34.69
+botocore==1.34.106
     # via
+    #   -c requirements/_base.txt
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
 certifi==2024.2.2
-    # via requests
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.86.4
+cfn-lint==0.87.3
     # via moto
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via flask
-coverage==7.5.0
-    # via pytest-cov
-cryptography==42.0.6
     # via
+    #   -c requirements/_base.txt
+    #   flask
+coverage==7.5.1
+    # via
+    #   -r requirements/_test.in
+    #   pytest-cov
+cryptography==42.0.7
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   joserfc
     #   moto
     #   pyopenssl
 docker==7.0.0
-    # via moto
+    # via
+    #   -r requirements/_test.in
+    #   moto
 exceptiongroup==1.2.1
-    # via pytest
-faker==24.11.0
+    # via
+    #   -c requirements/_base.txt
+    #   pytest
+faker==25.2.0
+    # via -r requirements/_test.in
 flask==3.0.3
     # via
     #   flask-cors
@@ -55,20 +69,25 @@ graphql-core==3.2.3
 icdiff==2.0.7
     # via pytest-icdiff
 idna==3.7
-    # via requests
+    # via
+    #   -c requirements/_base.txt
+    #   requests
 iniconfig==2.0.0
     # via pytest
 itsdangerous==2.2.0
     # via flask
-jinja2==3.1.3
+jinja2==3.1.4
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   flask
     #   moto
 jmespath==1.0.1
     # via
+    #   -c requirements/_base.txt
     #   boto3
     #   botocore
-joserfc==0.9.0
+joserfc==0.10.0
     # via moto
 jschema-to-python==1.2.3
     # via cfn-lint
@@ -82,8 +101,9 @@ jsonpickle==3.0.4
     # via jschema-to-python
 jsonpointer==2.4
     # via jsonpatch
-jsonschema==4.21.1
+jsonschema==4.22.0
     # via
+    #   -c requirements/_base.txt
     #   aws-sam-translator
     #   cfn-lint
     #   openapi-schema-validator
@@ -92,6 +112,7 @@ jsonschema-path==0.3.2
     # via openapi-spec-validator
 jsonschema-specifications==2023.7.1
     # via
+    #   -c requirements/_base.txt
     #   jsonschema
     #   openapi-schema-validator
 junit-xml==1.9
@@ -100,9 +121,11 @@ lazy-object-proxy==1.10.0
     # via openapi-spec-validator
 markupsafe==2.1.5
     # via
+    #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.0.6
+moto==5.0.7
+    # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
 networkx==3.3
@@ -113,6 +136,7 @@ openapi-spec-validator==0.7.1
     # via moto
 packaging==24.0
     # via
+    #   -c requirements/_base.txt
     #   docker
     #   pytest
     #   pytest-sugar
@@ -128,20 +152,24 @@ ply==3.11
     # via jsonpath-ng
 pprintpp==0.4.0
     # via pytest-icdiff
-py-partiql-parser==0.5.4
+py-partiql-parser==0.5.5
     # via moto
 pycparser==2.22
     # via cffi
 pydantic==1.10.15
-    # via aws-sam-translator
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   aws-sam-translator
 pyftpdlib==1.5.9
     # via pytest-localftpserver
 pyopenssl==24.1.0
     # via pytest-localftpserver
 pyparsing==3.1.2
     # via moto
-pytest==8.2.0
+pytest==8.2.1
     # via
+    #   -r requirements/_test.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-icdiff
@@ -150,32 +178,48 @@ pytest==8.2.0
     #   pytest-mock
     #   pytest-sugar
 pytest-asyncio==0.21.2
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/_test.in
 pytest-cov==5.0.0
+    # via -r requirements/_test.in
 pytest-icdiff==0.9
+    # via -r requirements/_test.in
 pytest-instafail==0.5.0
-pytest-localftpserver==1.2.0
+    # via -r requirements/_test.in
+pytest-localftpserver==1.3.2
+    # via -r requirements/_test.in
 pytest-mock==3.14.0
+    # via -r requirements/_test.in
 pytest-sugar==1.0.0
+    # via -r requirements/_test.in
 python-dateutil==2.9.0.post0
     # via
+    #   -c requirements/_base.txt
     #   botocore
     #   faker
     #   moto
 python-dotenv==1.0.1
+    # via
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   cfn-lint
     #   jsonschema-path
     #   moto
     #   responses
 referencing==0.29.3
     # via
+    #   -c requirements/_base.txt
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-regex==2024.4.16
+regex==2024.5.15
     # via cfn-lint
-requests==2.31.0
+requests==2.32.1
     # via
     #   docker
     #   jsonschema-path
@@ -185,18 +229,20 @@ responses==0.25.0
     # via moto
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.18.0
+rpds-py==0.18.1
     # via
+    #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
 s3transfer==0.10.1
     # via boto3
 sarif-om==1.0.4
     # via cfn-lint
-setuptools==69.5.1
+setuptools==70.0.0
     # via moto
 six==1.16.0
     # via
+    #   -c requirements/_base.txt
     #   junit-xml
     #   python-dateutil
     #   rfc3339-validator
@@ -210,10 +256,13 @@ tomli==2.0.1
     #   pytest
 typing-extensions==4.11.0
     # via
+    #   -c requirements/_base.txt
     #   aws-sam-translator
     #   pydantic
 urllib3==2.2.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   botocore
     #   docker
     #   requests
@@ -223,6 +272,8 @@ werkzeug==3.0.3
     #   flask
     #   moto
 wrapt==1.16.0
-    # via aws-xray-sdk
+    # via
+    #   -c requirements/_base.txt
+    #   aws-xray-sdk
 xmltodict==0.13.0
     # via moto

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -12,11 +12,11 @@ aws-xray-sdk==2.13.0
     # via moto
 blinker==1.8.1
     # via flask
-boto3==1.34.51
+boto3==1.34.69
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.34.51
+botocore==1.34.69
     # via
     #   aws-xray-sdk
     #   boto3
@@ -26,13 +26,13 @@ certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
-cfn-lint==0.87.1
+cfn-lint==0.86.4
     # via moto
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via flask
-coverage==7.5.1
+coverage==7.5.0
     # via pytest-cov
 cryptography==42.0.6
     # via
@@ -43,7 +43,7 @@ docker==7.0.0
     # via moto
 exceptiongroup==1.2.1
     # via pytest
-faker==25.0.1
+faker==24.11.0
 flask==3.0.3
     # via
     #   flask-cors
@@ -54,7 +54,7 @@ graphql-core==3.2.3
     # via moto
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.6
+idna==3.7
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -173,7 +173,7 @@ referencing==0.29.3
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-regex==2024.4.28
+regex==2024.4.16
     # via cfn-lint
 requests==2.31.0
     # via
@@ -212,7 +212,7 @@ typing-extensions==4.11.0
     # via
     #   aws-sam-translator
     #   pydantic
-urllib3==2.0.7
+urllib3==2.2.1
     # via
     #   botocore
     #   docker

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -1,6 +1,6 @@
 astroid==3.1.0
     # via pylint
-black==24.4.2
+black==24.4.1
 build==1.2.1
     # via pip-tools
 bump2version==1.0.1
@@ -14,7 +14,7 @@ dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-filelock==3.14.0
+filelock==3.13.4
     # via virtualenv
 identify==2.5.36
     # via pre-commit
@@ -50,7 +50,7 @@ pyyaml==6.0.1
     # via
     #   pre-commit
     #   watchdog
-ruff==0.4.3
+ruff==0.4.1
 setuptools==69.5.1
     # via
     #   nodeenv
@@ -67,7 +67,7 @@ typing-extensions==4.11.0
     # via
     #   astroid
     #   black
-virtualenv==20.26.1
+virtualenv==20.26.0
     # via pre-commit
 watchdog==4.0.0
 wheel==0.43.0

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -1,25 +1,31 @@
-astroid==3.1.0
+astroid==3.2.2
     # via pylint
-black==24.4.1
+black==24.4.2
+    # via -r requirements/../../../requirements/devenv.txt
 build==1.2.1
     # via pip-tools
 bump2version==1.0.1
+    # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
 click==8.1.7
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   black
     #   pip-tools
 dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.4
+filelock==3.14.0
     # via virtualenv
 identify==2.5.36
     # via pre-commit
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements/../../../requirements/devenv.txt
+    #   pylint
 mccabe==0.7.0
     # via pylint
 mypy-extensions==1.0.0
@@ -28,6 +34,8 @@ nodeenv==1.8.0
     # via pre-commit
 packaging==24.0
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   black
     #   build
 pathspec==0.12.1
@@ -35,40 +43,52 @@ pathspec==0.12.1
 pip==24.0
     # via pip-tools
 pip-tools==7.4.1
-platformdirs==4.2.1
+    # via -r requirements/../../../requirements/devenv.txt
+platformdirs==4.2.2
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.7.0
-pylint==3.1.0
+pre-commit==3.7.1
+    # via -r requirements/../../../requirements/devenv.txt
+pylint==3.2.2
+    # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.4.1
-setuptools==69.5.1
+ruff==0.4.4
+    # via -r requirements/../../../requirements/devenv.txt
+setuptools==70.0.0
     # via
+    #   -c requirements/_test.txt
     #   nodeenv
     #   pip-tools
 tomli==2.0.1
     # via
+    #   -c requirements/_test.txt
     #   black
     #   build
     #   pip-tools
     #   pylint
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via pylint
 typing-extensions==4.11.0
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.26.0
+virtualenv==20.26.2
     # via pre-commit
 watchdog==4.0.0
+    # via -r requirements/_tools.in
 wheel==0.43.0
     # via pip-tools

--- a/services/dask-sidecar/requirements/constraints.txt
+++ b/services/dask-sidecar/requirements/constraints.txt
@@ -5,7 +5,7 @@
 #
 # Breaking changes
 #
-dask[distributed]<2023.4 # issue with publish_dataset: https://github.com/dask/distributed/issues/7859
+dask[distributed]>=2024.4.2 # issue with publish_dataset: https://github.com/dask/distributed/issues/7859
 #
 # Bugs
 #

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -52,12 +52,12 @@ cloudpickle==3.0.0
     # via
     #   dask
     #   distributed
-dask==2023.3.2
+dask==2024.4.2
     # via
     #   dask-gateway
     #   distributed
 dask-gateway==2024.1.0
-distributed==2023.3.2
+distributed==2024.4.2
     # via
     #   dask
     #   dask-gateway
@@ -242,7 +242,7 @@ typing-extensions==4.11.0
     #   uvicorn
 ujson==5.9.0
     # via fastapi
-urllib3==2.0.7
+urllib3==2.2.1
     # via distributed
 uvicorn==0.29.0
     # via fastapi

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -1,18 +1,64 @@
 aio-pika==9.4.1
-aiocache==0.12.2
-aiodebug==2.3.0
-aiodocker==0.21.0
-aiofiles==23.2.1
-aiohttp==3.9.3
     # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
+aiocache==0.12.2
+    # via
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
+    #   -r requirements/_base.in
+aiodebug==2.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+aiodocker==0.21.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
+aiofiles==23.2.1
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
+aiohttp==3.9.5
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiodocker
     #   dask-gateway
 aiopg==1.4.0
+    # via
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
+    #   -r requirements/_base.in
 aiormq==6.8.0
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
 alembic==1.13.1
+    # via
+    #   -r requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
 anyio==4.3.0
     # via
     #   fast-depends
@@ -21,6 +67,16 @@ anyio==4.3.0
     #   starlette
     #   watchfiles
 arrow==1.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 async-timeout==4.0.3
     # via
     #   aiohttp
@@ -37,12 +93,31 @@ attrs==23.2.0
 bidict==0.23.1
     # via python-socketio
 blosc==1.11.1
+    # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
 certifi==2024.2.2
     # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   httpcore
     #   httpx
 click==8.1.7
     # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   dask-gateway
     #   distributed
@@ -50,15 +125,20 @@ click==8.1.7
     #   uvicorn
 cloudpickle==3.0.0
     # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-dask==2024.4.2
+dask==2024.5.1
     # via
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask-gateway
     #   distributed
 dask-gateway==2024.1.0
-distributed==2024.4.2
+    # via -r requirements/_base.in
+distributed==2024.5.1
     # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   dask-gateway
 dnspython==2.6.1
@@ -67,19 +147,45 @@ email-validator==2.1.1
     # via
     #   fastapi
     #   pydantic
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via anyio
 fast-depends==2.4.2
     # via faststream
 fastapi==0.99.1
-    # via prometheus-fastapi-instrumentator
-faststream==0.5.2
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   -r requirements/_base.in
+    #   prometheus-fastapi-instrumentator
+faststream==0.5.7
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.3.1
-    # via dask
+fsspec==2024.5.0
+    # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
 greenlet==3.0.3
     # via sqlalchemy
 h11==0.14.0
@@ -92,41 +198,110 @@ httpcore==1.0.5
 httptools==0.6.1
     # via uvicorn
 httpx==0.27.0
-    # via fastapi
-idna==3.6
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   -r requirements/_base.in
+    #   fastapi
+idna==3.7
     # via
     #   anyio
     #   email-validator
     #   httpx
     #   yarl
 importlib-metadata==7.1.0
-    # via dask
-itsdangerous==2.1.2
-    # via fastapi
-jinja2==3.1.3
     # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
+itsdangerous==2.2.0
+    # via fastapi
+jinja2==3.1.4
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
     #   fastapi
-jsonschema==4.21.1
+jsonschema==4.22.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
 jsonschema-specifications==2023.7.1
     # via jsonschema
 locket==1.0.0
     # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
     #   partd
 lz4==4.3.3
-mako==1.3.2
-    # via alembic
+    # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+mako==1.3.5
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   alembic
 markdown-it-py==3.0.0
     # via rich
 markupsafe==2.1.5
     # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   jinja2
     #   mako
 mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.0.8
     # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   aiocache
     #   distributed
 multidict==6.0.5
@@ -134,62 +309,195 @@ multidict==6.0.5
     #   aiohttp
     #   yarl
 networkx==3.3
+    # via -r requirements/_base.in
 numpy==1.26.4
+    # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
 ordered-set==4.1.0
-orjson==3.10.0
-    # via fastapi
+    # via -r requirements/_base.in
+orjson==3.10.3
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/_base.in
+    #   fastapi
 packaging==24.0
     # via
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
 pamqp==3.3.0
     # via aiormq
-partd==1.4.1
-    # via dask
+partd==1.4.2
+    # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
 pint==0.23
+    # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 prometheus-client==0.20.0
-    # via prometheus-fastapi-instrumentator
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
+    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 psutil==5.9.8
-    # via distributed
+    # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 psycopg2-binary==2.9.9
     # via
     #   aiopg
     #   sqlalchemy
 pydantic==1.10.15
     # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
+    #   -r requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
+    #   -r requirements/_base.in
     #   fast-depends
     #   fastapi
-pygments==2.17.2
+pygments==2.18.0
     # via rich
 pyinstrument==4.6.2
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via arrow
 python-dotenv==1.0.1
     # via
     #   pydantic
     #   uvicorn
-python-engineio==4.9.0
+python-engineio==4.9.1
     # via python-socketio
 python-multipart==0.0.9
     # via fastapi
 python-socketio==5.11.2
+    # via -r requirements/_base.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   dask-gateway
     #   distributed
     #   fastapi
     #   uvicorn
-redis==5.0.3
-    # via aiocache
+redis==5.0.4
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
+    #   aiocache
 referencing==0.29.3
     # via
+    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/./constraints.txt
     #   jsonschema
     #   jsonschema-specifications
 rich==13.7.1
-    # via typer
-rpds-py==0.18.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/_base.in
+    #   typer
+rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
@@ -204,28 +512,92 @@ sniffio==1.3.1
     #   anyio
     #   httpx
 sortedcontainers==2.4.0
-    # via distributed
+    # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 sqlalchemy==1.4.52
     # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
     #   aiopg
     #   alembic
 starlette==0.27.0
-    # via fastapi
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 tblib==3.0.0
-    # via distributed
-tenacity==8.2.3
+    # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
+tenacity==8.3.0
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
+    #   -r requirements/_base.in
 toolz==0.12.1
     # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
     #   partd
 tornado==6.4
     # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask-gateway
     #   distributed
-tqdm==4.66.2
-typer==0.12.1
-    # via faststream
+tqdm==4.66.4
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/./_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
+typer==0.12.3
+    # via
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
+    #   faststream
 types-python-dateutil==2.9.0.20240316
     # via arrow
 typing-extensions==4.11.0
@@ -240,12 +612,51 @@ typing-extensions==4.11.0
     #   pydantic
     #   typer
     #   uvicorn
-ujson==5.9.0
-    # via fastapi
+ujson==5.10.0
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 urllib3==2.2.1
-    # via distributed
+    # via
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 uvicorn==0.29.0
-    # via fastapi
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   fastapi
 uvloop==0.19.0
     # via uvicorn
 watchfiles==0.21.0
@@ -256,10 +667,16 @@ wsproto==1.2.0
     # via simple-websocket
 yarl==1.9.4
     # via
+    #   -r requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
     #   aio-pika
     #   aiohttp
     #   aiormq
 zict==3.0.0
-    # via distributed
-zipp==3.18.1
-    # via importlib-metadata
+    # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
+zipp==3.18.2
+    # via
+    #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
+    #   importlib-metadata

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -23,7 +23,7 @@ attrs==23.2.0
     # via
     #   aiohttp
     #   pytest-docker
-bokeh==2.4.3
+bokeh==3.4.1
     # via dask
 boto3==1.34.69
     # via aiobotocore
@@ -51,14 +51,16 @@ cloudpickle==3.0.0
     #   distributed
 colorlog==6.8.2
     # via dask-gateway-server
-coverage==7.5.1
+contourpy==1.2.1
+    # via bokeh
+coverage==7.4.4
     # via pytest-cov
 cryptography==42.0.6
     # via dask-gateway-server
-dask==2023.3.2
+dask==2024.4.2
     # via distributed
 dask-gateway-server==2023.1.1
-distributed==2023.3.2
+distributed==2024.4.2
     # via dask
 docker==7.0.0
 exceptiongroup==1.2.0
@@ -126,7 +128,10 @@ mypy==1.10.0
 mypy-extensions==1.0.0
     # via mypy
 numpy==1.26.4
-    # via bokeh
+    # via
+    #   bokeh
+    #   contourpy
+    #   pandas
 packaging==24.0
     # via
     #   bokeh
@@ -136,6 +141,8 @@ packaging==24.0
     #   pytest
 pamqp==3.3.0
     # via aiormq
+pandas==2.2.2
+    # via bokeh
 partd==1.4.1
     # via dask
 pillow==10.3.0
@@ -167,6 +174,9 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   faker
+    #   pandas
+pytz==2024.1
+    # via pandas
 pyyaml==6.0.1
     # via
     #   bokeh
@@ -216,10 +226,11 @@ typing-extensions==4.11.0
     # via
     #   alembic
     #   anyio
-    #   bokeh
     #   mypy
     #   sqlalchemy2-stubs
-urllib3==2.0.7
+tzdata==2024.1
+    # via pandas
+urllib3==2.2.1
     # via
     #   botocore
     #   distributed
@@ -227,6 +238,8 @@ urllib3==2.0.7
     #   requests
 wrapt==1.16.0
     # via aiobotocore
+xyzservices==2024.4.0
+    # via bokeh
 yarl==1.9.4
     # via
     #   aio-pika

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -1,26 +1,46 @@
 aio-pika==9.4.1
+    # via
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
 aioboto3==12.4.0
+    # via -r requirements/_test.in
 aiobotocore==2.12.3
     # via aioboto3
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   aiobotocore
     #   dask-gateway-server
 aioitertools==0.11.0
     # via aiobotocore
 aiormq==6.8.0
-    # via aio-pika
+    # via
+    #   -c requirements/_base.txt
+    #   aio-pika
 aiosignal==1.3.1
-    # via aiohttp
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 alembic==1.13.1
+    # via
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
 anyio==4.3.0
-    # via httpx
+    # via
+    #   -c requirements/_base.txt
+    #   httpx
 asgi-lifespan==2.1.0
+    # via -r requirements/_test.in
 async-asgi-testclient==1.4.11
+    # via -r requirements/_test.in
 async-timeout==4.0.3
-    # via aiohttp
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 attrs==23.2.0
     # via
+    #   -c requirements/_base.txt
     #   aiohttp
     #   pytest-docker
 bokeh==3.4.1
@@ -34,6 +54,8 @@ botocore==1.34.69
     #   s3transfer
 certifi==2024.2.2
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   httpcore
     #   httpx
     #   requests
@@ -43,62 +65,93 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
+    #   -c requirements/_base.txt
     #   dask
     #   distributed
 cloudpickle==3.0.0
     # via
+    #   -c requirements/_base.txt
     #   dask
     #   distributed
 colorlog==6.8.2
     # via dask-gateway-server
 contourpy==1.2.1
     # via bokeh
-coverage==7.4.4
+coverage==7.5.1
     # via pytest-cov
-cryptography==42.0.6
-    # via dask-gateway-server
-dask==2024.4.2
-    # via distributed
-dask-gateway-server==2023.1.1
-distributed==2024.4.2
-    # via dask
-docker==7.0.0
-exceptiongroup==1.2.0
+cryptography==42.0.7
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   dask-gateway-server
+dask==2024.5.1
+    # via
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
+    #   distributed
+dask-gateway-server==2023.1.1
+    # via -r requirements/_test.in
+distributed==2024.5.1
+    # via
+    #   -c requirements/_base.txt
+    #   dask
+docker==7.0.0
+    # via -r requirements/_test.in
+exceptiongroup==1.2.1
+    # via
+    #   -c requirements/_base.txt
     #   anyio
     #   pytest
 execnet==2.1.1
     # via pytest-xdist
-faker==25.0.1
+faker==25.2.0
+    # via -r requirements/_test.in
 flaky==3.8.1
+    # via -r requirements/_test.in
 frozenlist==1.4.1
     # via
+    #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
-fsspec==2024.3.1
-    # via dask
+fsspec==2024.5.0
+    # via
+    #   -c requirements/_base.txt
+    #   dask
 greenlet==3.0.3
-    # via sqlalchemy
+    # via
+    #   -c requirements/_base.txt
+    #   sqlalchemy
 h11==0.14.0
-    # via httpcore
+    # via
+    #   -c requirements/_base.txt
+    #   httpcore
 httpcore==1.0.5
-    # via httpx
+    # via
+    #   -c requirements/_base.txt
+    #   httpx
 httpx==0.27.0
-    # via respx
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   respx
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.6
+idna==3.7
     # via
+    #   -c requirements/_base.txt
     #   anyio
     #   httpx
     #   requests
     #   yarl
 importlib-metadata==7.1.0
-    # via dask
+    # via
+    #   -c requirements/_base.txt
+    #   dask
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.3
+jinja2==3.1.4
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   bokeh
     #   dask
     #   distributed
@@ -108,18 +161,26 @@ jmespath==1.0.1
     #   botocore
 locket==1.0.0
     # via
+    #   -c requirements/_base.txt
     #   distributed
     #   partd
-mako==1.3.2
-    # via alembic
+mako==1.3.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   alembic
 markupsafe==2.1.5
     # via
+    #   -c requirements/_base.txt
     #   jinja2
     #   mako
 msgpack==1.0.8
-    # via distributed
+    # via
+    #   -c requirements/_base.txt
+    #   distributed
 multidict==6.0.5
     # via
+    #   -c requirements/_base.txt
     #   aiohttp
     #   async-asgi-testclient
     #   yarl
@@ -129,22 +190,28 @@ mypy-extensions==1.0.0
     # via mypy
 numpy==1.26.4
     # via
+    #   -c requirements/_base.txt
     #   bokeh
     #   contourpy
     #   pandas
 packaging==24.0
     # via
+    #   -c requirements/_base.txt
     #   bokeh
     #   dask
     #   distributed
     #   docker
     #   pytest
 pamqp==3.3.0
-    # via aiormq
+    # via
+    #   -c requirements/_base.txt
+    #   aiormq
 pandas==2.2.2
     # via bokeh
-partd==1.4.1
-    # via dask
+partd==1.4.2
+    # via
+    #   -c requirements/_base.txt
+    #   dask
 pillow==10.3.0
     # via bokeh
 pluggy==1.5.0
@@ -152,11 +219,14 @@ pluggy==1.5.0
 pprintpp==0.4.0
     # via pytest-icdiff
 psutil==5.9.8
-    # via distributed
+    # via
+    #   -c requirements/_base.txt
+    #   distributed
 pycparser==2.22
     # via cffi
-pytest==8.2.0
+pytest==8.2.1
     # via
+    #   -r requirements/_test.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-docker
@@ -164,14 +234,24 @@ pytest==8.2.0
     #   pytest-mock
     #   pytest-xdist
 pytest-asyncio==0.21.2
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/_test.in
 pytest-cov==5.0.0
+    # via -r requirements/_test.in
 pytest-docker==3.1.1
+    # via -r requirements/_test.in
 pytest-icdiff==0.9
+    # via -r requirements/_test.in
 pytest-mock==3.14.0
+    # via -r requirements/_test.in
 pytest-runner==6.0.1
+    # via -r requirements/_test.in
 pytest-xdist==3.6.1
+    # via -r requirements/_test.in
 python-dateutil==2.9.0.post0
     # via
+    #   -c requirements/_base.txt
     #   botocore
     #   faker
     #   pandas
@@ -179,33 +259,46 @@ pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   bokeh
     #   dask
     #   distributed
-requests==2.31.0
+requests==2.32.1
     # via
     #   async-asgi-testclient
     #   docker
 respx==0.21.1
+    # via -r requirements/_test.in
 s3transfer==0.10.1
     # via boto3
 six==1.16.0
-    # via python-dateutil
+    # via
+    #   -c requirements/_base.txt
+    #   python-dateutil
 sniffio==1.3.1
     # via
+    #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
     #   httpx
 sortedcontainers==2.4.0
-    # via distributed
+    # via
+    #   -c requirements/_base.txt
+    #   distributed
 sqlalchemy==1.4.52
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
     #   alembic
     #   dask-gateway-server
 sqlalchemy2-stubs==0.0.2a38
     # via sqlalchemy
 tblib==3.0.0
-    # via distributed
+    # via
+    #   -c requirements/_base.txt
+    #   distributed
 tomli==2.0.1
     # via
     #   coverage
@@ -213,17 +306,20 @@ tomli==2.0.1
     #   pytest
 toolz==0.12.1
     # via
+    #   -c requirements/_base.txt
     #   dask
     #   distributed
     #   partd
 tornado==6.4
     # via
+    #   -c requirements/_base.txt
     #   bokeh
     #   distributed
 traitlets==5.14.3
     # via dask-gateway-server
 typing-extensions==4.11.0
     # via
+    #   -c requirements/_base.txt
     #   alembic
     #   anyio
     #   mypy
@@ -232,6 +328,8 @@ tzdata==2024.1
     # via pandas
 urllib3==2.2.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   botocore
     #   distributed
     #   docker
@@ -242,10 +340,15 @@ xyzservices==2024.4.0
     # via bokeh
 yarl==1.9.4
     # via
+    #   -c requirements/_base.txt
     #   aio-pika
     #   aiohttp
     #   aiormq
 zict==3.0.0
-    # via distributed
-zipp==3.18.1
-    # via importlib-metadata
+    # via
+    #   -c requirements/_base.txt
+    #   distributed
+zipp==3.18.2
+    # via
+    #   -c requirements/_base.txt
+    #   importlib-metadata

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -264,8 +264,9 @@ pyyaml==6.0.1
     #   bokeh
     #   dask
     #   distributed
-requests==2.32.1
+requests==2.31.0
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   async-asgi-testclient
     #   docker
 respx==0.21.1

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -1,13 +1,17 @@
-astroid==3.1.0
+astroid==3.2.2
     # via pylint
 black==24.4.2
+    # via -r requirements/../../../requirements/devenv.txt
 build==1.2.1
     # via pip-tools
 bump2version==1.0.1
+    # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
 click==8.1.7
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   black
     #   pip-tools
 dill==0.3.8
@@ -19,15 +23,21 @@ filelock==3.14.0
 identify==2.5.36
     # via pre-commit
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements/../../../requirements/devenv.txt
+    #   pylint
 mccabe==0.7.0
     # via pylint
 mypy-extensions==1.0.0
-    # via black
+    # via
+    #   -c requirements/_test.txt
+    #   black
 nodeenv==1.8.0
     # via pre-commit
 packaging==24.0
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   black
     #   build
 pathspec==0.12.1
@@ -35,40 +45,51 @@ pathspec==0.12.1
 pip==24.0
     # via pip-tools
 pip-tools==7.4.1
-platformdirs==4.2.1
+    # via -r requirements/../../../requirements/devenv.txt
+platformdirs==4.2.2
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.7.0
-pylint==3.1.0
+pre-commit==3.7.1
+    # via -r requirements/../../../requirements/devenv.txt
+pylint==3.2.2
+    # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.4.3
-setuptools==69.5.1
+ruff==0.4.4
+    # via -r requirements/../../../requirements/devenv.txt
+setuptools==70.0.0
     # via
     #   nodeenv
     #   pip-tools
 tomli==2.0.1
     # via
+    #   -c requirements/_test.txt
     #   black
     #   build
     #   pip-tools
     #   pylint
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via pylint
 typing-extensions==4.11.0
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via pre-commit
 watchdog==4.0.0
+    # via -r requirements/_tools.in
 wheel==0.43.0
     # via pip-tools

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -337,7 +337,6 @@ class DaskClient:
             if (self.cluster_type != ClusterTypeInModel.ON_DEMAND) and (
                 self.backend.gateway is None
             ):
-                _logger.warning("cluster type: %s", self.cluster_type)
                 dask_utils.check_if_cluster_is_able_to_run_pipeline(
                     project_id=project_id,
                     node_id=node_id,

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -257,9 +257,11 @@ async def compute_output_data_schema(
                 user_id=user_id,
                 project_id=f"{project_id}",
                 node_id=f"{node_id}",
-                file_name=next(iter(port.file_to_key_map))
-                if port.file_to_key_map
-                else port.key,
+                file_name=(
+                    next(iter(port.file_to_key_map))
+                    if port.file_to_key_map
+                    else port.key
+                ),
                 link_type=file_link_type,
                 file_size=ByteSize(0),  # will create a single presigned link
                 sha256_checksum=None,
@@ -268,9 +270,11 @@ async def compute_output_data_schema(
             assert len(value_links.urls) == 1  # nosec
             output_data_schema[port.key].update(
                 {
-                    "mapping": next(iter(port.file_to_key_map))
-                    if port.file_to_key_map
-                    else None,
+                    "mapping": (
+                        next(iter(port.file_to_key_map))
+                        if port.file_to_key_map
+                        else None
+                    ),
                     "url": f"{value_links.urls[0]}",
                 }
             )

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -578,7 +578,11 @@ def check_if_cluster_is_able_to_run_pipeline(
     node_image: Image,
     cluster_id: ClusterID,
 ) -> None:
-    _logger.debug("Dask scheduler infos: %s", json_dumps(scheduler_info, indent=2))
+
+    _logger.debug(
+        "Dask scheduler infos: %s", f"{scheduler_info}"
+    )  # NOTE: be careful not to json_dumps this as it sometimes contain keys that are tuples!
+
     workers = scheduler_info.get("workers", {})
 
     cluster_resources_counter: collections.Counter = collections.Counter()

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -596,7 +596,7 @@ async def test_run_computation(
         cluster_id=DEFAULT_CLUSTER_ID,
     )
 
-    # FIXME: currently the webserver is the one updating the projects table so we need to fake this by copying the run_hash
+    # NOTE: currently the webserver is the one updating the projects table so we need to fake this by copying the run_hash
     update_project_workbench_with_comp_tasks(str(sleepers_project.uuid))
     # run again should return a 422 cause everything is uptodate
     with pytest.raises(

--- a/services/osparc-gateway-server/requirements/_base.txt
+++ b/services/osparc-gateway-server/requirements/_base.txt
@@ -1,6 +1,8 @@
 aiodocker==0.21.0
-aiohttp==3.9.3
+    # via -r requirements/_base.in
+aiohttp==3.9.5
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   aiodocker
     #   dask-gateway-server
 aiosignal==1.3.1
@@ -13,9 +15,12 @@ cffi==1.16.0
     # via cryptography
 colorlog==6.8.2
     # via dask-gateway-server
-cryptography==42.0.5
-    # via dask-gateway-server
+cryptography==42.0.7
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   dask-gateway-server
 dask-gateway-server==2023.1.1
+    # via -r requirements/_base.in
 dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
@@ -26,7 +31,7 @@ frozenlist==1.4.1
     #   aiosignal
 greenlet==3.0.3
     # via sqlalchemy
-idna==3.6
+idna==3.7
     # via
     #   email-validator
     #   yarl
@@ -37,11 +42,16 @@ multidict==6.0.5
 pycparser==2.22
     # via cffi
 pydantic==1.10.15
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/_base.in
 python-dotenv==1.0.1
     # via pydantic
 sqlalchemy==1.4.52
-    # via dask-gateway-server
-traitlets==5.14.2
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   dask-gateway-server
+traitlets==5.14.3
     # via dask-gateway-server
 typing-extensions==4.11.0
     # via

--- a/services/osparc-gateway-server/requirements/_test.txt
+++ b/services/osparc-gateway-server/requirements/_test.txt
@@ -21,13 +21,13 @@ cloudpickle==3.0.0
     #   distributed
 coverage==7.5.1
     # via pytest-cov
-dask==2023.3.2
+dask==2024.4.2
     # via
     #   dask-gateway
     #   distributed
 dask-gateway==2024.1.0
 debugpy==1.8.1
-distributed==2023.3.2
+distributed==2024.4.2
     # via dask-gateway
 docker==7.0.0
 exceptiongroup==1.2.1
@@ -137,7 +137,7 @@ typing-extensions==4.11.0
     # via
     #   mypy
     #   sqlalchemy2-stubs
-urllib3==2.0.7
+urllib3==2.2.1
     # via
     #   distributed
     #   docker

--- a/services/osparc-gateway-server/requirements/_test.txt
+++ b/services/osparc-gateway-server/requirements/_test.txt
@@ -160,8 +160,10 @@ pyyaml==6.0.1
     #   dask
     #   dask-gateway
     #   distributed
-requests==2.32.1
-    # via docker
+requests==2.31.0
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   docker
 six==1.16.0
     # via python-dateutil
 sortedcontainers==2.4.0

--- a/services/osparc-gateway-server/requirements/_test.txt
+++ b/services/osparc-gateway-server/requirements/_test.txt
@@ -1,68 +1,107 @@
-aiohttp==3.9.3
-    # via dask-gateway
+aiohttp==3.9.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   dask-gateway
 aiosignal==1.3.1
-    # via aiohttp
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 async-timeout==4.0.3
-    # via aiohttp
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 attrs==23.2.0
-    # via aiohttp
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 certifi==2024.2.2
-    # via requests
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   requests
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   dask-gateway
     #   distributed
 cloudpickle==3.0.0
     # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
 coverage==7.5.1
-    # via pytest-cov
-dask==2024.4.2
     # via
+    #   -r requirements/_test.in
+    #   pytest-cov
+dask==2024.5.1
+    # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask-gateway
     #   distributed
 dask-gateway==2024.1.0
+    # via -r requirements/_test.in
 debugpy==1.8.1
-distributed==2024.4.2
-    # via dask-gateway
+    # via -r requirements/_test.in
+distributed==2024.5.1
+    # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   dask-gateway
 docker==7.0.0
+    # via -r requirements/_test.in
 exceptiongroup==1.2.1
     # via pytest
-faker==25.0.1
+faker==25.2.0
+    # via -r requirements/_test.in
 frozenlist==1.4.1
     # via
+    #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
-fsspec==2024.3.1
-    # via dask
+fsspec==2024.5.0
+    # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
 greenlet==3.0.3
-    # via sqlalchemy
+    # via
+    #   -c requirements/_base.txt
+    #   sqlalchemy
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.6
+idna==3.7
     # via
+    #   -c requirements/_base.txt
     #   requests
     #   yarl
 importlib-metadata==7.1.0
-    # via dask
+    # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.3
-    # via distributed
+jinja2==3.1.4
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 locket==1.0.0
     # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
     #   partd
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   jinja2
 msgpack==1.0.8
-    # via distributed
+    # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 multidict==6.0.5
     # via
+    #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
 mypy==1.10.0
@@ -71,21 +110,27 @@ mypy-extensions==1.0.0
     # via mypy
 packaging==24.0
     # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
     #   docker
     #   pytest
     #   pytest-sugar
-partd==1.4.1
-    # via dask
+partd==1.4.2
+    # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   dask
 pluggy==1.5.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
 psutil==5.9.8
-    # via distributed
-pytest==8.2.0
     # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
+pytest==8.2.1
+    # via
+    #   -r requirements/_test.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-icdiff
@@ -93,30 +138,49 @@ pytest==8.2.0
     #   pytest-mock
     #   pytest-sugar
 pytest-asyncio==0.21.2
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/_test.in
 pytest-cov==5.0.0
+    # via -r requirements/_test.in
 pytest-icdiff==0.9
+    # via -r requirements/_test.in
 pytest-instafail==0.5.0
+    # via -r requirements/_test.in
 pytest-mock==3.14.0
+    # via -r requirements/_test.in
 pytest-sugar==1.0.0
+    # via -r requirements/_test.in
 python-dateutil==2.9.0.post0
     # via faker
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   dask-gateway
     #   distributed
-requests==2.31.0
+requests==2.32.1
     # via docker
 six==1.16.0
     # via python-dateutil
 sortedcontainers==2.4.0
-    # via distributed
+    # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
 sqlalchemy==1.4.52
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   -r requirements/_test.in
 sqlalchemy2-stubs==0.0.2a38
     # via sqlalchemy
 tblib==3.0.0
-    # via distributed
-tenacity==8.2.3
+    # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
+tenacity==8.3.0
+    # via -r requirements/_test.in
 termcolor==2.4.0
     # via pytest-sugar
 tomli==2.0.1
@@ -126,25 +190,36 @@ tomli==2.0.1
     #   pytest
 toolz==0.12.1
     # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
     #   partd
 tornado==6.4
     # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
     #   dask-gateway
     #   distributed
 typing-extensions==4.11.0
     # via
+    #   -c requirements/_base.txt
     #   mypy
     #   sqlalchemy2-stubs
 urllib3==2.2.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
     #   docker
     #   requests
 yarl==1.9.4
-    # via aiohttp
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
 zict==3.0.0
-    # via distributed
-zipp==3.18.1
-    # via importlib-metadata
+    # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   distributed
+zipp==3.18.2
+    # via
+    #   -c requirements/../../dask-sidecar/requirements/_dask-distributed.txt
+    #   importlib-metadata

--- a/services/osparc-gateway-server/requirements/_tools.txt
+++ b/services/osparc-gateway-server/requirements/_tools.txt
@@ -1,13 +1,16 @@
-astroid==3.1.0
+astroid==3.2.2
     # via pylint
 black==24.4.2
+    # via -r requirements/../../../requirements/devenv.txt
 build==1.2.1
     # via pip-tools
 bump2version==1.0.1
+    # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
 click==8.1.7
     # via
+    #   -c requirements/_test.txt
     #   black
     #   pip-tools
 dill==0.3.8
@@ -19,15 +22,20 @@ filelock==3.14.0
 identify==2.5.36
     # via pre-commit
 isort==5.13.2
-    # via pylint
+    # via
+    #   -r requirements/../../../requirements/devenv.txt
+    #   pylint
 mccabe==0.7.0
     # via pylint
 mypy-extensions==1.0.0
-    # via black
+    # via
+    #   -c requirements/_test.txt
+    #   black
 nodeenv==1.8.0
     # via pre-commit
 packaging==24.0
     # via
+    #   -c requirements/_test.txt
     #   black
     #   build
 pathspec==0.12.1
@@ -35,40 +43,50 @@ pathspec==0.12.1
 pip==24.0
     # via pip-tools
 pip-tools==7.4.1
-platformdirs==4.2.1
+    # via -r requirements/../../../requirements/devenv.txt
+platformdirs==4.2.2
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.7.0
-pylint==3.1.0
+pre-commit==3.7.1
+    # via -r requirements/../../../requirements/devenv.txt
+pylint==3.2.2
+    # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
 pyyaml==6.0.1
     # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.4.3
-setuptools==69.5.1
+ruff==0.4.4
+    # via -r requirements/../../../requirements/devenv.txt
+setuptools==70.0.0
     # via
     #   nodeenv
     #   pip-tools
 tomli==2.0.1
     # via
+    #   -c requirements/_test.txt
     #   black
     #   build
     #   pip-tools
     #   pylint
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via pylint
 typing-extensions==4.11.0
     # via
+    #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   astroid
     #   black
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via pre-commit
 watchdog==4.0.0
+    # via -r requirements/_tools.in
 wheel==0.43.0
     # via pip-tools


### PR DESCRIPTION
## What do these changes do?

Test the upgrade to the latest dask library, hopefully fixing a long running issue.

## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/4526
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->
###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 57
- #packages after ~ 62

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aioboto3                  | 12.3.0          | 12.4.0     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|   2 | aiobotocore               | 2.11.2, 2.12.2  | 2.12.3,2.13.0 | *minor*    | 3 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️ |
|   3 | aiohttp                   | 3.9.3           | 3.9.5      |            | 8 | autoscaling⬆️</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️</br>director-v2⬆️🧪</br>osparc-gateway-server⬆️🧪 |
|   4 | astroid                   | 3.1.0           | 3.2.2      | *minor*    | 6 | autoscaling🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|   5 | aws-sam-translator        | 1.87.0          | 1.89.0     | *minor*    | 3 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|   6 | aws-xray-sdk              | 2.13.0          | 2.13.1     |            | 3 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|   7 | blinker                   | 1.8.1           | 1.8.2      |            | 3 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|   8 | bokeh                     | 2.4.3           | 3.4.1      | **MAJOR**  | 2 | dask-sidecar⬆️</br>director-v2🧪 |
|   9 | boto3                     | 1.34.51, 1.34.34 | 1.34.69,1.34.106 |            | 5 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar🧪 |
|  10 | botocore                  | 1.34.51, 1.34.34 | 1.34.69,1.34.106 |            | 6 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️🧪 |
|  11 | botocore-stubs            | 1.34.69         | 1.34.94    |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  12 | cfn-lint                  | 0.87.1          | 0.87.3     |            | 3 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|  13 | cryptography              | 42.0.6, 42.0.5  | 42.0.7     |            | 5 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪</br>director-v2🧪</br>osparc-gateway-server⬆️ |
|  14 | dask                      | 2023.3.2, 2024.5.0 | 2024.5.1   |            | 8 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  15 | distributed               | 2023.3.2, 2024.5.0 | 2024.5.1   |            | 8 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  16 | exceptiongroup            | 1.2.0           | 1.2.1      |            | 6 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>director-v2⬆️🧪 |
|  17 | faker                     | 25.0.1          | 25.2.0     | *minor*    | 6 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>director-v2🧪</br>osparc-gateway-server🧪 |
|  18 | fakeredis                 | 2.22.0          | 2.23.2     | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  19 | faststream                | 0.5.2           | 0.5.7      |            | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  20 | fsspec                    | 2024.3.1        | 2024.5.0   | *minor*    | 8 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  21 | idna                      | 3.6             | 3.7        | *minor*    | 10 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️🧪</br>director-v2⬆️🧪</br>osparc-gateway-server⬆️🧪 |
|  22 | itsdangerous              | 2.1.2           | 2.2.0      | *minor*    | 1 | director-v2⬆️ |
|  23 | jinja2                    | 3.1.3           | 3.1.4      |            | 10 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️⬆️🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  24 | joserfc                   | 0.9.0           | 0.10.0     | *minor*    | 3 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|  25 | jsonschema                | 4.21.1          | 4.22.0     | *minor*    | 7 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️🧪</br>director-v2⬆️ |
|  26 | mako                      | 1.3.2           | 1.3.5      |            | 2 | director-v2⬆️🧪 |
|  27 | moto                      | 5.0.6           | 5.0.7      |            | 3 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|  28 | orjson                    | 3.10.0          | 3.10.3     |            | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  29 | partd                     | 1.4.1           | 1.4.2      |            | 8 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  30 | platformdirs              | 4.2.1           | 4.2.2      |            | 6 | autoscaling🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  31 | pre-commit                | 3.7.0           | 3.7.1      |            | 6 | autoscaling🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  32 | py-partiql-parser         | 0.5.4           | 0.5.5      |            | 3 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|  33 | pygments                  | 2.17.2          | 2.18.0     | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  34 | pylint                    | 3.1.0           | 3.2.2      | *minor*    | 6 | autoscaling🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  35 | pytest                    | 8.2.0           | 8.2.1      |            | 6 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪</br>dask-task-models-library🧪</br>director-v2🧪</br>osparc-gateway-server🧪 |
|  36 | pytest-localftpserver     | 1.2.0           | 1.3.2      | *minor*    | 1 | dask-sidecar🧪 |
|  37 | python-engineio           | 4.9.0           | 4.9.1      |            | 1 | director-v2⬆️ |
|  38 | redis                     | 5.0.3           | 5.0.4      |            | 6 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  39 | regex                     | 2024.4.28       | 2024.5.15  | *minor*    | 3 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪 |
|  40 | requests                  | 2.31.0          | 2.32.1     | *minor*    | 5 | autoscaling🧪</br>clusters-keeper🧪</br>dask-sidecar🧪</br>director-v2🧪</br>osparc-gateway-server🧪 |
|  41 | rpds-py                   | 0.18.0          | 0.18.1     |            | 8 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️🧪</br>dask-task-models-library🧪</br>director-v2⬆️ |
|  42 | ruff                      | 0.4.3           | 0.4.4      |            | 6 | autoscaling🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  43 | s3fs                      | 2024.3.1        | 2024.5.0   | *minor*    | 1 | dask-sidecar⬆️ |
|  44 | setuptools                | 69.5.1          | 70.0.0     | **MAJOR**  | 9 | autoscaling🧪🔧</br>clusters-keeper🧪🔧</br>dask-sidecar🧪🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  45 | tenacity                  | 8.2.3           | 8.3.0      | *minor*    | 5 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️</br>osparc-gateway-server🧪 |
|  46 | tomlkit                   | 0.12.4          | 0.12.5     |            | 6 | autoscaling🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  47 | tqdm                      | 4.66.2          | 4.66.4     |            | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  48 | traitlets                 | 5.14.2          | 5.14.3     |            | 1 | osparc-gateway-server⬆️ |
|  49 | typer                     | 0.12.1          | 0.12.3     |            | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  50 | types-aiobotocore         | 2.12.2          | 2.13.0     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  51 | types-aiobotocore-ec2     | 2.12.2          | 2.13.0     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  52 | types-aiobotocore-s3      | 2.12.2          | 2.13.0     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  53 | types-awscrt              | 0.20.5          | 0.20.9     |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  54 | ujson                     | 5.9.0           | 5.10.0     | *minor*    | 1 | director-v2⬆️ |
|  55 | urllib3                   | 2.0.7           | 2.2.1      | *minor*    | 10 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️⬆️🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |
|  56 | virtualenv                | 20.26.1         | 20.26.2    |            | 6 | autoscaling🔧</br>clusters-keeper🔧</br>dask-sidecar🔧</br>dask-task-models-library🔧</br>director-v2🔧</br>osparc-gateway-server🔧 |
|  57 | zipp                      | 3.18.1          | 3.18.2     |            | 8 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪</br>osparc-gateway-server🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 138

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 6.7.1, 6.8.0, 9.1.2, 9.4.1 | 6.8.0, 9.4.1              |                           |
|   2 | aioboto3                  | 12.3.0, 12.4.0            | 9.6.0, 12.4.0             |                           |
|   3 | aiobotocore               | 1.0.7, 2.11.2, 2.12.3, 2.13.0 | 2.3.0, 2.12.3             |                           |
|   4 | aiocache                  | 0.11.1, 0.12.2            | 0.12.2                    |                           |
|   5 | aiodebug                  | 1.1.2, 2.3.0              | 1.1.2, 2.3.0              |                           |
|   6 | aiodocker                 | 0.19.1, 0.21.0            | 0.21.0                    |                           |
|   7 | aiofile                   | 3.1.0                     |                           |                           |
|   8 | aiofiles                  | 0.5.0, 0.6.0, 0.8.0, 23.2.1 | 0.6.0, 23.2.1             |                           |
|   9 | aiohttp                   | 3.6.3, 3.7.3, 3.7.4.post0, 3.8.5, 3.9.3, 3.9.5 | 3.6.3, 3.7.3, 3.7.4.post0, 3.8.5, 3.9.3, 3.9.5 |                           |
|  10 | aiohttp-jinja2            | 1.4.2, 1.5                |                           |                           |
|  11 | aiohttp-security          | 0.4.0                     |                           |                           |
|  12 | aiohttp-session           | 2.11.0                    |                           |                           |
|  13 | aiohttp-swagger           | 1.0.16                    |                           |                           |
|  14 | aioitertools              | 0.7.1, 0.11.0             | 0.11.0                    |                           |
|  15 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  16 | aioprocessing             | 2.0.1                     |                           |                           |
|  17 | aioredis                  | 1.3.1                     | 1.3.1                     |                           |
|  18 | aioredlock                | 0.5.2, 0.7.1              |                           |                           |
|  19 | aioresponses              |                           | 0.7.2, 0.7.6              |                           |
|  20 | aiormq                    | 3.2.3, 3.3.1, 6.7.6, 6.8.0 | 3.3.1, 6.8.0              |                           |
|  21 | aiosignal                 | 1.2.0, 1.3.1              | 1.2.0, 1.3.1              |                           |
|  22 | aiosmtplib                | 1.1.6, 3.0.1              |                           |                           |
|  23 | aiozipkin                 | 0.7.1, 1.1.1              | 0.7.1                     |                           |
|  24 | alembic                   | 1.8.1, 1.13.1             | 1.6.2, 1.8.1, 1.13.1      |                           |
|  25 | amqp                      | 2.6.1, 5.0.2, 5.0.6       | 5.0.2, 5.0.6              |                           |
|  26 | aniso8601                 | 7.0.0                     |                           |                           |
|  27 | annotated-types           |                           | 0.6.0                     |                           |
|  28 | antlr4-python3-runtime    |                           | 4.13.1                    |                           |
|  29 | anyio                     | 3.6.2, 4.3.0              | 3.6.2, 4.3.0              |                           |
|  30 | apipkg                    |                           | 1.5                       |                           |
|  31 | appdirs                   |                           |                           | 1.4.4                     |
|  32 | argh                      |                           |                           | 0.26.2                    |
|  33 | arrow                     | 1.2.3, 1.3.0              | 1.3.0                     |                           |
|  34 | asgi-lifespan             |                           | 1.0.1, 2.1.0              |                           |
|  35 | astroid                   |                           | 2.5, 2.5.6                | 2.5.6, 3.1.0, 3.2.2       |
|  36 | async-asgi-testclient     |                           | 1.4.6, 1.4.11             |                           |
|  37 | async-exit-stack          | 1.0.1                     | 1.0.1                     |                           |
|  38 | async-generator           | 1.10                      | 1.10                      |                           |
|  39 | async-timeout             | 3.0.1, 4.0.2, 4.0.3       | 3.0.1, 4.0.2, 4.0.3       |                           |
|  40 | asyncpg                   | 0.23.0, 0.27.0, 0.29.0    | 0.29.0                    |                           |
|  41 | attrs                     | 20.2.0, 20.3.0, 21.2.0, 21.4.0, 23.2.0 | 20.2.0, 20.3.0, 21.2.0, 21.4.0, 23.2.0 |                           |
|  42 | aws-sam-translator        |                           | 1.55.0, 1.87.0, 1.89.0    |                           |
|  43 | aws-xray-sdk              |                           | 2.13.0, 2.13.1            |                           |
|  44 | bcrypt                    | 3.2.0                     | 3.2.0                     |                           |
|  45 | bidict                    | 0.22.0, 0.23.1            | 0.23.1                    |                           |
|  46 | billiard                  | 3.6.3.0, 3.6.4.0          | 3.6.3.0, 3.6.4.0          |                           |
|  47 | black                     |                           |                           | 21.5b1, 21.5b2, 24.4.2    |
|  48 | blackfynn                 | 4.0.0                     |                           |                           |
|  49 | blinker                   |                           | 1.8.1, 1.8.2              |                           |
|  50 | blosc                     | 1.11.1                    |                           |                           |
|  51 | bokeh                     | 3.4.1                     | 3.4.1                     |                           |
|  52 | boto3                     | 1.12.32, 1.34.34, 1.34.69, 1.34.75 | 1.21.21, 1.34.34, 1.34.69, 1.34.98, 1.34.106 |                           |
|  53 | boto3-stubs               |                           | 1.34.98                   |                           |
|  54 | botocore                  | 1.15.32, 1.34.34, 1.34.69, 1.34.75, 1.34.106 | 1.24.21, 1.34.34, 1.34.69, 1.34.98, 1.34.106 |                           |
|  55 | botocore-stubs            | 1.34.69, 1.34.94          | 1.34.94                   |                           |
|  56 | build                     |                           |                           | 1.2.1                     |
|  57 | bump2version              |                           |                           | 1.0.1                     |
|  58 | cached-property           | 1.5.2                     | 1.5.2                     |                           |
|  59 | cachetools                | 5.3.2                     |                           |                           |
|  60 | caio                      | 0.6.1                     |                           |                           |
|  61 | captcha                   | 0.5.0                     |                           |                           |
|  62 | certifi                   | 2020.11.8, 2020.12.5, 2023.7.22, 2023.11.17, 2024.2.2 | 2020.11.8, 2020.12.5, 2023.7.22, 2023.11.17, 2024.2.2 |                           |
|  63 | cffi                      | 1.14.5, 1.15.0, 1.16.0    | 1.14.5, 1.16.0            |                           |
|  64 | cfgv                      |                           |                           | 3.2.0, 3.3.0, 3.4.0       |
|  65 | cfn-lint                  |                           | 0.72.0, 0.87.1, 0.87.3    |                           |
|  66 | change-case               | 0.5.2                     |                           | 0.5.2                     |
|  67 | chardet                   | 3.0.4, 4.0.0              | 3.0.4, 4.0.0              |                           |
|  68 | charset-normalizer        | 2.0.12, 2.1.1, 3.3.2      | 2.0.12, 2.1.1, 3.3.2      |                           |
|  69 | click                     | 7.1.2, 8.0.0, 8.1.3, 8.1.7 | 7.1.2, 8.0.0, 8.1.3, 8.1.7 | 7.1.2, 8.0.0, 8.1.3, 8.1.7 |
|  70 | click-didyoumean          | 0.0.3                     | 0.0.3                     |                           |
|  71 | click-plugins             | 1.1.1                     | 1.1.1                     |                           |
|  72 | click-repl                | 0.1.6                     | 0.1.6                     |                           |
|  73 | cloudpickle               | 3.0.0                     | 3.0.0                     |                           |
|  74 | codecov                   |                           | 2.1.11                    |                           |
|  75 | colorama                  | 0.4.6                     |                           |                           |
|  76 | colorlog                  | 6.8.2                     | 6.8.2                     |                           |
|  77 | configparser              | 5.0.2                     |                           |                           |
|  78 | contextvars               | 2.4                       | 2.4                       |                           |
|  79 | contourpy                 | 1.2.0, 1.2.1              | 1.2.1                     |                           |
|  80 | coverage                  |                           | 5.5, 7.5.1                |                           |
|  81 | coveralls                 |                           | 3.0.1, 3.1.0              |                           |
|  82 | cryptography              | 3.4.7, 41.0.7, 42.0.5, 42.0.7 | 3.4.7, 42.0.5, 42.0.6, 42.0.7 |                           |
|  83 | cycler                    | 0.12.1                    |                           |                           |
|  84 | dask                      | 2024.5.1                  | 2023.3.2, 2024.5.1        |                           |
|  85 | dask-gateway              | 2024.1.0                  | 2024.1.0                  |                           |
|  86 | dask-gateway-server       | 2023.1.1                  | 2023.1.1                  |                           |
|  87 | dataclasses               | 0.7, 0.8                  | 0.8                       | 0.7, 0.8                  |
|  88 | dateparser                | 1.2.0                     |                           |                           |
|  89 | debugpy                   |                           | 1.8.1                     |                           |
|  90 | decorator                 | 4.4.2                     | 4.4.2                     |                           |
|  91 | deepdiff                  |                           | 7.0.1                     |                           |
|  92 | deprecated                | 1.2.12                    |                           |                           |
|  93 | dill                      |                           |                           | 0.3.8                     |
|  94 | distlib                   |                           |                           | 0.3.1, 0.3.2, 0.3.8       |
|  95 | distributed               | 2024.5.1                  | 2023.3.2, 2024.5.1        |                           |
|  96 | distro                    | 1.5.0                     | 1.5.0                     |                           |
|  97 | dnspython                 | 2.0.0, 2.1.0, 2.2.1, 2.6.1 | 2.1.0, 2.6.1              |                           |
|  98 | docker                    | 5.0.0, 7.0.0              | 5.0.0, 6.1.3, 7.0.0       |                           |
|  99 | docker-compose            | 1.29.1                    | 1.29.1                    |                           |
| 100 | dockerpty                 | 0.4.1                     | 0.4.1                     |                           |
| 101 | docopt                    | 0.6.2                     | 0.6.2                     |                           |
| 102 | docutils                  | 0.15.2                    |                           |                           |
| 103 | ecdsa                     | 0.18.0                    | 0.19.0                    |                           |
| 104 | email-validator           | 1.1.1, 1.1.2, 1.2.1, 1.3.0, 2.1.1 | 1.1.2, 2.1.1              |                           |
| 105 | et-xmlfile                | 1.1.0                     |                           |                           |
| 106 | exceptiongroup            | 1.2.0, 1.2.1              | 1.2.0, 1.2.1              |                           |
| 107 | execnet                   |                           | 1.8.0, 2.1.1              |                           |
| 108 | expiringdict              | 1.2.1                     |                           |                           |
| 109 | faker                     | 19.6.1                    | 8.1.4, 8.2.0, 8.5.1, 19.6.1, 25.0.1, 25.2.0 |                           |
| 110 | fakeredis                 |                           | 2.22.0, 2.23.2            |                           |
| 111 | fast-depends              | 2.4.2                     | 2.4.2                     |                           |
| 112 | fastapi                   | 0.63.0, 0.96.0, 0.99.1    |                           |                           |
| 113 | fastapi-pagination        | 0.12.17, 0.12.21          |                           |                           |
| 114 | faststream                | 0.2.12, 0.4.7, 0.5.2, 0.5.4, 0.5.7 | 0.5.4                     |                           |
| 115 | filelock                  |                           |                           | 3.0.12, 3.14.0            |
| 116 | flaky                     |                           | 3.8.1                     |                           |
| 117 | flask                     |                           | 2.1.3, 3.0.3              |                           |
| 118 | flask-cors                |                           | 4.0.1                     |                           |
| 119 | fonttools                 | 4.50.0                    |                           |                           |
| 120 | frozenlist                | 1.3.0, 1.3.1, 1.4.1       | 1.3.0, 1.3.1, 1.4.1       |                           |
| 121 | fsspec                    | 2024.5.0                  | 2024.3.1, 2024.5.0        |                           |
| 122 | future                    | 0.18.2                    |                           |                           |
| 123 | graphene                  | 2.1.8                     |                           |                           |
| 124 | graphql-core              | 2.3.2                     | 3.2.3                     |                           |
| 125 | graphql-relay             | 2.0.1                     |                           |                           |
| 126 | greenlet                  | 2.0.2, 3.0.3              | 2.0.2, 3.0.3              |                           |
| 127 | gunicorn                  | 20.1.0                    |                           |                           |
| 128 | h11                       | 0.12.0, 0.14.0            | 0.12.0, 0.14.0            |                           |
| 129 | h2                        | 4.1.0                     |                           |                           |
| 130 | hiredis                   | 1.1.0, 2.0.0              | 2.0.0                     |                           |
| 131 | hpack                     | 4.0.0                     |                           |                           |
| 132 | httmock                   | 1.4.0                     |                           |                           |
| 133 | httpcore                  | 0.13.3, 1.0.2, 1.0.4, 1.0.5 | 0.13.3, 1.0.2, 1.0.4, 1.0.5 |                           |
| 134 | httptools                 | 0.1.1, 0.1.2, 0.6.1       |                           |                           |
| 135 | httpx                     | 0.18.1, 0.26.0, 0.27.0    | 0.18.1, 0.26.0, 0.27.0    |                           |
| 136 | hyperframe                | 6.0.1                     |                           |                           |
| 137 | hypothesis                |                           | 6.91.0, 6.100.4           |                           |
| 138 | icdiff                    |                           | 1.9.1, 2.0.7              |                           |
| 139 | identify                  |                           |                           | 2.2.4, 2.2.9, 2.5.36      |
| 140 | idna                      | 2.10, 3.3, 3.4, 3.6, 3.7  | 2.10, 3.3, 3.4, 3.6, 3.7  |                           |
| 141 | idna-ssl                  | 1.1.0                     | 1.1.0                     |                           |
| 142 | immutables                | 0.14, 0.15                | 0.14, 0.15                |                           |
| 143 | importlib-metadata        | 2.0.0, 4.0.1, 7.1.0       | 2.0.0, 4.0.1, 7.1.0       | 2.0.0, 4.0.1              |
| 144 | importlib-resources       | 5.1.3                     | 5.1.3                     | 5.1.3, 5.1.4              |
| 145 | iniconfig                 | 1.1.1, 2.0.0              | 1.1.1, 2.0.0              |                           |
| 146 | inotify                   |                           |                           | 0.2.10                    |
| 147 | isodate                   | 0.6.0, 0.6.1              | 0.6.0                     |                           |
| 148 | isort                     |                           | 4.3.21, 5.8.0             | 4.3.21, 5.8.0, 5.13.2     |
| 149 | itsdangerous              | 1.1.0, 2.1.2, 2.2.0       | 2.1.2, 2.2.0              |                           |
| 150 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 151 | jinja2                    | 2.11.3, 3.1.2, 3.1.3, 3.1.4 | 3.1.3, 3.1.4              | 2.11.3, 3.1.3             |
| 152 | jmespath                  | 0.10.0, 1.0.1             | 1.0.1                     |                           |
| 153 | joserfc                   |                           | 0.9.0, 0.10.0             |                           |
| 154 | jschema-to-python         |                           | 1.2.3                     |                           |
| 155 | json2html                 | 1.3.0                     |                           |                           |
| 156 | jsondiff                  | 1.3.0, 2.0.0              | 2.0.0                     |                           |
| 157 | jsonpatch                 |                           | 1.33                      |                           |
| 158 | jsonpath-ng               |                           | 1.6.1                     |                           |
| 159 | jsonpickle                |                           | 3.0.4                     |                           |
| 160 | jsonpointer               |                           | 2.4                       |                           |
| 161 | jsonref                   |                           | 1.1.0                     |                           |
| 162 | jsonschema                | 3.2.0, 4.21.1, 4.22.0     | 3.2.0, 4.21.1, 4.22.0     |                           |
| 163 | jsonschema-path           | 0.3.2                     | 0.3.2                     |                           |
| 164 | jsonschema-specifications | 2023.7.1, 2023.12.1       | 2023.7.1, 2023.12.1       |                           |
| 165 | junit-xml                 |                           | 1.9                       |                           |
| 166 | kiwisolver                | 1.4.5                     |                           |                           |
| 167 | kombu                     | 4.6.11, 5.0.2             | 5.0.2                     |                           |
| 168 | lazy-object-proxy         | 1.4.3, 1.7.1, 1.10.0      | 1.4.3, 1.6.0, 1.10.0      | 1.6.0                     |
| 169 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 170 | lupa                      |                           | 2.1                       |                           |
| 171 | lz4                       | 4.3.3                     | 4.3.3                     |                           |
| 172 | mako                      | 1.2.2, 1.3.2, 1.3.3, 1.3.5 | 1.1.4, 1.2.2, 1.3.2, 1.3.3, 1.3.5 |                           |
| 173 | markdown-it-py            | 3.0.0                     | 3.0.0                     | 3.0.0                     |
| 174 | markupsafe                | 1.1.1, 2.0.1, 2.1.1, 2.1.5 | 1.1.1, 2.0.0, 2.0.1, 2.1.1, 2.1.5 | 2.0.1, 2.1.5              |
| 175 | matplotlib                | 3.8.3                     |                           |                           |
| 176 | mccabe                    |                           | 0.6.1                     | 0.6.1, 0.7.0              |
| 177 | mdurl                     | 0.1.2                     | 0.1.2                     | 0.1.2                     |
| 178 | minio                     | 7.0.3                     | 7.0.3                     |                           |
| 179 | more-itertools            | 10.2.0                    |                           |                           |
| 180 | moto                      |                           | 4.0.1, 4.2.6, 5.0.6, 5.0.7 |                           |
| 181 | mpmath                    |                           | 1.3.0                     |                           |
| 182 | msgpack                   | 1.0.7, 1.0.8              | 1.0.8                     |                           |
| 183 | multidict                 | 4.7.6, 5.0.0, 5.1.0, 6.0.2, 6.0.5 | 4.7.6, 5.0.0, 5.1.0, 6.0.2, 6.0.5 |                           |
| 184 | mypy                      |                           | 1.10.0                    | 0.812                     |
| 185 | mypy-extensions           |                           | 1.0.0                     | 0.4.3, 1.0.0              |
| 186 | nest-asyncio              | 1.6.0                     |                           |                           |
| 187 | networkx                  | 2.5, 2.5.1, 3.3           | 2.5.1, 2.8.8, 3.3         |                           |
| 188 | nodeenv                   |                           |                           | 1.6.0, 1.8.0              |
| 189 | nose                      |                           |                           | 1.3.7                     |
| 190 | numpy                     | 1.26.4                    | 1.19.5, 1.26.4            |                           |
| 191 | openapi-core              | 0.12.0, 0.19.0            | 0.12.0                    |                           |
| 192 | openapi-schema-validator  | 0.1.5, 0.2.3, 0.6.2       | 0.1.5, 0.2.3, 0.6.2       |                           |
| 193 | openapi-spec-validator    | 0.3.0, 0.3.1, 0.4.0, 0.7.1 | 0.3.1, 0.4.0, 0.7.1       |                           |
| 194 | openpyxl                  | 3.0.7, 3.0.9              |                           |                           |
| 195 | ordered-set               | 4.1.0                     | 4.1.0                     |                           |
| 196 | orjson                    | 3.4.3, 3.4.8, 3.5.2, 3.10.0, 3.10.3 | 3.10.3                    |                           |
| 197 | osparc                    | 0.6.5                     |                           |                           |
| 198 | osparc-client             | 0.6.5                     |                           |                           |
| 199 | packaging                 | 20.4, 20.9, 23.1, 24.0    | 20.4, 20.9, 23.1, 24.0    | 23.1, 24.0                |
| 200 | pamqp                     | 2.3.0, 3.2.1, 3.3.0       | 2.3.0, 3.3.0              |                           |
| 201 | pandas                    | 2.2.1, 2.2.2              | 1.1.5, 2.2.2              |                           |
| 202 | paramiko                  | 2.7.2                     | 2.7.2                     |                           |
| 203 | parfive                   | 1.0.2                     |                           |                           |
| 204 | parse                     | 1.20.1                    | 1.20.1                    |                           |
| 205 | partd                     | 1.4.2                     | 1.4.1, 1.4.2              |                           |
| 206 | passlib                   | 1.7.4                     |                           |                           |
| 207 | pathable                  | 0.4.3                     | 0.4.3                     |                           |
| 208 | pathspec                  |                           |                           | 0.8.1, 0.12.1             |
| 209 | pbr                       |                           | 6.0.0                     |                           |
| 210 | pep517                    |                           |                           | 0.10.0                    |
| 211 | pillow                    | 10.2.0, 10.3.0            | 10.3.0                    |                           |
| 212 | pint                      | 0.19.2, 0.23              | 0.17, 0.23                |                           |
| 213 | pip                       |                           |                           | 24.0                      |
| 214 | pip-tools                 |                           |                           | 6.1.0, 7.4.1              |
| 215 | platformdirs              |                           |                           | 4.2.1, 4.2.2              |
| 216 | playwright                |                           | 1.43.0                    |                           |
| 217 | pluggy                    | 0.13.1, 1.5.0             | 0.13.1, 1.5.0             |                           |
| 218 | ply                       |                           | 3.11                      |                           |
| 219 | pprintpp                  |                           | 0.4.0                     |                           |
| 220 | pre-commit                |                           |                           | 2.12.1, 2.13.0, 3.7.0, 3.7.1 |
| 221 | prometheus-api-client     | 0.5.5                     |                           |                           |
| 222 | prometheus-client         | 0.10.1, 0.14.1, 0.19.0, 0.20.0 | 0.10.1                    |                           |
| 223 | prometheus-fastapi-instrumentator | 6.1.0                     |                           |                           |
| 224 | promise                   | 2.3                       |                           |                           |
| 225 | prompt-toolkit            | 3.0.8, 3.0.18             | 3.0.8, 3.0.18             |                           |
| 226 | protobuf                  | 3.15.8                    |                           |                           |
| 227 | psutil                    | 5.8.0, 5.9.8              | 5.9.8                     |                           |
| 228 | psycopg2-binary           | 2.8.6, 2.9.6, 2.9.9       | 2.8.6, 2.9.9              |                           |
| 229 | ptvsd                     |                           | 4.3.2                     | 4.3.2                     |
| 230 | py                        | 1.10.0                    | 1.10.0                    |                           |
| 231 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 232 | py-partiql-parser         |                           | 0.4.0, 0.5.4, 0.5.5       |                           |
| 233 | pyasn1                    | 0.5.1                     | 0.6.0                     |                           |
| 234 | pycountry                 | 23.12.11                  |                           |                           |
| 235 | pycparser                 | 2.20, 2.21, 2.22          | 2.20, 2.22                |                           |
| 236 | pydantic                  | 1.8.2, 1.9.0, 1.10.2, 1.10.14, 1.10.15 | 1.10.2, 1.10.14, 1.10.15, 2.7.1 |                           |
| 237 | pydantic-core             |                           | 2.18.2                    |                           |
| 238 | pyee                      |                           | 11.1.0                    |                           |
| 239 | pyftpdlib                 |                           | 1.5.9                     |                           |
| 240 | pygments                  | 2.15.1, 2.17.2, 2.18.0    | 2.18.0                    | 2.18.0                    |
| 241 | pyinstrument              | 3.4.2, 4.6.1, 4.6.2       | 3.4.2, 4.6.2              |                           |
| 242 | pyinstrument-cext         | 0.2.4                     | 0.2.4                     |                           |
| 243 | pyjwt                     | 2.4.0                     |                           |                           |
| 244 | pylint                    |                           | 2.5.0, 2.8.2, 2.8.3       | 2.8.2, 3.1.0, 3.2.2       |
| 245 | pynacl                    | 1.4.0                     | 1.4.0                     |                           |
| 246 | pyopenssl                 |                           | 24.1.0                    |                           |
| 247 | pyparsing                 | 2.4.7, 3.1.2              | 2.4.7, 3.1.2              |                           |
| 248 | pyproject-hooks           |                           |                           | 1.1.0                     |
| 249 | pyrsistent                | 0.17.3, 0.18.1, 0.19.2, 0.20.0 | 0.17.3, 0.18.1, 0.19.2, 0.20.0 |                           |
| 250 | pytest                    | 6.2.4, 8.2.0              | 6.2.4, 7.4.4, 8.2.0, 8.2.1 |                           |
| 251 | pytest-aiohttp            |                           | 0.3.0, 1.0.5              |                           |
| 252 | pytest-asyncio            |                           | 0.15.1, 0.21.2            |                           |
| 253 | pytest-base-url           |                           | 2.1.0                     |                           |
| 254 | pytest-benchmark          |                           | 4.0.0                     |                           |
| 255 | pytest-celery             |                           | 0.0.0                     |                           |
| 256 | pytest-cov                |                           | 2.11.1, 2.12.0, 2.12.1, 5.0.0 |                           |
| 257 | pytest-docker             |                           | 0.10.1, 3.1.1             |                           |
| 258 | pytest-forked             |                           | 1.3.0                     |                           |
| 259 | pytest-html               |                           | 4.1.1                     |                           |
| 260 | pytest-icdiff             |                           | 0.5, 0.9                  |                           |
| 261 | pytest-instafail          |                           | 0.4.2, 0.5.0              |                           |
| 262 | pytest-lazy-fixture       |                           | 0.6.3                     |                           |
| 263 | pytest-localftpserver     |                           | 1.3.2                     |                           |
| 264 | pytest-metadata           |                           | 3.1.1                     |                           |
| 265 | pytest-mock               |                           | 3.6.1, 3.14.0             |                           |
| 266 | pytest-playwright         |                           | 0.4.4                     |                           |
| 267 | pytest-runner             |                           | 5.3.0, 5.3.1, 6.0.1       |                           |
| 268 | pytest-sugar              |                           | 0.9.4, 1.0.0              |                           |
| 269 | pytest-xdist              |                           | 2.2.1, 3.6.1              |                           |
| 270 | python-dateutil           | 2.8.1, 2.8.2, 2.9.0.post0 | 2.8.1, 2.8.2, 2.9.0.post0 |                           |
| 271 | python-dotenv             | 0.15.0, 0.17.0, 0.17.1, 1.0.0, 1.0.1 | 0.15.0, 0.17.1, 1.0.1     |                           |
| 272 | python-editor             |                           | 1.0.4                     |                           |
| 273 | python-engineio           | 3.14.2, 4.3.4, 4.9.0, 4.9.1 | 4.9.0                     |                           |
| 274 | python-jose               | 3.3.0                     | 3.3.0                     |                           |
| 275 | python-magic              | 0.4.22, 0.4.25, 0.4.27    |                           |                           |
| 276 | python-multipart          | 0.0.5, 0.0.9              |                           |                           |
| 277 | python-slugify            |                           | 8.0.4                     |                           |
| 278 | python-socketio           | 4.6.1, 5.8.0, 5.11.2      | 5.11.2                    |                           |
| 279 | pytz                      | 2020.1, 2020.4, 2021.1, 2022.1, 2024.1 | 2020.4, 2021.1, 2024.1    |                           |
| 280 | pyyaml                    | 5.4.1, 6.0.1              | 5.4.1, 6.0.1              | 5.4.1, 6.0.1              |
| 281 | redis                     | 3.5.3, 4.5.4, 5.0.3, 5.0.4 | 3.5.3, 4.5.4, 5.0.3, 5.0.4 |                           |
| 282 | referencing               | 0.29.3, 0.35.1            | 0.29.3, 0.35.1            |                           |
| 283 | regex                     | 2023.12.25                | 2023.12.25, 2024.4.28, 2024.5.15 | 2021.4.4                  |
| 284 | requests                  | 2.25.1, 2.31.0            | 2.25.1, 2.31.0, 2.32.1    |                           |
| 285 | requests-mock             |                           | 1.12.1                    |                           |
| 286 | responses                 |                           | 0.25.0                    |                           |
| 287 | respx                     |                           | 0.17.0, 0.21.1            |                           |
| 288 | rfc3339-validator         | 0.1.4                     | 0.1.4                     |                           |
| 289 | rich                      | 13.4.2, 13.7.1            | 13.7.1                    | 13.7.1                    |
| 290 | rpds-py                   | 0.18.0, 0.18.1            | 0.18.0, 0.18.1            |                           |
| 291 | rsa                       | 4.9                       | 4.9                       |                           |
| 292 | ruff                      |                           |                           | 0.4.3, 0.4.4              |
| 293 | rx                        | 1.6.1                     |                           |                           |
| 294 | s3fs                      | 2024.5.0                  |                           |                           |
| 295 | s3transfer                | 0.3.7, 0.10.1             | 0.5.2, 0.10.1             |                           |
| 296 | sarif-om                  |                           | 1.0.4                     |                           |
| 297 | semantic-version          | 2.8.5                     |                           |                           |
| 298 | semver                    | 2.13.0                    |                           |                           |
| 299 | setproctitle              | 1.2.3                     |                           |                           |
| 300 | setuptools                | 69.1.1, 69.2.0            | 69.1.1, 69.2.0, 69.5.1, 70.0.0 | 69.1.1, 69.2.0, 69.5.1, 70.0.0 |
| 301 | sh                        | 2.0.6                     |                           |                           |
| 302 | shellingham               | 1.5.4                     | 1.5.4                     | 1.5.4                     |
| 303 | shortuuid                 | 1.0.13                    |                           |                           |
| 304 | simple-websocket          | 1.0.0                     | 1.0.0                     |                           |
| 305 | six                       | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            |
| 306 | sniffio                   | 1.2.0, 1.3.0, 1.3.1       | 1.2.0, 1.3.0, 1.3.1       |                           |
| 307 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 308 | sqlalchemy                | 1.4.47, 1.4.52            | 1.4.47, 1.4.52            |                           |
| 309 | sqlalchemy2-stubs         |                           | 0.0.2a38                  |                           |
| 310 | sshpubkeys                |                           | 3.3.1                     |                           |
| 311 | starlette                 | 0.13.6, 0.14.2, 0.27.0    |                           |                           |
| 312 | strict-rfc3339            | 0.7                       | 0.7                       |                           |
| 313 | sympy                     |                           | 1.12                      |                           |
| 314 | tblib                     | 3.0.0                     | 3.0.0                     |                           |
| 315 | tenacity                  | 6.2.0, 6.3.1, 7.0.0, 8.0.1, 8.2.3, 8.3.0 | 7.0.0, 8.0.1, 8.2.3, 8.3.0 |                           |
| 316 | termcolor                 |                           | 1.1.0, 2.4.0              |                           |
| 317 | text-unidecode            |                           | 1.3                       |                           |
| 318 | texttable                 | 1.6.3                     | 1.6.3                     |                           |
| 319 | toml                      | 0.10.2                    | 0.10.2                    | 0.10.2                    |
| 320 | tomli                     | 2.0.1                     | 2.0.1                     | 2.0.1                     |
| 321 | tomlkit                   |                           |                           | 0.12.4, 0.12.5            |
| 322 | toolz                     | 0.12.0, 0.12.1            | 0.12.1                    |                           |
| 323 | tornado                   | 6.4                       | 6.4                       |                           |
| 324 | tqdm                      | 4.60.0, 4.64.0, 4.66.2, 4.66.4 | 4.60.0, 4.66.4            |                           |
| 325 | trafaret                  | 2.1.0                     | 2.1.0                     |                           |
| 326 | trafaret-config           | 2.0.2                     | 2.0.2                     |                           |
| 327 | traitlets                 | 5.14.3                    | 5.14.3                    |                           |
| 328 | twilio                    | 7.12.0                    |                           |                           |
| 329 | typed-ast                 |                           | 1.4.3                     | 1.4.3                     |
| 330 | typer                     | 0.3.2, 0.4.1, 0.6.1, 0.10.0, 0.12.0, 0.12.1, 0.12.3 | 0.12.3                    | 0.12.3                    |
| 331 | typer-cli                 | 0.12.0                    |                           |                           |
| 332 | typer-slim                | 0.12.0                    |                           |                           |
| 333 | types-aiobotocore         | 2.12.1, 2.12.3, 2.13.0    | 2.12.3                    |                           |
| 334 | types-aiobotocore-ec2     | 2.12.1, 2.12.3, 2.13.0    |                           |                           |
| 335 | types-aiobotocore-s3      | 2.12.1, 2.12.3, 2.13.0    | 2.12.3                    |                           |
| 336 | types-aiofiles            |                           | 23.2.0.20240403           |                           |
| 337 | types-awscrt              | 0.20.5, 0.20.9            | 0.20.9                    |                           |
| 338 | types-boto3               |                           | 1.0.2                     |                           |
| 339 | types-cachetools          |                           |                           | 5.3.0.7                   |
| 340 | types-pkg-resources       |                           | 0.1.3                     |                           |
| 341 | types-python-dateutil     | 2.9.0.20240316            | 2.9.0.20240316            |                           |
| 342 | types-pyyaml              |                           | 6.0.12.20240311           |                           |
| 343 | types-s3transfer          |                           | 0.10.1                    |                           |
| 344 | typing-extensions         | 3.7.4.3, 3.10.0.0, 4.3.0, 4.4.0, 4.10.0, 4.11.0 | 3.7.4.3, 3.10.0.0, 4.3.0, 4.4.0, 4.10.0, 4.11.0 | 3.7.4.3, 3.10.0.0, 4.3.0, 4.4.0, 4.10.0, 4.11.0 |
| 345 | tzdata                    | 2024.1                    | 2024.1                    |                           |
| 346 | tzlocal                   | 5.2                       |                           |                           |
| 347 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 348 | ujson                     | 3.2.0, 4.0.2, 5.5.0, 5.9.0, 5.10.0 | 4.0.2                     |                           |
| 349 | urllib3                   | 1.25.11, 1.26.4, 1.26.11, 2.0.7, 2.2.1 | 1.25.11, 1.26.4, 1.26.11, 1.26.18, 2.0.7, 2.2.1 |                           |
| 350 | uvicorn                   | 0.13.4, 0.19.0, 0.29.0    |                           |                           |
| 351 | uvloop                    | 0.14.0, 0.19.0            |                           |                           |
| 352 | vine                      | 1.3.0, 5.0.0              | 5.0.0                     |                           |
| 353 | virtualenv                |                           |                           | 20.4.6, 20.4.7, 20.26.1, 20.26.2 |
| 354 | watchdog                  | 4.0.0                     |                           | 4.0.0                     |
| 355 | watchfiles                | 0.21.0                    |                           |                           |
| 356 | watchgod                  | 0.6, 0.7                  |                           |                           |
| 357 | wcwidth                   | 0.2.5                     | 0.2.5                     |                           |
| 358 | websocket-client          | 0.58.0, 0.59.0            | 0.59.0, 1.6.4             |                           |
| 359 | websockets                | 8.1, 12.0                 | 9.0.2, 12.0               |                           |
| 360 | werkzeug                  | 1.0.1, 2.0.0, 2.0.1, 2.1.2, 3.0.2 | 2.0.0, 2.1.2, 3.0.2, 3.0.3 |                           |
| 361 | wheel                     |                           |                           | 0.43.0                    |
| 362 | wrapt                     | 1.12.1, 1.16.0            | 1.12.1, 1.16.0            | 1.12.1                    |
| 363 | wsproto                   | 1.2.0                     | 1.2.0                     |                           |
| 364 | xmltodict                 |                           | 0.13.0                    |                           |
| 365 | xyzservices               | 2024.4.0                  | 2024.4.0                  |                           |
| 366 | yarl                      | 1.5.1, 1.6.2, 1.6.3, 1.9.2, 1.9.4 | 1.5.1, 1.6.2, 1.6.3, 1.9.2, 1.9.4 |                           |
| 367 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 368 | zipp                      | 3.2.0, 3.4.0, 3.4.1, 3.18.2 | 3.2.0, 3.4.0, 3.4.1, 3.18.1, 3.18.2 | 3.2.0, 3.4.0, 3.4.1       |
