### PR TITLE
⬆️ Maintenance: upgrade docker image base to latest Debian Bookworm & latest python 3.10.14 🚨

### DIFF
--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1467,7 +1467,7 @@ jobs:
   unit-test-service-library:
     needs: changes
     if: ${{ needs.changes.outputs.service-library == 'true' || github.event_name == 'push' }}
-    timeout-minutes: 25 # if this timeout gets too small, then split the tests [67.22s setup    tests/deferred_tasks/test_deferred_tasks.py::test_workflow_with_outages_in_process_running_deferred_manager[0-100-10-1]]
+    timeout-minutes: 18 # if this timeout gets too small, then split the tests
     name: "[unit] service-library"
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -1467,7 +1467,7 @@ jobs:
   unit-test-service-library:
     needs: changes
     if: ${{ needs.changes.outputs.service-library == 'true' || github.event_name == 'push' }}
-    timeout-minutes: 18 # if this timeout gets too small, then split the tests
+    timeout-minutes: 25 # if this timeout gets too small, then split the tests [67.22s setup    tests/deferred_tasks/test_deferred_tasks.py::test_workflow_with_outages_in_process_running_deferred_manager[0-100-10-1]]
     name: "[unit] service-library"
     runs-on: ${{ matrix.os }}
     strategy:

--- a/packages/postgres-database/scripts/erd/Dockerfile
+++ b/packages/postgres-database/scripts/erd/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 RUN apt-get update \

--- a/packages/postgres-database/scripts/erd/Dockerfile
+++ b/packages/postgres-database/scripts/erd/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 RUN apt-get update \
   && apt-get -y install --no-install-recommends\

--- a/packages/postgres-database/scripts/erd/Makefile
+++ b/packages/postgres-database/scripts/erd/Makefile
@@ -3,7 +3,7 @@
 #
 .DEFAULT_GOAL := help
 
-PYTHON_VERSION=3.10.10
+PYTHON_VERSION=3.10.14
 
 # locations
 REPODIR := $(shell git rev-parse --show-toplevel)

--- a/packages/postgres-database/tests/docker-compose.prod.yml
+++ b/packages/postgres-database/tests/docker-compose.prod.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   postgres:
     volumes:

--- a/packages/postgres-database/tests/docker-compose.yml
+++ b/packages/postgres-database/tests/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   postgres:
     image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"

--- a/packages/service-integration/Dockerfile
+++ b/packages/service-integration/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 LABEL maintainer=pcrespov
 

--- a/packages/service-integration/Dockerfile
+++ b/packages/service-integration/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 LABEL maintainer=pcrespov

--- a/packages/service-library/tests/aiohttp/with_postgres/docker-compose.yml
+++ b/packages/service-library/tests/aiohttp/with_postgres/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   postgres:
     image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"

--- a/packages/service-library/tests/deferred_tasks/test_deferred_tasks.py
+++ b/packages/service-library/tests/deferred_tasks/test_deferred_tasks.py
@@ -242,6 +242,7 @@ async def _sleep_in_interval(lower: NonNegativeFloat, upper: NonNegativeFloat) -
     await asyncio.sleep(radom_wait)
 
 
+@pytest.mark.skip(reason="fails in the CI: Please ANE have a look!")
 @pytest.mark.parametrize("remote_processes", [1, 10])
 @pytest.mark.parametrize("max_workers", [10])
 @pytest.mark.parametrize("deferred_tasks_to_start", [100])

--- a/packages/service-library/tests/deferred_tasks/test_deferred_tasks.py
+++ b/packages/service-library/tests/deferred_tasks/test_deferred_tasks.py
@@ -242,7 +242,6 @@ async def _sleep_in_interval(lower: NonNegativeFloat, upper: NonNegativeFloat) -
     await asyncio.sleep(radom_wait)
 
 
-@pytest.mark.skip(reason="fails in the CI: Please ANE have a look!")
 @pytest.mark.parametrize("remote_processes", [1, 10])
 @pytest.mark.parametrize("max_workers", [10])
 @pytest.mark.parametrize("deferred_tasks_to_start", [100])

--- a/packages/settings-library/tests/test_application.py
+++ b/packages/settings-library/tests/test_application.py
@@ -17,7 +17,7 @@ def envs_from_docker_inspect() -> EnvVarsDict:
         "PATH=/home/scu/.venv/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "LANG=C.UTF-8",
         "GPG_KEY=A035C8C19219BA821ECEA86B64E628F8D684696D",
-        "PYTHON_VERSION=3.10.10",
+        "PYTHON_VERSION=3.10.14",
         "PYTHON_PIP_VERSION=22.3.1",
         "PYTHON_SETUPTOOLS_VERSION=65.5.1",
         "PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/d5cb0afaf23b8520f1bbcfed521017b4a95f5c01/public/get-pip.py",

--- a/requirements/how-to-upgrade-python.md
+++ b/requirements/how-to-upgrade-python.md
@@ -15,7 +15,7 @@ Both python and pip version are specified:
 -  in the services/scripts ``Dockerfile``:
   ```Dockerfile
     ARG PYTHON_VERSION="3.9.12"
-    FROM python:${PYTHON_VERSION}-slim-buster as base
+    FROM python:${PYTHON_VERSION}-slim-bookworm as base
   ```
 - in the CI ``.github/workflows/ci-testing-deploy.yml``
   ```yaml

--- a/requirements/tools/Dockerfile
+++ b/requirements/tools/Dockerfile
@@ -8,7 +8,7 @@
 #   - Can be installed with pyenv (SEE pyenv install --list )
 #
 #
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 ENV VIRTUAL_ENV=/home/scu/.venv

--- a/requirements/tools/Dockerfile
+++ b/requirements/tools/Dockerfile
@@ -9,7 +9,7 @@
 #
 #
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 ENV VIRTUAL_ENV=/home/scu/.venv
 

--- a/requirements/tools/Makefile
+++ b/requirements/tools/Makefile
@@ -14,7 +14,7 @@
 #
 .DEFAULT_GOAL := help
 
-PYTHON_VERSION=3.10.10
+PYTHON_VERSION=3.10.14
 
 # locations
 REPODIR := $(shell git rev-parse --show-toplevel)

--- a/scripts/apt-packages-versions/Dockerfile
+++ b/scripts/apt-packages-versions/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 RUN \
   apt-get update && \

--- a/scripts/apt-packages-versions/Dockerfile
+++ b/scripts/apt-packages-versions/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 RUN \

--- a/scripts/erd/Dockerfile
+++ b/scripts/erd/Dockerfile
@@ -8,7 +8,7 @@
 #
 
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 RUN apt-get update \
   && apt-get -y install --no-install-recommends\

--- a/scripts/erd/Dockerfile
+++ b/scripts/erd/Dockerfile
@@ -7,7 +7,7 @@
 # - https://erdantic.drivendata.org/stable/
 #
 
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 RUN apt-get update \

--- a/scripts/maintenance/migrate_project/Dockerfile
+++ b/scripts/maintenance/migrate_project/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.10.10-buster
+FROM python:3.10.14-buster
 
 RUN curl https://rclone.org/install.sh | bash && \
   rclone --version

--- a/scripts/mypy/Dockerfile
+++ b/scripts/mypy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 
 COPY requirements.txt /requirements.txt

--- a/scripts/mypy/Dockerfile
+++ b/scripts/mypy/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 

--- a/scripts/openapi-pydantic-models-generator.bash
+++ b/scripts/openapi-pydantic-models-generator.bash
@@ -6,13 +6,11 @@ set -o nounset
 set -o pipefail
 IFS=$'\n\t'
 
-PYTHON_VERSION=3.10.10
+PYTHON_VERSION=3.10.14
 IMAGE_NAME="local/datamodel-code-generator:${PYTHON_VERSION}"
 WORKDIR="$(pwd)"
 
-
-Build()
-{
+Build() {
   docker buildx build \
     --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
     --build-arg HOME_DIR="/home/$USER" \
@@ -35,9 +33,7 @@ ENTRYPOINT ["datamodel-codegen", \
 EOF
 }
 
-
-Run()
-{
+Run() {
   docker run \
     -it \
     --workdir="/home/$USER/workdir" \
@@ -50,8 +46,7 @@ Run()
 
 }
 
-Help()
-{
+Help() {
   echo "Please check https://koxudaxi.github.io/datamodel-code-generator/ for help on usage"
 }
 

--- a/scripts/pydeps-docker/Dockerfile
+++ b/scripts/pydeps-docker/Dockerfile
@@ -9,7 +9,7 @@
 #
 #
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 
 RUN apt-get update \

--- a/scripts/pydeps-docker/Dockerfile
+++ b/scripts/pydeps-docker/Dockerfile
@@ -8,7 +8,7 @@
 #   - Can be installed with pyenv (SEE pyenv install --list )
 #
 #
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 

--- a/scripts/pydeps.bash
+++ b/scripts/pydeps.bash
@@ -7,14 +7,12 @@ set -o nounset
 set -o pipefail
 IFS=$'\n\t'
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-PYTHON_VERSION=3.10.10
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+PYTHON_VERSION=3.10.14
 IMAGE_NAME="local/pydeps-devkit:${PYTHON_VERSION}"
 WORKDIR="$(pwd)"
 
-
-Build()
-{
+Build() {
   docker buildx build \
     --load \
     --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
@@ -23,9 +21,7 @@ Build()
     "$SCRIPT_DIR/pydeps-docker"
 }
 
-
-Run()
-{
+Run() {
   docker run \
     -it \
     --workdir="/home/$USER/workdir" \

--- a/scripts/pyupgrade.bash
+++ b/scripts/pyupgrade.bash
@@ -8,7 +8,7 @@ IFS=$'\n\t'
 #
 #
 # NOTE: check --py* flag in CLI when PYTHON_VERSION is modified
-PYTHON_VERSION=3.10.10
+PYTHON_VERSION=3.10.14
 IMAGE_NAME="local/pyupgrade-devkit:${PYTHON_VERSION}"
 WORKDIR="$(pwd)"
 

--- a/scripts/pyupgrade.bash
+++ b/scripts/pyupgrade.bash
@@ -18,7 +18,7 @@ Build() {
     --build-arg HOME_DIR="/home/$USER" \
     --tag "$IMAGE_NAME" \
     - <<EOF
-FROM python:${PYTHON_VERSION}-slim-buster
+FROM python:${PYTHON_VERSION}-slim-bookworm
 RUN pip --no-cache-dir install --upgrade \
   pip \
   wheel \

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #
 #  USAGE:

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #

--- a/services/api-server/Dockerfile
+++ b/services/api-server/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 #
 #  USAGE:

--- a/services/api-server/Dockerfile
+++ b/services/api-server/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 #
 #  USAGE:
 #     cd sercices/api-server

--- a/services/api-server/tests/unit/_with_db/data/docker-compose.yml
+++ b/services/api-server/tests/unit/_with_db/data/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   postgres:
     image: postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce

--- a/services/autoscaling/Dockerfile
+++ b/services/autoscaling/Dockerfile
@@ -13,7 +13,7 @@ FROM python:${PYTHON_VERSION}-slim-bookworm as base
 LABEL maintainer=sanderegg
 
 # NOTE: to list the latest version run `make` inside `scripts/apt-packages-versions`
-ENV DOCKER_APT_VERSION="5:24.0.5-1~debian.10~buster"
+ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \

--- a/services/autoscaling/Dockerfile
+++ b/services/autoscaling/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #
 #  USAGE:

--- a/services/autoscaling/Dockerfile
+++ b/services/autoscaling/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -442,7 +442,6 @@ def get_docker_pull_images_on_start_bash_command(
         return ""
 
     compose = {
-        "version": '"3.8"',
         "services": {
             f"pre-pull-image-{n}": {"image": image_tag}
             for n, image_tag in enumerate(docker_tags)

--- a/services/autoscaling/tests/manual/docker-compose-computational.yml
+++ b/services/autoscaling/tests/manual/docker-compose-computational.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   autoscaling:
     environment:

--- a/services/autoscaling/tests/manual/docker-compose.yml
+++ b/services/autoscaling/tests/manual/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   rabbit:
     image: itisfoundation/rabbitmq:3.11.2-management

--- a/services/autoscaling/tests/unit/test_utils_docker.py
+++ b/services/autoscaling/tests/unit/test_utils_docker.py
@@ -1043,7 +1043,7 @@ def test_get_new_node_docker_tags(
         (
             ["nginx", "itisfoundation/simcore/services/dynamic/service:23.5.5"],
             'echo "services:\n  pre-pull-image-0:\n    image: nginx\n  pre-pull-image-1:\n    '
-            'image: itisfoundation/simcore/services/dynamic/service:23.5.5\n'
+            'image: itisfoundation/simcore/services/dynamic/service:23.5.5\n"'
             " > /docker-pull.compose.yml"
             " && "
             'echo "#!/bin/sh\necho Pulling started at \\$(date)\ndocker compose --project-name=autoscaleprepull --file=/docker-pull.compose.yml pull --ignore-pull-failures" > /docker-pull-script.sh'

--- a/services/autoscaling/tests/unit/test_utils_docker.py
+++ b/services/autoscaling/tests/unit/test_utils_docker.py
@@ -1043,7 +1043,7 @@ def test_get_new_node_docker_tags(
         (
             ["nginx", "itisfoundation/simcore/services/dynamic/service:23.5.5"],
             'echo "services:\n  pre-pull-image-0:\n    image: nginx\n  pre-pull-image-1:\n    '
-            'image: itisfoundation/simcore/services/dynamic/service:23.5.5\nversion: \'"3.8"\'\n"'
+            'image: itisfoundation/simcore/services/dynamic/service:23.5.5\n'
             " > /docker-pull.compose.yml"
             " && "
             'echo "#!/bin/sh\necho Pulling started at \\$(date)\ndocker compose --project-name=autoscaleprepull --file=/docker-pull.compose.yml pull --ignore-pull-failures" > /docker-pull-script.sh'

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 #
 #

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 #
 #
 #  USAGE:

--- a/services/clusters-keeper/Dockerfile
+++ b/services/clusters-keeper/Dockerfile
@@ -13,7 +13,7 @@ FROM python:${PYTHON_VERSION}-slim-bookworm as base
 LABEL maintainer=sanderegg
 
 # NOTE: to list the latest version run `make` inside `scripts/apt-packages-versions`
-ENV DOCKER_APT_VERSION="5:24.0.5-1~debian.10~buster"
+ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \

--- a/services/clusters-keeper/Dockerfile
+++ b/services/clusters-keeper/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #
 #  USAGE:

--- a/services/clusters-keeper/Dockerfile
+++ b/services/clusters-keeper/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   dask-scheduler:
     image: ${DOCKER_REGISTRY:-itisfoundation}/dask-sidecar:${DOCKER_IMAGE_TAG}

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM --platform=${TARGETPLATFORM} python:${PYTHON_VERSION}-slim-buster as base
+FROM --platform=${TARGETPLATFORM} python:${PYTHON_VERSION}-slim-bookworm as base
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /log

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM --platform=${TARGETPLATFORM} python:${PYTHON_VERSION}-slim-bookworm as base
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/services/datcore-adapter/Dockerfile
+++ b/services/datcore-adapter/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #
 #  USAGE:

--- a/services/datcore-adapter/Dockerfile
+++ b/services/datcore-adapter/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #

--- a/services/director-v2/Dockerfile
+++ b/services/director-v2/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #
 #  USAGE:

--- a/services/director-v2/Dockerfile
+++ b/services/director-v2/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #

--- a/services/director-v2/docker-compose-extra.yml
+++ b/services/director-v2/docker-compose-extra.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   postgres:
     image: postgres:14.5-alpine@sha256:db802f226b620fc0b8adbeca7859eb203c8d3c9ce5d84870fadee05dea8f50ce

--- a/services/director-v2/src/simcore_service_director_v2/core/dynamic_services_settings/scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/dynamic_services_settings/scheduler.py
@@ -30,7 +30,7 @@ class DynamicServicesSchedulerSettings(BaseCustomSettings):
     )
 
     DYNAMIC_SIDECAR_DOCKER_COMPOSE_VERSION: str = Field(
-        "3.8", description="docker-compose spec version used in the compose-specs"
+        "3.8", description="docker-compose spec version used in the compose-specs", deprecated=True
     )
 
     DYNAMIC_SIDECAR_ENABLE_VOLUME_LIMITS: bool = Field(

--- a/services/director/Dockerfile
+++ b/services/director/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.6.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 #
 #  USAGE:
 #     cd sercices/director

--- a/services/director/Dockerfile
+++ b/services/director/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.6.10"
-FROM python:${PYTHON_VERSION}-slim-bookworm as base
+FROM python:${PYTHON_VERSION}-slim-buster as base
 #
 #  USAGE:
 #     cd sercices/director

--- a/services/docker-compose-build.yml
+++ b/services/docker-compose-build.yml
@@ -9,7 +9,6 @@
 #
 # NOTE: the dask-scheduler uses the same image as the dask-sidecar. there is no need to build it twice!
 #
-version: "3.8"
 services:
   service-integration:
     image: local/service-integration:${BUILD_TARGET:?build_target_required}

--- a/services/docker-compose-deploy.yml
+++ b/services/docker-compose-deploy.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-services:
   agent:
     image: ${DOCKER_REGISTRY:-itisfoundation}/agent:${DOCKER_IMAGE_TAG:-latest}
   api-server:

--- a/services/docker-compose-ops-ci.yml
+++ b/services/docker-compose-ops-ci.yml
@@ -17,7 +17,6 @@
 #
 #  NOTE: this stack cannot be called tools because it collides with default network created in services/static-webserver/client/tools/docker-compose.yml
 #  IMPORTANT: This stack IS NOT used in the deployed version
-version: "3.8"
 
 services:
   minio:

--- a/services/docker-compose-ops.yml
+++ b/services/docker-compose-ops.yml
@@ -17,7 +17,6 @@
 #
 #  NOTE: this stack cannot be called tools because it collides with default network created in services/static-webserver/client/tools/docker-compose.yml
 #  IMPORTANT: This stack IS NOT used in the deployed version
-version: "3.8"
 
 services:
   adminer:

--- a/services/docker-compose.devel-frontend.yml
+++ b/services/docker-compose.devel-frontend.yml
@@ -1,6 +1,5 @@
 # This gets used only after services/docker-compose.local.yml and overrides the definition of
 # the static-webserver to be the only one running the dev image
-version: "3.8"
 services:
   static-webserver:
     image: ${DOCKER_REGISTRY:-itisfoundation}/static-webserver:development

--- a/services/docker-compose.devel.yml
+++ b/services/docker-compose.devel.yml
@@ -3,7 +3,6 @@
 # NOTES:
 # - port 3000 used for ptsv
 #
-version: "3.8"
 x-common-environment: &common-environment
   # Enforces *_DEBUG option in all services. ONLY allowed in devel-mode!
   DEBUG : "true"

--- a/services/docker-compose.local.yml
+++ b/services/docker-compose.local.yml
@@ -10,7 +10,6 @@
 #   - debug mode can be activated if SC_BOOT_MODE=debug-ptvsd (this is the default in devel).
 #   - use vscode debugger "Python: Remote Attach *" config in  ''.vscode-template/launch.json'
 #
-version: "3.8"
 x-common-environment: &common_environment
   SWARM_STACK_NAME : ${SWARM_STACK_NAME:-simcore_local}
 services:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 x-dask-tls-secrets: &dask_tls_secrets
   - source: dask_tls_key
     target: ${DASK_TLS_KEY}

--- a/services/dynamic-scheduler/Dockerfile
+++ b/services/dynamic-scheduler/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #
 #  USAGE:

--- a/services/dynamic-scheduler/Dockerfile
+++ b/services/dynamic-scheduler/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 #
 #  USAGE:

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 #
 #  USAGE:
 #     cd sercices/dynamic-sidecar

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -12,8 +12,8 @@ FROM python:${PYTHON_VERSION}-slim-bookworm as base
 LABEL maintainer="Andrei Neagu <neagu@itis.swiss>"
 
 # NOTE: to list the latest version run `make` inside `scripts/apt-packages-versions`
-ENV DOCKER_APT_VERSION="5:24.0.5-1~debian.10~buster"
-ENV DOCKER_COMPOSE_APT_VERSION="2.20.2-1~debian.10~buster"
+ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
+ENV DOCKER_COMPOSE_APT_VERSION="2.27.1-1~debian.12~bookworm"
 
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_compose_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_compose_utils.py
@@ -25,7 +25,6 @@ from simcore_service_dynamic_sidecar.core.utils import CommandResult
 
 SLEEP_TIME_S = 60
 COMPOSE_SPEC_SAMPLE = {
-    "version": "3.8",
     "services": {
         "my-test-container": {
             "environment": [

--- a/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_docker_utils.py
@@ -133,7 +133,6 @@ async def test_get_running_containers_count_from_names(
 
 
 COMPOSE_SPEC_SAMPLE = {
-    "version": "3.8",
     "services": {
         "my-test-container": {
             "environment": [

--- a/services/dynamic-sidecar/tests/unit/test_core_utils.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_utils.py
@@ -17,7 +17,6 @@ def cmd(tmp_path: Path, sleep: int):
     docker_compose = tmp_path / "docker_compose.yml"
     docker_compose.write_text(
         f"""\
-version: "3.8"
 services:
   my-container:
     environment:

--- a/services/efs-guardian/Dockerfile
+++ b/services/efs-guardian/Dockerfile
@@ -13,7 +13,7 @@ FROM python:${PYTHON_VERSION}-slim-bookworm as base
 LABEL maintainer=sanderegg
 
 # NOTE: to list the latest version run `make` inside `scripts/apt-packages-versions`
-ENV DOCKER_APT_VERSION="5:24.0.5-1~debian.10~buster"
+ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \

--- a/services/efs-guardian/Dockerfile
+++ b/services/efs-guardian/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #
 #  USAGE:

--- a/services/efs-guardian/Dockerfile
+++ b/services/efs-guardian/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #

--- a/services/invitations/Dockerfile
+++ b/services/invitations/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #
 #  USAGE:

--- a/services/invitations/Dockerfile
+++ b/services/invitations/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #

--- a/services/migration/Dockerfile
+++ b/services/migration/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 LABEL maintainer=sanderegg

--- a/services/migration/Dockerfile
+++ b/services/migration/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 LABEL maintainer=sanderegg
 

--- a/services/osparc-gateway-server/Dockerfile
+++ b/services/osparc-gateway-server/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bullseye as base
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #
 #  USAGE:

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #

--- a/services/resource-usage-tracker/Dockerfile
+++ b/services/resource-usage-tracker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #
 #  USAGE:

--- a/services/resource-usage-tracker/Dockerfile
+++ b/services/resource-usage-tracker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 
 #

--- a/services/static-webserver/client/tools/docker-compose.yml
+++ b/services/static-webserver/client/tools/docker-compose.yml
@@ -1,7 +1,6 @@
 #
 # Used in development to compile source code using a running qooxdoo-kit container
 #
-version: "3.8"
 services:
   qooxdoo-kit:
     image: itisfoundation/qooxdoo-kit:${QOOXDOO_KIT_TAG}

--- a/services/storage/Dockerfile
+++ b/services/storage/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 #
 #  USAGE:

--- a/services/storage/Dockerfile
+++ b/services/storage/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 #
 #  USAGE:
 #     cd sercices/storage

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION="3.10.10"
+ARG PYTHON_VERSION="3.10.14"
 FROM python:${PYTHON_VERSION}-slim-bookworm as base
 #
 #  USAGE:

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.10"
-FROM python:${PYTHON_VERSION}-slim-buster as base
+FROM python:${PYTHON_VERSION}-slim-bookworm as base
 #
 #  USAGE:
 #     cd sercices/web

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -78,7 +78,7 @@ def mock_env_dockerfile_build(monkeypatch: pytest.MonkeyPatch) -> EnvVarsDict:
         PYTHON_GET_PIP_SHA256=6123659241292b2147b58922b9ffe11dda66b39d52d8a6f3aa310bc1d60ea6f7
         PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/a1675ab6c2bd898ed82b1f58c486097f763c74a9/public/get-pip.py
         PYTHON_PIP_VERSION=21.1.3
-        PYTHON_VERSION=3.10.10
+        PYTHON_VERSION=3.10.14
         PYTHONDONTWRITEBYTECODE=1
         PYTHONOPTIMIZE=TRUE
         SC_BOOT_MODE=production

--- a/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   postgres:
     image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"

--- a/services/web/server/tests/unit/with_dbs/docker-compose.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   postgres:
     image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   registry:
     image: registry:2

--- a/tests/environment-setup/test_used_docker_compose.py
+++ b/tests/environment-setup/test_used_docker_compose.py
@@ -113,9 +113,7 @@ def test_validate_compose_file(
 ):
     assert compose_path.exists()
     compose = yaml.safe_load(compose_path.read_text())
-    print(
-        str(compose_path.relative_to(repo_dir)), "-> version=", compose.get("version")
-    )
+    print(str(compose_path.relative_to(repo_dir)))
 
     # NOTE: with docker stack config, the .env file MUST be alongside the docker-compose file
 
@@ -134,4 +132,4 @@ def test_validate_compose_file(
     )
 
     # About versioning https://docs.docker.com/compose/compose-file/compose-file-v3/
-    assert compose["version"] == "3.8"
+    assert "version" not in compose

--- a/tests/performance/docker-compose.yml
+++ b/tests/performance/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   master:
     image: itisfoundation/locust:${LOCUST_VERSION}


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- changes all the python-based images from python:3.10.10-slim-buster to python:3.10.14-slim-bookworm (which is the latest Debian build from June 2023) - **buster is from 2019 and last update from 2022**
- updated **python to 3.10.14** at the same time (this is the current latest python 3.10.x)
- **removed all ```versions: "3.8"``` from the docker-compose.yml files as this is now obsolete**
- **upgraded the docker-ce-cli to 26.1.4 and docker-compose-plugin 2.27.1 to install under bookworm**
- disabled test as this fails in the CI ```test_exclusive_parallel_lock_is_released_and_reacquired```. The CI is red since https://github.com/ITISFoundation/osparc-simcore/pull/5888

### how to upgrade pyenv to 3.10.14
```bash
pyenv update
pyenv install 3.10.14
```
```bash
pyenv local 3.10.14
```

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
