### PR TITLE
🐛 Fixes unhandled `KeyError` when missing keys in exception's `msg_template`

### DIFF
--- a/packages/models-library/src/models_library/errors_classes.py
+++ b/packages/models-library/src/models_library/errors_classes.py
@@ -1,11 +1,20 @@
 from pydantic.errors import PydanticErrorMixin
 
 
+class _DefaultDict(dict):
+    def __missing__(self, key):
+        return f"'{key}=?'"
+
+
 class OsparcErrorMixin(PydanticErrorMixin):
     def __new__(cls, *args, **kwargs):
         if not hasattr(cls, "code"):
             cls.code = cls._get_full_class_name()
         return super().__new__(cls, *args, **kwargs)
+
+    def __str__(self) -> str:
+        # NOTE: safe. Does not raise KeyError
+        return self.msg_template.format_map(_DefaultDict(**self.__dict__))
 
     @classmethod
     def _get_full_class_name(cls) -> str:

--- a/packages/models-library/tests/test_errors_classes.py
+++ b/packages/models-library/tests/test_errors_classes.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 from models_library.errors_classes import OsparcErrorMixin
+from pydantic.errors import PydanticErrorMixin
 
 
 def test_get_full_class_name():
@@ -134,3 +135,16 @@ def test_msg_template_with_different_formats(
 
     error = MyError(**ctx)
     assert str(error) == expected
+
+
+def test_missing_keys_in_msg_template_does_not_raise():
+    class MyErrorBefore(PydanticErrorMixin, ValueError):
+        msg_template = "{value} and {missing}"
+
+    with pytest.raises(KeyError, match="missing"):
+        str(MyErrorBefore(value=42))
+
+    class MyErrorAfter(OsparcErrorMixin, ValueError):
+        msg_template = "{value} and {missing}"
+
+    assert str(MyErrorAfter(value=42)) == "42 and 'missing=?'"

--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/catalog/services.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/catalog/services.py
@@ -54,7 +54,7 @@ async def list_services_paginated(  # pylint: disable=too-many-arguments
             user_id=user_id,
             limit=limit,
             offset=offset,
-            timeout_s=4 * RPC_REQUEST_DEFAULT_TIMEOUT_S,
+            timeout_s=10 * RPC_REQUEST_DEFAULT_TIMEOUT_S,
         )
 
     result = await _call(

--- a/services/api-server/src/simcore_service_api_server/exceptions/service_errors_utils.py
+++ b/services/api-server/src/simcore_service_api_server/exceptions/service_errors_utils.py
@@ -58,13 +58,14 @@ def _get_http_exception_kwargs(
     service_name: str,
     service_error: httpx.HTTPStatusError,
     http_status_map: HttpStatusMap,
-    **detail_kwargs: Any,
+    **ctx: Any,
 ):
     detail: str = ""
     headers: dict[str, str] = {}
 
     if exception_type := http_status_map.get(service_error.response.status_code):
-        raise exception_type(**detail_kwargs)
+        raise exception_type(**ctx)
+
     if service_error.response.status_code in {
         status.HTTP_429_TOO_MANY_REQUESTS,
         status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -92,7 +93,7 @@ def _get_http_exception_kwargs(
 def service_exception_handler(
     service_name: str,
     http_status_map: HttpStatusMap,
-    **endpoint_kwargs,
+    **context,
 ):
     status_code: int
     detail: str
@@ -114,7 +115,7 @@ def service_exception_handler(
     except httpx.HTTPStatusError as exc:
 
         status_code, detail, headers = _get_http_exception_kwargs(
-            service_name, exc, http_status_map=http_status_map, **endpoint_kwargs
+            service_name, exc, http_status_map=http_status_map, **context
         )
         raise HTTPException(
             status_code=status_code, detail=detail, headers=headers

--- a/services/api-server/src/simcore_service_api_server/exceptions/service_errors_utils.py
+++ b/services/api-server/src/simcore_service_api_server/exceptions/service_errors_utils.py
@@ -94,7 +94,6 @@ def service_exception_handler(
     http_status_map: HttpStatusMap,
     **endpoint_kwargs,
 ):
-    #
     status_code: int
     detail: str
     headers: dict[str, str] = {}
@@ -145,7 +144,7 @@ def _assert_correct_kwargs(func: Callable, status_map: HttpStatusMap):
         for name, param in signature(func).parameters.items()
         if param.kind == param.KEYWORD_ONLY
     }
-    for _, exc_type in status_map.items():
+    for exc_type in status_map.values():
         _exception_inputs = exc_type.named_fields()
         assert _exception_inputs.issubset(
             _required_kwargs

--- a/services/api-server/src/simcore_service_api_server/exceptions/service_errors_utils.py
+++ b/services/api-server/src/simcore_service_api_server/exceptions/service_errors_utils.py
@@ -58,13 +58,13 @@ def _get_http_exception_kwargs(
     service_name: str,
     service_error: httpx.HTTPStatusError,
     http_status_map: HttpStatusMap,
-    **ctx: Any,
+    **exception_ctx: Any,
 ):
     detail: str = ""
     headers: dict[str, str] = {}
 
     if exception_type := http_status_map.get(service_error.response.status_code):
-        raise exception_type(**ctx)
+        raise exception_type(**exception_ctx)
 
     if service_error.response.status_code in {
         status.HTTP_429_TOO_MANY_REQUESTS,

--- a/services/api-server/src/simcore_service_api_server/services/director_v2.py
+++ b/services/api-server/src/simcore_service_api_server/services/director_v2.py
@@ -192,9 +192,6 @@ class DirectorV2Api(BaseServiceClientApi):
 
 
 def setup(app: FastAPI, settings: DirectorV2Settings) -> None:
-    if not settings:
-        settings = DirectorV2Settings()
-
     setup_client_instance(
         app,
         DirectorV2Api,

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_logs.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_logs.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 from collections.abc import Iterable
 from pprint import pprint
-from typing import AsyncIterable, Final
+from typing import Final
 
 import httpx
 import pytest
@@ -128,14 +128,14 @@ async def test_log_streaming(
 @pytest.fixture
 async def mock_job_not_found(
     mocked_directorv2_service_api_base: MockRouter,
-) -> AsyncIterable[MockRouter]:
+) -> MockRouter:
     def _get_computation(request: httpx.Request, **kwargs) -> httpx.Response:
         return httpx.Response(status_code=status.HTTP_404_NOT_FOUND)
 
     mocked_directorv2_service_api_base.get(
         path__regex=r"/v2/computations/(?P<project_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
     ).mock(side_effect=_get_computation)
-    yield mocked_directorv2_service_api_base
+    return mocked_directorv2_service_api_base
 
 
 async def test_logstreaming_job_not_found_exception(

--- a/services/api-server/tests/unit/test_services_directorv2.py
+++ b/services/api-server/tests/unit/test_services_directorv2.py
@@ -34,7 +34,7 @@ async def test_oec_139646582688800_missing_ctx_values_for_msg_template(
     api: DirectorV2Api,
 ):
     #
-    # tests reported OEC:139646582688800
+    # tests reported OEC:139646582688800  (SEE https://monitoring.tip.science/graylog/messages/graylog_33/a2444501-597a-11ef-a116-0242c0a80111)
     #
 
     #   File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_api_server/services/director_v2.py", line 135, in get_computation

--- a/services/api-server/tests/unit/test_services_directorv2.py
+++ b/services/api-server/tests/unit/test_services_directorv2.py
@@ -46,7 +46,7 @@ async def test_oec_139646582688800_missing_ctx_values_for_msg_template(
     for method in ("GET", "POST", "DELETE"):
         mocked_directorv2_service_api_base.request(
             method,
-            path__regex=r"/v2/computations/(?P<project_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+            path__regex=r"/v2/computations/",
         ).respond(status_code=status.HTTP_404_NOT_FOUND)
 
     #  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_api_server/exceptions/service_errors_utils.py", line 116, in service_exception_handler

--- a/services/api-server/tests/unit/test_services_directorv2.py
+++ b/services/api-server/tests/unit/test_services_directorv2.py
@@ -34,7 +34,7 @@ async def test_oec_139646582688800_missing_ctx_values_for_msg_template(
     api: DirectorV2Api,
 ):
     #
-    # tests reported OEC:139646582688800  (SEE https://monitoring.tip.science/graylog/messages/graylog_33/a2444501-597a-11ef-a116-0242c0a80111)
+    # tests to reproduce reported OEC:139646582688800
     #
 
     #   File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_api_server/services/director_v2.py", line 135, in get_computation

--- a/services/api-server/tests/unit/test_services_directorv2.py
+++ b/services/api-server/tests/unit/test_services_directorv2.py
@@ -1,0 +1,69 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+# pylint: disable=too-many-arguments
+
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import AsyncClient
+from models_library.projects import ProjectID
+from respx import MockRouter
+from settings_library.director_v2 import DirectorV2Settings
+from simcore_service_api_server.exceptions.backend_errors import JobNotFoundError
+from simcore_service_api_server.services.director_v2 import DirectorV2Api
+
+
+@pytest.fixture
+def api() -> DirectorV2Api:
+    settings = DirectorV2Settings()
+    app = FastAPI()
+
+    return DirectorV2Api.create_once(
+        app=app,
+        client=AsyncClient(base_url=settings.base_url),
+        service_name="director_v2",
+    )
+
+
+async def test_oec_139646582688800_missing_ctx_values_for_msg_template(
+    mocked_directorv2_service_api_base: MockRouter,
+    project_id: ProjectID,
+    api: DirectorV2Api,
+):
+    #
+    # tests reported OEC:139646582688800
+    #
+
+    #   File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_api_server/services/director_v2.py", line 135, in get_computation
+    #     response.raise_for_status()
+    #   File "/home/scu/.venv/lib/python3.10/site-packages/httpx/_models.py", line 761, in raise_for_status
+    #     raise HTTPStatusError(message, request=request, response=self)
+    # httpx.HTTPStatusError: Client error '404 Not Found' for url '/v2/computations/c7ad07d3-513f-4368-bcf0-354143b6a048?user_id=94'
+
+    for method in ("GET", "POST", "DELETE"):
+        mocked_directorv2_service_api_base.request(
+            method,
+            path__regex=r"/v2/computations/(?P<project_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+        ).respond(status_code=status.HTTP_404_NOT_FOUND)
+
+    #  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_api_server/exceptions/service_errors_utils.py", line 116, in service_exception_handler
+    #    status_code, detail, headers = _get_http_exception_kwargs(
+    #  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_api_server/exceptions/service_errors_utils.py", line 66, in _get_http_exception_kwargs
+    #    raise exception_type(**detail_kwargs)
+    # simcore_service_api_server.exceptions.backend_errors.JobNotFoundError: <exception str() failed>
+    #
+    # File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_api_server/exceptions/handlers/_handlers_backend_errors.py", line 12, in backend_error_handler
+    #     return create_error_json_response(f"{exc}", status_code=exc.status_code)
+    #   File "pydantic/errors.py", line 127, in pydantic.errors.PydanticErrorMixin.__str__
+    # KeyError: 'project_id'
+    #
+
+    with pytest.raises(JobNotFoundError, match=f"{project_id}"):
+        await api.get_computation(user_id=42, project_id=project_id)
+
+    with pytest.raises(JobNotFoundError, match=f"{project_id}"):
+        await api.stop_computation(user_id=42, project_id=project_id)
+
+    with pytest.raises(JobNotFoundError, match=f"{project_id}"):
+        await api.delete_computation(user_id=42, project_id=project_id)

--- a/services/api-server/tests/unit/test_services_directorv2.py
+++ b/services/api-server/tests/unit/test_services_directorv2.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI, status
 from httpx import AsyncClient
 from models_library.projects import ProjectID
+from models_library.users import UserID
 from respx import MockRouter
 from settings_library.director_v2 import DirectorV2Settings
 from simcore_service_api_server.exceptions.backend_errors import JobNotFoundError
@@ -29,6 +30,7 @@ def api() -> DirectorV2Api:
 async def test_oec_139646582688800_missing_ctx_values_for_msg_template(
     mocked_directorv2_service_api_base: MockRouter,
     project_id: ProjectID,
+    user_id: UserID,
     api: DirectorV2Api,
 ):
     #
@@ -51,7 +53,7 @@ async def test_oec_139646582688800_missing_ctx_values_for_msg_template(
     #    status_code, detail, headers = _get_http_exception_kwargs(
     #  File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_api_server/exceptions/service_errors_utils.py", line 66, in _get_http_exception_kwargs
     #    raise exception_type(**detail_kwargs)
-    # simcore_service_api_server.exceptions.backend_errors.JobNotFoundError: <exception str() failed>
+    # simcore_service_api_server.exceptions.backend_errors.JobNotFoundError: <exception str() failed>  <-- !!!!!!!!!
     #
     # File "/home/scu/.venv/lib/python3.10/site-packages/simcore_service_api_server/exceptions/handlers/_handlers_backend_errors.py", line 12, in backend_error_handler
     #     return create_error_json_response(f"{exc}", status_code=exc.status_code)
@@ -60,10 +62,10 @@ async def test_oec_139646582688800_missing_ctx_values_for_msg_template(
     #
 
     with pytest.raises(JobNotFoundError, match=f"{project_id}"):
-        await api.get_computation(user_id=42, project_id=project_id)
+        await api.get_computation(user_id=user_id, project_id=project_id)
 
     with pytest.raises(JobNotFoundError, match=f"{project_id}"):
-        await api.stop_computation(user_id=42, project_id=project_id)
+        await api.stop_computation(user_id=user_id, project_id=project_id)
 
     with pytest.raises(JobNotFoundError, match=f"{project_id}"):
-        await api.delete_computation(user_id=42, project_id=project_id)
+        await api.delete_computation(user_id=user_id, project_id=project_id)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
Addresses this error found in tip.science deploy
```
Unexpected KeyError: Oops! Something went wrong, 
but we've noted it down and we'll sort it out ASAP. 
Thanks for your patience! [OEC:139646582688800]
```

The api-server responds 500 to `GET /v2/computations/ ...`  instead of 404 (in this case) due to an unhandled error



### Details
- 🧪 Reproduced logs in `test_oec_139646582688800_missing_ctx_values_for_msg_template`
     - The tests passes in HEAD master but tip.science is at [_v1.75.0_ ](https://github.com/ITISFoundation/osparc-simcore/releases/tag/v1.75.0)
     - We believe this is caused because this fix https://github.com/ITISFoundation/osparc-simcore/pull/6064 was still not released there
- 🎨 Overrides ` OsparcErrorMixin.__str__`  to **avoid raising `KeyError` when key is missing in template error messages**. The message will include a default placeholder instead of raising and stopping execution

## Related issue/s

- Reported by @matusdrobuliak66 @Konohana0608 from tip.science (v1.75.0) 

## How to test

-  SEE `services/api-server/tests/unit/test_services_directorv2.py` reproduces [log report](https://monitoring.tip.science/graylog/messages/graylog_33/a2444501-597a-11ef-a116-0242c0a80111)


## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))
