### PR TITLE
🐛 Frontend Fix: Make sure SelectBox's selection is not null

### DIFF
--- a/services/static-webserver/client/source/class/osparc/cluster/ClustersDetails.js
+++ b/services/static-webserver/client/source/class/osparc/cluster/ClustersDetails.js
@@ -50,8 +50,11 @@ qx.Class.define("osparc.cluster.ClustersDetails", {
       });
       osparc.cluster.Utils.populateClustersSelectBox(selectBox);
       selectBox.addListener("changeSelection", e => {
-        const clusterId = e.getData()[0].id;
-        this.__selectedClusterChanged(clusterId);
+        const selection = e.getData();
+        if (selection.length) {
+          const clusterId = [0].id;
+          this.__selectedClusterChanged(clusterId);
+        }
       }, this);
       clustersLayout.add(selectBox);
 

--- a/services/static-webserver/client/source/class/osparc/cluster/ClustersDetails.js
+++ b/services/static-webserver/client/source/class/osparc/cluster/ClustersDetails.js
@@ -52,7 +52,7 @@ qx.Class.define("osparc.cluster.ClustersDetails", {
       selectBox.addListener("changeSelection", e => {
         const selection = e.getData();
         if (selection.length) {
-          const clusterId = [0].id;
+          const clusterId = selection[0].id;
           this.__selectedClusterChanged(clusterId);
         }
       }, this);

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -245,9 +245,9 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
           });
 
           // then listen to changes
-          versionsBox.addListener("changeSelection", () => {
-            const selection = versionsBox.getSelection();
-            if (selection && selection.length) {
+          versionsBox.addListener("changeSelection", e => {
+            const selection = e.getData();
+            if (selection.length) {
               const serviceVersion = selection[0].getLabel();
               if (serviceVersion !== this.__resourceData["version"]) {
                 const serviceData = osparc.service.Utils.getFromObject(services, this.__resourceData["key"], serviceVersion);

--- a/services/static-webserver/client/source/class/osparc/desktop/credits/Usage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/Usage.js
@@ -84,8 +84,9 @@ qx.Class.define("osparc.desktop.credits.Usage", {
       this._add(container);
 
       walletSelectBox.addListener("changeSelection", e => {
-        if (walletSelectBox.getSelection().length) {
-          this.__selectedWallet = walletSelectBox.getSelection()[0].getModel()
+        const selection = e.getData();
+        if (selection.length) {
+          this.__selectedWallet = selection[0].getModel()
           if (this.__table) {
             this.__table.getTableModel().setWalletId(this.__selectedWallet.getWalletId())
             this.__table.getTableModel().reloadData()

--- a/services/static-webserver/client/source/class/osparc/desktop/organizations/OrganizationsList.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/organizations/OrganizationsList.js
@@ -168,7 +168,7 @@ qx.Class.define("osparc.desktop.organizations.OrganizationsList", {
     },
 
     __organizationSelected: function(data) {
-      if (data && data.length>0) {
+      if (data && data.length) {
         const org = data[0];
         this.fireDataEvent("organizationSelected", org.getModel());
       }

--- a/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/ClustersPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/ClustersPage.js
@@ -218,7 +218,7 @@ qx.Class.define("osparc.desktop.preferences.pages.ClustersPage", {
 
     __clusterSelected: function(data) {
       this.__selectOrgMemberLayout.exclude();
-      if (data && data.length>0) {
+      if (data && data.length) {
         this.__currentCluster = data[0];
       } else {
         this.__currentCluster = null;

--- a/services/static-webserver/client/source/class/osparc/metadata/QualityEditor.js
+++ b/services/static-webserver/client/source/class/osparc/metadata/QualityEditor.js
@@ -354,11 +354,14 @@ qx.Class.define("osparc.metadata.QualityEditor", {
             }
           });
           targetsBox.addListener("changeSelection", e => {
-            const newMaxScore = e.getData()[0].level;
-            copyTSRTarget[ruleKey].level = newMaxScore;
-            copyTSRCurrent[ruleKey].level = Math.min(newMaxScore, copyTSRCurrent[ruleKey].level);
-            updateCurrentLevel(copyTSRCurrent[ruleKey].level);
-            updateTotalTSR();
+            const selection = e.getData();
+            if (selection.length) {
+              const newMaxScore = selection[0].level;
+              copyTSRTarget[ruleKey].level = newMaxScore;
+              copyTSRCurrent[ruleKey].level = Math.min(newMaxScore, copyTSRCurrent[ruleKey].level);
+              updateCurrentLevel(copyTSRCurrent[ruleKey].level);
+              updateTotalTSR();
+            }
           }, this);
           this.bind("mode", targetsBox, "visibility", {
             converter: mode => mode === "edit" ? "visible" : "excluded"

--- a/services/static-webserver/client/source/class/osparc/metadata/ServicesInStudyBootOpts.js
+++ b/services/static-webserver/client/source/class/osparc/metadata/ServicesInStudyBootOpts.js
@@ -85,8 +85,11 @@ qx.Class.define("osparc.metadata.ServicesInStudyBootOpts", {
         if (canIWrite && hasBootModes) {
           const bootModeSB = osparc.data.model.Node.getBootModesSelectBox(nodeMetaData, workbench, nodeId);
           bootModeSB.addListener("changeSelection", e => {
-            const newBootModeId = e.getData()[0].bootModeId;
-            this.__updateBootMode(nodeId, newBootModeId);
+            const selection = e.getData();
+            if (selection.length) {
+              const newBootModeId = e.getData()[0].bootModeId;
+              this.__updateBootMode(nodeId, newBootModeId);
+            }
           }, this);
           this._servicesGrid.add(bootModeSB, {
             row: i,

--- a/services/static-webserver/client/source/class/osparc/node/BootOptionsView.js
+++ b/services/static-webserver/client/source/class/osparc/node/BootOptionsView.js
@@ -54,16 +54,19 @@ qx.Class.define("osparc.node.BootOptionsView", {
         converter: interactive => interactive === "idle"
       });
       bootModeSB.addListener("changeSelection", e => {
-        buttonsLayout.setEnabled(false);
-        const newBootModeId = e.getData()[0].bootModeId;
-        node.setBootOptions({
-          "boot_mode": newBootModeId
-        });
-        setTimeout(() => {
-          buttonsLayout.setEnabled(true);
-          node.requestStartNode();
-          this.fireEvent("bootModeChanged");
-        }, osparc.desktop.StudyEditor.AUTO_SAVE_INTERVAL*2);
+        const selection = e.getData();
+        if (selection.length) {
+          buttonsLayout.setEnabled(false);
+          const newBootModeId = selection[0].bootModeId;
+          node.setBootOptions({
+            "boot_mode": newBootModeId
+          });
+          setTimeout(() => {
+            buttonsLayout.setEnabled(true);
+            node.requestStartNode();
+            this.fireEvent("bootModeChanged");
+          }, osparc.desktop.StudyEditor.AUTO_SAVE_INTERVAL*2);
+        }
       }, this);
       buttonsLayout.add(bootModeSB);
 

--- a/services/static-webserver/client/source/class/osparc/po/MessageTemplates.js
+++ b/services/static-webserver/client/source/class/osparc/po/MessageTemplates.js
@@ -55,8 +55,11 @@ qx.Class.define("osparc.po.MessageTemplates", {
       });
 
       templatesSB.addListener("changeSelection", e => {
-        const templateId = e.getData()[0].getModel();
-        this.__populateMessage(templateId);
+        const selection = e.getData();
+        if (selection.length) {
+          const templateId = selection[0].getModel();
+          this.__populateMessage(templateId);
+        }
       }, this);
       this.__messageTemplates.forEach(template => {
         const lItem = new qx.ui.form.ListItem(template.id, null, template.id);

--- a/services/static-webserver/client/source/class/osparc/pricing/Plans.js
+++ b/services/static-webserver/client/source/class/osparc/pricing/Plans.js
@@ -58,8 +58,11 @@ qx.Class.define("osparc.pricing.Plans", {
             spacing: 3
           });
           control.addListener("changeSelection", e => {
-            const ppSelected = e.getData()[0];
-            this.fireDataEvent("pricingPlanSelected", ppSelected);
+            const selection = e.getData();
+            if (selection.length) {
+              const ppSelected = selection[0];
+              this.fireDataEvent("pricingPlanSelected", ppSelected);
+            }
           }, this);
           this.getChildControl("pricing-plans-container").add(control);
           break;

--- a/services/static-webserver/client/source/class/osparc/study/BillingSettings.js
+++ b/services/static-webserver/client/source/class/osparc/study/BillingSettings.js
@@ -78,30 +78,32 @@ qx.Class.define("osparc.study.BillingSettings", {
           .finally(() => {
             walletSelector.addListener("changeSelection", e => {
               const selection = e.getData();
-              const walletId = selection[0].walletId;
-              if (walletId === null) {
-                return;
-              }
-              hBox.setEnabled(false);
-              const paramsPut = {
-                url: {
-                  studyId: this.__studyData["uuid"],
-                  walletId
+              if (selection.length) {
+                const walletId = selection[0].walletId;
+                if (walletId === null) {
+                  return;
                 }
-              };
-              osparc.data.Resources.fetch("studies", "selectWallet", paramsPut)
-                .then(() => {
-                  const msg = this.tr("Credit Account saved");
-                  osparc.FlashMessenger.getInstance().logAs(msg, "INFO");
-                })
-                .catch(err => {
-                  console.error(err);
-                  osparc.FlashMessenger.logAs(err.message, "ERROR");
-                })
-                .finally(() => {
-                  hBox.setEnabled(true);
-                  populateCreditAccountBox();
-                });
+                hBox.setEnabled(false);
+                const paramsPut = {
+                  url: {
+                    studyId: this.__studyData["uuid"],
+                    walletId
+                  }
+                };
+                osparc.data.Resources.fetch("studies", "selectWallet", paramsPut)
+                  .then(() => {
+                    const msg = this.tr("Credit Account saved");
+                    osparc.FlashMessenger.getInstance().logAs(msg, "INFO");
+                  })
+                  .catch(err => {
+                    console.error(err);
+                    osparc.FlashMessenger.logAs(err.message, "ERROR");
+                  })
+                  .finally(() => {
+                    hBox.setEnabled(true);
+                    populateCreditAccountBox();
+                  });
+              }
             });
           });
       };

--- a/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
+++ b/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
@@ -236,7 +236,9 @@ qx.Class.define("osparc.study.StudyOptions", {
       };
       walletSelector.addListener("changeSelection", e => {
         const selection = e.getData();
-        selectWallet(selection[0].walletId);
+        if (selection.length) {
+          selectWallet(selection[0].walletId);
+        }
       });
       const preferredWallet = store.getPreferredWallet();
       if (wallets.find(wallet => wallet.getWalletId() === parseInt(this.__projectWalletId))) {


### PR DESCRIPTION
## What do these changes do?

Sometimes reproducible in Safari: it looks like, in this specific browser, when closing a window, the selection in the Select Boxes is reset.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
