### PR TITLE
🐛🎨 Fixes unhandled config error and new log helpers for better troubleshotting

### DIFF
--- a/packages/models-library/src/models_library/errors_classes.py
+++ b/packages/models-library/src/models_library/errors_classes.py
@@ -31,6 +31,6 @@ class OsparcErrorMixin(PydanticErrorMixin):
         ]
         return ".".join(reversed(relevant_classes))
 
-    def ctx(self):
-        """Returns context stored in the exception"""
+    def error_context(self):
+        """Returns context in which error occurred and stored within the exception"""
         return dict(**self.__dict__)

--- a/packages/models-library/src/models_library/errors_classes.py
+++ b/packages/models-library/src/models_library/errors_classes.py
@@ -30,3 +30,7 @@ class OsparcErrorMixin(PydanticErrorMixin):
             )
         ]
         return ".".join(reversed(relevant_classes))
+
+    def ctx(self):
+        """Returns context stored in the exception"""
+        return dict(**self.__dict__)

--- a/packages/models-library/tests/test_errors_classes.py
+++ b/packages/models-library/tests/test_errors_classes.py
@@ -155,7 +155,7 @@ def test_exception_context():
         msg_template = "{value} and {missing}"
 
     exc = MyError(value=42, missing="foo", extra="bar")
-    assert exc.ctx() == {"value": 42, "missing": "foo", "extra": "bar"}
+    assert exc.error_context() == {"value": 42, "missing": "foo", "extra": "bar"}
 
     exc = MyError(value=42)
-    assert exc.ctx() == {"value": 42}
+    assert exc.error_context() == {"value": 42}

--- a/packages/models-library/tests/test_errors_classes.py
+++ b/packages/models-library/tests/test_errors_classes.py
@@ -148,3 +148,14 @@ def test_missing_keys_in_msg_template_does_not_raise():
         msg_template = "{value} and {missing}"
 
     assert str(MyErrorAfter(value=42)) == "42 and 'missing=?'"
+
+
+def test_exception_context():
+    class MyError(OsparcErrorMixin, ValueError):
+        msg_template = "{value} and {missing}"
+
+    exc = MyError(value=42, missing="foo", extra="bar")
+    assert exc.ctx() == {"value": 42, "missing": "foo", "extra": "bar"}
+
+    exc = MyError(value=42)
+    assert exc.ctx() == {"value": 42}

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -346,10 +346,6 @@ def get_log_record_extra(
     return extra or None
 
 
-def _un_capitalize(s: str) -> str:
-    return s[:1].lower() + s[1:] if s else ""
-
-
 def create_troubleshotting_log_message(
     message_to_user: str,
     error: BaseException,
@@ -377,6 +373,10 @@ def create_troubleshotting_log_message(
     )
 
     return f"{message_to_user}.\n{debug_data}"
+
+
+def _un_capitalize(s: str) -> str:
+    return s[:1].lower() + s[1:] if s else ""
 
 
 @contextmanager

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -16,6 +16,9 @@ from inspect import getframeinfo, stack
 from pathlib import Path
 from typing import Any, TypeAlias, TypedDict, TypeVar
 
+from models_library.utils.json_serialization import json_dumps
+
+from .error_codes import ErrorCodeStr
 from .utils_secrets import mask_sensitive_data
 
 _logger = logging.getLogger(__name__)
@@ -320,22 +323,60 @@ def log_catch(logger: logging.Logger, *, reraise: bool = True) -> Iterator[None]
 
 class LogExtra(TypedDict, total=False):
     log_uid: str
+    log_oec: str
 
 
 LogLevelInt: TypeAlias = int
 LogMessageStr: TypeAlias = str
 
 
-def get_log_record_extra(*, user_id: int | str | None = None) -> LogExtra | None:
+def get_log_record_extra(
+    *,
+    user_id: int | str | None = None,
+    error_code: str | None = None,
+) -> LogExtra | None:
     extra: LogExtra = {}
+
     if user_id:
         assert int(user_id) > 0  # nosec
         extra["log_uid"] = f"{user_id}"
+    if error_code:
+        extra["log_oec"] = error_code
+
     return extra or None
 
 
 def _un_capitalize(s: str) -> str:
     return s[:1].lower() + s[1:] if s else ""
+
+
+def create_troubleshotting_log_message(
+    message_to_user: str,
+    error: BaseException,
+    error_code: ErrorCodeStr,
+    error_context: dict[str, Any] | None = None,
+    tip: str | None = None,
+) -> str:
+    """Create a formatted message for _logger.exception(...)
+
+    Arguments:
+        message_to_user -- A user-friendly message to be displayed on the front-end explaining the issue in simple terms.
+        error -- the instance of the handled exception
+        error_code -- A unique error code (e.g., OEC or osparc-specific) to identify the type or source of the error for easier tracking.
+        error_context -- Additional context surrounding the exception, such as environment variables or function-specific data. This can be derived from exc.error_context() (relevant when using the OsparcErrorMixin)
+        tip -- Helpful suggestions or possible solutions explaining why the error may have occurred and how it could potentially be resolved
+    """
+    debug_data = json_dumps(
+        {
+            "exception_details": f"{error}",
+            "error_code": error_code,
+            "context": error_context,
+            "tip": tip,
+        },
+        indent=1,
+    )
+
+    return f"{message_to_user}.\n{debug_data}"
 
 
 @contextmanager

--- a/packages/service-library/tests/test_error_codes.py
+++ b/packages/service-library/tests/test_error_codes.py
@@ -5,50 +5,50 @@
 
 import logging
 
+import pytest
 from servicelib.error_codes import create_error_code, parse_error_code
 
 logger = logging.getLogger(__name__)
 
 
-def test_error_code_use_case(caplog):
+def test_error_code_use_case(caplog: pytest.LogCaptureFixture):
     """use case for error-codes"""
-    try:
+    with pytest.raises(RuntimeError) as exc_info:
         raise RuntimeError("Something unexpected went wrong")
-    except Exception as err:
-        # 1. Unexpected ERROR
 
-        # 2. create error-code
-        error_code = create_error_code(err)
+    # 1. Unexpected ERROR
+    err = exc_info.value
 
-        # 3. log all details in service
-        caplog.clear()
+    # 2. create error-code
+    error_code = create_error_code(err)
 
-        # Can add a formatter that prefix error-codes
-        syslog = logging.StreamHandler()
-        syslog.setFormatter(
-            logging.Formatter("%(asctime)s %(error_code)s : %(message)s")
-        )
-        logger.addHandler(syslog)
+    # 3. log all details in service
+    caplog.clear()
 
-        logger.error("Fake Unexpected error", extra={"error_code": error_code})
+    # Can add a formatter that prefix error-codes
+    syslog = logging.StreamHandler()
+    syslog.setFormatter(logging.Formatter("%(asctime)s %(error_code)s : %(message)s"))
+    logger.addHandler(syslog)
 
-        # logs something like E.g. 2022-07-06 14:31:13,432 OEC:140350117529856 : Fake Unexpected error
-        assert parse_error_code(
-            f"2022-07-06 14:31:13,432 {error_code} : Fake Unexpected error"
-        ) == {
-            error_code,
-        }
+    logger.exception("Fake Unexpected error", extra={"error_code": error_code})
 
-        assert caplog.records[0].error_code == error_code
-        assert caplog.records[0]
+    # logs something like E.g. 2022-07-06 14:31:13,432 OEC:140350117529856 : Fake Unexpected error
+    assert parse_error_code(
+        f"2022-07-06 14:31:13,432 {error_code} : Fake Unexpected error"
+    ) == {
+        error_code,
+    }
 
-        logger.error("Fake without error_code")
+    assert caplog.records[0].error_code == error_code
+    assert caplog.records[0]
 
-        # 4. inform user (e.g. with new error or sending message)
-        user_message = (
-            f"This is a user-friendly message to inform about an error. [{error_code}]"
-        )
+    logger.exception("Fake without error_code")
 
-        assert parse_error_code(user_message) == {
-            error_code,
-        }
+    # 4. inform user (e.g. with new error or sending message)
+    user_message = (
+        f"This is a user-friendly message to inform about an error. [{error_code}]"
+    )
+
+    assert parse_error_code(user_message) == {
+        error_code,
+    }

--- a/services/web/server/src/simcore_service_webserver/_constants.py
+++ b/services/web/server/src/simcore_service_webserver/_constants.py
@@ -28,6 +28,19 @@ MSG_UNDER_DEVELOPMENT: Final[
 ] = "Under development. Use WEBSERVER_DEV_FEATURES_ENABLED=1 to enable current implementation"
 
 
+FMSG_SERVER_EXCEPTION_LOG: Final[
+    # formatted message for _logger.exception(...)
+    # Use these keys as guidance to provide necessary information for a good error message log
+    #
+    # user_msg: message seem by front-end user (should include OEC)
+    # exc: handled exception
+    # ctx: exception context e.g. exc.ctx()  (see OsparcErrorMixin)
+    # tip: tips on why this might have happened and or possible solution
+    #
+    str
+] = "{user_msg}.\nERROR: {exc}.\nCONTEXT: {ctx}.\nTIP: {tip}\n"
+
+
 __all__: tuple[str, ...] = (
     "APP_CONFIG_KEY",
     "APP_AIOPG_ENGINE_KEY",

--- a/services/web/server/src/simcore_service_webserver/_constants.py
+++ b/services/web/server/src/simcore_service_webserver/_constants.py
@@ -28,19 +28,6 @@ MSG_UNDER_DEVELOPMENT: Final[
 ] = "Under development. Use WEBSERVER_DEV_FEATURES_ENABLED=1 to enable current implementation"
 
 
-FMSG_SERVER_EXCEPTION_LOG: Final[
-    # formatted message for _logger.exception(...)
-    # Use these keys as guidance to provide necessary information for a good error message log
-    #
-    # user_msg: message seem by front-end user (should include OEC)
-    # exc: handled exception
-    # ctx: exception context e.g. exc.ctx()  (see OsparcErrorMixin)
-    # tip: tips on why this might have happened and or possible solution
-    #
-    str
-] = "{user_msg}.\nERROR: {exc}.\nCONTEXT: {ctx}.\nTIP: {tip}\n"
-
-
 __all__: tuple[str, ...] = (
     "APP_CONFIG_KEY",
     "APP_AIOPG_ENGINE_KEY",

--- a/services/web/server/src/simcore_service_webserver/users/_constants.py
+++ b/services/web/server/src/simcore_service_webserver/users/_constants.py
@@ -1,0 +1,7 @@
+from typing import Final
+
+FMSG_MISSING_CONFIG_WITH_OEC: Final[str] = (
+    "The product is not ready for use until the configuration is fully completed. "
+    "Please wait and try again. "
+    "If the issue continues, contact support with error code: {error_code}."
+)

--- a/services/web/server/src/simcore_service_webserver/users/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/users/_handlers.py
@@ -9,18 +9,24 @@ from servicelib.aiohttp.requests_validation import (
     parse_request_query_parameters_as,
 )
 from servicelib.aiohttp.typing_extension import Handler
+from servicelib.error_codes import create_error_code
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
 from servicelib.request_keys import RQT_USERID_KEY
 from servicelib.rest_constants import RESPONSE_MODEL_POLICY
 
-from .._constants import RQ_PRODUCT_KEY
+from .._constants import FMSG_SERVER_EXCEPTION_LOG, RQ_PRODUCT_KEY
 from .._meta import API_VTAG
 from ..login.decorators import login_required
 from ..security.decorators import permission_required
 from ..utils_aiohttp import envelope_json_response
 from . import _api, api
+from ._constants import FMSG_MISSING_CONFIG_WITH_OEC
 from ._schemas import PreUserProfile
-from .exceptions import AlreadyPreRegisteredError, UserNotFoundError
+from .exceptions import (
+    AlreadyPreRegisteredError,
+    MissingGroupExtraPropertiesForProductError,
+    UserNotFoundError,
+)
 from .schemas import ProfileGet, ProfileUpdate
 
 _logger = logging.getLogger(__name__)
@@ -42,6 +48,20 @@ def _handle_users_exceptions(handler: Handler):
 
         except UserNotFoundError as exc:
             raise web.HTTPNotFound(reason=f"{exc}") from exc
+        except MissingGroupExtraPropertiesForProductError as exc:
+            error_code = create_error_code(exc)
+            user_msg = FMSG_MISSING_CONFIG_WITH_OEC.format(error_code)
+            log_msg = FMSG_SERVER_EXCEPTION_LOG.format(
+                user_msg=user_msg,
+                exc=exc,
+                ctx=exc.ctx(),
+                tip="Row in `groups_extra_properties` for this product is missing.",
+            )
+            _logger.exception(
+                log_msg,
+                extra={"error_code": error_code},
+            )
+            raise web.HTTPServiceUnavailable(reason=user_msg) from exc
 
     return wrapper
 

--- a/services/web/server/src/simcore_service_webserver/users/api.py
+++ b/services/web/server/src/simcore_service_webserver/users/api.py
@@ -18,6 +18,9 @@ from models_library.products import ProductName
 from models_library.users import GroupID, UserID
 from pydantic import EmailStr, ValidationError, parse_obj_as
 from simcore_postgres_database.models.users import UserRole
+from simcore_postgres_database.utils_groups_extra_properties import (
+    GroupExtraPropertiesNotFoundError,
+)
 
 from ..db.models import GroupType, groups, user_to_groups, users
 from ..db.plugin import get_database_engine
@@ -27,7 +30,7 @@ from ..security.api import clean_auth_policy_cache
 from . import _db
 from ._api import get_user_credentials, get_user_invoice_address, set_user_as_deleted
 from ._preferences_api import get_frontend_user_preferences_aggregation
-from .exceptions import UserNotFoundError
+from .exceptions import MissingGroupExtraPropertiesForProductError, UserNotFoundError
 from .schemas import ProfileGet, ProfileUpdate
 
 _logger = logging.getLogger(__name__)
@@ -45,6 +48,7 @@ async def get_user_profile(
 ) -> ProfileGet:
     """
     :raises UserNotFoundError:
+    :raises MissingGroupExtraPropertiesForProductError: when product is not properly configured
     """
 
     engine = get_database_engine(app)
@@ -107,9 +111,14 @@ async def get_user_profile(
     if not user_profile:
         raise UserNotFoundError(uid=user_id)
 
-    preferences = await get_frontend_user_preferences_aggregation(
-        app, user_id=user_id, product_name=product_name
-    )
+    try:
+        preferences = await get_frontend_user_preferences_aggregation(
+            app, user_id=user_id, product_name=product_name
+        )
+    except GroupExtraPropertiesNotFoundError as err:
+        raise MissingGroupExtraPropertiesForProductError(
+            user_id=user_id, product_name=product_name
+        ) from err
 
     # NOTE: expirationDate null is not handled properly in front-end.
     # https://github.com/ITISFoundation/osparc-simcore/issues/5244

--- a/services/web/server/src/simcore_service_webserver/users/exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/users/exceptions.py
@@ -50,3 +50,7 @@ class AlreadyPreRegisteredError(UsersBaseError):
 class BillingDetailsNotFoundError(UsersBaseError):
     # NOTE: this is for internal log and should not be transmitted to the final user
     msg_template = "Billing details are missing for user_id={user_id}. TIP: Check whether this user is pre-registered"
+
+
+class MissingGroupExtraPropertiesForProductError(UsersBaseError):
+    msg_template = "Missing group_extra_property for product_name={product_name}"


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This PR provides some helpers for better error-handling and diagnostics.  This is applicable to any type of excption but in this case, we apply to a common unhandled error we found when a platform product is partially configured and the `groups_extra_properties` configuration is missing.

- The exception is first categorized as `MissingGroupExtraPropertiesForProductError` error in the web-server
- Using decorator `_handle_users_exceptions` we handle it in the users rest API handlers

There we handle as

![image](https://github.com/user-attachments/assets/d5403216-6620-4e84-b7b4-f12a78ee2e0f)

An exception is handled at the rest-handler level. This exception cannot be resolved and we need to send a comprehensive message to the front-end user as well as log sufficient information in the server for troubleshooting.  The handling of the exception has the following steps
1. create an OEC
2. compose a human-readable message appending the OEC.
3. user `create_troubleshotting_log_message` to produce a rich log message
4. `log.exception` including extras
5. raise HTTP error with human-readable message to the front-end


## Related issue/s

- maintenance: error handling

## How to test

- 

## Dev-ops checklist

None