### PR TITLE
🎨 Fixes  Deprecation Warning on redis and aiohttp

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/redis_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/redis_service.py
@@ -69,7 +69,7 @@ async def redis_client(
     yield client
 
     await client.flushall()
-    await client.close(close_connection_pool=True)
+    await client.aclose(close_connection_pool=True)
 
 
 @pytest.fixture()
@@ -86,7 +86,7 @@ async def redis_locks_client(
     yield client
 
     await client.flushall()
-    await client.close(close_connection_pool=True)
+    await client.aclose(close_connection_pool=True)
 
 
 @tenacity.retry(
@@ -103,4 +103,4 @@ async def wait_till_redis_responsive(redis_url: URL | str) -> None:
             msg = f"{redis_url=} not available"
             raise ConnectionError(msg)
     finally:
-        await client.close(close_connection_pool=True)
+        await client.aclose(close_connection_pool=True)

--- a/packages/service-library/src/servicelib/aiohttp/rest_models.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_models.py
@@ -27,4 +27,4 @@ class ErrorType:
     logs: list[LogMessageType] = field(default_factory=list)
     errors: list[ErrorItemType] = field(default_factory=list)
     status: int = 400
-    message: str = "Unexpected client error"
+    message: str = "Unexpected error"

--- a/packages/service-library/src/servicelib/aiohttp/rest_responses.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_responses.py
@@ -127,7 +127,6 @@ def exception_to_response(exc: HTTPError) -> web.Response:
         headers=exc.headers,
         reason=exc.reason,
         text=exc.text,
-        content_type=exc.content_type,
     )
 
 

--- a/packages/service-library/src/servicelib/aiohttp/rest_responses.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_responses.py
@@ -126,7 +126,6 @@ def exception_to_response(exc: HTTPError) -> web.Response:
         status=exc.status,
         headers=exc.headers,
         reason=exc.reason,
-        body=exc.body,
         text=exc.text,
         content_type=exc.content_type,
     )

--- a/packages/service-library/src/servicelib/aiohttp/rest_responses.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_responses.py
@@ -106,9 +106,9 @@ def create_error_response(
         )
 
     assert not http_error_cls.empty_body  # nosec
-
     payload = wrap_as_envelope(error=asdict(error))
-    # Returning web.HTTPException is deprecated
+
+    # Returning web.HTTPException is deprecated, returning instead a response object
     # SEE https://github.com/aio-libs/aiohttp/issues/2415
     return web.json_response(
         payload,

--- a/packages/service-library/src/servicelib/aiohttp/rest_responses.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_responses.py
@@ -12,6 +12,7 @@ from aiohttp.web_exceptions import HTTPError, HTTPException
 from models_library.utils.json_serialization import json_dumps
 from servicelib.aiohttp.status import HTTP_200_OK
 
+from ..mimetype_constants import MIMETYPE_APPLICATION_JSON
 from .rest_models import ErrorItemType, ErrorType
 
 _ENVELOPE_KEYS = ("data", "error")
@@ -64,24 +65,26 @@ def create_data_response(
 
         response = web.json_response(payload, dumps=json_dumps, status=status)
     except (TypeError, ValueError) as err:
-        response = create_error_response(
-            [
-                err,
-            ],
-            str(err),
-            web.HTTPInternalServerError,
-            skip_internal_error_details=skip_internal_error_details,
+        response = exception_to_response(
+            create_http_error(
+                [
+                    err,
+                ],
+                str(err),
+                web.HTTPInternalServerError,
+                skip_internal_error_details=skip_internal_error_details,
+            )
         )
     return response
 
 
-def create_error_response(
+def create_http_error(
     errors: list[Exception] | Exception,
     reason: str | None = None,
     http_error_cls: type[HTTPError] = web.HTTPInternalServerError,
     *,
     skip_internal_error_details: bool = False,
-) -> web.Response:
+) -> HTTPError:
     """
     - Response body conforms OAS schema model
     - Can skip internal details when 500 status e.g. to avoid transmitting server
@@ -108,13 +111,24 @@ def create_error_response(
     assert not http_error_cls.empty_body  # nosec
     payload = wrap_as_envelope(error=asdict(error))
 
-    # Returning web.HTTPException is deprecated, returning instead a response object
-    # SEE https://github.com/aio-libs/aiohttp/issues/2415
-    return web.json_response(
-        payload,
+    return http_error_cls(
         reason=reason,
-        status=http_error_cls.status_code,
-        dumps=json_dumps,
+        text=json_dumps(payload),
+        content_type=MIMETYPE_APPLICATION_JSON,
+    )
+
+
+def exception_to_response(exc: HTTPError) -> web.Response:
+    # Returning web.HTTPException is deprecated so here we have a converter to a response
+    # so it can be used as
+    # SEE https://github.com/aio-libs/aiohttp/issues/2415
+    return web.Response(
+        status=exc.status,
+        headers=exc.headers,
+        reason=exc.reason,
+        body=exc.body,
+        text=exc.text,
+        content_type=exc.content_type,
     )
 
 

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -87,7 +87,7 @@ async def __delete_all_redis_keys__(redis_settings: RedisSettings):
         decode_responses=True,
     )
     await client.flushall()
-    await client.close(close_connection_pool=True)
+    await client.aclose(close_connection_pool=True)
 
 
 @pytest.fixture(scope="session")

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -579,7 +579,7 @@ async def redis_locks_client(
     yield client
 
     await client.flushall()
-    await client.close(close_connection_pool=True)
+    await client.aclose(close_connection_pool=True)
 
 
 # SOCKETS FIXTURES  --------------------------------------------------------


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Fixes deprecation warning in `redis` library, provided that `redis==5.0.4` already repo-wide
```
DeprecationWarning: Call to deprecated close. (Use aclose() instead) -- Deprecated since version 5.0.1.
    await client.close(close_connection_pool=True)
```

- Fixes deprecation error in `aiohttp` library (SEE https://github.com/aio-libs/aiohttp/issues/2415)
```cmd
 ... /aiohttp/web_protocol.py:451: DeprecationWarning: returning HTTPException object is deprecated (#2415) and will be removed, please raise the exception instead
```
