### PR TITLE
✨ New repository helpers on asyncpg

### DIFF
--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -41,8 +41,6 @@ class Vendor(TypedDict, total=False):
     invitation_url: str  # How to request a trial invitation? (if applies)
     invitation_form: bool  # If True, it takes precendence over invitation_url and asks the FE to show the form (if defined)
 
-    has_landing_page: bool  # Is Landing page enabled
-
     release_notes_url_template: str  # a template url where `{vtag}` will be replaced, eg: "http://example.com/{vtag}.md"
 
 

--- a/packages/postgres-database/src/simcore_postgres_database/utils_repos.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_repos.py
@@ -1,0 +1,43 @@
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
+
+_logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def get_or_create_connection(
+    engine: AsyncEngine, connection: AsyncConnection | None = None
+) -> AsyncIterator[AsyncConnection]:
+    # NOTE: When connection is passed, the engine is actually not needed
+    # NOTE: Creator is responsible of closing connection
+    is_connection_created = connection is None
+    if is_connection_created:
+        connection = await engine.connect()
+    try:
+        assert connection  # nosec
+        yield connection
+    finally:
+        assert connection  # nosec
+        assert not connection.closed  # nosec
+        if is_connection_created and connection:
+            await connection.close()
+
+
+@asynccontextmanager
+async def transaction_context(
+    engine: AsyncEngine, connection: AsyncConnection | None = None
+):
+    async with get_or_create_connection(engine, connection) as conn:
+        if conn.in_transaction():
+            async with conn.begin_nested():  # inner transaction (savepoint)
+                yield conn
+        else:
+            try:
+                async with conn.begin():  # outer transaction (savepoint)
+                    yield conn
+            finally:
+                assert not conn.closed  # nosec
+                assert not conn.in_transaction()  # nosec

--- a/packages/postgres-database/tests/products/test_models_products.py
+++ b/packages/postgres-database/tests/products/test_models_products.py
@@ -26,14 +26,14 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 
 async def test_load_products(
-    pg_engine: Engine, make_products_table: Callable, products_regex: dict
+    aiopg_engine: Engine, make_products_table: Callable, products_regex: dict
 ):
     exclude = {
         products.c.created,
         products.c.modified,
     }
 
-    async with pg_engine.acquire() as conn:
+    async with aiopg_engine.acquire() as conn:
         await make_products_table(conn)
 
         stmt = sa.select(*[c for c in products.columns if c not in exclude])
@@ -49,14 +49,14 @@ async def test_load_products(
 
 
 async def test_jinja2_templates_table(
-    pg_engine: Engine, osparc_simcore_services_dir: Path
+    aiopg_engine: Engine, osparc_simcore_services_dir: Path
 ):
     templates_common_dir = (
         osparc_simcore_services_dir
         / "web/server/src/simcore_service_webserver/templates/common"
     )
 
-    async with pg_engine.acquire() as conn:
+    async with aiopg_engine.acquire() as conn:
         templates = []
         # templates table
         for p in templates_common_dir.glob("*.jinja2"):
@@ -135,7 +135,7 @@ async def test_jinja2_templates_table(
 
 
 async def test_insert_select_product(
-    pg_engine: Engine,
+    aiopg_engine: Engine,
 ):
     osparc_product = {
         "name": "osparc",
@@ -174,7 +174,7 @@ async def test_insert_select_product(
 
     print(json.dumps(osparc_product))
 
-    async with pg_engine.acquire() as conn:
+    async with aiopg_engine.acquire() as conn:
         # writes
         stmt = (
             pg_insert(products)

--- a/packages/postgres-database/tests/products/test_utils_products.py
+++ b/packages/postgres-database/tests/products/test_utils_products.py
@@ -19,24 +19,24 @@ from simcore_postgres_database.utils_products import (
 )
 
 
-async def test_default_product(pg_engine: Engine, make_products_table: Callable):
-    async with pg_engine.acquire() as conn:
+async def test_default_product(aiopg_engine: Engine, make_products_table: Callable):
+    async with aiopg_engine.acquire() as conn:
         await make_products_table(conn)
         default_product = await get_default_product_name(conn)
         assert default_product == "s4l"
 
 
 @pytest.mark.parametrize("pg_sa_engine", ["sqlModels"], indirect=True)
-async def test_default_product_undefined(pg_engine: Engine):
-    async with pg_engine.acquire() as conn:
+async def test_default_product_undefined(aiopg_engine: Engine):
+    async with aiopg_engine.acquire() as conn:
         with pytest.raises(ValueError):
             await get_default_product_name(conn)
 
 
 async def test_get_or_create_group_product(
-    pg_engine: Engine, make_products_table: Callable
+    aiopg_engine: Engine, make_products_table: Callable
 ):
-    async with pg_engine.acquire() as conn:
+    async with aiopg_engine.acquire() as conn:
         await make_products_table(conn)
 
         async for product_row in await conn.execute(
@@ -105,13 +105,13 @@ async def test_get_or_create_group_product(
     reason="Not relevant. Will review in https://github.com/ITISFoundation/osparc-simcore/issues/3754"
 )
 async def test_get_or_create_group_product_concurrent(
-    pg_engine: Engine, make_products_table: Callable
+    aiopg_engine: Engine, make_products_table: Callable
 ):
-    async with pg_engine.acquire() as conn:
+    async with aiopg_engine.acquire() as conn:
         await make_products_table(conn)
 
     async def _auto_create_products_groups():
-        async with pg_engine.acquire() as conn:
+        async with aiopg_engine.acquire() as conn:
             async for product_row in await conn.execute(
                 sa.select(products.c.name, products.c.group_id).order_by(
                     products.c.priority

--- a/packages/postgres-database/tests/projects/conftest.py
+++ b/packages/postgres-database/tests/projects/conftest.py
@@ -16,10 +16,10 @@ from simcore_postgres_database.models.users import users
 
 
 @pytest.fixture
-async def user(pg_engine: Engine) -> RowProxy:
+async def user(aiopg_engine: Engine) -> RowProxy:
     _USERNAME = f"{__name__}.me"
     # some user
-    async with pg_engine.acquire() as conn:
+    async with aiopg_engine.acquire() as conn:
         result: ResultProxy | None = await conn.execute(
             users.insert().values(**random_user(name=_USERNAME)).returning(users)
         )
@@ -32,10 +32,10 @@ async def user(pg_engine: Engine) -> RowProxy:
 
 
 @pytest.fixture
-async def project(pg_engine: Engine, user: RowProxy) -> RowProxy:
+async def project(aiopg_engine: Engine, user: RowProxy) -> RowProxy:
     _PARENT_PROJECT_NAME = f"{__name__}.parent"
     # a user's project
-    async with pg_engine.acquire() as conn:
+    async with aiopg_engine.acquire() as conn:
         result: ResultProxy | None = await conn.execute(
             projects.insert()
             .values(**random_project(prj_owner=user.id, name=_PARENT_PROJECT_NAME))
@@ -50,6 +50,6 @@ async def project(pg_engine: Engine, user: RowProxy) -> RowProxy:
 
 
 @pytest.fixture
-async def conn(pg_engine: Engine) -> AsyncIterable[SAConnection]:
-    async with pg_engine.acquire() as conn:
+async def conn(aiopg_engine: Engine) -> AsyncIterable[SAConnection]:
+    async with aiopg_engine.acquire() as conn:
         yield conn

--- a/packages/postgres-database/tests/test_classifiers.py
+++ b/packages/postgres-database/tests/test_classifiers.py
@@ -38,10 +38,10 @@ def classifiers_bundle(web_client_resource_folder: Path) -> dict:
 
 
 async def test_operations_on_group_classifiers(
-    pg_engine: Engine, classifiers_bundle: dict
+    aiopg_engine: Engine, classifiers_bundle: dict
 ):
     # NOTE: mostly for TDD
-    async with pg_engine.acquire() as conn:
+    async with aiopg_engine.acquire() as conn:
         # creates a group
         stmt = (
             groups.insert()

--- a/packages/postgres-database/tests/test_comp_tasks.py
+++ b/packages/postgres-database/tests/test_comp_tasks.py
@@ -19,8 +19,8 @@ from sqlalchemy.sql.elements import literal_column
 
 
 @pytest.fixture()
-async def db_connection(pg_engine: Engine) -> SAConnection:
-    async with pg_engine.acquire() as conn:
+async def db_connection(aiopg_engine: Engine) -> SAConnection:
+    async with aiopg_engine.acquire() as conn:
         yield conn
 
 

--- a/packages/postgres-database/tests/test_delete_projects_and_users.py
+++ b/packages/postgres-database/tests/test_delete_projects_and_users.py
@@ -15,8 +15,8 @@ from sqlalchemy import func
 
 
 @pytest.fixture
-async def engine(pg_engine: Engine):
-    async with pg_engine.acquire() as conn:
+async def engine(aiopg_engine: Engine):
+    async with aiopg_engine.acquire() as conn:
         await conn.execute(users.insert().values(**random_user(name="A")))
         await conn.execute(users.insert().values(**random_user()))
         await conn.execute(users.insert().values(**random_user()))
@@ -27,7 +27,7 @@ async def engine(pg_engine: Engine):
         with pytest.raises(ForeignKeyViolation):
             await conn.execute(projects.insert().values(**random_project(prj_owner=4)))
 
-    return pg_engine
+    return aiopg_engine
 
 
 @pytest.mark.skip(reason="sandbox for dev purposes")

--- a/packages/postgres-database/tests/test_services_consume_filetypes.py
+++ b/packages/postgres-database/tests/test_services_consume_filetypes.py
@@ -59,9 +59,9 @@ def make_table() -> Callable:
 
 @pytest.fixture
 async def connection(
-    pg_engine: sa.engine.Engine, connection: SAConnection, make_table: Callable
+    aiopg_engine: sa.engine.Engine, connection: SAConnection, make_table: Callable
 ):
-    assert pg_engine
+    assert aiopg_engine
     # NOTE: do not remove th pg_engine, or the test will fail as pytest
     # cannot set the parameters in the fixture
 

--- a/packages/postgres-database/tests/test_utils_aiopg_orm.py
+++ b/packages/postgres-database/tests/test_utils_aiopg_orm.py
@@ -16,12 +16,12 @@ from simcore_postgres_database.utils_aiopg_orm import ALL_COLUMNS, BaseOrm
 
 
 @pytest.fixture
-async def fake_scicrunch_ids(pg_engine: Engine) -> list[str]:
+async def fake_scicrunch_ids(aiopg_engine: Engine) -> list[str]:
     row1 = {"rrid": "RRID:foo", "name": "foo", "description": "fooing"}
     row2 = {"rrid": "RRID:bar", "name": "bar", "description": "barring"}
 
     row_ids = []
-    async with pg_engine.acquire() as conn:
+    async with aiopg_engine.acquire() as conn:
         for row in (row1, row2):
             row_id = await conn.scalar(
                 scicrunch_resources.insert()
@@ -35,7 +35,7 @@ async def fake_scicrunch_ids(pg_engine: Engine) -> list[str]:
 
 
 @pytest.fixture()
-async def scicrunch_orm(pg_engine: Engine) -> Iterator[BaseOrm[str]]:
+async def scicrunch_orm(aiopg_engine: Engine) -> Iterator[BaseOrm[str]]:
     # This is a table without dependencies and therefore easy to use as fixture
     class ScicrunchOrm(BaseOrm[str]):
         def __init__(self, connection: SAConnection):
@@ -46,7 +46,7 @@ async def scicrunch_orm(pg_engine: Engine) -> Iterator[BaseOrm[str]]:
                 writeonce={"rrid"},
             )
 
-    async with pg_engine.acquire() as conn:
+    async with aiopg_engine.acquire() as conn:
         orm_obj = ScicrunchOrm(conn)
         yield orm_obj
 

--- a/packages/postgres-database/tests/test_utils_projects_nodes.py
+++ b/packages/postgres-database/tests/test_utils_projects_nodes.py
@@ -309,7 +309,7 @@ async def test_delete_project_delete_all_nodes(
 
 @pytest.mark.parametrize("num_concurrent_workflows", [1, 250])
 async def test_multiple_creation_deletion_of_nodes(
-    pg_engine: Engine,
+    aiopg_engine: Engine,
     registered_user: RowProxy,
     create_fake_project: Callable[..., Awaitable[RowProxy]],
     create_fake_projects_node: Callable[..., ProjectNodeCreate],
@@ -318,7 +318,7 @@ async def test_multiple_creation_deletion_of_nodes(
     NUM_NODES = 11
 
     async def _workflow() -> None:
-        async with pg_engine.acquire() as connection:
+        async with aiopg_engine.acquire() as connection:
             project = await create_fake_project(connection, registered_user)
             projects_nodes_repo = ProjectNodesRepo(project_uuid=project.uuid)
 
@@ -341,7 +341,7 @@ async def test_multiple_creation_deletion_of_nodes(
 
 
 async def test_get_project_id_from_node_id(
-    pg_engine: Engine,
+    aiopg_engine: Engine,
     connection: SAConnection,
     projects_nodes_repo: ProjectNodesRepo,
     registered_user: RowProxy,
@@ -351,7 +351,7 @@ async def test_get_project_id_from_node_id(
     NUM_NODES = 11
 
     async def _workflow() -> dict[uuid.UUID, list[uuid.UUID]]:
-        async with pg_engine.acquire() as connection:
+        async with aiopg_engine.acquire() as connection:
             project = await create_fake_project(connection, registered_user)
             projects_nodes_repo = ProjectNodesRepo(project_uuid=project.uuid)
 
@@ -379,7 +379,7 @@ async def test_get_project_id_from_node_id(
 
 
 async def test_get_project_id_from_node_id_raises_for_invalid_node_id(
-    pg_engine: Engine,
+    aiopg_engine: Engine,
     connection: SAConnection,
     projects_nodes_repo: ProjectNodesRepo,
     faker: Faker,
@@ -393,7 +393,7 @@ async def test_get_project_id_from_node_id_raises_for_invalid_node_id(
 
 
 async def test_get_project_id_from_node_id_raises_if_multiple_projects_with_same_node_id_exist(
-    pg_engine: Engine,
+    aiopg_engine: Engine,
     connection: SAConnection,
     projects_nodes_repo: ProjectNodesRepo,
     registered_user: RowProxy,

--- a/packages/postgres-database/tests/test_utils_repos.py
+++ b/packages/postgres-database/tests/test_utils_repos.py
@@ -1,0 +1,213 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+# pylint: disable=too-many-arguments
+
+
+from typing import Any, NamedTuple
+
+import pytest
+import sqlalchemy as sa
+from simcore_postgres_database.models.tags import tags
+from simcore_postgres_database.utils_repos import (
+    get_or_create_connection,
+    transaction_context,
+)
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
+
+
+async def test_sa_transactions(asyncpg_engine: AsyncEngine):
+    #
+    # SEE https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#synopsis-core
+    #
+
+    # READ query
+    total_count_query = sa.select(sa.func.count()).select_from(tags)
+
+    # WRITE queries
+    query1 = (
+        tags.insert().values(id=2, name="query1", color="blue").returning(tags.c.id)
+    )
+    query11 = (
+        tags.insert().values(id=3, name="query11", color="blue").returning(tags.c.id)
+    )
+    query12 = (
+        tags.insert().values(id=5, name="query12", color="blue").returning(tags.c.id)
+    )
+    query2 = (
+        tags.insert().values(id=6, name="query2", color="blue").returning(tags.c.id)
+    )
+    query2 = (
+        tags.insert().values(id=7, name="query2", color="blue").returning(tags.c.id)
+    )
+
+    async with asyncpg_engine.connect() as conn, conn.begin():  # starts transaction (savepoint)
+
+        result = await conn.execute(query1)
+        assert result.scalar() == 2
+
+        total_count = (await conn.execute(total_count_query)).scalar()
+        assert total_count == 1
+
+        rows = (await conn.execute(tags.select().where(tags.c.id == 2))).fetchall()
+        assert rows
+        assert rows[0].id == 2
+
+        async with conn.begin_nested():  # savepoint
+            await conn.execute(query11)
+
+            with pytest.raises(IntegrityError):
+                async with conn.begin_nested():  # savepoint
+                    await conn.execute(query11)
+
+            await conn.execute(query12)
+
+            total_count = (await conn.execute(total_count_query)).scalar()
+            assert total_count == 3  # since query11 (second time) reverted!
+
+        await conn.execute(query2)
+
+        total_count = (await conn.execute(total_count_query)).scalar()
+        assert total_count == 4
+
+
+class _PageTuple(NamedTuple):
+    total_count: int
+    rows: list[dict[str, Any]]
+
+
+class OneResourceRepoDemo:
+    # This is a PROTOTYPE of how one could implement a generic
+    # repo that provides CRUD operations providing a given table
+    def __init__(self, engine: AsyncEngine, table: sa.Table):
+        if "id" not in table.columns:
+            msg = "id column expected"
+            raise ValueError(msg)
+        self.table = table
+
+        self.engine = engine
+
+    async def create(self, connection: AsyncConnection | None = None, **kwargs) -> int:
+        async with transaction_context(self.engine, connection) as conn:
+            result = await conn.execute(self.table.insert().values(**kwargs))
+            assert result  # nosec
+            return result.inserted_primary_key[0]
+
+    async def get_by_id(
+        self,
+        connection: AsyncConnection | None = None,
+        *,
+        row_id: int,
+    ) -> dict[str, Any] | None:
+        async with get_or_create_connection(self.engine, connection) as conn:
+            result = await conn.execute(
+                sa.select(self.table).where(self.table.c.id == row_id)
+            )
+            row = result.mappings().fetchone()
+            return dict(row) if row else None
+
+    async def get_page(
+        self,
+        connection: AsyncConnection | None = None,
+        *,
+        limit: int,
+        offset: int = 0,
+    ) -> _PageTuple:
+        async with get_or_create_connection(self.engine, connection) as conn:
+            # Compute total count
+            total_count_query = sa.select(sa.func.count()).select_from(self.table)
+            total_count_result = await conn.execute(total_count_query)
+            total_count = total_count_result.scalar()
+
+            # Fetch paginated results
+            query = sa.select(self.table).limit(limit).offset(offset)
+            result = await conn.execute(query)
+            rows = [dict(row) for row in result.mappings().fetchall()]
+
+            return _PageTuple(total_count=total_count or 0, rows=rows)
+
+    async def update(
+        self,
+        connection: AsyncConnection | None = None,
+        *,
+        row_id: int,
+        **values,
+    ) -> bool:
+        async with transaction_context(self.engine, connection) as conn:
+            result = await conn.execute(
+                self.table.update().where(self.table.c.id == row_id).values(**values)
+            )
+            return result.rowcount > 0
+
+    async def delete(
+        self,
+        connection: AsyncConnection | None = None,
+        *,
+        row_id: int,
+    ) -> bool:
+        async with transaction_context(self.engine, connection) as conn:
+            result = await conn.execute(
+                self.table.delete().where(self.table.c.id == row_id)
+            )
+            return result.rowcount > 0
+
+
+async def test_oneresourcerepodemo_prototype(asyncpg_engine: AsyncEngine):
+
+    tags_repo = OneResourceRepoDemo(engine=asyncpg_engine, table=tags)
+
+    # create
+    tag_id = await tags_repo.create(name="cyan tag", color="cyan")
+    assert tag_id > 0
+
+    # get, list
+    tag = await tags_repo.get_by_id(row_id=tag_id)
+    assert tag
+
+    page = await tags_repo.get_page(limit=10)
+    assert page.total_count == 1
+    assert page.rows == [tag]
+
+    # update
+    ok = await tags_repo.update(row_id=tag_id, name="changed name")
+    assert ok
+
+    updated_tag = await tags_repo.get_by_id(row_id=tag_id)
+    assert updated_tag
+    assert updated_tag["name"] != tag["name"]
+
+    # delete
+    ok = await tags_repo.delete(row_id=tag_id)
+    assert ok
+
+    assert not await tags_repo.get_by_id(row_id=tag_id)
+
+
+async def test_transaction_context(asyncpg_engine: AsyncEngine):
+    # (1) Using transaction_context and fails
+    fake_error_msg = "some error"
+
+    def _something_raises_here():
+        raise RuntimeError(fake_error_msg)
+
+    tags_repo = OneResourceRepoDemo(engine=asyncpg_engine, table=tags)
+
+    # using external transaction_context: commits upon __aexit__
+    async with transaction_context(asyncpg_engine) as conn:
+        await tags_repo.create(conn, name="cyan tag", color="cyan")
+        await tags_repo.create(conn, name="red tag", color="red")
+        assert (await tags_repo.get_page(conn, limit=10, offset=0)).total_count == 2
+
+    # using internal: auto-commit
+    await tags_repo.create(name="red tag", color="red")
+    assert (await tags_repo.get_page(limit=10, offset=0)).total_count == 3
+
+    # auto-rollback
+    with pytest.raises(RuntimeError, match=fake_error_msg):  # noqa: PT012
+        async with transaction_context(asyncpg_engine) as conn:
+            await tags_repo.create(conn, name="violet tag", color="violet")
+            assert (await tags_repo.get_page(conn, limit=10, offset=0)).total_count == 4
+            _something_raises_here()
+
+    assert (await tags_repo.get_page(limit=10, offset=0)).total_count == 3


### PR DESCRIPTION

## What do these changes do?

This PR implements some helper functions to build  repositories effectively on top of [`asyncpg`](https://github.com/MagicStack/asyncpg)

- ✅ New test fixtures to create  `asyncpg`  engine in `simcore-postgres-database` library tests
- ✨  New utility functions to build repositories and create unit. Specifically, two context managers
      -  `pass_or_acquire_connection`:  yields an existing connection or acquires one 
      -  `transaction_contexts`:  allows (i.e., database units of work) also across multiple repository calls. 
             - NOTE that up to now we could only do this within a single repository call at a time!
      - IMPORTANT: for a better insight see `tests/test_utils_repos.py`
- ⚗️ Prototypes of "template" repository class  `OneResourceRepoDemo` using aforementioned utils in `tests/test_utils_repos.py`. This class also demonstrate how the utils above can be used to build repositories


## Related issue/s

- Part of https://github.com/ITISFoundation/osparc-simcore/issues/4529


## How to test
```
cd packages/postgres-database
make install-dev
pytest -vv tests/test_utils_repos.py
```

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))
