### PR TITLE
✨Autoscaling: instrumentation improvements

### DIFF
--- a/packages/aws-library/src/aws_library/ec2/client.py
+++ b/packages/aws-library/src/aws_library/ec2/client.py
@@ -108,7 +108,7 @@ class SimcoreEC2API:
                 raise EC2InstanceTypeInvalidError from exc
             raise EC2RuntimeError from exc  # pragma: no cover
 
-    async def launch_aws_instance(
+    async def launch_instances(
         self,
         instance_config: EC2InstanceConfig,
         *,

--- a/packages/aws-library/src/aws_library/ec2/client.py
+++ b/packages/aws-library/src/aws_library/ec2/client.py
@@ -108,7 +108,7 @@ class SimcoreEC2API:
                 raise EC2InstanceTypeInvalidError from exc
             raise EC2RuntimeError from exc  # pragma: no cover
 
-    async def start_aws_instance(
+    async def launch_aws_instance(
         self,
         instance_config: EC2InstanceConfig,
         *,
@@ -116,7 +116,7 @@ class SimcoreEC2API:
         number_of_instances: PositiveInt,
         max_total_number_of_instances: PositiveInt = 10,
     ) -> list[EC2InstanceData]:
-        """starts EC2 instances
+        """launch new EC2 instance(s)
 
         Arguments:
             instance_config -- The EC2 instance configuration

--- a/packages/aws-library/src/aws_library/ec2/client.py
+++ b/packages/aws-library/src/aws_library/ec2/client.py
@@ -34,7 +34,7 @@ from .utils import compose_user_data
 _logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass()
 class SimcoreEC2API:
     client: EC2Client
     session: aioboto3.Session

--- a/packages/aws-library/tests/test_ec2_client.py
+++ b/packages/aws-library/tests/test_ec2_client.py
@@ -185,7 +185,7 @@ async def _assert_instances_in_ec2(
             assert instance["State"]["Name"] == expected_state
 
 
-async def test_start_aws_instance(
+async def test_launch_aws_instance(
     simcore_ec2_api: SimcoreEC2API,
     ec2_client: EC2Client,
     ec2_instance_config: EC2InstanceConfig,
@@ -226,7 +226,7 @@ async def test_start_aws_instance(
 
 
 @pytest.mark.parametrize("max_num_instances", [13])
-async def test_start_aws_instance_is_limited_in_number_of_instances(
+async def test_launch_aws_instance_is_limited_in_number_of_instances(
     simcore_ec2_api: SimcoreEC2API,
     ec2_client: EC2Client,
     ec2_instance_config: EC2InstanceConfig,

--- a/packages/aws-library/tests/test_ec2_client.py
+++ b/packages/aws-library/tests/test_ec2_client.py
@@ -185,7 +185,7 @@ async def _assert_instances_in_ec2(
             assert instance["State"]["Name"] == expected_state
 
 
-async def test_launch_aws_instance(
+async def test_launch_instances(
     simcore_ec2_api: SimcoreEC2API,
     ec2_client: EC2Client,
     ec2_instance_config: EC2InstanceConfig,
@@ -195,7 +195,7 @@ async def test_launch_aws_instance(
     number_of_instances = 1
 
     # let's create a first reservation and check that it is correctly created in EC2
-    await simcore_ec2_api.launch_aws_instance(
+    await simcore_ec2_api.launch_instances(
         ec2_instance_config,
         min_number_of_instances=number_of_instances,
         number_of_instances=number_of_instances,
@@ -210,7 +210,7 @@ async def test_launch_aws_instance(
     )
 
     # create a second reservation
-    await simcore_ec2_api.launch_aws_instance(
+    await simcore_ec2_api.launch_instances(
         ec2_instance_config,
         min_number_of_instances=number_of_instances,
         number_of_instances=number_of_instances,
@@ -226,7 +226,7 @@ async def test_launch_aws_instance(
 
 
 @pytest.mark.parametrize("max_num_instances", [13])
-async def test_launch_aws_instance_is_limited_in_number_of_instances(
+async def test_launch_instances_is_limited_in_number_of_instances(
     simcore_ec2_api: SimcoreEC2API,
     ec2_client: EC2Client,
     ec2_instance_config: EC2InstanceConfig,
@@ -236,7 +236,7 @@ async def test_launch_aws_instance_is_limited_in_number_of_instances(
 
     # create many instances in one go shall fail
     with pytest.raises(EC2TooManyInstancesError):
-        await simcore_ec2_api.launch_aws_instance(
+        await simcore_ec2_api.launch_instances(
             ec2_instance_config,
             min_number_of_instances=max_num_instances + 1,
             number_of_instances=max_num_instances + 1,
@@ -246,7 +246,7 @@ async def test_launch_aws_instance_is_limited_in_number_of_instances(
 
     # create instances 1 by 1
     for _ in range(max_num_instances):
-        await simcore_ec2_api.launch_aws_instance(
+        await simcore_ec2_api.launch_instances(
             ec2_instance_config,
             min_number_of_instances=1,
             number_of_instances=1,
@@ -263,7 +263,7 @@ async def test_launch_aws_instance_is_limited_in_number_of_instances(
 
     # now creating one more shall fail
     with pytest.raises(EC2TooManyInstancesError):
-        await simcore_ec2_api.launch_aws_instance(
+        await simcore_ec2_api.launch_instances(
             ec2_instance_config,
             min_number_of_instances=1,
             number_of_instances=1,
@@ -297,7 +297,7 @@ async def test_get_instances(
     # create some instance
     _MAX_NUM_INSTANCES = 10
     num_instances = faker.pyint(min_value=1, max_value=_MAX_NUM_INSTANCES)
-    created_instances = await simcore_ec2_api.launch_aws_instance(
+    created_instances = await simcore_ec2_api.launch_instances(
         ec2_instance_config,
         min_number_of_instances=num_instances,
         number_of_instances=num_instances,
@@ -354,7 +354,7 @@ async def test_stop_instances(
     # create some instance
     _NUM_INSTANCES = 10
     num_instances = faker.pyint(min_value=1, max_value=_NUM_INSTANCES)
-    created_instances = await simcore_ec2_api.launch_aws_instance(
+    created_instances = await simcore_ec2_api.launch_instances(
         ec2_instance_config,
         min_number_of_instances=num_instances,
         number_of_instances=num_instances,
@@ -401,7 +401,7 @@ async def test_terminate_instance(
     # create some instance
     _NUM_INSTANCES = 10
     num_instances = faker.pyint(min_value=1, max_value=_NUM_INSTANCES)
-    created_instances = await simcore_ec2_api.launch_aws_instance(
+    created_instances = await simcore_ec2_api.launch_instances(
         ec2_instance_config,
         min_number_of_instances=num_instances,
         number_of_instances=num_instances,
@@ -467,7 +467,7 @@ async def test_set_instance_tags(
     # create some instance
     _MAX_NUM_INSTANCES = 10
     num_instances = faker.pyint(min_value=1, max_value=_MAX_NUM_INSTANCES)
-    created_instances = await simcore_ec2_api.launch_aws_instance(
+    created_instances = await simcore_ec2_api.launch_instances(
         ec2_instance_config,
         min_number_of_instances=num_instances,
         number_of_instances=num_instances,

--- a/packages/aws-library/tests/test_ec2_client.py
+++ b/packages/aws-library/tests/test_ec2_client.py
@@ -195,7 +195,7 @@ async def test_start_aws_instance(
     number_of_instances = 1
 
     # let's create a first reservation and check that it is correctly created in EC2
-    await simcore_ec2_api.start_aws_instance(
+    await simcore_ec2_api.launch_aws_instance(
         ec2_instance_config,
         min_number_of_instances=number_of_instances,
         number_of_instances=number_of_instances,
@@ -210,7 +210,7 @@ async def test_start_aws_instance(
     )
 
     # create a second reservation
-    await simcore_ec2_api.start_aws_instance(
+    await simcore_ec2_api.launch_aws_instance(
         ec2_instance_config,
         min_number_of_instances=number_of_instances,
         number_of_instances=number_of_instances,
@@ -236,7 +236,7 @@ async def test_start_aws_instance_is_limited_in_number_of_instances(
 
     # create many instances in one go shall fail
     with pytest.raises(EC2TooManyInstancesError):
-        await simcore_ec2_api.start_aws_instance(
+        await simcore_ec2_api.launch_aws_instance(
             ec2_instance_config,
             min_number_of_instances=max_num_instances + 1,
             number_of_instances=max_num_instances + 1,
@@ -246,7 +246,7 @@ async def test_start_aws_instance_is_limited_in_number_of_instances(
 
     # create instances 1 by 1
     for _ in range(max_num_instances):
-        await simcore_ec2_api.start_aws_instance(
+        await simcore_ec2_api.launch_aws_instance(
             ec2_instance_config,
             min_number_of_instances=1,
             number_of_instances=1,
@@ -263,7 +263,7 @@ async def test_start_aws_instance_is_limited_in_number_of_instances(
 
     # now creating one more shall fail
     with pytest.raises(EC2TooManyInstancesError):
-        await simcore_ec2_api.start_aws_instance(
+        await simcore_ec2_api.launch_aws_instance(
             ec2_instance_config,
             min_number_of_instances=1,
             number_of_instances=1,
@@ -297,7 +297,7 @@ async def test_get_instances(
     # create some instance
     _MAX_NUM_INSTANCES = 10
     num_instances = faker.pyint(min_value=1, max_value=_MAX_NUM_INSTANCES)
-    created_instances = await simcore_ec2_api.start_aws_instance(
+    created_instances = await simcore_ec2_api.launch_aws_instance(
         ec2_instance_config,
         min_number_of_instances=num_instances,
         number_of_instances=num_instances,
@@ -354,7 +354,7 @@ async def test_stop_instances(
     # create some instance
     _NUM_INSTANCES = 10
     num_instances = faker.pyint(min_value=1, max_value=_NUM_INSTANCES)
-    created_instances = await simcore_ec2_api.start_aws_instance(
+    created_instances = await simcore_ec2_api.launch_aws_instance(
         ec2_instance_config,
         min_number_of_instances=num_instances,
         number_of_instances=num_instances,
@@ -401,7 +401,7 @@ async def test_terminate_instance(
     # create some instance
     _NUM_INSTANCES = 10
     num_instances = faker.pyint(min_value=1, max_value=_NUM_INSTANCES)
-    created_instances = await simcore_ec2_api.start_aws_instance(
+    created_instances = await simcore_ec2_api.launch_aws_instance(
         ec2_instance_config,
         min_number_of_instances=num_instances,
         number_of_instances=num_instances,
@@ -467,7 +467,7 @@ async def test_set_instance_tags(
     # create some instance
     _MAX_NUM_INSTANCES = 10
     num_instances = faker.pyint(min_value=1, max_value=_MAX_NUM_INSTANCES)
-    created_instances = await simcore_ec2_api.start_aws_instance(
+    created_instances = await simcore_ec2_api.launch_aws_instance(
         ec2_instance_config,
         min_number_of_instances=num_instances,
         number_of_instances=num_instances,

--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -98,7 +98,7 @@ class Cluster:  # pylint: disable=too-many-instance-attributes
             "description": "This is a EC2-backed docker node which is docker drained and waiting for termination"
         }
     )
-    terminated_instances: list[EC2InstanceData]
+    terminated_instances: list[NonAssociatedInstance]
 
     def can_scale_down(self) -> bool:
         return bool(
@@ -110,6 +110,7 @@ class Cluster:  # pylint: disable=too-many-instance-attributes
         )
 
     def total_number_of_machines(self) -> int:
+        """return the number of machines that are swtiched on"""
         return (
             len(self.active_nodes)
             + len(self.pending_nodes)
@@ -136,6 +137,7 @@ class Cluster:  # pylint: disable=too-many-instance-attributes
             f"buffer-ec2s: count={len(self.buffer_ec2s)} {_get_instance_ids(self.buffer_ec2s)}, "
             f"disconnected-nodes: count={len(self.disconnected_nodes)}, "
             f"terminating-nodes: count={len(self.terminating_nodes)} {_get_instance_ids(self.terminating_nodes)}, "
+            f"terminated-ec2s: count={len(self.terminated_instances)} {_get_instance_ids(self.terminated_instances)}, "
         )
 
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -928,7 +928,11 @@ async def _try_scale_down_cluster(app: FastAPI, cluster: Cluster) -> Cluster:
         cluster,
         drained_nodes=still_drained_nodes,
         terminating_nodes=cluster.terminating_nodes + new_terminating_instances,
-        terminated_instances=cluster.terminated_instances + instances_to_terminate,
+        terminated_instances=cluster.terminated_instances
+        + [
+            NonAssociatedInstance(ec2_instance=i.ec2_instance)
+            for i in instances_to_terminate
+        ],
     )
 
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -642,7 +642,7 @@ async def _start_instances(
 
     results = await asyncio.gather(
         *[
-            ec2_client.launch_aws_instance(
+            ec2_client.launch_instances(
                 EC2InstanceConfig(
                     type=instance_type,
                     tags=new_instance_tags,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -1027,7 +1027,7 @@ async def _autoscale_cluster(
 async def _notify_autoscaling_status(
     app: FastAPI, cluster: Cluster, auto_scaling_mode: BaseAutoscaling
 ) -> None:
-    # inform on rabbit about status
+
     monitored_instances = list(
         itertools.chain(
             cluster.active_nodes, cluster.drained_nodes, cluster.reserve_drained_nodes
@@ -1045,9 +1045,11 @@ async def _notify_autoscaling_status(
                 ),
             )
         )
+        # inform on rabbitMQ about status
         await post_autoscaling_status_message(
             app, cluster, total_resources, used_resources
         )
+        # prometheus instrumentation
         if has_instrumentation(app):
             get_instrumentation(app).update_from_cluster(cluster)
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -642,7 +642,7 @@ async def _start_instances(
 
     results = await asyncio.gather(
         *[
-            ec2_client.start_aws_instance(
+            ec2_client.launch_aws_instance(
                 EC2InstanceConfig(
                     type=instance_type,
                     tags=new_instance_tags,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -145,7 +145,9 @@ async def _analyze_current_cluster(
             NonAssociatedInstance(ec2_instance=i) for i in buffer_ec2_instances
         ],
         terminating_nodes=terminating_nodes,
-        terminated_instances=terminated_ec2_instances,
+        terminated_instances=[
+            NonAssociatedInstance(ec2_instance=i) for i in terminated_ec2_instances
+        ],
         disconnected_nodes=[n for n in docker_nodes if _node_not_ready(n)],
     )
     _logger.info("current state: %s", f"{cluster!r}")
@@ -186,7 +188,7 @@ async def _terminate_broken_ec2s(app: FastAPI, cluster: Cluster) -> Cluster:
     return dataclasses.replace(
         cluster,
         broken_ec2s=[],
-        terminated_instances=cluster.terminated_instances + broken_instances,
+        terminated_instances=cluster.terminated_instances + cluster.broken_ec2s,
     )
 
 
@@ -926,8 +928,7 @@ async def _try_scale_down_cluster(app: FastAPI, cluster: Cluster) -> Cluster:
         cluster,
         drained_nodes=still_drained_nodes,
         terminating_nodes=cluster.terminating_nodes + new_terminating_instances,
-        terminated_instances=cluster.terminated_instances
-        + [i.ec2_instance for i in instances_to_terminate],
+        terminated_instances=cluster.terminated_instances + instances_to_terminate,
     )
 
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -685,12 +685,12 @@ async def _start_instances(
             if has_instrumentation(app):
                 instrumentation = get_instrumentation(app)
                 for instance_data in r:
-                    instrumentation.instance_started(instance_data.type)
+                    instrumentation.instance_launched(instance_data.type)
         else:
             new_pending_instances.append(r)
             if has_instrumentation(app):
                 instrumentation = get_instrumentation(app)
-                instrumentation.instance_started(r.type)
+                instrumentation.instance_launched(r.type)
 
     log_message = (
         f"{sum(n for n in capped_needed_machines.values())} new machines launched"

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/buffer_machines_pool_core.py
@@ -211,7 +211,7 @@ async def _add_remove_buffer_instances(
         ec2_boot_specific = (
             app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES[ec2_type]
         )
-        await ec2_client.launch_aws_instance(
+        await ec2_client.launch_instances(
             EC2InstanceConfig(
                 type=EC2InstanceType(
                     name=ec2_type,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/buffer_machines_pool_core.py
@@ -211,7 +211,7 @@ async def _add_remove_buffer_instances(
         ec2_boot_specific = (
             app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES[ec2_type]
         )
-        await ec2_client.start_aws_instance(
+        await ec2_client.launch_aws_instance(
             EC2InstanceConfig(
                 type=EC2InstanceType(
                     name=ec2_type,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -27,8 +27,12 @@ def _update_gauge(
 
 
 @dataclass(slots=True, kw_only=True)
-class ClusterMetrics:
+class MetricsBase:
     subsystem: str
+
+
+@dataclass(slots=True, kw_only=True)
+class ClusterMetrics(MetricsBase):  # pylint: disable=too-many-instance-attributes
     _active_nodes: Gauge = field(init=False)
     _pending_nodes: Gauge = field(init=False)
     _drained_nodes: Gauge = field(init=False)
@@ -125,9 +129,8 @@ class ClusterMetrics:
 
 
 @dataclass(slots=True, kw_only=True)
-class AutoscalingInstrumentation:  # pylint: disable=too-many-instance-attributes
+class AutoscalingInstrumentation(MetricsBase):
     registry: CollectorRegistry
-    subsystem: str
 
     _cluster_metrics: ClusterMetrics = field(init=False)
     _launched_instances: Counter = field(init=False)

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -27,7 +27,7 @@ def _update_gauge(
 
 
 @dataclass(slots=True, kw_only=True)
-class ClusterInstrumentation:
+class ClusterMetrics:
     subsystem: str
     _active_nodes: Gauge = field(init=False)
     _pending_nodes: Gauge = field(init=False)
@@ -129,14 +129,14 @@ class AutoscalingInstrumentation:  # pylint: disable=too-many-instance-attribute
     registry: CollectorRegistry
     subsystem: str
 
-    _cluster_instrumentation: ClusterInstrumentation = field(init=False)
+    _cluster_metrics: ClusterMetrics = field(init=False)
     _launched_instances: Counter = field(init=False)
     _started_instances: Counter = field(init=False)
     _stopped_instances: Counter = field(init=False)
     _terminated_instances: Counter = field(init=False)
 
     def __post_init__(self) -> None:
-        self._cluster_instrumentation = ClusterInstrumentation(subsystem=self.subsystem)
+        self._cluster_metrics = ClusterMetrics(subsystem=self.subsystem)
         self._launched_instances = Counter(
             "launched_instances_total",
             "Number of EC2 instances that were launched",
@@ -165,6 +165,9 @@ class AutoscalingInstrumentation:  # pylint: disable=too-many-instance-attribute
             namespace=METRICS_NAMESPACE,
             subsystem=self.subsystem,
         )
+
+    def update_from_cluster(self, cluster: Cluster) -> None:
+        self._cluster_metrics.update_from_cluster(cluster)
 
     def instance_started(self, instance_type: str) -> None:
         self._started_instances.labels(instance_type=instance_type).inc()

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -224,19 +224,7 @@ def _instrumented_ec2_client_method(
     return decorator
 
 
-def _get_instance_type_from_launch_instances_return_value(
-    instance_datas: list[EC2InstanceData],
-) -> list[str]:
-    return [i.type for i in instance_datas]
-
-
-def _get_instance_type_from_stop_instances_args(
-    instance_datas: Iterable[EC2InstanceData],
-) -> list[str]:
-    return [i.type for i in instance_datas]
-
-
-def _get_instance_type_from_terminate_instances_args(
+def _instance_type_from_instance_datas(
     instance_datas: Iterable[EC2InstanceData],
 ) -> list[str]:
     return [i.type for i in instance_datas]
@@ -251,18 +239,18 @@ def instrument_ec2_client_methods(
             "launch_instances",
             autoscaling_instrumentation.instance_launched,
             None,
-            _get_instance_type_from_launch_instances_return_value,
+            _instance_type_from_instance_datas,
         ),
         (
             "stop_instances",
             autoscaling_instrumentation.instance_stopped,
-            _get_instance_type_from_stop_instances_args,
+            _instance_type_from_instance_datas,
             None,
         ),
         (
             "terminate_instances",
             autoscaling_instrumentation.instance_terminated,
-            _get_instance_type_from_terminate_instances_args,
+            _instance_type_from_instance_datas,
             None,
         ),
     ]

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -1,7 +1,7 @@
 import functools
 from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass, field
-from typing import Any, Concatenate, Final, ParamSpec, TypeVar, cast
+from typing import Any, Final, ParamSpec, TypeVar, cast
 
 from aws_library.ec2.client import SimcoreEC2API
 from aws_library.ec2.models import EC2InstanceData
@@ -191,7 +191,6 @@ class AutoscalingInstrumentation(MetricsBase):
 
 P = ParamSpec("P")
 R = TypeVar("R")
-Self = TypeVar("Self", bound="SimcoreEC2API")
 
 
 def _instrumented_ec2_client_method(
@@ -200,8 +199,8 @@ def _instrumented_ec2_client_method(
     instance_type_from_method_arguments: Callable[..., list[str]] | None,
     instance_type_from_method_return: Callable[..., list[str]] | None,
 ) -> Callable[
-    [Callable[Concatenate[Self, P], Coroutine[Any, Any, R]]],
-    Callable[Concatenate[Self, P], Coroutine[Any, Any, R]],
+    [Callable[P, Coroutine[Any, Any, R]]],
+    Callable[P, Coroutine[Any, Any, R]],
 ]:
     def decorator(
         func: Callable[P, Coroutine[Any, Any, R]]

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -218,7 +218,7 @@ def instrument_ec2_client_methods(
 ) -> SimcoreEC2API:
     autoscaling_instrumentation = get_instrumentation(app)
     methods_to_instrument = [
-        ("launch_aws_instance", autoscaling_instrumentation.instance_launched),
+        ("launch_instances", autoscaling_instrumentation.instance_launched),
         ("stop_instances", autoscaling_instrumentation.instance_stopped),
         ("terminate_instances", autoscaling_instrumentation.instance_terminated),
     ]

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -83,7 +83,7 @@ class ClusterMetrics:
             namespace=METRICS_NAMESPACE,
             subsystem=self.subsystem,
         )
-        self._pending_ec2s = Gauge(
+        self._buffer_ec2s = Gauge(
             "buffer_ec2s",
             "Number of buffer EC2 instance prepared, stopped and ready to to be activated",
             labelnames=EC2_INSTANCE_LABELS,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -204,11 +204,11 @@ def _instrumented_ec2_client_method(
     Callable[Concatenate[Self, P], Coroutine[Any, Any, R]],
 ]:
     def decorator(
-        func: Callable[Concatenate[Self, P], Coroutine[Any, Any, R]]
-    ) -> Callable[Concatenate[Self, P], Coroutine[Any, Any, R]]:
+        func: Callable[P, Coroutine[Any, Any, R]]
+    ) -> Callable[P, Coroutine[Any, Any, R]]:
         @functools.wraps(func)
-        async def wrapper(self: Self, *args: P.args, **kwargs: P.kwargs) -> R:
-            result = await func(self, *args, **kwargs)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            result = await func(*args, **kwargs)
             if instance_type_from_method_arguments:
                 for instance_type in instance_type_from_method_arguments(
                     *args, **kwargs

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -49,74 +49,75 @@ class ClusterMetrics(MetricsBase):  # pylint: disable=too-many-instance-attribut
     _terminated_instances: Gauge = field(init=False)
 
     def __post_init__(self) -> None:
+        cluster_subsystem = f"{self.subsystem}_cluster"
         self._active_nodes = Gauge(
             "active_nodes",
             "Number of EC2-backed docker nodes which are active and ready to run tasks",
             labelnames=EC2_INSTANCE_LABELS,
             namespace=METRICS_NAMESPACE,
-            subsystem=self.subsystem,
+            subsystem=cluster_subsystem,
         )
         self._pending_nodes = Gauge(
             "pending_nodes",
             "Number of EC2-backed docker nodes which are active and NOT ready to run tasks",
             labelnames=EC2_INSTANCE_LABELS,
             namespace=METRICS_NAMESPACE,
-            subsystem=self.subsystem,
+            subsystem=cluster_subsystem,
         )
         self._drained_nodes = Gauge(
             "drained_nodes",
             "Number of EC2-backed docker nodes which are drained",
             labelnames=EC2_INSTANCE_LABELS,
             namespace=METRICS_NAMESPACE,
-            subsystem=self.subsystem,
+            subsystem=cluster_subsystem,
         )
         self._reserve_drained_nodes = Gauge(
             "buffer_drained_nodes",
             "Number of EC2-backed docker nodes which are drained and in buffer/reserve",
             labelnames=EC2_INSTANCE_LABELS,
             namespace=METRICS_NAMESPACE,
-            subsystem=self.subsystem,
+            subsystem=cluster_subsystem,
         )
         self._pending_ec2s = Gauge(
             "pending_ec2s",
             "Number of EC2 instance not yet part of the cluster",
             labelnames=EC2_INSTANCE_LABELS,
             namespace=METRICS_NAMESPACE,
-            subsystem=self.subsystem,
+            subsystem=cluster_subsystem,
         )
         self._broken_ec2s = Gauge(
             "broken_ec2s",
             "Number of EC2 instance that failed joining the cluster",
             labelnames=EC2_INSTANCE_LABELS,
             namespace=METRICS_NAMESPACE,
-            subsystem=self.subsystem,
+            subsystem=cluster_subsystem,
         )
         self._buffer_ec2s = Gauge(
             "buffer_ec2s",
             "Number of buffer EC2 instance prepared, stopped and ready to to be activated",
             labelnames=EC2_INSTANCE_LABELS,
             namespace=METRICS_NAMESPACE,
-            subsystem=self.subsystem,
+            subsystem=cluster_subsystem,
         )
         self._disconnected_nodes = Gauge(
             "disconnected_nodes",
             "Number of docker node not backed by a running EC2 instance",
             namespace=METRICS_NAMESPACE,
-            subsystem=self.subsystem,
+            subsystem=cluster_subsystem,
         )
         self._terminating_nodes = Gauge(
             "terminating_nodes",
             "Number of EC2-backed docker nodes that started the termination process",
             labelnames=EC2_INSTANCE_LABELS,
             namespace=METRICS_NAMESPACE,
-            subsystem=self.subsystem,
+            subsystem=cluster_subsystem,
         )
         self._terminated_instances = Gauge(
             "terminated_instances",
             "Number of EC2 instances that were terminated (they are typically visible 1 hour)",
             labelnames=EC2_INSTANCE_LABELS,
             namespace=METRICS_NAMESPACE,
-            subsystem=self.subsystem,
+            subsystem=cluster_subsystem,
         )
 
     def update_from_cluster(self, cluster: Cluster) -> None:
@@ -166,7 +167,7 @@ class AutoscalingInstrumentation(MetricsBase):
             subsystem=self.subsystem,
         )
         self._terminated_instances = Counter(
-            "terminated_ec2_instances_total",
+            "terminated_instances_total",
             "Number of EC2 instances that were terminated",
             labelnames=EC2_INSTANCE_LABELS,
             namespace=METRICS_NAMESPACE,

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -811,7 +811,7 @@ def mock_docker_tag_node(mocker: MockerFixture) -> mock.Mock:
 
 
 @pytest.fixture
-def patch_ec2_client_start_aws_instances_min_number_of_instances(
+def patch_ec2_client_launch_aws_instances_min_number_of_instances(
     mocker: MockerFixture,
 ) -> mock.Mock:
     """the moto library always returns min number of instances instead of max number of instances which makes
@@ -820,12 +820,12 @@ def patch_ec2_client_start_aws_instances_min_number_of_instances(
 
     async def _change_parameters(*args, **kwargs) -> list[EC2InstanceData]:
         new_kwargs = kwargs | {"min_number_of_instances": kwargs["number_of_instances"]}
-        print(f"patching start_aws_instance with: {new_kwargs}")
+        print(f"patching launch_aws_instance with: {new_kwargs}")
         return await original_fct(*args, **new_kwargs)
 
     return mocker.patch.object(
         SimcoreEC2API,
-        "start_aws_instance",
+        "launch_aws_instance",
         autospec=True,
         side_effect=_change_parameters,
     )

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -811,21 +811,21 @@ def mock_docker_tag_node(mocker: MockerFixture) -> mock.Mock:
 
 
 @pytest.fixture
-def patch_ec2_client_launch_aws_instances_min_number_of_instances(
+def patch_ec2_client_launch_instancess_min_number_of_instances(
     mocker: MockerFixture,
 ) -> mock.Mock:
     """the moto library always returns min number of instances instead of max number of instances which makes
     it difficult to test scaling to multiple of machines. this should help"""
-    original_fct = SimcoreEC2API.launch_aws_instance
+    original_fct = SimcoreEC2API.launch_instances
 
     async def _change_parameters(*args, **kwargs) -> list[EC2InstanceData]:
         new_kwargs = kwargs | {"min_number_of_instances": kwargs["number_of_instances"]}
-        print(f"patching launch_aws_instance with: {new_kwargs}")
+        print(f"patching launch_instances with: {new_kwargs}")
         return await original_fct(*args, **new_kwargs)
 
     return mocker.patch.object(
         SimcoreEC2API,
-        "launch_aws_instance",
+        "launch_instances",
         autospec=True,
         side_effect=_change_parameters,
     )

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -816,7 +816,7 @@ def patch_ec2_client_start_aws_instances_min_number_of_instances(
 ) -> mock.Mock:
     """the moto library always returns min number of instances instead of max number of instances which makes
     it difficult to test scaling to multiple of machines. this should help"""
-    original_fct = SimcoreEC2API.start_aws_instance
+    original_fct = SimcoreEC2API.launch_aws_instance
 
     async def _change_parameters(*args, **kwargs) -> list[EC2InstanceData]:
         new_kwargs = kwargs | {"min_number_of_instances": kwargs["number_of_instances"]}

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_computational.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_computational.py
@@ -153,13 +153,13 @@ def mock_terminate_instances(mocker: MockerFixture) -> Iterator[mock.Mock]:
 
 
 @pytest.fixture
-def mock_start_aws_instance(
+def mock_launch_aws_instance(
     mocker: MockerFixture,
     aws_instance_private_dns: str,
     fake_ec2_instance_data: Callable[..., EC2InstanceData],
 ) -> Iterator[mock.Mock]:
     return mocker.patch(
-        "simcore_service_autoscaling.modules.ec2.SimcoreEC2API.start_aws_instance",
+        "simcore_service_autoscaling.modules.ec2.SimcoreEC2API.launch_aws_instance",
         autospec=True,
         return_value=fake_ec2_instance_data(aws_private_dns=aws_instance_private_dns),
     )
@@ -182,7 +182,7 @@ async def test_cluster_scaling_with_no_tasks_does_nothing(
     minimal_configuration: None,
     app_settings: ApplicationSettings,
     initialized_app: FastAPI,
-    mock_start_aws_instance: mock.Mock,
+    mock_launch_aws_instance: mock.Mock,
     mock_terminate_instances: mock.Mock,
     mock_rabbitmq_post_message: mock.Mock,
     dask_spec_local_cluster: distributed.SpecCluster,
@@ -190,7 +190,7 @@ async def test_cluster_scaling_with_no_tasks_does_nothing(
     await auto_scale_cluster(
         app=initialized_app, auto_scaling_mode=ComputationalAutoscaling()
     )
-    mock_start_aws_instance.assert_not_called()
+    mock_launch_aws_instance.assert_not_called()
     mock_terminate_instances.assert_not_called()
     _assert_rabbit_autoscaling_message_sent(
         mock_rabbitmq_post_message,
@@ -205,7 +205,7 @@ async def test_cluster_scaling_with_task_with_too_much_resources_starts_nothing(
     app_settings: ApplicationSettings,
     initialized_app: FastAPI,
     create_dask_task: Callable[[DaskTaskResources], distributed.Future],
-    mock_start_aws_instance: mock.Mock,
+    mock_launch_aws_instance: mock.Mock,
     mock_terminate_instances: mock.Mock,
     mock_rabbitmq_post_message: mock.Mock,
     dask_spec_local_cluster: distributed.SpecCluster,
@@ -217,7 +217,7 @@ async def test_cluster_scaling_with_task_with_too_much_resources_starts_nothing(
     await auto_scale_cluster(
         app=initialized_app, auto_scaling_mode=ComputationalAutoscaling()
     )
-    mock_start_aws_instance.assert_not_called()
+    mock_launch_aws_instance.assert_not_called()
     mock_terminate_instances.assert_not_called()
     _assert_rabbit_autoscaling_message_sent(
         mock_rabbitmq_post_message,
@@ -792,7 +792,7 @@ def _dask_task_resources_from_resources(resources: Resources) -> DaskTaskResourc
 
 
 @pytest.fixture
-def patch_ec2_client_start_aws_instances_min_number_of_instances(
+def patch_ec2_client_launch_aws_instances_min_number_of_instances(
     mocker: MockerFixture,
 ) -> mock.Mock:
     """the moto library always returns min number of instances instead of max number of instances which makes
@@ -801,12 +801,12 @@ def patch_ec2_client_start_aws_instances_min_number_of_instances(
 
     async def _change_parameters(*args, **kwargs) -> list[EC2InstanceData]:
         new_kwargs = kwargs | {"min_number_of_instances": kwargs["number_of_instances"]}
-        print(f"patching start_aws_instance with: {new_kwargs}")
+        print(f"patching launch_aws_instance with: {new_kwargs}")
         return await original_fct(*args, **new_kwargs)
 
     return mocker.patch.object(
         SimcoreEC2API,
-        "start_aws_instance",
+        "launch_aws_instance",
         autospec=True,
         side_effect=_change_parameters,
     )
@@ -827,7 +827,7 @@ def patch_ec2_client_start_aws_instances_min_number_of_instances(
     ],
 )
 async def test_cluster_scaling_up_starts_multiple_instances(
-    patch_ec2_client_start_aws_instances_min_number_of_instances: mock.Mock,
+    patch_ec2_client_launch_aws_instances_min_number_of_instances: mock.Mock,
     minimal_configuration: None,
     app_settings: ApplicationSettings,
     initialized_app: FastAPI,
@@ -889,7 +889,7 @@ async def test_cluster_scaling_up_starts_multiple_instances(
 
 
 async def test_cluster_scaling_up_more_than_allowed_max_starts_max_instances_and_not_more(
-    patch_ec2_client_start_aws_instances_min_number_of_instances: mock.Mock,
+    patch_ec2_client_launch_aws_instances_min_number_of_instances: mock.Mock,
     minimal_configuration: None,
     app_settings: ApplicationSettings,
     initialized_app: FastAPI,
@@ -977,7 +977,7 @@ async def test_cluster_scaling_up_more_than_allowed_max_starts_max_instances_and
 
 
 async def test_cluster_scaling_up_more_than_allowed_with_multiple_types_max_starts_max_instances_and_not_more(
-    patch_ec2_client_start_aws_instances_min_number_of_instances: mock.Mock,
+    patch_ec2_client_launch_aws_instances_min_number_of_instances: mock.Mock,
     minimal_configuration: None,
     app_settings: ApplicationSettings,
     initialized_app: FastAPI,

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_computational.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_computational.py
@@ -797,7 +797,7 @@ def patch_ec2_client_start_aws_instances_min_number_of_instances(
 ) -> mock.Mock:
     """the moto library always returns min number of instances instead of max number of instances which makes
     it difficult to test scaling to multiple of machines. this should help"""
-    original_fct = SimcoreEC2API.start_aws_instance
+    original_fct = SimcoreEC2API.launch_aws_instance
 
     async def _change_parameters(*args, **kwargs) -> list[EC2InstanceData]:
         new_kwargs = kwargs | {"min_number_of_instances": kwargs["number_of_instances"]}

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
@@ -70,13 +70,13 @@ def mock_terminate_instances(mocker: MockerFixture) -> Iterator[mock.Mock]:
 
 
 @pytest.fixture
-def mock_start_aws_instance(
+def mock_launch_aws_instance(
     mocker: MockerFixture,
     aws_instance_private_dns: str,
     fake_ec2_instance_data: Callable[..., EC2InstanceData],
 ) -> Iterator[mock.Mock]:
     return mocker.patch(
-        "simcore_service_autoscaling.modules.ec2.SimcoreEC2API.start_aws_instance",
+        "simcore_service_autoscaling.modules.ec2.SimcoreEC2API.launch_aws_instance",
         autospec=True,
         return_value=fake_ec2_instance_data(aws_private_dns=aws_instance_private_dns),
     )
@@ -211,14 +211,14 @@ async def test_cluster_scaling_with_no_services_does_nothing(
     minimal_configuration: None,
     app_settings: ApplicationSettings,
     initialized_app: FastAPI,
-    mock_start_aws_instance: mock.Mock,
+    mock_launch_aws_instance: mock.Mock,
     mock_terminate_instances: mock.Mock,
     mock_rabbitmq_post_message: mock.Mock,
 ):
     await auto_scale_cluster(
         app=initialized_app, auto_scaling_mode=DynamicAutoscaling()
     )
-    mock_start_aws_instance.assert_not_called()
+    mock_launch_aws_instance.assert_not_called()
     mock_terminate_instances.assert_not_called()
     _assert_rabbit_autoscaling_message_sent(
         mock_rabbitmq_post_message, app_settings, initialized_app
@@ -226,7 +226,7 @@ async def test_cluster_scaling_with_no_services_does_nothing(
 
 
 async def test_cluster_scaling_with_no_services_and_machine_buffer_starts_expected_machines(
-    patch_ec2_client_start_aws_instances_min_number_of_instances: mock.Mock,
+    patch_ec2_client_launch_aws_instances_min_number_of_instances: mock.Mock,
     minimal_configuration: None,
     mock_machines_buffer: int,
     app_settings: ApplicationSettings,
@@ -325,7 +325,7 @@ async def test_cluster_scaling_with_service_asking_for_too_much_resources_starts
     ],
     task_template: dict[str, Any],
     create_task_reservations: Callable[[int, int], dict[str, Any]],
-    mock_start_aws_instance: mock.Mock,
+    mock_launch_aws_instance: mock.Mock,
     mock_terminate_instances: mock.Mock,
     mock_rabbitmq_post_message: mock.Mock,
 ):
@@ -341,7 +341,7 @@ async def test_cluster_scaling_with_service_asking_for_too_much_resources_starts
     await auto_scale_cluster(
         app=initialized_app, auto_scaling_mode=DynamicAutoscaling()
     )
-    mock_start_aws_instance.assert_not_called()
+    mock_launch_aws_instance.assert_not_called()
     mock_terminate_instances.assert_not_called()
     _assert_rabbit_autoscaling_message_sent(
         mock_rabbitmq_post_message, app_settings, initialized_app
@@ -898,7 +898,7 @@ async def test_cluster_scaling_up_and_down(
     ],
 )
 async def test_cluster_scaling_up_starts_multiple_instances(
-    patch_ec2_client_start_aws_instances_min_number_of_instances: mock.Mock,
+    patch_ec2_client_launch_aws_instances_min_number_of_instances: mock.Mock,
     minimal_configuration: None,
     service_monitored_labels: dict[DockerLabelKey, str],
     osparc_docker_label_keys: StandardSimcoreDockerLabels,

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
@@ -70,13 +70,13 @@ def mock_terminate_instances(mocker: MockerFixture) -> Iterator[mock.Mock]:
 
 
 @pytest.fixture
-def mock_launch_aws_instance(
+def mock_launch_instances(
     mocker: MockerFixture,
     aws_instance_private_dns: str,
     fake_ec2_instance_data: Callable[..., EC2InstanceData],
 ) -> Iterator[mock.Mock]:
     return mocker.patch(
-        "simcore_service_autoscaling.modules.ec2.SimcoreEC2API.launch_aws_instance",
+        "simcore_service_autoscaling.modules.ec2.SimcoreEC2API.launch_instances",
         autospec=True,
         return_value=fake_ec2_instance_data(aws_private_dns=aws_instance_private_dns),
     )
@@ -211,14 +211,14 @@ async def test_cluster_scaling_with_no_services_does_nothing(
     minimal_configuration: None,
     app_settings: ApplicationSettings,
     initialized_app: FastAPI,
-    mock_launch_aws_instance: mock.Mock,
+    mock_launch_instances: mock.Mock,
     mock_terminate_instances: mock.Mock,
     mock_rabbitmq_post_message: mock.Mock,
 ):
     await auto_scale_cluster(
         app=initialized_app, auto_scaling_mode=DynamicAutoscaling()
     )
-    mock_launch_aws_instance.assert_not_called()
+    mock_launch_instances.assert_not_called()
     mock_terminate_instances.assert_not_called()
     _assert_rabbit_autoscaling_message_sent(
         mock_rabbitmq_post_message, app_settings, initialized_app
@@ -226,7 +226,7 @@ async def test_cluster_scaling_with_no_services_does_nothing(
 
 
 async def test_cluster_scaling_with_no_services_and_machine_buffer_starts_expected_machines(
-    patch_ec2_client_launch_aws_instances_min_number_of_instances: mock.Mock,
+    patch_ec2_client_launch_instancess_min_number_of_instances: mock.Mock,
     minimal_configuration: None,
     mock_machines_buffer: int,
     app_settings: ApplicationSettings,
@@ -325,7 +325,7 @@ async def test_cluster_scaling_with_service_asking_for_too_much_resources_starts
     ],
     task_template: dict[str, Any],
     create_task_reservations: Callable[[int, int], dict[str, Any]],
-    mock_launch_aws_instance: mock.Mock,
+    mock_launch_instances: mock.Mock,
     mock_terminate_instances: mock.Mock,
     mock_rabbitmq_post_message: mock.Mock,
 ):
@@ -341,7 +341,7 @@ async def test_cluster_scaling_with_service_asking_for_too_much_resources_starts
     await auto_scale_cluster(
         app=initialized_app, auto_scaling_mode=DynamicAutoscaling()
     )
-    mock_launch_aws_instance.assert_not_called()
+    mock_launch_instances.assert_not_called()
     mock_terminate_instances.assert_not_called()
     _assert_rabbit_autoscaling_message_sent(
         mock_rabbitmq_post_message, app_settings, initialized_app
@@ -898,7 +898,7 @@ async def test_cluster_scaling_up_and_down(
     ],
 )
 async def test_cluster_scaling_up_starts_multiple_instances(
-    patch_ec2_client_launch_aws_instances_min_number_of_instances: mock.Mock,
+    patch_ec2_client_launch_instancess_min_number_of_instances: mock.Mock,
     minimal_configuration: None,
     service_monitored_labels: dict[DockerLabelKey, str],
     osparc_docker_label_keys: StandardSimcoreDockerLabels,

--- a/services/autoscaling/tests/unit/test_modules_ec2.py
+++ b/services/autoscaling/tests/unit/test_modules_ec2.py
@@ -1,11 +1,22 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
+# pylint: disable=protected-access
+
+from typing import Callable
 
 import pytest
+from aws_library.ec2.models import EC2InstanceConfig, EC2InstanceType, Resources
+from faker import Faker
 from fastapi import FastAPI
+from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict
 from simcore_service_autoscaling.core.errors import ConfigurationError
 from simcore_service_autoscaling.modules.ec2 import get_ec2_client
+from simcore_service_autoscaling.modules.instrumentation import (
+    get_instrumentation,
+    has_instrumentation,
+)
+from types_aiobotocore_ec2.literals import InstanceTypeType
 
 
 async def test_ec2_does_not_initialize_if_deactivated(
@@ -18,3 +29,62 @@ async def test_ec2_does_not_initialize_if_deactivated(
     assert initialized_app.state.ec2_client is None
     with pytest.raises(ConfigurationError):
         get_ec2_client(initialized_app)
+
+
+@pytest.fixture
+def create_ec2_instance_config(
+    faker: Faker,
+    aws_subnet_id: str,
+    aws_security_group_id: str,
+    aws_ami_id: str,
+) -> Callable[[InstanceTypeType], EC2InstanceConfig]:
+    def _(instance_type: InstanceTypeType) -> EC2InstanceConfig:
+        return EC2InstanceConfig(
+            type=EC2InstanceType(
+                name="a1.large", resources=Resources.create_as_empty()
+            ),
+            tags=faker.pydict(allowed_types=(str,)),
+            startup_script=faker.pystr(),
+            ami_id=aws_ami_id,
+            key_name=faker.pystr(),
+            security_group_ids=[aws_security_group_id],
+            subnet_id=aws_subnet_id,
+            iam_instance_profile="",
+        )
+
+    return _
+
+
+async def test_ec2_with_instrumentation_enabled(
+    disabled_rabbitmq: None,
+    mocked_ec2_server_envs: EnvVarsDict,
+    mocked_redis_server: None,
+    initialized_app: FastAPI,
+    create_ec2_instance_config: Callable[[InstanceTypeType], EC2InstanceConfig],
+):
+    assert hasattr(initialized_app.state, "ec2_client")
+    assert initialized_app.state.ec2_client
+    ec2_client = get_ec2_client(initialized_app)
+    assert has_instrumentation(initialized_app)
+
+    instrumentation = get_instrumentation(initialized_app)
+    instance_launched_metrics = list(
+        instrumentation._launched_instances.collect()  # noqa: SLF001
+    )
+    assert len(instance_launched_metrics) == 1
+    assert instance_launched_metrics[0]
+    metrics = instance_launched_metrics[0]
+    assert metrics.samples == []
+
+    a1_2xlarge_config = create_ec2_instance_config("a1.2xlarge")
+    await ec2_client.launch_instances(
+        a1_2xlarge_config, min_number_of_instances=2, number_of_instances=2
+    )
+    instance_launched_metrics = list(
+        instrumentation._launched_instances.collect()  # noqa: SLF001
+    )
+    assert len(instance_launched_metrics) == 1
+
+    assert instance_launched_metrics[0]
+    metrics = instance_launched_metrics[0]
+    assert metrics.samples == [2.0]

--- a/services/autoscaling/tests/unit/test_modules_ec2.py
+++ b/services/autoscaling/tests/unit/test_modules_ec2.py
@@ -4,7 +4,6 @@
 # pylint: disable=protected-access
 
 from collections.abc import Callable
-from os import name
 from typing import TypedDict
 
 import pytest

--- a/services/autoscaling/tests/unit/test_modules_ec2.py
+++ b/services/autoscaling/tests/unit/test_modules_ec2.py
@@ -3,12 +3,15 @@
 # pylint: disable=unused-variable
 # pylint: disable=protected-access
 
-from typing import Callable
+from collections.abc import Callable
+from os import name
+from typing import TypedDict
 
 import pytest
 from aws_library.ec2.models import EC2InstanceConfig, EC2InstanceType, Resources
 from faker import Faker
 from fastapi import FastAPI
+from prometheus_client.metrics import MetricWrapperBase
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict
 from simcore_service_autoscaling.core.errors import ConfigurationError
 from simcore_service_autoscaling.modules.ec2 import get_ec2_client
@@ -41,7 +44,7 @@ def create_ec2_instance_config(
     def _(instance_type: InstanceTypeType) -> EC2InstanceConfig:
         return EC2InstanceConfig(
             type=EC2InstanceType(
-                name="a1.large", resources=Resources.create_as_empty()
+                name=instance_type, resources=Resources.create_as_empty()
             ),
             tags=faker.pydict(allowed_types=(str,)),
             startup_script=faker.pystr(),
@@ -55,36 +58,139 @@ def create_ec2_instance_config(
     return _
 
 
+class _ExpectedSample(TypedDict):
+    name: str
+    value: float
+    labels: dict[str, str]
+
+
+def _assert_metrics(
+    metrics_to_collect: MetricWrapperBase,
+    *,
+    expected_num_samples: int,
+    check_sample_index: int | None,
+    expected_sample: _ExpectedSample | None
+) -> None:
+    collected_metrics = list(metrics_to_collect.collect())
+    assert len(collected_metrics) == 1
+    assert collected_metrics[0]
+    metrics = collected_metrics[0]
+    assert len(metrics.samples) == expected_num_samples
+    if expected_num_samples > 0:
+        assert check_sample_index is not None
+        assert expected_sample is not None
+        sample_1 = metrics.samples[check_sample_index]
+        assert sample_1.name == expected_sample["name"]
+        assert sample_1.value == expected_sample["value"]
+        assert sample_1.labels == expected_sample["labels"]
+
+
 async def test_ec2_with_instrumentation_enabled(
     disabled_rabbitmq: None,
     mocked_ec2_server_envs: EnvVarsDict,
     mocked_redis_server: None,
     initialized_app: FastAPI,
     create_ec2_instance_config: Callable[[InstanceTypeType], EC2InstanceConfig],
+    faker: Faker,
 ):
     assert hasattr(initialized_app.state, "ec2_client")
     assert initialized_app.state.ec2_client
     ec2_client = get_ec2_client(initialized_app)
     assert has_instrumentation(initialized_app)
 
+    # check current metrics (should be 0)
     instrumentation = get_instrumentation(initialized_app)
-    instance_launched_metrics = list(
-        instrumentation._launched_instances.collect()  # noqa: SLF001
+    _assert_metrics(
+        instrumentation._launched_instances,  # noqa: SLF001
+        expected_num_samples=0,
+        check_sample_index=None,
+        expected_sample=None,
     )
-    assert len(instance_launched_metrics) == 1
-    assert instance_launched_metrics[0]
-    metrics = instance_launched_metrics[0]
-    assert metrics.samples == []
 
+    # create some EC2s
     a1_2xlarge_config = create_ec2_instance_config("a1.2xlarge")
-    await ec2_client.launch_instances(
-        a1_2xlarge_config, min_number_of_instances=2, number_of_instances=2
+    num_a1_2xlarge = faker.pyint(min_value=1, max_value=12)
+    a1_2xlarge_instances = await ec2_client.launch_instances(
+        a1_2xlarge_config,
+        min_number_of_instances=num_a1_2xlarge,
+        number_of_instances=num_a1_2xlarge,
+        max_total_number_of_instances=500,
     )
-    instance_launched_metrics = list(
-        instrumentation._launched_instances.collect()  # noqa: SLF001
-    )
-    assert len(instance_launched_metrics) == 1
 
-    assert instance_launched_metrics[0]
-    metrics = instance_launched_metrics[0]
-    assert metrics.samples == [2.0]
+    # now the metrics shall increase
+    _assert_metrics(
+        instrumentation._launched_instances,  # noqa: SLF001
+        expected_num_samples=2,
+        check_sample_index=0,
+        expected_sample={
+            "name": "simcore_service_autoscaling_computational_launched_instances_total",
+            "value": num_a1_2xlarge,
+            "labels": {"instance_type": "a1.2xlarge"},
+        },
+    )
+
+    # create some other EC2s
+    c5ad_12xlarge_config = create_ec2_instance_config("c5ad.12xlarge")
+    num_c5ad_12xlarge = faker.pyint(min_value=1, max_value=123)
+    c5ad_12xlarge_instances = await ec2_client.launch_instances(
+        c5ad_12xlarge_config,
+        min_number_of_instances=num_c5ad_12xlarge,
+        number_of_instances=num_c5ad_12xlarge,
+        max_total_number_of_instances=500,
+    )
+    # we should get additional metrics with different labels
+    _assert_metrics(
+        instrumentation._launched_instances,  # noqa: SLF001
+        expected_num_samples=4,
+        check_sample_index=2,
+        expected_sample={
+            "name": "simcore_service_autoscaling_computational_launched_instances_total",
+            "value": num_c5ad_12xlarge,
+            "labels": {"instance_type": "c5ad.12xlarge"},
+        },
+    )
+
+    # now we stop the last ones created
+    await ec2_client.stop_instances(c5ad_12xlarge_instances)
+
+    # we get the stopped metrics increased now
+    _assert_metrics(
+        instrumentation._stopped_instances,  # noqa: SLF001
+        expected_num_samples=2,
+        check_sample_index=0,
+        expected_sample={
+            "name": "simcore_service_autoscaling_computational_stopped_instances_total",
+            "value": num_c5ad_12xlarge,
+            "labels": {"instance_type": "c5ad.12xlarge"},
+        },
+    )
+
+    # we terminate them
+    await ec2_client.terminate_instances(c5ad_12xlarge_instances)
+
+    # we get the terminated metrics increased now
+    _assert_metrics(
+        instrumentation._terminated_instances,  # noqa: SLF001
+        expected_num_samples=2,
+        check_sample_index=0,
+        expected_sample={
+            "name": "simcore_service_autoscaling_computational_terminated_instances_total",
+            "value": num_c5ad_12xlarge,
+            "labels": {"instance_type": "c5ad.12xlarge"},
+        },
+    )
+
+    # we terminate the rest
+    await ec2_client.terminate_instances(a1_2xlarge_instances)
+
+    # we get the terminated metrics increased now
+    _assert_metrics(
+        instrumentation._terminated_instances,  # noqa: SLF001
+        expected_num_samples=4,
+        check_sample_index=2,
+        expected_sample={
+            "name": "simcore_service_autoscaling_computational_terminated_instances_total",
+            "value": num_a1_2xlarge,
+            "labels": {"instance_type": "a1.2xlarge"},
+        },
+    )

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
@@ -88,7 +88,7 @@ async def create_cluster(
         subnet_id=app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES.PRIMARY_EC2_INSTANCES_SUBNET_ID,
         iam_instance_profile=app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES.PRIMARY_EC2_INSTANCES_ATTACHED_IAM_PROFILE,
     )
-    new_ec2_instance_data: list[EC2InstanceData] = await ec2_client.start_aws_instance(
+    new_ec2_instance_data: list[EC2InstanceData] = await ec2_client.launch_aws_instance(
         instance_config,
         min_number_of_instances=1,
         number_of_instances=1,

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters.py
@@ -88,7 +88,7 @@ async def create_cluster(
         subnet_id=app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES.PRIMARY_EC2_INSTANCES_SUBNET_ID,
         iam_instance_profile=app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES.PRIMARY_EC2_INSTANCES_ATTACHED_IAM_PROFILE,
     )
-    new_ec2_instance_data: list[EC2InstanceData] = await ec2_client.launch_aws_instance(
+    new_ec2_instance_data: list[EC2InstanceData] = await ec2_client.launch_instances(
         instance_config,
         min_number_of_instances=1,
         number_of_instances=1,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

### Refactoring
- renamed ```start_aws_instance``` to ```launch_instances``` in EC2 client
- ```terminated_instances``` in ```Cluster``` is now a list of ```NonAssociatedInstances```
- instrumentation around the autoscaling EC2 client is now automatic via decoration of the ```launch_instances```, ```stop_instances``` and ```terminate_instances``` methods -> no miss on metrics

### Changes
- added more metrics related to the autoscaling Cluster class (added missing Gauges for broken, terminating and terminated fields)
- added Gauge for newer buffer instances field
- added Counters for started, stopped, launched and terminated instances

**--> this has implications on the Grafana dashboard for autoscaling which will require an update as the metrics names have changed. This will be done once this PR goes in.**


Driving Test: ```services/autoscaling/tests/unit/test_modules_ec2.py::test_ec2_with_instrumentation_enabled```


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
