### PR TITLE
⬆️ upgrades gunicorn dependencies in webserver

### DIFF
--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -40,6 +40,7 @@ echo "$INFO" "Log-level app/server: $APP_LOG_LEVEL/$SERVER_LOG_LEVEL"
 # NOTE: the number of workers ```(2 x $num_cores) + 1``` is
 # the official recommendation [https://docs.gunicorn.org/en/latest/design.html#how-many-workers]
 # For now we set it to 1 to check what happens with websockets
+# SEE also https://docs.aiohttp.org/en/stable/deployment.html#start-gunicorn
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: ptvsd is programmatically enabled inside of the service

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -271,7 +271,7 @@ orjson==3.10.0
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/_base.in
-packaging==23.1
+packaging==24.1
     # via
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
@@ -399,7 +399,7 @@ rich==13.4.2
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-setproctitle==1.2.3
+setproctitle==1.3.3
     # via gunicorn
 setuptools==69.1.1
     # via

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -88,7 +88,6 @@ async-timeout==4.0.3
     # via
     #   aiohttp
     #   aiopg
-    #   redis
 asyncpg==0.27.0
     # via
     #   -r requirements/_base.in
@@ -167,7 +166,7 @@ frozenlist==1.4.1
     #   aiosignal
 greenlet==2.0.2
     # via sqlalchemy
-gunicorn==20.1.0
+gunicorn==23.0.0
     # via -r requirements/_base.in
 idna==3.3
     # via
@@ -276,6 +275,7 @@ packaging==23.1
     # via
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
+    #   gunicorn
 pamqp==3.2.1
     # via aiormq
 passlib==1.7.4
@@ -403,7 +403,6 @@ setproctitle==1.2.3
     # via gunicorn
 setuptools==69.1.1
     # via
-    #   gunicorn
     #   jsonschema
     #   openapi-spec-validator
 shellingham==1.5.4

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -114,7 +114,7 @@ openapi-spec-validator==0.4.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-packaging==23.1
+packaging==24.1
     # via
     #   -c requirements/_base.txt
     #   pytest

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -18,7 +18,6 @@ async-timeout==4.0.3
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-    #   redis
 asyncpg==0.27.0
     # via
     #   -c requirements/_base.txt
@@ -217,8 +216,6 @@ tenacity==8.5.0
     #   -r requirements/_test.in
 termcolor==2.4.0
     # via pytest-sugar
-tomli==2.0.1
-    # via coverage
 types-aiofiles==24.1.0.20240626
     # via -r requirements/_test.in
 types-jsonschema==4.23.0.20240813

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -81,14 +81,6 @@ setuptools==69.1.1
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pip-tools
-tomli==2.0.1
-    # via
-    #   -c requirements/_test.txt
-    #   black
-    #   build
-    #   mypy
-    #   pip-tools
-    #   pylint
 tomlkit==0.13.2
     # via pylint
 types-cachetools==5.5.0.20240820

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -43,7 +43,7 @@ nodeenv==1.9.1
     # via pre-commit
 nose==1.3.7
     # via inotify
-packaging==23.1
+packaging==24.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

In master deploy webserver cannot start in one of the nodes and we speculate that it is due to guvicorn and how it uses memory.  This PR upgrades `gunicorn` 

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | gunicorn                  | 20.1.0          | 23.0.0     | **MAJOR**  | 1 | web⬆️ |
|   2 | packaging                 | 23.1            | 24.1       | **MAJOR**  | 3 | web⬆️🧪🔧 |
|   3 | setproctitle              | 1.2.3           | 1.3.3      | *minor*    | 1 | web⬆️ |
|   4 | tomli                     | 2.0.1           | 🗑️ removed |  | 2 | web🧪🔧 |

## Related issue/s

 - in master deploy webserver cannot start in one of the nodes and we speculate that it is due to guvicorn and how it uses memory
 
## How to test

in place

## Dev-ops checklist
None