### PR TITLE
🔨 New pytest-simcore `environment_config` fixtures and `utils_postgres` helpers

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
+++ b/packages/pytest-simcore/src/pytest_simcore/environment_configs.py
@@ -3,39 +3,13 @@
 # pylint: disable=unused-variable
 
 
+import re
 from pathlib import Path
 
 import pytest
 
 from .helpers.typing_env import EnvVarsDict
-from .helpers.utils_envs import delenvs_from_dict, load_dotenv, setenvs_from_dict
-
-
-@pytest.fixture(scope="session")  # MD: get this, I will mock it with my app environmnet
-def env_devel_dict(env_devel_file: Path) -> EnvVarsDict:
-    assert env_devel_file.exists()
-    assert env_devel_file.name == ".env-devel"
-    return load_dotenv(env_devel_file, verbose=True, interpolate=True)
-
-
-@pytest.fixture
-def mock_env_devel_environment(
-    env_devel_dict: EnvVarsDict, monkeypatch: pytest.MonkeyPatch
-) -> EnvVarsDict:
-    return setenvs_from_dict(monkeypatch, env_devel_dict)
-
-
-@pytest.fixture
-def all_env_devel_undefined(
-    monkeypatch: pytest.MonkeyPatch, env_devel_dict: EnvVarsDict
-):
-    """Ensures that all env vars in .env-devel are undefined in the test environment
-
-    NOTE: this is useful to have a clean starting point and avoid
-    the environment to influence your test. I found this situation
-    when some script was accidentaly injecting the entire .env-devel in the environment
-    """
-    delenvs_from_dict(monkeypatch, env_devel_dict, raising=False)
+from .helpers.utils_envs import load_dotenv, setenvs_from_dict
 
 
 def pytest_addoption(parser: pytest.Parser):
@@ -66,5 +40,67 @@ def external_envfile_dict(request: pytest.FixtureRequest) -> EnvVarsDict:
         assert envfile.is_file()
 
         envs = load_dotenv(envfile)
+
+    return envs
+
+
+@pytest.fixture(scope="session")
+def env_devel_dict(env_devel_file: Path) -> EnvVarsDict:
+    assert env_devel_file.exists()
+    assert env_devel_file.name == ".env-devel"
+    return load_dotenv(env_devel_file, verbose=True, interpolate=True)
+
+
+@pytest.fixture
+def mock_env_devel_environment(
+    env_devel_dict: EnvVarsDict, monkeypatch: pytest.MonkeyPatch
+) -> EnvVarsDict:
+    return setenvs_from_dict(monkeypatch, {**env_devel_dict})
+
+
+@pytest.fixture(scope="session")
+def service_name(project_slug_dir: Path) -> str:
+    """
+    project_slug_dir MUST be defined on root's conftest.py
+    """
+    return project_slug_dir.name
+
+
+@pytest.fixture(scope="session")
+def docker_compose_service_environment_dict(
+    services_docker_compose_file: Path, env_devel_dict: EnvVarsDict, service_name: str
+) -> EnvVarsDict:
+    """Returns env vars dict from the docker-compose `environment` section
+
+    - services_docker_compose_file in repository_paths plugin
+    - env_devel_dict in environment_configs plugin
+    - service_name needs to be defined
+    """
+    # NOTE: By keeping import here, this library is ONLY required when the fixture is used
+    import yaml
+
+    service = yaml.safe_load(services_docker_compose_file.read_text())["services"][
+        service_name
+    ]
+
+    def _substitute(key, value):
+        if m := re.match(r"\${([^{}:-]\w+)", value):
+            expected_env_var = m.group(1)
+            try:
+                # NOTE: if this raises, then the RHS env-vars in the docker-compose are
+                # not defined in the env-devel
+                if value := env_devel_dict[expected_env_var]:
+                    return key, value
+            except KeyError:
+                pytest.fail(
+                    f"{expected_env_var} is not defined in .env-devel but used in docker-compose services[{service}].environment[{key}]"
+                )
+        return None
+
+    envs: EnvVarsDict = {}
+    for key, value in service.get("environment", {}).items():
+        if found := _substitute(key, value):
+            _, new_value = found
+            envs[key] = new_value
 
     return envs

--- a/packages/pytest-simcore/src/pytest_simcore/postgres_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/postgres_service.py
@@ -12,6 +12,7 @@ import sqlalchemy as sa
 import tenacity
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict
+from sqlalchemy.ext.asyncio import AsyncEngine
 from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_fixed
 
@@ -200,7 +201,7 @@ def postgres_db(
         yield postgres_engine
 
 
-@pytest.fixture()
+@pytest.fixture
 async def aiopg_engine(
     postgres_db: sa.engine.Engine,
 ) -> AsyncIterator:
@@ -216,10 +217,10 @@ async def aiopg_engine(
         await engine.wait_closed()
 
 
-@pytest.fixture()
+@pytest.fixture
 async def sqlalchemy_async_engine(
     postgres_db: sa.engine.Engine,
-) -> AsyncIterator:
+) -> AsyncIterator[AsyncEngine]:
     # NOTE: prevent having to import this if latest sqlalchemy not installed
     from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -232,7 +233,7 @@ async def sqlalchemy_async_engine(
     await engine.dispose()
 
 
-@pytest.fixture()
+@pytest.fixture
 def postgres_env_vars_dict(postgres_dsn: PostgresTestConfig) -> EnvVarsDict:
     return {
         "POSTGRES_USER": postgres_dsn["user"],
@@ -244,7 +245,7 @@ def postgres_env_vars_dict(postgres_dsn: PostgresTestConfig) -> EnvVarsDict:
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def postgres_host_config(
     postgres_dsn: PostgresTestConfig,
     postgres_env_vars_dict: EnvVarsDict,

--- a/packages/service-library/src/servicelib/fastapi/requests_decorators.py
+++ b/packages/service-library/src/servicelib/fastapi/requests_decorators.py
@@ -22,13 +22,11 @@ def _validate_signature(handler: _HandlerWithRequestArg):
     try:
         p = next(iter(inspect.signature(handler).parameters.values()))
         if p.kind != inspect.Parameter.POSITIONAL_OR_KEYWORD or p.annotation != Request:
-            raise TypeError(
-                f"Invalid handler {handler.__name__} signature: first parameter must be a Request, got {p.annotation}"
-            )
+            msg = f"Invalid handler {handler.__name__} signature: first parameter must be a Request, got {p.annotation}"
+            raise TypeError(msg)
     except StopIteration as e:
-        raise TypeError(
-            f"Invalid handler {handler.__name__} signature: first parameter must be a Request, got none"
-        ) from e
+        msg = f"Invalid handler {handler.__name__} signature: first parameter must be a Request, got none"
+        raise TypeError(msg) from e
 
 
 #

--- a/packages/service-library/src/servicelib/fastapi/timing_middleware.py
+++ b/packages/service-library/src/servicelib/fastapi/timing_middleware.py
@@ -1,14 +1,15 @@
-import time
 import logging
+import time
+
 from fastapi import Request
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 async def add_process_time_header(request: Request, call_next):
     start_time = time.time()
     response = await call_next(request)
     process_time = time.time() - start_time
-    logger.debug("time to process %.2fs", process_time)
+    _logger.debug("time to process %.2fs", process_time)
     response.headers["X-Process-Time"] = str(process_time)
     return response

--- a/packages/settings-library/tests/test_email.py
+++ b/packages/settings-library/tests/test_email.py
@@ -7,7 +7,22 @@ from typing import Any
 
 import pytest
 from pydantic import ValidationError
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from pytest_simcore.helpers.utils_envs import delenvs_from_dict
 from settings_library.email import EmailProtocol, SMTPSettings
+
+
+@pytest.fixture
+def all_env_devel_undefined(
+    monkeypatch: pytest.MonkeyPatch, env_devel_dict: EnvVarsDict
+) -> None:
+    """Ensures that all env vars in .env-devel are undefined in the test environment
+
+    NOTE: this is useful to have a clean starting point and avoid
+    the environment to influence your test. I found this situation
+    when some script was accidentaly injecting the entire .env-devel in the environment
+    """
+    delenvs_from_dict(monkeypatch, env_devel_dict, raising=False)
 
 
 @pytest.mark.parametrize(

--- a/services/datcore-adapter/src/simcore_service_datcore_adapter/api/module_setup.py
+++ b/services/datcore-adapter/src/simcore_service_datcore_adapter/api/module_setup.py
@@ -4,12 +4,12 @@
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, FastAPI
 from fastapi.exceptions import HTTPException, RequestValidationError
+from servicelib.fastapi.timing_middleware import add_process_time_header
 
 from .._meta import API_VTAG
 from .errors.http_error import http_error_handler
 from .errors.pennsieve_error import botocore_exceptions_handler
 from .errors.validation_error import http422_error_handler
-from .middleware_timing import add_process_time_header
 from .routes import datasets, files, health, user
 
 

--- a/services/payments/tests/unit/test_db_payments_users_repo.py
+++ b/services/payments/tests/unit/test_db_payments_users_repo.py
@@ -9,11 +9,11 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 import pytest
-import sqlalchemy as sa
 from fastapi import FastAPI
 from models_library.users import GroupID, UserID
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.utils_envs import setenvs_from_dict
+from pytest_simcore.helpers.utils_postgres import insert_and_get_row_lifespan
 from simcore_postgres_database.models.payments_transactions import payments_transactions
 from simcore_postgres_database.models.products import products
 from simcore_postgres_database.models.users import users
@@ -49,21 +49,6 @@ def app_environment(
     )
 
 
-async def _insert_and_get_row(
-    conn, table: sa.Table, values: dict[str, Any], pk_col: sa.Column, pk_value: Any
-):
-    result = await conn.execute(table.insert().values(**values).returning(pk_col))
-    row = result.first()
-    assert row[pk_col] == pk_value
-
-    result = await conn.execute(sa.select(table).where(pk_col == pk_value))
-    return result.first()
-
-
-async def _delete_row(conn, table, pk_col: sa.Column, pk_value: Any):
-    await conn.execute(table.delete().where(pk_col == pk_value))
-
-
 @pytest.fixture
 async def user(
     app: FastAPI,
@@ -74,16 +59,14 @@ async def user(
     injects a user in db
     """
     assert user_id == user["id"]
-    pk_args = users.c.id, user["id"]
-
-    # NOTE: creation of primary group and setting `groupid`` is automatically triggered after creation of user by postgres
-    async with get_engine(app).begin() as conn:
-        row = await _insert_and_get_row(conn, users, user, *pk_args)
-
-    yield dict(row)
-
-    async with get_engine(app).begin() as conn:
-        await _delete_row(conn, users, *pk_args)
+    async with insert_and_get_row_lifespan(
+        get_engine(app),
+        table=users,
+        values=user,
+        pk_col=users.c.id,
+        pk_value=user["id"],
+    ) as row:
+        yield row
 
 
 @pytest.fixture
@@ -101,15 +84,14 @@ async def product(
     """
     # NOTE: this fixture ignores products' group-id but it is fine for this test context
     assert product["group_id"] is None
-    pk_args = products.c.name, product["name"]
-
-    async with get_engine(app).begin() as conn:
-        row = await _insert_and_get_row(conn, products, product, *pk_args)
-
-    yield dict(row)
-
-    async with get_engine(app).begin() as conn:
-        await _delete_row(conn, products, *pk_args)
+    async with insert_and_get_row_lifespan(
+        get_engine(app),
+        table=products,
+        values=product,
+        pk_col=products.c.name,
+        pk_value=product["name"],
+    ) as row:
+        yield row
 
 
 @pytest.fixture
@@ -119,17 +101,14 @@ async def successful_transaction(
     """
     injects transaction in db
     """
-    pk_args = payments_transactions.c.payment_id, successful_transaction["payment_id"]
-
-    async with get_engine(app).begin() as conn:
-        row = await _insert_and_get_row(
-            conn, payments_transactions, successful_transaction, *pk_args
-        )
-
-    yield dict(row)
-
-    async with get_engine(app).begin() as conn:
-        await _delete_row(conn, payments_transactions, *pk_args)
+    async with insert_and_get_row_lifespan(
+        get_engine(app),
+        table=payments_transactions,
+        values=successful_transaction,
+        pk_col=payments_transactions.c.payment_id,
+        pk_value=successful_transaction["payment_id"],
+    ) as row:
+        yield row
 
 
 async def test_payments_user_repo(

--- a/services/payments/tests/unit/test_services_notifier_email.py
+++ b/services/payments/tests/unit/test_services_notifier_email.py
@@ -37,12 +37,12 @@ from simcore_service_payments.services.notifier_email import (
 def app_environment(
     monkeypatch: pytest.MonkeyPatch,
     external_envfile_dict: EnvVarsDict,
-    docker_compose_service_payments_env_vars: EnvVarsDict,
+    docker_compose_service_environment_dict: EnvVarsDict,
 ) -> EnvVarsDict:
     return setenvs_from_dict(
         monkeypatch,
         {
-            **docker_compose_service_payments_env_vars,
+            **docker_compose_service_environment_dict,
             **external_envfile_dict,
         },
     )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Here are some changes in `pytest-simcore` and `servicelib` that can be useful in many services. I have used them in some of the services as example and will do systematically with many more in different PRs

- 🔨 new **fixture** `docker_compose_service_environment_dict`: **replicates the env vars that the real services will encounter**
    - resolves `.env-devel` and the `environment` section of a `service_name`. Detects e.g. missing env vars in `.env-devel`
   -  used in `payments` as example (NOTE: **recommended** to build `app_environment` fixture in all services services)
- 🔨 new **helper** `pytest_simcore.helpers.utils_postgres.insert_and_get_row_lifespan` context for a control lifespan of a new row.
- ♻️ moved **middleware** to `packages/service-library/src/servicelib/fastapi/timing_middleware.py` from `dat-core` service

## Related issue/s

- Preparation for https://github.com/ITISFoundation/osparc-simcore/pull/5904 (the latter was too big for a single PR)


## How to test

in place

## Dev-ops checklist
 None