### PR TITLE
🐛⚗️Prometheus instrumentation incorrectly setup

### DIFF
--- a/packages/service-library/src/servicelib/fastapi/prometheus_instrumentation.py
+++ b/packages/service-library/src/servicelib/fastapi/prometheus_instrumentation.py
@@ -8,9 +8,9 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 def setup_prometheus_instrumentation(app: FastAPI) -> Instrumentator:
     # NOTE: use that registry to prevent having a global one
-    registry = CollectorRegistry(auto_describe=True)
+    app.state.prometheus_registry = registry = CollectorRegistry(auto_describe=True)
     instrumentator = Instrumentator(
-        should_instrument_requests_inprogress=True,
+        should_instrument_requests_inprogress=False,  # bug in https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/317
         inprogress_labels=False,
         registry=registry,
     ).instrument(app)
@@ -20,10 +20,8 @@ def setup_prometheus_instrumentation(app: FastAPI) -> Instrumentator:
 
     def _unregister() -> None:
         # NOTE: avoid registering collectors multiple times when running unittests consecutively (https://stackoverflow.com/a/62489287)
-        for collector in list(
-            instrumentator.registry._collector_to_names.keys()  # noqa: SLF001
-        ):
-            instrumentator.registry.unregister(collector)
+        for collector in list(registry._collector_to_names.keys()):  # noqa: SLF001
+            registry.unregister(collector)
 
     app.add_event_handler("startup", _on_startup)
     app.add_event_handler("shutdown", _unregister)

--- a/packages/service-library/src/servicelib/fastapi/prometheus_instrumentation.py
+++ b/packages/service-library/src/servicelib/fastapi/prometheus_instrumentation.py
@@ -7,18 +7,20 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 def setup_prometheus_instrumentation(app: FastAPI) -> Instrumentator:
 
-    instrumentator = (
-        Instrumentator(
-            should_instrument_requests_inprogress=True, inprogress_labels=False
-        )
-        .instrument(app)
-        .expose(app, include_in_schema=False)
-    )
+    instrumentator = Instrumentator(
+        should_instrument_requests_inprogress=True, inprogress_labels=False
+    ).instrument(app)
 
-    def _unregister():
-        for collector in list(instrumentator.registry._collector_to_names.keys()):
+    async def on_startup(app: FastAPI) -> None:
+        instrumentator.expose(app, include_in_schema=False)
+
+    def _unregister() -> None:
+        # NOTE: avoid registering collectors multiple times when running unittests consecutively (https://stackoverflow.com/a/62489287)
+        for collector in list(
+            instrumentator.registry._collector_to_names.keys()  # noqa: SLF001
+        ):
             instrumentator.registry.unregister(collector)
 
-    # avoid registering collectors multiple times when running unittests consecutively (https://stackoverflow.com/a/62489287)
+    app.add_event_handler("startup", on_startup)
     app.add_event_handler("shutdown", _unregister)
     return instrumentator

--- a/packages/service-library/src/servicelib/fastapi/prometheus_instrumentation.py
+++ b/packages/service-library/src/servicelib/fastapi/prometheus_instrumentation.py
@@ -15,7 +15,7 @@ def setup_prometheus_instrumentation(app: FastAPI) -> Instrumentator:
         registry=registry,
     ).instrument(app)
 
-    async def _on_startup(app: FastAPI) -> None:
+    async def _on_startup() -> None:
         instrumentator.expose(app, include_in_schema=False)
 
     def _unregister() -> None:

--- a/packages/service-library/src/servicelib/fastapi/tracing.py
+++ b/packages/service-library/src/servicelib/fastapi/tracing.py
@@ -9,9 +9,7 @@ from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     OTLPSpanExporter as OTLPSpanExporterHTTP,
 )
-from opentelemetry.instrumentation.fastapi import (
-    FastAPIInstrumentor,  # pylint: disable=no-name-in-module
-)
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -29,15 +27,7 @@ def setup_tracing(
     ):
         log.warning("Skipping opentelemetry tracing setup")
         return
-    if (
-        not tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_ENDPOINT
-        or not tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_PORT
-    ):
-        msg = (
-            f"Variable opentelemetry_collector_endpoint [{tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_ENDPOINT}] "
-            f"or opentelemetry_collector_port [{tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_PORT}] unset. Tracing options incomplete."
-        )
-        raise RuntimeError(msg)
+
     # Set up the tracer provider
     resource = Resource(attributes={"service.name": service_name})
     trace.set_tracer_provider(TracerProvider(resource=resource))

--- a/packages/service-library/src/servicelib/fastapi/tracing.py
+++ b/packages/service-library/src/servicelib/fastapi/tracing.py
@@ -1,6 +1,7 @@
 """ Adds fastapi middleware for tracing using opentelemetry instrumentation.
 
 """
+
 import logging
 
 from fastapi import FastAPI
@@ -21,24 +22,27 @@ log = logging.getLogger(__name__)
 
 def setup_tracing(
     app: FastAPI, tracing_settings: TracingSettings, service_name: str
-) -> FastAPIInstrumentor | None:
+) -> None:
     if (
         not tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_ENDPOINT
         and not tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_PORT
     ):
         log.warning("Skipping opentelemetry tracing setup")
-        return None
+        return
     if (
         not tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_ENDPOINT
         or not tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_PORT
     ):
-        raise RuntimeError(
-            f"Variable opentelemetry_collector_endpoint [{tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_ENDPOINT}] or opentelemetry_collector_port [{tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_PORT}] unset. Tracing options incomplete."
+        msg = (
+            f"Variable opentelemetry_collector_endpoint [{tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_ENDPOINT}] "
+            f"or opentelemetry_collector_port [{tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_PORT}] unset. Tracing options incomplete."
         )
+        raise RuntimeError(msg)
     # Set up the tracer provider
     resource = Resource(attributes={"service.name": service_name})
     trace.set_tracer_provider(TracerProvider(resource=resource))
-    tracer_provider = trace.get_tracer_provider()
+    global_tracer_provider = trace.get_tracer_provider()
+    assert isinstance(global_tracer_provider, TracerProvider)  # nosec
     tracing_destination: str = f"{tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_ENDPOINT}:{tracing_settings.TRACING_OPENTELEMETRY_COLLECTOR_PORT}/v1/traces"
     log.info(
         "Trying to connect service %s to tracing collector at %s.",
@@ -48,7 +52,6 @@ def setup_tracing(
     # Configure OTLP exporter to send spans to the collector
     otlp_exporter = OTLPSpanExporterHTTP(endpoint=tracing_destination)
     span_processor = BatchSpanProcessor(otlp_exporter)
-    # Mypy bug --> https://github.com/open-telemetry/opentelemetry-python/issues/3713
-    tracer_provider.add_span_processor(span_processor)  # type: ignore[attr-defined]
+    global_tracer_provider.add_span_processor(span_processor)
     # Instrument FastAPI
-    return FastAPIInstrumentor().instrument_app(app)  # type: ignore[no-any-return]
+    FastAPIInstrumentor().instrument_app(app)

--- a/packages/service-library/src/servicelib/instrumentation.py
+++ b/packages/service-library/src/servicelib/instrumentation.py
@@ -1,2 +1,13 @@
+from dataclasses import dataclass
+
+from prometheus_client import CollectorRegistry
+
+
+@dataclass(slots=True, kw_only=True)
+class MetricsBase:
+    subsystem: str
+    registry: CollectorRegistry
+
+
 def get_metrics_namespace(application_name: str) -> str:
     return application_name.replace("-", "_")

--- a/services/agent/tests/unit/test_core_routes.py
+++ b/services/agent/tests/unit/test_core_routes.py
@@ -29,7 +29,7 @@ def test_client(initialized_app: FastAPI) -> TestClient:
 def test_health_ok(env: None, test_client: TestClient):
     response = test_client.get("/health")
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == None
+    assert response.json() is None
 
 
 def test_health_fails_not_started(
@@ -37,7 +37,7 @@ def test_health_fails_not_started(
 ):
     task_monitor: TaskMonitor = initialized_app.state.task_monitor
     # emulate monitor not being started
-    task_monitor._was_started = False
+    task_monitor._was_started = False  # noqa: SLF001
 
     response = test_client.get("/health")
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
@@ -50,8 +50,8 @@ def test_health_fails_hanging_tasks(
     task_monitor: TaskMonitor = initialized_app.state.task_monitor
 
     # emulate tasks hanging
-    for task_data in task_monitor._to_start.values():
-        task_data._start_time = time() - 1e6
+    for task_data in task_monitor._to_start.values():  # noqa: SLF001
+        task_data._start_time = time() - 1e6  # noqa: SLF001
 
     response = test_client.get("/health")
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_core.py
@@ -22,8 +22,10 @@ def setup(app: FastAPI) -> None:
         metrics_subsystem = (
             "dynamic" if app_settings.AUTOSCALING_NODES_MONITORING else "computational"
         )
-        app.state.instrumentation = AutoscalingInstrumentation(
-            registry=instrumentator.registry, subsystem=metrics_subsystem
+        app.state.instrumentation = (
+            AutoscalingInstrumentation(  # pylint: disable=unexpected-keyword-arg
+                registry=instrumentator.registry, subsystem=metrics_subsystem
+            )
         )
 
     async def on_shutdown() -> None:

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_models.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Final
 
 from prometheus_client import CollectorRegistry, Counter, Histogram
+from servicelib.instrumentation import MetricsBase
 
 from ...models import BufferPoolManager, Cluster
 from ._constants import (
@@ -11,12 +12,6 @@ from ._constants import (
     METRICS_NAMESPACE,
 )
 from ._utils import TrackedGauge, create_gauge
-
-
-@dataclass(slots=True, kw_only=True)
-class MetricsBase:
-    subsystem: str
-    registry: CollectorRegistry
 
 
 @dataclass(slots=True, kw_only=True)

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_models.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_models.py
@@ -186,12 +186,16 @@ class AutoscalingInstrumentation(MetricsBase):
     buffer_machines_pools_metrics: BufferPoolsMetrics = field(init=False)
 
     def __post_init__(self) -> None:
-        self.cluster_metrics = ClusterMetrics(
+        self.cluster_metrics = ClusterMetrics(  # pylint: disable=unexpected-keyword-arg
             subsystem=self.subsystem, registry=self.registry
         )
-        self.ec2_client_metrics = EC2ClientMetrics(
-            subsystem=self.subsystem, registry=self.registry
+        self.ec2_client_metrics = (
+            EC2ClientMetrics(  # pylint: disable=unexpected-keyword-arg
+                subsystem=self.subsystem, registry=self.registry
+            )
         )
-        self.buffer_machines_pools_metrics = BufferPoolsMetrics(
-            subsystem=self.subsystem, registry=self.registry
+        self.buffer_machines_pools_metrics = (
+            BufferPoolsMetrics(  # pylint: disable=unexpected-keyword-arg
+                subsystem=self.subsystem, registry=self.registry
+            )
         )

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_utils.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_utils.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from aws_library.ec2._models import EC2InstanceData
-from prometheus_client import Gauge
+from prometheus_client import CollectorRegistry, Gauge
 
 from ._constants import METRICS_NAMESPACE
 
@@ -27,9 +27,11 @@ class TrackedGauge:
 
 
 def create_gauge(
+    *,
     field_name: str,
     definition: tuple[str, tuple[str, ...]],
     subsystem: str,
+    registry: CollectorRegistry,
 ) -> TrackedGauge:
     description, labelnames = definition
     return TrackedGauge(
@@ -39,5 +41,6 @@ def create_gauge(
             labelnames=labelnames,
             namespace=METRICS_NAMESPACE,
             subsystem=subsystem,
+            registry=registry,
         )
     )

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -378,11 +378,17 @@ def enabled_rabbitmq(
     return rabbit_service
 
 
+_LIFESPAN_TIMEOUT: Final[int] = 10
+
+
 @pytest.fixture
 async def initialized_app(app_environment: EnvVarsDict) -> AsyncIterator[FastAPI]:
     settings = ApplicationSettings.create_from_envs()
     app = create_app(settings)
-    async with LifespanManager(app):
+    # NOTE: the timeout is sometime too small for CI machines, and even larger machines
+    async with LifespanManager(
+        app, startup_timeout=_LIFESPAN_TIMEOUT, shutdown_timeout=_LIFESPAN_TIMEOUT
+    ):
         yield app
 
 

--- a/services/autoscaling/tests/unit/test_modules_instrumentation_utils.py
+++ b/services/autoscaling/tests/unit/test_modules_instrumentation_utils.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from typing import TypedDict
 
 from aws_library.ec2._models import EC2InstanceData
+from prometheus_client import CollectorRegistry
 from prometheus_client.metrics import MetricWrapperBase
 from simcore_service_autoscaling.modules.instrumentation._constants import (
     EC2_INSTANCE_LABELS,
@@ -40,10 +41,12 @@ def test_update_gauge_sets_old_entries_to_0(
     fake_ec2_instance_data: Callable[..., EC2InstanceData]
 ):
     # Create a Gauge with example labels
+    registry = CollectorRegistry()
     tracked_gauge = create_gauge(
-        "example_gauge",
+        field_name="example_gauge",
         definition=("An example gauge", EC2_INSTANCE_LABELS),
         subsystem="whatever",
+        registry=registry,
     )
 
     ec2_instance_type_1 = fake_ec2_instance_data()

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
@@ -3,12 +3,11 @@ from typing import Final
 
 from prometheus_client import CollectorRegistry, Histogram
 from pydantic import ByteSize, parse_obj_as
-from servicelib.instrumentation import get_metrics_namespace
+from servicelib.instrumentation import MetricsBase, get_metrics_namespace
 
 from ..._meta import PROJECT_NAME
 
-_NAMESPACE_METRICS: Final[str] = get_metrics_namespace(PROJECT_NAME)
-_SUBSYSTEM_NAME: Final[str] = "dynamic_services"
+_METRICS_NAMESPACE: Final[str] = get_metrics_namespace(PROJECT_NAME)
 _INSTRUMENTATION_LABELS: Final[tuple[str, ...]] = (
     "user_id",
     "wallet_id",
@@ -31,7 +30,7 @@ _BUCKETS_TIME_S: Final[tuple[float, ...]] = (
 )
 
 
-_BUCKETS_RATE_BPS: Final[tuple[float, ...]] = tuple(
+_RATE_BPS_BUCKETS: Final[tuple[float, ...]] = tuple(
     parse_obj_as(ByteSize, f"{m}MiB")
     for m in (
         1,
@@ -50,8 +49,7 @@ _BUCKETS_RATE_BPS: Final[tuple[float, ...]] = tuple(
 
 
 @dataclass(slots=True, kw_only=True)
-class DynamiSidecarMetrics:
-
+class DynamiSidecarMetrics(MetricsBase):
     start_time_duration: Histogram = field(init=False)
     stop_time_duration: Histogram = field(init=False)
     pull_user_services_images_duration: Histogram = field(init=False)
@@ -69,69 +67,77 @@ class DynamiSidecarMetrics:
     def __post_init__(self) -> None:
         self.start_time_duration = Histogram(
             "start_time_duration_seconds",
-            "time to start dynamic-sidecar",
+            "time to start dynamic service (from start request in dv-2 till service containers are in running state (healthy))",
             labelnames=_INSTRUMENTATION_LABELS,
-            namespace=_NAMESPACE_METRICS,
+            namespace=_METRICS_NAMESPACE,
             buckets=_BUCKETS_TIME_S,
-            subsystem=_SUBSYSTEM_NAME,
+            subsystem=self.subsystem,
+            registry=self.registry,
         )
         self.stop_time_duration = Histogram(
             "stop_time_duration_seconds",
-            "time to stop dynamic-sidecar",
+            "time to stop dynamic service (from stop request in dv-2 till all allocated resources (services + dynamic-sidecar) are removed)",
             labelnames=_INSTRUMENTATION_LABELS,
-            namespace=_NAMESPACE_METRICS,
+            namespace=_METRICS_NAMESPACE,
             buckets=_BUCKETS_TIME_S,
-            subsystem=_SUBSYSTEM_NAME,
+            subsystem=self.subsystem,
+            registry=self.registry,
         )
         self.pull_user_services_images_duration = Histogram(
             "pull_user_services_images_duration_seconds",
             "time to pull docker images",
             labelnames=_INSTRUMENTATION_LABELS,
-            namespace=_NAMESPACE_METRICS,
-            buckets=_BUCKETS_RATE_BPS,
-            subsystem=_SUBSYSTEM_NAME,
+            namespace=_METRICS_NAMESPACE,
+            buckets=_RATE_BPS_BUCKETS,
+            subsystem=self.subsystem,
+            registry=self.registry,
         )
 
         self.output_ports_pull_rate = Histogram(
             "output_ports_pull_rate_bps",
             "rate at which output ports were pulled",
             labelnames=_INSTRUMENTATION_LABELS,
-            namespace=_NAMESPACE_METRICS,
-            buckets=_BUCKETS_RATE_BPS,
-            subsystem=_SUBSYSTEM_NAME,
+            namespace=_METRICS_NAMESPACE,
+            buckets=_RATE_BPS_BUCKETS,
+            subsystem=self.subsystem,
+            registry=self.registry,
         )
         self.input_ports_pull_rate = Histogram(
             "input_ports_pull_rate_bps",
             "rate at which input ports were pulled",
             labelnames=_INSTRUMENTATION_LABELS,
-            namespace=_NAMESPACE_METRICS,
-            buckets=_BUCKETS_RATE_BPS,
-            subsystem=_SUBSYSTEM_NAME,
+            namespace=_METRICS_NAMESPACE,
+            buckets=_RATE_BPS_BUCKETS,
+            subsystem=self.subsystem,
+            registry=self.registry,
         )
         self.pull_service_state_rate = Histogram(
             "pull_service_state_rate_bps",
             "rate at which service states were recovered",
             labelnames=_INSTRUMENTATION_LABELS,
-            namespace=_NAMESPACE_METRICS,
-            buckets=_BUCKETS_RATE_BPS,
-            subsystem=_SUBSYSTEM_NAME,
+            namespace=_METRICS_NAMESPACE,
+            buckets=_RATE_BPS_BUCKETS,
+            subsystem=self.subsystem,
+            registry=self.registry,
         )
 
         self.push_service_state_rate = Histogram(
             "push_service_state_rate_bps",
             "rate at which service states were saved",
             labelnames=_INSTRUMENTATION_LABELS,
-            namespace=_NAMESPACE_METRICS,
-            buckets=_BUCKETS_RATE_BPS,
-            subsystem=_SUBSYSTEM_NAME,
+            namespace=_METRICS_NAMESPACE,
+            buckets=_RATE_BPS_BUCKETS,
+            subsystem=self.subsystem,
+            registry=self.registry,
         )
 
 
 @dataclass(slots=True, kw_only=True)
 class DirectorV2Instrumentation:
     registry: CollectorRegistry
-
     dynamic_sidecar_metrics: DynamiSidecarMetrics = field(init=False)
 
     def __post_init__(self) -> None:
-        self.dynamic_sidecar_metrics = DynamiSidecarMetrics()
+        self.dynamic_sidecar_metrics = DynamiSidecarMetrics(
+            subsystem="dynamic_services", registry=self.registry
+        )

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
@@ -138,6 +138,8 @@ class DirectorV2Instrumentation:
     dynamic_sidecar_metrics: DynamiSidecarMetrics = field(init=False)
 
     def __post_init__(self) -> None:
-        self.dynamic_sidecar_metrics = DynamiSidecarMetrics(
-            subsystem="dynamic_services", registry=self.registry
+        self.dynamic_sidecar_metrics = (
+            DynamiSidecarMetrics(  # pylint: disable=unexpected-keyword-arg
+                subsystem="dynamic_services", registry=self.registry
+            )
         )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

- since https://github.com/ITISFoundation/osparc-simcore/pull/6168 came in, the unit tests in autoscaling started to fail randomly (for example like [this one](https://github.com/ITISFoundation/osparc-simcore/actions/runs/10937502398/job/30363827202))

Here is probably what was happening:
- in tests we use asgi-lifespan to emulate what fastapi does (this is how fastapi recommend of doing)
- since the tracing was introduced, it seems that initialization phase in the tests takes longer, and times-out sometimes (default is 5 seconds)
- the `prometheus_fastapi_instrumentator` library introduced by @bisgaard-itis a long time ago uses a global _CollectorRegistry_, and is initialized,
- after the time out happen, this is not cleaned up (since global are :imp: ),
- all subsequent tests fail, as the global registry is already full.

This PR does:
- creates a collector registry,
- increases the timeouts in the lifespan manager,
- does some cleaning

## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/6399
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
