### PR TITLE
🐛Fix ```up-devel``` Makefile target

### DIFF
--- a/services/docker-compose.devel.yml
+++ b/services/docker-compose.devel.yml
@@ -15,6 +15,7 @@ services:
     environment:
       <<: *common-environment
       API_SERVER_PROFILING : ${API_SERVER_PROFILING}
+      API_SERVER_LOGLEVEL: DEBUG
     volumes:
       - ./api-server:/devel/services/api-server
       - ../packages:/devel/packages
@@ -31,6 +32,7 @@ services:
   invitations:
     environment:
       <<: *common-environment
+      INVITATIONS_LOGLEVEL: DEBUG
     volumes:
       - ./invitations:/devel/services/invitations
       - ../packages:/devel/packages
@@ -38,6 +40,7 @@ services:
   payments:
     environment:
       <<: *common-environment
+      PAYMENTS_LOGLEVEL: DEBUG
     volumes:
       - ./payments:/devel/services/payments
       - ../packages:/devel/packages
@@ -46,6 +49,7 @@ services:
     environment:
       <<: *common-environment
       DYNAMIC_SCHEDULER_PROFILING : ${DYNAMIC_SCHEDULER_PROFILING}
+      DYNAMIC_SCHEDULER_LOGLEVEL: DEBUG
     volumes:
       - ./dynamic-scheduler:/devel/services/dynamic-scheduler
       - ../packages:/devel/packages
@@ -57,7 +61,7 @@ services:
       <<: *common-environment
       CATALOG_PROFILING : ${CATALOG_PROFILING}
       DYNAMIC_SIDECAR_MOUNT_PATH_DEV : ${PWD}/services/dynamic-sidecar
-
+      CATALOG_LOGLEVEL: DEBUG
     volumes:
       - ./catalog:/devel/services/catalog
       - ../packages:/devel/packages
@@ -65,6 +69,7 @@ services:
   clusters-keeper:
     environment:
       <<: *common-environment
+      CLUSTERS_KEEPER_LOGLEVEL: DEBUG
     volumes:
       - ./clusters-keeper:/devel/services/clusters-keeper
       - ../packages:/devel/packages
@@ -72,6 +77,7 @@ services:
   datcore-adapter:
     environment:
       <<: *common-environment
+      DATCORE_ADAPTER_LOGLEVEL: DEBUG
     volumes:
       - ./datcore-adapter:/devel/services/datcore-adapter
       - ../packages:/devel/packages
@@ -90,6 +96,7 @@ services:
       <<: *common-environment
       DIRECTOR_V2_PROFILING : ${DIRECTOR_V2_PROFILING}
       DYNAMIC_SIDECAR_MOUNT_PATH_DEV : ${PWD}/services/dynamic-sidecar
+      DIRECTOR_V2_LOGLEVEL: DEBUG
 
     volumes:
       - ./director-v2:/devel/services/director-v2
@@ -109,7 +116,7 @@ services:
     environment: &webserver_environment_devel
       <<: *common-environment
       DEBUG: 1 # NOTE: gunicorn expects an int not a boolean
-      WEBSERVER_LOGLEVEL: ${WEBSERVER_LOGLEVEL}
+      WEBSERVER_LOGLEVEL: DEBUG
       WEBSERVER_PROFILING: ${WEBSERVER_PROFILING}
       WEBSERVER_REMOTE_DEBUGGING_PORT: 3000
 
@@ -159,6 +166,7 @@ services:
   resource-usage-tracker:
     environment:
       <<: *common-environment
+      RESOURCE_USAGE_TRACKER_LOGLEVEL: DEBUG
     volumes:
       - ./resource-usage-tracker:/devel/services/resource-usage-tracker
       - ../packages:/devel/packages
@@ -170,11 +178,12 @@ services:
     environment:
       <<: *common-environment
       STORAGE_PROFILING : ${STORAGE_PROFILING}
+      STORAGE_LOGLEVEL: DEBUG
 
   agent:
     environment:
       <<: *common-environment
-
+      AGENT_LOGLEVEL: DEBUG
     volumes:
       - ./agent:/devel/services/agent
       - ../packages:/devel/packages

--- a/services/docker-compose.devel.yml
+++ b/services/docker-compose.devel.yml
@@ -108,6 +108,7 @@ services:
       - ../packages:/devel/packages
     environment: &webserver_environment_devel
       <<: *common-environment
+      DEBUG: 1 # NOTE: gunicorn expects an int not a boolean
       WEBSERVER_LOGLEVEL: ${WEBSERVER_LOGLEVEL}
       WEBSERVER_PROFILING: ${WEBSERVER_PROFILING}
       WEBSERVER_REMOTE_DEBUGGING_PORT: 3000
@@ -137,8 +138,7 @@ services:
       - ${ETC_HOSTNAME:-/etc/hostname}:/home/scu/hostname:ro
 
     environment:
-      LOGLEVEL: DEBUG
-      SC_BOOT_MODE: debug
+      <<: *common-environment
       SIDECAR_LOGLEVEL: DEBUG
     ports:
       - "3000"


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
PR [https://github.com/ITISFoundation/osparc-simcore/pull/5776](https://github.com/ITISFoundation/osparc-simcore/pull/5776) prevented ```make up-devel``` to be functional. This fixes that. The gunicorn is expecting a ```DEBUG``` env variable that is an integer and does not go well with booleans.

Also the log level in devel mode is set back to DEBUG level.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
