### PR TITLE
WIP: fixing 3D_em e2e errors

### DIFF
--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_studies_access.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_studies_access.py
@@ -361,7 +361,9 @@ async def get_redirection_to_study_page(request: web.Request) -> web.Response:
             extra={"error_code": error_code},
         )
         raise RedirectToFrontEndPageError(
-            MSG_UNEXPECTED_ERROR.format(hint="while copying your study"),
+            MSG_UNEXPECTED_ERROR.format(
+                hint=f"while copying your study [{error_code}]"
+            ),
             error_code=error_code,
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         ) from exc


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

The e2e 3D visualization shows this error:
```
log_level=ERROR | log_timestamp=2024-09-30 09:09:09,916 | log_source=simcore_service_webserver.studies_dispatcher._studies_access:get_redirection_to_study_page(356) | log_uid=None | log_msg=Failed while copying project '[ISAN] 3D Visualization' to 'zdhrwjbswy@guest-at-osparc.io' [OEC:139795976177120]
Traceback (most recent call last):
  File "/lib/python3.11/site-packages/aiohttp/client_reqrep.py", line 899, in start
    message, payload = await protocol.read()  # type: ignore[union-attr]
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/aiohttp/streams.py", line 616, in read
    await self._waiter
  File "/lib/python3.11/site-packages/aiohttp/client_proto.py", line 213, in data_received
    messages, upgraded, tail = self._parser.feed_data(data)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aiohttp/_http_parser.pyx", line 557, in aiohttp._http_parser.HttpParser.feed_data
aiohttp.http_exceptions.BadHttpMessage: 400, message:
  Invalid header token:

    b'percent'
             ^

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/lib/python3.11/site-packages/simcore_service_webserver/studies_dispatcher/_studies_access.py", line 350, in get_redirection_to_study_page
    copied_project_id = await copy_study_to_account(request, template_project, user)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/simcore_service_webserver/studies_dispatcher/_studies_access.py", line 212, in copy_study_to_account
    await lr_task.result()
  File "/usr/local/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/lib/python3.11/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    result = await fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/servicelib/aiohttp/long_running_tasks/client.py", line 81, in _task_result
    async with session.get(result_url) as response:
  File "/lib/python3.11/site-packages/aiohttp/client.py", line 1141, in __aenter__
    self._resp = await self._coro
                 ^^^^^^^^^^^^^^^^
  File "/lib/python3.11/site-packages/aiohttp/client.py", line 560, in _request
    await resp.start(conn)
  File "/lib/python3.11/site-packages/aiohttp/client_reqrep.py", line 901, in start
    raise ClientResponseError(
aiohttp.client_exceptions.ClientResponseError: 400, message="Invalid header token:

  b'percent'
           ^", url=URL('*/v0/futures/POST%2520%252Fv0%252Fsimcore-s3%252Ffolders%253Fuser_id%253D231026.12e6803e-c9f1-4ecd-9c14-eb1fbe88c5ac/result')
```
- raised when receiving response from long-running-task `/results` entrypoint coming from storage
- Can reproduce by just cloning the EM template in the GUI


### Fixes

- Show OEC in front-end (check with OM)
- 


## Related issue/s

- e2e


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
