### PR TITLE
🐛Storage: Copying returns wrong size

### DIFF
--- a/packages/aws-library/src/aws_library/s3/__init__.py
+++ b/packages/aws-library/src/aws_library/s3/__init__.py
@@ -1,4 +1,8 @@
-from ._client import SimcoreS3API
+from ._client import (
+    CopiedBytesTransferredCallback,
+    SimcoreS3API,
+    UploadedBytesTransferredCallback,
+)
 from ._constants import PRESIGNED_LINK_MAX_SIZE, S3_MAX_FILE_SIZE
 from ._errors import (
     S3AccessError,
@@ -18,20 +22,22 @@ from ._models import (
 )
 
 __all__: tuple[str, ...] = (
-    "SimcoreS3API",
+    "CopiedBytesTransferredCallback",
+    "MultiPartUploadLinks",
     "PRESIGNED_LINK_MAX_SIZE",
     "S3_MAX_FILE_SIZE",
     "S3AccessError",
     "S3BucketInvalidError",
     "S3DestinationNotEmptyError",
+    "S3DirectoryMetaData",
     "S3KeyNotFoundError",
+    "S3MetaData",
     "S3NotConnectedError",
+    "S3ObjectKey",
     "S3RuntimeError",
     "S3UploadNotFoundError",
-    "S3DirectoryMetaData",
-    "S3MetaData",
-    "S3ObjectKey",
-    "MultiPartUploadLinks",
+    "SimcoreS3API",
+    "UploadedBytesTransferredCallback",
     "UploadID",
 )
 

--- a/packages/aws-library/tests/test_s3_client.py
+++ b/packages/aws-library/tests/test_s3_client.py
@@ -263,11 +263,11 @@ class _ProgressCallback:
     logger: logging.Logger
     _total_bytes_transfered: int = 0
 
-    def __call__(self, bytes_transferred: int) -> None:
+    def __call__(self, bytes_transferred: int, file_name: str) -> None:
         self._total_bytes_transfered += bytes_transferred
         self.logger.debug(
             "progress: %s",
-            f"{self.action} {self._total_bytes_transfered} / {self.file_size} bytes",
+            f"{self.action} {file_name=} {self._total_bytes_transfered} / {self.file_size} bytes",
         )
 
 

--- a/services/storage/src/simcore_service_storage/s3_utils.py
+++ b/services/storage/src/simcore_service_storage/s3_utils.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pydantic import ByteSize, parse_obj_as
 from servicelib.aiohttp.long_running_tasks.server import (
@@ -27,24 +27,36 @@ class S3TransferDataCB:
     total_bytes_to_transfer: ByteSize
     task_progress_message_prefix: str = ""
     _total_bytes_copied: int = 0
+    _file_total_bytes_copied: dict[str, int] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        self.copy_transfer_cb(0)
+        self._update()
+
+    def _update(self) -> None:
+        update_task_progress(
+            self.task_progress,
+            f"{self.task_progress_message_prefix} - "
+            f"{parse_obj_as(ByteSize,self._total_bytes_copied).human_readable()}"
+            f"/{self.total_bytes_to_transfer.human_readable()}]",
+            ProgressPercent(
+                min(self._total_bytes_copied, self.total_bytes_to_transfer)
+                / self.total_bytes_to_transfer
+            ),
+        )
 
     def finalize_transfer(self) -> None:
-        self.copy_transfer_cb(self.total_bytes_to_transfer - self._total_bytes_copied)
+        self._total_bytes_copied = (
+            self.total_bytes_to_transfer - self._total_bytes_copied
+        )
+        self._update()
 
-    def copy_transfer_cb(self, copied_bytes: int) -> None:
-        logger.debug("Copied %s", parse_obj_as(ByteSize, copied_bytes).human_readable())
-        self._total_bytes_copied += copied_bytes
+    def copy_transfer_cb(self, file_total_bytes: int, *, file_name: str) -> None:
+        logger.debug(
+            "Copied %s of %s",
+            parse_obj_as(ByteSize, file_total_bytes).human_readable(),
+            file_name,
+        )
+        self._file_total_bytes_copied[file_name] = file_total_bytes
+        self._total_bytes_copied = sum(self._file_total_bytes_copied.values())
         if self.total_bytes_to_transfer != 0:
-            update_task_progress(
-                self.task_progress,
-                f"{self.task_progress_message_prefix} - "
-                f"{parse_obj_as(ByteSize,self._total_bytes_copied).human_readable()}"
-                f"/{self.total_bytes_to_transfer.human_readable()}]",
-                ProgressPercent(
-                    min(self._total_bytes_copied, self.total_bytes_to_transfer)
-                    / self.total_bytes_to_transfer
-                ),
-            )
+            self._update()

--- a/services/storage/src/simcore_service_storage/s3_utils.py
+++ b/services/storage/src/simcore_service_storage/s3_utils.py
@@ -28,13 +28,14 @@ class S3TransferDataCB:
     task_progress_message_prefix: str = ""
     _total_bytes_copied: int = 0
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.copy_transfer_cb(0)
 
-    def finalize_transfer(self):
+    def finalize_transfer(self) -> None:
         self.copy_transfer_cb(self.total_bytes_to_transfer - self._total_bytes_copied)
 
-    def copy_transfer_cb(self, copied_bytes: int):
+    def copy_transfer_cb(self, copied_bytes: int) -> None:
+        logger.debug("Copied %s", parse_obj_as(ByteSize, copied_bytes).human_readable())
         self._total_bytes_copied += copied_bytes
         if self.total_bytes_to_transfer != 0:
             update_task_progress(
@@ -43,7 +44,7 @@ class S3TransferDataCB:
                 f"{parse_obj_as(ByteSize,self._total_bytes_copied).human_readable()}"
                 f"/{self.total_bytes_to_transfer.human_readable()}]",
                 ProgressPercent(
-                    max(self._total_bytes_copied, self.total_bytes_to_transfer)
+                    min(self._total_bytes_copied, self.total_bytes_to_transfer)
                     / self.total_bytes_to_transfer
                 ),
             )

--- a/services/storage/src/simcore_service_storage/s3_utils.py
+++ b/services/storage/src/simcore_service_storage/s3_utils.py
@@ -43,7 +43,7 @@ class S3TransferDataCB:
             f"/{self.total_bytes_to_transfer.human_readable()}]",
             ProgressPercent(
                 min(self._total_bytes_copied, self.total_bytes_to_transfer)
-                / self.total_bytes_to_transfer
+                / (self.total_bytes_to_transfer or 1)
             ),
         )
 
@@ -53,19 +53,19 @@ class S3TransferDataCB:
         )
         self._update()
 
-    def copy_transfer_cb(self, file_total_bytes: int, file_name: str) -> None:
+    def copy_transfer_cb(self, total_bytes_copied: int, *, file_name: str) -> None:
         logger.debug(
             "Copied %s of %s",
-            parse_obj_as(ByteSize, file_total_bytes).human_readable(),
+            parse_obj_as(ByteSize, total_bytes_copied).human_readable(),
             file_name,
         )
-        self._file_total_bytes_copied[file_name] = file_total_bytes
+        self._file_total_bytes_copied[file_name] = total_bytes_copied
         self._total_bytes_copied = sum(self._file_total_bytes_copied.values())
         if self.total_bytes_to_transfer != 0:
             self._update()
 
-    def upload_transfer_cb(self, file_increment_bytes: int, file_name: str) -> None:
-        self._file_total_bytes_copied[file_name] += file_increment_bytes
+    def upload_transfer_cb(self, bytes_transferred: int, *, file_name: str) -> None:
+        self._file_total_bytes_copied[file_name] += bytes_transferred
         self._total_bytes_copied = sum(self._file_total_bytes_copied.values())
         if self.total_bytes_to_transfer != 0:
             self._update()

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -1,5 +1,6 @@
 import contextlib
 import datetime
+import functools
 import logging
 import tempfile
 import urllib.parse
@@ -650,7 +651,12 @@ class SimcoreS3DataManager(BaseDataManager):
                             dst_file_id=SimcoreS3FileID(
                                 f"{dst_project_uuid}/{new_node_id}/{src_fmd.object_name.split('/', maxsplit=2)[-1]}"
                             ),
-                            bytes_transfered_cb=s3_transfered_data_cb.copy_transfer_cb,
+                            bytes_transfered_cb=functools.partial(
+                                s3_transfered_data_cb.copy_transfer_cb,
+                                file_name=src_fmd.object_name.split("/", maxsplit=2)[
+                                    -1
+                                ],
+                            ),
                         )
                     )
         with log_context(
@@ -668,7 +674,10 @@ class SimcoreS3DataManager(BaseDataManager):
                             dest_project_id=dst_project_uuid,
                             dest_node_id=NodeID(node_id),
                             file_storage_link=output,
-                            bytes_transfered_cb=s3_transfered_data_cb.copy_transfer_cb,
+                            bytes_transfered_cb=functools.partial(
+                                s3_transfered_data_cb.copy_transfer_cb,
+                                file_name="datcore",
+                            ),
                         )
                         for output in node.get("outputs", {}).values()
                         if isinstance(output, dict)

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 import tempfile
 import urllib.parse
-from collections.abc import Callable, Coroutine
+from collections.abc import Coroutine
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,7 +13,13 @@ import arrow
 from aiohttp import web
 from aiopg.sa import Engine
 from aiopg.sa.connection import SAConnection
-from aws_library.s3 import S3DirectoryMetaData, S3KeyNotFoundError, S3MetaData
+from aws_library.s3 import (
+    CopiedBytesTransferredCallback,
+    S3DirectoryMetaData,
+    S3KeyNotFoundError,
+    S3MetaData,
+    UploadedBytesTransferredCallback,
+)
 from models_library.api_schemas_storage import LinkType, S3BucketName, UploadedPart
 from models_library.basic_types import SHA256Str
 from models_library.projects import ProjectID
@@ -953,7 +959,7 @@ class SimcoreS3DataManager(BaseDataManager):
         dest_project_id: ProjectID,
         dest_node_id: NodeID,
         file_storage_link: dict[str, Any],
-        bytes_transfered_cb: Callable[[int, str], None],
+        bytes_transfered_cb: UploadedBytesTransferredCallback,
     ) -> FileMetaData:
         session = get_client_session(self.app)
         # 2 steps: Get download link for local copy, then upload to S3
@@ -1004,7 +1010,7 @@ class SimcoreS3DataManager(BaseDataManager):
         *,
         src_fmd: FileMetaDataAtDB,
         dst_file_id: SimcoreS3FileID,
-        bytes_transfered_cb: Callable[[int, str], None],
+        bytes_transfered_cb: CopiedBytesTransferredCallback,
     ) -> FileMetaData:
         with log_context(
             _logger,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

it seems the interface to copy_file in aioboto3 changed a bit and the progress callback now returns the file total size

this PR fixes the progress reporting

## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/6209
- fixes https://github.com/ITISFoundation/osparc-issues/issues/1681
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
