### PR TITLE
🎨 Maintenance: Add new concurrency tooling

### DIFF
--- a/packages/service-library/src/servicelib/utils.py
+++ b/packages/service-library/src/servicelib/utils.py
@@ -202,11 +202,12 @@ async def limited_as_completed(
 
 
     """
-    if isinstance(awaitables, AsyncIterable):
-        awaitable_iterator = aiter(awaitables)
+    try:
+        awaitable_iterator = aiter(awaitables)  # type: ignore[arg-type]
         is_async = True
-    else:
-        awaitable_iterator = iter(awaitables)
+    except TypeError:
+        assert isinstance(awaitables, Iterable)  # nosec
+        awaitable_iterator = iter(awaitables)  # type: ignore[assignment]
         is_async = False
 
     completed_all_awaitables = False
@@ -220,7 +221,7 @@ async def limited_as_completed(
                 aw = (
                     await anext(awaitable_iterator)
                     if is_async
-                    else next(awaitable_iterator)
+                    else next(awaitable_iterator)  # type: ignore[call-overload]
                 )
                 pending_futures.add(asyncio.ensure_future(aw))
             except (StopIteration, StopAsyncIteration):  # noqa: PERF203

--- a/packages/service-library/src/servicelib/utils.py
+++ b/packages/service-library/src/servicelib/utils.py
@@ -258,7 +258,7 @@ async def limited_gather(
     reraise: bool = True,
     log: logging.Logger = _logger,
     limit: int = 1,
-) -> list[T | BaseException]:
+) -> list[T | BaseException | None]:
     """runs all the awaitables using the limited concurrency and returns them in the same order
 
     Arguments:
@@ -286,6 +286,5 @@ async def limited_gather(
     async for future in limited_as_completed(indexed_awaitables, limit=limit):
         index, result = await future
         results[index] = result
-    assert all(_ is not None for _ in results)  # nosec
 
     return results

--- a/packages/service-library/src/servicelib/utils.py
+++ b/packages/service-library/src/servicelib/utils.py
@@ -259,6 +259,13 @@ async def _wrapped(
 ) -> tuple[int, T | BaseException]:
     try:
         return index, await awaitable
+    except asyncio.CancelledError:
+        logger.debug(
+            "Cancelled %i-th concurrent task %s",
+            index + 1,
+            f"{awaitable=}",
+        )
+        raise
     except BaseException as exc:  # pylint: disable=broad-exception-caught
         logger.warning(
             "Error in %i-th concurrent task %s: %s",

--- a/packages/service-library/tests/test_archiving_utils.py
+++ b/packages/service-library/tests/test_archiving_utils.py
@@ -14,7 +14,7 @@ import tempfile
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Iterable, Iterator, Optional
+from typing import Callable, Iterable, Iterator
 
 import pytest
 from faker import Faker
@@ -23,7 +23,12 @@ from pytest_benchmark.plugin import BenchmarkFixture
 from servicelib import archiving_utils
 from servicelib.archiving_utils import ArchiveError, archive_dir, unarchive_dir
 
-from .test_utils import print_tree
+
+def _print_tree(path: Path, level=0):
+    tab = " " * level
+    print(f"{tab}{'+' if path.is_dir() else '-'} {path if level==0 else path.name}")
+    for p in path.glob("*"):
+        _print_tree(p, level + 1)
 
 
 @pytest.fixture
@@ -96,7 +101,7 @@ def exclude_patterns_validation_dir(tmp_path: Path, faker: Faker) -> Path:
     (base_dir / "d1" / "sd1" / "f2.txt").write_text(faker.text())
 
     print("exclude_patterns_validation_dir ---")
-    print_tree(base_dir)
+    _print_tree(base_dir)
     return base_dir
 
 
@@ -174,7 +179,7 @@ def _escape_undecodable_path(path: Path) -> Path:
 async def assert_same_directory_content(
     dir_to_compress: Path,
     output_dir: Path,
-    inject_relative_path: Optional[Path] = None,
+    inject_relative_path: Path | None = None,
     unsupported_replace: bool = False,
 ) -> None:
     def _relative_path(input_path: Path) -> Path:

--- a/packages/service-library/tests/test_archiving_utils_extra.py
+++ b/packages/service-library/tests/test_archiving_utils_extra.py
@@ -13,7 +13,12 @@ from servicelib.archiving_utils import (
     unarchive_dir,
 )
 
-from .test_utils import print_tree
+
+def _print_tree(path: Path, level=0):
+    tab = " " * level
+    print(f"{tab}{'+' if path.is_dir() else '-'} {path if level==0 else path.name}")
+    for p in path.glob("*"):
+        _print_tree(p, level + 1)
 
 
 @pytest.fixture
@@ -32,7 +37,7 @@ def state_dir(tmp_path) -> Path:
     (base_dir / "d1" / "d1_1" / "d1_1_1" / "f6").touch()
 
     print("state-dir ---")
-    print_tree(base_dir)
+    _print_tree(base_dir)
     # + /tmp/pytest-of-crespo/pytest-95/test_override_and_prune_from_a1/original
     #  + empty
     #  + d1
@@ -64,7 +69,7 @@ def new_state_dir(tmp_path) -> Path:
     # f6 deleted -> d1/d1_1/d2_2 remains empty and should be pruned
 
     print("new-state-dir ---")
-    print_tree(base_dir)
+    _print_tree(base_dir)
     # + /tmp/pytest-of-crespo/pytest-95/test_override_and_prune_from_a1/updated
     #  + d1
     #   + d1_1
@@ -120,7 +125,7 @@ def test_override_and_prune_folder(state_dir: Path, new_state_dir: Path):
     assert old_paths != got_paths
 
     print("after ----")
-    print_tree(state_dir)
+    _print_tree(state_dir)
 
 
 @pytest.mark.parametrize(

--- a/scripts/mypy.bash
+++ b/scripts/mypy.bash
@@ -29,12 +29,10 @@ echo_requirements() {
     --interactive \
     --rm \
     --user="$(id --user "$USER")":"$(id --group "$USER")" \
-    --entrypoint="pip" \
+    --entrypoint="uv" \
     "$IMAGE_NAME" \
-     --no-cache-dir freeze
+    --no-cache-dir pip freeze
 }
-
-
 
 run() {
   echo Using "$(docker run --rm "$IMAGE_NAME" --version)"

--- a/scripts/mypy/Dockerfile
+++ b/scripts/mypy/Dockerfile
@@ -1,13 +1,29 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.10.14"
-FROM python:${PYTHON_VERSION}-slim-bookworm as base
+FROM python:${PYTHON_VERSION}-slim-bookworm AS base
+
+# Sets utf-8 encoding for Python et al
+ENV LANG=C.UTF-8
+
+# Turns off writing .pyc files; superfluous on an ephemeral container.
+ENV PYTHONDONTWRITEBYTECODE=1 \
+  VIRTUAL_ENV=/home/scu/.venv
+
+# Ensures that the python and pip executables used in the image will be
+# those from our virtualenv.
+ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 
-COPY requirements.txt /requirements.txt
-
+# NOTE: install https://github.com/astral-sh/uv ultra-fast rust-based pip replacement
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
-  pip install --upgrade pip \
-  && pip install -r requirements.txt \
-  && pip freeze
+  pip install uv~=0.1
+
+RUN \
+  --mount=type=cache,mode=0755,target=/root/.cache/uv \
+  --mount=type=bind,source=./requirements.txt,target=requirements.txt \
+  uv venv "${VIRTUAL_ENV}" \
+  && uv pip install --upgrade pip wheel setuptools \
+  && uv pip install -r requirements.txt \
+  && uv pip list
 
 ENTRYPOINT ["mypy", "--config-file", "/config/mypy.ini", "--warn-unused-configs"]

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
@@ -134,7 +134,7 @@ async def upload_outputs(
                 # generic case let's create an archive
                 # only the filtered out files will be zipped
                 tmp_folder = Path(
-                    await stack.enter_async_context(AioTemporaryDirectory())
+                    await stack.enter_async_context(AioTemporaryDirectory())  # type: ignore[arg-type]
                 )
                 tmp_file = tmp_folder / f"{src_folder.stem}.zip"
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Reduced size of [https://github.com/ITISFoundation/osparc-simcore/pull/5981](https://github.com/ITISFoundation/osparc-simcore/pull/5981)

This PR brings learnings from this [article](https://death.andgravity.com/limit-concurrency#asyncio-wait):
Run concurrent asyncio awaitables without overloading the event loop. Tasks are created on the fly and based on need and are limited in number.

driving test: test_utils.py in servicelib.

Bonus:
- mypy script now uses uv
- fixed dynamic-sidecar new mypy issue by ignoring it @GitHK 

NOTE: I will not move that to async_utils.py yet to reduce noise.

- required by [https://github.com/ITISFoundation/osparc-simcore/pull/5981](https://github.com/ITISFoundation/osparc-simcore/pull/5981)



## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
