### PR TITLE
e2e: fixes wrong sequence in classic tip 

### DIFF
--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -94,15 +94,19 @@ def test_classic_ti_plan(  # noqa: PLR0915
     create_tip_plan_from_dashboard: Callable[[str], dict[str, Any]],
 ):
     with log_context(logging.INFO, "Checking 'Access TIP' teaser"):
+        # click to open and expand
+        page.get_by_test_id("userMenuBtn").click()
+
         if is_product_lite:
-            page.get_by_test_id("userMenuBtn").click()
             page.get_by_test_id("userMenuAccessTIPBtn").click()
             assert page.get_by_test_id("tipTeaserWindow").is_visible()
             page.get_by_test_id("tipTeaserWindowCloseBtn").click()
         else:
             assert (
-                page.get_by_test_id("userMenuBtn").count() == 0
+                page.get_by_test_id("userMenuAccessTIPBtn").count() == 0
             ), "full version should NOT have a teaser"
+            # click to close
+            page.get_by_test_id("userMenuBtn").click()
 
     # press + button
     project_data = create_tip_plan_from_dashboard("newTIPlanButton")


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

 fixes wrong sequence in classic tip 

## Related issue/s

- Follows up https://github.com/ITISFoundation/osparc-simcore/pull/6445

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
