### PR TITLE
🐛 viewers can now use new style dynamic services

### DIFF
--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_redirects_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_redirects_handlers.py
@@ -1,6 +1,7 @@
 """ Handles request to the viewers redirection entrypoints
 
 """
+
 import functools
 import logging
 import urllib.parse
@@ -16,6 +17,7 @@ from servicelib.aiohttp.requests_validation import parse_request_query_parameter
 from servicelib.aiohttp.typing_extension import Handler
 from servicelib.error_codes import create_error_code
 
+from ..director_v2.api import update_dynamic_service_networks_in_project
 from ..products.api import get_product_name
 from ..utils import compose_support_error_msg
 from ..utils_aiohttp import create_redirect_to_page_response
@@ -252,6 +254,7 @@ async def get_redirection_to_viewer(request: web.Request):
             file_params.download_link,
             product_name=get_product_name(request),
         )
+        await update_dynamic_service_networks_in_project(request.app, project_id)
 
         response = _create_redirect_response_to_view_page(
             request.app,
@@ -280,6 +283,7 @@ async def get_redirection_to_viewer(request: web.Request):
             service_info=_create_service_info_from(valid_service),
             product_name=get_product_name(request),
         )
+        await update_dynamic_service_networks_in_project(request.app, project_id)
 
         response = _create_redirect_response_to_view_page(
             request.app,
@@ -315,6 +319,7 @@ async def get_redirection_to_viewer(request: web.Request):
             ).STUDIES_DEFAULT_FILE_THUMBNAIL,
             product_name=get_product_name(request),
         )
+        await update_dynamic_service_networks_in_project(request.app, project_id)
 
         response = _create_redirect_response_to_view_page(
             request.app,

--- a/services/web/server/tests/unit/with_dbs/01/studies_dispatcher/test_studies_dispatcher_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/01/studies_dispatcher/test_studies_dispatcher_handlers.py
@@ -397,6 +397,10 @@ async def test_dispatch_study_anonymously(
         "simcore_service_webserver.director_v2.api.create_or_update_pipeline",
         return_value=None,
     )
+    mock_client_director_v2_project_networks = mocker.patch(
+        "simcore_service_webserver.studies_dispatcher._redirects_handlers.update_dynamic_service_networks_in_project",
+        return_value=None,
+    )
 
     response = await client.get(f"{redirect_url}")
 
@@ -435,6 +439,7 @@ async def test_dispatch_study_anonymously(
         assert guest_project["prjOwner"] == data["login"]
 
         assert mock_client_director_v2_func.called
+        assert mock_client_director_v2_project_networks.called
 
 
 @pytest.mark.parametrize(
@@ -455,8 +460,12 @@ async def test_dispatch_logged_in_user(
     mocks_on_projects_api,
 ):
     assert client.app
-    mock_client_director_v2_func = mocker.patch(
+    mock_client_director_v2_pipline_update = mocker.patch(
         "simcore_service_webserver.director_v2.api.create_or_update_pipeline",
+        return_value=None,
+    )
+    mock_client_director_v2_project_networks = mocker.patch(
+        "simcore_service_webserver.studies_dispatcher._redirects_handlers.update_dynamic_service_networks_in_project",
         return_value=None,
     )
 
@@ -487,7 +496,8 @@ async def test_dispatch_logged_in_user(
     assert expected_project_id == created_project["uuid"]
     assert created_project["prjOwner"] == data["login"]
 
-    assert mock_client_director_v2_func.called
+    assert mock_client_director_v2_pipline_update.called
+    assert mock_client_director_v2_project_networks.called
 
     # delete before exiting
     url = client.app.router["delete_project"].url_for(project_id=expected_project_id)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Viewers based on new style services, running via dynamic-sidecar, can now be used.

- 🐛 Fixes an issue where generated projects did not update the project_networks table. This did not allow for the dynamic-sidecar to start.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
