### PR TITLE
🐛 fixes cache issue in web-server services i/o model

### DIFF
--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -30,7 +30,6 @@ aiohttp-swagger[performance]
 aiopg[sa] # db
 aiosmtplib # email
 asyncpg # db
-cachetools # caching for sync functions
 captcha
 cryptography # security
 faker # Only used in dev-mode for proof-of-concepts

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -101,8 +101,6 @@ attrs==21.4.0
     #   openapi-core
 bidict==0.22.0
     # via python-socketio
-cachetools==5.3.2
-    # via -r requirements/_base.in
 captcha==0.5.0
     # via -r requirements/_base.in
 certifi==2023.7.22

--- a/services/web/server/src/simcore_service_webserver/catalog/_api.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_api.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from collections.abc import Iterator
 from typing import Any
@@ -66,8 +65,7 @@ async def _safe_replace_service_input_outputs(
     service: dict[str, Any], unit_registry: UnitRegistry
 ):
     try:
-        await asyncio.to_thread(
-            replace_service_input_outputs,
+        await replace_service_input_outputs(
             service,
             unit_registry=unit_registry,
             **RESPONSE_MODEL_POLICY,
@@ -133,8 +131,7 @@ async def dev_get_service(
     )
 
     data = jsonable_encoder(service, exclude_unset=True)
-    await asyncio.to_thread(
-        replace_service_input_outputs,
+    await replace_service_input_outputs(
         data,
         unit_registry=unit_registry,
         **RESPONSE_MODEL_POLICY,
@@ -163,8 +160,7 @@ async def dev_update_service(
     )
 
     data = jsonable_encoder(service, exclude_unset=True)
-    await asyncio.to_thread(
-        replace_service_input_outputs,
+    await replace_service_input_outputs(
         data,
         unit_registry=unit_registry,
         **RESPONSE_MODEL_POLICY,
@@ -194,8 +190,7 @@ async def get_service(
     service = await client.get_service(
         ctx.app, ctx.user_id, service_key, service_version, ctx.product_name
     )
-    await asyncio.to_thread(
-        replace_service_input_outputs,
+    await replace_service_input_outputs(
         service,
         unit_registry=ctx.unit_registry,
         **RESPONSE_MODEL_POLICY,
@@ -217,8 +212,7 @@ async def update_service(
         ctx.product_name,
         update_data,
     )
-    await asyncio.to_thread(
-        replace_service_input_outputs,
+    await replace_service_input_outputs(
         service,
         unit_registry=ctx.unit_registry,
         **RESPONSE_MODEL_POLICY,
@@ -232,13 +226,12 @@ async def list_service_inputs(
     service = await client.get_service(
         ctx.app, ctx.user_id, service_key, service_version, ctx.product_name
     )
-    inputs = []
-    for input_key in service["inputs"]:
-        service_input: ServiceInputGet = (
-            ServiceInputGetFactory.from_catalog_service_api_model(service, input_key)
+    return [
+        await ServiceInputGetFactory.from_catalog_service_api_model(
+            service=service, input_key=input_key
         )
-        inputs.append(service_input)
-    return inputs
+        for input_key in service["inputs"]
+    ]
 
 
 async def get_service_input(
@@ -251,7 +244,9 @@ async def get_service_input(
         ctx.app, ctx.user_id, service_key, service_version, ctx.product_name
     )
     service_input: ServiceInputGet = (
-        ServiceInputGetFactory.from_catalog_service_api_model(service, input_key)
+        await ServiceInputGetFactory.from_catalog_service_api_model(
+            service=service, input_key=input_key
+        )
     )
 
     return service_input

--- a/services/web/server/src/simcore_service_webserver/catalog/_api.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_api.py
@@ -302,14 +302,12 @@ async def list_service_outputs(
     service = await client.get_service(
         ctx.app, ctx.user_id, service_key, service_version, ctx.product_name
     )
-
-    outputs = []
-    for output_key in service["outputs"]:
-        service_output = ServiceOutputGetFactory.from_catalog_service_api_model(
-            service, output_key, None
+    return [
+        await ServiceOutputGetFactory.from_catalog_service_api_model(
+            service=service, output_key=output_key, ureg=None
         )
-        outputs.append(service_output)
-    return outputs
+        for output_key in service["outputs"]
+    ]
 
 
 async def get_service_output(
@@ -321,11 +319,9 @@ async def get_service_output(
     service = await client.get_service(
         ctx.app, ctx.user_id, service_key, service_version, ctx.product_name
     )
-    service_output: ServiceOutputGet = (
-        ServiceOutputGetFactory.from_catalog_service_api_model(service, output_key)
+    return await ServiceOutputGetFactory.from_catalog_service_api_model(
+        service=service, output_key=output_key
     )
-
-    return service_output
 
 
 async def get_compatible_outputs_given_target_input(

--- a/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
@@ -37,7 +37,7 @@ def _can_convert_units(from_unit: str, to_unit: str, ureg: UnitRegistry) -> bool
     return can
 
 
-def replace_service_input_outputs(
+async def replace_service_input_outputs(
     service: dict[str, Any],
     *,
     unit_registry: UnitRegistry | None = None,
@@ -47,16 +47,16 @@ def replace_service_input_outputs(
     # This is a fast solution until proper models are available for the web API
     for input_key in service["inputs"]:
         new_input: ServiceInputGet = (
-            ServiceInputGetFactory.from_catalog_service_api_model(
-                service, input_key, unit_registry
+            await ServiceInputGetFactory.from_catalog_service_api_model(
+                service=service, input_key=input_key, ureg=unit_registry
             )
         )
         service["inputs"][input_key] = new_input.dict(**export_options)
 
     for output_key in service["outputs"]:
         new_output: ServiceOutputGet = (
-            ServiceOutputGetFactory.from_catalog_service_api_model(
-                service, output_key, unit_registry
+            await ServiceOutputGetFactory.from_catalog_service_api_model(
+                service=service, output_key=output_key, ureg=unit_registry
             )
         )
         service["outputs"][output_key] = new_output.dict(**export_options)

--- a/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_api_units.py
@@ -1,9 +1,5 @@
 from typing import Any
 
-from models_library.api_schemas_webserver.catalog import (
-    ServiceInputGet,
-    ServiceOutputGet,
-)
 from models_library.services import BaseServiceIOModel, ServiceInput, ServiceOutput
 from pint import PintError, UnitRegistry
 
@@ -45,20 +41,25 @@ async def replace_service_input_outputs(
 ):
     """Thin wrapper to replace i/o ports in returned service model"""
     # This is a fast solution until proper models are available for the web API
-    for input_key in service["inputs"]:
-        new_input: ServiceInputGet = (
-            await ServiceInputGetFactory.from_catalog_service_api_model(
-                service=service, input_key=input_key, ureg=unit_registry
-            )
+    new_inputs = [
+        await ServiceInputGetFactory.from_catalog_service_api_model(
+            service=service, input_key=input_key, ureg=unit_registry
         )
+        for input_key in service["inputs"]
+    ]
+
+    new_outputs = [
+        await ServiceOutputGetFactory.from_catalog_service_api_model(
+            service=service, output_key=output_key, ureg=unit_registry
+        )
+        for output_key in service["outputs"]
+    ]
+
+    # replace if above is successful
+    for input_key, new_input in zip(service["inputs"], new_inputs, strict=True):
         service["inputs"][input_key] = new_input.dict(**export_options)
 
-    for output_key in service["outputs"]:
-        new_output: ServiceOutputGet = (
-            await ServiceOutputGetFactory.from_catalog_service_api_model(
-                service=service, output_key=output_key, ureg=unit_registry
-            )
-        )
+    for output_key, new_output in zip(service["outputs"], new_outputs, strict=True):
         service["outputs"][output_key] = new_output.dict(**export_options)
 
 

--- a/services/web/server/src/simcore_service_webserver/catalog/_models.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_models.py
@@ -53,7 +53,9 @@ def get_html_formatted_unit(
 #
 # Transforms from catalog api models -> webserver api models
 #
-
+# Uses aiocache (async) instead of cachetools (sync) in order to handle concurrency better
+# SEE https://github.com/ITISFoundation/osparc-simcore/pull/6169
+#
 _SECOND = 1  # in seconds
 _MINUTE = 60 * _SECOND
 _CACHE_TTL: Final = 1 * _MINUTE
@@ -114,8 +116,7 @@ class ServiceOutputGetFactory:
     ) -> ServiceOutputGet:
         data = service["outputs"][output_key]
         # NOTE: prunes invalid field that might have remained in database
-        if "defaultValue" in data:
-            data.pop("defaultValue")
+        data.pop("defaultValue", None)
 
         # NOTE: this call must be validated if port property type is "ref_contentSchema"
         port = ServiceOutputGet(key_id=output_key, **data)

--- a/services/web/server/src/simcore_service_webserver/catalog/_models.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_models.py
@@ -59,13 +59,11 @@ _MINUTE = 60 * _SECOND
 _CACHE_TTL: Final = 1 * _MINUTE
 
 
-def _hash_inputs(
-    service: dict[str, Any],
-    input_key: str,
-    *args,  # noqa: ARG001 # pylint: disable=unused-argument
-    **kwargs,  # noqa: ARG001 # pylint: disable=unused-argument
-):
-    return f"{service['key']}/{service['version']}/{input_key}"
+def _hash_inputs(_f, *_args, **kw):
+    assert _f.__name__  # nosec
+    assert not _args  # nosec
+    service: dict[str, Any] = kw["service"]
+    return f"ServiceInputGetFactory_{service['key']}_{service['version']}_{kw['input_key']}"
 
 
 class ServiceInputGetFactory:
@@ -95,13 +93,11 @@ class ServiceInputGetFactory:
         return port
 
 
-def _hash_outputs(
-    service: dict[str, Any],
-    output_key: str,
-    *args,  # noqa: ARG001 # pylint: disable=unused-argument
-    **kwargs,  # noqa: ARG001 # pylint: disable=unused-argument
-):
-    return f"{service['key']}/{service['version']}/{output_key}"
+def _hash_outputs(_f, *_args, **kw):
+    assert _f.__name__  # nosec
+    assert not _args  # nosec
+    service: dict[str, Any] = kw["service"]
+    return f"ServiceOutputGetFactory_{service['key']}/{service['version']}/{kw['output_key']}"
 
 
 class ServiceOutputGetFactory:

--- a/services/web/server/src/simcore_service_webserver/catalog/_models.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_models.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Final
+from typing import Any, Callable, Final
 
 from aiocache import cached
 from models_library.api_schemas_webserver.catalog import (
@@ -61,8 +61,7 @@ _MINUTE = 60 * _SECOND
 _CACHE_TTL: Final = 1 * _MINUTE
 
 
-def _hash_inputs(_f, *_args, **kw):
-    assert _f.__name__  # nosec
+def _hash_inputs(_f: Callable[..., Any], *_args, **kw):
     assert not _args  # nosec
     service: dict[str, Any] = kw["service"]
     return f"ServiceInputGetFactory_{service['key']}_{service['version']}_{kw['input_key']}"
@@ -95,8 +94,7 @@ class ServiceInputGetFactory:
         return port
 
 
-def _hash_outputs(_f, *_args, **kw):
-    assert _f.__name__  # nosec
+def _hash_outputs(_f: Callable[..., Any], *_args, **kw):
     assert not _args  # nosec
     service: dict[str, Any] = kw["service"]
     return f"ServiceOutputGetFactory_{service['key']}/{service['version']}/{kw['output_key']}"

--- a/services/web/server/tests/unit/isolated/test_catalog_models.py
+++ b/services/web/server/tests/unit/isolated/test_catalog_models.py
@@ -2,6 +2,7 @@
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
+import asyncio
 import json
 from copy import deepcopy
 
@@ -69,14 +70,16 @@ def test_from_catalog_to_webapi_service(
         "owner": "foo@fake.com",
     }
 
-    def _run():
+    def _run_async_test():
         s = deepcopy(catalog_service)
-        replace_service_input_outputs(
-            s, unit_registry=unit_registry, **RESPONSE_MODEL_POLICY
+        asyncio.get_event_loop().run_until_complete(
+            replace_service_input_outputs(
+                s, unit_registry=unit_registry, **RESPONSE_MODEL_POLICY
+            )
         )
         return s
 
-    result = benchmark(_run)
+    result = benchmark(_run_async_test)
 
     # check result
     got = json.dumps(result, indent=1)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

During manual testing on the master deployment, specifically with [PR #6169](https://github.com/ITISFoundation/osparc-simcore/pull/6169), we identified that the caching mechanism for the services listing is failing due to issues with async concurrency. This problem causes the entire service call to fail.

### Changes in This PR

- **Replaces Sync Caching with Async Caching:**
  - The existing synchronous caching implementation using [`cachetools`](https://cachetools.readthedocs.io/en/stable/) has been replaced with an asynchronous caching solution using [`aiocache`](https://aiocache.aio-libs.org/en/latest/index.html) to better handle concurrent calls.
  - This change eliminates the need for `asyncio.thread`, simplifying the implementation.
  - The `cachetools` dependency has been removed from the project.
- **Improves Error Handling:**
  - Previously, a failure in the cache would lead to a 500 error because the cache error resulted in an invalid model (e.g., some fields in the input were correct while others were not, due to the failure). 
  - The updated implementation ensures that the model is not modified until all I/O fields have been properly validated, thus preventing the propagation of incomplete or invalid data and improving the stability of the service.


## Related issue/s

- Follows up https://github.com/ITISFoundation/osparc-simcore/pull/6169
- Addresses e2e tests failures loading services entrypoint
- Related to https://github.com/ITISFoundation/osparc-simcore/issues/5964

## How to test

This issue can only be replicated using the config in master

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))
