### PR TITLE
🐛 catalog: fixes access-rights to `get` and `update` services

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: v2.1.4
     hooks:
       - id: pycln
-        args: [--all, --expand-stars]
+        args: [--expand-stars]
         name: prune imports
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: v2.1.4
     hooks:
       - id: pycln
-        args: [--expand-stars]
+        args: [--all, --expand-stars]
         name: prune imports
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -2,7 +2,7 @@ import itertools
 import logging
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import Any, cast
+from typing import Any
 
 import packaging.version
 import sqlalchemy as sa
@@ -268,7 +268,7 @@ class ServicesRepository(BaseRepository):
             if returning:
                 row = result.first()
                 assert row  # nosec
-                return cast(ServiceMetaDataAtDB, ServiceMetaDataAtDB.from_orm(row))
+                return ServiceMetaDataAtDB.from_orm(row)
         return None
 
     async def can_get_service(

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -265,14 +265,11 @@ class ServicesRepository(BaseRepository):
 
         async with self.db_engine.begin() as conn:
             result = await conn.execute(stmt_update)
-            row = result.first()
-            assert row  # nosec
-
-        return (
-            cast(ServiceMetaDataAtDB, ServiceMetaDataAtDB.from_orm(row))
-            if returning
-            else None
-        )
+            if returning:
+                row = result.first()
+                assert row  # nosec
+                return cast(ServiceMetaDataAtDB, ServiceMetaDataAtDB.from_orm(row))
+        return None
 
     async def can_get_service(
         self,

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -243,9 +243,7 @@ class ServicesRepository(BaseRepository):
                 await conn.execute(insert_stmt)
         return created_service
 
-    async def update_service(
-        self, patched_service: ServiceMetaDataAtDB, *, returning: bool = False
-    ) -> ServiceMetaDataAtDB | None:
+    async def update_service(self, patched_service: ServiceMetaDataAtDB) -> None:
 
         stmt_update = (
             services_meta_data.update()
@@ -261,16 +259,8 @@ class ServicesRepository(BaseRepository):
                 )
             )
         )
-        if returning:
-            stmt_update = stmt_update.returning(literal_column("*"))
-
         async with self.db_engine.begin() as conn:
-            result = await conn.execute(stmt_update)
-            if returning:
-                row = result.first()
-                assert row  # nosec
-                return ServiceMetaDataAtDB.from_orm(row)
-        return None
+            await conn.execute(stmt_update)
 
     async def can_get_service(
         self,

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -243,7 +243,7 @@ class ServicesRepository(BaseRepository):
         return created_service
 
     async def update_service(
-        self, patched_service: ServiceMetaDataAtDB, *, returning: bool = True
+        self, patched_service: ServiceMetaDataAtDB, *, returning: bool = False
     ) -> ServiceMetaDataAtDB | None:
 
         stmt_update = (

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -176,6 +176,7 @@ class ServicesRepository(BaseRepository):
         write_access: bool | None = None,
         product_name: str | None = None,
     ) -> ServiceMetaDataAtDB | None:
+
         query = sa.select(services_meta_data).where(
             (services_meta_data.c.key == key)
             & (services_meta_data.c.version == version)

--- a/services/catalog/src/simcore_service_catalog/db/repositories/services.py
+++ b/services/catalog/src/simcore_service_catalog/db/repositories/services.py
@@ -44,7 +44,7 @@ from ._services_sql import (
 _logger = logging.getLogger(__name__)
 
 
-def is_newer(
+def _is_newer(
     old: ServiceSpecificationsAtDB | None,
     new: ServiceSpecificationsAtDB,
 ) -> bool:
@@ -54,7 +54,7 @@ def is_newer(
     )
 
 
-def merge_specs(
+def _merge_specs(
     everyone_spec: ServiceSpecificationsAtDB | None,
     team_specs: dict[GroupID, ServiceSpecificationsAtDB],
     user_spec: ServiceSpecificationsAtDB | None,
@@ -600,16 +600,16 @@ class ServicesRepository(BaseRepository):
                         continue
                     # filter by group type
                     group = gid_to_group_map[row.gid]
-                    if (group.group_type == GroupTypeInModel.STANDARD) and is_newer(
+                    if (group.group_type == GroupTypeInModel.STANDARD) and _is_newer(
                         teams_specs.get(db_service_spec.gid),
                         db_service_spec,
                     ):
                         teams_specs[db_service_spec.gid] = db_service_spec
-                    elif (group.group_type == GroupTypeInModel.EVERYONE) and is_newer(
+                    elif (group.group_type == GroupTypeInModel.EVERYONE) and _is_newer(
                         everyone_specs, db_service_spec
                     ):
                         everyone_specs = db_service_spec
-                    elif (group.group_type == GroupTypeInModel.PRIMARY) and is_newer(
+                    elif (group.group_type == GroupTypeInModel.PRIMARY) and _is_newer(
                         primary_specs, db_service_spec
                     ):
                         primary_specs = db_service_spec
@@ -621,7 +621,7 @@ class ServicesRepository(BaseRepository):
                         f"{exc}",
                     )
 
-        if merged_specifications := merge_specs(
+        if merged_specifications := _merge_specs(
             everyone_specs, teams_specs, primary_specs
         ):
             return ServiceSpecifications.parse_obj(merged_specifications)

--- a/services/catalog/src/simcore_service_catalog/services/services_api.py
+++ b/services/catalog/src/simcore_service_catalog/services/services_api.py
@@ -274,7 +274,7 @@ async def update_service(
         await repo.upsert_service_access_rights(new_access_rights)
 
         # then delete the ones that were removed
-        rm_access_rights = [
+        removed_access_rights = [
             ServiceAccessRightsAtDB(
                 key=service_key,
                 version=service_version,
@@ -284,7 +284,7 @@ async def update_service(
             for gid in previous_gids
             if gid not in update.access_rights
         ]
-        await repo.delete_service_access_rights(rm_access_rights)
+        await repo.delete_service_access_rights(removed_access_rights)
 
     return await get_service(
         repo=repo,

--- a/services/catalog/src/simcore_service_catalog/services/services_api.py
+++ b/services/catalog/src/simcore_service_catalog/services/services_api.py
@@ -249,8 +249,7 @@ async def update_service(
             key=service_key,
             version=service_version,
             **update.dict(exclude_unset=True),
-        ),
-        returning=None,
+        )
     )
 
     # Updates service_access_rights (they can be added/removed/modified)

--- a/services/catalog/tests/unit/with_dbs/conftest.py
+++ b/services/catalog/tests/unit/with_dbs/conftest.py
@@ -368,8 +368,8 @@ async def create_fake_service_data(
         fake_service, *fake_access_rights = create_fake_service_data(
                 "simcore/services/dynamic/jupyterlab",
                 "0.0.1",
-                team_access=None,
-                everyone_access=None,
+                team_access="xw",
+                everyone_access="x",
                 product=target_product,
             ),
 

--- a/services/catalog/tests/unit/with_dbs/test_db_repositories.py
+++ b/services/catalog/tests/unit/with_dbs/test_db_repositories.py
@@ -384,7 +384,8 @@ async def test_get_and_update_service_meta_data(
     updated = await services_repo.update_service(
         ServiceMetaDataAtDB.construct(
             key=service_key, version=service_version, name="foo"
-        )
+        ),
+        returning=True,
     )
 
     assert got.copy(update={"name": "foo"}) == updated

--- a/services/catalog/tests/unit/with_dbs/test_db_repositories.py
+++ b/services/catalog/tests/unit/with_dbs/test_db_repositories.py
@@ -381,12 +381,12 @@ async def test_get_and_update_service_meta_data(
     assert got.key == service_key
     assert got.version == service_version
 
-    updated = await services_repo.update_service(
+    await services_repo.update_service(
         ServiceMetaDataAtDB.construct(
             key=service_key, version=service_version, name="foo"
         ),
-        returning=True,
     )
+    updated = await services_repo.get_service(service_key, service_version)
 
     assert got.copy(update={"name": "foo"}) == updated
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

 🐛 enforces access-rights for `get` and `update` on the catalog service


## Related issue/s

- Part of https://github.com/ITISFoundation/osparc-simcore/issues/6201

## How to test

```
make devenv
cd services/catalog
make install-dev
pytest -v -k test_rpc_get_service_access_rights tests
```

## Dev-ops checklist
None