### PR TITLE
🔨 Reuses pytest_simcore fixtures and exposes CLI options to override them

### DIFF
--- a/packages/notifications-library/tests/conftest.py
+++ b/packages/notifications-library/tests/conftest.py
@@ -12,7 +12,7 @@ import pytest
 from models_library.products import ProductName
 from notifications_library._models import ProductData, UserData
 from notifications_library.payments import PaymentData
-from pydantic import EmailStr, parse_obj_as
+from pydantic import EmailStr
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_postgres_database.models.products import Vendor
 
@@ -36,61 +36,12 @@ def package_dir() -> Path:
     return pdir
 
 
-def pytest_addoption(parser: pytest.Parser):
-    group = parser.getgroup(
-        "simcore",
-    )
-    group.addoption(
-        "--external-support-email",
-        action="store",
-        type=str,
-        default=None,
-        help="Overrides `support_email` fixture",
-    )
-
-
 @pytest.fixture(scope="session")
 def external_environment(external_environment: EnvVarsDict) -> EnvVarsDict:
     if external_environment:
         assert "PAYMENTS_GATEWAY_API_SECRET" in external_environment
         assert "PAYMENTS_GATEWAY_URL" in external_environment
     return external_environment
-
-
-@pytest.fixture(scope="session")
-def external_bcc_email(request: pytest.FixtureRequest) -> str | None:
-    email_or_none = request.config.getoption("--external-bcc-email", default=None)
-    return parse_obj_as(EmailStr, email_or_none) if email_or_none else None
-
-
-@pytest.fixture
-def bcc_email(bbc_email: EmailStr, external_bcc_email: EmailStr | None) -> EmailStr:
-    """Overrides pytest_simcore.faker_products_data.bcc_email"""
-    if external_bcc_email:
-        print(
-            f"📧 EXTERNAL `bcc_email` detected. Setting bcc_email={external_user_email}"
-        )
-        return external_bcc_email
-    return bcc_email
-
-
-@pytest.fixture(scope="session")
-def external_support_email(request: pytest.FixtureRequest) -> str | None:
-    email_or_none = request.config.getoption("--external-support-email", default=None)
-    return parse_obj_as(EmailStr, email_or_none) if email_or_none else None
-
-
-@pytest.fixture
-def support_email(
-    support_email: EmailStr, external_support_email: EmailStr | None
-) -> EmailStr:
-    """Overrides pytest_simcore.faker_products_data.support_email"""
-    if external_support_email:
-        print(
-            f"📧 EXTERNAL `support_email` detected. Setting support_email={external_support_email}"
-        )
-        return external_support_email
-    return support_email
 
 
 #

--- a/packages/notifications-library/tests/conftest.py
+++ b/packages/notifications-library/tests/conftest.py
@@ -37,11 +37,11 @@ def package_dir() -> Path:
 
 
 @pytest.fixture(scope="session")
-def external_environment(external_environment: EnvVarsDict) -> EnvVarsDict:
-    if external_environment:
-        assert "PAYMENTS_GATEWAY_API_SECRET" in external_environment
-        assert "PAYMENTS_GATEWAY_URL" in external_environment
-    return external_environment
+def external_envfile_dict(external_envfile_dict: EnvVarsDict) -> EnvVarsDict:
+    if external_envfile_dict:
+        assert "PAYMENTS_GATEWAY_API_SECRET" in external_envfile_dict
+        assert "PAYMENTS_GATEWAY_URL" in external_envfile_dict
+    return external_envfile_dict
 
 
 #

--- a/packages/notifications-library/tests/conftest.py
+++ b/packages/notifications-library/tests/conftest.py
@@ -41,13 +41,6 @@ def pytest_addoption(parser: pytest.Parser):
         "simcore",
     )
     group.addoption(
-        "--external-user-email",
-        action="store",
-        type=str,
-        default=None,
-        help="Overrides `user_email` fixture",
-    )
-    group.addoption(
         "--external-support-email",
         action="store",
         type=str,
@@ -62,23 +55,6 @@ def external_environment(external_environment: EnvVarsDict) -> EnvVarsDict:
         assert "PAYMENTS_GATEWAY_API_SECRET" in external_environment
         assert "PAYMENTS_GATEWAY_URL" in external_environment
     return external_environment
-
-
-@pytest.fixture(scope="session")
-def external_user_email(request: pytest.FixtureRequest) -> str | None:
-    email_or_none = request.config.getoption("--external-user-email", default=None)
-    return parse_obj_as(EmailStr, email_or_none) if email_or_none else None
-
-
-@pytest.fixture
-def user_email(user_email: EmailStr, external_user_email: EmailStr | None) -> EmailStr:
-    """Overrides pytest_simcore.faker_users_data.user_email"""
-    if external_user_email:
-        print(
-            f"📧 EXTERNAL `user_email` detected. Setting user_email={external_user_email}"
-        )
-        return external_user_email
-    return user_email
 
 
 @pytest.fixture(scope="session")

--- a/packages/notifications-library/tests/email/conftest.py
+++ b/packages/notifications-library/tests/email/conftest.py
@@ -24,9 +24,9 @@ def app_environment(
 
 @pytest.fixture
 def smtp_mock_or_none(
-    mocker: MockerFixture, external_user_email: EmailStr | None
+    mocker: MockerFixture, is_external_user_email: EmailStr | None, user_email: EmailStr
 ) -> MagicMock | None:
-    if not external_user_email:
+    if not is_external_user_email:
         return mocker.patch("notifications_library._email.SMTP")
-    print("🚨 Emails might be sent to", external_user_email)
+    print("🚨 Emails might be sent to", f"{user_email=}")
     return None

--- a/packages/notifications-library/tests/email/conftest.py
+++ b/packages/notifications-library/tests/email/conftest.py
@@ -11,13 +11,13 @@ from pytest_simcore.helpers.utils_envs import setenvs_from_dict
 def app_environment(
     monkeypatch: pytest.MonkeyPatch,
     env_devel_dict: EnvVarsDict,
-    external_environment: EnvVarsDict,
+    external_envfile_dict: EnvVarsDict,
 ) -> EnvVarsDict:
     return setenvs_from_dict(
         monkeypatch,
         {
             **env_devel_dict,
-            **external_environment,
+            **external_envfile_dict,
         },
     )
 

--- a/packages/notifications-library/tests/email/test_email_events.py
+++ b/packages/notifications-library/tests/email/test_email_events.py
@@ -2,7 +2,7 @@
 These tests can be run against external configuration
 
 cd packages/notifications-library
-pytest --external-envfile=.my-env --external-support-email=support@email.com  --external-user-email=my@email.com tests/email
+pytest --external-envfile=.my-env --external-support-email=support@email.com  --fake-user-email=my@email.com tests/email
 
 """
 

--- a/packages/notifications-library/tests/email/test_email_events.py
+++ b/packages/notifications-library/tests/email/test_email_events.py
@@ -2,7 +2,13 @@
 These tests can be run against external configuration
 
 cd packages/notifications-library
-pytest --external-envfile=.my-env --external-support-email=support@email.com  --fake-user-email=my@email.com tests/email
+make install-dev
+
+pytest \
+    --external-envfile=.my-env \
+    --faker-support-email=support@email.com  \
+    --faker-user-email=my@email.com \
+    tests/email
 
 """
 

--- a/packages/pytest-simcore/src/pytest_simcore/__init__.py
+++ b/packages/pytest-simcore/src/pytest_simcore/__init__.py
@@ -16,14 +16,6 @@ def pytest_addoption(parser: pytest.Parser):
         help="Keep stack/registry up after fixtures closes",
     )
 
-    simcore_group.addoption(
-        "--external-envfile",
-        action="store",
-        type=Path,
-        default=None,
-        help="Path to an env file. Consider passing a link to repo configs, i.e. `ln -s /path/to/osparc-ops-config/repo.config`",
-    )
-
     # DUMMY
     parser.addini("HELLO", "Dummy pytest.ini setting")
 

--- a/packages/pytest-simcore/src/pytest_simcore/docker_registry.py
+++ b/packages/pytest-simcore/src/pytest_simcore/docker_registry.py
@@ -101,11 +101,11 @@ def docker_registry(keep_docker_up: bool) -> Iterator[str]:
 
 @pytest.fixture
 def external_registry_settings(
-    external_environment: EnvVarsDict,
+    external_envfile_dict: EnvVarsDict,
 ) -> RegistrySettings | None:
-    if external_environment:
+    if external_envfile_dict:
         config = {
-            field: external_environment.get(field, None)
+            field: external_envfile_dict.get(field, None)
             for field in RegistrySettings.__fields__
         }
         return RegistrySettings.parse_obj(config)

--- a/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
+++ b/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
@@ -38,8 +38,19 @@ def all_env_devel_undefined(
     delenvs_from_dict(monkeypatch, env_devel_dict, raising=False)
 
 
+def pytest_addoption(parser: pytest.Parser):
+    simcore_group = parser.getgroup("simcore")
+    simcore_group.addoption(
+        "--external-envfile",
+        action="store",
+        type=Path,
+        default=None,
+        help="Path to an env file. Consider passing a link to repo configs, i.e. `ln -s /path/to/osparc-ops-config/repo.config`",
+    )
+
+
 @pytest.fixture(scope="session")
-def external_environment(request: pytest.FixtureRequest) -> EnvVarsDict:
+def external_envfile_dict(request: pytest.FixtureRequest) -> EnvVarsDict:
     """
     If a file under test folder prefixed with `.env-secret` is present,
     then this fixture captures it.

--- a/packages/pytest-simcore/src/pytest_simcore/faker_products_data.py
+++ b/packages/pytest-simcore/src/pytest_simcore/faker_products_data.py
@@ -14,24 +14,57 @@ from typing import Any
 import pytest
 from faker import Faker
 from models_library.products import ProductName, StripePriceID, StripeTaxRateID
-from pydantic import EmailStr
+from pydantic import EmailStr, parse_obj_as
 
 from .helpers.rawdata_fakers import random_product
+
+_MESSAGE = (
+    "If set, it overrides the fake value of `{}` fixture."
+    " Can be handy when interacting with external/real APIs"
+)
+
+
+def pytest_addoption(parser: pytest.Parser):
+    simcore_group = parser.getgroup("simcore")
+    simcore_group.addoption(
+        "--faker-support-email",
+        action="store",
+        type=str,
+        default=None,
+        help=_MESSAGE.format("support_email"),
+    )
+    simcore_group.addoption(
+        "--faker-bcc-email",
+        action="store",
+        type=str,
+        default=None,
+        help=_MESSAGE.format("bcc_email"),
+    )
 
 
 @pytest.fixture
 def product_name() -> ProductName:
-    return ProductName("the_test_product")
+    return ProductName("thetestproduct")
 
 
 @pytest.fixture
-def support_email(product_name: ProductName) -> EmailStr:
-    return EmailStr(f"support@{product_name}.info")
+def support_email(
+    request: pytest.FixtureRequest, product_name: ProductName
+) -> EmailStr:
+    return parse_obj_as(
+        EmailStr,
+        request.config.getoption("--faker-support-email", default=None)
+        or f"support@{product_name}.info",
+    )
 
 
 @pytest.fixture
-def bcc_email(product_name: ProductName) -> EmailStr:
-    return EmailStr(f"finance@{product_name}-department.info")
+def bcc_email(request: pytest.FixtureRequest, product_name: ProductName) -> EmailStr:
+    return parse_obj_as(
+        EmailStr,
+        request.config.getoption("--faker-bcc-email", default=None)
+        or f"finance@{product_name}-department.info",
+    )
 
 
 @pytest.fixture

--- a/packages/pytest-simcore/src/pytest_simcore/faker_users_data.py
+++ b/packages/pytest-simcore/src/pytest_simcore/faker_users_data.py
@@ -69,10 +69,7 @@ def user_id(faker: Faker, request: pytest.FixtureRequest) -> UserID:
 
 @pytest.fixture(scope="session")
 def is_external_user_email(request: pytest.FixtureRequest) -> bool:
-    if user_email := request.config.getoption(_FAKE_USER_EMAIL_OPTION, default=None):
-        print(f"📧 {user_email=} was passed externally via {_FAKE_USER_EMAIL_OPTION}")
-        return True
-    return False
+    return bool(request.config.getoption(_FAKE_USER_EMAIL_OPTION, default=None))
 
 
 @pytest.fixture

--- a/packages/pytest-simcore/src/pytest_simcore/faker_users_data.py
+++ b/packages/pytest-simcore/src/pytest_simcore/faker_users_data.py
@@ -24,6 +24,9 @@ _MESSAGE = (
 )
 
 
+_FAKE_USER_EMAIL_OPTION = "--faker-user-email"
+
+
 def pytest_addoption(parser: pytest.Parser):
     simcore_group = parser.getgroup("simcore")
     simcore_group.addoption(
@@ -34,7 +37,7 @@ def pytest_addoption(parser: pytest.Parser):
         help=_MESSAGE.format("user_id"),
     )
     simcore_group.addoption(
-        "--faker-user-email",
+        _FAKE_USER_EMAIL_OPTION,
         action="store",
         type=str,
         default=None,
@@ -64,11 +67,20 @@ def user_id(faker: Faker, request: pytest.FixtureRequest) -> UserID:
     )
 
 
+@pytest.fixture(scope="session")
+def is_external_user_email(request: pytest.FixtureRequest) -> bool:
+    if user_email := request.config.getoption(_FAKE_USER_EMAIL_OPTION, default=None):
+        print(f"📧 {user_email=} was passed externally via {_FAKE_USER_EMAIL_OPTION}")
+        return True
+    return False
+
+
 @pytest.fixture
 def user_email(faker: Faker, request: pytest.FixtureRequest) -> EmailStr:
     return parse_obj_as(
         EmailStr,
-        request.config.getoption("--faker-user-email", default=None) or faker.email(),
+        request.config.getoption(_FAKE_USER_EMAIL_OPTION, default=None)
+        or faker.email(),
     )
 
 

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/rawdata_fakers.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/rawdata_fakers.py
@@ -8,6 +8,8 @@
 
     NOTE: all outputs MUST be Dict-like or built-in data structures that fit at least
     required fields in postgres_database.models tables or pydantic models.
+
+    NOTE: to reduce coupling, please import simcore_postgres_database inside of the functions
 """
 
 

--- a/packages/simcore-sdk/tests/unit/conftest.py
+++ b/packages/simcore-sdk/tests/unit/conftest.py
@@ -3,8 +3,9 @@
 # pylint:disable=redefined-outer-name
 
 import json
+from collections.abc import AsyncIterator, Callable
 from random import randint
-from typing import Any, AsyncIterator, Callable, Dict
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -32,7 +33,7 @@ async def mock_db_manager(
     project_id: str,
     node_uuid: str,
 ) -> AsyncIterator[Callable]:
-    def _mock_db_manager(port_cfg: Dict[str, Any]) -> DBManager:
+    def _mock_db_manager(port_cfg: dict[str, Any]) -> DBManager:
         async def mock_get_ports_configuration_from_node_uuid(*args, **kwargs) -> str:
             return json.dumps(port_cfg)
 
@@ -57,4 +58,4 @@ async def mock_db_manager(
         db_manager = DBManager()
         return db_manager
 
-    yield _mock_db_manager
+    return _mock_db_manager

--- a/services/api-server/tests/conftest.py
+++ b/services/api-server/tests/conftest.py
@@ -16,6 +16,7 @@ pytest_plugins = [
     "pytest_simcore.cli_runner",
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_swarm",
+    "pytest_simcore.environment_configs",
     "pytest_simcore.faker_projects_data",
     "pytest_simcore.faker_users_data",
     "pytest_simcore.httpbin_service",

--- a/services/api-server/tests/unit/test_core_settings.py
+++ b/services/api-server/tests/unit/test_core_settings.py
@@ -2,7 +2,6 @@
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
 
-import logging
 
 import pytest
 from pytest_simcore.helpers.utils_envs import (
@@ -10,9 +9,10 @@ from pytest_simcore.helpers.utils_envs import (
     delenvs_from_dict,
     setenvs_from_dict,
 )
-from simcore_service_api_server.core.settings import ApplicationSettings, BootModeEnum
+from simcore_service_api_server.core.settings import ApplicationSettings
 
 
+@pytest.fixture
 def app_environment(
     monkeypatch: pytest.MonkeyPatch,
     app_environment: EnvVarsDict,
@@ -36,11 +36,5 @@ def app_environment(
 
 def test_unit_app_environment(app_environment: EnvVarsDict):
     assert app_environment
-
     settings = ApplicationSettings.create_from_envs()
     print("captured settings: \n", settings.json(indent=2))
-
-    assert settings.SC_BOOT_MODE == BootModeEnum.PRODUCTION
-    assert settings.log_level == logging.DEBUG
-
-    assert settings.API_SERVER_POSTGRES is None

--- a/services/api-server/tests/unit/test_core_settings.py
+++ b/services/api-server/tests/unit/test_core_settings.py
@@ -2,14 +2,41 @@
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
 
-
 import logging
 
-from pytest_simcore.helpers.utils_envs import EnvVarsDict
+import pytest
+from pytest_simcore.helpers.utils_envs import (
+    EnvVarsDict,
+    delenvs_from_dict,
+    setenvs_from_dict,
+)
 from simcore_service_api_server.core.settings import ApplicationSettings, BootModeEnum
 
 
+def app_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    app_environment: EnvVarsDict,
+    external_envfile_dict: EnvVarsDict,
+) -> EnvVarsDict:
+    """
+    NOTE: To run against repo.config in osparc-config repo
+
+    ln -s /path/to/osparc-config/deployments/mydeploy.com/repo.config .secrets
+    pytest --external-envfile=.secrets tests/unit/test_core_settings.py
+
+    """
+    if external_envfile_dict:
+        delenvs_from_dict(monkeypatch, app_environment, raising=False)
+        return setenvs_from_dict(
+            monkeypatch,
+            {**external_envfile_dict},
+        )
+    return app_environment
+
+
 def test_unit_app_environment(app_environment: EnvVarsDict):
+    assert app_environment
+
     settings = ApplicationSettings.create_from_envs()
     print("captured settings: \n", settings.json(indent=2))
 

--- a/services/catalog/tests/unit/conftest.py
+++ b/services/catalog/tests/unit/conftest.py
@@ -11,10 +11,11 @@ from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import load_dotenv, setenvs_from_envfile
 
 pytest_plugins = [
+    "pytest_simcore.postgres_service",
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
-    "pytest_simcore.faker_users_data" "pytest_simcore.postgres_service",
+    "pytest_simcore.faker_users_data",
     "pytest_simcore.pydantic_models",
     "pytest_simcore.pytest_global_environs",
     "pytest_simcore.repository_paths",

--- a/services/catalog/tests/unit/conftest.py
+++ b/services/catalog/tests/unit/conftest.py
@@ -14,7 +14,7 @@ pytest_plugins = [
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
-    "pytest_simcore.postgres_service",
+    "pytest_simcore.faker_users_data" "pytest_simcore.postgres_service",
     "pytest_simcore.pydantic_models",
     "pytest_simcore.pytest_global_environs",
     "pytest_simcore.repository_paths",

--- a/services/catalog/tests/unit/with_dbs/conftest.py
+++ b/services/catalog/tests/unit/with_dbs/conftest.py
@@ -7,7 +7,6 @@ import itertools
 import random
 from copy import deepcopy
 from datetime import datetime
-from random import randint
 from typing import Any, AsyncIterator, Awaitable, Callable, Iterator
 
 import pytest
@@ -125,11 +124,6 @@ def director_mockup(app: FastAPI) -> Iterator[respx.MockRouter]:
 #   -> user, user_to_groups
 # - products
 #
-
-
-@pytest.fixture(scope="session")
-def user_id() -> UserID:
-    return UserID(randint(1, 10000))
 
 
 @pytest.fixture()

--- a/services/clusters-keeper/tests/unit/conftest.py
+++ b/services/clusters-keeper/tests/unit/conftest.py
@@ -44,6 +44,7 @@ pytest_plugins = [
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_swarm",
     "pytest_simcore.environment_configs",
+    "pytest_simcore.faker_users_data",
     "pytest_simcore.rabbit_service",
     "pytest_simcore.repository_paths",
     "pytest_simcore.simcore_service_library_fixtures",

--- a/services/clusters-keeper/tests/unit/test_modules_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_modules_clusters.py
@@ -38,11 +38,6 @@ from types_aiobotocore_ec2 import EC2Client
 
 
 @pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
-@pytest.fixture
 def wallet_id(faker: Faker) -> WalletID:
     return faker.pyint(min_value=1)
 

--- a/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
+++ b/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
@@ -31,11 +31,6 @@ from types_aiobotocore_ec2 import EC2Client
 from types_aiobotocore_ec2.literals import InstanceStateNameType
 
 
-@pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
 @pytest.fixture(params=("with_wallet", "without_wallet"))
 def wallet_id(faker: Faker, request: pytest.FixtureRequest) -> WalletID | None:
     return faker.pyint(min_value=1) if request.param == "with_wallet" else None

--- a/services/clusters-keeper/tests/unit/test_rpc_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_rpc_clusters.py
@@ -32,11 +32,6 @@ pytest_simcore_ops_services_selection = []
 
 
 @pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
-@pytest.fixture
 def wallet_id(faker: Faker) -> WalletID:
     return faker.pyint(min_value=1)
 

--- a/services/clusters-keeper/tests/unit/test_utils_ec2.py
+++ b/services/clusters-keeper/tests/unit/test_utils_ec2.py
@@ -18,11 +18,6 @@ from simcore_service_clusters_keeper.utils.ec2 import (
 
 
 @pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
-@pytest.fixture
 def wallet_id(faker: Faker) -> WalletID:
     return faker.pyint(min_value=1)
 

--- a/services/dask-sidecar/tests/unit/conftest.py
+++ b/services/dask-sidecar/tests/unit/conftest.py
@@ -35,6 +35,7 @@ pytest_plugins = [
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
     "pytest_simcore.environment_configs",
+    "pytest_simcore.faker_users_data",
     "pytest_simcore.repository_paths",
     "pytest_simcore.tmp_path_extra",
 ]
@@ -251,11 +252,6 @@ def file_on_s3_server(
 @pytest.fixture
 def job_id() -> str:
     return "some_incredible_string"
-
-
-@pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
 
 
 @pytest.fixture

--- a/services/director-v2/tests/conftest.py
+++ b/services/director-v2/tests/conftest.py
@@ -35,6 +35,7 @@ pytest_plugins = [
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
     "pytest_simcore.environment_configs",
+    "pytest_simcore.faker_users_data",
     "pytest_simcore.minio_service",
     "pytest_simcore.postgres_service",
     "pytest_simcore.pydantic_models",

--- a/services/director-v2/tests/integration/02/test_dynamic_services_routes.py
+++ b/services/director-v2/tests/integration/02/test_dynamic_services_routes.py
@@ -90,12 +90,14 @@ def user_db(registered_user: Callable[..., dict[str, Any]]) -> dict[str, Any]:
 
 
 @pytest.fixture
-def user_id(user_db) -> UserID:
+def user_id(user_db: dict[str, Any]) -> UserID:
     return UserID(user_db["id"])
 
 
 @pytest.fixture
-async def project_id(user_db, project: Callable[..., Awaitable[ProjectAtDB]]) -> str:
+async def project_id(
+    user_db: dict[str, Any], project: Callable[..., Awaitable[ProjectAtDB]]
+) -> str:
     prj = await project(user=user_db)
     return f"{prj.uuid}"
 

--- a/services/director-v2/tests/unit/test_modules_api_keys_manager.py
+++ b/services/director-v2/tests/unit/test_modules_api_keys_manager.py
@@ -46,11 +46,6 @@ def product_name(faker: Faker) -> ProductName:
     return faker.pystr()
 
 
-@pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint()
-
-
 def test_get_api_key_name_is_not_randomly_generated(node_id: NodeID, run_id: RunID):
     api_key_names = {_get_api_key_name(node_id, run_id) for _ in range(1000)}
     assert len(api_key_names) == 1

--- a/services/director-v2/tests/unit/test_modules_catalog.py
+++ b/services/director-v2/tests/unit/test_modules_catalog.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import pytest
 import respx
-from faker import Faker
 from fastapi import FastAPI
 from models_library.services import ServiceKeyVersion
 from models_library.users import UserID
@@ -27,11 +26,6 @@ def minimal_catalog_config(
     monkeypatch.setenv("DIRECTOR_V0_ENABLED", "0")
     monkeypatch.setenv("COMPUTATIONAL_BACKEND_DASK_CLIENT_ENABLED", "0")
     monkeypatch.setenv("COMPUTATIONAL_BACKEND_ENABLED", "0")
-
-
-@pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return UserID(faker.pyint(min_value=1))
 
 
 def test_get_catalog_client_instance(

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -135,11 +135,6 @@ async def _assert_wait_for_task_status(
 
 
 @pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
-@pytest.fixture
 def _minimal_dask_config(
     disable_postgres: None,
     mock_env: EnvVarsDict,

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_volumes_resolver.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_volumes_resolver.py
@@ -43,11 +43,6 @@ def project_id(faker: Faker) -> ProjectID:
 
 
 @pytest.fixture
-def user_id() -> UserID:
-    return 42
-
-
-@pytest.fixture
 def expected_volume_config(
     swarm_stack_name: str,
     node_uuid: UUID,

--- a/services/director-v2/tests/unit/test_modules_notifier.py
+++ b/services/director-v2/tests/unit/test_modules_notifier.py
@@ -94,11 +94,6 @@ async def socketio_server(
 
 
 @pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint()
-
-
-@pytest.fixture
 def node_id(faker: Faker) -> NodeID:
     return faker.uuid4(cast_to=None)
 

--- a/services/director-v2/tests/unit/test_modules_project_networks.py
+++ b/services/director-v2/tests/unit/test_modules_project_networks.py
@@ -195,11 +195,6 @@ def fake_project_id() -> ProjectID:
 
 
 @pytest.fixture
-def user_id() -> PositiveInt:
-    return 1
-
-
-@pytest.fixture
 def mock_docker_calls(mocker: MockerFixture) -> Iterable[dict[str, AsyncMock]]:
     requires_dynamic_sidecar_mock = AsyncMock()
     requires_dynamic_sidecar_mock.return_value = True

--- a/services/director-v2/tests/unit/test_modules_storage.py
+++ b/services/director-v2/tests/unit/test_modules_storage.py
@@ -4,7 +4,6 @@
 # pylint:disable=protected-access
 
 import pytest
-from faker import Faker
 from fastapi import FastAPI
 from models_library.users import UserID
 from settings_library.s3 import S3Settings
@@ -22,11 +21,6 @@ def minimal_storage_config(
     monkeypatch.setenv("DIRECTOR_V2_CATALOG", "null")
     monkeypatch.setenv("COMPUTATIONAL_BACKEND_DASK_CLIENT_ENABLED", "0")
     monkeypatch.setenv("COMPUTATIONAL_BACKEND_ENABLED", "0")
-
-
-@pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return UserID(faker.pyint(min_value=1))
 
 
 def test_get_storage_client_instance(

--- a/services/director-v2/tests/unit/with_dbs/test_api_route_computations_tasks.py
+++ b/services/director-v2/tests/unit/with_dbs/test_api_route_computations_tasks.py
@@ -101,12 +101,12 @@ def mocked_nodeports_storage_client(mocker, faker: Faker) -> dict[str, mock.Magi
 
 
 @pytest.fixture
-def user(registered_user: Callable[..., dict[str, Any]]):
+def user(registered_user: Callable[..., dict[str, Any]]) -> dict[str, Any]:
     return registered_user()
 
 
 @pytest.fixture
-def user_id(user):
+def user_id(user: dict[str, Any]):
     return user["id"]
 
 

--- a/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_dynamic_sidecar_docker_api.py
@@ -220,11 +220,6 @@ async def cleanup_test_dynamic_sidecar_service(
 
 
 @pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
-@pytest.fixture
 def project_id(faker: Faker) -> ProjectID:
     return ProjectID(faker.uuid4())
 

--- a/services/director-v2/tests/unit/with_dbs/test_utils_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/test_utils_dask.py
@@ -126,11 +126,6 @@ def service_version() -> str:
 
 
 @pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
-@pytest.fixture
 def project_id(faker: Faker) -> ProjectID:
     return ProjectID(faker.uuid4())
 

--- a/services/dynamic-sidecar/tests/conftest.py
+++ b/services/dynamic-sidecar/tests/conftest.py
@@ -36,6 +36,7 @@ pytest_plugins = [
     "pytest_simcore.docker_compose",
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
+    "pytest_simcore.faker_users_data",
     "pytest_simcore.minio_service",
     "pytest_simcore.pytest_global_environs",
     "pytest_simcore.pytest_socketio",

--- a/services/dynamic-sidecar/tests/conftest.py
+++ b/services/dynamic-sidecar/tests/conftest.py
@@ -111,11 +111,6 @@ def state_exclude_dirs(container_base_dir: Path) -> list[Path]:
 
 
 @pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
-@pytest.fixture
 def project_id(faker: Faker) -> ProjectID:
     return faker.uuid4(cast_to=None)
 

--- a/services/payments/tests/conftest.py
+++ b/services/payments/tests/conftest.py
@@ -55,18 +55,6 @@ def secret_key() -> str:
     return generate_token_secret_key(32)
 
 
-def pytest_addoption(parser: pytest.Parser):
-    group = parser.getgroup("simcore")
-
-    group.addoption(
-        "--external-email",
-        action="store",
-        type=str,
-        default=None,
-        help="An email for test_services_notifier_email",
-    )
-
-
 @pytest.fixture(scope="session")
 def external_environment(external_environment: EnvVarsDict) -> EnvVarsDict:
     if external_environment:

--- a/services/payments/tests/conftest.py
+++ b/services/payments/tests/conftest.py
@@ -56,19 +56,20 @@ def secret_key() -> str:
 
 
 @pytest.fixture(scope="session")
-def external_environment(external_environment: EnvVarsDict) -> EnvVarsDict:
-    if external_environment:
-        assert "PAYMENTS_GATEWAY_API_SECRET" in external_environment
-        assert "PAYMENTS_GATEWAY_URL" in external_environment
-    return external_environment
+def external_envfile_dict(external_envfile_dict: EnvVarsDict) -> EnvVarsDict:
+    if external_envfile_dict:
+        assert "PAYMENTS_GATEWAY_API_SECRET" in external_envfile_dict
+        assert "PAYMENTS_GATEWAY_URL" in external_envfile_dict
+    return external_envfile_dict
 
 
 @pytest.fixture
 def env_devel_dict(
-    env_devel_dict: EnvVarsDict, external_environment: EnvVarsDict
+    env_devel_dict: EnvVarsDict, external_envfile_dict: EnvVarsDict
 ) -> EnvVarsDict:
-    if external_environment:
-        return external_environment
+    if external_envfile_dict:
+        print("")
+        return external_envfile_dict
     return env_devel_dict
 
 

--- a/services/payments/tests/conftest.py
+++ b/services/payments/tests/conftest.py
@@ -68,7 +68,6 @@ def env_devel_dict(
     env_devel_dict: EnvVarsDict, external_envfile_dict: EnvVarsDict
 ) -> EnvVarsDict:
     if external_envfile_dict:
-        print("")
         return external_envfile_dict
     return env_devel_dict
 

--- a/services/payments/tests/unit/api/test_rest_acknowledgements.py
+++ b/services/payments/tests/unit/api/test_rest_acknowledgements.py
@@ -37,7 +37,7 @@ pytest_simcore_ops_services_selection = [
 def app_environment(
     app_environment: EnvVarsDict,
     postgres_env_vars_dict: EnvVarsDict,
-    external_environment: EnvVarsDict,
+    external_envfile_dict: EnvVarsDict,
     wait_for_postgres_ready_and_db_migrated: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> EnvVarsDict:
@@ -49,7 +49,7 @@ def app_environment(
         {
             **app_environment,
             **postgres_env_vars_dict,
-            **external_environment,
+            **external_envfile_dict,
             "POSTGRES_CLIENT_NAME": "payments-service-pg-client",
         },
     )
@@ -66,10 +66,10 @@ def app(
 
 @pytest.fixture
 async def client(
-    client: httpx.AsyncClient, external_environment: EnvVarsDict
+    client: httpx.AsyncClient, external_envfile_dict: EnvVarsDict
 ) -> AsyncIterator[httpx.AsyncClient]:
     # EITHER tests against external payments API
-    if external_base_url := external_environment.get("PAYMENTS_SERVICE_API_BASE_URL"):
+    if external_base_url := external_envfile_dict.get("PAYMENTS_SERVICE_API_BASE_URL"):
         # If there are external secrets, build a new client and point to `external_base_url`
         print(
             "🚨 EXTERNAL: tests running against external payment API at",

--- a/services/payments/tests/unit/conftest.py
+++ b/services/payments/tests/unit/conftest.py
@@ -27,7 +27,6 @@ from pydantic import parse_obj_as
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.rawdata_fakers import random_payment_method_view
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.utils_envs import load_dotenv
 from respx import MockRouter
 from servicelib.rabbitmq import RabbitMQRPCClient
 from simcore_postgres_database.models.payments_transactions import payments_transactions
@@ -193,7 +192,7 @@ async def app(
 @pytest.fixture
 def mock_payments_gateway_service_api_base(app: FastAPI) -> Iterator[MockRouter]:
     """
-    If external_environment is present, then this mock is not really used
+    If external_envfile_dict is present, then this mock is not really used
     and instead the test runs against some real services
     """
     settings: ApplicationSettings = app.state.settings
@@ -383,10 +382,10 @@ def mock_payments_gateway_service_or_none(
     mock_payments_gateway_service_api_base: MockRouter,
     mock_payments_routes: Callable,
     mock_payments_methods_routes: Callable,
-    external_environment: EnvVarsDict,
+    external_envfile_dict: EnvVarsDict,
 ) -> MockRouter | None:
     # EITHER tests against external payments-gateway
-    if payments_gateway_url := external_environment.get("PAYMENTS_GATEWAY_URL"):
+    if payments_gateway_url := external_envfile_dict.get("PAYMENTS_GATEWAY_URL"):
         print("🚨 EXTERNAL: these tests are running against", f"{payments_gateway_url=}")
         mock_payments_gateway_service_api_base.stop()
         return None
@@ -405,7 +404,7 @@ def mock_payments_gateway_service_or_none(
 @pytest.fixture
 def mock_payments_stripe_api_base(app: FastAPI) -> Iterator[MockRouter]:
     """
-    If external_environment is present, then this mock is not really used
+    If external_envfile_dict is present, then this mock is not really used
     and instead the test runs against some real services
     """
     settings: ApplicationSettings = app.state.settings
@@ -452,7 +451,10 @@ def mock_payments_stripe_routes(faker: Faker) -> Callable:
 
 
 @pytest.fixture(scope="session")
-def external_stripe_environment(request: pytest.FixtureRequest) -> EnvVarsDict:
+def external_stripe_environment(
+    request: pytest.FixtureRequest,
+    external_envfile_dict: EnvVarsDict,
+) -> EnvVarsDict:
     """
     If a file under test folder prefixed with `.env-secret` is present,
     then this fixture captures it.
@@ -460,16 +462,11 @@ def external_stripe_environment(request: pytest.FixtureRequest) -> EnvVarsDict:
     This technique allows reusing the same tests to check against
     external development/production servers
     """
-    envs = {}
-    if envfile := request.config.getoption("--external-envfile"):
-        assert isinstance(envfile, Path)
-        assert envfile.is_file()
-        print("🚨 EXTERNAL: external envs detected. Loading", envfile, "...")
-        envs = load_dotenv(envfile)
-        assert "PAYMENTS_STRIPE_API_SECRET" in envs
-        assert "PAYMENTS_STRIPE_URL" in envs
-
-    return envs
+    if external_envfile_dict:
+        assert "PAYMENTS_STRIPE_API_SECRET" in external_envfile_dict
+        assert "PAYMENTS_STRIPE_URL" in external_envfile_dict
+        return external_envfile_dict
+    return {}
 
 
 @pytest.fixture(scope="session")

--- a/services/payments/tests/unit/test_core_settings.py
+++ b/services/payments/tests/unit/test_core_settings.py
@@ -12,7 +12,9 @@ def test_valid_web_application_settings(app_environment: EnvVarsDict):
     """
     We validate actual envfiles (e.g. repo.config files) by passing them via the CLI
 
-    > pytest --external-envfile=.myenv --pdb tests/unit/test_core_settings.py
+    $ ln -s /path/to/osparc-config/deployments/mydeploy.com/repo.config .secrets
+    $ pytest --external-envfile=.secrets --pdb tests/unit/test_core_settings.py
+
     """
     settings = ApplicationSettings()  # type: ignore
     assert settings

--- a/services/payments/tests/unit/test_rpc_payments.py
+++ b/services/payments/tests/unit/test_rpc_payments.py
@@ -37,7 +37,7 @@ def app_environment(
     rabbit_env_vars_dict: EnvVarsDict,  # rabbitMQ settings from 'rabbit' service
     postgres_env_vars_dict: EnvVarsDict,
     wait_for_postgres_ready_and_db_migrated: None,
-    external_environment: EnvVarsDict,
+    external_envfile_dict: EnvVarsDict,
 ):
     # set environs
     monkeypatch.delenv("PAYMENTS_RABBITMQ", raising=False)
@@ -49,7 +49,7 @@ def app_environment(
             **app_environment,
             **rabbit_env_vars_dict,
             **postgres_env_vars_dict,
-            **external_environment,
+            **external_envfile_dict,
             "POSTGRES_CLIENT_NAME": "payments-service-pg-client",
         },
     )

--- a/services/payments/tests/unit/test_rpc_payments_methods.py
+++ b/services/payments/tests/unit/test_rpc_payments_methods.py
@@ -52,7 +52,7 @@ def app_environment(
     rabbit_env_vars_dict: EnvVarsDict,  # rabbitMQ settings from 'rabbit' service
     postgres_env_vars_dict: EnvVarsDict,
     wait_for_postgres_ready_and_db_migrated: None,
-    external_environment: EnvVarsDict,
+    external_envfile_dict: EnvVarsDict,
 ):
     # set environs
     monkeypatch.delenv("PAYMENTS_RABBITMQ", raising=False)
@@ -64,7 +64,7 @@ def app_environment(
             **app_environment,
             **rabbit_env_vars_dict,
             **postgres_env_vars_dict,
-            **external_environment,
+            **external_envfile_dict,
             "POSTGRES_CLIENT_NAME": "payments-service-pg-client",
         },
     )

--- a/services/payments/tests/unit/test_services_auto_recharge_listener.py
+++ b/services/payments/tests/unit/test_services_auto_recharge_listener.py
@@ -74,7 +74,7 @@ def app_environment(
     rabbit_env_vars_dict: EnvVarsDict,  # rabbitMQ settings from 'rabbit' service
     postgres_env_vars_dict: EnvVarsDict,
     wait_for_postgres_ready_and_db_migrated: None,
-    external_environment: EnvVarsDict,
+    external_envfile_dict: EnvVarsDict,
 ):
     # set environs
     monkeypatch.delenv("PAYMENTS_RABBITMQ", raising=False)
@@ -86,7 +86,7 @@ def app_environment(
             **app_environment,
             **rabbit_env_vars_dict,
             **postgres_env_vars_dict,
-            **external_environment,
+            **external_envfile_dict,
             "POSTGRES_CLIENT_NAME": "payments-service-pg-client",
             "PAYMENTS_AUTORECHARGE_ENABLED": "1",
         },

--- a/services/payments/tests/unit/test_services_notifier_email.py
+++ b/services/payments/tests/unit/test_services_notifier_email.py
@@ -36,14 +36,14 @@ from simcore_service_payments.services.notifier_email import (
 @pytest.fixture
 def app_environment(
     monkeypatch: pytest.MonkeyPatch,
-    external_environment: EnvVarsDict,
+    external_envfile_dict: EnvVarsDict,
     docker_compose_service_payments_env_vars: EnvVarsDict,
 ) -> EnvVarsDict:
     return setenvs_from_dict(
         monkeypatch,
         {
             **docker_compose_service_payments_env_vars,
-            **external_environment,
+            **external_envfile_dict,
         },
     )
 

--- a/services/payments/tests/unit/test_services_notifier_email.py
+++ b/services/payments/tests/unit/test_services_notifier_email.py
@@ -50,10 +50,13 @@ def app_environment(
 
 @pytest.fixture
 def smtp_mock_or_none(
-    mocker: MockerFixture, is_external_user_email: bool
+    mocker: MockerFixture,
+    is_external_user_email: bool,
+    user_email: EmailStr,
 ) -> MagicMock | None:
     if not is_external_user_email:
         return mocker.patch("simcore_service_payments.services.notifier_email.SMTP")
+    print("🚨 Emails might be sent to", f"{user_email=}")
     return None
 
 

--- a/services/payments/tests/unit/test_services_payments_gateway.py
+++ b/services/payments/tests/unit/test_services_payments_gateway.py
@@ -43,12 +43,12 @@ def app_environment(
     app_environment: EnvVarsDict,
     with_disabled_rabbitmq_and_rpc: None,
     with_disabled_postgres: None,
-    external_environment: EnvVarsDict,
+    external_envfile_dict: EnvVarsDict,
 ):
     # set environs
     return setenvs_from_dict(
         monkeypatch,
-        {**app_environment, **external_environment},
+        {**app_environment, **external_envfile_dict},
     )
 
 

--- a/services/storage/tests/unit/test__legacy_storage_sdk_compatibility.py
+++ b/services/storage/tests/unit/test__legacy_storage_sdk_compatibility.py
@@ -30,11 +30,6 @@ pytest_simcore_ops_services_selection = [
 ]
 
 
-#
-
-#
-
-
 @pytest.fixture
 def user_id(user_id: UserID) -> str:
     """overrides tests/fixtures/data_models.py::user_id

--- a/services/web/server/tests/conftest.py
+++ b/services/web/server/tests/conftest.py
@@ -55,6 +55,7 @@ pytest_plugins = [
     "pytest_simcore.docker_registry",
     "pytest_simcore.docker_swarm",
     "pytest_simcore.environment_configs",
+    "pytest_simcore.faker_users_data",
     "pytest_simcore.hypothesis_type_strategies",
     "pytest_simcore.postgres_service",
     "pytest_simcore.pydantic_models",

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -25,11 +25,6 @@ MODULE_GC_CORE_ORPHANS: Final[
 
 
 @pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
-@pytest.fixture
 def project_id(faker: Faker) -> ProjectID:
     return faker.uuid4(cast_to=None)
 

--- a/services/web/server/tests/unit/isolated/test_projects__db_utils.py
+++ b/services/web/server/tests/unit/isolated/test_projects__db_utils.py
@@ -149,11 +149,6 @@ def all_permission_combinations() -> list[str]:
 
 
 @pytest.fixture
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
-@pytest.fixture
 def group_id(faker: Faker) -> GroupID:
     return faker.pyint(min_value=1)
 

--- a/services/web/server/tests/unit/with_dbs/02/test_project_lock.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_project_lock.py
@@ -24,11 +24,6 @@ from simcore_service_webserver.users.api import FullNameDict
 
 
 @pytest.fixture()
-def user_id(faker: Faker) -> UserID:
-    return faker.pyint(min_value=1)
-
-
-@pytest.fixture()
 def project_uuid(faker: Faker) -> ProjectID:
     return faker.uuid4(cast_to=None)
 

--- a/services/web/server/tests/unit/with_dbs/03/test_project_db.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_project_db.py
@@ -46,11 +46,6 @@ def group_id() -> int:
     return 234
 
 
-@pytest.fixture
-def user_id() -> int:
-    return 132
-
-
 async def test_setup_projects_db(client: TestClient):
     assert client.app
     db_api = ProjectDBAPI.get_from_app_context(app=client.app)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This PR reuses some of the basic fixtures in the repo and extends the concept of overriding fakes via CLI

#### Reusing `faker_*_data` fixtures
- common **data fixtures** are defined `pytest_simcore.faker_*_data`  plugins
- some of these fixtures can be overridden via the CLI. 
   - this approach can be handy to run tests against real services/configuration/datasets (see below some examples)
- ♻️ reuses `user_id` fixture everywhere
- ♻️  moves all `pytest` options to corresponding plugins in `pytest_simcore`

#### Using external env file

- 🔨 pytest plugin: `pytest_simcore.environment_configs`
   - New CLI option `--external-envfile`
   - New session-scoped fixture: `external_envfile_dict`
- ⚗️ Example: Run `test_core_settings.py` against a real configuration
```cmd
$ ln -s /path/to/osparc-config/deployments/mydeploy.com/repo.config .secrets
$ pytest --external-envfile=.secrets tests/unit/test_core_settings.py
```


## Related issue/s

- part of `refactor pytest fixtures` item in @sanderegg maintenance list 

## How to test

All tests should run as before

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))
