### PR TITLE
✨Autoscaling: EBS-backed buffer, label EC2 machines with prepulled images list

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/helpers/aws_ec2.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/aws_ec2.py
@@ -2,6 +2,7 @@ import base64
 from typing import Sequence
 
 from models_library.docker import DockerGenericTag
+from models_library.utils.json_serialization import json_dumps
 from types_aiobotocore_ec2 import EC2Client
 from types_aiobotocore_ec2.literals import InstanceStateNameType, InstanceTypeType
 from types_aiobotocore_ec2.type_defs import FilterTypeDef, InstanceTypeDef, TagTypeDef
@@ -135,7 +136,7 @@ async def assert_ec2_instances(
                 assert "Value" in instance_pre_pulled_images_aws_tag
                 assert (
                     instance_pre_pulled_images_aws_tag["Value"]
-                    == f"{expected_pre_pulled_images}"
+                    == f"{json_dumps(expected_pre_pulled_images)}"
                 )
 
             assert "PrivateDnsName" in instance

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/aws_ec2.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/aws_ec2.py
@@ -1,9 +1,10 @@
 import base64
 from typing import Sequence
 
+from models_library.docker import DockerGenericTag
 from types_aiobotocore_ec2 import EC2Client
 from types_aiobotocore_ec2.literals import InstanceStateNameType, InstanceTypeType
-from types_aiobotocore_ec2.type_defs import FilterTypeDef, InstanceTypeDef
+from types_aiobotocore_ec2.type_defs import FilterTypeDef, InstanceTypeDef, TagTypeDef
 
 
 async def assert_autoscaled_computational_ec2_instances(
@@ -63,6 +64,7 @@ async def assert_autoscaled_dynamic_warm_pools_ec2_instances(
     expected_instance_type: InstanceTypeType,
     expected_instance_state: InstanceStateNameType,
     expected_additional_tag_keys: list[str],
+    expected_pre_pulled_images: list[DockerGenericTag],
     instance_filters: Sequence[FilterTypeDef] | None,
 ) -> list[InstanceTypeDef]:
     return await assert_ec2_instances(
@@ -75,8 +77,10 @@ async def assert_autoscaled_dynamic_warm_pools_ec2_instances(
             "io.simcore.autoscaling.monitored_nodes_labels",
             "io.simcore.autoscaling.monitored_services_labels",
             "io.simcore.autoscaling.buffer_machine",
+            "io.simcore.autoscaling.pre_pulled_images",
             *expected_additional_tag_keys,
         ],
+        expected_pre_pulled_images=expected_pre_pulled_images,
         expected_user_data=[],
         instance_filters=instance_filters,
     )
@@ -91,6 +95,7 @@ async def assert_ec2_instances(
     expected_instance_state: InstanceStateNameType,
     expected_instance_tag_keys: list[str],
     expected_user_data: list[str],
+    expected_pre_pulled_images: list[DockerGenericTag] | None = None,
     instance_filters: Sequence[FilterTypeDef] | None = None,
 ) -> list[InstanceTypeDef]:
     list_instances: list[InstanceTypeDef] = []
@@ -112,8 +117,27 @@ async def assert_ec2_instances(
                 "Name",
             }
             instance_tag_keys = {tag["Key"] for tag in instance["Tags"] if "Key" in tag}
-
             assert instance_tag_keys == expected_tag_keys
+
+            if expected_pre_pulled_images is None:
+                assert (
+                    "io.simcore.autoscaling.pre_pulled_images" not in instance_tag_keys
+                )
+            else:
+                assert "io.simcore.autoscaling.pre_pulled_images" in instance_tag_keys
+
+                def _by_pre_pull_image(ec2_tag: TagTypeDef) -> bool:
+                    assert "Key" in ec2_tag
+                    return ec2_tag["Key"] == "io.simcore.autoscaling.pre_pulled_images"
+
+                instance_pre_pulled_images_aws_tag = next(
+                    iter(filter(_by_pre_pull_image, instance["Tags"]))
+                )
+                assert "Value" in instance_pre_pulled_images_aws_tag
+                assert (
+                    instance_pre_pulled_images_aws_tag["Value"]
+                    == f"{expected_pre_pulled_images}"
+                )
 
             assert "PrivateDnsName" in instance
             instance_private_dns_name = instance["PrivateDnsName"]

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/aws_ec2.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/aws_ec2.py
@@ -64,7 +64,7 @@ async def assert_autoscaled_dynamic_warm_pools_ec2_instances(
     expected_instance_type: InstanceTypeType,
     expected_instance_state: InstanceStateNameType,
     expected_additional_tag_keys: list[str],
-    expected_pre_pulled_images: list[DockerGenericTag],
+    expected_pre_pulled_images: list[DockerGenericTag] | None,
     instance_filters: Sequence[FilterTypeDef] | None,
 ) -> list[InstanceTypeDef]:
     return await assert_ec2_instances(
@@ -77,7 +77,6 @@ async def assert_autoscaled_dynamic_warm_pools_ec2_instances(
             "io.simcore.autoscaling.monitored_nodes_labels",
             "io.simcore.autoscaling.monitored_services_labels",
             "io.simcore.autoscaling.buffer_machine",
-            "io.simcore.autoscaling.pre_pulled_images",
             *expected_additional_tag_keys,
         ],
         expected_pre_pulled_images=expected_pre_pulled_images,

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -185,9 +185,7 @@ class BufferPool:
 
     def pre_pulled_instances(self) -> set[EC2InstanceData]:
         """returns all the instances that completed image pre pulling"""
-        return self.ready_instances.union(
-            self.stopping_instances, self.waiting_to_stop_instances
-        )
+        return self.ready_instances.union(self.stopping_instances)
 
     def all_instances(self) -> set[EC2InstanceData]:
         """sorted by importance: READY (stopped) > STOPPING >"""

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -183,6 +183,12 @@ class BufferPool:
         else:
             yield from order
 
+    def pre_pulled_instances(self) -> set[EC2InstanceData]:
+        """returns all the instances that completed image pre pulling"""
+        return self.ready_instances.union(
+            self.stopping_instances, self.waiting_to_stop_instances
+        )
+
     def all_instances(self) -> set[EC2InstanceData]:
         """sorted by importance: READY (stopped) > STOPPING >"""
         gen = self._sort_by_readyness()

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -52,7 +52,7 @@ class NonAssociatedInstance(_BaseInstance):
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
-class Cluster:
+class Cluster:  # pylint: disable=too-many-instance-attributes
     active_nodes: list[AssociatedInstance] = field(
         metadata={
             "description": "This is a EC2-backed docker node which is active and ready to receive tasks (or with running tasks)"
@@ -81,6 +81,11 @@ class Cluster:
     broken_ec2s: list[NonAssociatedInstance] = field(
         metadata={
             "description": "This is an existing EC2 instance that never properly joined the cluster and is deemed as broken and will be terminated"
+        }
+    )
+    buffer_ec2s: list[NonAssociatedInstance] = field(
+        metadata={
+            "description": "This is a prepared stopped EC2 instance, not yet associated to a docker node, ready to be used"
         }
     )
     disconnected_nodes: list[Node] = field(
@@ -126,8 +131,9 @@ class Cluster:
             f"pending-nodes: count={len(self.pending_nodes)} {_get_instance_ids(self.pending_nodes)}, "
             f"drained-nodes: count={len(self.drained_nodes)} {_get_instance_ids(self.drained_nodes)}, "
             f"reserve-drained-nodes: count={len(self.reserve_drained_nodes)} {_get_instance_ids(self.reserve_drained_nodes)}, "
-            f"pending-ec2-instances: count={len(self.pending_ec2s)} {_get_instance_ids(self.pending_ec2s)}, "
-            f"broken-ec2-instances: count={len(self.broken_ec2s)} {_get_instance_ids(self.broken_ec2s)}, "
+            f"pending-ec2s: count={len(self.pending_ec2s)} {_get_instance_ids(self.pending_ec2s)}, "
+            f"broken-ec2s: count={len(self.broken_ec2s)} {_get_instance_ids(self.broken_ec2s)}, "
+            f"buffer-ec2s: count={len(self.buffer_ec2s)} {_get_instance_ids(self.buffer_ec2s)}, "
             f"disconnected-nodes: count={len(self.disconnected_nodes)}, "
             f"terminating-nodes: count={len(self.terminating_nodes)} {_get_instance_ids(self.terminating_nodes)}, "
         )

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -42,6 +42,7 @@ from ..utils.auto_scaling_core import (
     node_host_name_from_ec2_private_dns,
     sort_drained_nodes,
 )
+from ..utils.buffer_machines_pool_core import get_buffer_ec2_tags
 from ..utils.rabbitmq import post_autoscaling_status_message
 from .auto_scaling_mode_base import BaseAutoscaling
 from .docker import get_docker_client
@@ -77,6 +78,12 @@ async def _analyze_current_cluster(
         key_names=[app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_KEY_NAME],
         tags=auto_scaling_mode.get_ec2_tags(app),
         state_names=["terminated"],
+    )
+
+    buffer_ec2_instances = await get_ec2_client(app).get_instances(
+        key_names=[app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_KEY_NAME],
+        tags=get_buffer_ec2_tags(app, auto_scaling_mode),
+        state_names=["stopped"],
     )
 
     attached_ec2s, pending_ec2s = await associate_ec2_instances_with_nodes(
@@ -134,6 +141,9 @@ async def _analyze_current_cluster(
         reserve_drained_nodes=reserve_drained_nodes,
         pending_ec2s=[NonAssociatedInstance(ec2_instance=i) for i in pending_ec2s],
         broken_ec2s=[NonAssociatedInstance(ec2_instance=i) for i in broken_ec2s],
+        buffer_ec2s=[
+            NonAssociatedInstance(ec2_instance=i) for i in buffer_ec2_instances
+        ],
         terminating_nodes=terminating_nodes,
         terminated_instances=terminated_ec2_instances,
         disconnected_nodes=[n for n in docker_nodes if _node_not_ready(n)],

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/buffer_machines_pool_core.py
@@ -27,7 +27,7 @@ from aws_library.ec2.models import (
     Resources,
 )
 from fastapi import FastAPI
-from models_library.utils.json_serialization import json_loads
+from models_library.utils.json_serialization import json_dumps, json_loads
 from pydantic import NonNegativeInt, parse_obj_as
 from servicelib.logging_utils import log_context
 from types_aiobotocore_ec2.literals import InstanceTypeType
@@ -296,9 +296,11 @@ async def _handle_pool_image_pulling(
             tuple(instances_to_stop),
             tags={
                 _PRE_PULLED_IMAGES_EC2_TAG_KEY: AWSTagValue(
-                    app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES[
-                        instance_type
-                    ].pre_pull_images
+                    json_dumps(
+                        app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES[
+                            instance_type
+                        ].pre_pull_images
+                    )
                 )
             },
         )

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/buffer_machines_pool_core.py
@@ -1,0 +1,22 @@
+from typing import Final
+
+from aws_library.ec2.models import AWSTagKey, AWSTagValue, EC2Tags
+from fastapi import FastAPI
+from pydantic import parse_obj_as
+
+from ..modules.auto_scaling_mode_base import BaseAutoscaling
+
+_BUFFER_MACHINE_TAG_KEY: Final[AWSTagKey] = parse_obj_as(
+    AWSTagKey, "io.simcore.autoscaling.buffer_machine"
+)
+_BUFFER_MACHINE_EC2_TAGS: EC2Tags = {
+    _BUFFER_MACHINE_TAG_KEY: parse_obj_as(AWSTagValue, "true")
+}
+
+
+def get_buffer_ec2_tags(app: FastAPI, auto_scaling_mode: BaseAutoscaling) -> EC2Tags:
+    base_ec2_tags = auto_scaling_mode.get_ec2_tags(app) | _BUFFER_MACHINE_EC2_TAGS
+    base_ec2_tags[AWSTagKey("Name")] = AWSTagValue(
+        f"{base_ec2_tags[AWSTagKey('Name')]}-buffer"
+    )
+    return base_ec2_tags

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -735,6 +735,7 @@ def cluster() -> Callable[..., Cluster]:
                 reserve_drained_nodes=[],
                 pending_ec2s=[],
                 broken_ec2s=[],
+                buffer_ec2s=[],
                 disconnected_nodes=[],
                 terminating_nodes=[],
                 terminated_instances=[],

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
@@ -835,7 +835,7 @@ class _ScaleUpParams:
     imposed_instance_type: str | None
     service_resources: Resources
     num_services: int
-    expected_instance_type: str
+    expected_instance_type: InstanceTypeType
     expected_num_instances: int
 
 

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -185,8 +185,10 @@ async def _test_monitor_buffer_machines(
                     expected_num_instances=buffer_count,
                     expected_instance_type=next(iter(ec2_instances_allowed_types)),
                     expected_instance_state="running",
-                    expected_additional_tag_keys=list(ec2_instance_custom_tags),
-                    expected_pre_pulled_images=[],
+                    expected_additional_tag_keys=[
+                        *list(ec2_instance_custom_tags),
+                    ],
+                    expected_pre_pulled_images=None,
                     instance_filters=instance_type_filters,
                 )
 
@@ -218,7 +220,7 @@ async def _test_monitor_buffer_machines(
                     "ssm-command-id",
                     *list(ec2_instance_custom_tags),
                 ],
-                expected_pre_pulled_images=[],
+                expected_pre_pulled_images=None,
                 instance_filters=instance_type_filters,
             )
 
@@ -252,7 +254,7 @@ async def _test_monitor_buffer_machines(
                     _PREPULLED_EC2_TAG_KEY,
                     *list(ec2_instance_custom_tags),
                 ],
-                expected_pre_pulled_images=[],
+                expected_pre_pulled_images=pre_pulled_images,
                 instance_filters=instance_type_filters,
             )
 
@@ -378,7 +380,8 @@ async def test_monitor_buffer_machines_terminates_supernumerary_instances(
     ec2_instance_custom_tags: dict[str, str],
     initialized_app: FastAPI,
     create_buffer_machines: Callable[
-        [int, InstanceTypeType, InstanceStateNameType], Awaitable[list[str]]
+        [int, InstanceTypeType, InstanceStateNameType, list[DockerGenericTag]],
+        Awaitable[list[str]],
     ],
     expected_state_name: InstanceStateNameType,
 ):
@@ -387,6 +390,7 @@ async def test_monitor_buffer_machines_terminates_supernumerary_instances(
         buffer_count + 5,
         next(iter(list(ec2_instances_allowed_types))),
         expected_state_name,
+        [],
     )
     await assert_autoscaled_dynamic_warm_pools_ec2_instances(
         ec2_client,
@@ -394,7 +398,10 @@ async def test_monitor_buffer_machines_terminates_supernumerary_instances(
         expected_num_instances=len(buffer_machines),
         expected_instance_type=next(iter(ec2_instances_allowed_types)),
         expected_instance_state=expected_state_name,
-        expected_additional_tag_keys=list(ec2_instance_custom_tags),
+        expected_additional_tag_keys=[
+            *list(ec2_instance_custom_tags),
+            "io.simcore.autoscaling.pre_pulled_images",
+        ],
         expected_pre_pulled_images=[],
         instance_filters=instance_type_filters,
     )
@@ -408,7 +415,10 @@ async def test_monitor_buffer_machines_terminates_supernumerary_instances(
         expected_num_instances=buffer_count,
         expected_instance_type=next(iter(ec2_instances_allowed_types)),
         expected_instance_state=expected_state_name,
-        expected_additional_tag_keys=list(ec2_instance_custom_tags),
+        expected_additional_tag_keys=[
+            *list(ec2_instance_custom_tags),
+            "io.simcore.autoscaling.pre_pulled_images",
+        ],
         expected_pre_pulled_images=[],
         instance_filters=instance_type_filters,
     )

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -152,7 +152,9 @@ async def _test_monitor_buffer_machines(
 ):
     # 0. we have no instances now
     all_instances = await ec2_client.describe_instances(Filters=instance_type_filters)
-    assert not all_instances["Reservations"]
+    assert not all_instances[
+        "Reservations"
+    ], f"There should be no instances at the start of the test. Found following instance ids: {[i['InstanceId'] for r in all_instances['Reservations'] for i in r['Instances']]}"
 
     # 1. run, this will create as many buffer machines as needed
     with log_context(logging.INFO, "create buffer machines"):

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -35,7 +35,7 @@ from simcore_service_autoscaling.modules.auto_scaling_mode_dynamic import (
     DynamicAutoscaling,
 )
 from simcore_service_autoscaling.modules.buffer_machines_pool_core import (
-    _PREPULLED_EC2_TAG_KEY,
+    _PRE_PULLED_IMAGES_EC2_TAG_KEY,
     monitor_buffer_machines,
 )
 from simcore_service_autoscaling.utils.buffer_machines_pool_core import (
@@ -252,7 +252,7 @@ async def _test_monitor_buffer_machines(
                 expected_instance_type=next(iter(ec2_instances_allowed_types)),
                 expected_instance_state="stopped",
                 expected_additional_tag_keys=[
-                    _PREPULLED_EC2_TAG_KEY,
+                    _PRE_PULLED_IMAGES_EC2_TAG_KEY,
                     *list(ec2_instance_custom_tags),
                 ],
                 expected_pre_pulled_images=pre_pulled_images,
@@ -315,7 +315,7 @@ async def create_buffer_machines(
         ]
         if pre_pull_images is not None and instance_state_name == "stopped":
             resource_tags.append(
-                {"Key": _PREPULLED_EC2_TAG_KEY, "Value": f"{pre_pull_images}"}
+                {"Key": _PRE_PULLED_IMAGES_EC2_TAG_KEY, "Value": f"{pre_pull_images}"}
             )
         with log_context(
             logging.INFO, f"creating {num} buffer machines of {instance_type}"

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -472,6 +472,7 @@ def buffer_count(
             allowed_ec2_types.items(),
         )
     )
+    assert allowed_ec2_types_with_buffer_defined, "you need one type with buffer"
     assert (
         len(allowed_ec2_types_with_buffer_defined) == 1
     ), "more than one type with buffer is disallowed in this test!"

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -34,6 +34,7 @@ from simcore_service_autoscaling.modules.auto_scaling_mode_dynamic import (
     DynamicAutoscaling,
 )
 from simcore_service_autoscaling.modules.buffer_machines_pool_core import (
+    _PREPULLED_EC2_TAG_KEY,
     _get_buffer_ec2_tags,
     monitor_buffer_machines,
 )
@@ -238,7 +239,10 @@ async def _test_monitor_buffer_machines(
                 expected_num_instances=buffer_count,
                 expected_instance_type=next(iter(ec2_instances_allowed_types)),
                 expected_instance_state="stopped",
-                expected_additional_tag_keys=list(ec2_instance_custom_tags),
+                expected_additional_tag_keys=[
+                    _PREPULLED_EC2_TAG_KEY,
+                    *list(ec2_instance_custom_tags),
+                ],
                 instance_filters=instance_type_filters,
             )
 

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -591,6 +591,9 @@ def ec2_instances_allowed_types(
         )
     )
     assert (
+        allowed_ec2_types_with_buffer_defined
+    ), "one type with buffer is needed for the tests!"
+    assert (
         len(allowed_ec2_types_with_buffer_defined) == 1
     ), "more than one type with buffer is disallowed in this test!"
     return {

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -537,6 +537,15 @@ def skip_if_external_envfile_dict(external_envfile_dict: EnvVarsDict) -> None:
         pytest.skip("Skipping test since external-envfile is not set")
 
 
+def _skip_test_if_not_using_external_envfile(
+    external_envfile_dict: EnvVarsDict,
+) -> None:
+    if not external_envfile_dict:
+        pytest.skip(
+            "This test is only for use directly with AWS server, please define --external-envfile"
+        )
+
+
 async def test_monitor_buffer_machines_against_aws(
     skip_if_external_envfile_dict: None,
     disable_buffers_pool_background_task: None,
@@ -551,10 +560,7 @@ async def test_monitor_buffer_machines_against_aws(
     ec2_instance_custom_tags: dict[str, str],
     initialized_app: FastAPI,
 ):
-    if not external_envfile_dict:
-        pytest.skip(
-            "This test is only for use directly with AWS server, please define --external-envfile"
-        )
+    _skip_test_if_not_using_external_envfile(external_envfile_dict)
 
     await _test_monitor_buffer_machines(
         ec2_client=ec2_client,

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -341,6 +341,15 @@ async def create_buffer_machines(
 
         if instance_state_name == "stopped":
             await ec2_client.stop_instances(InstanceIds=instance_ids)
+            instances = await ec2_client.describe_instances(InstanceIds=instance_ids)
+            assert "Reservations" in instances
+            assert instances["Reservations"]
+            assert "Instances" in instances["Reservations"][0]
+            assert len(instances["Reservations"][0]["Instances"]) == num
+            for instance in instances["Reservations"][0]["Instances"]:
+                assert "State" in instance
+                assert "Name" in instance["State"]
+                assert instance["State"]["Name"] == "stopped"
 
         return instance_ids
 

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -35,8 +35,10 @@ from simcore_service_autoscaling.modules.auto_scaling_mode_dynamic import (
 )
 from simcore_service_autoscaling.modules.buffer_machines_pool_core import (
     _PREPULLED_EC2_TAG_KEY,
-    _get_buffer_ec2_tags,
     monitor_buffer_machines,
+)
+from simcore_service_autoscaling.utils.buffer_machines_pool_core import (
+    get_buffer_ec2_tags,
 )
 from types_aiobotocore_ec2 import EC2Client
 from types_aiobotocore_ec2.literals import InstanceTypeType
@@ -281,7 +283,7 @@ async def create_buffer_machines(
 
         resource_tags: list[TagTypeDef] = [
             {"Key": tag_key, "Value": tag_value}
-            for tag_key, tag_value in _get_buffer_ec2_tags(
+            for tag_key, tag_value in get_buffer_ec2_tags(
                 initialized_app, DynamicAutoscaling()
             ).items()
         ]


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR introduces EC2 Tag that contain the pre-pulled images list as another step towards fully fledged EBS-backed buffering.
This will be useful once OP modifies the list of pre-pulled images, or to check for compatiblilty.

- [x] introduced new tag ```io.simcore.autoscaling.pre_pulled_images``` on the EC2 instances that contains information about what was pre-pulled (e.g. it is not necessary to start the instance to find the information). This tag is added **after** pre-pulling was successfully achieved.
- [x] based on the above tag, and if the OP changes the required pre-pulled images list the autoscaling service will _terminate_ all the buffer machines with wrong pre-pulled images and create new ones with the correct images.
- [x] ensure same test code is used for ```test_monitor_buffer_machines_against``` and ```test_monitor_buffer_machines_against_aws```
- [x] main autoscaling task now also reports on available buffers **(NOTE that it is still not used)**
Driving tests: 
- ```services/autoscaling/tests/unit/test_modules_buffer_machine_core.py```
- also tested against AWS from local

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
