### PR TITLE
🐛Garbage collector: possible fix to "spurious" shutdowns

### DIFF
--- a/packages/postgres-database/requirements/_base.in
+++ b/packages/postgres-database/requirements/_base.in
@@ -5,5 +5,6 @@
 --constraint ./constraints.txt
 
 alembic
+pydantic
 sqlalchemy[postgresql_psycopg2binary,postgresql_asyncpg] # SEE extras in https://github.com/sqlalchemy/sqlalchemy/blob/main/setup.cfg#L43
 yarl

--- a/packages/postgres-database/requirements/_base.txt
+++ b/packages/postgres-database/requirements/_base.txt
@@ -13,8 +13,11 @@ multidict==6.0.4
     # via yarl
 psycopg2-binary==2.9.9
     # via sqlalchemy
+pydantic==1.10.15
 sqlalchemy==1.4.50
     # via alembic
 typing-extensions==4.8.0
-    # via alembic
+    # via
+    #   alembic
+    #   pydantic
 yarl==1.9.2

--- a/packages/postgres-database/src/simcore_postgres_database/utils_projects_nodes.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_projects_nodes.py
@@ -1,7 +1,7 @@
 import datetime
 import uuid
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
 import sqlalchemy
 from aiopg.sa.connection import SAConnection
@@ -154,7 +154,7 @@ class ProjectNodesRepo:
             msg = f"Node with {node_id} not found"
             raise ProjectNodesNodeNotFound(msg)
         assert row  # nosec
-        return cast(ProjectNode, ProjectNode.from_orm(row))  # sonar
+        return ProjectNode.from_orm(row)
 
     async def update(
         self, connection: SAConnection, *, node_id: uuid.UUID, **values
@@ -183,7 +183,7 @@ class ProjectNodesRepo:
             msg = f"Node with {node_id} not found"
             raise ProjectNodesNodeNotFound(msg)
         assert row  # nosec
-        return cast(ProjectNode, ProjectNode.from_orm(row))  # sonar
+        return ProjectNode.from_orm(row)
 
     async def delete(self, connection: SAConnection, *, node_id: uuid.UUID) -> None:
         """delete a node in the current project

--- a/packages/postgres-database/src/simcore_postgres_database/utils_projects_nodes.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_projects_nodes.py
@@ -1,7 +1,7 @@
 import datetime
 import uuid
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import sqlalchemy
 from aiopg.sa.connection import SAConnection
@@ -154,7 +154,7 @@ class ProjectNodesRepo:
             msg = f"Node with {node_id} not found"
             raise ProjectNodesNodeNotFound(msg)
         assert row  # nosec
-        return ProjectNode.from_orm(row)
+        return cast(ProjectNode, ProjectNode.from_orm(row))  # sonar
 
     async def update(
         self, connection: SAConnection, *, node_id: uuid.UUID, **values
@@ -183,7 +183,7 @@ class ProjectNodesRepo:
             msg = f"Node with {node_id} not found"
             raise ProjectNodesNodeNotFound(msg)
         assert row  # nosec
-        return ProjectNode.from_orm(row)
+        return cast(ProjectNode, ProjectNode.from_orm(row))  # sonar
 
     async def delete(self, connection: SAConnection, *, node_id: uuid.UUID) -> None:
         """delete a node in the current project

--- a/packages/postgres-database/src/simcore_postgres_database/utils_projects_nodes.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_projects_nodes.py
@@ -1,10 +1,11 @@
 import datetime
 import uuid
-from dataclasses import asdict, dataclass, field, fields
+from dataclasses import asdict, field, fields
 from typing import Any
 
 import sqlalchemy
 from aiopg.sa.connection import SAConnection
+from pydantic import dataclasses as py_dataclasses
 from simcore_postgres_database.models.projects_node_to_pricing_unit import (
     projects_node_to_pricing_unit,
 )
@@ -12,7 +13,6 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from .errors import ForeignKeyViolation, UniqueViolation
 from .models.projects_nodes import projects_nodes
-from .utils_models import FromRowMixin
 
 
 #
@@ -38,7 +38,7 @@ class ProjectNodesDuplicateNode(BaseProjectNodesError):
     ...
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
+@py_dataclasses.dataclass(frozen=True, kw_only=True)
 class ProjectNodeCreate:
     node_id: uuid.UUID
     required_resources: dict[str, Any] = field(default_factory=dict)
@@ -48,13 +48,13 @@ class ProjectNodeCreate:
         return {f.name for f in fields(ProjectNodeCreate) if f.name not in exclude}
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
-class ProjectNode(ProjectNodeCreate, FromRowMixin):
+@py_dataclasses.dataclass(frozen=True, kw_only=True)
+class ProjectNode(ProjectNodeCreate):
     created: datetime.datetime
     modified: datetime.datetime
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
+@py_dataclasses.dataclass(frozen=True, kw_only=True)
 class ProjectNodesRepo:
     project_uuid: uuid.UUID
 

--- a/packages/postgres-database/src/simcore_postgres_database/utils_projects_nodes.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_projects_nodes.py
@@ -1,17 +1,15 @@
 import datetime
 import uuid
-from dataclasses import asdict, field, fields
+from dataclasses import dataclass
 from typing import Any
 
 import sqlalchemy
 from aiopg.sa.connection import SAConnection
-from pydantic import dataclasses as py_dataclasses
-from simcore_postgres_database.models.projects_node_to_pricing_unit import (
-    projects_node_to_pricing_unit,
-)
+from pydantic import BaseModel, Field
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from .errors import ForeignKeyViolation, UniqueViolation
+from .models.projects_node_to_pricing_unit import projects_node_to_pricing_unit
 from .models.projects_nodes import projects_nodes
 
 
@@ -38,23 +36,27 @@ class ProjectNodesDuplicateNode(BaseProjectNodesError):
     ...
 
 
-@py_dataclasses.dataclass(frozen=True, kw_only=True)
-class ProjectNodeCreate:
+class ProjectNodeCreate(BaseModel):
     node_id: uuid.UUID
-    required_resources: dict[str, Any] = field(default_factory=dict)
+    required_resources: dict[str, Any] = Field(default_factory=dict)
 
-    @staticmethod
-    def get_field_names(*, exclude: set[str]) -> set[str]:
-        return {f.name for f in fields(ProjectNodeCreate) if f.name not in exclude}
+    @classmethod
+    def get_field_names(cls, *, exclude: set[str]) -> set[str]:
+        return {name for name in cls.__fields__ if name not in exclude}
+
+    class Config:
+        frozen = True
 
 
-@py_dataclasses.dataclass(frozen=True, kw_only=True)
 class ProjectNode(ProjectNodeCreate):
     created: datetime.datetime
     modified: datetime.datetime
 
+    class Config(ProjectNodeCreate.Config):
+        orm_mode = True
 
-@py_dataclasses.dataclass(frozen=True, kw_only=True)
+
+@dataclass(frozen=True, kw_only=True)
 class ProjectNodesRepo:
     project_uuid: uuid.UUID
 
@@ -82,7 +84,7 @@ class ProjectNodesRepo:
                 [
                     {
                         "project_uuid": f"{self.project_uuid}",
-                        **asdict(node),
+                        **node.dict(),
                     }
                     for node in nodes
                 ]
@@ -101,7 +103,7 @@ class ProjectNodesRepo:
             assert result  # nosec
             rows = await result.fetchall()
             assert rows is not None  # nosec
-            return [ProjectNode.from_row(r) for r in rows]
+            return [ProjectNode.from_orm(r) for r in rows]
         except ForeignKeyViolation as exc:
             # this happens when the project does not exist, as we first check the node exists
             msg = f"Project {self.project_uuid} not found"
@@ -127,7 +129,7 @@ class ProjectNodesRepo:
         assert result  # nosec
         rows = await result.fetchall()
         assert rows is not None  # nosec
-        return [ProjectNode.from_row(row) for row in rows]
+        return [ProjectNode.from_orm(row) for row in rows]
 
     async def get(self, connection: SAConnection, *, node_id: uuid.UUID) -> ProjectNode:
         """get a node in the current project
@@ -152,7 +154,7 @@ class ProjectNodesRepo:
             msg = f"Node with {node_id} not found"
             raise ProjectNodesNodeNotFound(msg)
         assert row  # nosec
-        return ProjectNode.from_row(row)
+        return ProjectNode.from_orm(row)
 
     async def update(
         self, connection: SAConnection, *, node_id: uuid.UUID, **values
@@ -181,7 +183,7 @@ class ProjectNodesRepo:
             msg = f"Node with {node_id} not found"
             raise ProjectNodesNodeNotFound(msg)
         assert row  # nosec
-        return ProjectNode.from_row(row)
+        return ProjectNode.from_orm(row)
 
     async def delete(self, connection: SAConnection, *, node_id: uuid.UUID) -> None:
         """delete a node in the current project

--- a/services/web/server/src/simcore_service_webserver/director_v2/_core_dynamic_services.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2/_core_dynamic_services.py
@@ -7,9 +7,10 @@
 import logging
 
 from aiohttp import web
+from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.projects import ProjectID
 from models_library.services import ServicePortKey
-from pydantic import BaseModel
+from pydantic import BaseModel, parse_obj_as
 from pydantic.types import NonNegativeFloat, PositiveInt
 from servicelib.logging_utils import log_decorator
 from yarl import URL
@@ -30,7 +31,7 @@ async def list_dynamic_services(
     app: web.Application,
     user_id: PositiveInt | None = None,
     project_id: str | None = None,
-) -> list[DataType]:
+) -> list[DynamicServiceGet]:
     params = _Params(user_id=user_id, project_id=project_id)
     params_dict = params.dict(exclude_none=True)
     settings: DirectorV2Settings = get_plugin_settings(app)
@@ -48,7 +49,7 @@ async def list_dynamic_services(
     if services is None:
         services = []
     assert isinstance(services, list)  # nosec
-    return services
+    return parse_obj_as(list[DynamicServiceGet], services)
 
 
 # NOTE: ANE https://github.com/ITISFoundation/osparc-simcore/issues/3191

--- a/services/web/server/src/simcore_service_webserver/dynamic_scheduler/api.py
+++ b/services/web/server/src/simcore_service_webserver/dynamic_scheduler/api.py
@@ -118,11 +118,11 @@ async def stop_dynamic_services_in_project(
         services_to_stop = [
             stop_dynamic_service(
                 app=app,
-                node_id=service["service_uuid"],
+                node_id=service.node_uuid,
                 simcore_user_agent=simcore_user_agent,
                 save_state=save_state,
                 progress=progress_bar.sub_progress(
-                    1, description=service["service_uuid"]
+                    1, description=f"{service.node_uuid}"
                 ),
             )
             for service in running_dynamic_services

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core.py
@@ -58,8 +58,4 @@ async def collect_garbage(app: web.Application):
         # the projects are closed or the user was disconencted.
         # This will close and remove all these services from
         # the cluster, thus freeing important resources.
-
-        # Temporary disabling GC to until the dynamic service
-        # safe function is invoked by the GC. This will avoid
-        # data loss for current users.
         await remove_orphaned_services(registry, app)

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
@@ -1,15 +1,12 @@
-import contextlib
 import logging
-from typing import Any
+from typing import Any, Final
 
 from aiohttp import web
+from models_library.projects import ProjectID
+from models_library.projects_nodes_io import NodeID
+from models_library.users import UserID
 from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
-from servicelib.logging_utils import log_decorator
-from servicelib.rabbitmq import RPCServerError
-from servicelib.rabbitmq.rpc_interfaces.dynamic_scheduler.errors import (
-    ServiceWaitingForManualInterventionError,
-    ServiceWasNotFoundError,
-)
+from servicelib.logging_utils import log_catch, log_context
 from servicelib.utils import logged_gather
 from simcore_postgres_database.models.users import UserRole
 
@@ -17,8 +14,8 @@ from ..director_v2 import api as director_v2_api
 from ..dynamic_scheduler import api as dynamic_scheduler_api
 from ..projects.db import ProjectDBAPI
 from ..projects.projects_api import (
-    get_workbench_node_ids_from_project_uuid,
     is_node_id_present_in_any_project_workbench,
+    list_node_ids_in_project,
 )
 from ..resource_manager.registry import RedisResourceRegistry
 from ..users.api import get_user_role
@@ -26,155 +23,116 @@ from ..users.exceptions import UserNotFoundError
 
 _logger = logging.getLogger(__name__)
 
+_MAX_CONCURRENT_CALLS: Final[int] = 2
 
-@log_decorator(_logger, log_traceback=True)
-async def _remove_single_service_if_orphan(
-    app: web.Application,
-    dynamic_service: dict[str, Any],
-    currently_opened_projects_node_ids: dict[str, str],
+
+async def _remove_service(
+    app: web.Application, node_id: NodeID, service: dict[str, Any]
 ) -> None:
-    """ "orphan" is a service who is not present in the DB or not part of a currently opened project"""
+    save_service_state = True
+    if not await is_node_id_present_in_any_project_workbench(app, node_id):
+        # this is a loner service that is not part of any project
+        save_service_state = False
+    elif "user_id" not in service:
+        save_service_state = False
+    else:
+        user_id = UserID(service["user_id"])
+        user_role: UserRole | None = None
+        try:
+            user_role = await get_user_role(app, user_id)
+        except (UserNotFoundError, ValueError):
+            user_role = None
 
-    service_host = dynamic_service["service_host"]
-    service_uuid = dynamic_service["service_uuid"]
+        project_uuid = service["project_id"]
 
-    # if not present in DB or not part of currently opened projects, can be removed
-    # if the node does not exist in any project in the db
-    # they can be safely remove it without saving any state
-    if not await is_node_id_present_in_any_project_workbench(app, service_uuid):
-        _logger.info(
-            "Will remove orphaned service without saving state since "
-            "this service is not part of any project %s",
-            f"{service_host=}",
+        save_service_state = await ProjectDBAPI.get_from_app_context(
+            app
+        ).has_permission(user_id, project_uuid, "write")
+        if user_role is None or user_role <= UserRole.GUEST:
+            save_service_state = False
+
+    with log_context(
+        _logger, logging.INFO, msg=f"removing {service=} with {save_service_state=}"
+    ):
+        await dynamic_scheduler_api.stop_dynamic_service(
+            app,
+            node_id=node_id,
+            simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+            save_state=save_service_state,
         )
-        try:
-            await dynamic_scheduler_api.stop_dynamic_service(
-                app,
-                node_id=service_uuid,
-                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-                save_state=False,
-            )
-        except (
-            RPCServerError,
-            ServiceWaitingForManualInterventionError,
-            ServiceWasNotFoundError,
-        ) as err:
-            _logger.warning("Error while stopping service: %s", err)
-        return
-
-    # if the node is not present in any of the currently opened project it shall be closed
-    if service_uuid not in currently_opened_projects_node_ids:
-        if service_state := dynamic_service.get("service_state") in [
-            "pulling",
-            "starting",
-        ]:
-            # Services returned in running_interactive_services
-            # might be still pulling its image and when stop_service is
-            # called, will cancel the pull operation as well.
-            # This enforces next run to start again by pulling the image
-            # which is costly and sometimes the cause of timeout and
-            # service malfunction.
-            # For that reason, we prefer here to allow the image to
-            # be completely pulled and stop it instead at the next gc round
-            #
-            # This should eventually be responsibility of the director, but
-            # the functionality is in the old service which is frozen.
-            #
-            # a service state might be one of [pending, pulling, starting, running, complete, failed]
-            _logger.warning(
-                "Skipping %s since service state is %s",
-                f"{service_host=}",
-                service_state,
-            )
-            return
-
-        _logger.info("Will remove service %s", service_host)
-        try:
-            # let's be conservative here.
-            # 1. opened project disappeared from redis?
-            # 2. something bad happened when closing a project?
-
-            user_id = int(dynamic_service.get("user_id", -1))
-
-            user_role: UserRole | None = None
-            try:
-                user_role = await get_user_role(app, user_id)
-            except (UserNotFoundError, ValueError):
-                user_role = None
-
-            project_uuid = dynamic_service["project_id"]
-
-            save_state = await ProjectDBAPI.get_from_app_context(app).has_permission(
-                user_id, project_uuid, "write"
-            )
-            if user_role is None or user_role <= UserRole.GUEST:
-                save_state = False
-            # -------------------------------------------
-
-            with contextlib.suppress(ServiceWaitingForManualInterventionError):
-                await dynamic_scheduler_api.stop_dynamic_service(
-                    app,
-                    node_id=service_uuid,
-                    simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-                    save_state=save_state,
-                )
-
-        except (RPCServerError, ServiceWasNotFoundError) as err:
-            _logger.warning("Error while stopping service: %s", err)
 
 
-async def remove_orphaned_services(
-    registry: RedisResourceRegistry, app: web.Application
-) -> None:
-    """Removes orphan services: which are no longer tracked in the database
-
-    Multiple deployments can be active at the same time on the same cluster.
-    This will also check the current SWARM_STACK_NAME label of the service which
-    must be matching its own. The director service spawns dynamic services
-    which have this new label and it also filters by this label.
-
-    """
-    _logger.debug("Starting orphaned services removal...")
-
-    currently_opened_projects_node_ids: dict[str, str] = {}
+async def _list_opened_project_ids(registry: RedisResourceRegistry) -> list[ProjectID]:
+    opened_projects: list[ProjectID] = []
     all_session_alive, _ = await registry.get_all_resource_keys()
     for alive_session in all_session_alive:
         resources = await registry.get_resources(alive_session)
         if "project_id" not in resources:
             continue
 
-        project_uuid = resources["project_id"]
-        node_ids: set[str] = await get_workbench_node_ids_from_project_uuid(
-            app, project_uuid
+        opened_projects.append(ProjectID(resources["project_id"]))
+    return opened_projects
+
+
+async def remove_orphaned_services(
+    registry: RedisResourceRegistry, app: web.Application
+) -> None:
+    """Removes orphan services: orphan services are dynamic services running in the cluster
+    that are not known to the webserver (i.e. which service UUID is not part of any node inside opened projects).
+
+    """
+
+    # NOTE: First get the runnning services in the system before checking what should be opened
+    # otherwise if some time goes it could very well be that there are new projects opened
+    # in between and the GC would remove services that actually should be running.
+
+    with log_catch(_logger, reraise=False):
+        running_dynamic_services: list[
+            dict[str, Any]
+        ] = await director_v2_api.list_dynamic_services(app)
+        if not running_dynamic_services:
+            # nothing to do
+            return
+        _logger.debug(
+            "Currently running dynamic services: %s",
+            [
+                (x.get("service_uuid", ""), x.get("service_host", ""))
+                for x in running_dynamic_services
+            ],
         )
-        for node_id in node_ids:
-            currently_opened_projects_node_ids[node_id] = project_uuid
+        running_service_ids: dict[NodeID, dict[str, Any]] = {
+            NodeID(service["service_uuid"]): service
+            for service in running_dynamic_services
+            if "service_uuid" in service
+        }
 
-    running_dynamic_services: list[dict[str, Any]] = []
-    try:
-        running_dynamic_services = await director_v2_api.list_dynamic_services(app)
-    except director_v2_api.DirectorServiceError:
-        _logger.debug("Could not fetch list_dynamic_services")
-
-    _logger.info(
-        "Observing running services (this does not mean I am removing them) %s",
-        [
-            (x.get("service_uuid", ""), x.get("service_host", ""))
-            for x in running_dynamic_services
-        ],
-    )
-
-    # if there are multiple dynamic services to stop,
-    # this ensures they are being stopped in parallel
-    # when the user is timed out and the GC needs to close
-    # a big study with logs of heavy projects, this will
-    # ensure it gets done in parallel
-    tasks = [
-        _remove_single_service_if_orphan(
-            app, service, currently_opened_projects_node_ids
+        known_opened_project_ids = await _list_opened_project_ids(registry)
+        potentially_running_service_ids: list[
+            set[NodeID] | BaseException
+        ] = await logged_gather(
+            *(list_node_ids_in_project(app, _) for _ in known_opened_project_ids),
+            log=_logger,
+            max_concurrency=_MAX_CONCURRENT_CALLS,
+            reraise=False,
         )
-        for service in running_dynamic_services
-    ]
-    await logged_gather(*tasks, reraise=False)
+        potentially_running_service_ids_set: set[NodeID] = set().union(
+            *(_ for _ in potentially_running_service_ids if isinstance(_, set))
+        )
+        _logger.debug(
+            "Currently known opened node ids: %s", potentially_running_service_ids_set
+        )
 
-    _logger.debug("Finished orphaned services removal")
+        # compute the difference to find the orphaned services
+        orphaned_running_service_ids = (
+            set(running_service_ids) - potentially_running_service_ids_set
+        )
+
+        await logged_gather(
+            *(
+                _remove_service(app, node_id, running_service_ids[node_id])
+                for node_id in orphaned_running_service_ids
+            ),
+            log=_logger,
+            max_concurrency=_MAX_CONCURRENT_CALLS,
+            reraise=False,
+        )

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
@@ -62,10 +62,8 @@ async def _list_opened_project_ids(registry: RedisResourceRegistry) -> list[Proj
     all_session_alive, _ = await registry.get_all_resource_keys()
     for alive_session in all_session_alive:
         resources = await registry.get_resources(alive_session)
-        if "project_id" not in resources:
-            continue
-
-        opened_projects.append(ProjectID(resources["project_id"]))
+        if "project_id" in resources:
+            opened_projects.append(ProjectID(resources["project_id"]))
     return opened_projects
 
 

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
@@ -39,12 +39,10 @@ async def _remove_service(
             user_role = await get_user_role(app, service.user_id)
         except (UserNotFoundError, ValueError):
             user_role = None
-
-        project_uuid = service["project_id"]
-
-        save_service_state = await ProjectDBAPI.get_from_app_context(
-            app
-        ).has_permission(service.user_id, project_uuid, "write")
+        project_db_api = ProjectDBAPI.get_from_app_context(app)
+        save_service_state = await project_db_api.has_permission(
+            service.user_id, f"{service.project_id}", "write"
+        )
         if user_role is None or user_role <= UserRole.GUEST:
             save_service_state = False
 

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -1322,7 +1322,7 @@ async def run_project_dynamic_services(
     # first get the services if they already exist
     project_settings: ProjectsSettings = get_plugin_settings(request.app)
     running_services_uuids: list[NodeIDStr] = [
-        f"{d.node_uuid}"
+        NodeIDStr(f"{d.node_uuid}")
         for d in await director_v2_api.list_dynamic_services(
             request.app, user_id, project["uuid"]
         )

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -703,7 +703,7 @@ async def delete_project_node(
                 X_SIMCORE_USER_AGENT, UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
             ),
             stop_service=any(
-                s["service_uuid"] == node_uuid for s in list_running_dynamic_services
+                f"{s.node_uuid}" == node_uuid for s in list_running_dynamic_services
             ),
         ),
         task_suffix_name=f"_remove_service_and_its_data_folders_{user_id=}_{project_uuid=}_{node_uuid}",
@@ -1322,7 +1322,7 @@ async def run_project_dynamic_services(
     # first get the services if they already exist
     project_settings: ProjectsSettings = get_plugin_settings(request.app)
     running_services_uuids: list[NodeIDStr] = [
-        d["service_uuid"]
+        f"{d.node_uuid}"
         for d in await director_v2_api.list_dynamic_services(
             request.app, user_id, project["uuid"]
         )

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -807,10 +807,10 @@ async def update_project_node_outputs(
     return updated_project, changed_keys
 
 
-async def get_workbench_node_ids_from_project_uuid(
+async def list_node_ids_in_project(
     app: web.Application,
-    project_uuid: str,
-) -> set[str]:
+    project_uuid: ProjectID,
+) -> set[NodeID]:
     """Returns a set with all the node_ids from a project's workbench"""
     db: ProjectDBAPI = app[APP_PROJECT_DBAPI]
     return await db.list_node_ids_in_project(project_uuid)
@@ -818,7 +818,7 @@ async def get_workbench_node_ids_from_project_uuid(
 
 async def is_node_id_present_in_any_project_workbench(
     app: web.Application,
-    node_id: str,
+    node_id: NodeID,
 ) -> bool:
     """If the node_id is presnet in one of the projects' workbenche returns True"""
     db: ProjectDBAPI = app[APP_PROJECT_DBAPI]

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -99,12 +99,16 @@ async def mock_stop_dynamic_service(mocker: MockerFixture) -> mock.AsyncMock:
 async def test_remove_orphaned_services_with_no_running_services_does_nothing(
     mock_list_node_ids_in_project: mock.AsyncMock,
     mock_list_dynamic_services: mock.AsyncMock,
+    mock_is_node_id_present_in_any_project_workbench: mock.AsyncMock,
+    mock_stop_dynamic_service: mock.AsyncMock,
     mock_registry: mock.AsyncMock,
     mock_app: mock.AsyncMock,
 ):
     await remove_orphaned_services(mock_registry, mock_app)
     mock_list_dynamic_services.assert_called_once()
     mock_list_node_ids_in_project.assert_not_called()
+    mock_is_node_id_present_in_any_project_workbench.assert_not_called()
+    mock_stop_dynamic_service.assert_not_called()
 
 
 @pytest.fixture

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -53,7 +53,7 @@ def mock_list_dynamic_services(mocker: MockerFixture):
     )
 
 
-async def test_regressionremove_orphaned_services_node_ids_unhashable_type_set(
+async def test_remove_orphaned_services(
     mock_get_workbench_node_ids_from_project_uuid: None,
     mock_list_dynamic_services: None,
     mock_registry: AsyncMock,

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -63,11 +63,12 @@ async def test_remove_orphaned_services_with_no_running_services_does_nothing(
 
 
 async def test_removed_orphaned_service_of_invalid_service_does_not_hang_or_block_gc(
-    mock_list_node_ids_in_project: None,
-    mock_list_dynamic_services: None,
+    mock_list_node_ids_in_project: mock.AsyncMock,
+    mock_list_dynamic_services: mock.AsyncMock,
     mock_registry: mock.AsyncMock,
     mock_app: mock.AsyncMock,
 ):
+    mock_list_dynamic_services.return_value = []
     await remove_orphaned_services(mock_registry, mock_app)
 
 

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -1,7 +1,9 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
+# pylint: disable=too-many-arguments
 
-from typing import Callable, Final
+from collections.abc import Callable
+from typing import Final
 from unittest import mock
 
 import pytest
@@ -15,6 +17,7 @@ from simcore_service_webserver.garbage_collector._core_orphans import (
     remove_orphaned_services,
 )
 from simcore_service_webserver.resource_manager.registry import UserSessionDict
+from simcore_service_webserver.users.exceptions import UserNotFoundError
 
 MODULE_GC_CORE_ORPHANS: Final[
     str
@@ -165,14 +168,14 @@ async def mock_get_user_role(
 
 
 async def test_remove_orphaned_services(
+    mock_app: mock.AsyncMock,
+    mock_registry: mock.AsyncMock,
     mock_list_node_ids_in_project: mock.AsyncMock,
     mock_is_node_id_present_in_any_project_workbench: mock.AsyncMock,
     mock_list_dynamic_services: mock.AsyncMock,
     mock_stop_dynamic_service: mock.AsyncMock,
     mock_has_write_permission: mock.AsyncMock,
     mock_get_user_role: mock.AsyncMock,
-    mock_registry: mock.AsyncMock,
-    mock_app: mock.AsyncMock,
     faker_dynamic_service_get: Callable[[], DynamicServiceGet],
     project_id: ProjectID,
     node_exists: bool,
@@ -210,81 +213,37 @@ async def test_remove_orphaned_services(
     )
 
 
-# async def test_regression_project_id_recovered_from_the_wrong_data_structure(
-#     faker: Faker, mocker: MockerFixture
-# ):
-#     # tests that KeyError is not raised
-
-#     mocker.patch(
-#         f"{MODULE_GC_CORE_ORPHANS}.is_node_id_present_in_any_project_workbench",
-#         autospec=True,
-#         return_value=True,
-#     )
-#     mocker.patch(
-#         f"{MODULE_GC_CORE_ORPHANS}.ProjectDBAPI.get_from_app_context",
-#         autospec=True,
-#         return_value=mock.AsyncMock(),
-#     )
-#     mocker.patch(
-#         f"{MODULE_GC_CORE_ORPHANS}.dynamic_scheduler_api.stop_dynamic_service",
-#         autospec=True,
-#     )
-
-#     await _remove_single_service_if_orphan(
-#         app=mock.AsyncMock(),
-#         dynamic_service={
-#             "service_host": "host",
-#             "service_uuid": faker.uuid4(),
-#             "user_id": 1,
-#             "project_id": faker.uuid4(),
-#         },
-#         currently_opened_projects_node_ids={},
-#     )
-
-
-# async def test_remove_single_service_if_orphan_service_is_waiting_manual_intervention(
-#     faker: Faker,
-#     mocker: MockerFixture,
-# ):
-#     mocker.patch(
-#         f"{MODULE_GC_CORE_ORPHANS}.is_node_id_present_in_any_project_workbench",
-#         autospec=True,
-#         return_value=True,
-#     )
-#     mocker.patch(
-#         f"{MODULE_GC_CORE_ORPHANS}.ProjectDBAPI.get_from_app_context",
-#         autospec=True,
-#         return_value=mock.AsyncMock(),
-#     )
-
-#     # mock settings
-#     mocked_settings = mock.AsyncMock()
-#     mocked_settings.base_url = URL("http://director-v2:8000/v2")
-#     mocked_settings.DIRECTOR_V2_STOP_SERVICE_TIMEOUT = 10
-#     mocker.patch(
-#         "simcore_service_webserver.director_v2._core_dynamic_services.get_plugin_settings",
-#         autospec=True,
-#         return_value=mocked_settings,
-#     )
-
-#     mocker.patch(
-#         "simcore_service_webserver.director_v2._core_base.get_client_session",
-#         autospec=True,
-#         return_value=ClientSession(),
-#     )
-
-#     mocker.patch(
-#         f"{MODULE_GC_CORE_ORPHANS}.dynamic_scheduler_api.stop_dynamic_service",
-#         side_effect=ServiceWaitingForManualInterventionError,
-#     )
-
-#     await _remove_single_service_if_orphan(
-#         app=mock.AsyncMock(),
-#         dynamic_service={
-#             "service_host": "host",
-#             "service_uuid": faker.uuid4(),
-#             "user_id": 1,
-#             "project_id": faker.uuid4(),
-#         },
-#         currently_opened_projects_node_ids={},
-#     )
+@pytest.mark.parametrize("node_exists", [True], indirect=True)
+@pytest.mark.parametrize(
+    "get_user_role_error", [UserNotFoundError, ValueError], ids=str
+)
+async def test_remove_orphaned_services_inexisting_user_does_not_save_state(
+    mock_app: mock.AsyncMock,
+    mock_registry: mock.AsyncMock,
+    mock_list_node_ids_in_project: mock.AsyncMock,
+    mock_is_node_id_present_in_any_project_workbench: mock.AsyncMock,
+    mock_list_dynamic_services: mock.AsyncMock,
+    mock_stop_dynamic_service: mock.AsyncMock,
+    mock_has_write_permission: mock.AsyncMock,
+    mock_get_user_role: mock.AsyncMock,
+    faker_dynamic_service_get: Callable[[], DynamicServiceGet],
+    project_id: ProjectID,
+    get_user_role_error: Exception,
+):
+    mock_get_user_role.side_effect = get_user_role_error
+    fake_running_service = faker_dynamic_service_get()
+    mock_list_dynamic_services.return_value = [fake_running_service]
+    await remove_orphaned_services(mock_registry, mock_app)
+    mock_list_dynamic_services.assert_called_once()
+    mock_is_node_id_present_in_any_project_workbench.assert_called_once_with(
+        mock.ANY, fake_running_service.node_uuid
+    )
+    mock_list_node_ids_in_project.assert_called_once_with(mock.ANY, project_id)
+    mock_get_user_role.assert_called_once_with(mock_app, fake_running_service.user_id)
+    mock_has_write_permission.assert_not_called()
+    mock_stop_dynamic_service.assert_called_once_with(
+        mock_app,
+        node_id=fake_running_service.node_uuid,
+        simcore_user_agent=mock.ANY,
+        save_state=False,
+    )

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -37,12 +37,8 @@ def mock_list_node_ids_in_project(
 ) -> mock.AsyncMock:
     return mocker.patch(
         f"{MODULE_GC_CORE_ORPHANS}.list_node_ids_in_project",
-        return_value={
-            faker.uuid4(cast_to=None),
-            faker.uuid4(cast_to=None),
-            faker.uuid4(cast_to=None),
-        },
         autospec=True,
+        return_value=set(),
     )
 
 
@@ -55,7 +51,7 @@ async def mock_list_dynamic_services(mocker: MockerFixture) -> mock.AsyncMock:
     )
 
 
-async def test_remove_orphaned_services(
+async def test_remove_orphaned_services_with_no_running_services_does_nothing(
     mock_list_node_ids_in_project: mock.AsyncMock,
     mock_list_dynamic_services: mock.AsyncMock,
     mock_registry: mock.AsyncMock,

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -1,11 +1,12 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 
-from typing import Final
+from typing import Callable, Final
 from unittest import mock
 
 import pytest
 from faker import Faker
+from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from pytest_mock import MockerFixture
 from simcore_service_webserver.garbage_collector._core_orphans import (
     remove_orphaned_services,
@@ -62,13 +63,19 @@ async def test_remove_orphaned_services_with_no_running_services_does_nothing(
     mock_list_node_ids_in_project.assert_not_called()
 
 
+@pytest.fixture
+def faker_dynamic_service_get(faker: Faker) -> Callable[[], DynamicServiceGet]:
+    return DynamicServiceGet(host=faker.url())
+
+
 async def test_removed_orphaned_service_of_invalid_service_does_not_hang_or_block_gc(
     mock_list_node_ids_in_project: mock.AsyncMock,
     mock_list_dynamic_services: mock.AsyncMock,
     mock_registry: mock.AsyncMock,
     mock_app: mock.AsyncMock,
+    faker_dynamic_service_get,
 ):
-    mock_list_dynamic_services.return_value = []
+    mock_list_dynamic_services.return_value = [DynamicServiceGet()]
     await remove_orphaned_services(mock_registry, mock_app)
 
 

--- a/services/web/server/tests/unit/with_dbs/02/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/02/conftest.py
@@ -3,7 +3,6 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
-import asyncio
 import contextlib
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable
@@ -224,9 +223,7 @@ def fake_services(
     create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]]
 ) -> Callable[..., Awaitable[list[DynamicServiceGet]]]:
     async def create_fakes(number_services: int) -> list[DynamicServiceGet]:
-        return await asyncio.gather(
-            *(create_dynamic_service_mock() for _ in range(number_services))
-        )
+        return [await create_dynamic_service_mock() for _ in range(number_services)]
 
     return create_fakes
 

--- a/services/web/server/tests/unit/with_dbs/02/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/02/conftest.py
@@ -3,6 +3,7 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
+import asyncio
 import contextlib
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable
@@ -17,6 +18,7 @@ import pytest
 from aiohttp.test_utils import TestClient
 from aioresponses import aioresponses
 from faker import Faker
+from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.projects_nodes import Node, NodeID
 from models_library.projects_state import ProjectState
 from models_library.services_resources import (
@@ -218,9 +220,13 @@ async def create_template_project(
 
 
 @pytest.fixture
-def fake_services():
-    def create_fakes(number_services: int) -> list[dict]:
-        return [{"service_uuid": f"{i}_uuid"} for i in range(number_services)]
+def fake_services(
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]]
+) -> Callable[..., Awaitable[list[DynamicServiceGet]]]:
+    async def create_fakes(number_services: int) -> list[DynamicServiceGet]:
+        return await asyncio.gather(
+            *(create_dynamic_service_mock() for _ in range(number_services))
+        )
 
     return create_fakes
 

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
@@ -6,6 +6,7 @@
 
 from collections.abc import Callable, Iterator
 from http import HTTPStatus
+from typing import Awaitable
 from unittest import mock
 from unittest.mock import MagicMock, call
 
@@ -17,7 +18,6 @@ from faker import Faker
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.projects import ProjectID
 from models_library.projects_state import ProjectStatus
-from models_library.users import UserID
 from pytest_simcore.helpers.utils_assert import assert_status
 from pytest_simcore.helpers.utils_login import UserInfoDict
 from pytest_simcore.helpers.utils_webserver_unit_with_db import (
@@ -58,14 +58,14 @@ async def test_delete_project(
     storage_subsystem_mock: MockedStorageSubsystem,
     mocked_director_v2_api: dict[str, MagicMock],
     catalog_subsystem_mock: Callable[[list[ProjectDict]], None],
-    fake_services: Callable,
+    fake_services: Callable[..., Awaitable[list[DynamicServiceGet]]],
     assert_get_same_project_caller: Callable,
     mock_dynamic_scheduler_rabbitmq: None,
 ):
     assert client.app
 
     # DELETE /v0/projects/{project_id}
-    fakes = fake_services(5)
+    fakes = await fake_services(5)
     mocked_director_v2_api[
         "dynamic_scheduler.api.list_dynamic_services"
     ].return_value = fakes
@@ -91,7 +91,7 @@ async def test_delete_project(
         expected_calls = [
             call(
                 app=client.app,
-                node_id=service["service_uuid"],
+                node_id=service.node_uuid,
                 simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
                 save_state=True,
                 progress=mock.ANY,
@@ -132,7 +132,7 @@ async def test_delete_multiple_opened_project_forbidden(
     logged_user: UserInfoDict,
     user_project: ProjectDict,
     mocked_director_v2_api,
-    create_dynamic_service_mock: Callable[[UserID, ProjectID], DynamicServiceGet],
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
     socketio_client_factory: Callable,
     client_session_id_factory: Callable,
     user_role: UserRole,
@@ -143,7 +143,9 @@ async def test_delete_multiple_opened_project_forbidden(
     assert client.app
 
     # service in project
-    await create_dynamic_service_mock(logged_user["id"], user_project["uuid"])
+    await create_dynamic_service_mock(
+        user_id=logged_user["id"], project_id=user_project["uuid"]
+    )
     # open project in tab1
     client_session_id1 = client_session_id_factory()
     try:

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
@@ -14,8 +14,10 @@ import redis.asyncio as aioredis
 import sqlalchemy as sa
 from aiohttp.test_utils import TestClient
 from faker import Faker
+from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.projects import ProjectID
 from models_library.projects_state import ProjectStatus
+from models_library.users import UserID
 from pytest_simcore.helpers.utils_assert import assert_status
 from pytest_simcore.helpers.utils_login import UserInfoDict
 from pytest_simcore.helpers.utils_webserver_unit_with_db import (
@@ -130,7 +132,7 @@ async def test_delete_multiple_opened_project_forbidden(
     logged_user: UserInfoDict,
     user_project: ProjectDict,
     mocked_director_v2_api,
-    create_dynamic_service_mock,
+    create_dynamic_service_mock: Callable[[UserID, ProjectID], DynamicServiceGet],
     socketio_client_factory: Callable,
     client_session_id_factory: Callable,
     user_role: UserRole,

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
@@ -20,6 +20,7 @@ import sqlalchemy as sa
 from aiohttp import ClientResponse
 from aiohttp.test_utils import TestClient, TestServer
 from faker import Faker
+from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
     RPCDynamicServiceCreate,
 )
@@ -761,12 +762,12 @@ async def test_close_project(
     expected,
     mocked_director_v2_api: dict[str, mock.Mock],
     mock_catalog_api: dict[str, mock.Mock],
-    fake_services,
+    fake_services: Callable[..., Awaitable[list[DynamicServiceGet]]],
     mock_dynamic_scheduler_rabbitmq: None,
     mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # POST /v0/projects/{project_id}:close
-    fake_dynamic_services = fake_services(number_services=5)
+    fake_dynamic_services = await fake_services(number_services=5)
     assert len(fake_dynamic_services) == 5
     mocked_director_v2_api[
         "dynamic_scheduler.api.list_dynamic_services"
@@ -815,7 +816,7 @@ async def test_close_project(
         calls = [
             call(
                 app=client.app,
-                node_id=service["service_uuid"],
+                node_id=service.node_uuid,
                 simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
                 save_state=True,
                 progress=mock.ANY,

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
@@ -34,6 +34,7 @@ from models_library.projects_state import (
     ProjectStatus,
     RunningState,
 )
+from models_library.services_enums import ServiceState
 from models_library.services_resources import (
     ServiceResourcesDict,
     ServiceResourcesDictHelpers,
@@ -611,6 +612,8 @@ async def test_open_project_with_large_amount_of_dynamic_services_does_not_start
     mock_catalog_api: dict[str, mock.Mock],
     max_amount_of_auto_started_dyn_services: int,
     mocked_notifications_plugin: dict[str, mock.Mock],
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
+    faker: Faker,
 ):
     assert client.app
 
@@ -618,21 +621,29 @@ async def test_open_project_with_large_amount_of_dynamic_services_does_not_start
         max_amount_of_auto_started_dyn_services + 1
     )
     all_service_uuids = list(project["workbench"])
-    for num_service_already_running in range(max_amount_of_auto_started_dyn_services):
-        mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
-            {"service_uuid": all_service_uuids[service_id]}
-            for service_id in range(num_service_already_running)
-        ]
-        url = client.app.router["open_project"].url_for(project_id=project["uuid"])
-        resp = await client.post(f"{url}", json=client_session_id_factory())
-        await assert_status(resp, expected.ok)
-        mocked_notifications_plugin["subscribe"].assert_called_once_with(
-            client.app, ProjectID(project["uuid"])
+    num_service_already_running = faker.pyint(
+        min_value=0, max_value=max_amount_of_auto_started_dyn_services
+    )
+    assert num_service_already_running <= max_amount_of_auto_started_dyn_services
+    _ = [
+        await create_dynamic_service_mock(
+            user_id=logged_user["id"],
+            project_id=project["uuid"],
+            service_uuid=all_service_uuids[service_id],
         )
-        mocked_notifications_plugin["subscribe"].reset_mock()
-        mocked_director_v2_api[
-            "dynamic_scheduler.api.run_dynamic_service"
-        ].assert_not_called()
+        for service_id in range(num_service_already_running)
+    ]
+
+    url = client.app.router["open_project"].url_for(project_id=project["uuid"])
+    resp = await client.post(f"{url}", json=client_session_id_factory())
+    await assert_status(resp, expected.ok)
+    mocked_notifications_plugin["subscribe"].assert_called_once_with(
+        client.app, ProjectID(project["uuid"])
+    )
+    mocked_notifications_plugin["subscribe"].reset_mock()
+    mocked_director_v2_api[
+        "dynamic_scheduler.api.run_dynamic_service"
+    ].assert_not_called()
 
 
 @pytest.mark.parametrize(*standard_user_role())
@@ -649,6 +660,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_starts_them_if
     max_amount_of_auto_started_dyn_services: int,
     faker: Faker,
     mocked_notifications_plugin: dict[str, mock.Mock],
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
 ):
     assert client.app
     assert max_amount_of_auto_started_dyn_services == 0, "setting not disabled!"
@@ -659,21 +671,27 @@ async def test_open_project_with_large_amount_of_dynamic_services_starts_them_if
     num_of_dyn_services = 7
     project = await user_project_with_num_dynamic_services(num_of_dyn_services + 1)
     all_service_uuids = list(project["workbench"])
-    for num_service_already_running in range(num_of_dyn_services):
-        mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
-            {"service_uuid": all_service_uuids[service_id]}
-            for service_id in range(num_service_already_running)
-        ]
-        url = client.app.router["open_project"].url_for(project_id=project["uuid"])
-        resp = await client.post(f"{url}", json=client_session_id_factory())
-        await assert_status(resp, expected.ok)
-        mocked_notifications_plugin["subscribe"].assert_called_once_with(
-            client.app, ProjectID(project["uuid"])
+    num_service_already_running = faker.pyint(
+        min_value=0, max_value=num_of_dyn_services
+    )
+    assert num_service_already_running <= num_of_dyn_services
+    _ = [
+        await create_dynamic_service_mock(
+            user_id=logged_user["id"],
+            project_id=project["uuid"],
+            service_uuid=all_service_uuids[service_id],
         )
-        mocked_notifications_plugin["subscribe"].reset_mock()
-        mocked_director_v2_api[
-            "dynamic_scheduler.api.run_dynamic_service"
-        ].assert_called()
+        for service_id in range(num_service_already_running)
+    ]
+
+    url = client.app.router["open_project"].url_for(project_id=project["uuid"])
+    resp = await client.post(f"{url}", json=client_session_id_factory())
+    await assert_status(resp, expected.ok)
+    mocked_notifications_plugin["subscribe"].assert_called_once_with(
+        client.app, ProjectID(project["uuid"])
+    )
+    mocked_notifications_plugin["subscribe"].reset_mock()
+    mocked_director_v2_api["dynamic_scheduler.api.run_dynamic_service"].assert_called()
 
 
 @pytest.mark.parametrize(*standard_user_role())
@@ -952,6 +970,7 @@ async def test_project_node_lifetime(  # noqa: PLR0915
     mock_catalog_api: dict[str, mock.Mock],
     mocker,
     faker: Faker,
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
 ):
     mock_storage_api_delete_data_folders_of_project_node = mocker.patch(
         "simcore_service_webserver.projects._crud_handlers.projects_api.storage_api.delete_data_folders_of_project_node",
@@ -964,13 +983,13 @@ async def test_project_node_lifetime(  # noqa: PLR0915
     body = {"service_key": "simcore/services/dynamic/key", "service_version": "1.3.4"}
     resp = await client.post(url.path, json=body)
     data, errors = await assert_status(resp, expected_response_on_create)
-    node_id = None
+    dynamic_node_id = None
     if resp.status == status.HTTP_201_CREATED:
         mocked_director_v2_api[
             "dynamic_scheduler.api.run_dynamic_service"
         ].assert_called_once()
         assert "node_id" in data
-        node_id = data["node_id"]
+        dynamic_node_id = data["node_id"]
     else:
         mocked_director_v2_api[
             "dynamic_scheduler.api.run_dynamic_service"
@@ -985,24 +1004,28 @@ async def test_project_node_lifetime(  # noqa: PLR0915
     }
     resp = await client.post(f"{url}", json=body)
     data, errors = await assert_status(resp, expected_response_on_create)
-    node_id_2 = None
+    computational_node_id = None
     if resp.status == status.HTTP_201_CREATED:
         mocked_director_v2_api[
             "dynamic_scheduler.api.run_dynamic_service"
         ].assert_not_called()
         assert "node_id" in data
-        node_id_2 = data["node_id"]
+        computational_node_id = data["node_id"]
     else:
         mocked_director_v2_api[
             "dynamic_scheduler.api.run_dynamic_service"
         ].assert_not_called()
 
     # get the node state
-    mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
-        {"service_uuid": node_id, "service_state": "running"}
-    ]
+    _created_dynamic_service_mock = await create_dynamic_service_mock(
+        user_id=logged_user["id"],
+        project_id=user_project["uuid"],
+        service_uuid=dynamic_node_id,
+        service_state=ServiceState.RUNNING,
+    )
+    assert dynamic_node_id
     url = client.app.router["get_node"].url_for(
-        project_id=user_project["uuid"], node_id=node_id
+        project_id=user_project["uuid"], node_id=dynamic_node_id
     )
 
     node_sample = deepcopy(NodeGet.Config.schema_extra["example"])
@@ -1021,10 +1044,9 @@ async def test_project_node_lifetime(  # noqa: PLR0915
         assert data["service_state"] == "running"
 
     # get the NOT dynamic node state
-    mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = []
-
+    assert computational_node_id
     url = client.app.router["get_node"].url_for(
-        project_id=user_project["uuid"], node_id=node_id_2
+        project_id=user_project["uuid"], node_id=computational_node_id
     )
     mocked_director_v2_api[
         "dynamic_scheduler.api.get_dynamic_service"
@@ -1041,14 +1063,12 @@ async def test_project_node_lifetime(  # noqa: PLR0915
         assert data["service_state"] == "idle"
 
     # delete the node
-    mocked_director_v2_api["director_v2.api.list_dynamic_services"].return_value = [
-        {**node_sample, "service_uuid": node_id}
-    ]
     url = client.app.router["delete_node"].url_for(
-        project_id=user_project["uuid"], node_id=node_id
+        project_id=user_project["uuid"], node_id=dynamic_node_id
     )
     resp = await client.delete(f"{url}")
     data, errors = await assert_status(resp, expected_response_on_delete)
+    await asyncio.sleep(5)
     if resp.status == status.HTTP_204_NO_CONTENT:
         mocked_director_v2_api[
             "dynamic_scheduler.api.stop_dynamic_service"
@@ -1065,7 +1085,7 @@ async def test_project_node_lifetime(  # noqa: PLR0915
     mock_storage_api_delete_data_folders_of_project_node.reset_mock()
     # mock_director_api_get_running_services.return_value.set_result([{"service_uuid": node_id}])
     url = client.app.router["delete_node"].url_for(
-        project_id=user_project["uuid"], node_id=node_id_2
+        project_id=user_project["uuid"], node_id=computational_node_id
     )
     resp = await client.delete(f"{url}")
     data, errors = await assert_status(resp, expected_response_on_delete)

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
@@ -249,6 +249,7 @@ async def _delete_project(client: TestClient, project: dict) -> ClientResponse:
         {"read": True, "write": False, "delete": False},
         {"read": False, "write": False, "delete": False},
     ],
+    ids=str,
 )
 async def test_share_project(
     client: TestClient,
@@ -1083,7 +1084,6 @@ async def test_project_node_lifetime(  # noqa: PLR0915
     # delete the NOT dynamic node
     mocked_director_v2_api["dynamic_scheduler.api.stop_dynamic_service"].reset_mock()
     mock_storage_api_delete_data_folders_of_project_node.reset_mock()
-    # mock_director_api_get_running_services.return_value.set_result([{"service_uuid": node_id}])
     url = client.app.router["delete_node"].url_for(
         project_id=user_project["uuid"], node_id=computational_node_id
     )

--- a/services/web/server/tests/unit/with_dbs/03/garbage_collector/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/03/garbage_collector/test_resource_manager.py
@@ -20,8 +20,6 @@ import sqlalchemy as sa
 from aiohttp.test_utils import TestClient
 from aioresponses import aioresponses
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
-from models_library.projects import ProjectID
-from models_library.users import UserID
 from models_library.utils.fastapi_encoders import jsonable_encoder
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.utils_assert import assert_status
@@ -478,7 +476,7 @@ async def test_interactive_services_removed_after_logout(
     logged_user: dict[str, Any],
     empty_user_project: dict[str, Any],
     mocked_director_v2_api: dict[str, mock.MagicMock],
-    create_dynamic_service_mock: Callable[[UserID, ProjectID], DynamicServiceGet],
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
     client_session_id_factory: Callable[[], str],
     socketio_client_factory: Callable,
     storage_subsystem_mock: MockedStorageSubsystem,  # when guest user logs out garbage is collected
@@ -489,11 +487,8 @@ async def test_interactive_services_removed_after_logout(
 ):
     assert client.app
 
-    # login - logged_user fixture
-    # create empty study - empty_user_project fixture
-    # create dynamic service - create_dynamic_service_mock fixture
     service = await create_dynamic_service_mock(
-        logged_user["id"], empty_user_project["uuid"]
+        user_id=logged_user["id"], project_id=empty_user_project["uuid"]
     )
     # create websocket
     client_session_id1 = client_session_id_factory()
@@ -543,7 +538,7 @@ async def test_interactive_services_remain_after_websocket_reconnection_from_2_t
     logged_user: UserInfoDict,
     empty_user_project,
     mocked_director_v2_api,
-    create_dynamic_service_mock: Callable[[UserID, ProjectID], DynamicServiceGet],
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
     socketio_client_factory: Callable,
     client_session_id_factory: Callable[[], str],
     storage_subsystem_mock,  # when guest user logs out garbage is collected
@@ -554,11 +549,8 @@ async def test_interactive_services_remain_after_websocket_reconnection_from_2_t
 ):
     assert client.app
 
-    # login - logged_user fixture
-    # create empty study - empty_user_project fixture
-    # create dynamic service - create_dynamic_service_mock fixture
     service = await create_dynamic_service_mock(
-        logged_user["id"], empty_user_project["uuid"]
+        user_id=logged_user["id"], project_id=empty_user_project["uuid"]
     )
     # create first websocket
     client_session_id1 = client_session_id_factory()
@@ -680,7 +672,7 @@ async def test_interactive_services_removed_per_project(
     empty_user_project,
     empty_user_project2,
     mocked_director_v2_api,
-    create_dynamic_service_mock: Callable[[UserID, ProjectID], DynamicServiceGet],
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
     mocked_notification_system,
     socketio_client_factory: Callable,
     client_session_id_factory: Callable[[], str],
@@ -691,20 +683,14 @@ async def test_interactive_services_removed_per_project(
     mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # create server with delay set to DELAY
-    # login - logged_user fixture
-    # create empty study1 in project1 - empty_user_project fixture
-    # create empty study2 in project2- empty_user_project2 fixture
-    # service1 in project1 = await create_dynamic_service_mock(logged_user["id"], empty_user_project["uuid"])
-    # service2 in project2 = await create_dynamic_service_mock(logged_user["id"], empty_user_project["uuid"])
-    # service3 in project2 = await create_dynamic_service_mock(logged_user["id"], empty_user_project["uuid"])
     service1 = await create_dynamic_service_mock(
-        logged_user["id"], empty_user_project["uuid"]
+        user_id=logged_user["id"], project_id=empty_user_project["uuid"]
     )
     service2 = await create_dynamic_service_mock(
-        logged_user["id"], empty_user_project2["uuid"]
+        user_id=logged_user["id"], project_id=empty_user_project2["uuid"]
     )
     service3 = await create_dynamic_service_mock(
-        logged_user["id"], empty_user_project2["uuid"]
+        user_id=logged_user["id"], project_id=empty_user_project2["uuid"]
     )
     # create websocket1 from tab1
     client_session_id1 = client_session_id_factory()
@@ -790,18 +776,15 @@ async def test_services_remain_after_closing_one_out_of_two_tabs(
     empty_user_project,
     empty_user_project2,
     mocked_director_v2_api,
-    create_dynamic_service_mock: Callable[[UserID, ProjectID], DynamicServiceGet],
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
     socketio_client_factory: Callable,
     client_session_id_factory: Callable[[], str],
     expected_save_state: bool,
     open_project: Callable,
 ):
     # create server with delay set to DELAY
-    # login - logged_user fixture
-    # create empty study in project - empty_user_project fixture
-    # service in project = await create_dynamic_service_mock(logged_user["id"], empty_user_project["uuid"])
     service = await create_dynamic_service_mock(
-        logged_user["id"], empty_user_project["uuid"]
+        user_id=logged_user["id"], project_id=empty_user_project["uuid"]
     )
     # open project in tab1
     client_session_id1 = client_session_id_factory()
@@ -847,7 +830,7 @@ async def test_websocket_disconnected_remove_or_maintain_files_based_on_role(
     logged_user,
     empty_user_project,
     mocked_director_v2_api,
-    create_dynamic_service_mock: Callable[[UserID, ProjectID], DynamicServiceGet],
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
     client_session_id_factory: Callable[[], str],
     socketio_client_factory: Callable,
     # asyncpg_storage_system_mock,
@@ -857,11 +840,8 @@ async def test_websocket_disconnected_remove_or_maintain_files_based_on_role(
     open_project: Callable,
     mocked_notifications_plugin: dict[str, mock.Mock],
 ):
-    # login - logged_user fixture
-    # create empty study - empty_user_project fixture
-    # create dynamic service - create_dynamic_service_mock fixture
     service = await create_dynamic_service_mock(
-        logged_user["id"], empty_user_project["uuid"]
+        user_id=logged_user["id"], project_id=empty_user_project["uuid"]
     )
     # create websocket
     client_session_id1 = client_session_id_factory()

--- a/services/web/server/tests/unit/with_dbs/03/tags/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/03/tags/conftest.py
@@ -142,14 +142,6 @@ async def template_project(
 
 
 @pytest.fixture
-def fake_services():
-    def create_fakes(number_services: int) -> list[dict]:
-        return [{"service_uuid": f"{i}_uuid"} for i in range(number_services)]
-
-    return create_fakes
-
-
-@pytest.fixture
 async def project_db_cleaner(client):
     yield
     await delete_all_projects(client.app)

--- a/services/web/server/tests/unit/with_dbs/03/test_project_db.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_project_db.py
@@ -681,11 +681,11 @@ async def test_node_id_exists(
     )
 
     node_id_exists = await db_api.node_id_exists(
-        f"{not_existing_node_id_in_existing_project}"
+        not_existing_node_id_in_existing_project
     )
     assert node_id_exists is False
     existing_node_id = choice(some_projects_and_nodes[existing_project_id])
-    node_id_exists = await db_api.node_id_exists(f"{existing_node_id}")
+    node_id_exists = await db_api.node_id_exists(existing_node_id)
     assert node_id_exists is True
 
 
@@ -706,7 +706,7 @@ async def test_get_node_ids_from_project(
     for project_id, node_ids_inside_project in zip(
         some_projects_and_nodes, node_ids_inside_project_list, strict=True
     ):
-        assert node_ids_inside_project == some_projects_and_nodes[project_id]
+        assert node_ids_inside_project == set(some_projects_and_nodes[project_id])
 
 
 @pytest.mark.parametrize(

--- a/services/web/server/tests/unit/with_dbs/03/test_project_db.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_project_db.py
@@ -698,7 +698,7 @@ async def test_get_node_ids_from_project(
 ):
     node_ids_inside_project_list = await asyncio.gather(
         *(
-            db_api.list_node_ids_in_project(f"{project_id}")
+            db_api.list_node_ids_in_project(project_id)
             for project_id in some_projects_and_nodes
         )
     )
@@ -706,9 +706,7 @@ async def test_get_node_ids_from_project(
     for project_id, node_ids_inside_project in zip(
         some_projects_and_nodes, node_ids_inside_project_list, strict=True
     ):
-        assert node_ids_inside_project == {
-            f"{n}" for n in some_projects_and_nodes[project_id]
-        }
+        assert node_ids_inside_project == some_projects_and_nodes[project_id]
 
 
 @pytest.mark.parametrize(

--- a/services/web/server/tests/unit/with_dbs/03/version_control/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/03/version_control/conftest.py
@@ -184,7 +184,7 @@ def request_update_project(
     )
     mocker.patch(
         "simcore_service_webserver.director_v2.api.list_dynamic_services",
-        return_value={},
+        return_value=[],
     )
 
     async def _go(client: TestClient, project_uuid: UUID) -> None:

--- a/services/web/server/tests/unit/with_dbs/03/wallets/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/03/wallets/conftest.py
@@ -111,14 +111,6 @@ async def template_project(
 
 
 @pytest.fixture
-def fake_services():
-    def create_fakes(number_services: int) -> list[dict]:
-        return [{"service_uuid": f"{i}_uuid"} for i in range(number_services)]
-
-    return create_fakes
-
-
-@pytest.fixture
 async def project_db_cleaner(client):
     yield
     await delete_all_projects(client.app)

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -389,7 +389,7 @@ async def mocked_director_v2_api(mocker: MockerFixture) -> dict[str, MagicMock]:
         mock[name] = mocker.patch(
             f"simcore_service_webserver.{name}",
             autospec=True,
-            return_value={},
+            return_value=[],
         )
     # add here redirects from director-v2 via dynamic-scheduler
     # NOTE: once all above are moved to dynamic-scheduler

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -427,14 +427,13 @@ def create_dynamic_service_mock(
     services = []
 
     async def _create(**service_override_kwargs) -> DynamicServiceGet:
-        SERVICE_UUID = faker.uuid4(cast_to=None)
         SERVICE_KEY = "simcore/services/dynamic/3d-viewer"
         SERVICE_VERSION = "1.4.2"
         assert client.app
 
         service_config = {
             "published_port": faker.pyint(min_value=3000, max_value=60000),
-            "service_uuid": SERVICE_UUID,
+            "service_uuid": faker.uuid4(cast_to=None),
             "service_key": SERVICE_KEY,
             "service_version": SERVICE_VERSION,
             "service_host": faker.url(),

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -15,10 +15,10 @@ import asyncio
 import random
 import sys
 import textwrap
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Awaitable, Final
+from typing import Any, Final
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
@@ -37,9 +37,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from faker import Faker
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.products import ProductName
-from models_library.projects import ProjectID
 from models_library.services_enums import ServiceState
-from models_library.users import UserID
 from pydantic import ByteSize, parse_obj_as
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -442,6 +442,8 @@ def create_dynamic_service_mock(
                 "service_host": faker.url(),
                 "service_port": faker.pyint(min_value=3000, max_value=60000),
                 "service_state": random.choice(ServiceState),
+                "user_id": user_id,
+                "project_id": project_id,
             }
         )
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
One fundamental flaw in the GC was that the order of checking for orphaned services might lead to a wrong closing of these services:
1. Lookup of theoretical services running
2. Lookup of actual services running

That means that if any new project is started between 1 and 2, then the services found in 2 might not be in the previous call to 1. --> the GC then kills these services.
This could be identified by setting the GC Interval to 1 second locally.

This PR inverts this and also refactors slightly this part of the code.
Also the testing was improved hopefully.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
