### PR TITLE
🐛 [Frontend] Fix Service listing helpers

### DIFF
--- a/services/static-webserver/client/source/class/osparc/service/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/service/Utils.js
@@ -173,7 +173,7 @@ qx.Class.define("osparc.service.Utils", {
             version: canUpdateTo["version"]
           }
         }
-        // that version itself is the latest compatible
+        // the provided key/version itself is the latest compatible
         return {
           key,
           version

--- a/services/static-webserver/client/source/class/osparc/service/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/service/Utils.js
@@ -155,7 +155,9 @@ qx.Class.define("osparc.service.Utils", {
       const services = osparc.service.Store.servicesCached;
       if (key in services) {
         const versions = this.getVersions(key, true);
-        return services[key][versions[0]];
+        if (versions.length) {
+          return services[key][versions[0]];
+        }
       }
       return null;
     },

--- a/services/static-webserver/client/source/class/osparc/service/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/service/Utils.js
@@ -173,6 +173,11 @@ qx.Class.define("osparc.service.Utils", {
             version: canUpdateTo["version"]
           }
         }
+        // that version itself is the latest compatible
+        return {
+          key,
+          version
+        }
       }
       return null;
     },

--- a/services/static-webserver/client/source/class/osparc/study/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/study/Utils.js
@@ -109,9 +109,6 @@ qx.Class.define("osparc.study.Utils", {
 
     createStudyFromService: function(key, version, existingStudies, newStudyLabel) {
       return new Promise((resolve, reject) => {
-        if (!version) {
-          version = osparc.service.Utils.getLatest(key);
-        }
         osparc.service.Store.getService(key, version)
           .then(metadata => {
             const newUuid = osparc.utils.Utils.uuidV4();


### PR DESCRIPTION
## What do these changes do?

Bug found in the Service Catalog:
There might be cases where all the versions of a service are either retired or deprecated. This PR deals with that situation.

Fix getLatestCompatible helper function: it used to return null if there was no compatibility.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
