### PR TITLE
🐛Bugfix: Cannot instantiate templates

### DIFF
--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_aws_s3_cli.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_aws_s3_cli.py
@@ -251,10 +251,10 @@ async def dir_downloaded_files_2(tmp_path: Path, faker: Faker) -> AsyncIterator[
         (2, parse_obj_as(ByteSize, "1mib"), False),
         (1, parse_obj_as(ByteSize, "1Gib"), True),
         pytest.param(
-            (4, parse_obj_as(ByteSize, "500Mib"), True), marks=pytest.mark.heavy_load
+            4, parse_obj_as(ByteSize, "500Mib"), True, marks=pytest.mark.heavy_load
         ),
         pytest.param(
-            (100, parse_obj_as(ByteSize, "20mib"), True), marks=pytest.mark.heavy_load
+            100, parse_obj_as(ByteSize, "20mib"), True, marks=pytest.mark.heavy_load
         ),
     ],
 )

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_aws_s3_cli.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_aws_s3_cli.py
@@ -250,8 +250,12 @@ async def dir_downloaded_files_2(tmp_path: Path, faker: Faker) -> AsyncIterator[
         (1, parse_obj_as(ByteSize, "1mib"), False),
         (2, parse_obj_as(ByteSize, "1mib"), False),
         (1, parse_obj_as(ByteSize, "1Gib"), True),
-        (4, parse_obj_as(ByteSize, "500Mib"), True),
-        (100, parse_obj_as(ByteSize, "20mib"), True),
+        pytest.param(
+            (4, parse_obj_as(ByteSize, "500Mib"), True), marks=pytest.mark.heavy_load
+        ),
+        pytest.param(
+            (100, parse_obj_as(ByteSize, "20mib"), True), marks=pytest.mark.heavy_load
+        ),
     ],
 )
 async def test_local_to_remote_to_local(

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
@@ -262,8 +262,12 @@ async def dir_downloaded_files_2(tmp_path: Path, faker: Faker) -> AsyncIterator[
         (1, parse_obj_as(ByteSize, "1mib"), False),
         (2, parse_obj_as(ByteSize, "1mib"), False),
         (1, parse_obj_as(ByteSize, "1Gib"), True),
-        (4, parse_obj_as(ByteSize, "500Mib"), True),
-        (100, parse_obj_as(ByteSize, "20mib"), True),
+        pytest.param(
+            (4, parse_obj_as(ByteSize, "500Mib"), True), marks=pytest.mark.heavy_load
+        ),
+        pytest.param(
+            (100, parse_obj_as(ByteSize, "20mib"), True), marks=pytest.mark.heavy_load
+        ),
     ],
 )
 async def test_local_to_remote_to_local(

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_r_clone.py
@@ -263,10 +263,10 @@ async def dir_downloaded_files_2(tmp_path: Path, faker: Faker) -> AsyncIterator[
         (2, parse_obj_as(ByteSize, "1mib"), False),
         (1, parse_obj_as(ByteSize, "1Gib"), True),
         pytest.param(
-            (4, parse_obj_as(ByteSize, "500Mib"), True), marks=pytest.mark.heavy_load
+            4, parse_obj_as(ByteSize, "500Mib"), True, marks=pytest.mark.heavy_load
         ),
         pytest.param(
-            (100, parse_obj_as(ByteSize, "20mib"), True), marks=pytest.mark.heavy_load
+            100, parse_obj_as(ByteSize, "20mib"), True, marks=pytest.mark.heavy_load
         ),
     ],
 )

--- a/services/storage/src/simcore_service_storage/handlers_files.py
+++ b/services/storage/src/simcore_service_storage/handlers_files.py
@@ -68,7 +68,8 @@ async def get_files_metadata(request: web.Request) -> web.Response:
     data: list[FileMetaData] = await dsm.list_files(
         user_id=query_params.user_id,
         expand_dirs=query_params.expand_dirs,
-        uuid_filter=query_params.uuid_filter,
+        uuid_filter=query_params.uuid_filter
+        or f"{query_params.project_id or ''}",  # NOTE: https://github.com/ITISFoundation/osparc-issues/issues/1593
         project_id=query_params.project_id,
     )
     return web.json_response(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This [https://github.com/ITISFoundation/osparc-simcore/pull/5786](https://github.com/ITISFoundation/osparc-simcore/pull/5786) changed how the webserver calls into storage by replacing uuid_filter with project_id. This in effect created an issue with how much files were returned.
This was indirectly fixed by [https://github.com/ITISFoundation/osparc-simcore/pull/5796](https://github.com/ITISFoundation/osparc-simcore/pull/5796), which introduced then another problem:
https://github.com/ITISFoundation/osparc-issues/issues/1587

so now, there is again an in-between, which should fix most of the issues. but maybe have a slight reduce

- fixes https://github.com/ITISFoundation/osparc-issues/issues/1593


- Bonus:
  - reduce needed storage to run tests and should implement https://github.com/ITISFoundation/osparc-simcore/pull/6191
## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
