### PR TITLE
⬆️ upgrading faststream repo wide

### DIFF
--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -65,7 +65,7 @@ exceptiongroup==1.2.1
     # via anyio
 fast-depends==2.4.2
     # via faststream
-faststream==0.5.4
+faststream==0.5.10
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 frozenlist==1.4.1
     # via

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -43,7 +43,7 @@ exceptiongroup==1.2.1
     # via anyio
 fast-depends==2.4.2
     # via faststream
-faststream==0.5.4
+faststream==0.5.10
     # via -r requirements/_base.in
 frozenlist==1.4.1
     # via

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -134,6 +134,7 @@ pathable==0.4.3
 pluggy==1.5.0
     # via pytest
 psutil==5.9.8
+    # via -r requirements/_test.in
 py-cpuinfo==9.0.0
     # via pytest-benchmark
 pytest==8.2.0

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -61,7 +61,7 @@ exceptiongroup==1.2.1
     # via anyio
 fast-depends==2.4.2
     # via faststream
-faststream==0.5.4
+faststream==0.5.10
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 frozenlist==1.4.1
     # via

--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -141,8 +141,11 @@ rich==13.4.2
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   typer
 setuptools==69.2.0
     # via jsonschema
+shellingham==1.5.4
+    # via typer
 six==1.16.0
     # via
     #   jsonschema
@@ -160,7 +163,7 @@ starlette==0.27.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   fastapi
-typer==0.6.1
+typer==0.12.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
@@ -168,6 +171,7 @@ typing-extensions==4.4.0
     # via
     #   aiodocker
     #   pydantic
+    #   typer
 uvicorn==0.19.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -103,7 +103,7 @@ cffi==1.16.0
     # via cryptography
 click==8.1.7
     # via
-    #   typer-slim
+    #   typer
     #   uvicorn
 cryptography==42.0.5
     # via
@@ -156,7 +156,7 @@ fastapi-pagination==0.12.17
     # via
     #   -c requirements/./constraints.txt
     #   -r requirements/_base.in
-faststream==0.4.7
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -400,11 +400,11 @@ rich==13.7.1
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
-    #   typer-slim
+    #   typer
 setuptools==69.2.0
     # via jsonschema
 shellingham==1.5.4
-    # via typer-slim
+    # via typer
 six==1.16.0
     # via
     #   jsonschema
@@ -468,7 +468,7 @@ tqdm==4.66.2
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-typer==0.12.0
+typer==0.12.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
@@ -477,12 +477,6 @@ typer==0.12.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
     #   faststream
-typer-cli==0.12.0
-    # via typer
-typer-slim==0.12.0
-    # via
-    #   typer
-    #   typer-cli
 types-python-dateutil==2.9.0.20240316
     # via arrow
 typing-extensions==4.10.0
@@ -496,7 +490,7 @@ typing-extensions==4.10.0
     #   faststream
     #   pint
     #   pydantic
-    #   typer-slim
+    #   typer
     #   uvicorn
 ujson==5.9.0
     # via

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -145,7 +145,7 @@ fastapi==0.99.1
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   prometheus-fastapi-instrumentator
-faststream==0.5.7
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -97,7 +97,7 @@ fastapi==0.99.1
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   prometheus-fastapi-instrumentator
-faststream==0.5.2
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -272,10 +272,13 @@ rich==13.7.1
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   typer
 rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
+shellingham==1.5.4
+    # via typer
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.1
@@ -316,7 +319,7 @@ tqdm==4.66.2
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.10.0
+typer==0.12.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -142,7 +142,7 @@ fastapi==0.99.1
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   prometheus-fastapi-instrumentator
-faststream==0.5.7
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -92,7 +92,7 @@ exceptiongroup==1.2.1
     # via anyio
 fast-depends==2.4.2
     # via faststream
-faststream==0.5.7
+faststream==0.5.10
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 frozenlist==1.4.1
     # via

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -71,7 +71,7 @@ certifi==2024.2.2
     #   httpx
 click==8.1.7
     # via
-    #   typer-slim
+    #   typer
     #   uvicorn
 dnspython==2.6.1
     # via email-validator
@@ -95,7 +95,7 @@ fastapi==0.99.1
     #   prometheus-fastapi-instrumentator
 fastapi-pagination==0.12.21
     # via -r requirements/_base.in
-faststream==0.4.7
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -236,7 +236,7 @@ rich==13.7.1
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-    #   typer-slim
+    #   typer
 rpds-py==0.18.0
     # via
     #   jsonschema
@@ -244,7 +244,7 @@ rpds-py==0.18.0
 s3transfer==0.10.1
     # via boto3
 shellingham==1.5.4
-    # via typer-slim
+    # via typer
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.1
@@ -272,18 +272,12 @@ tqdm==4.66.2
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.12.0
+typer==0.12.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   faststream
-typer-cli==0.12.0
-    # via typer
-typer-slim==0.12.0
-    # via
-    #   typer
-    #   typer-cli
 types-python-dateutil==2.9.0.20240316
     # via arrow
 typing-extensions==4.10.0
@@ -295,7 +289,7 @@ typing-extensions==4.10.0
     #   fastapi-pagination
     #   faststream
     #   pydantic
-    #   typer-slim
+    #   typer
     #   uvicorn
 urllib3==2.2.1
     # via

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -173,7 +173,7 @@ fastapi==0.99.1
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   prometheus-fastapi-instrumentator
-faststream==0.5.7
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -69,7 +69,7 @@ certifi==2024.2.2
     #   httpx
 click==8.1.7
     # via
-    #   typer-slim
+    #   typer
     #   uvicorn
 dnspython==2.6.1
     # via email-validator
@@ -91,7 +91,7 @@ fastapi==0.99.1
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   prometheus-fastapi-instrumentator
-faststream==0.4.7
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -240,13 +240,13 @@ rich==13.7.1
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-    #   typer-slim
+    #   typer
 rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
 shellingham==1.5.4
-    # via typer-slim
+    # via typer
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.1
@@ -286,19 +286,13 @@ tqdm==4.66.2
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.12.0
+typer==0.12.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
     #   faststream
-typer-cli==0.12.0
-    # via typer
-typer-slim==0.12.0
-    # via
-    #   typer
-    #   typer-cli
 types-python-dateutil==2.9.0.20240316
     # via arrow
 typing-extensions==4.10.0
@@ -310,7 +304,7 @@ typing-extensions==4.10.0
     #   fastapi
     #   faststream
     #   pydantic
-    #   typer-slim
+    #   typer
     #   uvicorn
 uvicorn==0.29.0
     # via

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -135,7 +135,7 @@ fastapi==0.99.1
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   prometheus-fastapi-instrumentator
-faststream==0.5.2
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -423,7 +423,7 @@ tqdm==4.66.2
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-typer==0.12.1
+typer==0.12.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -66,8 +66,6 @@ click==8.1.7
     # via
     #   typer
     #   uvicorn
-colorama==0.4.6
-    # via typer
 cryptography==42.0.5
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -96,7 +94,7 @@ fastapi==0.99.1
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   prometheus-fastapi-instrumentator
-faststream==0.5.2
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -258,7 +256,7 @@ tqdm==4.66.2
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.10.0
+typer==0.12.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -77,8 +77,6 @@ click==8.1.7
     # via
     #   typer
     #   uvicorn
-colorama==0.4.6
-    # via typer
 cryptography==42.0.5
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -111,7 +109,7 @@ fastapi==0.99.1
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   prometheus-fastapi-instrumentator
-faststream==0.5.2
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -347,7 +345,7 @@ tqdm==4.66.2
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.10.0
+typer==0.12.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -113,8 +113,6 @@ click==8.1.7
     # via
     #   typer
     #   uvicorn
-colorama==0.4.6
-    # via typer
 contourpy==1.2.0
     # via matplotlib
 cycler==0.12.1
@@ -147,7 +145,7 @@ fastapi==0.99.1
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   prometheus-fastapi-instrumentator
-faststream==0.5.2
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -459,7 +457,7 @@ tqdm==4.66.2
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.10.0
+typer==0.12.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -120,7 +120,7 @@ certifi==2024.2.2
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via typer-slim
+    # via typer
 dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
@@ -129,7 +129,7 @@ exceptiongroup==1.2.1
     # via anyio
 fast-depends==2.4.2
     # via faststream
-faststream==0.4.7
+faststream==0.5.10
     # via
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -360,7 +360,7 @@ rich==13.7.1
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-    #   typer-slim
+    #   typer
 rpds-py==0.18.0
     # via
     #   jsonschema
@@ -370,7 +370,7 @@ s3transfer==0.10.1
 sh==2.0.6
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 shellingham==1.5.4
-    # via typer-slim
+    # via typer
 six==1.16.0
     # via
     #   isodate
@@ -412,7 +412,7 @@ tqdm==4.66.2
     #   -c requirements/../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.12.0
+typer==0.12.3
     # via
     #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
@@ -421,12 +421,6 @@ typer==0.12.0
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
     #   faststream
-typer-cli==0.12.0
-    # via typer
-typer-slim==0.12.0
-    # via
-    #   typer
-    #   typer-cli
 types-aiobotocore==2.12.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/_base.in
@@ -447,7 +441,7 @@ typing-extensions==4.10.0
     #   anyio
     #   faststream
     #   pydantic
-    #   typer-slim
+    #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
     #   types-aiobotocore-s3

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -79,7 +79,7 @@ alembic==1.8.1
 anyio==4.3.0
     # via
     #   fast-depends
-    #   watchfiles
+    #   faststream
 arrow==1.2.3
     # via
     #   -c requirements/../../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
@@ -166,7 +166,7 @@ faker==19.6.1
     # via -r requirements/_base.in
 fast-depends==2.4.2
     # via faststream
-faststream==0.2.12
+faststream==0.5.10
     # via
     #   -c requirements/../../../../packages/service-library/requirements/./_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
@@ -415,6 +415,7 @@ rich==13.4.2
     #   -r requirements/../../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
+    #   typer
 setproctitle==1.2.3
     # via gunicorn
 setuptools==69.1.1
@@ -422,6 +423,8 @@ setuptools==69.1.1
     #   gunicorn
     #   jsonschema
     #   openapi-spec-validator
+shellingham==1.5.4
+    # via typer
 six==1.16.0
     # via
     #   isodate
@@ -472,7 +475,7 @@ tqdm==4.64.0
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
 twilio==7.12.0
     # via -r requirements/_base.in
-typer==0.4.1
+typer==0.12.3
     # via
     #   -c requirements/../../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
@@ -480,12 +483,14 @@ typer==0.4.1
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
     #   faststream
-typing-extensions==4.3.0
+typing-extensions==4.12.0
     # via
     #   aiodebug
     #   aiodocker
     #   anyio
+    #   faststream
     #   pydantic
+    #   typer
 ujson==5.5.0
     # via
     #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
@@ -520,10 +525,6 @@ urllib3==1.26.11
     #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../requirements/constraints.txt
     #   requests
-uvloop==0.19.0
-    # via faststream
-watchfiles==0.21.0
-    # via faststream
 werkzeug==2.1.2
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
 yarl==1.5.1

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -217,7 +217,7 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   pytest
-typing-extensions==4.3.0
+typing-extensions==4.12.0
     # via
     #   -c requirements/_base.txt
     #   mypy

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -88,7 +88,7 @@ tomlkit==0.12.4
     # via pylint
 types-cachetools==5.3.0.7
     # via -r requirements/_tools.in
-typing-extensions==4.3.0
+typing-extensions==4.12.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -112,7 +112,7 @@ exceptiongroup==1.2.1
     #   pytest
 fast-depends==2.4.2
     # via faststream
-faststream==0.5.4
+faststream==0.5.10
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

To upgrade `faststream` `typer` had to be bumped as well. Since it was blocking the upgrade

###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 8
- #packages after ~ 4

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | colorama                  | 0.4.6           | 🗑️ removed |  | 3 | invitations⬆️</br>payments⬆️</br>resource-usage-tracker⬆️ |
|   2 | faststream                | 0.5.2, 0.4.7, 0.2.12, 0.5.7, 0.5.4 | 0.5.10     |            | 18 | api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>invitations⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>swarm-deploy🧪</br>web⬆️ |
|   3 | typer                     | 0.12.0, 0.12.1, 0.10.0, 0.6.1, 0.4.1 | 0.12.3     |            | 11 | agent⬆️</br>api-server⬆️</br>catalog⬆️</br>datcore-adapter⬆️</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>invitations⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>storage⬆️</br>web⬆️ |
|   4 | typer-cli                 | 0.12.0          | 🗑️ removed |  | 4 | api-server⬆️</br>datcore-adapter⬆️</br>dynamic-scheduler⬆️</br>storage⬆️ |
|   5 | typer-slim                | 0.12.0          | 🗑️ removed |  | 4 | api-server⬆️</br>datcore-adapter⬆️</br>dynamic-scheduler⬆️</br>storage⬆️ |
|   6 | typing-extensions         | 4.3.0           | 4.12.0     | *minor*    | 3 | web⬆️🧪🔧 |
|   7 | uvloop                    | 0.19.0          | 🗑️ removed |  | 1 | web⬆️ |
|   8 | watchfiles                | 0.21.0          | 🗑️ removed |  | 1 | web⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 162

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 6.7.1, 6.8.0, 9.1.2, 9.4.1 | 6.7.1, 6.8.0, 9.4.1       |                           |
|   2 | aioboto3                  | 12.3.0, 12.4.0            | 9.6.0, 12.4.0             |                           |
|   3 | aiobotocore               | 1.0.7, 2.11.2, 2.12.3, 2.13.0 | 1.0.7, 2.3.0, 2.12.3      |                           |
|   4 | aiocache                  | 0.11.1, 0.12.2            | 0.12.2                    |                           |
|   5 | aiodebug                  | 1.1.2, 2.3.0              | 1.1.2, 2.3.0              |                           |
|   6 | aiodocker                 | 0.19.1, 0.21.0            | 0.19.1, 0.21.0            |                           |
|   7 | aiofile                   | 3.1.0                     | 3.1.0                     |                           |
|   8 | aiofiles                  | 0.5.0, 0.6.0, 0.8.0, 23.2.1 | 0.5.0, 0.6.0, 23.2.1      |                           |
|   9 | aiohttp                   | 3.6.3, 3.7.2, 3.7.3, 3.7.4.post0, 3.8.5, 3.9.3, 3.9.5 | 3.6.3, 3.7.2, 3.7.3, 3.7.4.post0, 3.8.5, 3.9.3, 3.9.5 |                           |
|  10 | aiohttp-jinja2            | 1.2.0, 1.4.2, 1.5         | 1.2.0                     |                           |
|  11 | aiohttp-security          | 0.4.0                     | 0.4.0                     |                           |
|  12 | aiohttp-session           | 2.11.0                    |                           |                           |
|  13 | aiohttp-swagger           | 1.0.16                    | 1.0.15                    |                           |
|  14 | aioitertools              | 0.7.0, 0.7.1, 0.11.0      | 0.7.0, 0.11.0             |                           |
|  15 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  16 | aioprocessing             | 2.0.1                     |                           |                           |
|  17 | aioredis                  | 1.3.1                     | 1.3.1                     |                           |
|  18 | aioredlock                | 0.5.2, 0.7.1              | 0.5.2                     |                           |
|  19 | aioresponses              |                           | 0.7.2, 0.7.6              |                           |
|  20 | aiormq                    | 3.2.3, 3.3.1, 6.7.6, 6.8.0 | 3.2.3, 3.3.1, 6.8.0       |                           |
|  21 | aiosignal                 | 1.2.0, 1.3.1              | 1.2.0, 1.3.1              |                           |
|  22 | aiosmtplib                | 1.1.3, 1.1.6, 3.0.1       | 1.1.3                     |                           |
|  23 | aiozipkin                 | 0.7.0, 0.7.1, 1.1.1       | 0.7.0, 0.7.1              |                           |
|  24 | alembic                   | 1.8.1, 1.13.1             | 1.4.2, 1.4.3, 1.6.2, 1.8.1, 1.13.1 |                           |
|  25 | amqp                      | 2.6.1, 5.0.1, 5.0.2, 5.0.6 | 2.6.1, 5.0.1, 5.0.2, 5.0.6 |                           |
|  26 | aniso8601                 | 7.0.0                     | 7.0.0                     |                           |
|  27 | annotated-types           |                           | 0.6.0                     |                           |
|  28 | antlr4-python3-runtime    |                           | 4.13.1                    |                           |
|  29 | anyio                     | 3.6.2, 4.3.0              | 3.6.2, 4.3.0              |                           |
|  30 | apipkg                    |                           | 1.5                       |                           |
|  31 | appdirs                   |                           |                           | 1.4.4                     |
|  32 | argh                      |                           |                           | 0.26.2                    |
|  33 | arrow                     | 1.2.3, 1.3.0              | 1.3.0                     |                           |
|  34 | asgi-lifespan             |                           | 1.0.1, 2.1.0              |                           |
|  35 | astroid                   |                           | 2.4.2, 2.5, 2.5.6         | 2.5.6, 3.1.0, 3.2.2       |
|  36 | async-asgi-testclient     |                           | 1.4.6, 1.4.11             |                           |
|  37 | async-exit-stack          | 1.0.1                     | 1.0.1                     |                           |
|  38 | async-generator           | 1.10                      | 1.10                      |                           |
|  39 | async-timeout             | 3.0.1, 4.0.2, 4.0.3       | 3.0.1, 4.0.2, 4.0.3       |                           |
|  40 | asyncpg                   | 0.21.0, 0.23.0, 0.27.0, 0.29.0 | 0.21.0, 0.29.0            |                           |
|  41 | attrs                     | 19.3.0, 20.2.0, 20.3.0, 21.2.0, 21.4.0, 23.2.0 | 19.3.0, 20.2.0, 20.3.0, 21.2.0, 21.4.0, 23.2.0 |                           |
|  42 | aws-sam-translator        |                           | 1.55.0, 1.87.0, 1.89.0    |                           |
|  43 | aws-xray-sdk              |                           | 2.13.0, 2.13.1            |                           |
|  44 | bcrypt                    | 3.2.0                     | 3.2.0                     |                           |
|  45 | bidict                    | 0.22.0, 0.23.1            | 0.23.1                    |                           |
|  46 | billiard                  | 3.6.3.0, 3.6.4.0          | 3.6.3.0, 3.6.4.0          |                           |
|  47 | black                     |                           |                           | 21.5b1, 21.5b2, 24.4.2    |
|  48 | blackfynn                 | 4.0.0                     | 4.0.0                     |                           |
|  49 | blinker                   |                           | 1.8.1, 1.8.2              |                           |
|  50 | blosc                     | 1.11.1                    |                           |                           |
|  51 | bokeh                     | 3.4.1                     | 3.4.1                     |                           |
|  52 | boto3                     | 1.12.32, 1.34.34, 1.34.69, 1.34.75 | 1.12.32, 1.21.21, 1.34.34, 1.34.69, 1.34.98, 1.34.106 |                           |
|  53 | boto3-stubs               |                           | 1.34.98                   |                           |
|  54 | botocore                  | 1.15.32, 1.34.34, 1.34.69, 1.34.75, 1.34.106 | 1.15.32, 1.24.21, 1.34.34, 1.34.69, 1.34.98, 1.34.106 |                           |
|  55 | botocore-stubs            | 1.34.69, 1.34.94          | 1.34.94                   |                           |
|  56 | build                     |                           |                           | 1.2.1                     |
|  57 | bump2version              |                           |                           | 1.0.1                     |
|  58 | cached-property           | 1.5.2                     | 1.5.1, 1.5.2              |                           |
|  59 | cachetools                | 5.3.2                     |                           |                           |
|  60 | caio                      | 0.6.1                     | 0.6.1                     |                           |
|  61 | captcha                   | 0.5.0                     |                           |                           |
|  62 | certifi                   | 2020.6.20, 2020.11.8, 2020.12.5, 2023.7.22, 2023.11.17, 2024.2.2 | 2020.6.20, 2020.11.8, 2020.12.5, 2023.7.22, 2023.11.17, 2024.2.2 |                           |
|  63 | cffi                      | 1.14.2, 1.14.5, 1.15.0, 1.16.0 | 1.14.2, 1.14.3, 1.14.5, 1.16.0 |                           |
|  64 | cfgv                      |                           |                           | 3.2.0, 3.3.0, 3.4.0       |
|  65 | cfn-lint                  |                           | 0.72.0, 0.87.1, 0.87.3    |                           |
|  66 | change-case               | 0.5.2                     | 0.5.2                     | 0.5.2                     |
|  67 | chardet                   | 3.0.4, 4.0.0              | 3.0.4, 4.0.0              |                           |
|  68 | charset-normalizer        | 2.0.12, 2.1.1, 3.3.2      | 2.0.12, 2.1.1, 3.3.2      |                           |
|  69 | click                     | 7.1.2, 8.0.0, 8.1.3, 8.1.7 | 7.1.2, 8.0.0, 8.1.3, 8.1.7 | 7.1.2, 8.0.0, 8.1.3, 8.1.7 |
|  70 | click-didyoumean          | 0.0.3                     | 0.0.3                     |                           |
|  71 | click-plugins             | 1.1.1                     | 1.1.1                     |                           |
|  72 | click-repl                | 0.1.6                     | 0.1.6                     |                           |
|  73 | cloudpickle               | 3.0.0                     | 3.0.0                     |                           |
|  74 | codecov                   |                           | 2.1.8, 2.1.9, 2.1.10, 2.1.11 |                           |
|  75 | colorlog                  | 6.8.2                     | 6.8.2                     |                           |
|  76 | configparser              | 5.0.0, 5.0.1, 5.0.2       | 5.0.0, 5.0.1              |                           |
|  77 | contextvars               | 2.4                       | 2.4                       |                           |
|  78 | contourpy                 | 1.2.0, 1.2.1              | 1.2.1                     |                           |
|  79 | coverage                  |                           | 5.2.1, 5.3, 5.5, 7.5.1    |                           |
|  80 | coveralls                 |                           | 2.1.2, 3.0.1, 3.1.0       |                           |
|  81 | cryptography              | 3.2.1, 3.4.7, 41.0.7, 42.0.5, 42.0.7 | 3.2.1, 3.4.7, 42.0.5, 42.0.6, 42.0.7 |                           |
|  82 | cycler                    | 0.12.1                    |                           |                           |
|  83 | dask                      | 2024.5.1                  | 2024.5.1                  |                           |
|  84 | dask-gateway              | 2024.1.0                  | 2024.1.0                  |                           |
|  85 | dask-gateway-server       | 2023.1.1                  | 2023.1.1                  |                           |
|  86 | dataclasses               | 0.7, 0.8                  | 0.7, 0.8                  | 0.7, 0.8                  |
|  87 | dateparser                | 1.2.0                     |                           |                           |
|  88 | debugpy                   |                           | 1.8.1                     |                           |
|  89 | decorator                 | 4.4.2                     | 4.4.2                     |                           |
|  90 | deepdiff                  |                           | 7.0.1                     |                           |
|  91 | deprecated                | 1.2.10, 1.2.12            | 1.2.10                    |                           |
|  92 | dill                      |                           |                           | 0.3.8                     |
|  93 | distlib                   |                           |                           | 0.3.1, 0.3.2, 0.3.8       |
|  94 | distributed               | 2024.5.1                  | 2024.5.1                  |                           |
|  95 | distro                    | 1.5.0                     | 1.5.0                     |                           |
|  96 | dnspython                 | 2.0.0, 2.1.0, 2.2.1, 2.6.1 | 2.0.0, 2.1.0, 2.6.1       |                           |
|  97 | docker                    | 5.0.0, 7.1.0              | 4.3.1, 5.0.0, 7.1.0       |                           |
|  98 | docker-compose            | 1.29.1                    | 1.27.4, 1.29.1            |                           |
|  99 | dockerpty                 | 0.4.1                     | 0.4.1                     |                           |
| 100 | docopt                    | 0.6.2                     | 0.6.2                     |                           |
| 101 | docutils                  | 0.15.2                    | 0.15.2                    |                           |
| 102 | ecdsa                     | 0.18.0                    | 0.19.0                    |                           |
| 103 | email-validator           | 1.1.1, 1.1.2, 1.2.1, 1.3.0, 2.1.1 | 1.1.1, 1.1.2, 2.1.1       |                           |
| 104 | et-xmlfile                | 1.1.0                     |                           |                           |
| 105 | exceptiongroup            | 1.2.0, 1.2.1              | 1.2.0, 1.2.1              |                           |
| 106 | execnet                   |                           | 1.8.0, 2.1.1              |                           |
| 107 | expiringdict              | 1.2.1                     | 1.2.1                     |                           |
| 108 | faker                     | 19.6.1                    | 4.14.0, 8.1.4, 8.2.0, 8.5.1, 19.6.1, 25.0.1, 25.2.0 |                           |
| 109 | fakeredis                 |                           | 2.22.0, 2.23.2            |                           |
| 110 | fast-depends              | 2.4.2                     | 2.4.2                     |                           |
| 111 | fastapi                   | 0.63.0, 0.96.0, 0.99.1    |                           |                           |
| 112 | fastapi-pagination        | 0.12.17, 0.12.21          |                           |                           |
| 113 | faststream                | 0.5.10                    | 0.5.10                    |                           |
| 114 | filelock                  |                           |                           | 3.0.12, 3.14.0            |
| 115 | flaky                     |                           | 3.8.1                     |                           |
| 116 | flask                     |                           | 2.1.3, 3.0.3              |                           |
| 117 | flask-cors                |                           | 4.0.1                     |                           |
| 118 | fonttools                 | 4.50.0                    |                           |                           |
| 119 | frozenlist                | 1.3.0, 1.3.1, 1.4.1       | 1.3.0, 1.3.1, 1.4.1       |                           |
| 120 | fsspec                    | 2024.5.0                  | 2024.5.0                  |                           |
| 121 | future                    | 0.18.2                    | 0.18.2                    |                           |
| 122 | graphene                  | 2.1.8                     | 2.1.8                     |                           |
| 123 | graphql-core              | 2.3.2                     | 2.3.2, 3.2.3              |                           |
| 124 | graphql-relay             | 2.0.1                     | 2.0.1                     |                           |
| 125 | greenlet                  | 2.0.2, 3.0.3              | 2.0.2, 3.0.3              |                           |
| 126 | gunicorn                  | 20.1.0                    |                           |                           |
| 127 | h11                       | 0.9.0, 0.12.0, 0.14.0     | 0.9.0, 0.12.0, 0.14.0     |                           |
| 128 | h2                        | 4.1.0                     |                           |                           |
| 129 | hiredis                   | 1.1.0, 2.0.0              | 1.1.0, 2.0.0              |                           |
| 130 | hpack                     | 4.0.0                     |                           |                           |
| 131 | httmock                   | 1.4.0                     |                           |                           |
| 132 | httpcore                  | 0.10.2, 0.13.3, 1.0.2, 1.0.4, 1.0.5 | 0.10.2, 0.12.0, 0.13.3, 1.0.2, 1.0.4, 1.0.5 |                           |
| 133 | httptools                 | 0.1.1, 0.1.2, 0.6.1       | 0.1.1                     |                           |
| 134 | httpx                     | 0.14.3, 0.18.1, 0.26.0, 0.27.0 | 0.14.3, 0.16.1, 0.18.1, 0.26.0, 0.27.0 |                           |
| 135 | hyperframe                | 6.0.1                     |                           |                           |
| 136 | hypothesis                |                           | 6.91.0, 6.100.4           |                           |
| 137 | icdiff                    |                           | 1.9.1, 2.0.7              |                           |
| 138 | identify                  |                           |                           | 2.2.4, 2.2.9, 2.5.36      |
| 139 | idna                      | 2.10, 3.3, 3.4, 3.6, 3.7  | 2.10, 3.3, 3.4, 3.6, 3.7  |                           |
| 140 | idna-ssl                  | 1.1.0                     | 1.1.0                     |                           |
| 141 | immutables                | 0.14, 0.15                | 0.14, 0.15                |                           |
| 142 | importlib-metadata        | 1.7.0, 2.0.0, 4.0.1, 7.1.0 | 1.7.0, 2.0.0, 4.0.1, 7.1.0 | 2.0.0, 4.0.1              |
| 143 | importlib-resources       | 5.1.3                     | 5.1.3                     | 5.1.3, 5.1.4              |
| 144 | iniconfig                 | 1.1.1, 2.0.0              | 1.0.1, 1.1.1, 2.0.0       |                           |
| 145 | inotify                   |                           |                           | 0.2.10                    |
| 146 | isodate                   | 0.6.0, 0.6.1              | 0.6.0                     |                           |
| 147 | isort                     |                           | 4.3.21, 5.6.4, 5.8.0      | 4.3.21, 5.8.0, 5.13.2     |
| 148 | itsdangerous              | 1.1.0, 2.1.2, 2.2.0       | 1.1.0, 2.1.2, 2.2.0       |                           |
| 149 | jinja-app-loader          | 1.0.2                     | 1.0.2                     |                           |
| 150 | jinja2                    | 2.11.2, 2.11.3, 3.1.2, 3.1.3, 3.1.4 | 2.11.2, 3.1.3, 3.1.4      | 2.11.3, 3.1.3             |
| 151 | jmespath                  | 0.10.0, 1.0.1             | 0.10.0, 1.0.1             |                           |
| 152 | joserfc                   |                           | 0.9.0, 0.10.0             |                           |
| 153 | jschema-to-python         |                           | 1.2.3                     |                           |
| 154 | json2html                 | 1.3.0                     | 1.3.0                     |                           |
| 155 | jsondiff                  | 1.2.0, 1.3.0, 2.0.0       | 1.2.0, 2.0.0              |                           |
| 156 | jsonpatch                 |                           | 1.33                      |                           |
| 157 | jsonpath-ng               |                           | 1.6.1                     |                           |
| 158 | jsonpickle                |                           | 3.0.4                     |                           |
| 159 | jsonpointer               |                           | 2.4                       |                           |
| 160 | jsonref                   |                           | 1.1.0                     |                           |
| 161 | jsonschema                | 3.2.0, 4.21.1, 4.22.0     | 3.2.0, 4.21.1, 4.22.0     |                           |
| 162 | jsonschema-path           | 0.3.2                     | 0.3.2                     |                           |
| 163 | jsonschema-specifications | 2023.7.1, 2023.12.1       | 2023.7.1, 2023.12.1       |                           |
| 164 | junit-xml                 |                           | 1.9                       |                           |
| 165 | kiwisolver                | 1.4.5                     |                           |                           |
| 166 | kombu                     | 4.6.11, 5.0.2             | 4.6.11, 5.0.2             |                           |
| 167 | lazy-object-proxy         | 1.4.3, 1.7.1, 1.10.0      | 1.4.3, 1.6.0, 1.10.0      | 1.6.0                     |
| 168 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 169 | lupa                      |                           | 2.1                       |                           |
| 170 | lz4                       | 4.3.3                     | 4.3.3                     |                           |
| 171 | mako                      | 1.2.2, 1.3.2, 1.3.3, 1.3.5 | 1.1.3, 1.1.4, 1.2.2, 1.3.2, 1.3.3, 1.3.5 |                           |
| 172 | markdown-it-py            | 3.0.0                     | 3.0.0                     | 3.0.0                     |
| 173 | markupsafe                | 1.1.1, 2.0.1, 2.1.1, 2.1.5 | 1.1.1, 2.0.0, 2.0.1, 2.1.1, 2.1.5 | 2.0.1, 2.1.5              |
| 174 | matplotlib                | 3.8.3                     |                           |                           |
| 175 | mccabe                    |                           | 0.6.1                     | 0.6.1, 0.7.0              |
| 176 | mdurl                     | 0.1.2                     | 0.1.2                     | 0.1.2                     |
| 177 | minio                     | 6.0.0, 7.0.3              | 6.0.0, 7.0.3              |                           |
| 178 | mock                      |                           | 4.0.2                     |                           |
| 179 | more-itertools            | 10.2.0                    |                           |                           |
| 180 | moto                      |                           | 4.0.1, 4.2.6, 5.0.6, 5.0.7 |                           |
| 181 | mpmath                    |                           | 1.3.0                     |                           |
| 182 | msgpack                   | 1.0.7, 1.0.8              | 1.0.8                     |                           |
| 183 | multidict                 | 4.7.6, 5.0.0, 5.1.0, 6.0.2, 6.0.5 | 4.7.6, 5.0.0, 5.1.0, 6.0.2, 6.0.5 |                           |
| 184 | mypy                      |                           | 1.10.0                    | 0.812                     |
| 185 | mypy-extensions           |                           | 1.0.0                     | 0.4.3, 1.0.0              |
| 186 | nest-asyncio              | 1.6.0                     |                           |                           |
| 187 | networkx                  | 2.5, 2.5.1, 3.3           | 2.5, 2.5.1, 2.8.8, 3.3    |                           |
| 188 | nodeenv                   |                           |                           | 1.6.0, 1.8.0              |
| 189 | nose                      |                           |                           | 1.3.7                     |
| 190 | numpy                     | 1.26.4                    | 1.19.3, 1.19.5, 1.26.4    |                           |
| 191 | openapi-core              | 0.12.0, 0.19.0            | 0.12.0                    |                           |
| 192 | openapi-schema-validator  | 0.1.5, 0.2.3, 0.6.2       | 0.1.5, 0.2.3, 0.6.2       |                           |
| 193 | openapi-spec-validator    | 0.2.9, 0.3.0, 0.3.1, 0.4.0, 0.7.1 | 0.2.9, 0.3.1, 0.4.0, 0.7.1 |                           |
| 194 | openpyxl                  | 3.0.7, 3.0.9              |                           |                           |
| 195 | ordered-set               | 4.1.0                     | 4.1.0                     |                           |
| 196 | orjson                    | 3.3.1, 3.4.0, 3.4.3, 3.4.8, 3.5.2, 3.10.0, 3.10.3 | 3.3.1, 3.4.0, 3.10.3      |                           |
| 197 | osparc                    | 0.6.5                     |                           |                           |
| 198 | osparc-client             | 0.6.5                     |                           |                           |
| 199 | packaging                 | 20.4, 20.9, 23.1, 24.0    | 20.4, 20.9, 23.1, 24.0    | 23.1, 24.0                |
| 200 | pamqp                     | 2.3.0, 3.2.1, 3.3.0       | 2.3.0, 3.3.0              |                           |
| 201 | pandas                    | 2.2.1, 2.2.2              | 1.1.3, 1.1.5, 2.2.2       |                           |
| 202 | paramiko                  | 2.7.2                     | 2.7.1, 2.7.2              |                           |
| 203 | parfive                   | 1.0.2                     |                           |                           |
| 204 | parse                     | 1.20.1                    | 1.20.1                    |                           |
| 205 | partd                     | 1.4.2                     | 1.4.2                     |                           |
| 206 | passlib                   | 1.7.2, 1.7.4              | 1.7.2                     |                           |
| 207 | pathable                  | 0.4.3                     | 0.4.3                     |                           |
| 208 | pathspec                  |                           |                           | 0.8.1, 0.12.1             |
| 209 | pbr                       |                           | 6.0.0                     |                           |
| 210 | pep517                    |                           |                           | 0.10.0                    |
| 211 | pillow                    | 10.2.0, 10.3.0            | 10.3.0                    |                           |
| 212 | pint                      | 0.19.2, 0.23              | 0.17, 0.23                |                           |
| 213 | pip                       |                           |                           | 24.0                      |
| 214 | pip-tools                 |                           |                           | 6.1.0, 7.4.1              |
| 215 | platformdirs              |                           |                           | 4.2.1, 4.2.2              |
| 216 | playwright                |                           | 1.43.0                    |                           |
| 217 | pluggy                    | 0.13.1, 1.5.0             | 0.13.1, 1.5.0             |                           |
| 218 | ply                       |                           | 3.11                      |                           |
| 219 | pprintpp                  |                           | 0.4.0                     |                           |
| 220 | pre-commit                |                           |                           | 2.12.1, 2.13.0, 3.7.0, 3.7.1 |
| 221 | prometheus-api-client     | 0.5.5                     |                           |                           |
| 222 | prometheus-client         | 0.8.0, 0.10.1, 0.14.1, 0.19.0, 0.20.0 | 0.8.0, 0.10.1             |                           |
| 223 | prometheus-fastapi-instrumentator | 6.1.0                     |                           |                           |
| 224 | promise                   | 2.3                       | 2.3                       |                           |
| 225 | prompt-toolkit            | 3.0.8, 3.0.18             | 3.0.8, 3.0.18             |                           |
| 226 | protobuf                  | 3.13.0, 3.15.8            | 3.13.0                    |                           |
| 227 | psutil                    | 5.7.3, 5.8.0, 5.9.8       | 5.7.3, 5.9.8              |                           |
| 228 | psycopg2-binary           | 2.8.5, 2.8.6, 2.9.6, 2.9.9 | 2.8.5, 2.8.6, 2.9.9       |                           |
| 229 | ptvsd                     |                           | 4.3.2                     | 4.3.2                     |
| 230 | py                        | 1.10.0                    | 1.9.0, 1.10.0             |                           |
| 231 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 232 | py-partiql-parser         |                           | 0.4.0, 0.5.4, 0.5.5       |                           |
| 233 | pyasn1                    | 0.5.1                     | 0.6.0                     |                           |
| 234 | pycountry                 | 23.12.11                  |                           |                           |
| 235 | pycparser                 | 2.20, 2.21, 2.22          | 2.20, 2.22                |                           |
| 236 | pydantic                  | 1.6.1, 1.8.2, 1.9.0, 1.10.2, 1.10.14, 1.10.15 | 1.6.1, 1.10.2, 1.10.14, 1.10.15, 2.7.1 |                           |
| 237 | pydantic-core             |                           | 2.18.2                    |                           |
| 238 | pyee                      |                           | 11.1.0                    |                           |
| 239 | pyftpdlib                 |                           | 1.5.9                     |                           |
| 240 | pygments                  | 2.15.1, 2.17.2, 2.18.0    | 2.18.0                    | 2.18.0                    |
| 241 | pyinstrument              | 3.4.2, 4.6.1, 4.6.2       | 3.4.2, 4.6.2              |                           |
| 242 | pyinstrument-cext         | 0.2.4                     | 0.2.4                     |                           |
| 243 | pyjwt                     | 2.4.0                     |                           |                           |
| 244 | pylint                    |                           | 2.5.0, 2.6.0, 2.8.2, 2.8.3 | 2.8.2, 3.1.0, 3.2.2       |
| 245 | pynacl                    | 1.4.0                     | 1.4.0                     |                           |
| 246 | pyopenssl                 |                           | 24.1.0                    |                           |
| 247 | pyparsing                 | 2.4.7, 3.1.2              | 2.4.7, 3.1.2              |                           |
| 248 | pyproject-hooks           |                           |                           | 1.1.0                     |
| 249 | pyrsistent                | 0.16.0, 0.17.3, 0.18.1, 0.19.2, 0.20.0 | 0.16.0, 0.17.3, 0.18.1, 0.19.2, 0.20.0 |                           |
| 250 | pytest                    | 6.2.4, 8.2.0              | 6.1.1, 6.1.2, 6.2.4, 7.4.4, 8.2.0, 8.2.1 |                           |
| 251 | pytest-aiohttp            |                           | 0.3.0, 1.0.5              |                           |
| 252 | pytest-asyncio            |                           | 0.15.1, 0.21.2            |                           |
| 253 | pytest-base-url           |                           | 2.1.0                     |                           |
| 254 | pytest-benchmark          |                           | 4.0.0                     |                           |
| 255 | pytest-celery             |                           | 0.0.0                     |                           |
| 256 | pytest-cov                |                           | 2.10.1, 2.11.1, 2.12.0, 2.12.1, 5.0.0 |                           |
| 257 | pytest-docker             |                           | 0.10.1, 3.1.1             |                           |
| 258 | pytest-forked             |                           | 1.3.0                     |                           |
| 259 | pytest-html               |                           | 4.1.1                     |                           |
| 260 | pytest-icdiff             |                           | 0.5, 0.9                  |                           |
| 261 | pytest-instafail          |                           | 0.4.2, 0.5.0              |                           |
| 262 | pytest-lazy-fixture       |                           | 0.6.3                     |                           |
| 263 | pytest-localftpserver     |                           | 1.3.2                     |                           |
| 264 | pytest-metadata           |                           | 3.1.1                     |                           |
| 265 | pytest-mock               |                           | 3.2.0, 3.3.1, 3.6.1, 3.14.0 |                           |
| 266 | pytest-playwright         |                           | 0.4.4                     |                           |
| 267 | pytest-runner             |                           | 5.2, 5.3.0, 5.3.1, 6.0.1  |                           |
| 268 | pytest-sugar              |                           | 0.9.4, 1.0.0              |                           |
| 269 | pytest-xdist              |                           | 2.2.1, 3.6.1              |                           |
| 270 | python-dateutil           | 2.8.1, 2.8.2, 2.9.0.post0 | 2.8.1, 2.8.2, 2.9.0.post0 |                           |
| 271 | python-dotenv             | 0.14.0, 0.15.0, 0.17.0, 0.17.1, 1.0.0, 1.0.1 | 0.14.0, 0.15.0, 0.17.1, 1.0.1 |                           |
| 272 | python-editor             |                           | 1.0.4                     |                           |
| 273 | python-engineio           | 3.13.2, 3.14.2, 4.3.4, 4.9.0, 4.9.1 | 3.13.2, 4.9.0             |                           |
| 274 | python-jose               | 3.3.0                     | 3.3.0                     |                           |
| 275 | python-magic              | 0.4.22, 0.4.25, 0.4.27    |                           |                           |
| 276 | python-multipart          | 0.0.5, 0.0.9              | 0.0.5                     |                           |
| 277 | python-slugify            |                           | 8.0.4                     |                           |
| 278 | python-socketio           | 4.6.0, 4.6.1, 5.8.0, 5.11.2 | 4.6.0, 5.11.2             |                           |
| 279 | pytz                      | 2020.1, 2020.4, 2021.1, 2022.1, 2024.1 | 2020.1, 2020.4, 2021.1, 2024.1 |                           |
| 280 | pyyaml                    | 5.3.1, 5.4.1, 6.0.1       | 5.3.1, 5.4.1, 6.0.1       | 5.4.1, 6.0.1              |
| 281 | redis                     | 3.5.3, 5.0.4              | 3.5.3, 5.0.4              |                           |
| 282 | referencing               | 0.29.3, 0.35.1            | 0.29.3, 0.35.1            |                           |
| 283 | regex                     | 2023.12.25                | 2023.12.25, 2024.4.28, 2024.5.15 | 2021.4.4                  |
| 284 | requests                  | 2.24.0, 2.25.1, 2.32.2    | 2.24.0, 2.25.1, 2.32.2    |                           |
| 285 | requests-mock             |                           | 1.12.1                    |                           |
| 286 | responses                 |                           | 0.25.0                    |                           |
| 287 | respx                     |                           | 0.12.1, 0.14.0, 0.17.0, 0.21.1 |                           |
| 288 | rfc3339-validator         | 0.1.4                     | 0.1.4                     |                           |
| 289 | rich                      | 13.4.2, 13.7.1            | 13.7.1                    | 13.7.1                    |
| 290 | rpds-py                   | 0.18.0, 0.18.1            | 0.18.0, 0.18.1            |                           |
| 291 | rsa                       | 4.9                       | 4.9                       |                           |
| 292 | ruff                      |                           |                           | 0.4.3, 0.4.4, 0.4.5       |
| 293 | rx                        | 1.6.1                     | 1.6.1                     |                           |
| 294 | s3fs                      | 2024.5.0                  |                           |                           |
| 295 | s3transfer                | 0.3.3, 0.3.7, 0.10.1      | 0.3.3, 0.5.2, 0.10.1      |                           |
| 296 | sarif-om                  |                           | 1.0.4                     |                           |
| 297 | semantic-version          | 2.8.5                     | 2.8.5                     |                           |
| 298 | semver                    | 2.13.0                    | 2.13.0                    |                           |
| 299 | setproctitle              | 1.2.3                     |                           |                           |
| 300 | setuptools                | 69.1.1, 69.2.0            | 69.1.1, 69.2.0, 69.5.1, 70.0.0 | 69.1.1, 69.2.0, 69.5.1, 70.0.0 |
| 301 | sh                        | 2.0.6                     |                           |                           |
| 302 | shellingham               | 1.5.4                     | 1.5.4                     | 1.5.4                     |
| 303 | shortuuid                 | 1.0.13                    |                           |                           |
| 304 | simple-websocket          | 1.0.0                     | 1.0.0                     |                           |
| 305 | six                       | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            | 1.15.0, 1.16.0            |
| 306 | sniffio                   | 1.1.0, 1.2.0, 1.3.0, 1.3.1 | 1.1.0, 1.2.0, 1.3.0, 1.3.1 |                           |
| 307 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 308 | sqlalchemy                | 1.4.47, 1.4.52            | 1.3.20, 1.4.47, 1.4.52    |                           |
| 309 | sqlalchemy2-stubs         |                           | 0.0.2a38                  |                           |
| 310 | sshpubkeys                |                           | 3.3.1                     |                           |
| 311 | starlette                 | 0.13.6, 0.14.2, 0.27.0    | 0.13.6                    |                           |
| 312 | strict-rfc3339            | 0.7                       | 0.7                       |                           |
| 313 | sympy                     |                           | 1.12                      |                           |
| 314 | tblib                     | 3.0.0                     | 3.0.0                     |                           |
| 315 | tenacity                  | 6.2.0, 6.3.1, 7.0.0, 8.0.1, 8.2.3, 8.3.0 | 6.2.0, 7.0.0, 8.0.1, 8.2.3, 8.3.0 |                           |
| 316 | termcolor                 |                           | 1.1.0, 2.4.0              |                           |
| 317 | text-unidecode            |                           | 1.3                       |                           |
| 318 | texttable                 | 1.6.3                     | 1.6.2, 1.6.3              |                           |
| 319 | toml                      | 0.10.2                    | 0.10.1, 0.10.2            | 0.10.2                    |
| 320 | tomli                     | 2.0.1                     | 2.0.1                     | 2.0.1                     |
| 321 | tomlkit                   |                           |                           | 0.12.4, 0.12.5            |
| 322 | toolz                     | 0.12.0, 0.12.1            | 0.12.1                    |                           |
| 323 | tornado                   | 6.4                       | 6.4                       |                           |
| 324 | tqdm                      | 4.60.0, 4.64.0, 4.66.2, 4.66.4 | 4.60.0, 4.66.4            |                           |
| 325 | trafaret                  | 2.0.2, 2.1.0              | 2.0.2, 2.1.0              |                           |
| 326 | trafaret-config           | 2.0.2                     | 2.0.2                     |                           |
| 327 | traitlets                 | 5.14.3                    | 5.14.3                    |                           |
| 328 | twilio                    | 7.12.0                    |                           |                           |
| 329 | typed-ast                 |                           | 1.4.1, 1.4.3              | 1.4.3                     |
| 330 | typer                     | 0.3.2, 0.12.3             | 0.12.3                    | 0.12.3                    |
| 331 | types-aiobotocore         | 2.12.1, 2.12.3, 2.13.0    | 2.12.3                    |                           |
| 332 | types-aiobotocore-ec2     | 2.12.1, 2.12.3, 2.13.0    |                           |                           |
| 333 | types-aiobotocore-s3      | 2.12.1, 2.12.3, 2.13.0    | 2.12.3                    |                           |
| 334 | types-aiofiles            |                           | 23.2.0.20240403           |                           |
| 335 | types-awscrt              | 0.20.5, 0.20.9            | 0.20.9                    |                           |
| 336 | types-boto3               |                           | 1.0.2                     |                           |
| 337 | types-cachetools          |                           |                           | 5.3.0.7                   |
| 338 | types-python-dateutil     | 2.9.0.20240316            | 2.9.0.20240316            |                           |
| 339 | types-pyyaml              |                           | 6.0.12.20240311           |                           |
| 340 | types-s3transfer          |                           | 0.10.1                    |                           |
| 341 | typing-extensions         | 3.7.4.2, 3.7.4.3, 3.10.0.0, 4.4.0, 4.10.0, 4.11.0, 4.12.0 | 3.7.4.2, 3.7.4.3, 3.10.0.0, 4.4.0, 4.10.0, 4.11.0, 4.12.0 | 3.7.4.3, 3.10.0.0, 4.4.0, 4.10.0, 4.11.0, 4.12.0 |
| 342 | tzdata                    | 2024.1                    | 2024.1                    |                           |
| 343 | tzlocal                   | 5.2                       |                           |                           |
| 344 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 345 | ujson                     | 3.1.0, 3.2.0, 4.0.1, 4.0.2, 5.5.0, 5.9.0, 5.10.0 | 3.1.0, 3.2.0, 4.0.1, 4.0.2 |                           |
| 346 | urllib3                   | 1.25.11, 1.26.4, 1.26.11, 2.0.7, 2.2.1 | 1.25.11, 1.26.4, 1.26.11, 1.26.18, 2.0.7, 2.2.1 |                           |
| 347 | uvicorn                   | 0.11.8, 0.13.4, 0.19.0, 0.29.0 | 0.11.8                    |                           |
| 348 | uvloop                    | 0.14.0, 0.19.0            | 0.14.0                    |                           |
| 349 | vine                      | 1.3.0, 5.0.0              | 1.3.0, 5.0.0              |                           |
| 350 | virtualenv                |                           |                           | 20.4.6, 20.4.7, 20.26.1, 20.26.2 |
| 351 | watchdog                  | 4.0.0                     |                           | 4.0.0                     |
| 352 | watchfiles                | 0.21.0                    |                           |                           |
| 353 | watchgod                  | 0.6, 0.7                  |                           |                           |
| 354 | wcwidth                   | 0.2.5                     | 0.2.5                     |                           |
| 355 | websocket-client          | 0.57.0, 0.58.0, 0.59.0    | 0.57.0, 0.59.0            |                           |
| 356 | websockets                | 8.1, 12.0                 | 8.1, 9.0.2, 12.0          |                           |
| 357 | werkzeug                  | 1.0.1, 2.0.0, 2.0.1, 2.1.2, 3.0.2 | 1.0.1, 2.0.0, 2.1.2, 3.0.2, 3.0.3 |                           |
| 358 | wheel                     |                           |                           | 0.43.0                    |
| 359 | wrapt                     | 1.12.1, 1.16.0            | 1.12.1, 1.16.0            | 1.12.1                    |
| 360 | wsproto                   | 1.2.0                     | 1.2.0                     |                           |
| 361 | xmltodict                 |                           | 0.13.0                    |                           |
| 362 | xyzservices               | 2024.4.0                  | 2024.4.0                  |                           |
| 363 | yarl                      | 1.5.1, 1.6.0, 1.6.2, 1.6.3, 1.9.2, 1.9.4 | 1.5.1, 1.6.0, 1.6.2, 1.6.3, 1.9.2, 1.9.4 |                           |
| 364 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 365 | zipp                      | 3.1.0, 3.2.0, 3.3.1, 3.4.0, 3.4.1, 3.18.2 | 3.1.0, 3.2.0, 3.3.1, 3.4.0, 3.4.1, 3.18.2 | 3.2.0, 3.4.0, 3.4.1       |



## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
