### PR TITLE
🐛 Fixes replicas in catalog services

### DIFF
--- a/api/specs/web-server/_catalog.py
+++ b/api/specs/web-server/_catalog.py
@@ -4,13 +4,13 @@ from fastapi import APIRouter, Depends
 from models_library.api_schemas_api_server.pricing_plans import ServicePricingPlanGet
 from models_library.api_schemas_webserver.catalog import (
     CatalogServiceGet,
+    CatalogServiceUpdate,
     ServiceGet,
     ServiceInputGet,
     ServiceInputKey,
     ServiceOutputGet,
     ServiceOutputKey,
     ServiceResourcesGet,
-    ServiceUpdate,
 )
 from models_library.generics import Envelope
 from models_library.rest_pagination import Page
@@ -59,7 +59,7 @@ def dev_get_service(_path_params: Annotated[ServicePathParams, Depends()]):
 )
 def dev_update_service(
     _path_params: Annotated[ServicePathParams, Depends()],
-    _update: ServiceUpdate,
+    _update: CatalogServiceUpdate,
 ):
     ...
 
@@ -86,7 +86,7 @@ def get_service(_path_params: Annotated[ServicePathParams, Depends()]):
 )
 def update_service(
     _path_params: Annotated[ServicePathParams, Depends()],
-    _update: ServiceUpdate,
+    _update: CatalogServiceUpdate,
 ):
     ...
 

--- a/packages/models-library/src/models_library/api_schemas_webserver/catalog.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/catalog.py
@@ -230,11 +230,6 @@ class ServiceGet(api_schemas_catalog_services.ServiceGet):
         }
 
 
-class ServiceUpdate(api_schemas_catalog_services.ServiceUpdate):
-    class Config(InputSchema.Config):
-        ...
-
-
 class ServiceResourcesGet(api_schemas_catalog_services.ServiceResourcesGet):
     class Config(OutputSchema.Config):
         ...
@@ -266,3 +261,8 @@ class CatalogServiceGet(api_schemas_catalog_services.ServiceGetV2):
                 "outputs": {"outFile": ServiceOutputGet.Config.schema_extra["example"]},
             }
         }
+
+
+class CatalogServiceUpdate(api_schemas_catalog_services.ServiceUpdate):
+    class Config(InputSchema.Config):
+        ...

--- a/services/catalog/src/simcore_service_catalog/db/repositories/_services_sql.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/_services_sql.py
@@ -238,6 +238,7 @@ def list_latest_services_with_history_stmt(
         sa.select(
             services_meta_data.c.key,
             services_meta_data.c.version,
+            services_meta_data.c.version_display,
             services_meta_data.c.deprecated,
             services_meta_data.c.created,
             services_compatibility.c.custom_policy,  # CompatiblePolicyDict | None
@@ -283,6 +284,8 @@ def list_latest_services_with_history_stmt(
                 func.json_build_object(
                     "version",
                     history_subquery.c.version,
+                    "version_display",
+                    history_subquery.c.version_display,
                     "deprecated",
                     history_subquery.c.deprecated,
                     "created",
@@ -403,6 +406,7 @@ def get_service_history_stmt(
         sa.select(
             services_meta_data.c.key,
             services_meta_data.c.version,
+            services_meta_data.c.version_display,
             services_meta_data.c.deprecated,
             services_meta_data.c.created,
             services_compatibility.c.custom_policy,  # CompatiblePolicyDict | None
@@ -447,6 +451,8 @@ def get_service_history_stmt(
                 func.json_build_object(
                     "version",
                     history_subquery.c.version,
+                    "version_display",
+                    history_subquery.c.version_display,
                     "deprecated",
                     history_subquery.c.deprecated,
                     "created",

--- a/services/catalog/src/simcore_service_catalog/db/repositories/_services_sql.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/_services_sql.py
@@ -377,7 +377,8 @@ def get_service_history_stmt(
     access_rights: sa.sql.ClauseElement,
     service_key: ServiceKey,
 ):
-    history_subquery = (
+
+    _sq = (
         sa.select(
             services_meta_data.c.key,
             services_meta_data.c.version,
@@ -408,9 +409,13 @@ def get_service_history_stmt(
             & (user_to_groups.c.uid == user_id)
             & access_rights
         )
+        .distinct()
+    ).subquery()
+
+    history_subquery = (
+        sa.select(_sq)
         .order_by(
-            services_meta_data.c.key,
-            sa.desc(_version(services_meta_data.c.version)),  # latest version first
+            sa.desc(_version(_sq.c.version)),  # latest version first
         )
         .alias("history_subquery")
     )

--- a/services/catalog/src/simcore_service_catalog/db/repositories/_services_sql.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/_services_sql.py
@@ -255,7 +255,7 @@ def list_latest_services_with_history_stmt(
         )
         .order_by(
             services_meta_data.c.key,
-            sa.asc(_version(services_meta_data.c.version)),  # latest version first
+            sa.desc(_version(services_meta_data.c.version)),  # latest version first
         )
         .subquery("history_sq")
     )

--- a/services/catalog/src/simcore_service_catalog/models/services_db.py
+++ b/services/catalog/src/simcore_service_catalog/models/services_db.py
@@ -53,6 +53,7 @@ class ServiceMetaDataAtDB(ServiceKeyVersion, ServiceMetaDataEditable):
 
 class ReleaseFromDB(BaseModel):
     version: ServiceVersion
+    version_display: str | None
     deprecated: datetime | None
     created: datetime
     compatibility_policy: CompatiblePolicyDict | None

--- a/services/catalog/src/simcore_service_catalog/services/services_api.py
+++ b/services/catalog/src/simcore_service_catalog/services/services_api.py
@@ -78,6 +78,7 @@ def _db_to_api_model(
         history=[
             ServiceRelease.construct(
                 version=h.version,
+                version_display=h.version_display,
                 released=h.created,
                 retired=h.deprecated,
                 compatibility=compatibility_map.get(h.version),

--- a/services/catalog/tests/unit/test_db_repositories_services_sql.py
+++ b/services/catalog/tests/unit/test_db_repositories_services_sql.py
@@ -24,14 +24,16 @@ def test_building_services_sql_statements():
 
     # some data
     product_name = "osparc"
-    user_id = 425  # 4
+    user_id = 4  # 425 (san)  # 4 (odei)
+    service_key = "simcore/services/comp/isolve"
+    service_version = "2.11.2"
 
     _check(
         get_service_history_stmt,
         product_name=product_name,
         user_id=user_id,
         access_rights=AccessRightsClauses.can_read,
-        service_key="simcore/services/comp/isolve",
+        service_key="simcore/services/dynamic/raw-graphs",
     )
 
     _check(

--- a/services/catalog/tests/unit/test_db_repositories_services_sql.py
+++ b/services/catalog/tests/unit/test_db_repositories_services_sql.py
@@ -62,7 +62,7 @@ def test_building_services_sql_statements():
         product_name=product_name,
         user_id=user_id,
         access_rights=AccessRightsClauses.can_read,
-        limit=10,
+        limit=100,
         offset=None,
     )
 

--- a/services/catalog/tests/unit/test_db_repositories_services_sql.py
+++ b/services/catalog/tests/unit/test_db_repositories_services_sql.py
@@ -26,6 +26,9 @@ def test_building_services_sql_statements():
     product_name = "osparc"
     user_id = 4  # 425 (san)  # 4 (odei)
     service_key = "simcore/services/comp/isolve"
+    service_version = "2.0.85"
+
+    service_key = "simcore/services/dynamic/raw-graphs"
     service_version = "2.11.2"
 
     _check(
@@ -33,7 +36,7 @@ def test_building_services_sql_statements():
         product_name=product_name,
         user_id=user_id,
         access_rights=AccessRightsClauses.can_read,
-        service_key="simcore/services/dynamic/raw-graphs",
+        service_key=service_key,
     )
 
     _check(
@@ -41,8 +44,8 @@ def test_building_services_sql_statements():
         product_name=product_name,
         user_id=user_id,
         access_rights=AccessRightsClauses.can_read,
-        service_key="simcore/services/comp/isolve",
-        service_version="2.0.85",
+        service_key=service_key,
+        service_version=service_version,
     )
 
     _check(
@@ -50,8 +53,8 @@ def test_building_services_sql_statements():
         product_name=product_name,
         user_id=user_id,
         access_rights=AccessRightsClauses.can_read,
-        service_key="simcore/services/comp/isolve",
-        service_version="2.0.85",
+        service_key=service_key,
+        service_version=service_version,
     )
 
     _check(

--- a/services/catalog/tests/unit/with_dbs/test_api_rpc.py
+++ b/services/catalog/tests/unit/with_dbs/test_api_rpc.py
@@ -149,6 +149,7 @@ async def test_rpc_catalog_client(
         update={
             "name": "foo",
             "description": "bar",
+            "version_display": "this is a nice version",
         },
     )
 
@@ -156,6 +157,7 @@ async def test_rpc_catalog_client(
     assert updated.version == got.version
     assert updated.name == "foo"
     assert updated.description == "bar"
+    assert updated.version_display == "this is a nice version"
     assert not updated.classifiers
 
     got = await get_service(

--- a/services/director/src/simcore_service_director/api/v0/schemas/node-meta-v0.0.1.json
+++ b/services/director/src/simcore_service_director/api/v0/schemas/node-meta-v0.0.1.json
@@ -42,6 +42,10 @@
         "0.0.1"
       ]
     },
+    "version_display": {
+      "type": "string",
+      "description": "human readable version"
+    },
     "type": {
       "type": "string",
       "description": "service type",

--- a/services/web/server/src/simcore_service_webserver/catalog/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_handlers.py
@@ -13,10 +13,10 @@ from aiohttp import web
 from aiohttp.web import Request, RouteTableDef
 from models_library.api_schemas_webserver.catalog import (
     CatalogServiceGet,
+    CatalogServiceUpdate,
     ServiceGet,
     ServiceInputKey,
     ServiceOutputKey,
-    ServiceUpdate,
 )
 from models_library.api_schemas_webserver.resource_usage import PricingPlanGet
 from models_library.rest_pagination import Page, PageQueryParameters
@@ -145,7 +145,9 @@ async def dev_get_service(request: Request):
 async def dev_update_service(request: Request):
     request_ctx = CatalogRequestContext.create(request)
     path_params = parse_request_path_parameters_as(ServicePathParams, request)
-    update: ServiceUpdate = await parse_request_body_as(ServiceUpdate, request)
+    update: CatalogServiceUpdate = await parse_request_body_as(
+        CatalogServiceUpdate, request
+    )
 
     assert request_ctx  # nosec
     assert path_params  # nosec
@@ -216,7 +218,7 @@ async def update_service(request: Request):
     path_params = parse_request_path_parameters_as(ServicePathParams, request)
     update_data: dict[str, Any] = await request.json(loads=json_loads)
 
-    assert parse_obj_as(ServiceUpdate, update_data) is not None  # nosec
+    assert parse_obj_as(CatalogServiceUpdate, update_data) is not None  # nosec
 
     # Evaluate and return validated model
     data = await _api.update_service(

--- a/services/web/server/tests/unit/with_dbs/01/test_catalog_handlers__services.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_catalog_handlers__services.py
@@ -11,7 +11,7 @@ from aiohttp.test_utils import TestClient
 from models_library.api_schemas_catalog.services import ServiceGetV2
 from models_library.api_schemas_webserver.catalog import (
     CatalogServiceGet,
-    ServiceUpdate,
+    CatalogServiceUpdate,
 )
 from models_library.products import ProductName
 from models_library.rest_pagination import Page
@@ -94,7 +94,7 @@ def mocked_rpc_catalog_service_api(mocker: MockerFixture) -> dict[str, MagicMock
         user_id: UserID,
         service_key: ServiceKey,
         service_version: ServiceVersion,
-        update: ServiceUpdate,
+        update: CatalogServiceUpdate,
     ):
         assert app
         assert product_name
@@ -188,7 +188,7 @@ async def test_dev_get_and_patch_service(
     assert not mocked_rpc_catalog_service_api["update_service"].called
 
     # PATCH
-    update = ServiceUpdate(
+    update = CatalogServiceUpdate(
         name="foo",
         thumbnail=None,
         description="bar",

--- a/services/web/server/tests/unit/with_dbs/01/test_catalog_handlers__services.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_catalog_handlers__services.py
@@ -193,6 +193,7 @@ async def test_dev_get_and_patch_service(
         thumbnail=None,
         description="bar",
         classifiers=None,
+        versionDisplay="Some nice name",
     )
     response = await client.patch(
         f"{url}", json=jsonable_encoder(update, exclude_unset=True)
@@ -206,6 +207,7 @@ async def test_dev_get_and_patch_service(
     assert model.version == service_version
     assert model.name == "foo"
     assert model.description == "bar"
+    assert model.version_display == "Some nice name"
 
     assert mocked_rpc_catalog_service_api["get_service"].call_count == 1
     assert mocked_rpc_catalog_service_api["update_service"].call_count == 1


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

A user might gain access to the same service via different groups. This resulted in replicas after joins which made the catalog malfunction

- 🐛Fixes queries for users with multiple GID giving access to the same service
- ✅ Adds more tests for update
- 🐛now returns `versionDisplay` as well in the history
![image](https://github.com/user-attachments/assets/c210da76-2129-4b7d-b176-bde0e2e08e5d)

## Related issue/s

- Fixes on code for #5964 

## How to test

in place

## Dev-ops checklist
No
- Will reduce replicas of catalog in [osparc-config](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/730)