### PR TITLE
🐛 [Frontend] Log fetch call's response to running service

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -1341,11 +1341,11 @@ qx.Class.define("osparc.data.model.Node", {
       // ping for some time until it is really reachable
       try {
         if (osparc.utils.Utils.isDevelopmentPlatform()) {
-          console.log("about to fetch ", srvUrl);
+          console.log("Connecting: about to fetch ", srvUrl);
         }
         const response = await fetch(srvUrl);
         if (osparc.utils.Utils.isDevelopmentPlatform()) {
-          console.log("fetch's response ", response);
+          console.log("Connecting: fetch's response ", response);
         }
         if (response.ok || response.status === 302) {
           // ok = status in the range 200-299
@@ -1356,11 +1356,11 @@ qx.Class.define("osparc.data.model.Node", {
           // we will skip those steps and directly switch its iframe
           this.__serviceReadyIn(srvUrl);
         } else {
-          console.log(`${srvUrl} is not reachable. Status: ${response.status}`);
+          console.log(`Connecting: ${srvUrl} is not reachable. Status: ${response.status}`);
           retry();
         }
       } catch (error) {
-        console.error(`Error while checking ${srvUrl}:`, error);
+        console.error(`Connecting: Error while checking ${srvUrl}:`, error);
         retry();
       }
     },

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -1328,8 +1328,8 @@ qx.Class.define("osparc.data.model.Node", {
     },
 
     __waitForServiceReady: async function(srvUrl) {
+      this.getStatus().setInteractive("connecting");
       const retry = () => {
-        this.getStatus().setInteractive("connecting");
         // Check if node is still there
         if (this.getWorkbench().getNode(this.getNodeId()) === null) {
           return;
@@ -1340,7 +1340,13 @@ qx.Class.define("osparc.data.model.Node", {
 
       // ping for some time until it is really reachable
       try {
+        if (osparc.utils.Utils.isDevelopmentPlatform()) {
+          console.log("about to fetch ", srvUrl);
+        }
         const response = await fetch(srvUrl);
+        if (osparc.utils.Utils.isDevelopmentPlatform()) {
+          console.log("fetch's response ", response);
+        }
         if (response.ok || response.status === 302) {
           // ok = status in the range 200-299
           // some services might respond with a 302 which is also fine

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -477,10 +477,6 @@ qx.Class.define("osparc.utils.Utils", {
       return window.location.hostname.includes("speag");
     },
 
-    isDevelEnv: function() {
-      return window.location.hostname.includes("master.speag") || window.location.port === "9081";
-    },
-
     addBorder: function(widget, width = 1, color = "transparent") {
       widget.getContentElement().setStyle("border", width+"px solid " + color);
     },


### PR DESCRIPTION
## What do these changes do?

The previous [PR](https://github.com/ITISFoundation/osparc-simcore/pull/5963) didn't fix the issue.

This one logs (only in master) the response to the fetch call to a running service.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
