### PR TITLE
 🐛 Improved Error Handling for Missing  Billing Details

### DIFF
--- a/packages/models-library/src/models_library/users.py
+++ b/packages/models-library/src/models_library/users.py
@@ -22,7 +22,7 @@ class UserBillingDetails(BaseModel):
     address: str | None
     city: str | None
     state: str | None = Field(description="State, province, canton, ...")
-    country: str
+    country: str  # Required for taxes
     postal_code: str | None
     phone: str | None
 

--- a/services/web/server/src/simcore_service_webserver/payments/_onetime_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_onetime_api.py
@@ -279,6 +279,7 @@ async def init_creation_of_wallet_payment(
     Raises:
         UserNotFoundError
         WalletAccessForbiddenError
+        BillingDetailsNotFoundError
     """
 
     # wallet: check permissions
@@ -293,6 +294,7 @@ async def init_creation_of_wallet_payment(
     # user info
     user = await get_user_display_and_id_names(app, user_id=user_id)
     user_invoice_address = await get_user_invoice_address(app, user_id=user_id)
+
     # stripe info
     product_stripe_info = await get_product_stripe_info(app, product_name=product_name)
 

--- a/services/web/server/src/simcore_service_webserver/users/_db.py
+++ b/services/web/server/src/simcore_service_webserver/users/_db.py
@@ -21,6 +21,7 @@ from simcore_service_webserver.users.exceptions import UserNotFoundError
 
 from ..db.models import user_to_groups
 from ..db.plugin import get_database_engine
+from .exceptions import BillingDetailsNotFoundError
 from .schemas import Permission
 
 _ALL = None
@@ -203,9 +204,12 @@ async def new_user_details(
 async def get_user_billing_details(
     engine: Engine, user_id: UserID
 ) -> UserBillingDetails:
+    """
+    Raises:
+        BillingDetailsNotFoundError
+    """
     async with engine.acquire() as conn:
         user_billing_details = await UsersRepo.get_billing_details(conn, user_id)
         if not user_billing_details:
-            msg = f"Missing biling details for user {user_id}"
-            raise ValueError(msg)
+            raise BillingDetailsNotFoundError(user_id=user_id)
         return UserBillingDetails.from_orm(user_billing_details)

--- a/services/web/server/src/simcore_service_webserver/users/exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/users/exceptions.py
@@ -45,3 +45,10 @@ class AlreadyPreRegisteredError(UsersBaseError):
     msg_template = (
         "Found {num_found} matches for '{email}'. Cannot pre-register existing user"
     )
+
+
+class BillingDetailsNotFoundError(UsersBaseError):
+    def log_msg(self):
+        return "Billing details are missing for user_id={user_id}. TIP: Check whether this user is pre-registered".format(
+            **self.__dict__
+        )

--- a/services/web/server/src/simcore_service_webserver/users/exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/users/exceptions.py
@@ -48,7 +48,5 @@ class AlreadyPreRegisteredError(UsersBaseError):
 
 
 class BillingDetailsNotFoundError(UsersBaseError):
-    def log_msg(self):
-        return "Billing details are missing for user_id={user_id}. TIP: Check whether this user is pre-registered".format(
-            **self.__dict__
-        )
+    # NOTE: this is for internal log and should not be transmitted to the final user
+    msg_template = "Billing details are missing for user_id={user_id}. TIP: Check whether this user is pre-registered"

--- a/services/web/server/src/simcore_service_webserver/wallets/_constants.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_constants.py
@@ -3,3 +3,8 @@ from typing import Final
 MSG_PRICE_NOT_DEFINED_ERROR: Final[
     str
 ] = "No payments are accepted until this product has a price"
+
+MSG_BILLING_DETAILS_NOT_DEFINED_ERROR: Final[str] = (
+    "Payments cannot be processed: Required billing details (e.g. country for tax) are missing from your account."
+    "Please contact support to resolve this configuration issue."
+)

--- a/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
@@ -96,7 +96,7 @@ def handle_wallets_exceptions(handler: Handler):
 
             _logger.exception(
                 "%s [%s]",
-                exc.log_msg(),
+                f"{exc}",
                 f"{error_code}",
                 extra={"error_code": error_code, **log_extra},
             )

--- a/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
@@ -18,6 +18,8 @@ from servicelib.aiohttp.requests_validation import (
     parse_request_path_parameters_as,
 )
 from servicelib.aiohttp.typing_extension import Handler
+from servicelib.error_codes import create_error_code
+from servicelib.logging_utils import get_log_record_extra
 from servicelib.request_keys import RQT_USERID_KEY
 
 from .._constants import RQ_PRODUCT_KEY
@@ -36,10 +38,16 @@ from ..payments.errors import (
 )
 from ..products.errors import BelowMinimumPaymentError, ProductPriceNotDefinedError
 from ..security.decorators import permission_required
-from ..users.exceptions import UserDefaultWalletNotFoundError
+from ..users.exceptions import (
+    BillingDetailsNotFoundError,
+    UserDefaultWalletNotFoundError,
+)
 from ..utils_aiohttp import envelope_json_response
 from . import _api
-from ._constants import MSG_PRICE_NOT_DEFINED_ERROR
+from ._constants import (
+    MSG_BILLING_DETAILS_NOT_DEFINED_ERROR,
+    MSG_PRICE_NOT_DEFINED_ERROR,
+)
 from .errors import WalletAccessForbiddenError, WalletNotFoundError
 
 _logger = logging.getLogger(__name__)
@@ -79,6 +87,21 @@ def handle_wallets_exceptions(handler: Handler):
 
         except ProductPriceNotDefinedError as exc:
             raise web.HTTPConflict(reason=MSG_PRICE_NOT_DEFINED_ERROR) from exc
+
+        except BillingDetailsNotFoundError as exc:
+            error_code = create_error_code(exc)
+            log_extra = {}
+            if user_id := getattr(exc, "user_id", None):
+                log_extra = get_log_record_extra(user_id=user_id) or {}
+
+            _logger.exception(
+                "%s [%s]",
+                exc.log_msg(),
+                f"{error_code}",
+                extra={"error_code": error_code, **log_extra},
+            )
+            user_msg = MSG_BILLING_DETAILS_NOT_DEFINED_ERROR + f" ({error_code})"
+            raise web.HTTPServiceUnavailable(reason=user_msg) from exc
 
     return wrapper
 

--- a/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
@@ -19,7 +19,7 @@ from servicelib.aiohttp.requests_validation import (
 )
 from servicelib.aiohttp.typing_extension import Handler
 from servicelib.error_codes import create_error_code
-from servicelib.logging_utils import get_log_record_extra
+from servicelib.logging_utils import LogExtra, get_log_record_extra
 from servicelib.request_keys import RQT_USERID_KEY
 
 from .._constants import RQ_PRODUCT_KEY
@@ -90,17 +90,16 @@ def handle_wallets_exceptions(handler: Handler):
 
         except BillingDetailsNotFoundError as exc:
             error_code = create_error_code(exc)
-            log_extra = {}
+            log_extra: LogExtra = {}
             if user_id := getattr(exc, "user_id", None):
                 log_extra = get_log_record_extra(user_id=user_id) or {}
 
+            log_msg = f"{exc} [{error_code}]"
             _logger.exception(
-                "%s [%s]",
-                f"{exc}",
-                f"{error_code}",
+                log_msg,
                 extra={"error_code": error_code, **log_extra},
             )
-            user_msg = MSG_BILLING_DETAILS_NOT_DEFINED_ERROR + f" ({error_code})"
+            user_msg = f"{MSG_BILLING_DETAILS_NOT_DEFINED_ERROR} ({error_code})"
             raise web.HTTPServiceUnavailable(reason=user_msg) from exc
 
     return wrapper


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?


Improved Error Handling for Missing Pre-registration and Billing Details**

Previously, when account setup was incomplete or pre-registration information (such as billing country) was missing, the payment process would fail raising an 500 that displayed confusing message in the front-end (should be address in https://github.com/ITISFoundation/osparc-simcore/pull/5487). This was due to the REST handlers not properly addressing the absence of required billing details.

![image](https://github.com/user-attachments/assets/847cbd7e-c615-406a-bcd6-9018123c984a)


With this update, the service now responds with `HTTP_503_SERVICE_UNAVAILABLE` and an explicit message indicating that the payment service is unavailable until the necessary billing details are provided. Currently, these details can only be supplied on the service side (filling the `user_pre_registration` table).

Additionally, errors related to missing billing information are now logged with an `OEC` code and relevant debug data, making them easier to trace in the logs or use as triggers for alerts.


## Related issue/s

- Occurred using misconfigured master deploy with @odeimaiz 

## How to test

```
cd services/web/server
pytest -vv tests/units/with_dbs -k test_billing_info_missing_error
```

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))
