### PR TITLE
🎨 Enhances Product parsing to strip whitespaces in host_regex

### DIFF
--- a/services/web/server/src/simcore_service_webserver/products/_model.py
+++ b/services/web/server/src/simcore_service_webserver/products/_model.py
@@ -111,7 +111,7 @@ class Product(BaseModel):
 
     @validator("*", pre=True)
     @classmethod
-    def parse_empty_string_as_null(cls, v):
+    def _parse_empty_string_as_null(cls, v):
         """Safe measure: database entries are sometimes left blank instead of null"""
         if isinstance(v, str) and len(v.strip()) == 0:
             return None
@@ -119,10 +119,19 @@ class Product(BaseModel):
 
     @validator("name", pre=True, always=True)
     @classmethod
-    def validate_name(cls, v):
+    def _validate_name(cls, v):
         if v not in FRONTEND_APPS_AVAILABLE:
             msg = f"{v} is not in available front-end apps {FRONTEND_APPS_AVAILABLE}"
             raise ValueError(msg)
+        return v
+
+    @validator("host_regex", pre=True)
+    @classmethod
+    def _strip_whitespaces(cls, v):
+        if v and isinstance(v, str):
+            # Prevents unintended leading & trailing spaces when added
+            # manually in the database
+            return v.strip()
         return v
 
     @property
@@ -132,9 +141,10 @@ class Product(BaseModel):
     class Config:
         alias_generator = snake_to_camel  # to export
         allow_population_by_field_name = True
+        anystr_strip_whitespace = True
+        extra = Extra.ignore
         frozen = True  # read-only
         orm_mode = True
-        extra = Extra.ignore
         schema_extra: ClassVar[dict[str, Any]] = {
             "examples": [
                 {

--- a/services/web/server/tests/unit/isolated/test_products_model.py
+++ b/services/web/server/tests/unit/isolated/test_products_model.py
@@ -79,11 +79,16 @@ def test_product_to_static():
 
 
 def test_product_host_regex_with_spaces():
-    expected = r"([\.-]{0,1}osparc[\.-])".strip()
-
     data = Product.Config.schema_extra["examples"][2]
-    data["host_regex"] = expected + "   "  # spaces added at the end
+
+    data["support_email"] = "  foo@BaR.com    "  # with leading and trailing spaces and
+
+    expected = r"([\.-]{0,1}osparc[\.-])".strip()
+    data["host_regex"] = expected + "   "  # with leading trailing spaces
 
     product = Product.parse_obj(data)
+
     assert product.host_regex.pattern == expected
-    assert product.host_regex.search("osparc.speag.com")
+    assert product.host_regex.search("osparc.bar.com")
+
+    assert product.support_email == "foo@bar.com"

--- a/services/web/server/tests/unit/isolated/test_products_model.py
+++ b/services/web/server/tests/unit/isolated/test_products_model.py
@@ -81,11 +81,14 @@ def test_product_to_static():
 def test_product_host_regex_with_spaces():
     data = Product.Config.schema_extra["examples"][2]
 
-    data["support_email"] = "  foo@BaR.com    "  # with leading and trailing spaces and
+    # with leading and trailing spaces and uppercase (tests anystr_strip_whitespace )
+    data["support_email"] = "  fOO@BaR.COM    "
 
+    # with leading trailing spaces (tests validator("host_regex", pre=True))
     expected = r"([\.-]{0,1}osparc[\.-])".strip()
-    data["host_regex"] = expected + "   "  # with leading trailing spaces
+    data["host_regex"] = expected + "   "
 
+    # parsing should strip all whitespaces and normalize email
     product = Product.parse_obj(data)
 
     assert product.host_regex.pattern == expected

--- a/services/web/server/tests/unit/isolated/test_products_model.py
+++ b/services/web/server/tests/unit/isolated/test_products_model.py
@@ -86,4 +86,4 @@ def test_product_host_regex_with_spaces():
 
     product = Product.parse_obj(data)
     assert product.host_regex.pattern == expected
-    assert product.host_regex.search("osparcf.speag.com")
+    assert product.host_regex.search("osparc.speag.com")

--- a/services/web/server/tests/unit/isolated/test_products_model.py
+++ b/services/web/server/tests/unit/isolated/test_products_model.py
@@ -76,3 +76,14 @@ def test_product_to_static():
         ],
         "isPaymentEnabled": False,
     }
+
+
+def test_product_host_regex_with_spaces():
+    expected = r"([\.-]{0,1}osparc[\.-])".strip()
+
+    data = Product.Config.schema_extra["examples"][2]
+    data["host_regex"] = expected + "   "  # spaces added at the end
+
+    product = Product.parse_obj(data)
+    assert product.host_regex.pattern == expected
+    assert product.host_regex.search("osparcf.speag.com")


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

The configuration of the products are currently set directly in the database via adminer. I found that it is easy to make a mistake and introduce spaces in `Product.host_regex` which lead to the system not delivering the right product.

This PR ensures that the Product pre-validator trims all leading and trailing whitespaces in the regex entry

## Related issue/s

Maintenance

## How to test

```
pytest tests/unit/isolated -k test_product_host_regex_with_spaces
```

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))
