### PR TITLE
🐛 [Frontend] Fix ``Automatic Shutdown`` = 0

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/WorkspaceHeader.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/WorkspaceHeader.js
@@ -159,14 +159,15 @@ qx.Class.define("osparc.dashboard.WorkspaceHeader", {
     __buildLayout: function(workspaceId) {
       this.getChildControl("icon");
       const title = this.getChildControl("title");
+
       this.getChildControl("edit-button").exclude();
+      this.resetAccessRights();
+      this.resetMyAccessRights();
 
       const workspace = osparc.store.Workspaces.getInstance().getWorkspace(workspaceId);
       if (workspaceId === -1) {
         this.__setIcon(osparc.store.Workspaces.iconPath(32));
         title.setValue(this.tr("Shared Workspaces"));
-        this.resetAccessRights();
-        this.resetMyAccessRights();
       } else if (workspace) {
         const thumbnail = workspace.getThumbnail();
         this.__setIcon(thumbnail ? thumbnail : osparc.store.Workspaces.iconPath(32));
@@ -176,8 +177,6 @@ qx.Class.define("osparc.dashboard.WorkspaceHeader", {
       } else {
         this.__setIcon("@FontAwesome5Solid/home/30");
         title.setValue(this.tr("My Workspace"));
-        this.resetAccessRights();
-        this.resetMyAccessRights();
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditorIdlingTracker.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditorIdlingTracker.js
@@ -89,7 +89,7 @@ qx.Class.define("osparc.desktop.StudyEditorIdlingTracker", {
     __startTimer: function() {
       const inactivityThresholdT = osparc.Preferences.getInstance().getUserInactivityThreshold();
       if (inactivityThresholdT === 0) {
-        // If 0 "Automatic Shutdown of Idle Instances" is disabled
+        // If 0, "Automatic Shutdown of Idle Instances" is disabled
         return;
       }
 

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditorIdlingTracker.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditorIdlingTracker.js
@@ -87,8 +87,13 @@ qx.Class.define("osparc.desktop.StudyEditorIdlingTracker", {
     },
 
     __startTimer: function() {
+      const inactivityThresholdT = osparc.Preferences.getInstance().getUserInactivityThreshold();
+      if (inactivityThresholdT === 0) {
+        // If 0 "Automatic Shutdown of Idle Instances" is disabled
+        return;
+      }
+
       const checkFn = () => {
-        const inactivityThresholdT = osparc.Preferences.getInstance().getUserInactivityThreshold();
         const flashMessageDurationS = Math.round(inactivityThresholdT * 0.2);
         this.__idlingTime++;
 


### PR DESCRIPTION
## What do these changes do?

reported by @cosfor1 

If, in the user preferences, the "Automatic Shutdown of Idle Instances" is set to 0, the Idling tracker should never start.

Currently, as soon as the service starts, the frontend will ask the backend if it's inactive, the backend will say, "yes, it's inactive", and the frontend will react as the user was Idle, closing the project.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
