### PR TITLE
🔨 Retires deprecated `pkg_resources` module

### DIFF
--- a/packages/service-library/src/servicelib/resources.py
+++ b/packages/service-library/src/servicelib/resources.py
@@ -1,6 +1,6 @@
 """ Safe access to all data resources distributed with this package
 
-See https://setuptools.readthedocs.io/en/latest/pkg_resources.html
+https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources
 """
 
 import importlib.resources
@@ -12,7 +12,7 @@ from pathlib import Path
 class DataResourcesFacade:
     """Facade to access data resources installed with a distribution
 
-    - Built on top of pkg_resources
+    - Built on top of importlib.resources
 
     Resources are read-only files/folders
     """

--- a/requirements/packages-notes.md
+++ b/requirements/packages-notes.md
@@ -17,9 +17,6 @@ Keeps a list notes with relevant information about releases of python package. S
   - is a backport of Python 3.9’s standard library [importlib.resources](https://docs.python.org/3.7/library/importlib.html#module-importlib.resources)
 - [packaging](https://packaging.pypa.io/en/latest/)
   - used for  version handling, specifiers, markers, requirements, tags, utilities. It follows several PEPs and will probably end up in the python standard library
-  - might prefer over ``pkg_resources``
-- [pkg_resources](https://setuptools.readthedocs.io/en/latest/pkg_resources.html)
-  - most of the functionlity seems to be moved into the standard library. Some backports of those are ``importlib-metadata``, ``importlib-resources`` and ``packaging``.
 - [dataclasses](https://pypi.org/project/dataclasses/)
   - a backport of the [``dataclasses`` module](https://docs.python.org/3/library/dataclasses.html) for Python 3.6. Included as dataclasses in standard library from python >=3.7.
   - here is included as a dependency to [pydantic](https://pydantic-docs.helpmanual.io/)

--- a/services/dynamic-sidecar/requirements/_test.in
+++ b/services/dynamic-sidecar/requirements/_test.in
@@ -17,7 +17,6 @@ python-dotenv
 sqlalchemy[mypy] # adds Mypy / Pep-484 Support for ORM Mappings SEE https://docs.sqlalchemy.org/en/20/orm/extensions/mypy.html
 types_aiobotocore_s3
 types-aiofiles # missing mypy stubs
-types-pkg_resources # missing mypy stubs
 types-PyYAML # missing mypy stubs
 
 

--- a/services/dynamic-sidecar/requirements/_test.txt
+++ b/services/dynamic-sidecar/requirements/_test.txt
@@ -95,7 +95,6 @@ tomli==2.0.1
     #   pytest
 types-aiobotocore-s3==2.12.3
 types-aiofiles==23.2.0.20240403
-types-pkg-resources==0.1.3
 types-pyyaml==6.0.12.20240311
 typing-extensions==4.11.0
     # via


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Removes any reference to `pkg_resources`

## Related issue/s

-  closes https://github.com/ITISFoundation/osparc-simcore/issues/3151
