### PR TITLE
🚑️Rclone: downgrade to 1.63.1

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone.py
@@ -172,9 +172,6 @@ async def _get_folder_size(
     return rclone_folder_size_result.bytes
 
 
-_DISABLE_RCLONE_MULTI_THREADED: Final[int] = 1
-
-
 async def _sync_sources(
     r_clone_settings: RCloneSettings,
     progress_bar: ProgressBarData,
@@ -222,8 +219,6 @@ async def _sync_sources(
             # filter options
             *_get_exclude_filters(exclude_patterns),
             "--links",
-            "--multi-thread-streams",
-            f"{_DISABLE_RCLONE_MULTI_THREADED}",
         )
 
         async with progress_bar.sub_progress(

--- a/scripts/install_rclone.bash
+++ b/scripts/install_rclone.bash
@@ -9,7 +9,7 @@ set -o nounset  # abort on unbound variable
 set -o pipefail # don't hide errors within pipes
 IFS=$'\n\t'
 
-R_CLONE_VERSION="1.66.0"
+R_CLONE_VERSION="1.63.1"
 curl --silent --location --remote-name "https://downloads.rclone.org/v${R_CLONE_VERSION}/rclone-v${R_CLONE_VERSION}-linux-amd64.deb"
 dpkg --install "rclone-v${R_CLONE_VERSION}-linux-amd64.deb"
 rm "rclone-v${R_CLONE_VERSION}-linux-amd64.deb"

--- a/services/agent/src/simcore_service_agent/modules/volumes_cleanup/_s3.py
+++ b/services/agent/src/simcore_service_agent/modules/volumes_cleanup/_s3.py
@@ -114,9 +114,6 @@ def _log_expected_operation(
     logger.log(log_level, formatted_message)
 
 
-_DISABLE_RCLONE_MULTI_THREADED: Final[int] = 1
-
-
 async def store_to_s3(  # pylint:disable=too-many-locals,too-many-arguments
     volume_name: str,
     dyv_volume: dict,
@@ -192,8 +189,6 @@ async def store_to_s3(  # pylint:disable=too-many-locals,too-many-arguments
         f"{source_dir}",
         f"dst:{s3_path}",
         "--verbose",
-        "--multi-thread-streams",
-        f"{_DISABLE_RCLONE_MULTI_THREADED}",
     ]
 
     str_r_clone_sync = _get_r_clone_str_command(r_clone_sync, exclude_files)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
After the tests done in https://github.com/ITISFoundation/osparc-simcore/discussions/5828 it is pretty visible that the new version of RClone, beside having a very bad bug that makes EC2 instances kernel panic that the current parameters make the download very slow, very bad.

Therefore this PR aims at downgrading the RClone back to 1.63.1 version, which seemed to be more stable even though still much slower (2x) than using official AWS tools. But at least it seems more or less bugfree.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
