### PR TITLE
✅ e2e: Final touches to tip testing

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -225,18 +225,18 @@ class SocketIONodeProgressCompleteWaiter:
                         ] = new_progress
 
                         self.logger.info(
-                            "Current startup progress [expected number of states=%d]: %s",
+                            "Current startup progress [expected number of node-progress-types=%d]: %s",
                             NodeProgressType.required_types_for_started_service(),
                             f"{json.dumps({k:round(v,1) for k,v in self._current_progress.items()})}",
                         )
 
-                return self.received_required_node_progress_types() and all(
+                return self.got_expected_node_progress_types() and all(
                     round(progress, 1) == 1.0
                     for progress in self._current_progress.values()
                 )
         return False
 
-    def received_required_node_progress_types(self):
+    def got_expected_node_progress_types(self):
         return all(
             progress_type in self._current_progress
             for progress_type in NodeProgressType.required_types_for_started_service()
@@ -346,7 +346,7 @@ def expected_service_running(
                 yield service_running
 
         except PlaywrightTimeoutError:
-            if waiter.received_required_node_progress_types():
+            if waiter.got_expected_node_progress_types():
                 ctx.logger.warning(
                     "⚠️ Progress bar didn't receive 100 percent but all states are there: %s ⚠️",  # https://github.com/ITISFoundation/osparc-simcore/issues/6449
                     waiter.get_current_progress(),

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -348,7 +348,7 @@ def expected_service_running(
         except PlaywrightTimeoutError:
             if waiter.got_expected_node_progress_types():
                 ctx.logger.warning(
-                    "⚠️ Progress bar didn't receive 100 percent but all states are there: %s ⚠️",  # https://github.com/ITISFoundation/osparc-simcore/issues/6449
+                    "⚠️ Progress bar didn't receive 100 percent but all expected node-progress-types are in place: %s ⚠️",  # https://github.com/ITISFoundation/osparc-simcore/issues/6449
                     waiter.get_current_progress(),
                 )
             else:

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -196,7 +196,6 @@ class SocketIOOsparcMessagePrinter:
 class SocketIONodeProgressCompleteWaiter:
     node_id: str
     logger: logging.Logger
-    _last_call_return: bool = False
     _current_progress: dict[NodeProgressType, float] = field(
         default_factory=defaultdict
     )
@@ -224,24 +223,24 @@ class SocketIONodeProgressCompleteWaiter:
                         self._current_progress[
                             node_progress_event.progress_type
                         ] = new_progress
+
                         self.logger.info(
-                            "current startup progress: %s",
+                            "Current startup progress [expected number of states=%d]: %s",
+                            NodeProgressType.required_types_for_started_service(),
                             f"{json.dumps({k:round(v,1) for k,v in self._current_progress.items()})}",
                         )
 
-                self._last_call_return = all(
-                    progress_type in self._current_progress
-                    for progress_type in NodeProgressType.required_types_for_started_service()
-                ) and all(
+                return self.has_progress_on_all_expected_node_states() and all(
                     round(progress, 1) == 1.0
                     for progress in self._current_progress.values()
                 )
-                return self._last_call_return
-        self._last_call_return = False
         return False
 
-    def get_last_call_return(self):
-        return self._last_call_return
+    def has_progress_on_all_expected_node_states(self):
+        return all(
+            progress_type in self._current_progress
+            for progress_type in NodeProgressType.required_types_for_started_service()
+        )
 
     def get_current_progress(self):
         return self._current_progress.values()
@@ -346,9 +345,9 @@ def expected_service_running(
                 yield service_running
 
         except PlaywrightTimeoutError:
-            if waiter.get_last_call_return() is False:
+            if waiter.has_progress_on_all_expected_node_states():
                 ctx.logger.warning(
-                    "⚠️  Progress bar didn't receive 100 percent: %s ⚠️",  # https://github.com/ITISFoundation/osparc-simcore/issues/6449
+                    "⚠️ Progress bar didn't receive 100 percent but all states are there: %s ⚠️",  # https://github.com/ITISFoundation/osparc-simcore/issues/6449
                     waiter.get_current_progress(),
                 )
             else:

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -230,13 +230,13 @@ class SocketIONodeProgressCompleteWaiter:
                             f"{json.dumps({k:round(v,1) for k,v in self._current_progress.items()})}",
                         )
 
-                return self.has_progress_on_all_expected_node_states() and all(
+                return self.received_required_node_progress_types() and all(
                     round(progress, 1) == 1.0
                     for progress in self._current_progress.values()
                 )
         return False
 
-    def has_progress_on_all_expected_node_states(self):
+    def received_required_node_progress_types(self):
         return all(
             progress_type in self._current_progress
             for progress_type in NodeProgressType.required_types_for_started_service()
@@ -338,6 +338,7 @@ def expected_service_running(
         service_running = ServiceRunning(iframe_locator=None)
 
         try:
+
             with websocket.expect_event("framereceived", waiter, timeout=timeout):
                 if press_start_button:
                     _trigger_service_start(page, node_id)
@@ -345,7 +346,7 @@ def expected_service_running(
                 yield service_running
 
         except PlaywrightTimeoutError:
-            if waiter.has_progress_on_all_expected_node_states():
+            if waiter.received_required_node_progress_types():
                 ctx.logger.warning(
                     "⚠️ Progress bar didn't receive 100 percent but all states are there: %s ⚠️",  # https://github.com/ITISFoundation/osparc-simcore/issues/6449
                     waiter.get_current_progress(),


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Enhancements:

- Logs expected number of expected states transmitted via socketio
- Dedicated function to check states: `received_required_node_progress_types`
- Timeout is ignored only when progress of all required_node_progress_types are received (https://github.com/ITISFoundation/osparc-simcore/issues/6449)


## Related issue/s

- Follows https://github.com/ITISFoundation/osparc-simcore/pull/6458

