### PR TITLE
🐛 Fixes error while updated study with long description

### DIFF
--- a/packages/models-library/src/models_library/api_schemas_webserver/projects.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects.py
@@ -84,7 +84,7 @@ class ProjectListItem(ProjectGet):
 
 
 class TitleStr(ConstrainedStr):
-    # Truncate title strings that exceed the specified limit.
+    # Truncate title strings that exceed the specified characters limit (curtail_length).
     # This ensures the **input** to the API is controlled and prevents exceeding
     # the database's constraints without causing errors.
     curtail_length = 200
@@ -92,7 +92,7 @@ class TitleStr(ConstrainedStr):
 
 
 class DescriptionStr(ConstrainedStr):
-    # Truncate description strings that exceed the specified limit.
+    # Truncate description strings that exceed the specified characters limit (curtail_length).
     curtail_length = 1000
     strip_whitespace = True
 

--- a/packages/models-library/src/models_library/api_schemas_webserver/projects.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects.py
@@ -122,8 +122,10 @@ ProjectName: TypeAlias = IDStr
 
 
 class DescriptionStr(ConstrainedStr):
-    # Truncates input strings longer than 500 characters to limit the explanation of
-    curtail_length = 500
+    # Truncates description strings when it goes over a limit
+    # Limits the input of the API and bounds the amount of data injected
+    # in the database without erroring.
+    curtail_length = 1000
 
 
 class ProjectPatch(InputSchema):

--- a/packages/models-library/src/models_library/api_schemas_webserver/projects.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects.py
@@ -83,15 +83,16 @@ class ProjectListItem(ProjectGet):
     ...
 
 
-# Truncate title and description strings that exceed the specified limit.
-# This ensures the **input** to the API is controlled and prevents exceeding
-# the database's constraints without causing errors.
 class TitleStr(ConstrainedStr):
+    # Truncate title strings that exceed the specified limit.
+    # This ensures the **input** to the API is controlled and prevents exceeding
+    # the database's constraints without causing errors.
     curtail_length = 200
     strip_whitespace = True
 
 
 class DescriptionStr(ConstrainedStr):
+    # Truncate description strings that exceed the specified limit.
     curtail_length = 1000
     strip_whitespace = True
 

--- a/packages/models-library/src/models_library/api_schemas_webserver/projects.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects.py
@@ -7,10 +7,14 @@ SEE rationale in https://fastapi.tiangolo.com/tutorial/extra-models/#multiple-mo
 
 from typing import Any, Literal, TypeAlias
 
-from pydantic import ConstrainedStr, Field, validator
+from pydantic import Field, validator
 
 from ..api_schemas_long_running_tasks.tasks import TaskGet
-from ..basic_types import HttpUrlWithCustomMinLength
+from ..basic_types import (
+    HttpUrlWithCustomMinLength,
+    LongTruncatedStr,
+    ShortTruncatedStr,
+)
 from ..emails import LowerCaseEmailStr
 from ..projects import ClassifierID, DateTimeStr, NodesDict, ProjectID
 from ..projects_access import AccessRights, GroupIDStr
@@ -83,24 +87,10 @@ class ProjectListItem(ProjectGet):
     ...
 
 
-class TitleStr(ConstrainedStr):
-    # Truncate title strings that exceed the specified characters limit (curtail_length).
-    # This ensures the **input** to the API is controlled and prevents exceeding
-    # the database's constraints without causing errors.
-    curtail_length = 200
-    strip_whitespace = True
-
-
-class DescriptionStr(ConstrainedStr):
-    # Truncate description strings that exceed the specified characters limit (curtail_length).
-    curtail_length = 1000
-    strip_whitespace = True
-
-
 class ProjectReplace(InputSchema):
     uuid: ProjectID
-    name: TitleStr
-    description: DescriptionStr
+    name: ShortTruncatedStr
+    description: LongTruncatedStr
     thumbnail: HttpUrlWithCustomMinLength | None
     creation_date: DateTimeStr
     last_change_date: DateTimeStr
@@ -121,8 +111,8 @@ class ProjectReplace(InputSchema):
 
 
 class ProjectUpdate(InputSchema):
-    name: TitleStr = FieldNotRequired()
-    description: DescriptionStr = FieldNotRequired()
+    name: ShortTruncatedStr = FieldNotRequired()
+    description: LongTruncatedStr = FieldNotRequired()
     thumbnail: HttpUrlWithCustomMinLength = FieldNotRequired()
     workbench: NodesDict = FieldNotRequired()
     access_rights: dict[GroupIDStr, AccessRights] = FieldNotRequired()
@@ -133,8 +123,8 @@ class ProjectUpdate(InputSchema):
 
 
 class ProjectPatch(InputSchema):
-    name: TitleStr = FieldNotRequired()
-    description: DescriptionStr = FieldNotRequired()
+    name: ShortTruncatedStr = FieldNotRequired()
+    description: LongTruncatedStr = FieldNotRequired()
     thumbnail: HttpUrlWithCustomMinLength = FieldNotRequired()
     access_rights: dict[GroupIDStr, AccessRights] = FieldNotRequired()
     classifiers: list[ClassifierID] = FieldNotRequired()

--- a/packages/models-library/src/models_library/api_schemas_webserver/projects.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects.py
@@ -122,9 +122,9 @@ ProjectName: TypeAlias = IDStr
 
 
 class DescriptionStr(ConstrainedStr):
-    # Truncates description strings when it goes over a limit
-    # Limits the input of the API and bounds the amount of data injected
-    # in the database without erroring.
+    # Truncate description strings that exceed the specified limit.
+    # This ensures the input to the API is controlled and prevents exceeding
+    # the database's constraints without causing errors.
     curtail_length = 1000
 
 

--- a/packages/models-library/src/models_library/api_schemas_webserver/projects.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects.py
@@ -84,7 +84,7 @@ class ProjectListItem(ProjectGet):
 
 
 # Truncate title and description strings that exceed the specified limit.
-# This ensures the input to the API is controlled and prevents exceeding
+# This ensures the **input** to the API is controlled and prevents exceeding
 # the database's constraints without causing errors.
 class TitleStr(ConstrainedStr):
     curtail_length = 200

--- a/packages/models-library/src/models_library/api_schemas_webserver/projects.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects.py
@@ -7,7 +7,7 @@ SEE rationale in https://fastapi.tiangolo.com/tutorial/extra-models/#multiple-mo
 
 from typing import Any, Literal, TypeAlias
 
-from pydantic import Field, validator
+from pydantic import ConstrainedStr, Field, validator
 
 from ..api_schemas_long_running_tasks.tasks import TaskGet
 from ..basic_types import HttpUrlWithCustomMinLength, IDStr
@@ -119,12 +119,16 @@ class ProjectUpdate(InputSchema):
 
 
 ProjectName: TypeAlias = IDStr
-ProjectDescription: TypeAlias = IDStr
+
+
+class DescriptionStr(ConstrainedStr):
+    # Truncates input strings longer than 500 characters to limit the explanation of
+    curtail_length = 500
 
 
 class ProjectPatch(InputSchema):
     name: ProjectName = FieldNotRequired()
-    description: ProjectDescription = FieldNotRequired()
+    description: DescriptionStr = FieldNotRequired()
     thumbnail: HttpUrlWithCustomMinLength = FieldNotRequired()
     access_rights: dict[GroupIDStr, AccessRights] = FieldNotRequired()
     classifiers: list[ClassifierID] = FieldNotRequired()

--- a/packages/models-library/src/models_library/basic_types.py
+++ b/packages/models-library/src/models_library/basic_types.py
@@ -80,20 +80,20 @@ class IDStr(ConstrainedStr):
     max_length = 100
 
 
-# Truncated Str:
-#   - Strips whitespaces and truncate strings that exceed the specified characters limit (curtail_length).
-#   - This ensures the **input** to the API is controlled and prevents exceeding the database's constraints
-#   silently, i.e. without raising errors.
 class ShortTruncatedStr(ConstrainedStr):
+    # Truncated Str:
+    #   - Strips whitespaces and truncate strings that exceed the specified characters limit (curtail_length).
+    #   - This ensures the **input** to the API is controlled and prevents exceeding large inputs silently, i.e. without raising errors.
     # Use to input e.g. titles or display names
-    curtail_length = 200
     strip_whitespace = True
+    curtail_length = 250
 
 
 class LongTruncatedStr(ConstrainedStr):
+    # Analogous to ShortTruncatedStr
     # Use to input e.g. descriptions or summaries
-    curtail_length = 1000
     strip_whitespace = True
+    curtail_length = 2500
 
 
 # auto-incremented primary-key IDs

--- a/packages/models-library/src/models_library/basic_types.py
+++ b/packages/models-library/src/models_library/basic_types.py
@@ -86,14 +86,14 @@ class ShortTruncatedStr(ConstrainedStr):
     #   - This ensures the **input** to the API is controlled and prevents exceeding large inputs silently, i.e. without raising errors.
     # Use to input e.g. titles or display names
     strip_whitespace = True
-    curtail_length = 250
+    curtail_length = 600
 
 
 class LongTruncatedStr(ConstrainedStr):
     # Analogous to ShortTruncatedStr
     # Use to input e.g. descriptions or summaries
     strip_whitespace = True
-    curtail_length = 2500
+    curtail_length = 65536  # same as github descripton
 
 
 # auto-incremented primary-key IDs

--- a/packages/models-library/src/models_library/basic_types.py
+++ b/packages/models-library/src/models_library/basic_types.py
@@ -81,17 +81,18 @@ class IDStr(ConstrainedStr):
 
 
 class ShortTruncatedStr(ConstrainedStr):
-    # Truncated Str:
+    # NOTE: Use to input e.g. titles or display names
+    # A truncated string:
     #   - Strips whitespaces and truncate strings that exceed the specified characters limit (curtail_length).
-    #   - This ensures the **input** to the API is controlled and prevents exceeding large inputs silently, i.e. without raising errors.
-    # Use to input e.g. titles or display names
+    #   - Ensures that the **input** data length to the API is controlled and prevents exceeding large inputs silently, i.e. without raising errors.
+    # SEE https://github.com/ITISFoundation/osparc-simcore/pull/5989#discussion_r1650506583
     strip_whitespace = True
     curtail_length = 600
 
 
 class LongTruncatedStr(ConstrainedStr):
+    # NOTE: Use to input e.g. descriptions or summaries
     # Analogous to ShortTruncatedStr
-    # Use to input e.g. descriptions or summaries
     strip_whitespace = True
     curtail_length = 65536  # same as github descripton
 

--- a/packages/models-library/src/models_library/basic_types.py
+++ b/packages/models-library/src/models_library/basic_types.py
@@ -80,6 +80,22 @@ class IDStr(ConstrainedStr):
     max_length = 100
 
 
+# Truncated Str:
+#   - Strips whitespaces and truncate strings that exceed the specified characters limit (curtail_length).
+#   - This ensures the **input** to the API is controlled and prevents exceeding the database's constraints
+#   silently, i.e. without raising errors.
+class ShortTruncatedStr(ConstrainedStr):
+    # Use to input e.g. titles or display names
+    curtail_length = 200
+    strip_whitespace = True
+
+
+class LongTruncatedStr(ConstrainedStr):
+    # Use to input e.g. descriptions or summaries
+    curtail_length = 1000
+    strip_whitespace = True
+
+
 # auto-incremented primary-key IDs
 IdInt: TypeAlias = PositiveInt
 PrimaryKeyInt: TypeAlias = PositiveInt

--- a/packages/models-library/tests/test_projects.py
+++ b/packages/models-library/tests/test_projects.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 from faker import Faker
-from models_library.api_schemas_webserver.projects import DescriptionStr, ProjectPatch
+from models_library.api_schemas_webserver.projects import LongTruncatedStr, ProjectPatch
 from models_library.projects import Project
 
 
@@ -44,8 +44,9 @@ def test_project_with_thumbnail_as_empty_string(minimal_project: dict[str, Any])
 
 
 def test_project_patch_truncates_description():
-    assert DescriptionStr.curtail_length
-    len_truncated = int(DescriptionStr.curtail_length)
+    # NOTE: checks https://github.com/ITISFoundation/osparc-simcore/issues/5988
+    assert LongTruncatedStr.curtail_length
+    len_truncated = int(LongTruncatedStr.curtail_length)
 
     long_description = "X" * (len_truncated + 10)
     assert len(long_description) > len_truncated

--- a/packages/models-library/tests/test_projects.py
+++ b/packages/models-library/tests/test_projects.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 from faker import Faker
+from models_library.api_schemas_webserver.projects import DescriptionStr, ProjectPatch
 from models_library.projects import Project
 
 
@@ -40,3 +41,18 @@ def test_project_with_thumbnail_as_empty_string(minimal_project: dict[str, Any])
 
     assert project
     assert project.thumbnail is None
+
+
+def test_project_patch_truncates_description():
+    assert DescriptionStr.curtail_length
+    len_truncated = int(DescriptionStr.curtail_length)
+
+    long_description = "X" * (len_truncated + 10)
+    assert len(long_description) > len_truncated
+
+    update = ProjectPatch(description=long_description)
+    assert len(update.description) == len_truncated
+
+    short_description = "X"
+    update = ProjectPatch(description=short_description)
+    assert len(update.description) == len(short_description)

--- a/services/api-server/src/simcore_service_api_server/api/routes/studies_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/studies_jobs.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Header, Query, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, RedirectResponse
-from models_library.api_schemas_webserver.projects import ProjectName, ProjectPatch
+from models_library.api_schemas_webserver.projects import ProjectPatch
 from models_library.api_schemas_webserver.projects_nodes import NodeOutputs
 from models_library.clusters import ClusterID
 from models_library.function_services_catalog.services import file_picker
@@ -116,7 +116,7 @@ async def create_study_job(
     )
 
     await webserver_api.patch_project(
-        project_id=job.id, patch_params=ProjectPatch(name=ProjectName(job.name))
+        project_id=job.id, patch_params=ProjectPatch(name=job.name)
     )
 
     project_inputs = await webserver_api.get_project_inputs(project_id=project.uuid)

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -9549,13 +9549,9 @@ components:
       properties:
         name:
           title: Name
-          maxLength: 100
-          minLength: 1
           type: string
         description:
           title: Description
-          maxLength: 100
-          minLength: 1
           type: string
         thumbnail:
           title: Thumbnail


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Fixes error produced when the user updates a study with a long description. After these changes very long descriptions (>1000 chars) and titles (>200 chars) will be truncated without reporting an error. Note that these truncation only happens for input strings in the API. As a general rule all input data to the API should be constrained either with a hard error or silently (e.g. truncating).

As a side note, the front-end should have reacted better to a 4XX errors provided that is a client error (the description maximum length was surpassed). I believe changes like https://github.com/ITISFoundation/osparc-simcore/pull/5487 should help in this direction .

## Related issue/s

- resolves https://github.com/ITISFoundation/osparc-simcore/issues/5988


## How to test

- Driving test `-k test_project_patch_truncates_description`

## Dev-ops checklist
None