### PR TITLE
🐛 [Frontend] Announcements: allow in ribbon only

### DIFF
--- a/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
+++ b/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
@@ -46,6 +46,7 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
         const titleLabel = new qx.ui.basic.Label().set({
           value: title,
           font: "text-16",
+          alignX: "center",
           textAlign: "center",
           rich: true
         });
@@ -56,6 +57,7 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
         const descriptionLabel = new qx.ui.basic.Label().set({
           value: description,
           font: "text-14",
+          alignX: "center",
           textAlign: "center",
           rich: true
         });

--- a/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
+++ b/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
@@ -30,7 +30,7 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
   },
 
   statics: {
-    createLoginAnnouncement: function(title, text) {
+    createLoginAnnouncement: function(title, description) {
       const loginAnnouncement = new qx.ui.container.Composite(new qx.ui.layout.VBox(5)).set({
         backgroundColor: "strong-main",
         alignX: "center",
@@ -54,9 +54,9 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
         loginAnnouncement.add(titleLabel);
       }
 
-      if (text) {
+      if (description) {
         const descriptionLabel = new qx.ui.basic.Label().set({
-          value: text,
+          value: description,
           font: "text-14",
           textColor: "white",
           alignX: "center",
@@ -124,8 +124,10 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
         return;
       }
 
-      let text = announcement.getTitle() + ": ";
-      text += announcement.getDescription();
+      let text = announcement.getTitle();
+      if (announcement.getDescription()) {
+        text += ": " + announcement.getDescription();
+      }
 
       const ribbonAnnouncement = this.__ribbonAnnouncement = new osparc.notification.RibbonNotification(text, "announcement", true);
       ribbonAnnouncement.announcementId = announcement.getId();

--- a/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
+++ b/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
@@ -46,7 +46,7 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
         const titleLabel = new qx.ui.basic.Label().set({
           value: title,
           font: "text-16",
-          alignX: "center",
+          textAlign: "center",
           rich: true
         });
         loginAnnouncement.add(titleLabel);
@@ -56,7 +56,7 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
         const descriptionLabel = new qx.ui.basic.Label().set({
           value: description,
           font: "text-14",
-          alignX: "center",
+          textAlign: "center",
           rich: true
         });
         loginAnnouncement.add(descriptionLabel);

--- a/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
+++ b/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
@@ -75,7 +75,6 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
 
     __isValid: function(widgetType) {
       const announcement = this.getAnnouncement();
-
       if (announcement) {
         const now = new Date();
         const validPeriod = now > announcement.getStart() && now < announcement.getEnd();

--- a/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
+++ b/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
@@ -76,15 +76,12 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
     __isValid: function(widgetType) {
       const announcement = this.getAnnouncement();
 
-      const now = new Date();
-      if (
-        announcement &&
-        announcement.getProducts().includes(osparc.product.Utils.getProductName()) &&
-        announcement.getWidgets().includes(widgetType) &&
-        now > announcement.getStart() &&
-        now < announcement.getEnd()
-      ) {
-        return true;
+      if (announcement) {
+        const now = new Date();
+        const validPeriod = now > announcement.getStart() && now < announcement.getEnd();
+        const validProduct = announcement.getProducts().includes(osparc.product.Utils.getProductName());
+        const validWidget = widgetType ? announcement.getWidgets().includes(widgetType) : true;
+        return validPeriod && validProduct && validWidget;
       }
       return false;
     },

--- a/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
+++ b/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
@@ -46,10 +46,8 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
         const titleLabel = new qx.ui.basic.Label().set({
           value: title,
           font: "text-16",
-          textColor: "white",
           alignX: "center",
-          rich: true,
-          wrap: true
+          rich: true
         });
         loginAnnouncement.add(titleLabel);
       }
@@ -58,10 +56,8 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
         const descriptionLabel = new qx.ui.basic.Label().set({
           value: description,
           font: "text-14",
-          textColor: "white",
           alignX: "center",
-          rich: true,
-          wrap: true
+          rich: true
         });
         loginAnnouncement.add(descriptionLabel);
       }

--- a/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
+++ b/services/static-webserver/client/source/class/osparc/announcement/AnnouncementUIFactory.js
@@ -80,8 +80,8 @@ qx.Class.define("osparc.announcement.AnnouncementUIFactory", {
         const now = new Date();
         const validPeriod = now > announcement.getStart() && now < announcement.getEnd();
         const validProduct = announcement.getProducts().includes(osparc.product.Utils.getProductName());
-        const validWidget = widgetType ? announcement.getWidgets().includes(widgetType) : true;
-        return validPeriod && validProduct && validWidget;
+        const validWidgetType = widgetType ? announcement.getWidgets().includes(widgetType) : true;
+        return validPeriod && validProduct && validWidgetType;
       }
       return false;
     },

--- a/services/static-webserver/client/source/class/osparc/auth/ui/LoginView.js
+++ b/services/static-webserver/client/source/class/osparc/auth/ui/LoginView.js
@@ -45,8 +45,7 @@ qx.Class.define("osparc.auth.ui.LoginView", {
         this.addAt(announcementUIFactory.createLoginAnnouncement(), 0);
       } else {
         announcementUIFactory.addListenerOnce("changeAnnouncement", e => {
-          const announcement = e.getData();
-          if (announcement) {
+          if (announcementUIFactory.hasLoginAnnouncement()) {
             this.addAt(announcementUIFactory.createLoginAnnouncement(), 0);
           }
         });


### PR DESCRIPTION
## What do these changes do?

Right now, all announcements are shown in the login page.

- [x] Fix: Check if announcement goes in "login"
- [x] Enh: Center texts in login page's announcement
- [x] Enh: Make description optional

Before:
![image](https://github.com/user-attachments/assets/5d9f05dd-4c8e-4191-a8b4-7e7ff83412dc)

After:
![image](https://github.com/user-attachments/assets/37c80f78-1254-4f92-ad66-f1537c0a6f84)


## Related issue/s

related to https://github.com/ITISFoundation/osparc-issues/issues/1701


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
