### PR TITLE
♻️ skipping AWS S3 CLI tests

### DIFF
--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_aws_s3_cli.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_aws_s3_cli.py
@@ -243,6 +243,9 @@ async def dir_downloaded_files_2(tmp_path: Path, faker: Faker) -> AsyncIterator[
     await remove_directory(path)
 
 
+@pytest.mark.skip(
+    reason="We disabled the AWS S3 CLI and will use RClone for now; https://github.com/ITISFoundation/osparc-simcore/discussions/5828"
+)
 @pytest.mark.parametrize(
     "file_count, file_size, check_progress",
     [
@@ -343,6 +346,9 @@ def _regression_add_broken_symlink(
     os.symlink(f"{path_does_not_exist_on_fs}", f"{broken_symlink}")
 
 
+@pytest.mark.skip(
+    reason="We disabled the AWS S3 CLI and will use RClone for now; https://github.com/ITISFoundation/osparc-simcore/discussions/5828"
+)
 @pytest.mark.parametrize(
     "changes_callable",
     [
@@ -411,6 +417,9 @@ async def test_overwrite_an_existing_file_and_sync_again(
     )
 
 
+@pytest.mark.skip(
+    reason="We disabled the AWS S3 CLI and will use RClone for now; https://github.com/ITISFoundation/osparc-simcore/discussions/5828"
+)
 async def test_raises_error_if_local_directory_path_is_a_file(
     tmp_path: Path, faker: Faker, cleanup_bucket_after_test: None
 ):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- ♻️ skipping heavy integration AWS S3 CLI tests (as we decided we will not use it for now and stay with RClone)


## Related issue/s
- relates https://github.com/ITISFoundation/osparc-simcore/discussions/5828
- relates https://github.com/ITISFoundation/osparc-simcore/issues/5833
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
