### PR TITLE
🐛Dask sidecar: disable concurrent pulling of files until new version is out

### DIFF
--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -92,7 +92,9 @@ class ComputationalSidecar:
                 )
             else:
                 local_input_data_file[input_key] = input_params
-        await asyncio.gather(*download_tasks)
+        # NOTE: temporary solution until new version is created
+        for task in download_tasks:
+            await task
         input_data_file.write_text(json.dumps(local_input_data_file))
 
         await self._publish_sidecar_log("All the input data were downloaded.")

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -108,8 +108,6 @@ clean-up: ## remove everything
 test: ## test the platform
 	# tests
 	npm test
-	# tests whether tutorial run
-	npm run tutorials http://127.0.0.1:9081
 
 
 .PHONY: dev-prepare-jupyters


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
https://github.com/ITISFoundation/osparc-simcore/issues/5900 showed that if a user runs a computational service with multiple inputs, and these inputs have the same file name, there is a risk of collision. Therefore this PR disable concurrent pulling of inputs (this will slightly reduce execution performance but will ensure that there is no collision).

Bonus:
- removing puppeteer-based sleeper test
## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
