### PR TITLE
🐛 [Frontend] Fix always visible Update available icon

### DIFF
--- a/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsSummary.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsSummary.js
@@ -103,7 +103,7 @@ qx.Class.define("osparc.desktop.credits.CreditsSummary", {
           topLayout.add(control);
           break;
         }
-        case "time-range-sb":
+        case "time-range-sb": {
           control = new qx.ui.form.SelectBox().set({
             allowGrowX: false,
             alignX: "center",
@@ -113,8 +113,14 @@ qx.Class.define("osparc.desktop.credits.CreditsSummary", {
             const trItem = new qx.ui.form.ListItem(tr.label, null, tr.key);
             control.add(trItem);
           });
+          // default one week
+          const found = control.getSelectables().find(trItem => trItem.getModel() === 7);
+          if (found) {
+            control.setSelection([found]);
+          }
           this._add(control);
           break;
+        }
         case "services-consumption":
           control = new osparc.desktop.credits.CreditsPerService();
           this._add(control);

--- a/services/static-webserver/client/source/class/osparc/node/LifeCycleView.js
+++ b/services/static-webserver/client/source/class/osparc/node/LifeCycleView.js
@@ -114,8 +114,13 @@ qx.Class.define("osparc.node.LifeCycleView", {
       });
       updateButton.addListener("execute", () => {
         updateButton.setFetching(true);
-        const latestCompatibleMetadata = osparc.service.Utils.getLatestCompatible(node.getKey(), node.getVersion());
-        node.setVersion(latestCompatibleMetadata["version"]);
+        const latestCompatible = osparc.service.Utils.getLatestCompatible(node.getKey(), node.getVersion());
+        if (node.getKey() !== latestCompatible["key"]) {
+          node.setKey(latestCompatible["key"]);
+        }
+        if (node.getVersion() !== latestCompatible["version"]) {
+          node.setVersion(latestCompatible["version"]);
+        }
         node.fireEvent("updateStudyDocument");
         setTimeout(() => {
           updateButton.setFetching(false);

--- a/services/static-webserver/client/source/class/osparc/service/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/service/Utils.js
@@ -229,8 +229,8 @@ qx.Class.define("osparc.service.Utils", {
     RETIRED_AUTOUPDATABLE_INSTRUCTIONS: qx.locale.Manager.tr("Please Update the Service"),
 
     isUpdatable: function(metadata) {
-      const latestCompatibleMetadata = this.getLatestCompatible(metadata["key"], metadata["version"]);
-      return latestCompatibleMetadata && (metadata["key"] !== latestCompatibleMetadata["key"] || metadata["version"] !== latestCompatibleMetadata["version"]);
+      const latestCompatible = this.getLatestCompatible(metadata["key"], metadata["version"]);
+      return latestCompatible && (metadata["key"] !== latestCompatible["key"] || metadata["version"] !== latestCompatible["version"]);
     },
 
     isDeprecated: function(metadata) {

--- a/services/static-webserver/client/source/class/osparc/study/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/study/Utils.js
@@ -65,9 +65,7 @@ qx.Class.define("osparc.study.Utils", {
 
     isWorkbenchUpdatable: function(workbench) {
       const services = new Set(this.extractServices(workbench));
-      const isUpdatable = Array.from(services).some(srv => {
-        return osparc.service.Utils.getLatestCompatible(srv.key, srv.version) !== null;
-      });
+      const isUpdatable = Array.from(services).some(srv => osparc.service.Utils.isUpdatable(srv));
       return isUpdatable;
     },
 


### PR DESCRIPTION
## What do these changes do?

The "Update available" icon was always visible, this PR fixes it.
![UpdateAvailable](https://github.com/user-attachments/assets/49d8b260-c0e6-4aa9-b5da-89be93c7a9b4)

Before:
![image](https://github.com/user-attachments/assets/a5f29e25-dbbc-4d1a-b43a-134367f50f54)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
