### PR TITLE
🐛 Fixes issue with parsing logs polluting sidecar logs

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_utils.py
@@ -44,6 +44,7 @@ _RCloneSyncMessages = Union[  # noqa: UP007
     _RCloneSyncTransferCompletedMessage,
     _RCloneSyncUpdatedMessage,
     _RCloneSyncTransferringMessage,
+    _RCloneSyncMessageBase,
 ]
 
 

--- a/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_utils.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_utils.py
@@ -1,0 +1,75 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import parse_raw_as
+from simcore_sdk.node_ports_common.r_clone_utils import (
+    SyncProgressLogParser,
+    _RCloneSyncMessageBase,
+    _RCloneSyncMessages,
+    _RCloneSyncTransferCompletedMessage,
+    _RCloneSyncTransferringMessage,
+    _RCloneSyncUpdatedMessage,
+)
+
+
+@pytest.mark.parametrize(
+    "log_message,expected",
+    [
+        (
+            '{"level":"info","msg":"There was nothing to transfer","source":"sync/sync.go:954","time":"2024-09-25T10:18:04.904537+00:00"}',
+            _RCloneSyncMessageBase,
+        ),
+        (
+            '{"level":"info","msg":"","object":".hidden_do_not_remove","objectType":"*s3.Object","source":"operations/operations.go:277","time":"2024-09-24T07:11:22.147117+00:00"}',
+            _RCloneSyncUpdatedMessage,
+        ),
+        (
+            '{"level":"info","msg":"Copied (new)","object":"README.ipynb","objectType":"*s3.Object","size":5123,"source":"operations/copy.go:360","time":"2024-04-23T14:05:10.408277+00:00"}',
+            _RCloneSyncTransferCompletedMessage,
+        ),
+        (
+            json.dumps(
+                {
+                    "level": "",
+                    "msg": "",
+                    "source": "",
+                    "time": "2024-09-24T07:11:22.147117+00:00",
+                    "object": "str",
+                }
+            ),
+            _RCloneSyncUpdatedMessage,
+        ),
+        (
+            json.dumps(
+                {
+                    "level": "",
+                    "msg": "",
+                    "source": "",
+                    "time": "2024-09-24T07:11:22.147117+00:00",
+                    "object": "str",
+                    "size": 1,
+                }
+            ),
+            _RCloneSyncTransferCompletedMessage,
+        ),
+        (
+            json.dumps(
+                {
+                    "level": "",
+                    "msg": "",
+                    "source": "",
+                    "time": "2024-09-24T07:11:22.147117+00:00",
+                    "stats": {"bytes": 1, "totalBytes": 1},
+                }
+            ),
+            _RCloneSyncTransferringMessage,
+        ),
+    ],
+)
+async def test_regression_parsing(log_message: str, expected: type):
+    obj = parse_raw_as(_RCloneSyncMessages, log_message)
+
+    assert isinstance(obj, expected)
+    progress_log_parser = SyncProgressLogParser(AsyncMock())
+    await progress_log_parser(log_message)

--- a/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_utils.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_utils.py
@@ -67,9 +67,9 @@ from simcore_sdk.node_ports_common.r_clone_utils import (
         ),
     ],
 )
-async def test_regression_parsing(log_message: str, expected: type):
-    obj = parse_raw_as(_RCloneSyncMessages, log_message)
+async def test_rclone_stbc_message_parsing_regression(log_message: str, expected: type):
+    parsed_log = parse_raw_as(_RCloneSyncMessages, log_message)  # type: ignore[arg-type]
+    assert isinstance(parsed_log, expected)
 
-    assert isinstance(obj, expected)
     progress_log_parser = SyncProgressLogParser(AsyncMock())
     await progress_log_parser(log_message)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This issue was polluting the logs with tracebacks, event though it had no side effect.
Issue was caused by a missing parser for a log line similar to `'{"level":"info","msg":"There was nothing to transfer","source":"sync/sync.go:954","time":"2024-09-25T10:18:04.904537+00:00"}'`


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/6429

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
