### PR TITLE
🐛♻️Clusters-keeper: use private dns name instead of public IP (#5883)

### DIFF
--- a/packages/aws-library/src/aws_library/ec2/client.py
+++ b/packages/aws-library/src/aws_library/ec2/client.py
@@ -200,11 +200,7 @@ class SimcoreEC2API:
                     launch_time=instance["LaunchTime"],
                     id=instance["InstanceId"],
                     aws_private_dns=instance["PrivateDnsName"],
-                    aws_public_ip=(
-                        instance["PublicIpAddress"]
-                        if "PublicIpAddress" in instance
-                        else None
-                    ),
+                    aws_public_ip=instance.get("PublicIpAddress", None),
                     type=instance["InstanceType"],
                     state=instance["State"]["Name"],
                     tags=parse_obj_as(
@@ -264,11 +260,7 @@ class SimcoreEC2API:
                         launch_time=instance["LaunchTime"],
                         id=instance["InstanceId"],
                         aws_private_dns=instance["PrivateDnsName"],
-                        aws_public_ip=(
-                            instance["PublicIpAddress"]
-                            if "PublicIpAddress" in instance
-                            else None
-                        ),
+                        aws_public_ip=instance.get("PublicIpAddress", None),
                         type=instance["InstanceType"],
                         state=instance["State"]["Name"],
                         resources=ec2_instance_types[0].resources,

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/dask.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/dask.py
@@ -7,7 +7,7 @@ from ..core.settings import get_application_settings
 
 
 def get_scheduler_url(ec2_instance: EC2InstanceData) -> AnyUrl:
-    url: AnyUrl = parse_obj_as(AnyUrl, f"tls://{ec2_instance.aws_public_ip}:8786")
+    url: AnyUrl = parse_obj_as(AnyUrl, f"tls://{ec2_instance.aws_private_dns}:8786")
     return url
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR applies again a previous PR that was reverted by [https://github.com/ITISFoundation/osparc-simcore/pull/6082](https://github.com/ITISFoundation/osparc-simcore/pull/6082) and this was not required.

In essence this tells the clusters-keeper to use the external cluster primary machine private DNS instead of its public IP to communicate.
This has no influence on s4llife.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
