### PR TITLE
🐛 Logs out previously logged in users to avoid authentication issues with the cookie which is passed in all subdomains

### DIFF
--- a/packages/settings-library/src/settings_library/utils_session.py
+++ b/packages/settings-library/src/settings_library/utils_session.py
@@ -3,7 +3,6 @@ import binascii
 from typing import Final
 
 DEFAULT_SESSION_COOKIE_NAME: Final[str] = "osparc-sc-v2"
-DEFAULT_SESSION_COOKIE_NAME_LEGACY: Final[str] = "osparc-sc"
 _32_BYTES_LENGTH: Final[int] = 32
 
 

--- a/packages/settings-library/src/settings_library/utils_session.py
+++ b/packages/settings-library/src/settings_library/utils_session.py
@@ -2,7 +2,8 @@ import base64
 import binascii
 from typing import Final
 
-DEFAULT_SESSION_COOKIE_NAME: Final[str] = "osparc-sc"
+DEFAULT_SESSION_COOKIE_NAME: Final[str] = "osparc-sc-v2"
+DEFAULT_SESSION_COOKIE_NAME_LEGACY: Final[str] = "osparc-sc"
 _32_BYTES_LENGTH: Final[int] = 32
 
 

--- a/services/docker-compose-dev-vendors.yml
+++ b/services/docker-compose-dev-vendors.yml
@@ -17,7 +17,7 @@ services:
         # auth
         - traefik.http.middlewares.${SWARM_STACK_NAME}_manual-auth.forwardauth.address=http://${WEBSERVER_HOST}:${WEBSERVER_PORT}/v0/auth:check
         - traefik.http.middlewares.${SWARM_STACK_NAME}_manual-auth.forwardauth.trustForwardHeader=true
-        - traefik.http.middlewares.${SWARM_STACK_NAME}_manual-auth.forwardauth.authResponseHeaders=Set-Cookie,osparc-sc
+        - traefik.http.middlewares.${SWARM_STACK_NAME}_manual-auth.forwardauth.authResponseHeaders=Set-Cookie,osparc-sc-v2
         # routing
         - traefik.http.services.${SWARM_STACK_NAME}_manual.loadbalancer.server.port=80
         - traefik.http.services.${SWARM_STACK_NAME}_manual.loadbalancer.healthcheck.path=/

--- a/services/web/server/src/simcore_service_webserver/login/_auth_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/login/_auth_handlers.py
@@ -10,6 +10,7 @@ from servicelib.aiohttp.requests_validation import parse_request_body_as
 from servicelib.logging_utils import get_log_record_extra, log_context
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
 from servicelib.request_keys import RQT_USERID_KEY
+from settings_library.utils_session import DEFAULT_SESSION_COOKIE_NAME_LEGACY
 from simcore_postgres_database.models.users import UserRole
 
 from .._meta import API_VTAG
@@ -270,7 +271,9 @@ async def login_2fa(request: web.Request):
     # dispose since code was used
     await delete_2fa_code(request.app, login_2fa_.email)
 
-    return await login_granted_response(request, user=dict(user))
+    response = await login_granted_response(request, user=dict(user))
+    response.del_cookie(DEFAULT_SESSION_COOKIE_NAME_LEGACY)
+    return response
 
 
 class LogoutBody(InputSchema):

--- a/services/web/server/src/simcore_service_webserver/login/_auth_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/login/_auth_handlers.py
@@ -269,6 +269,7 @@ async def login_2fa(request: web.Request):
 
     # dispose since code was used
     await delete_2fa_code(request.app, login_2fa_.email)
+
     return await login_granted_response(request, user=dict(user))
 
 

--- a/services/web/server/src/simcore_service_webserver/login/_auth_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/login/_auth_handlers.py
@@ -10,7 +10,6 @@ from servicelib.aiohttp.requests_validation import parse_request_body_as
 from servicelib.logging_utils import get_log_record_extra, log_context
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
 from servicelib.request_keys import RQT_USERID_KEY
-from settings_library.utils_session import DEFAULT_SESSION_COOKIE_NAME_LEGACY
 from simcore_postgres_database.models.users import UserRole
 
 from .._meta import API_VTAG
@@ -270,10 +269,7 @@ async def login_2fa(request: web.Request):
 
     # dispose since code was used
     await delete_2fa_code(request.app, login_2fa_.email)
-
-    response = await login_granted_response(request, user=dict(user))
-    response.del_cookie(DEFAULT_SESSION_COOKIE_NAME_LEGACY)
-    return response
+    return await login_granted_response(request, user=dict(user))
 
 
 class LogoutBody(InputSchema):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

After https://github.com/ITISFoundation/osparc-simcore/pull/6484 was merged it became obvious that we need to logout users. Current functionality does not allow us to logout users which do not have running services or a running frontend at the moment when the maintenance page is put up.

To avoid issues, the cookie name was changed and the old cookie is also removed.

**NOTE:** tried multiple ways to delete the session cookie but it appears to be impossible:
- removing the cookie via del_cookie and name does not work
- using a header does not work
- using max-age or expires fields does not work

Any ideas are here are welcomed.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
