### PR TITLE
🐛 More than 1 input port containing files can be safely pulled

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/data_items_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/data_items_utils.py
@@ -22,9 +22,9 @@ def create_simcore_file_id(
     return SimcoreS3FileID(f"{clean_path}")
 
 
-def create_folder_path(key: str) -> Path:
+def get_folder_path(key: str) -> Path:
     return _TMP_SIMCOREFILES / f"{uuid4()}" / key
 
 
-def create_file_path(key: str, name: str) -> Path:
+def get_file_path(key: str, name: str) -> Path:
     return _TMP_SIMCOREFILES / f"{uuid4()}" / key / name

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/data_items_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/data_items_utils.py
@@ -1,11 +1,11 @@
 import tempfile
-import uuid
 from pathlib import Path
 from typing import Final
+from uuid import uuid4
 
 from models_library.projects_nodes_io import SimcoreS3FileID
 
-_TMP_SIMCOREFILES: Final[Path] = Path(tempfile.gettempdir(), "simcorefiles")
+_TMP_SIMCOREFILES: Final[Path] = Path(tempfile.gettempdir()) / "simcorefiles"
 
 
 def create_simcore_file_id(
@@ -23,8 +23,8 @@ def create_simcore_file_id(
 
 
 def create_folder_path(key: str) -> Path:
-    return _TMP_SIMCOREFILES / f"{uuid.uuid4()}" / key
+    return _TMP_SIMCOREFILES / f"{uuid4()}" / key
 
 
 def create_file_path(key: str, name: str) -> Path:
-    return _TMP_SIMCOREFILES / f"{uuid.uuid4()}" / key / name
+    return _TMP_SIMCOREFILES / f"{uuid4()}" / key / name

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/data_items_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/data_items_utils.py
@@ -1,9 +1,11 @@
 import tempfile
-import threading
+import uuid
 from pathlib import Path
-from typing import Optional
+from typing import Final
 
 from models_library.projects_nodes_io import SimcoreS3FileID
+
+_TMP_SIMCOREFILES: Final[Path] = Path(tempfile.gettempdir(), "simcorefiles")
 
 
 def create_simcore_file_id(
@@ -11,7 +13,7 @@ def create_simcore_file_id(
     project_id: str,
     node_id: str,
     *,
-    file_base_path: Optional[Path] = None,
+    file_base_path: Path | None = None,
 ) -> SimcoreS3FileID:
     s3_file_name = file_path.name
     if file_base_path:
@@ -20,12 +22,9 @@ def create_simcore_file_id(
     return SimcoreS3FileID(f"{clean_path}")
 
 
-_INTERNAL_DIR = Path(tempfile.gettempdir(), "simcorefiles")
-
-
 def create_folder_path(key: str) -> Path:
-    return Path(_INTERNAL_DIR, f"{threading.get_ident()}", key)
+    return _TMP_SIMCOREFILES / f"{uuid.uuid4()}" / key
 
 
 def create_file_path(key: str, name: str) -> Path:
-    return Path(_INTERNAL_DIR, f"{threading.get_ident()}", key, name)
+    return _TMP_SIMCOREFILES / f"{uuid.uuid4()}" / key / name

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
@@ -67,7 +67,7 @@ async def get_value_from_link(
         if file_to_key_map:
             file_name = next(iter(file_to_key_map))
 
-        file_path = data_items_utils.create_file_path(key, file_name)
+        file_path = data_items_utils.get_file_path(key, file_name)
         if other_value == file_path:
             # this is a corner case: in case the output key of the other node has the same name as the input key
             return other_value
@@ -194,7 +194,7 @@ async def pull_file_from_store(
 ) -> Path:
     log.debug("pulling file from storage %s", value)
     # do not make any assumption about s3_path, it is a str containing stuff that can be anything depending on the store
-    local_path = data_items_utils.create_folder_path(key)
+    local_path = data_items_utils.get_folder_path(key)
     downloaded_file = await filemanager.download_path_from_s3(
         user_id=user_id,
         store_id=value.store,
@@ -275,7 +275,7 @@ async def pull_file_from_download_link(
         value.label,
     )
 
-    local_path = data_items_utils.create_folder_path(key)
+    local_path = data_items_utils.get_folder_path(key)
     downloaded_file = await filemanager.download_file_from_link(
         URL(f"{value.download_link}"),
         local_path,

--- a/packages/simcore-sdk/tests/conftest.py
+++ b/packages/simcore-sdk/tests/conftest.py
@@ -79,7 +79,7 @@ def mock_io_log_redirect_cb() -> LogRedirectCB:
 
 
 @pytest.fixture
-def mock_uuid4(mocker: MockerFixture) -> None:
+def constant_uuid4(mocker: MockerFixture) -> None:
     mocker.patch(
         "simcore_sdk.node_ports_common.data_items_utils.uuid4",
         return_value=CONSTANT_UUID,

--- a/packages/simcore-sdk/tests/conftest.py
+++ b/packages/simcore-sdk/tests/conftest.py
@@ -7,9 +7,11 @@ import json
 import sys
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 import pytest
 import simcore_sdk
+from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.postgres_tools import PostgresTestConfig
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_sdk.node_ports_common.file_io_utils import LogRedirectCB
@@ -74,3 +76,11 @@ def mock_io_log_redirect_cb() -> LogRedirectCB:
         pass
 
     return _mocked_function
+
+
+@pytest.fixture
+def mock_uuid4(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "simcore_sdk.node_ports_common.data_items_utils.uuid4",
+        return_value=UUID(int=0),
+    )

--- a/packages/simcore-sdk/tests/conftest.py
+++ b/packages/simcore-sdk/tests/conftest.py
@@ -7,7 +7,6 @@ import json
 import sys
 from pathlib import Path
 from typing import Any
-from uuid import UUID
 
 import pytest
 import simcore_sdk
@@ -15,6 +14,7 @@ from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.postgres_tools import PostgresTestConfig
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_sdk.node_ports_common.file_io_utils import LogRedirectCB
+from utils_port_v2 import CONSTANT_UUID
 
 current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 sys.path.append(str(current_dir / "helpers"))
@@ -82,5 +82,5 @@ def mock_io_log_redirect_cb() -> LogRedirectCB:
 def mock_uuid4(mocker: MockerFixture) -> None:
     mocker.patch(
         "simcore_sdk.node_ports_common.data_items_utils.uuid4",
-        return_value=UUID(int=0),
+        return_value=CONSTANT_UUID,
     )

--- a/packages/simcore-sdk/tests/conftest.py
+++ b/packages/simcore-sdk/tests/conftest.py
@@ -10,11 +10,11 @@ from typing import Any
 
 import pytest
 import simcore_sdk
+from helpers.utils_port_v2 import CONSTANT_UUID
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.postgres_tools import PostgresTestConfig
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_sdk.node_ports_common.file_io_utils import LogRedirectCB
-from utils_port_v2 import CONSTANT_UUID
 
 current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 sys.path.append(str(current_dir / "helpers"))

--- a/packages/simcore-sdk/tests/helpers/utils_port_v2.py
+++ b/packages/simcore-sdk/tests/helpers/utils_port_v2.py
@@ -1,6 +1,9 @@
-from typing import Any
+from typing import Any, Final
+from uuid import UUID
 
 from simcore_sdk.node_ports_v2.ports_mapping import InputsList, OutputsList
+
+CONSTANT_UUID: Final[UUID] = UUID(int=0)
 
 
 def create_valid_port_config(conf_type: str, **kwargs) -> dict[str, Any]:

--- a/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
@@ -273,7 +273,7 @@ async def test_port_file_accessors(
     e_tag: str,
     option_r_clone_settings: RCloneSettings | None,
     request: pytest.FixtureRequest,
-    mock_uuid4: None,
+    constant_uuid4: None,
 ):
 
     if item_value == "symlink_path":
@@ -496,7 +496,7 @@ async def test_get_file_from_previous_node(
     item_value: str,
     item_pytype: type,
     option_r_clone_settings: RCloneSettings | None,
-    mock_uuid4: None,
+    constant_uuid4: None,
 ):
     config_dict, _, _ = create_2nodes_configuration(
         prev_node_inputs=None,
@@ -553,7 +553,7 @@ async def test_get_file_from_previous_node_with_mapping_of_same_key_name(
     item_alias: str,
     item_pytype: type,
     option_r_clone_settings: RCloneSettings | None,
-    mock_uuid4: None,
+    constant_uuid4: None,
 ):
     config_dict, _, this_node_uuid = create_2nodes_configuration(
         prev_node_inputs=None,
@@ -615,7 +615,7 @@ async def test_file_mapping(
     item_pytype: type,
     option_r_clone_settings: RCloneSettings | None,
     create_valid_file_uuid: Callable[[str, Path], SimcoreS3FileID],
-    mock_uuid4: None,
+    constant_uuid4: None,
 ):
     config_dict, project_id, node_uuid = create_special_configuration(
         inputs=[("in_1", item_type, await create_store_link(item_value))],

--- a/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
@@ -12,8 +12,8 @@ import tempfile
 from asyncio import gather
 from collections.abc import Awaitable, Callable, Iterable
 from pathlib import Path
-from typing import Any, Final
-from uuid import UUID, uuid4
+from typing import Any
+from uuid import uuid4
 
 import np_helpers
 import pytest
@@ -36,6 +36,7 @@ from simcore_sdk.node_ports_v2 import exceptions
 from simcore_sdk.node_ports_v2.links import ItemConcreteValue, PortLink
 from simcore_sdk.node_ports_v2.nodeports_v2 import Nodeports
 from simcore_sdk.node_ports_v2.port import Port
+from utils_port_v2 import CONSTANT_UUID
 
 pytest_simcore_core_services_selection = [
     "migration",
@@ -48,8 +49,6 @@ pytest_simcore_ops_services_selection = [
     "minio",
     "adminer",
 ]
-
-_MOCKED_UUID: Final[UUID] = UUID(int=0)
 
 
 async def _check_port_valid(
@@ -333,7 +332,7 @@ async def test_port_file_accessors(
             Path(
                 tempfile.gettempdir(),
                 "simcorefiles",
-                f"{_MOCKED_UUID}",
+                f"{CONSTANT_UUID}",
                 "out_34",
             )
         )
@@ -522,7 +521,7 @@ async def test_get_file_from_previous_node(
     assert file_path == Path(
         tempfile.gettempdir(),
         "simcorefiles",
-        f"{_MOCKED_UUID}",
+        f"{CONSTANT_UUID}",
         "in_15",
         Path(item_value).name,
     )
@@ -583,7 +582,7 @@ async def test_get_file_from_previous_node_with_mapping_of_same_key_name(
     assert file_path == Path(
         tempfile.gettempdir(),
         "simcorefiles",
-        f"{_MOCKED_UUID}",
+        f"{CONSTANT_UUID}",
         "in_15",
         item_alias,
     )
@@ -643,7 +642,7 @@ async def test_file_mapping(
     assert file_path == Path(
         tempfile.gettempdir(),
         "simcorefiles",
-        f"{_MOCKED_UUID}",
+        f"{CONSTANT_UUID}",
         "in_1",
         item_alias,
     )
@@ -654,7 +653,7 @@ async def test_file_mapping(
     assert file_path == Path(
         tempfile.gettempdir(),
         "simcorefiles",
-        f"{_MOCKED_UUID}",
+        f"{CONSTANT_UUID}",
         "in_1",
         item_alias,
     )

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
@@ -140,7 +140,7 @@ def another_node_file() -> Iterator[Path]:
 
 
 @pytest.fixture
-def download_file_folder(mock_uuid4: None) -> Iterator[Path]:
+def download_file_folder(constant_uuid4: None) -> Iterator[Path]:
     destination_path = download_file_folder_name()
     destination_path.mkdir(parents=True, exist_ok=True)
     yield destination_path

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
@@ -10,12 +10,12 @@ import os
 import re
 import shutil
 import tempfile
-import threading
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, Final, NamedTuple
 from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
 
 import pytest
 from aiohttp.client import ClientSession
@@ -42,6 +42,8 @@ from simcore_sdk.node_ports_v2.ports_mapping import InputsList, OutputsList
 from utils_port_v2 import create_valid_port_config
 from yarl import URL
 
+_MOCKED_UUID: Final[UUID] = uuid4()
+
 
 def camel_to_snake(name):
     name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
@@ -57,7 +59,7 @@ def another_node_file_name() -> Path:
 
 
 def download_file_folder_name() -> Path:
-    return Path(tempfile.gettempdir(), "simcorefiles", f"{threading.get_ident()}")
+    return Path(tempfile.gettempdir()) / "simcorefiles" / f"{_MOCKED_UUID}"
 
 
 def project_id() -> str:
@@ -141,7 +143,15 @@ def another_node_file() -> Iterator[Path]:
 
 
 @pytest.fixture
-def download_file_folder() -> Iterator[Path]:
+def mock_uud4(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "simcore_sdk.node_ports_common.data_items_utils.uuid4",
+        return_value=_MOCKED_UUID,
+    )
+
+
+@pytest.fixture
+def download_file_folder(mock_uud4: None) -> Iterator[Path]:
     destination_path = download_file_folder_name()
     destination_path.mkdir(parents=True, exist_ok=True)
     yield destination_path

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
@@ -143,7 +143,7 @@ def another_node_file() -> Iterator[Path]:
 
 
 @pytest.fixture
-def mock_uud4(mocker: MockerFixture) -> None:
+def mock_uuid4(mocker: MockerFixture) -> None:
     mocker.patch(
         "simcore_sdk.node_ports_common.data_items_utils.uuid4",
         return_value=_MOCKED_UUID,
@@ -151,7 +151,7 @@ def mock_uud4(mocker: MockerFixture) -> None:
 
 
 @pytest.fixture
-def download_file_folder(mock_uud4: None) -> Iterator[Path]:
+def download_file_folder(mock_uuid4: None) -> Iterator[Path]:
     destination_path = download_file_folder_name()
     destination_path.mkdir(parents=True, exist_ok=True)
     yield destination_path

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Final, NamedTuple
 from unittest.mock import AsyncMock
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import pytest
 from aiohttp.client import ClientSession
@@ -42,7 +42,7 @@ from simcore_sdk.node_ports_v2.ports_mapping import InputsList, OutputsList
 from utils_port_v2 import create_valid_port_config
 from yarl import URL
 
-_MOCKED_UUID: Final[UUID] = uuid4()
+_MOCKED_UUID: Final[UUID] = UUID(int=0)
 
 
 def camel_to_snake(name):
@@ -140,14 +140,6 @@ def another_node_file() -> Iterator[Path]:
     yield file_path
     if file_path.exists():
         file_path.unlink()
-
-
-@pytest.fixture
-def mock_uuid4(mocker: MockerFixture) -> None:
-    mocker.patch(
-        "simcore_sdk.node_ports_common.data_items_utils.uuid4",
-        return_value=_MOCKED_UUID,
-    )
 
 
 @pytest.fixture

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_port.py
@@ -13,9 +13,8 @@ import tempfile
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Final, NamedTuple
+from typing import Any, NamedTuple
 from unittest.mock import AsyncMock
-from uuid import UUID
 
 import pytest
 from aiohttp.client import ClientSession
@@ -39,10 +38,8 @@ from simcore_sdk.node_ports_v2.links import (
 )
 from simcore_sdk.node_ports_v2.port import Port
 from simcore_sdk.node_ports_v2.ports_mapping import InputsList, OutputsList
-from utils_port_v2 import create_valid_port_config
+from utils_port_v2 import CONSTANT_UUID, create_valid_port_config
 from yarl import URL
-
-_MOCKED_UUID: Final[UUID] = UUID(int=0)
 
 
 def camel_to_snake(name):
@@ -59,7 +56,7 @@ def another_node_file_name() -> Path:
 
 
 def download_file_folder_name() -> Path:
-    return Path(tempfile.gettempdir()) / "simcorefiles" / f"{_MOCKED_UUID}"
+    return Path(tempfile.gettempdir()) / "simcorefiles" / f"{CONSTANT_UUID}"
 
 
 def project_id() -> str:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This issue was simple to reproduce, but we never had a good report. This was a nightmare for so many people reporting missing files in their inputs.

If input ports contain more than one port with files, these would get downloaded two at a time.
What happened? `threading.get_ident()` would return a unique id for the given thread. Too bad that this ID can be reassigned. To avoid future issues uuid4 replaced it.

It is now possible to pull 10 ports with each containing a 1GB file without any issue. It now works reliably every time.

Before this, almost always you would have issues when pulling 5 ports with a 1GB file in each port.



## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->

- fixes https://github.com/ITISFoundation/osparc-simcore/issues/6276

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
