### PR TITLE
e2e: Fix old puppeteer guests

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -712,7 +712,7 @@ qx.Class.define("osparc.data.model.Node", {
       if (outputs) {
         let hasOutputs = false;
         Object.keys(this.getOutputs()).forEach(outputKey => {
-          if (Object.hasOwn(outputs, outputKey)) {
+          if (outputKey in outputs) {
             this.setOutputs({
               ...this.getOutputs(),
               [outputKey]: {

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -1094,7 +1094,11 @@ qx.Class.define("osparc.data.model.Node", {
         };
         this.fireDataEvent("showInLogger", msgData);
 
-        this.getIframeHandler().startPolling();
+        if (this.getIframeHandler()) {
+          this.getIframeHandler().startPolling();
+        } else {
+          console.error(this.getLabel() + " iframe handler not ready");
+        }
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -364,23 +364,6 @@ qx.Class.define("osparc.desktop.MainPage", {
         });
     },
 
-    closeStudy: function(studyId) {
-      if (studyId === undefined) {
-        if (this.__studyEditor && this.__studyEditor.getStudy()) {
-          studyId = this.__studyEditor.getStudy().getUuid();
-        } else {
-          return;
-        }
-      }
-      const params = {
-        url: {
-          "studyId": studyId
-        },
-        data: osparc.utils.Utils.getClientSessionID()
-      };
-      osparc.data.Resources.fetch("studies", "close", params);
-    },
-
     __getStudyEditor: function() {
       if (this.__studyEditor) {
         return this.__studyEditor;

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -797,7 +797,8 @@ qx.Class.define("osparc.desktop.StudyEditor", {
         },
         data: osparc.utils.Utils.getClientSessionID()
       };
-      osparc.data.Resources.fetch("studies", "close", params);
+      osparc.data.Resources.fetch("studies", "close", params)
+        .catch(err => console.error(err));
     },
 
     closeEditor: function() {

--- a/services/static-webserver/client/source/class/osparc/viewer/NodeViewer.js
+++ b/services/static-webserver/client/source/class/osparc/viewer/NodeViewer.js
@@ -60,6 +60,8 @@ qx.Class.define("osparc.viewer.NodeViewer", {
           this.__iFrameChanged();
 
           this.__attachSocketEventHandlers();
+        } else {
+          console.error(node.getLabel() + " iframe handler not ready");
         }
       })
       .catch(err => console.error(err));


### PR DESCRIPTION
## What do these changes do?

Our [old puppeteer's browser doesn't support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn#browser_compatibility) the ``hasOwn`` method, this PR replaces it with the ``in`` which does almost exactly the same.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
