### PR TITLE
✨Autoscaling: Drain node before terminating

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -111,7 +111,7 @@ class EC2InstancesSettings(BaseCustomSettings):
         "(default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formating)",
     )
     EC2_INSTANCES_TIME_BEFORE_FINAL_TERMINATION: datetime.timedelta = Field(
-        default=datetime.timedelta(seconds=15),
+        default=datetime.timedelta(seconds=30),
         description="Time after which an EC2 instance is terminated after draining"
         "(default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formating)",
     )

--- a/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/settings.py
@@ -107,7 +107,12 @@ class EC2InstancesSettings(BaseCustomSettings):
     )
     EC2_INSTANCES_TIME_BEFORE_TERMINATION: datetime.timedelta = Field(
         default=datetime.timedelta(minutes=1),
-        description="Time after which an EC2 instance may be terminated (0<=T<=59 minutes, is automatically capped)"
+        description="Time after which an EC2 instance may being the termination process (0<=T<=59 minutes, is automatically capped)"
+        "(default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formating)",
+    )
+    EC2_INSTANCES_TIME_BEFORE_FINAL_TERMINATION: datetime.timedelta = Field(
+        default=datetime.timedelta(seconds=15),
+        description="Time after which an EC2 instance is terminated after draining"
         "(default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formating)",
     )
     EC2_INSTANCES_CUSTOM_TAGS: EC2Tags = Field(

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -85,6 +85,11 @@ class Cluster:
             "description": "This is a docker node which is not backed by a running EC2 instance"
         }
     )
+    terminateable_nodes: list[AssociatedInstance] = field(
+        metadata={
+            "description": "This is a EC2-backed docker node which is docker drained and waiting for termination"
+        }
+    )
     terminated_instances: list[EC2InstanceData]
 
     def can_scale_down(self) -> bool:
@@ -93,6 +98,7 @@ class Cluster:
             or self.pending_nodes
             or self.drained_nodes
             or self.pending_ec2s
+            or self.terminateable_nodes
         )
 
     def total_number_of_machines(self) -> int:
@@ -103,6 +109,7 @@ class Cluster:
             + len(self.reserve_drained_nodes)
             + len(self.pending_ec2s)
             + len(self.broken_ec2s)
+            + len(self.terminateable_nodes)
         )
 
 

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -85,7 +85,7 @@ class Cluster:
             "description": "This is a docker node which is not backed by a running EC2 instance"
         }
     )
-    terminateable_nodes: list[AssociatedInstance] = field(
+    terminating_nodes: list[AssociatedInstance] = field(
         metadata={
             "description": "This is a EC2-backed docker node which is docker drained and waiting for termination"
         }
@@ -98,7 +98,7 @@ class Cluster:
             or self.pending_nodes
             or self.drained_nodes
             or self.pending_ec2s
-            or self.terminateable_nodes
+            or self.terminating_nodes
         )
 
     def total_number_of_machines(self) -> int:
@@ -109,7 +109,7 @@ class Cluster:
             + len(self.reserve_drained_nodes)
             + len(self.pending_ec2s)
             + len(self.broken_ec2s)
-            + len(self.terminateable_nodes)
+            + len(self.terminating_nodes)
         )
 
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -126,7 +126,7 @@ async def _analyze_current_cluster(
         else:
             pending_nodes.append(instance)
 
-    drained_nodes, reserve_drained_nodes = sort_drained_nodes(
+    drained_nodes, reserve_drained_nodes, terminating_nodes = sort_drained_nodes(
         app_settings, all_drained_nodes, allowed_instance_types
     )
     cluster = Cluster(
@@ -136,6 +136,7 @@ async def _analyze_current_cluster(
         reserve_drained_nodes=reserve_drained_nodes,
         pending_ec2s=[NonAssociatedInstance(ec2_instance=i) for i in pending_ec2s],
         broken_ec2s=[NonAssociatedInstance(ec2_instance=i) for i in broken_ec2s],
+        terminating_nodes=terminating_nodes,
         terminated_instances=terminated_ec2_instances,
         disconnected_nodes=[n for n in docker_nodes if _node_not_ready(n)],
     )
@@ -148,6 +149,7 @@ async def _analyze_current_cluster(
             "reserve_drained_nodes": True,
             "pending_ec2s": "ec2_instance",
             "broken_ec2s": "ec2_instance",
+            "terminating_nodes": "ec2_instance",
         },
     )
     _logger.info(
@@ -239,7 +241,7 @@ async def _try_attach_pending_ec2s(
     all_drained_nodes = (
         cluster.drained_nodes + cluster.reserve_drained_nodes + new_found_instances
     )
-    drained_nodes, reserve_drained_nodes = sort_drained_nodes(
+    drained_nodes, reserve_drained_nodes, _ = sort_drained_nodes(
         app_settings, all_drained_nodes, allowed_instance_types
     )
     return dataclasses.replace(

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
@@ -172,7 +172,7 @@ class ComputationalAutoscaling(BaseAutoscaling):
         if not utils_docker.is_node_osparc_ready(instance.node):
             return False
 
-        # now check if dask-scheduler is available
+        # now check if dask-scheduler/dask-worker is available and running
         return await dask.is_worker_connected(
             _scheduler_url(app), _scheduler_auth(app), instance.ec2_instance
         )

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/auto_scaling_core.py
@@ -159,24 +159,34 @@ def get_machine_buffer_type(
 
 DrainedNodes = list[AssociatedInstance]
 BufferDrainedNodes = list[AssociatedInstance]
+TerminatingNodes = list[AssociatedInstance]
 
 
 def sort_drained_nodes(
     app_settings: ApplicationSettings,
     all_drained_nodes: list[AssociatedInstance],
     available_ec2_types: list[EC2InstanceType],
-) -> tuple[DrainedNodes, BufferDrainedNodes]:
+) -> tuple[DrainedNodes, BufferDrainedNodes, TerminatingNodes]:
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
+    # first sort out the drained nodes that started termination
+    terminating_nodes = [
+        n
+        for n in all_drained_nodes
+        if utils_docker.get_node_termination_started_since(n.node) is not None
+    ]
+    remaining_drained_nodes = [
+        n for n in all_drained_nodes if n not in terminating_nodes
+    ]
     # we need to keep in reserve only the drained nodes of the right type
     machine_buffer_type = get_machine_buffer_type(available_ec2_types)
     # NOTE: we keep only in buffer the drained nodes with the right EC2 type, AND the right amount
     buffer_drained_nodes = [
         node
-        for node in all_drained_nodes
+        for node in remaining_drained_nodes
         if node.ec2_instance.type == machine_buffer_type.name
     ][: app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER]
     # all the others are "normal" drained nodes and may be terminated at some point
     other_drained_nodes = [
-        node for node in all_drained_nodes if node not in buffer_drained_nodes
+        node for node in remaining_drained_nodes if node not in buffer_drained_nodes
     ]
-    return (other_drained_nodes, buffer_drained_nodes)
+    return (other_drained_nodes, buffer_drained_nodes, terminating_nodes)

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -614,6 +614,11 @@ def get_node_last_readyness_update(node: Node) -> datetime.datetime:
     )  # mypy
 
 
+def get_node_last_updated_timestamp(node: Node) -> datetime.datetime:
+    assert node.UpdatedAt
+    return arrow.get(node.UpdatedAt).datetime
+
+
 async def set_node_found_empty(
     docker_client: AutoscalingDocker,
     node: Node,

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -618,11 +618,6 @@ def get_node_last_readyness_update(node: Node) -> datetime.datetime:
     )  # mypy
 
 
-def get_node_last_updated_timestamp(node: Node) -> datetime.datetime:
-    assert node.UpdatedAt
-    return arrow.get(node.UpdatedAt).datetime
-
-
 async def set_node_found_empty(
     docker_client: AutoscalingDocker,
     node: Node,

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -658,6 +658,7 @@ async def get_node_empty_since(node: Node) -> datetime.datetime | None:
 async def set_node_begin_termination_process(
     docker_client: AutoscalingDocker, node: Node
 ) -> Node:
+    """sets the node to drain and adds a docker label with the time"""
     assert node.Spec  # nosec
     new_tags = deepcopy(cast(dict[DockerLabelKey, str], node.Spec.Labels))
     new_tags[_OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY] = arrow.utcnow().isoformat()
@@ -666,7 +667,7 @@ async def set_node_begin_termination_process(
         docker_client,
         node,
         tags=new_tags,
-        available=bool(node.Spec.Availability is Availability.active),
+        available=False,
     )
 
 

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -75,6 +75,10 @@ _OSPARC_NODE_EMPTY_DATETIME_LABEL_KEY: Final[DockerLabelKey] = parse_obj_as(
     DockerLabelKey, "io.simcore.osparc-node-found-empty"
 )
 
+_OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY: Final[DockerLabelKey] = parse_obj_as(
+    DockerLabelKey, "io.simcore.osparc-node-termination-started"
+)
+
 
 async def get_monitored_nodes(
     docker_client: AutoscalingDocker, node_labels: list[DockerLabelKey]
@@ -648,6 +652,34 @@ async def get_node_empty_since(node: Node) -> datetime.datetime | None:
     return cast(
         datetime.datetime,
         arrow.get(node.Spec.Labels[_OSPARC_NODE_EMPTY_DATETIME_LABEL_KEY]).datetime,
+    )  # mypy
+
+
+async def set_node_begin_termination_process(
+    docker_client: AutoscalingDocker, node: Node
+) -> Node:
+    assert node.Spec  # nosec
+    new_tags = deepcopy(cast(dict[DockerLabelKey, str], node.Spec.Labels))
+    new_tags[_OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY] = arrow.utcnow().isoformat()
+
+    return await tag_node(
+        docker_client,
+        node,
+        tags=new_tags,
+        available=bool(node.Spec.Availability is Availability.active),
+    )
+
+
+def get_node_termination_started_since(node: Node) -> datetime.datetime | None:
+    assert node.Spec  # nosec
+    assert node.Spec.Labels  # nosec
+    if _OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY not in node.Spec.Labels:
+        return None
+    return cast(
+        datetime.datetime,
+        arrow.get(
+            node.Spec.Labels[_OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY]
+        ).datetime,
     )  # mypy
 
 

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -10,7 +10,7 @@ import random
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Final, cast
+from typing import Any, Final, cast, get_args
 from unittest import mock
 
 import aiodocker
@@ -524,7 +524,7 @@ async def create_service(
         diff = DeepDiff(
             task_template,
             service.Spec.TaskTemplate.dict(exclude_unset=True),
-            exclude_paths=excluded_paths,
+            exclude_paths=list(excluded_paths),
         )
         assert not diff, f"{diff}"
         assert service.Spec.Labels == base_labels
@@ -686,6 +686,7 @@ def cluster() -> Callable[..., Cluster]:
                 pending_ec2s=[],
                 broken_ec2s=[],
                 disconnected_nodes=[],
+                terminating_nodes=[],
                 terminated_instances=[],
             ),
             **cluter_overrides,
@@ -783,7 +784,7 @@ def patch_ec2_client_start_aws_instances_min_number_of_instances(
 def random_fake_available_instances(faker: Faker) -> list[EC2InstanceType]:
     list_of_instances = [
         EC2InstanceType(
-            name=faker.pystr(),
+            name=random.choice(get_args(InstanceTypeType)),  # noqa: S311
             resources=Resources(cpus=n, ram=ByteSize(n)),
         )
         for n in range(1, 30)

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_computational.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_computational.py
@@ -45,6 +45,7 @@ from simcore_service_autoscaling.modules.docker import get_docker_client
 from simcore_service_autoscaling.modules.ec2 import SimcoreEC2API
 from simcore_service_autoscaling.utils.utils_docker import (
     _OSPARC_NODE_EMPTY_DATETIME_LABEL_KEY,
+    _OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY,
     _OSPARC_SERVICE_READY_LABEL_KEY,
     _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY,
 )
@@ -690,6 +691,36 @@ async def test_cluster_scaling_up_and_down(  # noqa: PLR0915
         - app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
         - datetime.timedelta(seconds=1)
     ).isoformat()
+    # first making sure the node is drained, then terminate it after a delay to let it drain
+    await auto_scale_cluster(app=initialized_app, auto_scaling_mode=auto_scaling_mode)
+    mocked_docker_remove_node.assert_not_called()
+    await _assert_ec2_instances(
+        ec2_client,
+        num_reservations=1,
+        num_instances=1,
+        instance_type=expected_ec2_type,
+        instance_state="running",
+    )
+    mock_docker_tag_node.assert_called_once_with(
+        get_docker_client(initialized_app),
+        fake_attached_node,
+        tags=fake_attached_node.Spec.Labels
+        | {
+            _OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY: mock.ANY,
+        },
+        available=False,
+    )
+    mock_docker_tag_node.reset_mock()
+    # set the fake node to drain
+    fake_attached_node.Spec.Availability = Availability.drain
+    fake_attached_node.Spec.Labels[_OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY] = (
+        arrow.utcnow()
+        .shift(
+            seconds=-app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_FINAL_TERMINATION.total_seconds()
+            - 1
+        )
+        .datetime.isoformat()
+    )
     await auto_scale_cluster(app=initialized_app, auto_scaling_mode=auto_scaling_mode)
     mocked_docker_remove_node.assert_called_once_with(
         mock.ANY, nodes=[fake_attached_node], force=True

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
@@ -778,7 +778,7 @@ async def test_cluster_scaling_up_and_down(  # noqa: PLR0915
         - datetime.timedelta(seconds=1)
     ).isoformat()
     if with_labelize_drain_nodes:
-        # first making sure the node is drained, then terminate it after a delay
+        # first making sure the node is drained, then terminate it after a delay to let it drain
         await auto_scale_cluster(
             app=initialized_app, auto_scaling_mode=auto_scaling_mode
         )

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
@@ -742,9 +742,8 @@ async def test_cluster_scaling_up_and_down(  # noqa: PLR0915
     )
 
     # we artifically set the node to drain
-    fake_attached_node.Spec.Availability = (
-        Availability.active if with_drain_nodes_labelled else Availability.drain
-    )
+    if not with_drain_nodes_labelled:
+        fake_attached_node.Spec.Availability = Availability.drain
     fake_attached_node.Spec.Labels[_OSPARC_SERVICE_READY_LABEL_KEY] = "false"
     fake_attached_node.Spec.Labels[
         _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY
@@ -797,6 +796,8 @@ async def test_cluster_scaling_up_and_down(  # noqa: PLR0915
             available=False,
         )
         mock_docker_tag_node.reset_mock()
+        # set the fake node to drain
+        fake_attached_node.Spec.Availability = Availability.drain
 
     await auto_scale_cluster(app=initialized_app, auto_scaling_mode=auto_scaling_mode)
     mocked_docker_remove_node.assert_called_once_with(

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
@@ -53,14 +53,13 @@ from simcore_service_autoscaling.modules.docker import (
 )
 from simcore_service_autoscaling.utils.utils_docker import (
     _OSPARC_NODE_EMPTY_DATETIME_LABEL_KEY,
+    _OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY,
     _OSPARC_SERVICE_READY_LABEL_KEY,
     _OSPARC_SERVICES_READY_DATETIME_LABEL_KEY,
 )
 from types_aiobotocore_ec2.client import EC2Client
 from types_aiobotocore_ec2.literals import InstanceTypeType
 from types_aiobotocore_ec2.type_defs import InstanceTypeDef
-
-from services.autoscaling.tests.unit.conftest import with_labelize_drain_nodes
 
 
 @pytest.fixture
@@ -776,28 +775,36 @@ async def test_cluster_scaling_up_and_down(  # noqa: PLR0915
         - app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_TERMINATION
         - datetime.timedelta(seconds=1)
     ).isoformat()
-    if with_labelize_drain_nodes:
-        # first making sure the node is drained, then terminate it after a delay to let it drain
-        await auto_scale_cluster(
-            app=initialized_app, auto_scaling_mode=auto_scaling_mode
+    # first making sure the node is drained, then terminate it after a delay to let it drain
+    await auto_scale_cluster(app=initialized_app, auto_scaling_mode=auto_scaling_mode)
+    mocked_docker_remove_node.assert_not_called()
+    await _assert_ec2_instances(
+        ec2_client,
+        num_reservations=1,
+        num_instances=1,
+        instance_type=expected_ec2_type,
+        instance_state="running",
+    )
+    mock_docker_tag_node.assert_called_once_with(
+        get_docker_client(initialized_app),
+        fake_attached_node,
+        tags=fake_attached_node.Spec.Labels
+        | {
+            _OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY: mock.ANY,
+        },
+        available=False,
+    )
+    mock_docker_tag_node.reset_mock()
+    # set the fake node to drain
+    fake_attached_node.Spec.Availability = Availability.drain
+    fake_attached_node.Spec.Labels[_OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY] = (
+        arrow.utcnow()
+        .shift(
+            seconds=-app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_TIME_BEFORE_FINAL_TERMINATION.total_seconds()
+            - 1
         )
-        mocked_docker_remove_node.assert_not_called()
-        await _assert_ec2_instances(
-            ec2_client,
-            num_reservations=1,
-            num_instances=1,
-            instance_type=expected_ec2_type,
-            instance_state="running",
-        )
-        mock_docker_tag_node.assert_called_once_with(
-            get_docker_client(initialized_app),
-            fake_attached_node,
-            tags=fake_attached_node.Spec.Labels,
-            available=False,
-        )
-        mock_docker_tag_node.reset_mock()
-        # set the fake node to drain
-        fake_attached_node.Spec.Availability = Availability.drain
+        .datetime.isoformat()
+    )
 
     await auto_scale_cluster(app=initialized_app, auto_scaling_mode=auto_scaling_mode)
     mocked_docker_remove_node.assert_called_once_with(

--- a/services/autoscaling/tests/unit/test_utils_auto_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_utils_auto_scaling_core.py
@@ -10,6 +10,7 @@ import re
 from collections.abc import Callable
 from random import choice, shuffle
 
+import arrow
 import pytest
 from aws_library.ec2.models import EC2InstanceType
 from faker import Faker
@@ -27,6 +28,9 @@ from simcore_service_autoscaling.utils.auto_scaling_core import (
     get_machine_buffer_type,
     node_host_name_from_ec2_private_dns,
     sort_drained_nodes,
+)
+from simcore_service_autoscaling.utils.utils_docker import (
+    _OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY,
 )
 
 
@@ -314,6 +318,7 @@ def test_sort_empty_drained_nodes(
     assert sort_drained_nodes(app_settings, [], random_fake_available_instances) == (
         [],
         [],
+        [],
     )
 
 
@@ -328,6 +333,7 @@ def test_sort_drained_nodes(
     machine_buffer_type = get_machine_buffer_type(random_fake_available_instances)
     _NUM_DRAINED_NODES = 20
     _NUM_NODE_WITH_TYPE_BUFFER = 3 * mock_machines_buffer
+    _NUM_NODES_TERMINATING = 13
     fake_drained_nodes = []
     for _ in range(_NUM_DRAINED_NODES):
         fake_node = create_fake_node()
@@ -354,10 +360,31 @@ def test_sort_drained_nodes(
             fake_ec2_instance_data_override={"type": machine_buffer_type.name},
         )
         fake_drained_nodes.append(fake_associated_instance)
+
+    for _ in range(_NUM_NODES_TERMINATING):
+        fake_node = create_fake_node()
+        assert fake_node.Spec
+        assert fake_node.Spec.Labels
+        fake_node.Spec.Labels[
+            _OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY
+        ] = arrow.utcnow().datetime.isoformat()
+        fake_associated_instance = create_associated_instance(
+            fake_node,
+            terminateable_time=False,
+            fake_ec2_instance_data_override={"type": machine_buffer_type.name},
+        )
+        fake_drained_nodes.append(fake_associated_instance)
     shuffle(fake_drained_nodes)
 
-    assert len(fake_drained_nodes) == _NUM_DRAINED_NODES + _NUM_NODE_WITH_TYPE_BUFFER
-    sorted_drained_nodes, sorted_buffer_drained_nodes = sort_drained_nodes(
+    assert (
+        len(fake_drained_nodes)
+        == _NUM_DRAINED_NODES + _NUM_NODE_WITH_TYPE_BUFFER + _NUM_NODES_TERMINATING
+    )
+    (
+        sorted_drained_nodes,
+        sorted_buffer_drained_nodes,
+        terminating_nodes,
+    ) = sort_drained_nodes(
         app_settings, fake_drained_nodes, random_fake_available_instances
     )
     assert app_settings.AUTOSCALING_EC2_INSTANCES
@@ -365,12 +392,17 @@ def test_sort_drained_nodes(
         mock_machines_buffer
         == app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
     )
-    assert (
-        len(sorted_drained_nodes)
-        == len(fake_drained_nodes)
+    assert len(sorted_drained_nodes) == (
+        _NUM_DRAINED_NODES
+        + _NUM_NODE_WITH_TYPE_BUFFER
         - app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
     )
     assert (
         len(sorted_buffer_drained_nodes)
         == app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MACHINES_BUFFER
     )
+    assert len(terminating_nodes) == _NUM_NODES_TERMINATING
+    for n in terminating_nodes:
+        assert n.node.Spec
+        assert n.node.Spec.Labels
+        assert _OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY in n.node.Spec.Labels

--- a/services/autoscaling/tests/unit/test_utils_docker.py
+++ b/services/autoscaling/tests/unit/test_utils_docker.py
@@ -72,6 +72,10 @@ from simcore_service_autoscaling.utils.utils_docker import (
 )
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
+from services.autoscaling.src.simcore_service_autoscaling.utils.utils_docker import (
+    get_node_last_updated_timestamp,
+)
+
 
 @pytest.fixture
 async def create_node_labels(
@@ -1186,6 +1190,19 @@ async def test_set_node_osparc_ready(
     assert not is_node_osparc_ready(updated_node)
     assert is_node_ready_and_available(updated_node, availability=Availability.drain)
     assert get_node_last_readyness_update(updated_node) > updated_last_readyness
+
+
+def test_get_node_last_updated_timestamp(
+    disabled_rabbitmq: None,
+    disabled_ec2: None,
+    mocked_redis_server: None,
+    enabled_dynamic_mode: EnvVarsDict,
+    disable_dynamic_service_background_task: None,
+    app_settings: ApplicationSettings,
+    host_node: Node,
+):
+    node_last_updated_time = get_node_last_updated_timestamp(host_node)
+    assert node_last_updated_time == arrow.get(host_node.UpdatedAt).datetime
 
 
 async def test_set_node_found_empty(

--- a/services/autoscaling/tests/unit/test_utils_docker.py
+++ b/services/autoscaling/tests/unit/test_utils_docker.py
@@ -59,7 +59,6 @@ from simcore_service_autoscaling.utils.utils_docker import (
     get_new_node_docker_tags,
     get_node_empty_since,
     get_node_last_readyness_update,
-    get_node_last_updated_timestamp,
     get_node_termination_started_since,
     get_node_total_resources,
     get_task_instance_restriction,
@@ -1190,19 +1189,6 @@ async def test_set_node_osparc_ready(
     assert not is_node_osparc_ready(updated_node)
     assert is_node_ready_and_available(updated_node, availability=Availability.drain)
     assert get_node_last_readyness_update(updated_node) > updated_last_readyness
-
-
-def test_get_node_last_updated_timestamp(
-    disabled_rabbitmq: None,
-    disabled_ec2: None,
-    mocked_redis_server: None,
-    enabled_dynamic_mode: EnvVarsDict,
-    disable_dynamic_service_background_task: None,
-    app_settings: ApplicationSettings,
-    host_node: Node,
-):
-    node_last_updated_time = get_node_last_updated_timestamp(host_node)
-    assert node_last_updated_time == arrow.get(host_node.UpdatedAt).datetime
 
 
 async def test_set_node_found_empty(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

After [the changes that stopped using docker node drain ](https://github.com/ITISFoundation/osparc-simcore/pull/5340) a new issue arose: container IPs are not properly returned to the docker swarm https://github.com/ITISFoundation/osparc-ops-environments/issues/665.

So it is preferable to first drain a node before terminating it.

With this PR, the termination process was complexified. Once a node is deemed as terminateable (after empty time exceeds ```EC2_INSTANCES_TIME_BEFORE_TERMINATION```) the autoscaling service will begin the "termination" process.

**BEFORE:**
- the EC2 instance is instantly terminated
- the node is removed from the cluster

**AFTER:**
- the docker node is drained
- after ```EC2_INSTANCES_TIME_BEFORE_FINAL_TERMINATION=15seconds``` it will proceed with termination as in **BEFORE**.

**NOTE:** Once the termination process is started, there is no way back. The termination process will label the node for termination by docker labelling the node with _io.simcore.osparc-node-termination-started_ which contains the timepoint when this happens. That means that if for some reason the docker engine is not responding, there might be an accumulation of EC2 instances. If this becomes a problem then the tagging might work by using the EC2 API instead.
**NOTE2:** ```EC2_INSTANCES_TIME_BEFORE_FINAL_TERMINATION``` is not defined as an ENV variable and is currently hard-coded as there is no foreseeable motivation to have it changeable at the moment.
## Related issue/s
- resolves https://github.com/ITISFoundation/osparc-simcore/issues/5827 
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
