### PR TITLE
✨Clusters-keeper: terminate broken EC2s🚨

### DIFF
--- a/packages/aws-library/src/aws_library/ec2/client.py
+++ b/packages/aws-library/src/aws_library/ec2/client.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import cast
 
@@ -281,7 +282,9 @@ class SimcoreEC2API:
         )
         return all_instances
 
-    async def terminate_instances(self, instance_datas: list[EC2InstanceData]) -> None:
+    async def terminate_instances(
+        self, instance_datas: Iterable[EC2InstanceData]
+    ) -> None:
         try:
             with log_context(
                 _logger,

--- a/packages/aws-library/src/aws_library/ec2/models.py
+++ b/packages/aws-library/src/aws_library/ec2/models.py
@@ -93,7 +93,7 @@ class EC2InstanceData:
     tags: EC2Tags
 
     def __hash__(self) -> int:
-        return hash(self.id)
+        return hash(self.__dict__)
 
 
 @dataclass(frozen=True)

--- a/packages/aws-library/src/aws_library/ec2/models.py
+++ b/packages/aws-library/src/aws_library/ec2/models.py
@@ -84,13 +84,16 @@ EC2Tags: TypeAlias = dict[AWSTagKey, AWSTagValue]
 @dataclass(frozen=True)
 class EC2InstanceData:
     launch_time: datetime.datetime
-    id: str  # noqa: A003
+    id: str
     aws_private_dns: InstancePrivateDNSName
     aws_public_ip: str | None
-    type: InstanceTypeType  # noqa: A003
+    type: InstanceTypeType
     state: InstanceStateNameType
     resources: Resources
     tags: EC2Tags
+
+    def __hash__(self) -> int:
+        return hash(self.id)
 
 
 @dataclass(frozen=True)

--- a/packages/aws-library/src/aws_library/ec2/models.py
+++ b/packages/aws-library/src/aws_library/ec2/models.py
@@ -93,7 +93,18 @@ class EC2InstanceData:
     tags: EC2Tags
 
     def __hash__(self) -> int:
-        return hash(self.__dict__)
+        return hash(
+            (
+                self.launch_time,
+                self.id,
+                self.aws_private_dns,
+                self.aws_public_ip,
+                self.type,
+                self.state,
+                self.resources,
+                tuple(sorted(self.tags.items())),
+            )
+        )
 
 
 @dataclass(frozen=True)

--- a/packages/aws-library/tests/test_ec2_models.py
+++ b/packages/aws-library/tests/test_ec2_models.py
@@ -4,7 +4,8 @@
 
 
 import pytest
-from aws_library.ec2.models import AWSTagKey, AWSTagValue, Resources
+from aws_library.ec2.models import AWSTagKey, AWSTagValue, EC2InstanceData, Resources
+from faker import Faker
 from pydantic import ByteSize, ValidationError, parse_obj_as
 
 
@@ -132,3 +133,40 @@ def test_aws_tag_key_invalid(ec2_tag_key: str):
 
     # for a value it does not
     parse_obj_as(AWSTagValue, ec2_tag_key)
+
+
+def test_ec2_instance_data_hashable(faker: Faker):
+    first_set_of_ec2s = {
+        EC2InstanceData(
+            faker.date_time(),
+            faker.pystr(),
+            faker.pystr(),
+            f"{faker.ipv4()}",
+            "g4dn.xlarge",
+            "running",
+            Resources(
+                cpus=faker.pyfloat(min_value=0.1),
+                ram=ByteSize(faker.pyint(min_value=123)),
+            ),
+            {AWSTagKey("mytagkey"): AWSTagValue("mytagvalue")},
+        )
+    }
+    second_set_of_ec2s = {
+        EC2InstanceData(
+            faker.date_time(),
+            faker.pystr(),
+            faker.pystr(),
+            f"{faker.ipv4()}",
+            "g4dn.xlarge",
+            "running",
+            Resources(
+                cpus=faker.pyfloat(min_value=0.1),
+                ram=ByteSize(faker.pyint(min_value=123)),
+            ),
+            {AWSTagKey("mytagkey"): AWSTagValue("mytagvalue")},
+        )
+    }
+
+    union_of_sets = first_set_of_ec2s.union(second_set_of_ec2s)
+    assert next(iter(first_set_of_ec2s)) in union_of_sets
+    assert next(iter(second_set_of_ec2s)) in union_of_sets

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/core/settings.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/core/settings.py
@@ -115,11 +115,8 @@ class WorkersEC2InstancesSettings(BaseCustomSettings):
     ) -> dict[str, EC2InstanceBootSpecific]:
         # NOTE: needed because of a flaw in BaseCustomSettings
         # issubclass raises TypeError if used on Aliases
-        if all(parse_obj_as(InstanceTypeType, key) for key in value):
-            return value
-
-        msg = "Invalid instance type name"
-        raise ValueError(msg)
+        parse_obj_as(list[InstanceTypeType], list(value))
+        return value
 
 
 class PrimaryEC2InstancesSettings(BaseCustomSettings):

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/core/settings.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/core/settings.py
@@ -177,6 +177,14 @@ class PrimaryEC2InstancesSettings(BaseCustomSettings):
         ..., description="Password for accessing prometheus data"
     )
 
+    PRIMARY_EC2_INSTANCES_MAX_START_TIME: datetime.timedelta = Field(
+        default=datetime.timedelta(minutes=2),
+        description="Usual time taken an EC2 instance with the given AMI takes to startup and be ready to receive jobs "
+        "(default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formating)."
+        "NOTE: be careful that this time should always be a factor larger than the real time, as EC2 instances"
+        "that take longer than this time will be terminated as sometimes it happens that EC2 machine fail on start.",
+    )
+
     @validator("PRIMARY_EC2_INSTANCES_ALLOWED_TYPES")
     @classmethod
     def check_valid_instance_names(

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/core/settings.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/core/settings.py
@@ -189,11 +189,8 @@ class PrimaryEC2InstancesSettings(BaseCustomSettings):
     ) -> dict[str, EC2InstanceBootSpecific]:
         # NOTE: needed because of a flaw in BaseCustomSettings
         # issubclass raises TypeError if used on Aliases
-        if all(parse_obj_as(InstanceTypeType, key) for key in value):
-            return value
-
-        msg = "Invalid instance type name"
-        raise ValueError(msg)
+        parse_obj_as(list[InstanceTypeType], list(value))
+        return value
 
     @validator("PRIMARY_EC2_INSTANCES_ALLOWED_TYPES")
     @classmethod

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
@@ -96,15 +96,17 @@ async def create_cluster(
     return new_ec2_instance_data
 
 
-async def get_all_clusters(app: FastAPI) -> list[EC2InstanceData]:
+async def get_all_clusters(app: FastAPI) -> set[EC2InstanceData]:
     app_settings = get_application_settings(app)
     assert app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES  # nosec
-    ec2_instance_data: list[EC2InstanceData] = await get_ec2_client(app).get_instances(
-        key_names=[
-            app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES.PRIMARY_EC2_INSTANCES_KEY_NAME
-        ],
-        tags=all_created_ec2_instances_filter(app_settings),
-        state_names=["running"],
+    ec2_instance_data: set[EC2InstanceData] = set(
+        await get_ec2_client(app).get_instances(
+            key_names=[
+                app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES.PRIMARY_EC2_INSTANCES_KEY_NAME
+            ],
+            tags=all_created_ec2_instances_filter(app_settings),
+            state_names=["running"],
+        )
     )
     return ec2_instance_data
 

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable
+from collections.abc import Iterable
 
 import arrow
 from aws_library.ec2.client import SimcoreEC2API

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
@@ -162,7 +162,7 @@ async def set_instance_heartbeat(app: FastAPI, *, instance: EC2InstanceData) -> 
         ec2_client = get_ec2_client(app)
         await ec2_client.set_instances_tags(
             [instance],
-            tags={HEARTBEAT_TAG_KEY: f"{arrow.utcnow().datetime}"},
+            tags={HEARTBEAT_TAG_KEY: AWSTagValue(arrow.utcnow().datetime.isoformat())},
         )
 
 

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
@@ -1,6 +1,7 @@
-import datetime
 import logging
+from typing import Iterable
 
+import arrow
 from aws_library.ec2.client import SimcoreEC2API
 from aws_library.ec2.models import (
     AWSTagKey,
@@ -161,9 +162,11 @@ async def set_instance_heartbeat(app: FastAPI, *, instance: EC2InstanceData) -> 
         ec2_client = get_ec2_client(app)
         await ec2_client.set_instances_tags(
             [instance],
-            tags={HEARTBEAT_TAG_KEY: f"{datetime.datetime.now(datetime.timezone.utc)}"},
+            tags={HEARTBEAT_TAG_KEY: f"{arrow.utcnow().datetime}"},
         )
 
 
-async def delete_clusters(app: FastAPI, *, instances: list[EC2InstanceData]) -> None:
+async def delete_clusters(
+    app: FastAPI, *, instances: Iterable[EC2InstanceData]
+) -> None:
     await get_ec2_client(app).terminate_instances(instances)

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_core.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_core.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
-from typing import Final, Iterable
+from collections.abc import Iterable
+from typing import Final
 
 import arrow
 from aws_library.ec2.models import AWSTagKey, EC2InstanceData
@@ -8,6 +9,7 @@ from fastapi import FastAPI
 from models_library.users import UserID
 from models_library.wallets import WalletID
 from pydantic import parse_obj_as
+from servicelib.logging_utils import log_catch
 
 from ..core.settings import get_application_settings
 from ..modules.clusters import (
@@ -23,12 +25,14 @@ from .dask import is_scheduler_busy, ping_scheduler
 _logger = logging.getLogger(__name__)
 
 
-def _get_instance_last_heartbeat(instance: EC2InstanceData) -> datetime.datetime:
-    if last_heartbeat := instance.tags.get(HEARTBEAT_TAG_KEY, None):
+def _get_instance_last_heartbeat(instance: EC2InstanceData) -> datetime.datetime | None:
+    if last_heartbeat := instance.tags.get(
+        HEARTBEAT_TAG_KEY,
+    ):
         last_heartbeat_time: datetime.datetime = arrow.get(last_heartbeat).datetime
         return last_heartbeat_time
-    launch_time: datetime.datetime = instance.launch_time
-    return launch_time
+
+    return None
 
 
 _USER_ID_TAG_KEY: Final[AWSTagKey] = parse_obj_as(AWSTagKey, "user_id")
@@ -70,20 +74,26 @@ async def _find_terminateable_instances(
         app_settings.CLUSTERS_KEEPER_MAX_MISSED_HEARTBEATS_BEFORE_CLUSTER_TERMINATION
         * app_settings.SERVICE_TRACKING_HEARTBEAT
     )
+    startup_delay = (
+        app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES.PRIMARY_EC2_INSTANCES_MAX_START_TIME
+    )
     for instance in instances:
-        last_heartbeat = _get_instance_last_heartbeat(instance)
-
-        elapsed_time_since_heartbeat = (
-            datetime.datetime.now(datetime.timezone.utc) - last_heartbeat
-        )
-        _logger.info(
-            "%s has still %ss before being terminateable",
-            f"{instance.id=}",
-            f"{(time_to_wait_before_termination - elapsed_time_since_heartbeat).total_seconds()}",
-        )
-        if elapsed_time_since_heartbeat >= time_to_wait_before_termination:
-            # let's terminate that one
-            terminateable_instances.append(instance)
+        if last_heartbeat := _get_instance_last_heartbeat(instance):
+            elapsed_time_since_heartbeat = arrow.utcnow().datetime - last_heartbeat
+            allowed_time_to_wait = time_to_wait_before_termination
+            if elapsed_time_since_heartbeat >= allowed_time_to_wait:
+                terminateable_instances.append(instance)
+            else:
+                _logger.info(
+                    "%s has still %ss before being terminateable",
+                    f"{instance.id=}",
+                    f"{(allowed_time_to_wait - elapsed_time_since_heartbeat).total_seconds()}",
+                )
+        else:
+            elapsed_time_since_startup = arrow.utcnow().datetime - instance.launch_time
+            allowed_time_to_wait = startup_delay
+            if elapsed_time_since_startup >= allowed_time_to_wait:
+                terminateable_instances.append(instance)
 
     # get all terminateable instances associated worker instances
     worker_instances = await _get_all_associated_worker_instances(
@@ -94,37 +104,54 @@ async def _find_terminateable_instances(
 
 
 async def check_clusters(app: FastAPI) -> None:
-    instances = await get_all_clusters(app)
+    primary_instances = await get_all_clusters(app)
 
-    # analyse connected clusters (e.g. normal function)
-    connected_intances = [
+    connected_intances = {
         instance
-        for instance in instances
+        for instance in primary_instances
         if await ping_scheduler(get_scheduler_url(instance), get_scheduler_auth(app))
-    ]
+    }
+
     for instance in connected_intances:
-        is_busy = await is_scheduler_busy(
-            get_scheduler_url(instance), get_scheduler_auth(app)
-        )
-        _logger.info(
-            "%s currently %s",
-            f"{instance.id=} for {instance.tags=}",
-            f"{'is running tasks' if is_busy else 'not doing anything!'}",
-        )
-        if is_busy:
-            await set_instance_heartbeat(app, instance=instance)
+        with log_catch(_logger, reraise=False):
+            # NOTE: some connected instance could in theory break between these 2 calls, therefore this is silenced and will
+            # be handled in the next call to check_clusters
+            if await is_scheduler_busy(
+                get_scheduler_url(instance), get_scheduler_auth(app)
+            ):
+                _logger.info(
+                    "%s is running tasks",
+                    f"{instance.id=} for {instance.tags=}",
+                )
+                await set_instance_heartbeat(app, instance=instance)
     if terminateable_instances := await _find_terminateable_instances(
         app, connected_intances
     ):
         await delete_clusters(app, instances=terminateable_instances)
 
     # analyse disconnected instances (currently starting or broken)
-    disconnected_instances = set(instances) - set(connected_intances)
+    disconnected_instances = primary_instances - connected_intances
+
+    starting_instances = {
+        instance
+        for instance in disconnected_instances
+        if _get_instance_last_heartbeat(instance) is None
+    }
+
     if terminateable_instances := await _find_terminateable_instances(
-        app, disconnected_instances
+        app, starting_instances
     ):
-        _logger.error(
-            "The following clusters'primary EC2 were found as unresponsive and will be terminated: '%s",
+        _logger.warning(
+            "The following clusters'primary EC2 were starting for too long and will be terminated now "
+            "(either because a cluster was started and is not needed anymore, or there is an issue): '%s",
             f"{[i.id for i in terminateable_instances]}",
         )
         await delete_clusters(app, instances=terminateable_instances)
+
+    if broken_instances := disconnected_instances - starting_instances:
+        _logger.error(
+            "The following clusters'primary EC2 were found as unresponsive "
+            "(TIP: there is something wrong here, please inform support) and will be terminated now: '%s",
+            f"{[i.id for i in broken_instances]}",
+        )
+        await delete_clusters(app, instances=broken_instances)

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_core.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_core.py
@@ -42,7 +42,7 @@ _WALLET_ID_TAG_KEY: Final[AWSTagKey] = parse_obj_as(AWSTagKey, "wallet_id")
 async def _get_all_associated_worker_instances(
     app: FastAPI,
     primary_instances: Iterable[EC2InstanceData],
-):
+) -> list[EC2InstanceData]:
     worker_instances = []
     for instance in primary_instances:
         assert "user_id" in instance.tags  # nosec

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
@@ -28,6 +28,7 @@ async def get_or_create_cluster(
     ec2_instance: EC2InstanceData | None = None
     redis = get_redis_client(app)
     dask_scheduler_ready = False
+    cluster_auth = get_scheduler_auth(app)
     async with redis.lock_context(
         f"get_or_create_cluster-{user_id=}-{wallet_id=}",
         blocking=True,
@@ -37,15 +38,6 @@ async def get_or_create_cluster(
             ec2_instance = await clusters.get_cluster(
                 app, user_id=user_id, wallet_id=wallet_id
             )
-            cluster_auth = get_scheduler_auth(app)
-            dask_scheduler_ready = bool(
-                ec2_instance.state == "running"
-                and await ping_scheduler(get_scheduler_url(ec2_instance), cluster_auth)
-            )
-            if dask_scheduler_ready:
-                await clusters.cluster_heartbeat(
-                    app, user_id=user_id, wallet_id=wallet_id
-                )
         except Ec2InstanceNotFoundError:
             new_ec2_instances = await clusters.create_cluster(
                 app, user_id=user_id, wallet_id=wallet_id
@@ -53,6 +45,13 @@ async def get_or_create_cluster(
             assert new_ec2_instances  # nosec
             assert len(new_ec2_instances) == 1  # nosec
             ec2_instance = new_ec2_instances[0]
+
+        dask_scheduler_ready = bool(
+            ec2_instance.state == "running"
+            and await ping_scheduler(get_scheduler_url(ec2_instance), cluster_auth)
+        )
+        if dask_scheduler_ready:
+            await clusters.cluster_heartbeat(app, user_id=user_id, wallet_id=wallet_id)
     assert ec2_instance is not None  # nosec
     app_settings = get_application_settings(app)
     assert app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES  # nosec

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/clusters.py
@@ -27,6 +27,7 @@ async def get_or_create_cluster(
     """
     ec2_instance: EC2InstanceData | None = None
     redis = get_redis_client(app)
+    dask_scheduler_ready = False
     async with redis.lock_context(
         f"get_or_create_cluster-{user_id=}-{wallet_id=}",
         blocking=True,
@@ -36,7 +37,15 @@ async def get_or_create_cluster(
             ec2_instance = await clusters.get_cluster(
                 app, user_id=user_id, wallet_id=wallet_id
             )
-            await clusters.cluster_heartbeat(app, user_id=user_id, wallet_id=wallet_id)
+            cluster_auth = get_scheduler_auth(app)
+            dask_scheduler_ready = bool(
+                ec2_instance.state == "running"
+                and await ping_scheduler(get_scheduler_url(ec2_instance), cluster_auth)
+            )
+            if dask_scheduler_ready:
+                await clusters.cluster_heartbeat(
+                    app, user_id=user_id, wallet_id=wallet_id
+                )
         except Ec2InstanceNotFoundError:
             new_ec2_instances = await clusters.create_cluster(
                 app, user_id=user_id, wallet_id=wallet_id
@@ -45,17 +54,13 @@ async def get_or_create_cluster(
             assert len(new_ec2_instances) == 1  # nosec
             ec2_instance = new_ec2_instances[0]
     assert ec2_instance is not None  # nosec
-    cluster_auth = get_scheduler_auth(app)
     app_settings = get_application_settings(app)
     assert app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES  # nosec
     return create_cluster_from_ec2_instance(
         ec2_instance,
         user_id,
         wallet_id,
-        dask_scheduler_ready=bool(
-            ec2_instance.state == "running"
-            and await ping_scheduler(get_scheduler_url(ec2_instance), cluster_auth)
-        ),
+        dask_scheduler_ready=dask_scheduler_ready,
         cluster_auth=cluster_auth,
         max_cluster_start_time=app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES.PRIMARY_EC2_INSTANCES_MAX_START_TIME,
     )

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from typing import Any, Final
 
+import arrow
 import yaml
 from aws_library.ec2.models import EC2InstanceBootSpecific, EC2InstanceData, EC2Tags
 from fastapi.encoders import jsonable_encoder
@@ -161,24 +162,14 @@ def _convert_ec2_state_to_cluster_state(
             return ClusterState.STOPPED
 
 
-_EC2_INSTANCE_MAX_START_TIME: Final[datetime.timedelta] = datetime.timedelta(minutes=1)
-_DASK_SCHEDULER_READYNESS_MAX_TIME: Final[datetime.timedelta] = datetime.timedelta(
-    minutes=1
-)
-
-
 def _create_eta(
     instance_launch_time: datetime.datetime,
     *,
     dask_scheduler_ready: bool,
+    max_cluster_start_time: datetime.timedelta,
 ) -> datetime.timedelta:
-    now = datetime.datetime.now(datetime.timezone.utc)
-    estimated_time_to_running = (
-        instance_launch_time
-        + _EC2_INSTANCE_MAX_START_TIME
-        + _DASK_SCHEDULER_READYNESS_MAX_TIME
-        - now
-    )
+    now = arrow.utcnow().datetime
+    estimated_time_to_running = instance_launch_time + max_cluster_start_time - now
     if dask_scheduler_ready is True:
         estimated_time_to_running = datetime.timedelta(seconds=0)
     return estimated_time_to_running
@@ -191,6 +182,7 @@ def create_cluster_from_ec2_instance(
     *,
     dask_scheduler_ready: bool,
     cluster_auth: InternalClusterAuthentication,
+    max_cluster_start_time: datetime.timedelta,
 ) -> OnDemandCluster:
     return OnDemandCluster(
         endpoint=get_scheduler_url(instance),
@@ -200,6 +192,8 @@ def create_cluster_from_ec2_instance(
         wallet_id=wallet_id,
         dask_scheduler_ready=dask_scheduler_ready,
         eta=_create_eta(
-            instance.launch_time, dask_scheduler_ready=dask_scheduler_ready
+            instance.launch_time,
+            dask_scheduler_ready=dask_scheduler_ready,
+            max_cluster_start_time=max_cluster_start_time,
         ),
     )

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
@@ -3,7 +3,7 @@ import datetime
 import functools
 import json
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, Final, cast
 
 import arrow
 import yaml
@@ -172,7 +172,7 @@ def _create_eta(
     estimated_time_to_running = instance_launch_time + max_cluster_start_time - now
     if dask_scheduler_ready is True:
         estimated_time_to_running = datetime.timedelta(seconds=0)
-    return estimated_time_to_running
+    return cast(datetime.timedelta, estimated_time_to_running)  # mypy
 
 
 def create_cluster_from_ec2_instance(

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/ec2.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/ec2.py
@@ -14,7 +14,7 @@ _APPLICATION_VERSION_TAG: Final[EC2Tags] = parse_obj_as(
     EC2Tags, {f"{_APPLICATION_TAG_KEY}.version": f"{VERSION}"}
 )
 
-HEARTBEAT_TAG_KEY: Final[str] = "last_heartbeat"
+HEARTBEAT_TAG_KEY: Final[AWSTagKey] = parse_obj_as(AWSTagKey, "last_heartbeat")
 CLUSTER_NAME_PREFIX: Final[str] = "osparc-computational-cluster-"
 
 

--- a/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
+++ b/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
@@ -308,6 +308,7 @@ async def test_cluster_management_core_removes_broken_clusters_after_some_delay(
     mocked_dask_ping_scheduler.ping_scheduler.return_value = False
 
     # TODO: we need a delay here as well. a network issue might have happened and this kills it instantly.
+    assert False, "let's not do it this way!"
 
     # running now the cluster management task shall remove the cluster
     await check_clusters(initialized_app)

--- a/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
+++ b/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
@@ -307,6 +307,8 @@ async def test_cluster_management_core_removes_broken_clusters_after_some_delay(
     # simulate now a non responsive dask-scheduler, which means it is broken
     mocked_dask_ping_scheduler.ping_scheduler.return_value = False
 
+    # TODO: we need a delay here as well. a network issue might have happened and this kills it instantly.
+
     # running now the cluster management task shall remove the cluster
     await check_clusters(initialized_app)
     await _assert_cluster_exist_and_state(

--- a/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
+++ b/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
@@ -3,10 +3,12 @@
 # pylint: disable=unused-variable
 
 import asyncio
+import dataclasses
 from collections.abc import Awaitable, Callable
 from typing import Final
 from unittest.mock import MagicMock
 
+import arrow
 import pytest
 from attr import dataclass
 from aws_library.ec2.models import EC2InstanceData
@@ -17,6 +19,7 @@ from models_library.wallets import WalletID
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict
+from simcore_service_clusters_keeper.core.settings import ApplicationSettings
 from simcore_service_clusters_keeper.modules.clusters import (
     cluster_heartbeat,
     create_cluster,
@@ -215,7 +218,7 @@ async def test_cluster_management_core_properly_removes_workers_on_shutdown(
     )
 
 
-async def test_cluster_management_core_removes_broken_clusters_after_some_delay(
+async def test_cluster_management_core_removes_long_starting_clusters_after_some_delay(
     disable_clusters_management_background_task: None,
     _base_configuration: None,
     ec2_client: EC2Client,
@@ -223,7 +226,8 @@ async def test_cluster_management_core_removes_broken_clusters_after_some_delay(
     wallet_id: WalletID | None,
     initialized_app: FastAPI,
     mocked_dask_ping_scheduler: MockedDaskModule,
-    create_ec2_workers: Callable[[int], Awaitable[list[str]]],
+    app_settings: ApplicationSettings,
+    mocker: MockerFixture,
 ):
     created_clusters = await create_cluster(
         initialized_app, user_id=user_id, wallet_id=wallet_id
@@ -237,6 +241,76 @@ async def test_cluster_management_core_removes_broken_clusters_after_some_delay(
     await check_clusters(initialized_app)
     await _assert_cluster_exist_and_state(
         ec2_client, instances=created_clusters, state="running"
+    )
+    mocked_dask_ping_scheduler.ping_scheduler.assert_called_once()
+    mocked_dask_ping_scheduler.ping_scheduler.reset_mock()
+    mocked_dask_ping_scheduler.is_scheduler_busy.assert_not_called()
+
+    the_cluster = created_clusters[0]
+
+    # running now the cluster management task shall remove the cluster
+    assert app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES
+    mocked_get_all_clusters = mocker.patch(
+        "simcore_service_clusters_keeper.modules.clusters_management_core.get_all_clusters",
+        autospec=True,
+        return_value={
+            dataclasses.replace(
+                the_cluster,
+                launch_time=arrow.utcnow()
+                .shift(
+                    seconds=-app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES.PRIMARY_EC2_INSTANCES_MAX_START_TIME.total_seconds()
+                )
+                .datetime,
+            )
+        },
+    )
+    await check_clusters(initialized_app)
+    mocked_get_all_clusters.assert_called_once()
+    await _assert_cluster_exist_and_state(
+        ec2_client, instances=created_clusters, state="terminated"
+    )
+    mocked_dask_ping_scheduler.ping_scheduler.assert_called_once()
+    mocked_dask_ping_scheduler.ping_scheduler.reset_mock()
+    mocked_dask_ping_scheduler.is_scheduler_busy.assert_not_called()
+
+
+async def test_cluster_management_core_removes_broken_clusters_after_some_delay(
+    disable_clusters_management_background_task: None,
+    _base_configuration: None,
+    ec2_client: EC2Client,
+    user_id: UserID,
+    wallet_id: WalletID | None,
+    initialized_app: FastAPI,
+    mocked_dask_ping_scheduler: MockedDaskModule,
+    create_ec2_workers: Callable[[int], Awaitable[list[str]]],
+    app_settings: ApplicationSettings,
+    mocker: MockerFixture,
+):
+    created_clusters = await create_cluster(
+        initialized_app, user_id=user_id, wallet_id=wallet_id
+    )
+    assert len(created_clusters) == 1
+
+    # simulate a responsive dask-scheduler
+    mocked_dask_ping_scheduler.ping_scheduler.return_value = True
+
+    # running the cluster management task shall not remove anything
+    await check_clusters(initialized_app)
+    await _assert_cluster_exist_and_state(
+        ec2_client, instances=created_clusters, state="running"
+    )
+    mocked_dask_ping_scheduler.ping_scheduler.assert_called_once()
+    mocked_dask_ping_scheduler.ping_scheduler.reset_mock()
+    mocked_dask_ping_scheduler.is_scheduler_busy.assert_called_once()
+    mocked_dask_ping_scheduler.is_scheduler_busy.reset_mock()
+
+    # simulate now a non responsive dask-scheduler, which means it is broken
+    mocked_dask_ping_scheduler.ping_scheduler.return_value = False
+
+    # running now the cluster management task shall remove the cluster
+    await check_clusters(initialized_app)
+    await _assert_cluster_exist_and_state(
+        ec2_client, instances=created_clusters, state="terminated"
     )
     mocked_dask_ping_scheduler.ping_scheduler.assert_called_once()
     mocked_dask_ping_scheduler.ping_scheduler.reset_mock()

--- a/services/clusters-keeper/tests/unit/test_utils_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_utils_clusters.py
@@ -241,6 +241,7 @@ def test_create_cluster_from_ec2_instance(
         faker.pyint(),
         dask_scheduler_ready=faker.pybool(),
         cluster_auth=authentication,
+        max_cluster_start_time=faker.time_delta(),
     )
     assert cluster_instance
     assert cluster_instance.state is expected_cluster_state

--- a/services/clusters-keeper/tests/unit/test_utils_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_utils_clusters.py
@@ -22,8 +22,9 @@ from models_library.clusters import (
     NoAuthentication,
     TLSAuthentication,
 )
+from models_library.utils.json_serialization import json_dumps
 from pydantic import ByteSize, parse_obj_as
-from pytest_simcore.helpers.utils_envs import EnvVarsDict
+from pytest_simcore.helpers.utils_envs import EnvVarsDict, setenvs_from_dict
 from simcore_service_clusters_keeper.core.settings import ApplicationSettings
 from simcore_service_clusters_keeper.utils.clusters import (
     _prepare_environment_variables,
@@ -48,6 +49,21 @@ def ec2_boot_specs(app_settings: ApplicationSettings) -> EC2InstanceBootSpecific
     )
     assert isinstance(ec2_boot_specs, EC2InstanceBootSpecific)
     return ec2_boot_specs
+
+
+@pytest.fixture
+def app_environment(
+    app_environment: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> EnvVarsDict:
+    return app_environment | setenvs_from_dict(
+        monkeypatch,
+        {
+            "CLUSTERS_KEEPER_COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_AUTH": json_dumps(
+                TLSAuthentication.Config.schema_extra["examples"][0]
+            )
+        },
+    )
 
 
 def test_create_startup_script(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- [x] cluster heartbeats are set only after the cluster effectively started, and ```PRIMARY_EC2_INSTANCES_MAX_START_TIME``` keeps now a hard-coded 2minutes value. not an ENV for now at least.
- [x] if a started primary machine does not respond after ```PRIMARY_EC2_INSTANCES_MAX_START_TIME``` it will be terminated with a warning in the logs, if the dv-2 still wants a machine a new one will then be started
- [x] if a primary machine suddenly stops responding (e.g. the dask-scheduler is somehow broken), it will be removed with its workers after 5 minutes.
- [x] some refactoring and missing tests

🚨Needs some testing in master **BEFORE** it goes anywhere else. as this is an AWS only feature.

## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/5436
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
