### PR TITLE
🐛 Avoid aioredis client form hanging on calls if redis is no longer available

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/container_pause.py
+++ b/packages/pytest-simcore/src/pytest_simcore/container_pause.py
@@ -1,0 +1,42 @@
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager
+
+import aiodocker
+import pytest
+
+
+@contextlib.asynccontextmanager
+async def _pause_container(
+    async_docker_client: aiodocker.Docker, container_name: str
+) -> AsyncIterator[None]:
+    containers = await async_docker_client.containers.list(
+        filters={"name": [f"{container_name}."]}
+    )
+    await asyncio.gather(*(c.pause() for c in containers))
+    # refresh
+    container_attrs = await asyncio.gather(*(c.show() for c in containers))
+    for container_status in container_attrs:
+        assert container_status["State"]["Status"] == "paused"
+
+    yield
+
+    await asyncio.gather(*(c.unpause() for c in containers))
+    # refresh
+    container_attrs = await asyncio.gather(*(c.show() for c in containers))
+    for container_status in container_attrs:
+        assert container_status["State"]["Status"] == "running"
+    # NOTE: container takes some time to start
+
+
+@pytest.fixture
+async def paused_container() -> Callable[[str], AbstractAsyncContextManager[None]]:
+    @contextlib.asynccontextmanager
+    async def _(container_name: str) -> AsyncIterator[None]:
+        async with aiodocker.Docker() as docker_client, _pause_container(
+            docker_client, container_name
+        ):
+            yield None
+
+    return _

--- a/packages/service-library/src/servicelib/redis.py
+++ b/packages/service-library/src/servicelib/redis.py
@@ -23,9 +23,10 @@ from .retry_policies import RedisRetryPolicyUponInitialization
 from .utils import logged_gather
 
 _DEFAULT_LOCK_TTL: Final[datetime.timedelta] = datetime.timedelta(seconds=10)
+_DEFAULT_SOCKET_TIMEOUT: Final[datetime.timedelta] = datetime.timedelta(seconds=5)
 
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class BaseRedisError(PydanticErrorMixin, RuntimeError):
@@ -59,16 +60,19 @@ class RedisClientSDK:
                 redis.exceptions.ConnectionError,
                 redis.exceptions.TimeoutError,
             ],
+            socket_timeout=_DEFAULT_SOCKET_TIMEOUT.total_seconds(),
+            socket_connect_timeout=_DEFAULT_SOCKET_TIMEOUT.total_seconds(),
+            retry_on_timeout=True,
             encoding="utf-8",
             decode_responses=True,
         )
 
-    @retry(**RedisRetryPolicyUponInitialization(logger).kwargs)
+    @retry(**RedisRetryPolicyUponInitialization(_logger).kwargs)
     async def setup(self) -> None:
         if not await self._client.ping():
             await self.shutdown()
             raise CouldNotConnectToRedisError(dsn=self.redis_dsn)
-        logger.info(
+        _logger.info(
             "Connection to %s succeeded with %s",
             f"redis at {self.redis_dsn=}",
             f"{self._client=}",
@@ -78,10 +82,10 @@ class RedisClientSDK:
         await self._client.close(close_connection_pool=True)
 
     async def ping(self) -> bool:
-        try:
-            return await self._client.ping()
-        except redis.exceptions.ConnectionError:
-            return False
+        with log_catch(_logger, reraise=False):
+            await self._client.ping()
+            return True
+        return False
 
     @contextlib.asynccontextmanager
     async def lock_context(
@@ -119,8 +123,8 @@ class RedisClientSDK:
 
         async def _extend_lock(lock: Lock) -> None:
             with log_context(
-                logger, logging.DEBUG, f"Extending lock {lock_unique_id}"
-            ), log_catch(logger, reraise=False):
+                _logger, logging.DEBUG, f"Extending lock {lock_unique_id}"
+            ), log_catch(_logger, reraise=False):
                 await lock.reacquire()
 
         try:
@@ -156,7 +160,7 @@ class RedisClientSDK:
                 await ttl_lock.release()
             except redis.exceptions.LockNotOwnedError:
                 # if this appears outside tests it can cause issues since something might be happening
-                logger.warning(
+                _logger.warning(
                     "Attention: lock is no longer owned. This is unexpected and requires investigation"
                 )
 

--- a/packages/service-library/tests/conftest.py
+++ b/packages/service-library/tests/conftest.py
@@ -12,6 +12,7 @@ import servicelib
 from faker import Faker
 
 pytest_plugins = [
+    "pytest_simcore.container_pause",
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
@@ -21,9 +22,9 @@ pytest_plugins = [
     "pytest_simcore.rabbit_service",
     "pytest_simcore.redis_service",
     "pytest_simcore.repository_paths",
+    "pytest_simcore.schemas",
     "pytest_simcore.simcore_service_library_fixtures",
     "pytest_simcore.tmp_path_extra",
-    "pytest_simcore.schemas",
 ]
 
 

--- a/packages/service-library/tests/test_redis.py
+++ b/packages/service-library/tests/test_redis.py
@@ -6,7 +6,8 @@
 
 import asyncio
 import datetime
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager
 from typing import Final
 
 import pytest
@@ -279,3 +280,16 @@ async def test_redis_client_sdk_health_checked(redis_service: RedisSettings):
     # cleanup
     await client.redis.flushall()
     await client.shutdown()
+
+
+async def test_regression_fails_if_on_redis_service_outage(
+    paused_container: Callable[[str], AbstractAsyncContextManager[None]],
+    redis_client_sdk: RedisClientSDK,
+):
+    assert await redis_client_sdk.ping() is True
+
+    async with paused_container("redis"):
+        # no connection available any longer should not hang but timeout
+        assert await redis_client_sdk.ping() is False
+
+    assert await redis_client_sdk.ping() is True


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Currently the redis client used no timeouts for reading and connecting to Redis database. This caused it to hang while executing a command if the service were to disappear.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
