### PR TITLE
🎨Autoscaling: chunk prepulled image AWS EC2 tags

### DIFF
--- a/packages/aws-library/src/aws_library/ec2/_models.py
+++ b/packages/aws-library/src/aws_library/ec2/_models.py
@@ -69,13 +69,17 @@ InstancePrivateDNSName: TypeAlias = str
 
 class AWSTagKey(ConstrainedStr):
     # see [https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions]
-    regex = re.compile(r"^(?!(_index|\.{1,2})$)[a-zA-Z0-9\+\-=\._:@]{1,128}$")
+    regex = re.compile(r"^(?!(_index|\.{1,2})$)[a-zA-Z0-9\+\-=\._:@]+$")
+    min_length = 1
+    max_length = 128
 
 
 class AWSTagValue(ConstrainedStr):
     # see [https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions]
     # quotes []{} were added as it allows to json encode. it seems to be accepted as a value
-    regex = re.compile(r"^[a-zA-Z0-9\s\+\-=\.,_:/@\"\'\[\]\{\}]{0,256}$")
+    regex = re.compile(r"^[a-zA-Z0-9\s\+\-=\.,_:/@\"\'\[\]\{\}]*$")
+    min_length = 0
+    max_length = 256
 
 
 EC2Tags: TypeAlias = dict[AWSTagKey, AWSTagValue]

--- a/services/autoscaling/src/simcore_service_autoscaling/constants.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/constants.py
@@ -1,6 +1,6 @@
 from typing import Final
 
-from aws_library.ec2._models import AWSTagKey
+from aws_library.ec2._models import AWSTagKey, AWSTagValue, EC2Tags
 from pydantic import parse_obj_as
 
 BUFFER_MACHINE_PULLING_EC2_TAG_KEY: Final[AWSTagKey] = parse_obj_as(
@@ -18,3 +18,13 @@ DOCKER_PULL_COMMAND: Final[
 PRE_PULLED_IMAGES_EC2_TAG_KEY: Final[AWSTagKey] = parse_obj_as(
     AWSTagKey, "io.simcore.autoscaling.pre_pulled_images"
 )
+
+BUFFER_MACHINE_TAG_KEY: Final[AWSTagKey] = parse_obj_as(
+    AWSTagKey, "io.simcore.autoscaling.buffer_machine"
+)
+DEACTIVATED_BUFFER_MACHINE_EC2_TAGS: Final[EC2Tags] = {
+    BUFFER_MACHINE_TAG_KEY: parse_obj_as(AWSTagValue, "true")
+}
+ACTIVATED_BUFFER_MACHINE_EC2_TAGS: Final[EC2Tags] = {
+    BUFFER_MACHINE_TAG_KEY: parse_obj_as(AWSTagValue, "false")
+}

--- a/services/autoscaling/src/simcore_service_autoscaling/constants.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/constants.py
@@ -1,0 +1,20 @@
+from typing import Final
+
+from aws_library.ec2._models import AWSTagKey
+from pydantic import parse_obj_as
+
+BUFFER_MACHINE_PULLING_EC2_TAG_KEY: Final[AWSTagKey] = parse_obj_as(
+    AWSTagKey, "pulling"
+)
+BUFFER_MACHINE_PULLING_COMMAND_ID_EC2_TAG_KEY: Final[AWSTagKey] = parse_obj_as(
+    AWSTagKey, "ssm-command-id"
+)
+PREPULL_COMMAND_NAME: Final[str] = "docker images pulling"
+
+DOCKER_PULL_COMMAND: Final[
+    str
+] = "docker compose -f /docker-pull.compose.yml -p buffering pull"
+
+PRE_PULLED_IMAGES_EC2_TAG_KEY: Final[AWSTagKey] = parse_obj_as(
+    AWSTagKey, "io.simcore.autoscaling.pre_pulled_images"
+)

--- a/services/autoscaling/src/simcore_service_autoscaling/constants.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/constants.py
@@ -1,3 +1,4 @@
+import re
 from typing import Final
 
 from aws_library.ec2._models import AWSTagKey, AWSTagValue, EC2Tags
@@ -28,3 +29,6 @@ DEACTIVATED_BUFFER_MACHINE_EC2_TAGS: Final[EC2Tags] = {
 ACTIVATED_BUFFER_MACHINE_EC2_TAGS: Final[EC2Tags] = {
     BUFFER_MACHINE_TAG_KEY: parse_obj_as(AWSTagValue, "false")
 }
+PRE_PULLED_IMAGES_RE: Final[re.Pattern] = re.compile(
+    rf"{PRE_PULLED_IMAGES_EC2_TAG_KEY}_\((\d+)\)"
+)

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/buffer_machines_pool_core.py
@@ -4,7 +4,7 @@ from operator import itemgetter
 from aws_library.ec2 import AWSTagKey, AWSTagValue, EC2Tags
 from fastapi import FastAPI
 from models_library.docker import DockerGenericTag
-from models_library.utils.json_serialization import json_dumps, json_loads
+from models_library.utils.json_serialization import json_dumps
 from pydantic import parse_obj_as, parse_raw_as
 
 from ..constants import (
@@ -64,7 +64,7 @@ def load_pre_pulled_images_from_tags(tags: EC2Tags) -> list[DockerGenericTag]:
     # AWS Tag values are limited to 256 characters so we chunk the images
     if PRE_PULLED_IMAGES_EC2_TAG_KEY in tags:
         # read directly
-        return json_loads(tags[PRE_PULLED_IMAGES_EC2_TAG_KEY])
+        return parse_raw_as(list[DockerGenericTag], tags[PRE_PULLED_IMAGES_EC2_TAG_KEY])
 
     assembled_json = "".join(
         map(

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/buffer_machines_pool_core.py
@@ -79,5 +79,6 @@ def load_pre_pulled_images_from_tags(tags: EC2Tags) -> list[DockerGenericTag]:
             ),
         )
     )
-
-    return parse_raw_as(list[DockerGenericTag], assembled_json)
+    if assembled_json:
+        return parse_raw_as(list[DockerGenericTag], assembled_json)
+    return []

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/buffer_machines_pool_core.py
@@ -1,7 +1,8 @@
-from typing import Final
+from typing import Final, Iterable
 
 from aws_library.ec2 import AWSTagKey, AWSTagValue, EC2Tags
 from fastapi import FastAPI
+from models_library.docker import DockerGenericTag
 from pydantic import parse_obj_as
 
 from ..modules.auto_scaling_mode_base import BaseAutoscaling
@@ -37,3 +38,14 @@ def get_deactivated_buffer_ec2_tags(
 
 def is_buffer_machine(tags: EC2Tags) -> bool:
     return bool(_BUFFER_MACHINE_TAG_KEY in tags)
+
+
+def dump_pre_pulled_images_as_tags(images: Iterable[DockerGenericTag]) -> EC2Tags:
+    # AWS Tag Values are limited to 256 characaters so we chunk the images
+    # into smaller chunks
+    ...
+
+
+def load_pre_pulled_images_from_tags(tags: EC2Tags) -> tuple[DockerGenericTag]:
+    # AWS Tag values are limited to 256 characters so we chunk the images
+    ...

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/buffer_machines_pool_core.py
@@ -1,34 +1,28 @@
-from typing import Final, Iterable
+from collections.abc import Iterable
 
 from aws_library.ec2 import AWSTagKey, AWSTagValue, EC2Tags
 from fastapi import FastAPI
 from models_library.docker import DockerGenericTag
-from pydantic import parse_obj_as
 
-from ..modules.auto_scaling_mode_base import BaseAutoscaling
-
-_BUFFER_MACHINE_TAG_KEY: Final[AWSTagKey] = parse_obj_as(
-    AWSTagKey, "io.simcore.autoscaling.buffer_machine"
+from ..constants import (
+    ACTIVATED_BUFFER_MACHINE_EC2_TAGS,
+    BUFFER_MACHINE_TAG_KEY,
+    DEACTIVATED_BUFFER_MACHINE_EC2_TAGS,
 )
-_DEACTIVATED_BUFFER_MACHINE_EC2_TAGS: Final[EC2Tags] = {
-    _BUFFER_MACHINE_TAG_KEY: parse_obj_as(AWSTagValue, "true")
-}
-_ACTIVATED_BUFFER_MACHINE_EC2_TAGS: Final[EC2Tags] = {
-    _BUFFER_MACHINE_TAG_KEY: parse_obj_as(AWSTagValue, "false")
-}
+from ..modules.auto_scaling_mode_base import BaseAutoscaling
 
 
 def get_activated_buffer_ec2_tags(
     app: FastAPI, auto_scaling_mode: BaseAutoscaling
 ) -> EC2Tags:
-    return auto_scaling_mode.get_ec2_tags(app) | _ACTIVATED_BUFFER_MACHINE_EC2_TAGS
+    return auto_scaling_mode.get_ec2_tags(app) | ACTIVATED_BUFFER_MACHINE_EC2_TAGS
 
 
 def get_deactivated_buffer_ec2_tags(
     app: FastAPI, auto_scaling_mode: BaseAutoscaling
 ) -> EC2Tags:
     base_ec2_tags = (
-        auto_scaling_mode.get_ec2_tags(app) | _DEACTIVATED_BUFFER_MACHINE_EC2_TAGS
+        auto_scaling_mode.get_ec2_tags(app) | DEACTIVATED_BUFFER_MACHINE_EC2_TAGS
     )
     base_ec2_tags[AWSTagKey("Name")] = AWSTagValue(
         f"{base_ec2_tags[AWSTagKey('Name')]}-buffer"
@@ -37,7 +31,7 @@ def get_deactivated_buffer_ec2_tags(
 
 
 def is_buffer_machine(tags: EC2Tags) -> bool:
-    return bool(_BUFFER_MACHINE_TAG_KEY in tags)
+    return bool(BUFFER_MACHINE_TAG_KEY in tags)
 
 
 def dump_pre_pulled_images_as_tags(images: Iterable[DockerGenericTag]) -> EC2Tags:

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -28,12 +28,12 @@ from pytest_simcore.helpers.aws_ec2 import (
 )
 from pytest_simcore.helpers.logging_tools import log_context
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
+from simcore_service_autoscaling.constants import PRE_PULLED_IMAGES_EC2_TAG_KEY
 from simcore_service_autoscaling.core.settings import ApplicationSettings
 from simcore_service_autoscaling.modules.auto_scaling_mode_dynamic import (
     DynamicAutoscaling,
 )
 from simcore_service_autoscaling.modules.buffer_machines_pool_core import (
-    _PRE_PULLED_IMAGES_EC2_TAG_KEY,
     monitor_buffer_machines,
 )
 from simcore_service_autoscaling.utils.buffer_machines_pool_core import (
@@ -311,7 +311,7 @@ async def _test_monitor_buffer_machines(
                 expected_instance_type=next(iter(ec2_instances_allowed_types)),
                 expected_instance_state="stopped",
                 expected_additional_tag_keys=[
-                    _PRE_PULLED_IMAGES_EC2_TAG_KEY,
+                    PRE_PULLED_IMAGES_EC2_TAG_KEY,
                     *list(ec2_instance_custom_tags),
                 ],
                 expected_pre_pulled_images=pre_pulled_images,
@@ -376,7 +376,7 @@ async def create_buffer_machines(
         if pre_pull_images is not None and instance_state_name == "stopped":
             resource_tags.append(
                 {
-                    "Key": _PRE_PULLED_IMAGES_EC2_TAG_KEY,
+                    "Key": PRE_PULLED_IMAGES_EC2_TAG_KEY,
                     "Value": f"{json_dumps(pre_pull_images)}",
                 }
             )

--- a/services/autoscaling/tests/unit/test_utils_buffer_machines_pool_core.py
+++ b/services/autoscaling/tests/unit/test_utils_buffer_machines_pool_core.py
@@ -1,0 +1,61 @@
+import pytest
+from fastapi import FastAPI
+from simcore_service_autoscaling.constants import (
+    ACTIVATED_BUFFER_MACHINE_EC2_TAGS,
+    DEACTIVATED_BUFFER_MACHINE_EC2_TAGS,
+)
+from simcore_service_autoscaling.modules import BaseAutoscaling
+from simcore_service_autoscaling.modules.auto_scaling_mode_computational import (
+    ComputationalAutoscaling,
+)
+from simcore_service_autoscaling.modules.auto_scaling_mode_dynamic import (
+    DynamicAutoscaling,
+)
+from simcore_service_autoscaling.utils.buffer_machines_pool_core import (
+    get_activated_buffer_ec2_tags,
+    get_deactivated_buffer_ec2_tags,
+)
+
+
+@pytest.mark.parametrize(
+    "auto_scaling_mode", [(DynamicAutoscaling()), (ComputationalAutoscaling())]
+)
+def test_get_activated_buffer_ec2_tags(
+    initialized_app: FastAPI, auto_scaling_mode: BaseAutoscaling
+):
+    activated_buffer_tags = get_activated_buffer_ec2_tags(
+        initialized_app, auto_scaling_mode
+    )
+    assert (
+        auto_scaling_mode.get_ec2_tags(initialized_app)
+        | ACTIVATED_BUFFER_MACHINE_EC2_TAGS
+    ) == activated_buffer_tags
+
+
+@pytest.mark.parametrize(
+    "auto_scaling_mode", [(DynamicAutoscaling()), (ComputationalAutoscaling())]
+)
+def test_get_deactivated_buffer_ec2_tags(
+    initialized_app: FastAPI, auto_scaling_mode: BaseAutoscaling
+):
+    deactivated_buffer_tags = get_deactivated_buffer_ec2_tags(
+        initialized_app, auto_scaling_mode
+    )
+    # when deactivated the buffer EC2 name has an additional -buffer suffix
+    expected_tags = (
+        auto_scaling_mode.get_ec2_tags(initialized_app)
+        | DEACTIVATED_BUFFER_MACHINE_EC2_TAGS
+    )
+    assert expected_tags == deactivated_buffer_tags
+
+
+def test_is_buffer_machine():
+    ...
+
+
+def test_dump_pre_pulled_images_as_tags():
+    ...
+
+
+def test_load_pre_pulled_images_from_tags():
+    ...

--- a/services/autoscaling/tests/unit/test_utils_buffer_machines_pool_core.py
+++ b/services/autoscaling/tests/unit/test_utils_buffer_machines_pool_core.py
@@ -1,10 +1,18 @@
+# pylint:disable=unused-variable
+# pylint:disable=unused-argument
+# pylint:disable=redefined-outer-name
 import pytest
+from aws_library.ec2 import AWSTagKey, AWSTagValue, EC2Tags
 from fastapi import FastAPI
+from models_library.docker import DockerGenericTag
+from pydantic import parse_obj_as
+from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict
 from simcore_service_autoscaling.constants import (
     ACTIVATED_BUFFER_MACHINE_EC2_TAGS,
+    BUFFER_MACHINE_TAG_KEY,
     DEACTIVATED_BUFFER_MACHINE_EC2_TAGS,
+    PRE_PULLED_IMAGES_EC2_TAG_KEY,
 )
-from simcore_service_autoscaling.modules import BaseAutoscaling
 from simcore_service_autoscaling.modules.auto_scaling_mode_computational import (
     ComputationalAutoscaling,
 )
@@ -12,17 +20,22 @@ from simcore_service_autoscaling.modules.auto_scaling_mode_dynamic import (
     DynamicAutoscaling,
 )
 from simcore_service_autoscaling.utils.buffer_machines_pool_core import (
+    dump_pre_pulled_images_as_tags,
     get_activated_buffer_ec2_tags,
     get_deactivated_buffer_ec2_tags,
+    is_buffer_machine,
 )
 
 
-@pytest.mark.parametrize(
-    "auto_scaling_mode", [(DynamicAutoscaling()), (ComputationalAutoscaling())]
-)
-def test_get_activated_buffer_ec2_tags(
-    initialized_app: FastAPI, auto_scaling_mode: BaseAutoscaling
+def test_get_activated_buffer_ec2_tags_dynamic(
+    disabled_rabbitmq: None,
+    disabled_ec2: None,
+    disabled_ssm: None,
+    mocked_redis_server: None,
+    enabled_dynamic_mode: EnvVarsDict,
+    initialized_app: FastAPI,
 ):
+    auto_scaling_mode = DynamicAutoscaling()
     activated_buffer_tags = get_activated_buffer_ec2_tags(
         initialized_app, auto_scaling_mode
     )
@@ -32,12 +45,15 @@ def test_get_activated_buffer_ec2_tags(
     ) == activated_buffer_tags
 
 
-@pytest.mark.parametrize(
-    "auto_scaling_mode", [(DynamicAutoscaling()), (ComputationalAutoscaling())]
-)
-def test_get_deactivated_buffer_ec2_tags(
-    initialized_app: FastAPI, auto_scaling_mode: BaseAutoscaling
+def test_get_deactivated_buffer_ec2_tags_dynamic(
+    disabled_rabbitmq: None,
+    disabled_ec2: None,
+    disabled_ssm: None,
+    mocked_redis_server: None,
+    enabled_dynamic_mode: EnvVarsDict,
+    initialized_app: FastAPI,
 ):
+    auto_scaling_mode = DynamicAutoscaling()
     deactivated_buffer_tags = get_deactivated_buffer_ec2_tags(
         initialized_app, auto_scaling_mode
     )
@@ -46,15 +62,106 @@ def test_get_deactivated_buffer_ec2_tags(
         auto_scaling_mode.get_ec2_tags(initialized_app)
         | DEACTIVATED_BUFFER_MACHINE_EC2_TAGS
     )
+    assert "Name" in expected_tags
+    expected_tags[AWSTagKey("Name")] = parse_obj_as(
+        AWSTagValue, str(expected_tags[AWSTagKey("Name")]) + "-buffer"
+    )
     assert expected_tags == deactivated_buffer_tags
 
 
-def test_is_buffer_machine():
-    ...
+def test_get_activated_buffer_ec2_tags_computational(
+    disabled_rabbitmq: None,
+    disabled_ec2: None,
+    disabled_ssm: None,
+    mocked_redis_server: None,
+    enabled_computational_mode: EnvVarsDict,
+    initialized_app: FastAPI,
+):
+    auto_scaling_mode = ComputationalAutoscaling()
+    activated_buffer_tags = get_activated_buffer_ec2_tags(
+        initialized_app, auto_scaling_mode
+    )
+    assert (
+        auto_scaling_mode.get_ec2_tags(initialized_app)
+        | ACTIVATED_BUFFER_MACHINE_EC2_TAGS
+    ) == activated_buffer_tags
 
 
-def test_dump_pre_pulled_images_as_tags():
-    ...
+def test_get_deactivated_buffer_ec2_tags_computational(
+    disabled_rabbitmq: None,
+    disabled_ec2: None,
+    disabled_ssm: None,
+    mocked_redis_server: None,
+    enabled_computational_mode: EnvVarsDict,
+    initialized_app: FastAPI,
+):
+    auto_scaling_mode = ComputationalAutoscaling()
+    deactivated_buffer_tags = get_deactivated_buffer_ec2_tags(
+        initialized_app, auto_scaling_mode
+    )
+    # when deactivated the buffer EC2 name has an additional -buffer suffix
+    expected_tags = (
+        auto_scaling_mode.get_ec2_tags(initialized_app)
+        | DEACTIVATED_BUFFER_MACHINE_EC2_TAGS
+    )
+    assert "Name" in expected_tags
+    expected_tags[AWSTagKey("Name")] = parse_obj_as(
+        AWSTagValue, str(expected_tags[AWSTagKey("Name")]) + "-buffer"
+    )
+    assert expected_tags == deactivated_buffer_tags
+
+
+@pytest.mark.parametrize(
+    "tags, expected_is_buffer",
+    [
+        ({"whatever_key": "whatever_value"}, False),
+        ({BUFFER_MACHINE_TAG_KEY: "whatever_value"}, True),
+    ],
+)
+def test_is_buffer_machine(tags: EC2Tags, expected_is_buffer: bool):
+    assert is_buffer_machine(tags) is expected_is_buffer
+
+
+@pytest.mark.parametrize(
+    "images, expected_tags",
+    [
+        pytest.param(
+            [
+                "itisfoundation/dynamic-sidecar:latest",
+                "itisfoundation/agent:latest",
+                "registry.pytest.com/simcore/services/dynamic/ti-postpro:2.0.34",
+                "registry.pytest.com/simcore/services/dynamic/ti-simu:1.0.12",
+                "registry.pytest.com/simcore/services/dynamic/ti-pers:1.0.19",
+                "registry.pytest.com/simcore/services/dynamic/sim4life-postpro:2.0.106",
+                "registry.pytest.com/simcore/services/dynamic/s4l-core-postpro:2.0.106",
+                "registry.pytest.com/simcore/services/dynamic/s4l-core-stream:2.0.106",
+                "registry.pytest.com/simcore/services/dynamic/sym-server-8-0-0-dy:2.0.106",
+                "registry.pytest.com/simcore/services/dynamic/sim4life-8-0-0-modeling:3.2.34",
+                "registry.pytest.com/simcore/services/dynamic/s4l-core-8-0-0-modeling:3.2.34",
+                "registry.pytest.com/simcore/services/dynamic/s4l-stream-8-0-0-dy:3.2.34",
+                "registry.pytest.com/simcore/services/dynamic/sym-server-8-0-0-dy:3.2.34",
+            ],
+            {
+                f"{PRE_PULLED_IMAGES_EC2_TAG_KEY}_(0)": '["itisfoundation/dynamic-sidecar:latest","itisfoundation/agent:latest","registry.pytest.com/simcore/services/dynamic/ti-postpro:2.0.34","registry.pytest.com/simcore/services/dynamic/ti-simu:1.0.12","registry.pytest.com/simcore/services/dynamic/ti-pers:1.0.',
+                f"{PRE_PULLED_IMAGES_EC2_TAG_KEY}_(1)": '19","registry.pytest.com/simcore/services/dynamic/sim4life-postpro:2.0.106","registry.pytest.com/simcore/services/dynamic/s4l-core-postpro:2.0.106","registry.pytest.com/simcore/services/dynamic/s4l-core-stream:2.0.106","registry.pytest.com/simcore/services',
+                f"{PRE_PULLED_IMAGES_EC2_TAG_KEY}_(2)": '/dynamic/sym-server-8-0-0-dy:2.0.106","registry.pytest.com/simcore/services/dynamic/sim4life-8-0-0-modeling:3.2.34","registry.pytest.com/simcore/services/dynamic/s4l-core-8-0-0-modeling:3.2.34","registry.pytest.com/simcore/services/dynamic/s4l-stream-8-0-0',
+                f"{PRE_PULLED_IMAGES_EC2_TAG_KEY}_(3)": '-dy:3.2.34","registry.pytest.com/simcore/services/dynamic/sym-server-8-0-0-dy:3.2.34"]',
+            },
+            id="many images that get chunked to AWS Tag max length",
+        ),
+        pytest.param(
+            ["itisfoundation/dynamic-sidecar:latest", "itisfoundation/agent:latest"],
+            {
+                PRE_PULLED_IMAGES_EC2_TAG_KEY: '["itisfoundation/dynamic-sidecar:latest","itisfoundation/agent:latest"]'
+            },
+            id="<256 characters jsonized number of images does not get chunked",
+        ),
+    ],
+)
+def test_dump_pre_pulled_images_as_tags(
+    images: list[DockerGenericTag], expected_tags: EC2Tags
+):
+    assert dump_pre_pulled_images_as_tags(images) == expected_tags
 
 
 def test_load_pre_pulled_images_from_tags():

--- a/services/autoscaling/tests/unit/test_utils_buffer_machines_pool_core.py
+++ b/services/autoscaling/tests/unit/test_utils_buffer_machines_pool_core.py
@@ -3,6 +3,7 @@
 # pylint:disable=redefined-outer-name
 import pytest
 from aws_library.ec2 import AWSTagKey, AWSTagValue, EC2Tags
+from faker import Faker
 from fastapi import FastAPI
 from models_library.docker import DockerGenericTag
 from pydantic import parse_obj_as
@@ -169,3 +170,7 @@ def test_dump_load_pre_pulled_images_as_tags(
 ):
     assert dump_pre_pulled_images_as_tags(images) == expected_tags
     assert load_pre_pulled_images_from_tags(expected_tags) == images
+
+
+def test_load_pre_pulled_images_as_tags_no_tag_present_returns_empty_list(faker: Faker):
+    assert load_pre_pulled_images_from_tags(faker.pydict(allowed_types=(str,))) == []

--- a/services/autoscaling/tests/unit/test_utils_buffer_machines_pool_core.py
+++ b/services/autoscaling/tests/unit/test_utils_buffer_machines_pool_core.py
@@ -24,6 +24,7 @@ from simcore_service_autoscaling.utils.buffer_machines_pool_core import (
     get_activated_buffer_ec2_tags,
     get_deactivated_buffer_ec2_tags,
     is_buffer_machine,
+    load_pre_pulled_images_from_tags,
 )
 
 
@@ -156,13 +157,15 @@ def test_is_buffer_machine(tags: EC2Tags, expected_is_buffer: bool):
             },
             id="<256 characters jsonized number of images does not get chunked",
         ),
+        pytest.param(
+            [],
+            {PRE_PULLED_IMAGES_EC2_TAG_KEY: "[]"},
+            id="empty list",
+        ),
     ],
 )
-def test_dump_pre_pulled_images_as_tags(
+def test_dump_load_pre_pulled_images_as_tags(
     images: list[DockerGenericTag], expected_tags: EC2Tags
 ):
     assert dump_pre_pulled_images_as_tags(images) == expected_tags
-
-
-def test_load_pre_pulled_images_from_tags():
-    ...
+    assert load_pre_pulled_images_from_tags(expected_tags) == images

--- a/services/clusters-keeper/tests/unit/test_core_settings.py
+++ b/services/clusters-keeper/tests/unit/test_core_settings.py
@@ -76,7 +76,7 @@ def test_invalid_primary_custom_tags_raises(
         monkeypatch,
         {"PRIMARY_EC2_INSTANCES_CUSTOM_TAGS": json.dumps(invalid_tag)},
     )
-    with pytest.raises(ValidationError, match="string does not match regex"):
+    with pytest.raises(ValidationError):
         ApplicationSettings.create_from_envs()
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

during early testing, this was identified as a problem. AWS EC2 Tags take a maximum of 256 characters. When pre pulling images in buffer EC2, a tag with the pre-pulled images is set on the instance for fast retrieval.
Since the list of pre pulled images can be quite long now this is chunked.

### driving tests:
```services/autoscaling/tests/unit/test_utils_buffer_machines_pool_core.py```


## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/6230
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
