### PR TITLE
♻️ refactor stop service command ⚠️🚨

### DIFF
--- a/packages/models-library/src/models_library/api_schemas_dynamic_scheduler/dynamic_services.py
+++ b/packages/models-library/src/models_library/api_schemas_dynamic_scheduler/dynamic_services.py
@@ -38,7 +38,7 @@ class RPCDynamicServiceCreate(DynamicServiceCreate):
         }
 
 
-class RPCDynamicServiceStop(BaseModel):
+class DynamicServiceStop(BaseModel):
     user_id: UserID
     project_id: ProjectID
     node_id: NodeID

--- a/packages/models-library/src/models_library/api_schemas_dynamic_scheduler/dynamic_services.py
+++ b/packages/models-library/src/models_library/api_schemas_dynamic_scheduler/dynamic_services.py
@@ -1,9 +1,13 @@
 from typing import Any, ClassVar
 
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceCreate
+from models_library.projects import ProjectID
+from models_library.projects_nodes_io import NodeID
 from models_library.resource_tracker import HardwareInfo, PricingInfo
 from models_library.services_resources import ServiceResourcesDictHelpers
+from models_library.users import UserID
 from models_library.wallets import WalletInfo
+from pydantic import BaseModel
 
 
 class RPCDynamicServiceCreate(DynamicServiceCreate):
@@ -30,5 +34,24 @@ class RPCDynamicServiceCreate(DynamicServiceCreate):
                 "wallet_info": WalletInfo.Config.schema_extra["examples"][0],
                 "pricing_info": PricingInfo.Config.schema_extra["examples"][0],
                 "hardware_info": HardwareInfo.Config.schema_extra["examples"][0],
+            }
+        }
+
+
+class RPCDynamicServiceStop(BaseModel):
+    user_id: UserID
+    project_id: ProjectID
+    node_id: NodeID
+    simcore_user_agent: str
+    save_state: bool
+
+    class Config:
+        schema_extra: ClassVar[dict[str, Any]] = {
+            "example": {
+                "user_id": 234,
+                "project_id": "dd1d04d9-d704-4f7e-8f0f-1ca60cc771fe",
+                "node_id": "75c7f3f4-18f9-4678-8610-54a2ade78eaa",
+                "simcore_user_agent": "",
+                "can_save": True,
             }
         }

--- a/packages/models-library/src/models_library/api_schemas_dynamic_scheduler/dynamic_services.py
+++ b/packages/models-library/src/models_library/api_schemas_dynamic_scheduler/dynamic_services.py
@@ -52,6 +52,6 @@ class RPCDynamicServiceStop(BaseModel):
                 "project_id": "dd1d04d9-d704-4f7e-8f0f-1ca60cc771fe",
                 "node_id": "75c7f3f4-18f9-4678-8610-54a2ade78eaa",
                 "simcore_user_agent": "",
-                "can_save": True,
+                "save_state": True,
             }
         }

--- a/packages/models-library/src/models_library/api_schemas_dynamic_scheduler/dynamic_services.py
+++ b/packages/models-library/src/models_library/api_schemas_dynamic_scheduler/dynamic_services.py
@@ -10,7 +10,7 @@ from models_library.wallets import WalletInfo
 from pydantic import BaseModel
 
 
-class RPCDynamicServiceCreate(DynamicServiceCreate):
+class DynamicServiceStart(DynamicServiceCreate):
     request_dns: str
     request_scheme: str
     simcore_user_agent: str

--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/dynamic_scheduler/services.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/dynamic_scheduler/services.py
@@ -5,6 +5,7 @@ from models_library.api_schemas_directorv2.dynamic_services import DynamicServic
 from models_library.api_schemas_dynamic_scheduler import DYNAMIC_SCHEDULER_RPC_NAMESPACE
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
     RPCDynamicServiceCreate,
+    RPCDynamicServiceStop,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects_nodes_io import NodeID
@@ -60,17 +61,13 @@ async def run_dynamic_service(
 async def stop_dynamic_service(
     rabbitmq_rpc_client: RabbitMQRPCClient,
     *,
-    node_id: NodeID,
-    simcore_user_agent: str,
-    save_state: bool,
+    rpc_dynamic_service_stop: RPCDynamicServiceStop,
     timeout_s: NonNegativeInt,
 ) -> None:
     result = await rabbitmq_rpc_client.request(
         DYNAMIC_SCHEDULER_RPC_NAMESPACE,
         parse_obj_as(RPCMethodName, "stop_dynamic_service"),
-        node_id=node_id,
-        simcore_user_agent=simcore_user_agent,
-        save_state=save_state,
+        rpc_dynamic_service_stop=rpc_dynamic_service_stop,
         timeout_s=timeout_s,
     )
     assert result is None  # nosec

--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/dynamic_scheduler/services.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/dynamic_scheduler/services.py
@@ -4,8 +4,8 @@ from typing import Final
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler import DYNAMIC_SCHEDULER_RPC_NAMESPACE
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    DynamicServiceStart,
     DynamicServiceStop,
-    RPCDynamicServiceCreate,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects_nodes_io import NodeID
@@ -45,12 +45,12 @@ async def get_service_status(
 async def run_dynamic_service(
     rabbitmq_rpc_client: RabbitMQRPCClient,
     *,
-    rpc_dynamic_service_create: RPCDynamicServiceCreate,
+    dynamic_service_start: DynamicServiceStart,
 ) -> DynamicServiceGet | NodeGet:
     result = await rabbitmq_rpc_client.request(
         DYNAMIC_SCHEDULER_RPC_NAMESPACE,
         parse_obj_as(RPCMethodName, "run_dynamic_service"),
-        rpc_dynamic_service_create=rpc_dynamic_service_create,
+        dynamic_service_start=dynamic_service_start,
         timeout_s=_RPC_DEFAULT_TIMEOUT_S,
     )
     assert isinstance(result, DynamicServiceGet | NodeGet)  # nosec

--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/dynamic_scheduler/services.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/dynamic_scheduler/services.py
@@ -4,8 +4,8 @@ from typing import Final
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler import DYNAMIC_SCHEDULER_RPC_NAMESPACE
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    DynamicServiceStop,
     RPCDynamicServiceCreate,
-    RPCDynamicServiceStop,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects_nodes_io import NodeID
@@ -61,13 +61,13 @@ async def run_dynamic_service(
 async def stop_dynamic_service(
     rabbitmq_rpc_client: RabbitMQRPCClient,
     *,
-    rpc_dynamic_service_stop: RPCDynamicServiceStop,
+    dynamic_service_stop: DynamicServiceStop,
     timeout_s: NonNegativeInt,
 ) -> None:
     result = await rabbitmq_rpc_client.request(
         DYNAMIC_SCHEDULER_RPC_NAMESPACE,
         parse_obj_as(RPCMethodName, "stop_dynamic_service"),
-        rpc_dynamic_service_stop=rpc_dynamic_service_stop,
+        dynamic_service_stop=dynamic_service_stop,
         timeout_s=timeout_s,
     )
     assert result is None  # nosec

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/rpc/_services.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/rpc/_services.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    DynamicServiceStart,
     DynamicServiceStop,
-    RPCDynamicServiceCreate,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects_nodes_io import NodeID
@@ -28,10 +28,10 @@ async def get_service_status(
 
 @router.expose()
 async def run_dynamic_service(
-    app: FastAPI, *, rpc_dynamic_service_create: RPCDynamicServiceCreate
+    app: FastAPI, *, dynamic_service_start: DynamicServiceStart
 ) -> NodeGet | DynamicServiceGet:
     director_v2_client = DirectorV2Client.get_from_app_state(app)
-    return await director_v2_client.run_dynamic_service(rpc_dynamic_service_create)
+    return await director_v2_client.run_dynamic_service(dynamic_service_start)
 
 
 @router.expose(

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/rpc/_services.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/rpc/_services.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
     RPCDynamicServiceCreate,
+    RPCDynamicServiceStop,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects_nodes_io import NodeID
@@ -40,13 +41,13 @@ async def run_dynamic_service(
     )
 )
 async def stop_dynamic_service(
-    app: FastAPI, *, node_id: NodeID, simcore_user_agent: str, save_state: bool
+    app: FastAPI, *, rpc_dynamic_service_stop: RPCDynamicServiceStop
 ) -> NodeGet | DynamicServiceGet:
     director_v2_client = DirectorV2Client.get_from_app_state(app)
     settings: ApplicationSettings = app.state.settings
     return await director_v2_client.stop_dynamic_service(
-        node_id=node_id,
-        simcore_user_agent=simcore_user_agent,
-        save_state=save_state,
+        node_id=rpc_dynamic_service_stop.node_id,
+        simcore_user_agent=rpc_dynamic_service_stop.simcore_user_agent,
+        save_state=rpc_dynamic_service_stop.save_state,
         timeout=settings.DYNAMIC_SCHEDULER_STOP_SERVICE_TIMEOUT,
     )

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/rpc/_services.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/rpc/_services.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    DynamicServiceStop,
     RPCDynamicServiceCreate,
-    RPCDynamicServiceStop,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects_nodes_io import NodeID
@@ -41,13 +41,13 @@ async def run_dynamic_service(
     )
 )
 async def stop_dynamic_service(
-    app: FastAPI, *, rpc_dynamic_service_stop: RPCDynamicServiceStop
+    app: FastAPI, *, dynamic_service_stop: DynamicServiceStop
 ) -> NodeGet | DynamicServiceGet:
     director_v2_client = DirectorV2Client.get_from_app_state(app)
     settings: ApplicationSettings = app.state.settings
     return await director_v2_client.stop_dynamic_service(
-        node_id=rpc_dynamic_service_stop.node_id,
-        simcore_user_agent=rpc_dynamic_service_stop.simcore_user_agent,
-        save_state=rpc_dynamic_service_stop.save_state,
+        node_id=dynamic_service_stop.node_id,
+        simcore_user_agent=dynamic_service_stop.simcore_user_agent,
+        save_state=dynamic_service_stop.save_state,
         timeout=settings.DYNAMIC_SCHEDULER_STOP_SERVICE_TIMEOUT,
     )

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/director_v2/_public_client.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/director_v2/_public_client.py
@@ -4,7 +4,7 @@ from typing import Any
 from fastapi import FastAPI, status
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
-    RPCDynamicServiceCreate,
+    DynamicServiceStart,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects_nodes_io import NodeID
@@ -55,11 +55,9 @@ class DirectorV2Client(
             raise
 
     async def run_dynamic_service(
-        self, rpc_dynamic_service_create: RPCDynamicServiceCreate
+        self, dynamic_service_start: DynamicServiceStart
     ) -> NodeGet | DynamicServiceGet:
-        response = await self.thin_client.post_dynamic_service(
-            rpc_dynamic_service_create
-        )
+        response = await self.thin_client.post_dynamic_service(dynamic_service_start)
         dict_response: dict[str, Any] = response.json()
 
         # legacy services

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/director_v2/_thin_client.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/director_v2/_thin_client.py
@@ -3,7 +3,7 @@ import datetime
 from fastapi import FastAPI, status
 from httpx import Response, Timeout
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
-    RPCDynamicServiceCreate,
+    DynamicServiceStart,
 )
 from models_library.projects_nodes_io import NodeID
 from models_library.services_resources import ServiceResourcesDictHelpers
@@ -48,29 +48,29 @@ class DirectorV2ThinClient(BaseThinClient, AttachLifespanMixin):
     @retry_on_errors()
     @expect_status(status.HTTP_201_CREATED)
     async def post_dynamic_service(
-        self, rpc_dynamic_service_create: RPCDynamicServiceCreate
+        self, dynamic_service_start: DynamicServiceStart
     ) -> Response:
         post_data = {
-            "product_name": rpc_dynamic_service_create.product_name,
-            "can_save": rpc_dynamic_service_create.can_save,
-            "user_id": rpc_dynamic_service_create.user_id,
-            "project_id": rpc_dynamic_service_create.project_id,
-            "key": rpc_dynamic_service_create.key,
-            "version": rpc_dynamic_service_create.version,
-            "node_uuid": rpc_dynamic_service_create.node_uuid,
-            "basepath": f"/x/{rpc_dynamic_service_create.node_uuid}",
+            "product_name": dynamic_service_start.product_name,
+            "can_save": dynamic_service_start.can_save,
+            "user_id": dynamic_service_start.user_id,
+            "project_id": dynamic_service_start.project_id,
+            "key": dynamic_service_start.key,
+            "version": dynamic_service_start.version,
+            "node_uuid": dynamic_service_start.node_uuid,
+            "basepath": f"/x/{dynamic_service_start.node_uuid}",
             "service_resources": ServiceResourcesDictHelpers.create_jsonable(
-                rpc_dynamic_service_create.service_resources
+                dynamic_service_start.service_resources
             ),
-            "wallet_info": rpc_dynamic_service_create.wallet_info,
-            "pricing_info": rpc_dynamic_service_create.pricing_info,
-            "hardware_info": rpc_dynamic_service_create.hardware_info,
+            "wallet_info": dynamic_service_start.wallet_info,
+            "pricing_info": dynamic_service_start.pricing_info,
+            "hardware_info": dynamic_service_start.hardware_info,
         }
 
         headers = {
-            X_DYNAMIC_SIDECAR_REQUEST_DNS: rpc_dynamic_service_create.request_dns,
-            X_DYNAMIC_SIDECAR_REQUEST_SCHEME: rpc_dynamic_service_create.request_scheme,
-            X_SIMCORE_USER_AGENT: rpc_dynamic_service_create.simcore_user_agent,
+            X_DYNAMIC_SIDECAR_REQUEST_DNS: dynamic_service_start.request_dns,
+            X_DYNAMIC_SIDECAR_REQUEST_SCHEME: dynamic_service_start.request_scheme,
+            X_SIMCORE_USER_AGENT: dynamic_service_start.simcore_user_agent,
         }
 
         return await self.client.post(

--- a/services/dynamic-scheduler/tests/unit/api_rpc/test_api_rpc__services.py
+++ b/services/dynamic-scheduler/tests/unit/api_rpc/test_api_rpc__services.py
@@ -11,8 +11,8 @@ from fastapi import FastAPI, status
 from fastapi.encoders import jsonable_encoder
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    DynamicServiceStop,
     RPCDynamicServiceCreate,
-    RPCDynamicServiceStop,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects import ProjectID
@@ -367,8 +367,8 @@ async def test_stop_dynamic_service(
     simcore_user_agent: str,
     save_state: bool,
 ):
-    def _get_rpc_stop(with_node_id: NodeID) -> RPCDynamicServiceStop:
-        return RPCDynamicServiceStop(
+    def _get_rpc_stop(with_node_id: NodeID) -> DynamicServiceStop:
+        return DynamicServiceStop(
             user_id=user_id,
             project_id=project_id,
             node_id=with_node_id,
@@ -379,7 +379,7 @@ async def test_stop_dynamic_service(
     # service was stopped
     result = await services.stop_dynamic_service(
         rpc_client,
-        rpc_dynamic_service_stop=_get_rpc_stop(node_id),
+        dynamic_service_stop=_get_rpc_stop(node_id),
         timeout_s=5,
     )
     assert result is None
@@ -388,7 +388,7 @@ async def test_stop_dynamic_service(
     with pytest.raises(ServiceWasNotFoundError):
         await services.stop_dynamic_service(
             rpc_client,
-            rpc_dynamic_service_stop=_get_rpc_stop(node_id_not_found),
+            dynamic_service_stop=_get_rpc_stop(node_id_not_found),
             timeout_s=5,
         )
 
@@ -396,7 +396,7 @@ async def test_stop_dynamic_service(
     with pytest.raises(ServiceWaitingForManualInterventionError):
         await services.stop_dynamic_service(
             rpc_client,
-            rpc_dynamic_service_stop=_get_rpc_stop(node_id_manual_intervention),
+            dynamic_service_stop=_get_rpc_stop(node_id_manual_intervention),
             timeout_s=5,
         )
 
@@ -430,7 +430,7 @@ async def test_stop_dynamic_service_serializes_generic_errors(
     ):
         await services.stop_dynamic_service(
             rpc_client,
-            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+            dynamic_service_stop=DynamicServiceStop(
                 user_id=user_id,
                 project_id=project_id,
                 node_id=node_id,

--- a/services/dynamic-scheduler/tests/unit/api_rpc/test_api_rpc__services.py
+++ b/services/dynamic-scheduler/tests/unit/api_rpc/test_api_rpc__services.py
@@ -11,8 +11,8 @@ from fastapi import FastAPI, status
 from fastapi.encoders import jsonable_encoder
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    DynamicServiceStart,
     DynamicServiceStop,
-    RPCDynamicServiceCreate,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects import ProjectID
@@ -171,10 +171,10 @@ async def test_get_state(
 
 
 @pytest.fixture
-def rpc_dynamic_service_create() -> RPCDynamicServiceCreate:
+def dynamic_service_start() -> DynamicServiceStart:
     # one for legacy and one for new style?
-    return RPCDynamicServiceCreate.parse_obj(
-        RPCDynamicServiceCreate.Config.schema_extra["example"]
+    return DynamicServiceStart.parse_obj(
+        DynamicServiceStart.Config.schema_extra["example"]
     )
 
 
@@ -226,11 +226,11 @@ async def test_run_dynamic_service(
     mock_director_v0_service_run: None,
     mock_director_v2_service_run: None,
     rpc_client: RabbitMQRPCClient,
-    rpc_dynamic_service_create: RPCDynamicServiceCreate,
+    dynamic_service_start: DynamicServiceStart,
     is_legacy: bool,
 ):
     result = await services.run_dynamic_service(
-        rpc_client, rpc_dynamic_service_create=rpc_dynamic_service_create
+        rpc_client, dynamic_service_start=dynamic_service_start
     )
 
     if is_legacy:

--- a/services/web/server/src/simcore_service_webserver/dynamic_scheduler/api.py
+++ b/services/web/server/src/simcore_service_webserver/dynamic_scheduler/api.py
@@ -5,8 +5,8 @@ from functools import partial
 from aiohttp import web
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    DynamicServiceStart,
     DynamicServiceStop,
-    RPCDynamicServiceCreate,
 )
 from models_library.api_schemas_webserver.projects_nodes import (
     NodeGet,
@@ -43,11 +43,11 @@ async def get_dynamic_service(
 
 
 async def run_dynamic_service(
-    app: web.Application, *, rpc_dynamic_service_create: RPCDynamicServiceCreate
+    app: web.Application, *, dynamic_service_start: DynamicServiceStart
 ) -> DynamicServiceGet | NodeGet:
     return await services.run_dynamic_service(
         get_rabbitmq_rpc_client(app),
-        rpc_dynamic_service_create=rpc_dynamic_service_create,
+        dynamic_service_start=dynamic_service_start,
     )
 
 

--- a/services/web/server/src/simcore_service_webserver/dynamic_scheduler/api.py
+++ b/services/web/server/src/simcore_service_webserver/dynamic_scheduler/api.py
@@ -6,6 +6,7 @@ from aiohttp import web
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
     RPCDynamicServiceCreate,
+    RPCDynamicServiceStop,
 )
 from models_library.api_schemas_webserver.projects_nodes import (
     NodeGet,
@@ -53,9 +54,7 @@ async def run_dynamic_service(
 async def stop_dynamic_service(
     app: web.Application,
     *,
-    node_id: NodeID,
-    simcore_user_agent: str,
-    save_state: bool,
+    rpc_dynamic_service_stop: RPCDynamicServiceStop,
     progress: ProgressBarData | None = None,
 ) -> None:
     async with AsyncExitStack() as stack:
@@ -65,9 +64,7 @@ async def stop_dynamic_service(
         settings: DynamicSchedulerSettings = get_plugin_settings(app)
         await services.stop_dynamic_service(
             get_rabbitmq_rpc_client(app),
-            node_id=node_id,
-            simcore_user_agent=simcore_user_agent,
-            save_state=save_state,
+            rpc_dynamic_service_stop=rpc_dynamic_service_stop,
             timeout_s=settings.DYNAMIC_SCHEDULER_STOP_SERVICE_TIMEOUT,
         )
 
@@ -118,9 +115,13 @@ async def stop_dynamic_services_in_project(
         services_to_stop = [
             stop_dynamic_service(
                 app=app,
-                node_id=service.node_uuid,
-                simcore_user_agent=simcore_user_agent,
-                save_state=save_state,
+                rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                    user_id=user_id,
+                    project_id=service.project_id,
+                    node_id=service.node_uuid,
+                    simcore_user_agent=simcore_user_agent,
+                    save_state=save_state,
+                ),
                 progress=progress_bar.sub_progress(
                     1, description=f"{service.node_uuid}"
                 ),

--- a/services/web/server/src/simcore_service_webserver/dynamic_scheduler/api.py
+++ b/services/web/server/src/simcore_service_webserver/dynamic_scheduler/api.py
@@ -5,8 +5,8 @@ from functools import partial
 from aiohttp import web
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    DynamicServiceStop,
     RPCDynamicServiceCreate,
-    RPCDynamicServiceStop,
 )
 from models_library.api_schemas_webserver.projects_nodes import (
     NodeGet,
@@ -54,7 +54,7 @@ async def run_dynamic_service(
 async def stop_dynamic_service(
     app: web.Application,
     *,
-    rpc_dynamic_service_stop: RPCDynamicServiceStop,
+    dynamic_service_stop: DynamicServiceStop,
     progress: ProgressBarData | None = None,
 ) -> None:
     async with AsyncExitStack() as stack:
@@ -64,7 +64,7 @@ async def stop_dynamic_service(
         settings: DynamicSchedulerSettings = get_plugin_settings(app)
         await services.stop_dynamic_service(
             get_rabbitmq_rpc_client(app),
-            rpc_dynamic_service_stop=rpc_dynamic_service_stop,
+            dynamic_service_stop=dynamic_service_stop,
             timeout_s=settings.DYNAMIC_SCHEDULER_STOP_SERVICE_TIMEOUT,
         )
 
@@ -115,7 +115,7 @@ async def stop_dynamic_services_in_project(
         services_to_stop = [
             stop_dynamic_service(
                 app=app,
-                rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                dynamic_service_stop=DynamicServiceStop(
                     user_id=user_id,
                     project_id=service.project_id,
                     node_id=service.node_uuid,

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
@@ -3,6 +3,9 @@ from typing import Final
 
 from aiohttp import web
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
+from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    RPCDynamicServiceStop,
+)
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
@@ -51,9 +54,13 @@ async def _remove_service(
     ):
         await dynamic_scheduler_api.stop_dynamic_service(
             app,
-            node_id=node_id,
-            simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-            save_state=save_service_state,
+            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                user_id=service.user_id,
+                project_id=service.project_id,
+                node_id=service.node_uuid,
+                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                save_state=save_service_state,
+            ),
         )
 
 

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
@@ -4,7 +4,7 @@ from typing import Final
 from aiohttp import web
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
-    RPCDynamicServiceStop,
+    DynamicServiceStop,
 )
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
@@ -54,7 +54,7 @@ async def _remove_service(
     ):
         await dynamic_scheduler_api.stop_dynamic_service(
             app,
-            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+            dynamic_service_stop=DynamicServiceStop(
                 user_id=service.user_id,
                 project_id=service.project_id,
                 node_id=service.node_uuid,

--- a/services/web/server/src/simcore_service_webserver/projects/_nodes_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_nodes_handlers.py
@@ -12,7 +12,7 @@ from models_library.api_schemas_catalog.service_access_rights import (
 )
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
-    RPCDynamicServiceStop,
+    DynamicServiceStop,
 )
 from models_library.api_schemas_webserver.projects_nodes import (
     NodeCreate,
@@ -329,12 +329,12 @@ async def _stop_dynamic_service_task(
     _task_progress: TaskProgress,
     *,
     app: web.Application,
-    rpc_dynamic_service_stop: RPCDynamicServiceStop,
+    dynamic_service_stop: DynamicServiceStop,
 ):
     # NOTE: _handle_project_nodes_exceptions only decorate handlers
     try:
         await dynamic_scheduler_api.stop_dynamic_service(
-            app, rpc_dynamic_service_stop=rpc_dynamic_service_stop
+            app, dynamic_service_stop=dynamic_service_stop
         )
         raise web.HTTPNoContent(content_type=MIMETYPE_APPLICATION_JSON)
 
@@ -374,7 +374,7 @@ async def stop_node(request: web.Request) -> web.Response:
         task_context=jsonable_encoder(req_ctx),
         # task arguments from here on ---
         app=request.app,
-        rpc_dynamic_service_stop=RPCDynamicServiceStop(
+        dynamic_service_stop=DynamicServiceStop(
             user_id=req_ctx.user_id,
             project_id=path_params.project_id,
             node_id=path_params.node_id,

--- a/services/web/server/src/simcore_service_webserver/projects/_nodes_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_nodes_handlers.py
@@ -11,6 +11,9 @@ from models_library.api_schemas_catalog.service_access_rights import (
     ServiceAccessRightsGet,
 )
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
+from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    RPCDynamicServiceStop,
+)
 from models_library.api_schemas_webserver.projects_nodes import (
     NodeCreate,
     NodeCreated,
@@ -326,17 +329,12 @@ async def _stop_dynamic_service_task(
     _task_progress: TaskProgress,
     *,
     app: web.Application,
-    node_id: NodeID,
-    simcore_user_agent: str,
-    save_state: bool,
+    rpc_dynamic_service_stop: RPCDynamicServiceStop,
 ):
     # NOTE: _handle_project_nodes_exceptions only decorate handlers
     try:
         await dynamic_scheduler_api.stop_dynamic_service(
-            app,
-            node_id=node_id,
-            simcore_user_agent=simcore_user_agent,
-            save_state=save_state,
+            app, rpc_dynamic_service_stop=rpc_dynamic_service_stop
         )
         raise web.HTTPNoContent(content_type=MIMETYPE_APPLICATION_JSON)
 
@@ -376,11 +374,15 @@ async def stop_node(request: web.Request) -> web.Response:
         task_context=jsonable_encoder(req_ctx),
         # task arguments from here on ---
         app=request.app,
-        node_id=path_params.node_id,
-        simcore_user_agent=request.headers.get(
-            X_SIMCORE_USER_AGENT, UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
+        rpc_dynamic_service_stop=RPCDynamicServiceStop(
+            user_id=req_ctx.user_id,
+            project_id=path_params.project_id,
+            node_id=path_params.node_id,
+            simcore_user_agent=request.headers.get(
+                X_SIMCORE_USER_AGENT, UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
+            ),
+            save_state=save_state,
         ),
-        save_state=save_state,
         fire_and_forget=True,
     )
 

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -27,8 +27,8 @@ from models_library.api_schemas_directorv2.dynamic_services import (
     GetProjectInactivityResponse,
 )
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    DynamicServiceStop,
     RPCDynamicServiceCreate,
-    RPCDynamicServiceStop,
 )
 from models_library.api_schemas_webserver.projects import ProjectPatch
 from models_library.api_schemas_webserver.projects_nodes import NodePatch
@@ -801,7 +801,7 @@ async def _remove_service_and_its_data_folders(
         # no need to save the state of the node when deleting it
         await dynamic_scheduler_api.stop_dynamic_service(
             app,
-            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+            dynamic_service_stop=DynamicServiceStop(
                 user_id=user_id,
                 project_id=project_uuid,
                 node_id=NodeID(node_uuid),

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -27,8 +27,8 @@ from models_library.api_schemas_directorv2.dynamic_services import (
     GetProjectInactivityResponse,
 )
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    DynamicServiceStart,
     DynamicServiceStop,
-    RPCDynamicServiceCreate,
 )
 from models_library.api_schemas_webserver.projects import ProjectPatch
 from models_library.api_schemas_webserver.projects_nodes import NodePatch
@@ -680,7 +680,7 @@ async def _start_dynamic_service(
         )
         await dynamic_scheduler_api.run_dynamic_service(
             app=request.app,
-            rpc_dynamic_service_create=RPCDynamicServiceCreate(
+            dynamic_service_start=DynamicServiceStart(
                 product_name=product_name,
                 can_save=save_state,
                 project_id=project_uuid,

--- a/services/web/server/src/simcore_service_webserver/projects/projects_api.py
+++ b/services/web/server/src/simcore_service_webserver/projects/projects_api.py
@@ -28,6 +28,7 @@ from models_library.api_schemas_directorv2.dynamic_services import (
 )
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
     RPCDynamicServiceCreate,
+    RPCDynamicServiceStop,
 )
 from models_library.api_schemas_webserver.projects import ProjectPatch
 from models_library.api_schemas_webserver.projects_nodes import NodePatch
@@ -800,9 +801,13 @@ async def _remove_service_and_its_data_folders(
         # no need to save the state of the node when deleting it
         await dynamic_scheduler_api.stop_dynamic_service(
             app,
-            node_id=NodeID(node_uuid),
-            simcore_user_agent=user_agent,
-            save_state=False,
+            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                user_id=user_id,
+                project_id=project_uuid,
+                node_id=NodeID(node_uuid),
+                simcore_user_agent=user_agent,
+                save_state=False,
+            ),
         )
 
     # remove the node's data if any

--- a/services/web/server/tests/unit/isolated/test_dynamic_scheduler.py
+++ b/services/web/server/tests/unit/isolated/test_dynamic_scheduler.py
@@ -7,7 +7,7 @@ import pytest
 from faker import Faker
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
-    RPCDynamicServiceCreate,
+    DynamicServiceStart,
 )
 from models_library.api_schemas_webserver.projects_nodes import (
     NodeGet,
@@ -46,9 +46,9 @@ def mock_rpc_client(
 
 
 @pytest.fixture
-def rpc_dynamic_service_create() -> RPCDynamicServiceCreate:
-    return RPCDynamicServiceCreate.parse_obj(
-        RPCDynamicServiceCreate.Config.schema_extra["example"]
+def dynamic_service_start() -> DynamicServiceStart:
+    return DynamicServiceStart.parse_obj(
+        DynamicServiceStart.Config.schema_extra["example"]
     )
 
 
@@ -108,11 +108,11 @@ async def test_run_dynamic_service(
     mock_rpc_client: None,
     mocked_app: AsyncMock,
     expected_response: NodeGet | NodeGetIdle | DynamicServiceGet,
-    rpc_dynamic_service_create: RPCDynamicServiceCreate,
+    dynamic_service_start: DynamicServiceStart,
 ):
     assert (
         await run_dynamic_service(
-            mocked_app, rpc_dynamic_service_create=rpc_dynamic_service_create
+            mocked_app, dynamic_service_start=dynamic_service_start
         )
         == expected_response
     )

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -10,7 +10,7 @@ import pytest
 from faker import Faker
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
-    RPCDynamicServiceStop,
+    DynamicServiceStop,
 )
 from models_library.projects import ProjectID
 from models_library.users import UserID
@@ -207,7 +207,7 @@ async def test_remove_orphaned_services(
 
     mock_stop_dynamic_service.assert_called_once_with(
         mock_app,
-        rpc_dynamic_service_stop=RPCDynamicServiceStop(
+        dynamic_service_stop=DynamicServiceStop(
             user_id=fake_running_service.user_id,
             project_id=fake_running_service.project_id,
             node_id=fake_running_service.node_uuid,
@@ -247,7 +247,7 @@ async def test_remove_orphaned_services_inexisting_user_does_not_save_state(
     mock_has_write_permission.assert_not_called()
     mock_stop_dynamic_service.assert_called_once_with(
         mock_app,
-        rpc_dynamic_service_stop=RPCDynamicServiceStop(
+        dynamic_service_stop=DynamicServiceStop(
             user_id=fake_running_service.user_id,
             project_id=fake_running_service.project_id,
             node_id=fake_running_service.node_uuid,

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -9,9 +9,13 @@ from unittest import mock
 import pytest
 from faker import Faker
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
+from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    RPCDynamicServiceStop,
+)
 from models_library.projects import ProjectID
 from models_library.users import UserID
 from pytest_mock import MockerFixture
+from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
 from simcore_postgres_database.models.users import UserRole
 from simcore_service_webserver.garbage_collector._core_orphans import (
     remove_orphaned_services,
@@ -200,11 +204,16 @@ async def test_remove_orphaned_services(
     else:
         mock_get_user_role.assert_not_called()
         mock_has_write_permission.assert_not_called()
+
     mock_stop_dynamic_service.assert_called_once_with(
         mock_app,
-        node_id=fake_running_service.node_uuid,
-        simcore_user_agent=mock.ANY,
-        save_state=expected_save_state,
+        rpc_dynamic_service_stop=RPCDynamicServiceStop(
+            user_id=fake_running_service.user_id,
+            project_id=fake_running_service.project_id,
+            node_id=fake_running_service.node_uuid,
+            simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+            save_state=expected_save_state,
+        ),
     )
 
 
@@ -238,9 +247,13 @@ async def test_remove_orphaned_services_inexisting_user_does_not_save_state(
     mock_has_write_permission.assert_not_called()
     mock_stop_dynamic_service.assert_called_once_with(
         mock_app,
-        node_id=fake_running_service.node_uuid,
-        simcore_user_agent=mock.ANY,
-        save_state=False,
+        rpc_dynamic_service_stop=RPCDynamicServiceStop(
+            user_id=fake_running_service.user_id,
+            project_id=fake_running_service.project_id,
+            node_id=fake_running_service.node_uuid,
+            simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+            save_state=False,
+        ),
     )
 
 

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
@@ -17,7 +17,7 @@ from aiohttp.test_utils import TestClient
 from faker import Faker
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
-    RPCDynamicServiceStop,
+    DynamicServiceStop,
 )
 from models_library.projects import ProjectID
 from models_library.projects_state import ProjectStatus
@@ -96,7 +96,7 @@ async def test_delete_project(
         expected_calls = [
             call(
                 app=client.app,
-                rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                dynamic_service_stop=DynamicServiceStop(
                     user_id=user_id,
                     project_id=service.project_id,
                     node_id=service.node_uuid,

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
@@ -16,6 +16,9 @@ import sqlalchemy as sa
 from aiohttp.test_utils import TestClient
 from faker import Faker
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
+from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    RPCDynamicServiceStop,
+)
 from models_library.projects import ProjectID
 from models_library.projects_state import ProjectStatus
 from pytest_simcore.helpers.utils_assert import assert_status
@@ -72,8 +75,10 @@ async def test_delete_project(
 
     await _request_delete_project(client, user_project, expected.no_content)
 
+    user_id: int = logged_user["id"]
+
     tasks = _crud_api_delete.get_scheduled_tasks(
-        project_uuid=user_project["uuid"], user_id=logged_user["id"]
+        project_uuid=user_project["uuid"], user_id=user_id
     )
 
     if expected.no_content == status.HTTP_204_NO_CONTENT:
@@ -91,9 +96,13 @@ async def test_delete_project(
         expected_calls = [
             call(
                 app=client.app,
-                node_id=service.node_uuid,
-                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-                save_state=True,
+                rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                    user_id=user_id,
+                    project_id=service.project_id,
+                    node_id=service.node_uuid,
+                    simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                    save_state=True,
+                ),
                 progress=mock.ANY,
             )
             for service in fakes

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
@@ -22,7 +22,7 @@ from aioresponses import aioresponses
 from faker import Faker
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
-    RPCDynamicServiceStop,
+    DynamicServiceStop,
 )
 from models_library.api_schemas_storage import FileMetaDataGet, PresignedLink
 from models_library.generics import Envelope
@@ -685,7 +685,7 @@ async def test_delete_node(
                 "dynamic_scheduler.api.stop_dynamic_service"
             ].assert_called_once_with(
                 mock.ANY,
-                rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                dynamic_service_stop=DynamicServiceStop(
                     user_id=logged_user["id"],
                     project_id=user_project["uuid"],
                     node_id=NodeID(node_id),

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
@@ -392,7 +392,7 @@ async def test_create_and_delete_many_nodes_in_parallel(
 
         def inc_running_services(self, *args, **kwargs):  # noqa: ARG002
             self.running_services_uuids.append(
-                kwargs["rpc_dynamic_service_create"].node_uuid
+                kwargs["dynamic_service_start"].node_uuid
             )
 
     # let's count the started services
@@ -515,7 +515,7 @@ async def test_create_many_nodes_in_parallel_still_is_limited_to_the_defined_max
             # reproduces real world conditions and makes test to fail
             await asyncio.sleep(SERVICE_IS_RUNNING_AFTER_S)
             self.running_services_uuids.append(
-                kwargs["rpc_dynamic_service_create"].node_uuid
+                kwargs["dynamic_service_start"].node_uuid
             )
 
     # let's count the started services

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
@@ -21,6 +21,9 @@ from aiohttp.test_utils import TestClient
 from aioresponses import aioresponses
 from faker import Faker
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
+from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    RPCDynamicServiceStop,
+)
 from models_library.api_schemas_storage import FileMetaDataGet, PresignedLink
 from models_library.generics import Envelope
 from models_library.projects_nodes_io import NodeID
@@ -634,6 +637,7 @@ async def test_creating_deprecated_node_returns_406_not_acceptable(
 @pytest.mark.parametrize(*standard_role_response(), ids=str)
 async def test_delete_node(
     client: TestClient,
+    logged_user: dict,
     user_project: ProjectDict,
     expected: ExpectedResponse,
     mocked_director_v2_api: dict[str, mock.MagicMock],
@@ -681,9 +685,13 @@ async def test_delete_node(
                 "dynamic_scheduler.api.stop_dynamic_service"
             ].assert_called_once_with(
                 mock.ANY,
-                node_id=NodeID(node_id),
-                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-                save_state=False,
+                rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                    user_id=logged_user["id"],
+                    project_id=user_project["uuid"],
+                    node_id=NodeID(node_id),
+                    simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                    save_state=False,
+                ),
             )
             mocked_director_v2_api[
                 "dynamic_scheduler.api.stop_dynamic_service"

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
@@ -22,7 +22,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from faker import Faker
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
-    RPCDynamicServiceCreate,
+    DynamicServiceStart,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects import ProjectID
@@ -370,7 +370,7 @@ async def test_open_project(
             calls.append(
                 call(
                     app=client.app,
-                    rpc_dynamic_service_create=RPCDynamicServiceCreate(
+                    dynamic_service_start=DynamicServiceStart(
                         project_id=user_project["uuid"],
                         service_key=service["key"],
                         service_uuid=service_uuid,
@@ -449,7 +449,7 @@ async def test_open_template_project_for_edition(
             calls.append(
                 call(
                     app=client.app,
-                    rpc_dynamic_service_create=RPCDynamicServiceCreate(
+                    dynamic_service_start=DynamicServiceStart(
                         project_id=template_project["uuid"],
                         service_key=service["key"],
                         service_uuid=service_uuid,

--- a/services/web/server/tests/unit/with_dbs/03/garbage_collector/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/03/garbage_collector/test_resource_manager.py
@@ -21,7 +21,7 @@ from aiohttp.test_utils import TestClient
 from aioresponses import aioresponses
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
-    RPCDynamicServiceStop,
+    DynamicServiceStop,
 )
 from models_library.utils.fastapi_encoders import jsonable_encoder
 from pytest_mock import MockerFixture
@@ -521,7 +521,7 @@ async def test_interactive_services_removed_after_logout(
                 "dynamic_scheduler.api.stop_dynamic_service"
             ].assert_awaited_with(
                 app=client.app,
-                rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                dynamic_service_stop=DynamicServiceStop(
                     user_id=user_id,
                     project_id=service.project_id,
                     node_id=service.node_uuid,
@@ -642,7 +642,7 @@ async def test_interactive_services_remain_after_websocket_reconnection_from_2_t
     calls = [
         call(
             app=client.app,
-            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+            dynamic_service_stop=DynamicServiceStop(
                 user_id=user_id,
                 project_id=service.project_id,
                 simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
@@ -726,7 +726,7 @@ async def test_interactive_services_removed_per_project(
     calls = [
         call(
             app=client.app,
-            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+            dynamic_service_stop=DynamicServiceStop(
                 user_id=user_id,
                 project_id=service1.project_id,
                 node_id=service1.node_uuid,
@@ -755,7 +755,7 @@ async def test_interactive_services_removed_per_project(
     calls = [
         call(
             app=client.server.app,
-            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+            dynamic_service_stop=DynamicServiceStop(
                 user_id=user_id,
                 project_id=service2.project_id,
                 node_id=service2.node_uuid,
@@ -766,7 +766,7 @@ async def test_interactive_services_removed_per_project(
         ),
         call(
             app=client.server.app,
-            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+            dynamic_service_stop=DynamicServiceStop(
                 user_id=user_id,
                 project_id=service3.project_id,
                 node_id=service3.node_uuid,
@@ -888,7 +888,7 @@ async def test_websocket_disconnected_remove_or_maintain_files_based_on_role(
     calls = [
         call(
             app=client.server.app,
-            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+            dynamic_service_stop=DynamicServiceStop(
                 user_id=user_id,
                 project_id=service.project_id,
                 simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,

--- a/services/web/server/tests/unit/with_dbs/03/garbage_collector/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/03/garbage_collector/test_resource_manager.py
@@ -20,6 +20,9 @@ import sqlalchemy as sa
 from aiohttp.test_utils import TestClient
 from aioresponses import aioresponses
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
+from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    RPCDynamicServiceStop,
+)
 from models_library.utils.fastapi_encoders import jsonable_encoder
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.utils_assert import assert_status
@@ -486,9 +489,9 @@ async def test_interactive_services_removed_after_logout(
     mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     assert client.app
-
+    user_id = logged_user["id"]
     service = await create_dynamic_service_mock(
-        user_id=logged_user["id"], project_id=empty_user_project["uuid"]
+        user_id=user_id, project_id=empty_user_project["uuid"]
     )
     # create websocket
     client_session_id1 = client_session_id_factory()
@@ -518,9 +521,13 @@ async def test_interactive_services_removed_after_logout(
                 "dynamic_scheduler.api.stop_dynamic_service"
             ].assert_awaited_with(
                 app=client.app,
-                node_id=service.node_uuid,
-                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-                save_state=expected_save_state,
+                rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                    user_id=user_id,
+                    project_id=service.project_id,
+                    node_id=service.node_uuid,
+                    simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                    save_state=expected_save_state,
+                ),
                 progress=mock.ANY,
             )
 
@@ -548,9 +555,9 @@ async def test_interactive_services_remain_after_websocket_reconnection_from_2_t
     mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     assert client.app
-
+    user_id = logged_user["id"]
     service = await create_dynamic_service_mock(
-        user_id=logged_user["id"], project_id=empty_user_project["uuid"]
+        user_id=user_id, project_id=empty_user_project["uuid"]
     )
     # create first websocket
     client_session_id1 = client_session_id_factory()
@@ -584,7 +591,7 @@ async def test_interactive_services_remain_after_websocket_reconnection_from_2_t
                             "locked": {
                                 "value": False,
                                 "owner": {
-                                    "user_id": logged_user["id"],
+                                    "user_id": user_id,
                                     "first_name": logged_user.get("first_name", None),
                                     "last_name": logged_user.get("last_name", None),
                                 },
@@ -635,9 +642,13 @@ async def test_interactive_services_remain_after_websocket_reconnection_from_2_t
     calls = [
         call(
             app=client.app,
-            simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-            save_state=expected_save_state,
-            node_id=service.node_uuid,
+            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                user_id=user_id,
+                project_id=service.project_id,
+                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                save_state=expected_save_state,
+                node_id=service.node_uuid,
+            ),
             progress=mock.ANY,
         )
     ]
@@ -682,15 +693,16 @@ async def test_interactive_services_removed_per_project(
     open_project: Callable,
     mocked_notifications_plugin: dict[str, mock.Mock],
 ):
+    user_id = logged_user["id"]
     # create server with delay set to DELAY
     service1 = await create_dynamic_service_mock(
-        user_id=logged_user["id"], project_id=empty_user_project["uuid"]
+        user_id=user_id, project_id=empty_user_project["uuid"]
     )
     service2 = await create_dynamic_service_mock(
-        user_id=logged_user["id"], project_id=empty_user_project2["uuid"]
+        user_id=user_id, project_id=empty_user_project2["uuid"]
     )
     service3 = await create_dynamic_service_mock(
-        user_id=logged_user["id"], project_id=empty_user_project2["uuid"]
+        user_id=user_id, project_id=empty_user_project2["uuid"]
     )
     # create websocket1 from tab1
     client_session_id1 = client_session_id_factory()
@@ -714,9 +726,13 @@ async def test_interactive_services_removed_per_project(
     calls = [
         call(
             app=client.app,
-            node_id=service1.node_uuid,
-            simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-            save_state=expected_save_state,
+            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                user_id=user_id,
+                project_id=service1.project_id,
+                node_id=service1.node_uuid,
+                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                save_state=expected_save_state,
+            ),
             progress=mock.ANY,
         )
     ]
@@ -739,16 +755,24 @@ async def test_interactive_services_removed_per_project(
     calls = [
         call(
             app=client.server.app,
-            node_id=service2.node_uuid,
-            simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-            save_state=expected_save_state,
+            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                user_id=user_id,
+                project_id=service2.project_id,
+                node_id=service2.node_uuid,
+                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                save_state=expected_save_state,
+            ),
             progress=mock.ANY,
         ),
         call(
             app=client.server.app,
-            node_id=service3.node_uuid,
-            simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-            save_state=expected_save_state,
+            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                user_id=user_id,
+                project_id=service3.project_id,
+                node_id=service3.node_uuid,
+                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                save_state=expected_save_state,
+            ),
             progress=mock.ANY,
         ),
     ]
@@ -840,8 +864,9 @@ async def test_websocket_disconnected_remove_or_maintain_files_based_on_role(
     open_project: Callable,
     mocked_notifications_plugin: dict[str, mock.Mock],
 ):
+    user_id = logged_user["id"]
     service = await create_dynamic_service_mock(
-        user_id=logged_user["id"], project_id=empty_user_project["uuid"]
+        user_id=user_id, project_id=empty_user_project["uuid"]
     )
     # create websocket
     client_session_id1 = client_session_id_factory()
@@ -863,9 +888,13 @@ async def test_websocket_disconnected_remove_or_maintain_files_based_on_role(
     calls = [
         call(
             app=client.server.app,
-            simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-            save_state=expected_save_state,
-            node_id=service.node_uuid,
+            rpc_dynamic_service_stop=RPCDynamicServiceStop(
+                user_id=user_id,
+                project_id=service.project_id,
+                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                save_state=expected_save_state,
+                node_id=service.node_uuid,
+            ),
             progress=mock.ANY,
         )
     ]
@@ -899,26 +928,27 @@ async def test_regression_removing_unexisting_user(
     # regression test for https://github.com/ITISFoundation/osparc-simcore/issues/2504
     assert client.app
     # remove project
+    user_id = logged_user["id"]
     delete_task = await submit_delete_project_task(
         app=client.app,
         project_uuid=empty_user_project["uuid"],
-        user_id=logged_user["id"],
+        user_id=user_id,
         simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
     )
     await delete_task
     # remove user
-    await delete_user_without_projects(app=client.app, user_id=logged_user["id"])
+    await delete_user_without_projects(app=client.app, user_id=user_id)
 
     with pytest.raises(UserNotFoundError):
         await remove_project_dynamic_services(
-            user_id=logged_user["id"],
+            user_id=user_id,
             project_uuid=empty_user_project["uuid"],
             app=client.app,
             simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
         )
     with pytest.raises(ProjectNotFoundError):
         await remove_project_dynamic_services(
-            user_id=logged_user["id"],
+            user_id=user_id,
             project_uuid=empty_user_project["uuid"],
             app=client.app,
             user_name={"first_name": "my name is", "last_name": "pytest"},


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## ⚠️ Dev-ops
This code has to be deployed with all dynamic-services stopped. The service stop API from `webserver`-> `dynamic-scheduler` changed in a backwards incompatible way.

## What do these changes do?

Adds `project_id` and `user_id` to the stop command sent to the `dynamic-scheduler`. These changes are required to cover an edge case: enables stopping a service that is not tracked by the scheduler.

These changes are part of https://github.com/ITISFoundation/osparc-simcore/pull/5892


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->

- required by https://github.com/ITISFoundation/osparc-simcore/pull/5892

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
