### PR TITLE
🐛 Fixes mismatch on error status-code for start-computation

### DIFF
--- a/api/specs/web-server/_computations.py
+++ b/api/specs/web-server/_computations.py
@@ -33,7 +33,7 @@ async def get_computation(project_id: ProjectID):
             "description": "Project/wallet/pricing details not found"
         },
         status.HTTP_402_PAYMENT_REQUIRED: {
-            "description": "Insufficient osparc credits."
+            "description": "Insufficient credits to run computation"
         },
         status.HTTP_406_NOT_ACCEPTABLE: {
             "description": "Cluster not found",

--- a/api/specs/web-server/_computations.py
+++ b/api/specs/web-server/_computations.py
@@ -29,22 +29,16 @@ async def get_computation(project_id: ProjectID):
     "/computations/{project_id}:start",
     response_model=Envelope[_ComputationStarted],
     responses={
-        status.HTTP_404_NOT_FOUND: {
-            "description": "Project/wallet/pricing details not found"
-        },
         status.HTTP_402_PAYMENT_REQUIRED: {
             "description": "Insufficient credits to run computation"
         },
-        status.HTTP_406_NOT_ACCEPTABLE: {
-            "description": "Cluster not found",
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Project/wallet/pricing details were not found"
         },
-        status.HTTP_503_SERVICE_UNAVAILABLE: {
-            "description": "Service not available",
-        },
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {
-            "description": "Configuration error",
-        },
+        status.HTTP_406_NOT_ACCEPTABLE: {"description": "Cluster not found"},
         status.HTTP_409_CONFLICT: {"description": "Project already started"},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Configuration error"},
+        status.HTTP_503_SERVICE_UNAVAILABLE: {"description": "Service not available"},
     },
 )
 async def start_computation(project_id: ProjectID, _start: ComputationStart):

--- a/api/specs/web-server/_computations.py
+++ b/api/specs/web-server/_computations.py
@@ -33,7 +33,7 @@ async def get_computation(project_id: ProjectID):
             "description": "Project/wallet/pricing details not found"
         },
         status.HTTP_402_PAYMENT_REQUIRED: {
-            "description": "Insufficient osparc credits"
+            "description": "Insufficient osparc credits."
         },
         status.HTTP_406_NOT_ACCEPTABLE: {
             "description": "Cluster not found",
@@ -44,7 +44,6 @@ async def get_computation(project_id: ProjectID):
         status.HTTP_422_UNPROCESSABLE_ENTITY: {
             "description": "Configuration error",
         },
-        status.HTTP_402_PAYMENT_REQUIRED: {"description": "Payment required"},
         status.HTTP_409_CONFLICT: {"description": "Project already started"},
     },
 )

--- a/services/director-v2/openapi.json
+++ b/services/director-v2/openapi.json
@@ -103,7 +103,7 @@
           "402": {
             "description": "Payment required"
           },
-          "403": {
+          "409": {
             "description": "Project already started"
           }
         }

--- a/services/director-v2/openapi.json
+++ b/services/director-v2/openapi.json
@@ -103,7 +103,7 @@
           "402": {
             "description": "Payment required"
           },
-          "409": {
+          "403": {
             "description": "Project already started"
           }
         }

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -111,7 +111,7 @@ async def _check_pipeline_not_running_or_raise_409(
         )
 
 
-async def _check_pipeline_startable_or_raise(
+async def _check_pipeline_startable(
     pipeline_dag: nx.DiGraph,
     computation: ComputationCreate,
     catalog_client: CatalogClient,
@@ -338,7 +338,7 @@ async def create_computation(  # noqa: PLR0913
         )
 
         if computation.start_pipeline:
-            await _check_pipeline_startable_or_raise(
+            await _check_pipeline_startable(
                 minimal_computational_dag, computation, catalog_client, clusters_repo
             )
 

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -98,7 +98,7 @@ _logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-async def _check_pipeline_not_running(
+async def _check_pipeline_not_running_or_raise_403(
     comp_tasks_repo: CompTasksRepository, computation: ComputationCreate
 ) -> None:
     pipeline_state = utils.get_pipeline_state_from_task_states(
@@ -281,7 +281,7 @@ async def _try_start_pipeline(
             "description": "Configuration error",
         },
         status.HTTP_402_PAYMENT_REQUIRED: {"description": "Payment required"},
-        status.HTTP_409_CONFLICT: {"description": "Project already started"},
+        status.HTTP_403_FORBIDDEN: {"description": "Project already started"},
     },
 )
 # NOTE: in case of a burst of calls to that endpoint, we might end up in a weird state.
@@ -324,7 +324,7 @@ async def create_computation(  # noqa: PLR0913
         project: ProjectAtDB = await project_repo.get_project(computation.project_id)
 
         # check if current state allow to modify the computation
-        await _check_pipeline_not_running(comp_tasks_repo, computation)
+        await _check_pipeline_not_running_or_raise_403(comp_tasks_repo, computation)
 
         # create the complete DAG graph
         complete_dag = create_complete_dag(project.workbench)

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -835,7 +835,7 @@ async def test_update_and_delete_computation(
     ), f"pipeline is not in the expected starting state but in {task_out.state}"
 
     # now try to update the pipeline, is expected to be forbidden
-    with pytest.raises(httpx.HTTPStatusError, match=f"{status.HTTP_403_FORBIDDEN}"):
+    with pytest.raises(httpx.HTTPStatusError, match=f"{status.HTTP_409_CONFLICT}"):
         await create_pipeline(
             async_client,
             project=sleepers_project,

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -472,7 +472,7 @@ qx.Class.define("osparc.desktop.StudyEditor", {
         this.getStudy().setPipelineRunning(false);
       }, this);
       req.addListener("fail", async e => {
-        if (e.getTarget().getStatus() == "403") {
+        if (e.getTarget().getStatus() == "409") {
           this.getStudyLogger().error(null, "Pipeline is already running");
         } else if (e.getTarget().getStatus() == "422") {
           this.getStudyLogger().info(null, "The pipeline is up-to-date");

--- a/services/web/server/tests/integration/02/test_computation.py
+++ b/services/web/server/tests/integration/02/test_computation.py
@@ -85,7 +85,7 @@ class _ExpectedResponseTuple(NamedTuple):
     ok: int
     created: int
     no_content: int
-    forbidden: int
+    confict: int
 
     # pylint: disable=no-member
     def __str__(self) -> str:
@@ -105,7 +105,7 @@ def standard_role_response():
                     ok=status.HTTP_401_UNAUTHORIZED,
                     created=status.HTTP_401_UNAUTHORIZED,
                     no_content=status.HTTP_401_UNAUTHORIZED,
-                    forbidden=status.HTTP_401_UNAUTHORIZED,
+                    confict=status.HTTP_401_UNAUTHORIZED,
                 ),
             ),
             pytest.param(
@@ -114,7 +114,7 @@ def standard_role_response():
                     ok=status.HTTP_200_OK,
                     created=status.HTTP_201_CREATED,
                     no_content=status.HTTP_204_NO_CONTENT,
-                    forbidden=status.HTTP_403_FORBIDDEN,
+                    confict=status.HTTP_409_CONFLICT,
                 ),
             ),
             pytest.param(
@@ -123,7 +123,7 @@ def standard_role_response():
                     ok=status.HTTP_200_OK,
                     created=status.HTTP_201_CREATED,
                     no_content=status.HTTP_204_NO_CONTENT,
-                    forbidden=status.HTTP_403_FORBIDDEN,
+                    confict=status.HTTP_409_CONFLICT,
                 ),
             ),
             pytest.param(
@@ -132,7 +132,7 @@ def standard_role_response():
                     ok=status.HTTP_200_OK,
                     created=status.HTTP_201_CREATED,
                     no_content=status.HTTP_204_NO_CONTENT,
-                    forbidden=status.HTTP_403_FORBIDDEN,
+                    confict=status.HTTP_409_CONFLICT,
                 ),
             ),
         ],
@@ -390,7 +390,7 @@ async def test_start_stop_computation(
     if not error:
         # starting again should be disallowed, since it's already running
         resp = await client.post(f"{url_start}")
-        assert resp.status == expected.forbidden
+        assert resp.status == expected.confict
 
         assert "pipeline_id" in data
         assert data["pipeline_id"] == project_id


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Mismatch between the error code specified in the OAS and the actual error code when starting a computation.

- the director-v2 service would respond with [HTTP_403_FORBIDDEN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) for computation:start when the computation was started.  Nonetheless, the OAS was reporting [HTTP_409_CONFLICT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409). 
- This error was propagated via the web-server and handled in the api-server.
- Due to the mismatch, the error was not handled properly in the api-server causing errors like [this](https://monitoring.osparc-master.speag.com/graylog/messages/graylog_277/a55e2401-32be-11ef-8bc2-0242c0a80207)
- IMO [HTTP_409_CONFLICT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409) is more suitable than [HTTP_403_FORBIDDEN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) since the latter is mostly related to authentication.
- Therefore, I changed the logic of the directorv2 to respond with [HTTP_409_CONFLICT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409).
- Adapted also the front-end. 
    - @odeimaiz I see you handle [HTTP_422_UNPROCESSABLE_ENTITY](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) as a non-error. Please double check the error codes in the [OAS for that entrypoint](https://github.com/ITISFoundation/osparc-simcore/blob/master/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml#L1129-L1147). thx



## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test



## Dev-ops checklist
None
