### PR TITLE
🐛Autoscaling: Cluster gauges not reset correctly, too many buffer created, log improvements

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -128,7 +128,7 @@ class Cluster:  # pylint: disable=too-many-instance-attributes
             return f"[{','.join(n.ec2_instance.id for n in instances)}]"
 
         return (
-            f"active-nodes: count={len(self.active_nodes)} {_get_instance_ids(self.active_nodes)}, "
+            f"Cluster(active-nodes: count={len(self.active_nodes)} {_get_instance_ids(self.active_nodes)}, "
             f"pending-nodes: count={len(self.pending_nodes)} {_get_instance_ids(self.pending_nodes)}, "
             f"drained-nodes: count={len(self.drained_nodes)} {_get_instance_ids(self.drained_nodes)}, "
             f"reserve-drained-nodes: count={len(self.reserve_drained_nodes)} {_get_instance_ids(self.reserve_drained_nodes)}, "
@@ -137,7 +137,7 @@ class Cluster:  # pylint: disable=too-many-instance-attributes
             f"buffer-ec2s: count={len(self.buffer_ec2s)} {_get_instance_ids(self.buffer_ec2s)}, "
             f"disconnected-nodes: count={len(self.disconnected_nodes)}, "
             f"terminating-nodes: count={len(self.terminating_nodes)} {_get_instance_ids(self.terminating_nodes)}, "
-            f"terminated-ec2s: count={len(self.terminated_instances)} {_get_instance_ids(self.terminated_instances)}, "
+            f"terminated-ec2s: count={len(self.terminated_instances)} {_get_instance_ids(self.terminated_instances)})"
         )
 
 
@@ -167,7 +167,7 @@ class BufferPool:
             f"waiting-to-pull-count={len(self.waiting_to_pull_instances)}, "
             f"waiting-to-stop-count={len(self.waiting_to_stop_instances)}, "
             f"pulling-count={len(self.pulling_instances)}, "
-            f"stopping-count={len(self.stopping_instances)})"
+            f"stopping-count={len(self.stopping_instances)}, "
             f"broken-count={len(self.broken_instances)})"
         )
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/buffer_machines_pool_core.py
@@ -84,6 +84,9 @@ async def _analyze_running_instance_state(
                 "The machine will be terminated. TIP: check the initialization phase for errors."
             )
             buffer_pool.broken_instances.add(instance)
+    else:
+        # TODO: this can go for a long while
+        buffer_pool.pending_instances.add(instance)
 
 
 async def _analyse_current_state(
@@ -98,7 +101,6 @@ async def _analyse_current_state(
         tags=get_deactivated_buffer_ec2_tags(app, auto_scaling_mode),
         state_names=["stopped", "pending", "running", "stopping"],
     )
-
     buffers_manager = BufferPoolManager()
     for instance in all_buffer_instances:
         match instance.state:
@@ -214,6 +216,7 @@ async def _add_remove_buffer_instances(
     # let's find what is missing and what is not needed
     missing_instances: dict[InstanceTypeType, NonNegativeInt] = defaultdict(int)
     unneeded_instances: set[EC2InstanceData] = set()
+
     for (
         ec2_type,
         ec2_boot_config,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/buffer_machines_pool_core.py
@@ -18,6 +18,7 @@ import logging
 from collections import defaultdict
 from typing import TypeAlias, cast
 
+import arrow
 from aws_library.ec2 import (
     AWSTagValue,
     EC2InstanceConfig,
@@ -59,12 +60,12 @@ async def _analyze_running_instance_state(
     app: FastAPI, *, buffer_pool: BufferPool, instance: EC2InstanceData
 ):
     ssm_client = get_ssm_client(app)
+    app_settings = get_application_settings(app)
+    assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
 
     if BUFFER_MACHINE_PULLING_EC2_TAG_KEY in instance.tags:
         buffer_pool.pulling_instances.add(instance)
     elif await ssm_client.is_instance_connected_to_ssm_server(instance.id):
-        app_settings = get_application_settings(app)
-        assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
         try:
             if await ssm_client.wait_for_has_instance_completed_cloud_init(instance.id):
                 if app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES[
@@ -85,8 +86,19 @@ async def _analyze_running_instance_state(
             )
             buffer_pool.broken_instances.add(instance)
     else:
-        # TODO: this can go for a long while
-        buffer_pool.pending_instances.add(instance)
+        is_broken = bool(
+            (arrow.utcnow().datetime - instance.launch_time)
+            > app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MAX_START_TIME
+        )
+
+        if is_broken:
+            _logger.error(
+                "The machine does not connect to the SSM server after %s. It will be terminated. TIP: check the initialization phase for errors.",
+                app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MAX_START_TIME,
+            )
+            buffer_pool.broken_instances.add(instance)
+        else:
+            buffer_pool.pending_instances.add(instance)
 
 
 async def _analyse_current_state(

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation.py
@@ -1,3 +1,4 @@
+import collections
 import functools
 from collections.abc import Callable, Coroutine, Iterable
 from dataclasses import dataclass, field
@@ -24,9 +25,12 @@ def _update_gauge(
     nodes: list[AssociatedInstance] | list[NonAssociatedInstance],
 ) -> None:
     gauge.clear()
+    # Create a Counter to count nodes by instance type
+    instance_type_counts = collections.Counter(node.ec2_instance.type for node in nodes)
 
-    for node in nodes:
-        gauge.labels(instance_type=node.ec2_instance.type).inc()
+    # Set the gauge for each instance type to the count
+    for instance_type, count in instance_type_counts.items():
+        gauge.labels(instance_type=instance_type).set(count)
 
 
 @dataclass(slots=True, kw_only=True)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- too many buffer machines were created due to an incorrect analysis of the buffer pools
- the Gauges metrics for the cluster machines were not correctly decreasing, thus showing wrong metrics on the number of  nodes. Especially in pending nodes. @JavierGOrdonnez 
- small log improvements


## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/6250
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/6123

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
