### PR TITLE
♻️ Renaming session cookie once again

### DIFF
--- a/packages/settings-library/src/settings_library/utils_session.py
+++ b/packages/settings-library/src/settings_library/utils_session.py
@@ -2,7 +2,7 @@ import base64
 import binascii
 from typing import Final
 
-DEFAULT_SESSION_COOKIE_NAME: Final[str] = "osparc-sc"
+DEFAULT_SESSION_COOKIE_NAME: Final[str] = "osparc-sc2"
 _32_BYTES_LENGTH: Final[int] = 32
 
 

--- a/services/docker-compose-dev-vendors.yml
+++ b/services/docker-compose-dev-vendors.yml
@@ -17,7 +17,7 @@ services:
         # auth: https://doc.traefik.io/traefik/middlewares/http/forwardauth
         - traefik.http.middlewares.${SWARM_STACK_NAME}_manual-auth.forwardauth.address=http://${WEBSERVER_HOST}:${WEBSERVER_PORT}/v0/auth:check
         - traefik.http.middlewares.${SWARM_STACK_NAME}_manual-auth.forwardauth.trustForwardHeader=true
-        - traefik.http.middlewares.${SWARM_STACK_NAME}_manual-auth.forwardauth.authResponseHeaders=Set-Cookie,osparc-sc
+        - traefik.http.middlewares.${SWARM_STACK_NAME}_manual-auth.forwardauth.authResponseHeaders=Set-Cookie,osparc-sc2
         # routing
         - traefik.http.services.${SWARM_STACK_NAME}_manual.loadbalancer.server.port=80
         - traefik.http.services.${SWARM_STACK_NAME}_manual.loadbalancer.healthcheck.path=/


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Apparently `Firefox` handles cookies differently than `Chrome` and `Safari`. It keeps cookies with the same name but different domains.
Even after invalidating the session key for the cookies. You login into `Firefox` open a new style dynamic service and authentication fails. Apparently it send out old cookie, the one with domain `osparc.io` (which is invalid) instead of the one with `.osparc.io` domain. This causes a 401 reply when opening `UUID.services.osparc.io`.

To avoid issues for users, the session cookie is being renamed.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->
- https://github.com/ITISFoundation/osparc-simcore/pull/6484

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
