### PR TITLE
🐛Autoscaling: Buffer pools metrics always showing 0

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/models.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Generator
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import Any, TypeAlias
 
 from aws_library.ec2 import EC2InstanceData, EC2InstanceType, Resources
@@ -212,3 +212,13 @@ class BufferPoolManager:
 
     def __repr__(self) -> str:
         return f"BufferPoolManager({dict(self.buffer_pools)})"
+
+    def flatten_buffer_pool(self) -> BufferPool:
+        """returns a flattened buffer pool with all the EC2InstanceData"""
+        flat_pool = BufferPool()
+
+        for buffer_pool in self.buffer_pools.values():
+            for f in fields(BufferPool):
+                getattr(flat_pool, f.name).update(getattr(buffer_pool, f.name))
+
+        return flat_pool

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_models.py
@@ -154,13 +154,14 @@ class BufferPoolsMetrics(MetricsBase):
     def update_from_buffer_pool_manager(
         self, buffer_pool_manager: BufferPoolManager
     ) -> None:
-        for buffer_pool in buffer_pool_manager.buffer_pools.values():
-            for field_name in BUFFER_POOLS_METRICS_DEFINITIONS:
-                tracked_gauge = getattr(self, field_name)
-                assert isinstance(tracked_gauge, TrackedGauge)  # nosec
-                instances = getattr(buffer_pool, field_name)
-                assert isinstance(instances, set)  # nosec
-                tracked_gauge.update_from_instances(instances)
+        flat_pool = buffer_pool_manager.flatten_buffer_pool()
+
+        for field_name in BUFFER_POOLS_METRICS_DEFINITIONS:
+            tracked_gauge = getattr(self, field_name)
+            assert isinstance(tracked_gauge, TrackedGauge)  # nosec
+            instances = getattr(flat_pool, field_name)
+            assert isinstance(instances, set)  # nosec
+            tracked_gauge.update_from_instances(instances)
 
 
 @dataclass(slots=True, kw_only=True)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
The metrics values for the autoscaling EBS buffers were always showing 0.

This PR fixes this issue as the Gauge used were overriden due to multiple instance types. Using a flat list fixes this.


related dashboard: 
![image](https://github.com/user-attachments/assets/25867cf6-24e3-4697-83bb-acf1a08408f9)

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
