### PR TITLE
🐛 [Frontend] Guided Tours: point to visible selector or skip

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/ToggleButtonContainer.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ToggleButtonContainer.js
@@ -95,7 +95,7 @@ qx.Class.define("osparc.dashboard.ToggleButtonContainer", {
     },
 
     areMoreResourcesRequired: function(loadingResourcesBtn) {
-      if (this.nextRequest !== null && loadingResourcesBtn && osparc.utils.Utils.checkIsOnScreen(loadingResourcesBtn)) {
+      if (this.nextRequest !== null && loadingResourcesBtn && osparc.utils.Utils.isWidgetOnScreen(loadingResourcesBtn)) {
         return true;
       }
       return false;

--- a/services/static-webserver/client/source/class/osparc/tours/Manager.js
+++ b/services/static-webserver/client/source/class/osparc/tours/Manager.js
@@ -192,7 +192,7 @@ qx.Class.define("osparc.tours.Manager", {
           } else {
             targetWidget.execute();
           }
-          setTimeout(() => this.__toStep(steps, idx), 100);
+          setTimeout(() => this.__toStep(steps, idx), 150);
         } else {
           // target not found, move to the next step
           this.__toStepCheck(this.__currentIdx+1);

--- a/services/static-webserver/client/source/class/osparc/tours/Manager.js
+++ b/services/static-webserver/client/source/class/osparc/tours/Manager.js
@@ -169,7 +169,7 @@ qx.Class.define("osparc.tours.Manager", {
     __toStepCheck: function(idx = 0) {
       const steps = this.getSteps();
       if (idx >= steps.length) {
-        idx = 0;
+        return;
       }
 
       this.__removeCurrentBubble();

--- a/services/static-webserver/client/source/class/osparc/tours/Manager.js
+++ b/services/static-webserver/client/source/class/osparc/tours/Manager.js
@@ -161,7 +161,9 @@ qx.Class.define("osparc.tours.Manager", {
     },
 
     __getVisibleElement: function(selector) {
+      // get all elements...
       const elements = document.querySelectorAll(`[${selector}]`);
+      // ...and use the first on screen match
       const element = [...elements].find(el => osparc.utils.Utils.isElementOnScreen(el));
       return element;
     },

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -287,27 +287,27 @@ qx.Class.define("osparc.utils.Utils", {
       return title;
     },
 
-    checkIsOnScreen: function(elem) {
-      const isInViewport = element => {
-        if (element) {
-          const rect = element.getBoundingClientRect();
-          const html = document.documentElement;
-          return (
-            rect.width > 0 &&
-            rect.height > 0 &&
-            rect.top >= 0 &&
-            rect.left >= 0 &&
-            // a bit of tolerance to deal with zooming factors
-            rect.bottom*0.95 <= (window.innerHeight || html.clientHeight) &&
-            rect.right*0.95 <= (window.innerWidth || html.clientWidth)
-          );
-        }
-        return false;
-      };
+    isElementOnScreen: function(element) {
+      if (element) {
+        const rect = element.getBoundingClientRect();
+        const html = document.documentElement;
+        return (
+          rect.width > 0 &&
+          rect.height > 0 &&
+          rect.top >= 0 &&
+          rect.left >= 0 &&
+          // a bit of tolerance to deal with zooming factors
+          rect.bottom*0.95 <= (window.innerHeight || html.clientHeight) &&
+          rect.right*0.95 <= (window.innerWidth || html.clientWidth)
+        );
+      }
+      return false;
+    },
 
-      const domElem = elem.getContentElement().getDomElement();
-      const checkIsOnScreen = isInViewport(domElem);
-      return checkIsOnScreen;
+    isWidgetOnScreen: function(widget) {
+      const domElem = widget.getContentElement().getDomElement();
+      const isWidgetOnScreen = this.isElementOnScreen(domElem);
+      return isWidgetOnScreen;
     },
 
     growSelectBox: function(selectBox, maxWidth) {

--- a/services/static-webserver/client/source/class/osparc/widget/logger/LoggerView.js
+++ b/services/static-webserver/client/source/class/osparc/widget/logger/LoggerView.js
@@ -413,8 +413,8 @@ qx.Class.define("osparc.widget.logger.LoggerView", {
     __updateTable: function() {
       if (this.__loggerModel) {
         this.__loggerModel.reloadData();
-        // checkIsOnScreen will avoid rendering every single line when the user click on the Logger button the first time
-        if (!this.isLockLogs() && osparc.utils.Utils.checkIsOnScreen(this.__loggerTable)) {
+        // isWidgetOnScreen will avoid rendering every single line when the user click on the Logger button the first time
+        if (!this.isLockLogs() && osparc.utils.Utils.isWidgetOnScreen(this.__loggerTable)) {
           const nFilteredRows = this.__loggerModel.getFilteredRowCount();
           this.__loggerTable.scrollCellVisible(0, nFilteredRows);
         }


### PR DESCRIPTION
## What do these changes do?

reported by @cosfor1 

If the ``selector`` defined in the Guided Tour was present more than once, the frontend would try to point to the first match, but it could happen that the ``selector`` wasn't on screen. This PR will fix that scenario by pointing only at the first on-screen-match.

![OnlyIfVisible](https://github.com/user-attachments/assets/c4812627-f3db-406f-8099-b09d54d5fd14)


## Related issue/s

- closes https://github.com/ITISFoundation/osparc-simcore/issues/6462


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
