### PR TITLE
🐛 [Frontend] Annotations fix: Convert named colors to HEX

### DIFF
--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -679,6 +679,14 @@ qx.Class.define("osparc.utils.Utils", {
       return L > 0.35 ? "#FFF" : "#000";
     },
 
+    namedColorToHex: function(namedColor) {
+      if (qx.util.ExtendedColor.isExtendedColor(namedColor)) {
+        const rgb = qx.util.ExtendedColor.toRgb(namedColor);
+        return qx.util.ColorUtil.rgbToHexString(rgb);
+      }
+      return "#888888";
+    },
+
     bytesToSize: function(bytes, decimals = 2, isDecimalCollapsed = true) {
       if (!+bytes) {
         return "0 Bytes";

--- a/services/static-webserver/client/source/class/osparc/workbench/Annotation.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/Annotation.js
@@ -33,10 +33,14 @@ qx.Class.define("osparc.workbench.Annotation", {
     if (id === undefined) {
       id = osparc.utils.Utils.uuidV4();
     }
+    let color = "color" in data ? data.color : this.getColor();
+    if (color && color[0] !== "#") {
+      color = osparc.utils.Utils.namedColorToHex(color);
+    }
     this.set({
       id,
       type: data.type,
-      color: "color" in data ? data.color : this.getColor(),
+      color,
       attributes: data.attributes
     });
   },


### PR DESCRIPTION
## What do these changes do?

When listing projects, pydantic, I believe, is translating the colors used in the annotations from hex to named colors. The frontend wasn't able to understand some of those named colors (i.e. #0FF -> Cyan).

This PR workarounds that problem by checking the named colors in a longer list and converting it again to hex. If the named color doesn't exist in the list it will default it to light gray.

The annotations that were failing in the deserialization step:
![image](https://github.com/user-attachments/assets/94dbeb4a-dd9b-48b7-bf4c-20ac0b52f8bc)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
