### PR TITLE
🎨 Frontend: Credits indicator only visible in warning zone by default (🚨)

### DIFF
--- a/services/static-webserver/client/source/class/osparc/Preferences.js
+++ b/services/static-webserver/client/source/class/osparc/Preferences.js
@@ -95,7 +95,7 @@ qx.Class.define("osparc.Preferences", {
     walletIndicatorVisibility: {
       check: ["always", "warning"],
       nullable: false,
-      init: "always",
+      init: "warning",
       event: "changeWalletIndicatorVisibility",
       apply: "__patchPreference"
     },

--- a/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/GeneralPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/GeneralPage.js
@@ -55,9 +55,9 @@ qx.Class.define("osparc.desktop.preferences.pages.GeneralPage", {
           const lItem = new qx.ui.form.ListItem(options.label, null, options.id);
           walletIndicatorVisibilitySB.add(lItem);
         });
-        const value2 = preferencesSettings.getWalletIndicatorVisibility();
+        const value = preferencesSettings.getWalletIndicatorVisibility();
         walletIndicatorVisibilitySB.getSelectables().forEach(selectable => {
-          if (selectable.getModel() === value2) {
+          if (selectable.getModel() === value) {
             walletIndicatorVisibilitySB.setSelection([selectable]);
           }
         });
@@ -70,7 +70,6 @@ qx.Class.define("osparc.desktop.preferences.pages.GeneralPage", {
         const creditsWarningThresholdField = new qx.ui.form.Spinner().set({
           minimum: 50,
           maximum: 10000,
-          value: 100,
           singleStep: 10,
           allowGrowX: false
         });

--- a/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/GeneralPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/GeneralPage.js
@@ -68,8 +68,9 @@ qx.Class.define("osparc.desktop.preferences.pages.GeneralPage", {
         form.add(walletIndicatorVisibilitySB, this.tr("Show indicator"));
 
         const creditsWarningThresholdField = new qx.ui.form.Spinner().set({
-          minimum: 100,
+          minimum: 50,
           maximum: 10000,
+          value: 100,
           singleStep: 10,
           allowGrowX: false
         });

--- a/services/static-webserver/client/source/class/osparc/info/StudyLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/StudyLarge.js
@@ -39,8 +39,7 @@ qx.Class.define("osparc.info.StudyLarge", {
   },
 
   events: {
-    "updateStudy": "qx.event.type.Data",
-    "updateService": "qx.event.type.Data"
+    "updateStudy": "qx.event.type.Data"
   },
 
   properties: {

--- a/services/static-webserver/client/source/class/osparc/metadata/ClassifiersEditor.js
+++ b/services/static-webserver/client/source/class/osparc/metadata/ClassifiersEditor.js
@@ -99,8 +99,8 @@ qx.Class.define("osparc.metadata.ClassifiersEditor", {
     },
 
     __createClassifiersTree: function() {
-      const studyData = this.__resourceData;
-      const classifiers = studyData.classifiers && studyData.classifiers ? studyData.classifiers : [];
+      const resourceData = this.__resourceData;
+      const classifiers = resourceData.classifiers && resourceData.classifiers ? resourceData.classifiers : [];
       const classifiersTree = this.__classifiersTree = new osparc.filter.ClassifiersFilter("classifiersEditor", "searchBarFilter", classifiers);
       osparc.store.Store.getInstance().addListener("changeClassifiers", e => {
         classifiersTree.recreateTree();

--- a/services/static-webserver/client/source/class/osparc/metadata/QualityEditor.js
+++ b/services/static-webserver/client/source/class/osparc/metadata/QualityEditor.js
@@ -451,7 +451,7 @@ qx.Class.define("osparc.metadata.QualityEditor", {
         "tsr_target": this.__copyQualityData["tsr_target"]
       };
       const patchData = {
-        "quality" : newQuality
+        "quality": newQuality
       };
       if (this.__validate(this.__schema, patchData["quality"])) {
         btn.setFetching(true);

--- a/services/static-webserver/client/source/class/osparc/navigation/CreditsMenuButton.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/CreditsMenuButton.js
@@ -100,6 +100,7 @@ qx.Class.define("osparc.navigation.CreditsMenuButton", {
           textColor: osparc.desktop.credits.Utils.creditsToColor(creditsLeft, "text")
         });
       }
+      this.__computeVisibility();
     },
 
     __computeVisibility: function() {

--- a/services/static-webserver/client/source/class/osparc/navigation/CreditsMenuButton.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/CreditsMenuButton.js
@@ -37,12 +37,8 @@ qx.Class.define("osparc.navigation.CreditsMenuButton", {
     this.getContentElement().setStyle("line-height", 1.2);
 
     const preferencesSettings = osparc.Preferences.getInstance();
-    this.__computeVisibility();
     preferencesSettings.addListener("changeWalletIndicatorVisibility", () => this.__computeVisibility());
-    preferencesSettings.addListener("changeCreditsWarningThreshold", () => {
-      this.__computeVisibility();
-      this.__updateCredits();
-    });
+    preferencesSettings.addListener("changeCreditsWarningThreshold", () => this.__updateCredits());
 
     const store = osparc.store.Store.getInstance();
     this.__contextWalletChanged(store.getContextWallet());

--- a/services/web/server/src/simcore_service_webserver/users/_preferences_models.py
+++ b/services/web/server/src/simcore_service_webserver/users/_preferences_models.py
@@ -79,7 +79,7 @@ class CreditsWarningThresholdFrontendUserPreference(FrontendUserPreference):
 
 class WalletIndicatorVisibilityFrontendUserPreference(FrontendUserPreference):
     preference_identifier: PreferenceIdentifier = "walletIndicatorVisibility"
-    value: str | None = "always"
+    value: str | None = "warning"
 
 
 class UserInactivityThresholdFrontendUserPreference(FrontendUserPreference):


### PR DESCRIPTION
## What do these changes do?

This PR will only affect the new users.

🚨 If we want to change the default value of the existing users, we need to go through the DB, either deleting ``WalletIndicatorVisibilityFrontendUserPreference`` preference entries or changing their value (I believe there is a sql script somewhere).

demo with user with no ``WalletIndicatorVisibilityFrontendUserPreference`` entry in the DB:
![Credits](https://github.com/ITISFoundation/osparc-simcore/assets/33152403/02b2fdcd-a2dd-403f-b19a-f9a8c6e2b577)


## Related issue/s

closes https://github.com/ITISFoundation/osparc-issues/issues/1474


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
