### PR TITLE
🐛S3: when copying files there is no callback if the multipart threshold is not reached

### DIFF
--- a/packages/aws-library/src/aws_library/s3/_constants.py
+++ b/packages/aws-library/src/aws_library/s3/_constants.py
@@ -4,7 +4,7 @@ from pydantic import ByteSize, parse_obj_as
 
 # NOTE: AWS S3 upload limits https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
 MULTIPART_UPLOADS_MIN_TOTAL_SIZE: Final[ByteSize] = parse_obj_as(ByteSize, "100MiB")
-
+MULTIPART_COPY_THRESHOLD: Final[ByteSize] = parse_obj_as(ByteSize, "100MiB")
 
 PRESIGNED_LINK_MAX_SIZE: Final[ByteSize] = parse_obj_as(ByteSize, "5GiB")
 S3_MAX_FILE_SIZE: Final[ByteSize] = parse_obj_as(ByteSize, "5TiB")

--- a/services/storage/src/simcore_service_storage/s3_utils.py
+++ b/services/storage/src/simcore_service_storage/s3_utils.py
@@ -9,7 +9,7 @@ from servicelib.aiohttp.long_running_tasks.server import (
     TaskProgress,
 )
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 def update_task_progress(
@@ -17,7 +17,7 @@ def update_task_progress(
     message: ProgressMessage | None = None,
     progress: ProgressPercent | None = None,
 ) -> None:
-    logger.debug("%s [%s]", message or "", progress or "n/a")
+    _logger.debug("%s [%s]", message or "", progress or "n/a")
     if task_progress:
         task_progress.update(message=message, percent=progress)
 
@@ -53,7 +53,7 @@ class S3TransferDataCB:
         self._update()
 
     def copy_transfer_cb(self, total_bytes_copied: int, *, file_name: str) -> None:
-        logger.debug(
+        _logger.debug(
             "Copied %s of %s",
             parse_obj_as(ByteSize, total_bytes_copied).human_readable(),
             file_name,
@@ -64,6 +64,11 @@ class S3TransferDataCB:
             self._update()
 
     def upload_transfer_cb(self, bytes_transferred: int, *, file_name: str) -> None:
+        _logger.debug(
+            "Uploaded %s of %s",
+            parse_obj_as(ByteSize, bytes_transferred).human_readable(),
+            file_name,
+        )
         self._file_total_bytes_copied[file_name] += bytes_transferred
         self._total_bytes_copied = sum(self._file_total_bytes_copied.values())
         if self.total_bytes_to_transfer != 0:

--- a/services/storage/tests/unit/test_simcore_s3_dsm.py
+++ b/services/storage/tests/unit/test_simcore_s3_dsm.py
@@ -28,8 +28,8 @@ def file_size() -> ByteSize:
 
 
 @pytest.fixture
-def mock_copy_transfer_cb() -> Callable[[int], None]:
-    def copy_transfer_cb(copied_bytes: int) -> None:
+def mock_copy_transfer_cb() -> Callable[..., None]:
+    def copy_transfer_cb(total_bytes_copied: int, *, file_name: str) -> None:
         ...
 
     return copy_transfer_cb
@@ -43,7 +43,7 @@ async def test__copy_path_s3_s3(
     upload_file: Callable[[ByteSize, str], Awaitable[tuple[Path, SimcoreS3FileID]]],
     file_size: ByteSize,
     user_id: UserID,
-    mock_copy_transfer_cb: Callable[[int], None],
+    mock_copy_transfer_cb: Callable[..., None],
     aiopg_engine: Engine,
 ):
     def _get_dest_file_id(src: SimcoreS3FileID) -> SimcoreS3FileID:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
https://github.com/ITISFoundation/osparc-simcore/pull/6272 did not completely fix the issue of the progress while duplicating studies or instantiating templates:
- we use boto3 which officially wraps the AWS API for python,
- the copy() function of boto3 auto-switches between copy_object and multipart copying based on a threshold that was overriden by us at a value of 5GB instead of the default value of 8MB,
- this was done as copy_object seemed much faster and seemed to not download/upload data contrary to the multipart counterpart,
- the problem here is that copy_object does not provide any kind of feedback on the copy progress,
- the copy callback for progress would only be called with files larger than 5GB, which is not ideal.


This PR therefore adds:
1. explicit call on the progress callback **after** the copy to ensure that at least the final feedback comes in,
  - in the case of folder copying, the size of each files is known already,
  - in the case of single file copying, an additional call to S3 API is done to get the size of the object.
2. reduced the multipart threshold to 100MB for now (@pcrespov I would need here your measurements to see if this is reasonable - if 5GB is copied in 2 seconds or a reasonable time, then we can revert that part)



## Related issue/s
- https://github.com/ITISFoundation/osparc-simcore/issues/6209
- https://github.com/ITISFoundation/osparc-issues/issues/1681

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
