### PR TITLE
🐛 [Frontend] Fix: unlink port

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
@@ -167,7 +167,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
       const preResourcePromises = [];
       const store = osparc.store.Store.getInstance();
       preResourcePromises.push(store.getAllGroupsAndMembers());
-      preResourcePromises.push(osparc.service.Store.getServicesLatest(false));
+      preResourcePromises.push(osparc.store.Services.getServicesLatest(false));
       if (permissions.canDo("study.tag")) {
         preResourcePromises.push(osparc.data.Resources.get("tags"));
       }

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -257,7 +257,7 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
         if (selection.length) {
           const serviceVersion = selection[0].version;
           if (serviceVersion !== this.__resourceData["version"]) {
-            osparc.service.Store.getService(this.__resourceData["key"], serviceVersion)
+            osparc.store.Services.getService(this.__resourceData["key"], serviceVersion)
               .then(serviceData => {
                 serviceData["resourceType"] = "service";
                 this.__resourceData = serviceData;

--- a/services/static-webserver/client/source/class/osparc/dashboard/ServiceBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ServiceBrowser.js
@@ -58,7 +58,7 @@ qx.Class.define("osparc.dashboard.ServiceBrowser", {
     },
 
     __loadServices: function() {
-      osparc.service.Store.getServicesLatest()
+      osparc.store.Services.getServicesLatest()
         .then(servicesLatest => {
           const servicesList = [];
           Object.keys(servicesLatest).forEach(key => {

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -186,7 +186,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
           if (nStudies === 0) {
             const promises = [
               osparc.store.Store.getInstance().getTemplates(),
-              osparc.service.Store.getServicesLatest(),
+              osparc.store.Services.getServicesLatest(),
             ];
             if (osparc.utils.DisabledPlugins.isFoldersEnabled()) {
               promises.push(osparc.store.Folders.getInstance().fetchFolders());
@@ -671,7 +671,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
         // scale to latest compatible
         const latestVersion = versions[0];
         const latestCompatible = osparc.service.Utils.getLatestCompatible(key, latestVersion);
-        osparc.service.Store.getService(latestCompatible["key"], latestCompatible["version"])
+        osparc.store.Services.getService(latestCompatible["key"], latestCompatible["version"])
           .then(latestMetadata => {
             const title = newButtonInfo.title + " " + osparc.service.Utils.extractVersionDisplay(latestMetadata);
             const desc = newButtonInfo.description;

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -470,7 +470,7 @@ qx.Class.define("osparc.data.Resources", {
        * SERVICES V2 (web-api >=0.42.0)
        */
       "servicesV2": {
-        useCache: false, // handled in osparc.service.Store
+        useCache: false, // handled in osparc.store.Services
         idField: ["key", "version"],
         endpoints: {
           get: {

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -382,7 +382,7 @@ qx.Class.define("osparc.data.model.Node", {
 
     __applyNewMetaData: function(newV, oldV) {
       if (oldV !== null) {
-        const metadata = osparc.service.Store.getMetadata(this.getKey(), this.getVersion());
+        const metadata = osparc.store.Services.getMetadata(this.getKey(), this.getVersion());
         if (metadata) {
           this.__metaData = metadata;
         }

--- a/services/static-webserver/client/source/class/osparc/data/model/Study.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Study.js
@@ -299,7 +299,7 @@ qx.Class.define("osparc.data.model.Study", {
       let nCompNodes = 0;
       let overallProgress = 0;
       Object.values(nodes).forEach(node => {
-        const metadata = osparc.service.Store.getMetadata(node["key"], node["version"]);
+        const metadata = osparc.store.Services.getMetadata(node["key"], node["version"]);
         if (metadata && osparc.data.model.Node.isComputational(metadata)) {
           const progress = "progress" in node ? node["progress"] : 0;
           overallProgress += progress;

--- a/services/static-webserver/client/source/class/osparc/data/model/Workbench.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Workbench.js
@@ -295,7 +295,7 @@ qx.Class.define("osparc.data.model.Workbench", {
       };
 
       try {
-        const metadata = await osparc.service.Store.getService(key, version);
+        const metadata = await osparc.store.Services.getService(key, version);
         const resp = await osparc.data.Resources.fetch("studies", "addNode", params);
         const nodeId = resp["node_id"];
 
@@ -679,7 +679,7 @@ qx.Class.define("osparc.data.model.Workbench", {
       const metadataPromises = [];
       nodeIds.forEach(nodeId => {
         const nodeData = workbenchData[nodeId];
-        metadataPromises.push(osparc.service.Store.getService(nodeData.key, nodeData.version));
+        metadataPromises.push(osparc.store.Services.getService(nodeData.key, nodeData.version));
       });
 
       return Promise.all(metadataPromises)

--- a/services/static-webserver/client/source/class/osparc/desktop/organizations/ServicesList.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/organizations/ServicesList.js
@@ -115,7 +115,7 @@ qx.Class.define("osparc.desktop.organizations.ServicesList", {
       }
 
       const gid = orgModel.getGid();
-      osparc.service.Store.getServicesLatest()
+      osparc.store.Services.getServicesLatest()
         .then(servicesLatest => {
           const orgServices = [];
           Object.keys(servicesLatest).forEach(key => {

--- a/services/static-webserver/client/source/class/osparc/editor/ThumbnailSuggestions.js
+++ b/services/static-webserver/client/source/class/osparc/editor/ThumbnailSuggestions.js
@@ -138,7 +138,7 @@ qx.Class.define("osparc.editor.ThumbnailSuggestions", {
       }
 
       const promises = [];
-      queryParams.forEach(qP => promises.push(osparc.service.Store.getService(qP.key, qP.version)));
+      queryParams.forEach(qP => promises.push(osparc.store.Services.getService(qP.key, qP.version)));
       return Promise.all(promises)
         .then(values => {
           const suggestions = new Set([]);

--- a/services/static-webserver/client/source/class/osparc/form/renderer/PropForm.js
+++ b/services/static-webserver/client/source/class/osparc/form/renderer/PropForm.js
@@ -861,7 +861,7 @@ qx.Class.define("osparc.form.renderer.PropForm", {
       if (this.__resetCtrlField(portId)) {
         if (portId in this.__linkUnlinkStackMap) {
           const stack = this.__linkUnlinkStackMap[portId];
-          if (stack.getSelectables() > 0) {
+          if (stack.getSelectables().length > 0) {
             stack.setSelection([stack.getSelectables()[0]]);
           }
         }

--- a/services/static-webserver/client/source/class/osparc/info/MergedLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/MergedLarge.js
@@ -325,7 +325,7 @@ qx.Class.define("osparc.info.MergedLarge", {
         };
         promise = osparc.data.Resources.get("nodesInStudyResources", params);
       } else {
-        promise = osparc.service.Store.getResources(this.getNode().getKey(), this.getNode().getVersion())
+        promise = osparc.store.Services.getResources(this.getNode().getKey(), this.getNode().getVersion())
       }
       promise
         .then(serviceResources => {

--- a/services/static-webserver/client/source/class/osparc/info/ServiceLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/ServiceLarge.js
@@ -360,7 +360,7 @@ qx.Class.define("osparc.info.ServiceLarge", {
         };
         promise = osparc.data.Resources.get("nodesInStudyResources", params);
       } else {
-        promise = osparc.service.Store.getResources(this.getService()["key"], this.getService()["version"])
+        promise = osparc.store.Services.getResources(this.getService()["key"], this.getService()["version"])
       }
       promise
         .then(serviceResources => {
@@ -474,7 +474,7 @@ qx.Class.define("osparc.info.ServiceLarge", {
 
     __patchService: function(key, value) {
       const serviceDataCopy = osparc.utils.Utils.deepCloneObject(this.getService());
-      osparc.service.Store.patchServiceData(serviceDataCopy, key, value)
+      osparc.store.Services.patchServiceData(serviceDataCopy, key, value)
         .then(() => {
           this.setService(serviceDataCopy);
           this.fireDataEvent("updateService", this.getService());

--- a/services/static-webserver/client/source/class/osparc/metadata/ClassifiersEditor.js
+++ b/services/static-webserver/client/source/class/osparc/metadata/ClassifiersEditor.js
@@ -158,7 +158,7 @@ qx.Class.define("osparc.metadata.ClassifiersEditor", {
           });
       } else {
         const serviceDataCopy = osparc.utils.Utils.deepCloneObject(this.__resourceData);
-        osparc.service.Store.patchServiceData(serviceDataCopy, "classifiers", newClassifiers)
+        osparc.store.Services.patchServiceData(serviceDataCopy, "classifiers", newClassifiers)
           .then(() => {
             osparc.FlashMessenger.getInstance().logAs(this.tr("Classifiers successfully edited"));
             saveBtn.setFetching(false);

--- a/services/static-webserver/client/source/class/osparc/metadata/QualityEditor.js
+++ b/services/static-webserver/client/source/class/osparc/metadata/QualityEditor.js
@@ -457,7 +457,7 @@ qx.Class.define("osparc.metadata.QualityEditor", {
         btn.setFetching(true);
         if (osparc.utils.Resources.isService(this.__resourceData)) {
           const serviceDataCopy = osparc.utils.Utils.deepCloneObject(this.__resourceData);
-          osparc.service.Store.patchServiceData(serviceDataCopy, "quality", newQuality)
+          osparc.store.Services.patchServiceData(serviceDataCopy, "quality", newQuality)
             .then(() => {
               this.__initResourceData(serviceDataCopy);
               this.fireDataEvent("updateQuality", serviceDataCopy);

--- a/services/static-webserver/client/source/class/osparc/metadata/ServicesInStudy.js
+++ b/services/static-webserver/client/source/class/osparc/metadata/ServicesInStudy.js
@@ -45,7 +45,7 @@ qx.Class.define("osparc.metadata.ServicesInStudy", {
     const servicesInStudy = osparc.study.Utils.extractServices(this._studyData["workbench"]);
     if (servicesInStudy.length) {
       const promises = [];
-      servicesInStudy.forEach(srv => promises.push(osparc.service.Store.getService(srv.key, srv.version)));
+      servicesInStudy.forEach(srv => promises.push(osparc.store.Services.getService(srv.key, srv.version)));
       Promise.all(promises)
         .then(() => this._populateLayout());
     } else {
@@ -137,7 +137,7 @@ qx.Class.define("osparc.metadata.ServicesInStudy", {
 
         const infoButton = new qx.ui.form.Button(null, "@MaterialIcons/info_outline/14");
         infoButton.addListener("execute", () => {
-          const metadata = osparc.service.Store.getMetadata(node["key"], node["version"]);
+          const metadata = osparc.store.Services.getMetadata(node["key"], node["version"]);
           if (metadata === null) {
             osparc.FlashMessenger.logAs(this.tr("Service information could not be retrieved"), "WARNING");
             return;
@@ -167,7 +167,7 @@ qx.Class.define("osparc.metadata.ServicesInStudy", {
         });
         this.__grid.setRowHeight(i, 24);
 
-        const nodeMetadata = osparc.service.Store.getMetadata(node["key"], node["version"]);
+        const nodeMetadata = osparc.store.Services.getMetadata(node["key"], node["version"]);
         if (nodeMetadata === null) {
           osparc.FlashMessenger.logAs(this.tr("Some service information could not be retrieved"), "WARNING");
           break;

--- a/services/static-webserver/client/source/class/osparc/metadata/ServicesInStudyBootOpts.js
+++ b/services/static-webserver/client/source/class/osparc/metadata/ServicesInStudyBootOpts.js
@@ -25,7 +25,7 @@ qx.Class.define("osparc.metadata.ServicesInStudyBootOpts", {
       if ("workbench" in studyData) {
         for (const nodeId in studyData["workbench"]) {
           const node = studyData["workbench"][nodeId];
-          const metadata = osparc.service.Store.getMetadata(node["key"], node["version"]);
+          const metadata = osparc.store.Services.getMetadata(node["key"], node["version"]);
           if (metadata && osparc.data.model.Node.hasBootModes(metadata)) {
             return true;
           }
@@ -74,7 +74,7 @@ qx.Class.define("osparc.metadata.ServicesInStudyBootOpts", {
       for (const nodeId in workbench) {
         i++;
         const node = workbench[nodeId];
-        const nodeMetadata = osparc.service.Store.getMetadata(node["key"], node["version"]);
+        const nodeMetadata = osparc.store.Services.getMetadata(node["key"], node["version"]);
         if (nodeMetadata === null) {
           osparc.FlashMessenger.logAs(this.tr("Some service information could not be retrieved"), "WARNING");
           break;

--- a/services/static-webserver/client/source/class/osparc/metadata/ServicesInStudyUpdate.js
+++ b/services/static-webserver/client/source/class/osparc/metadata/ServicesInStudyUpdate.js
@@ -205,7 +205,7 @@ qx.Class.define("osparc.metadata.ServicesInStudyUpdate", {
       for (const nodeId in workbench) {
         i++;
         const node = workbench[nodeId];
-        const metadata = osparc.service.Store.getMetadata(node["key"], node["version"]);
+        const metadata = osparc.store.Services.getMetadata(node["key"], node["version"]);
         const currentVersionLabel = new qx.ui.basic.Label(osparc.service.Utils.extractVersionDisplay(metadata)).set({
           font: "text-14"
         });
@@ -221,7 +221,7 @@ qx.Class.define("osparc.metadata.ServicesInStudyUpdate", {
         const latestCompatible = osparc.service.Utils.getLatestCompatible(node["key"], node["version"]);
         if (latestCompatible) {
           // updatable
-          osparc.service.Store.getService(latestCompatible["key"], latestCompatible["version"])
+          osparc.store.Services.getService(latestCompatible["key"], latestCompatible["version"])
             .then(latestMetadata => {
               let label = osparc.service.Utils.extractVersionDisplay(latestMetadata)
               if (node["key"] !== latestMetadata["key"]) {

--- a/services/static-webserver/client/source/class/osparc/pricing/ServicesList.js
+++ b/services/static-webserver/client/source/class/osparc/pricing/ServicesList.js
@@ -83,7 +83,7 @@ qx.Class.define("osparc.pricing.ServicesList", {
       services.forEach(service => {
         const key = service["serviceKey"];
         const version = service["serviceVersion"];
-        metadataPromises.push(osparc.service.Store.getService(key, version));
+        metadataPromises.push(osparc.store.Services.getService(key, version));
       });
       Promise.all(metadataPromises)
         .catch(err => console.error(err))
@@ -92,7 +92,7 @@ qx.Class.define("osparc.pricing.ServicesList", {
           services.forEach(service => {
             const key = service["serviceKey"];
             const version = service["serviceVersion"];
-            const serviceMetadata = osparc.service.Store.getMetadata(key, version);
+            const serviceMetadata = osparc.store.Services.getMetadata(key, version);
             if (serviceMetadata) {
               sList.push(new osparc.data.model.Service(serviceMetadata));
             }

--- a/services/static-webserver/client/source/class/osparc/service/ServiceListItem.js
+++ b/services/static-webserver/client/source/class/osparc/service/ServiceListItem.js
@@ -158,7 +158,7 @@ qx.Class.define("osparc.service.ServiceListItem", {
       if (version === this.self().LATEST) {
         version = this.__versionsBox.getChildrenContainer().getSelectables()[1].version;
       }
-      osparc.service.Store.getService(key, version)
+      osparc.store.Services.getService(key, version)
         .then(serviceMetadata => {
           const serviceDetails = new osparc.info.ServiceLarge(serviceMetadata);
           const title = this.tr("Service information");

--- a/services/static-webserver/client/source/class/osparc/service/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/service/Utils.js
@@ -133,7 +133,7 @@ qx.Class.define("osparc.service.Utils", {
     },
 
     getVersions: function(key, filterDeprecated = true) {
-      const services = osparc.service.Store.servicesCached;
+      const services = osparc.store.Services.servicesCached;
       let versions = [];
       if (key in services) {
         const serviceVersions = services[key];
@@ -152,7 +152,7 @@ qx.Class.define("osparc.service.Utils", {
     },
 
     getLatest: function(key) {
-      const services = osparc.service.Store.servicesCached;
+      const services = osparc.store.Services.servicesCached;
       if (key in services) {
         const versions = this.getVersions(key, true);
         if (versions.length) {
@@ -163,7 +163,7 @@ qx.Class.define("osparc.service.Utils", {
     },
 
     getLatestCompatible: function(key, version) {
-      const services = osparc.service.Store.servicesCached;
+      const services = osparc.store.Services.servicesCached;
       if (key in services && version in services[key]) {
         const serviceMD = services[key][version];
         if (serviceMD["compatibility"] && serviceMD["compatibility"]["canUpdateTo"]) {
@@ -183,7 +183,7 @@ qx.Class.define("osparc.service.Utils", {
     },
 
     getVersionDisplay: function(key, version) {
-      const services = osparc.service.Store.servicesCached;
+      const services = osparc.store.Services.servicesCached;
       if (key in services && version in services[key]) {
         return this.extractVersionDisplay(services[key][version]);
       }
@@ -195,7 +195,7 @@ qx.Class.define("osparc.service.Utils", {
     },
 
     getReleasedDate: function(key, version) {
-      const services = osparc.service.Store.servicesCached;
+      const services = osparc.store.Services.servicesCached;
       if (
         key in services &&
         version in services[key] &&

--- a/services/static-webserver/client/source/class/osparc/share/CollaboratorsService.js
+++ b/services/static-webserver/client/source/class/osparc/share/CollaboratorsService.js
@@ -90,7 +90,7 @@ qx.Class.define("osparc.share.CollaboratorsService", {
       gids.forEach(gid => {
         newAccessRights[gid] = this.self().getCollaboratorAccessRight();
       });
-      osparc.service.Store.patchServiceData(this._serializedDataCopy, "accessRights", newAccessRights)
+      osparc.store.Services.patchServiceData(this._serializedDataCopy, "accessRights", newAccessRights)
         .then(() => {
           this.fireDataEvent("updateAccessRights", this._serializedDataCopy);
           let text = this.tr("Editor(s) successfully added.");
@@ -119,7 +119,7 @@ qx.Class.define("osparc.share.CollaboratorsService", {
         return;
       }
 
-      osparc.service.Store.patchServiceData(this._serializedDataCopy, "accessRights", this._serializedDataCopy["accessRights"])
+      osparc.store.Services.patchServiceData(this._serializedDataCopy, "accessRights", this._serializedDataCopy["accessRights"])
         .then(() => {
           this.fireDataEvent("updateAccessRights", this._serializedDataCopy);
           osparc.FlashMessenger.getInstance().logAs(this.tr("Member successfully removed"));
@@ -139,7 +139,7 @@ qx.Class.define("osparc.share.CollaboratorsService", {
     __make: function(collaboratorGId, newAccessRights, successMsg, failureMsg, item) {
       item.setEnabled(false);
       this._serializedDataCopy["accessRights"][collaboratorGId] = newAccessRights;
-      osparc.service.Store.patchServiceData(this._serializedDataCopy, "accessRights", this._serializedDataCopy["accessRights"])
+      osparc.store.Services.patchServiceData(this._serializedDataCopy, "accessRights", this._serializedDataCopy["accessRights"])
         .then(() => {
           this.fireDataEvent("updateAccessRights", this._serializedDataCopy);
           osparc.FlashMessenger.getInstance().logAs(successMsg);

--- a/services/static-webserver/client/source/class/osparc/share/ShareePermissions.js
+++ b/services/static-webserver/client/source/class/osparc/share/ShareePermissions.js
@@ -51,7 +51,7 @@ qx.Class.define("osparc.share.ShareePermissions", {
                 const label = new qx.ui.basic.Label();
                 hBox.add(infoButton);
                 hBox.add(label);
-                osparc.service.Store.getService(inaccessibleService.key, inaccessibleService.version)
+                osparc.store.Services.getService(inaccessibleService.key, inaccessibleService.version)
                   .then(metadata => {
                     label.setValue(metadata["name"] + " : " + metadata["version"])
                     infoButton.addListener("execute", () => {

--- a/services/static-webserver/client/source/class/osparc/store/Services.js
+++ b/services/static-webserver/client/source/class/osparc/store/Services.js
@@ -15,7 +15,7 @@
 
 ************************************************************************ */
 
-qx.Class.define("osparc.service.Store", {
+qx.Class.define("osparc.store.Services", {
   type: "static",
 
   statics: {

--- a/services/static-webserver/client/source/class/osparc/study/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/study/Utils.js
@@ -35,7 +35,7 @@ qx.Class.define("osparc.study.Utils", {
     },
 
     getInaccessibleServices: function(workbench) {
-      const allServices = osparc.service.Store.servicesCached;
+      const allServices = osparc.store.Services.servicesCached;
       const unaccessibleServices = [];
       const wbServices = new Set(this.extractServices(workbench));
       wbServices.forEach(srv => {
@@ -70,7 +70,7 @@ qx.Class.define("osparc.study.Utils", {
     },
 
     isWorkbenchRetired: function(workbench) {
-      const allServices = osparc.service.Store.servicesCached;
+      const allServices = osparc.store.Services.servicesCached;
       const services = new Set(this.extractServices(workbench));
       const isRetired = Array.from(services).some(srv => {
         if (srv.key in allServices && srv.version in allServices[srv.key]) {
@@ -88,7 +88,7 @@ qx.Class.define("osparc.study.Utils", {
     },
 
     isWorkbenchDeprecated: function(workbench) {
-      const allServices = osparc.service.Store.servicesCached;
+      const allServices = osparc.store.Services.servicesCached;
       const services = new Set(this.extractServices(workbench));
       const isRetired = Array.from(services).some(srv => {
         if (srv.key in allServices && srv.version in allServices[srv.key]) {
@@ -107,7 +107,7 @@ qx.Class.define("osparc.study.Utils", {
 
     createStudyFromService: function(key, version, existingStudies, newStudyLabel) {
       return new Promise((resolve, reject) => {
-        osparc.service.Store.getService(key, version)
+        osparc.store.Services.getService(key, version)
           .then(metadata => {
             const newUuid = osparc.utils.Utils.uuidV4();
             const minStudyData = osparc.data.model.Study.createMyNewStudyObject();

--- a/services/static-webserver/client/source/class/osparc/workbench/ServiceCatalog.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/ServiceCatalog.js
@@ -197,7 +197,7 @@ qx.Class.define("osparc.workbench.ServiceCatalog", {
 
     __populateList: function() {
       this.__servicesLatest = [];
-      osparc.service.Store.getServicesLatest()
+      osparc.store.Services.getServicesLatest()
         .then(servicesLatest => {
           Object.keys(servicesLatest).forEach(key => {
             this.__servicesLatest.push(servicesLatest[key]);
@@ -293,7 +293,7 @@ qx.Class.define("osparc.workbench.ServiceCatalog", {
       if (version == this.self(arguments).LATEST.toString()) {
         version = this.__versionsBox.getChildrenContainer().getSelectables()[1].version;
       }
-      const serviceMetadata = await osparc.service.Store.getService(key, version);
+      const serviceMetadata = await osparc.store.Services.getService(key, version);
       return serviceMetadata;
     },
 


### PR DESCRIPTION
## What do these changes do?

Fixes the link<-> unlink port button's logic.

![FixUnlink](https://github.com/user-attachments/assets/098f96cb-c418-493e-822d-0bb415893138)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
