### PR TITLE
⚗️ env-vars to control cachetools

### DIFF
--- a/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
@@ -45,7 +45,6 @@ def replace_service_input_outputs(
 ):
     """Thin wrapper to replace i/o ports in returned service model"""
     # This is a fast solution until proper models are available for the web API
-
     for input_key in service["inputs"]:
         new_input: ServiceInputGet = (
             ServiceInputGetFactory.from_catalog_service_api_model(

--- a/services/web/server/src/simcore_service_webserver/catalog/_models.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_models.py
@@ -75,9 +75,9 @@ def _hash_inputs(
     return f"{service['key']}/{service['version']}/{input_key}"
 
 
-def _conditional_cached(*args, **kwargs):
+def _cachetools_cached(*args, **kwargs):
     def decorator(func):
-        if os.getenv("AIOCACHE_DISABLE", "0") == "0":
+        if os.getenv("CACHETOOLS_DISABLE", "0") == "0":
             return cachetools.cached(*args, **kwargs)(func)
         _logger.warning("cachetools disabled")
         return func
@@ -87,7 +87,7 @@ def _conditional_cached(*args, **kwargs):
 
 class ServiceInputGetFactory:
     @staticmethod
-    @_conditional_cached(
+    @_cachetools_cached(
         cachetools.TTLCache(ttl=_CACHE_TTL, maxsize=_CACHE_MAXSIZE), key=_hash_inputs
     )
     def from_catalog_service_api_model(
@@ -121,7 +121,7 @@ def _hash_outputs(
 
 class ServiceOutputGetFactory:
     @staticmethod
-    @_conditional_cached(
+    @_cachetools_cached(
         cachetools.TTLCache(ttl=_CACHE_TTL, maxsize=_CACHE_MAXSIZE), key=_hash_outputs
     )
     def from_catalog_service_api_model(

--- a/services/web/server/src/simcore_service_webserver/catalog/_models.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_models.py
@@ -60,10 +60,10 @@ def get_html_formatted_unit(
 # - the least recently used items will be discarded first to make space when necessary.
 #
 
-_CACHE_MAXSIZE: Final = (
-    1000  # number of items  i.e. ServiceInputGet/ServiceOutputGet insteances
-)
-_CACHE_TTL: Final = 60 * 60  # secs
+_CACHE_MAXSIZE: Final = int(
+    os.getenv("CACHETOOLS_CACHE_MAXSIZE", "100")
+)  # number of items  i.e. ServiceInputGet/ServiceOutputGet instances
+_CACHE_TTL: Final = int(os.getenv("CACHETOOLS_CACHE_TTL_SECS", "60"))  # secs
 
 
 def _hash_inputs(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?


Occasionally, listing services respond with a 500 error.
![image](https://github.com/user-attachments/assets/10f19270-d52c-4da5-bb84-a0325b474dda)

The logs indicate that this issue is due to a validation error caused by an invalid key in the caching mechanism, which uses the **sync** library [cachetools](https://cachetools.readthedocs.io/en/stable/). The bug appears to stem from concurrent access to a synchronous cache registry. It's important to note that the new design requests each page concurrently, and validation is also performed asynchronously.

The likely solution is to switch to [`aiocache`](https://aiocache.aio-libs.org/en/latest/index.html) even for this synchronous case, but that would require some design changes. Before moving forward with that approach, I'd like to introduce these new variables to control the `cachetools` options and conduct some manual exploratory testing:

- `CACHETOOLS_CACHE_MAXSIZE`: Maximum number of items (defaults to 100)
- `CACHETOOLS_CACHE_TTL_SECS`: Time-to-live in seconds (defaults to 60 seconds)
- `CACHETOOLS_DISABLE`: If set to `1`, caching is disabled (defaults to `0`)



## Related issue/s

- Related to #5964 
- e2e failures in master


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

These variables are only for development pursposes and therefore should not be part of the repo.configs
