### PR TITLE
⬆️ ♻️ Upgrade pagination customisation in api-server

### DIFF
--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -156,12 +156,9 @@ fastapi==0.99.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-    #   fastapi-pagination
     #   prometheus-fastapi-instrumentator
-fastapi-pagination==0.12.17
-    # via
-    #   -c requirements/./constraints.txt
-    #   -r requirements/_base.in
+fastapi-pagination==0.12.31
+    # via -r requirements/_base.in
 faststream==0.5.10
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/api-server/requirements/constraints.txt
+++ b/services/api-server/requirements/constraints.txt
@@ -40,31 +40,3 @@ aws-sam-translator<1.56.0
 # #   aws-sam-translator<1.55.0 (from -c ./constraints.txt (line 32))
 # #   aws-sam-translator>=1.57.0 (from cfn-lint==0.72.10->-c ./constraints.txt (line 33))
 cfn-lint<0.72.1
-
-
-
-#
-# .venv/lib/python3.10/site-packages/fastapi_pagination/api.py:352: in _update_route
-#     get_parameterless_sub_dependant(
-# .venv/lib/python3.10/site-packages/fastapi/dependencies/utils.py:136: in get_parameterless_sub_dependant
-#     return get_sub_dependant(depends=depends, dependency=depends.dependency, path=path)
-# .venv/lib/python3.10/site-packages/fastapi/dependencies/utils.py:159: in get_sub_dependant
-#     sub_dependant = get_dependant(
-# .venv/lib/python3.10/site-packages/fastapi/dependencies/utils.py:310: in get_dependant
-#     sub_dependant = get_param_sub_dependant(
-# .venv/lib/python3.10/site-packages/fastapi/dependencies/utils.py:123: in get_param_sub_dependant
-#     return get_sub_dependant(
-# .venv/lib/python3.10/site-packages/fastapi/dependencies/utils.py:159: in get_sub_dependant
-#     sub_dependant = get_dependant(
-# .venv/lib/python3.10/site-packages/fastapi/dependencies/utils.py:331: in get_dependant
-#     add_param_to_fields(field=param_field, dependant=dependant)
-# _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-#     def add_param_to_fields(*, field: ModelField, dependant: Dependant) -> None:
-#         field_info = cast(params.Param, field.field_info)
-# >       if field_info.in_ == params.ParamTypes.path:
-# E       AttributeError: 'FieldInfo' object has no attribute 'in_'
-
-# .venv/lib/python3.10/site-packages/fastapi/dependencies/utils.py:500: AttributeError
-
-fastapi-pagination<=0.12.17

--- a/services/api-server/src/simcore_service_api_server/models/pagination.py
+++ b/services/api-server/src/simcore_service_api_server/models/pagination.py
@@ -9,7 +9,8 @@ Usage:
 from collections.abc import Sequence
 from typing import Any, ClassVar, Generic, TypeAlias, TypeVar
 
-from fastapi_pagination.customization import CustomizedPage, UseParamsFields
+from fastapi import Query
+from fastapi_pagination.customization import CustomizedPage, UseName, UseParamsFields
 from fastapi_pagination.limit_offset import LimitOffsetParams as _LimitOffsetParams
 from fastapi_pagination.links import LimitOffsetPage as _LimitOffsetPage
 from models_library.rest_pagination import (
@@ -17,24 +18,25 @@ from models_library.rest_pagination import (
     MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
 )
 from models_library.utils.pydantic_tools_extension import FieldNotRequired
-from pydantic import Field, NonNegativeInt, validator
+from pydantic import NonNegativeInt, validator
 from pydantic.generics import GenericModel
 
 T = TypeVar("T")
 
-
-# NOTE: same pagination limits and defaults as web-server,
-# otherwise it is more difficult to sync
 Page = CustomizedPage[
     _LimitOffsetPage[T],
+    # Customizes the default and maximum to fit those of the web-server. It simplifies interconnection
     UseParamsFields(
-        limit=Field(
-            DEFAULT_NUMBER_OF_ITEMS_PER_PAGE, ge=1, le=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE
+        limit=Query(
+            DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
+            ge=1,
+            le=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
+            description="Page size limit",
         )
     ),
+    # Renames class for the openapi.json to make the python-client's name models shorter
+    UseName(name="Page"),
 ]
-# NOTE: Renamed to make shorter clients name models
-Page.__name__ = "Page"  # type: ignore
 
 PaginationParams: TypeAlias = _LimitOffsetParams
 

--- a/services/api-server/src/simcore_service_api_server/models/pagination.py
+++ b/services/api-server/src/simcore_service_api_server/models/pagination.py
@@ -10,8 +10,8 @@ from collections.abc import Sequence
 from typing import Any, ClassVar, Generic, TypeAlias, TypeVar
 
 from fastapi_pagination.customization import CustomizedPage, UseParamsFields
-from fastapi_pagination.limit_offset import LimitOffsetPage as _LimitOffsetPage
 from fastapi_pagination.limit_offset import LimitOffsetParams as _LimitOffsetParams
+from fastapi_pagination.links import LimitOffsetPage as _LimitOffsetPage
 from models_library.rest_pagination import (
     DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
     MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
@@ -34,7 +34,7 @@ Page = CustomizedPage[
     ),
 ]
 # NOTE: Renamed to make shorter clients name models
-Page.__name__ = "Page"
+Page.__name__ = "Page"  # type: ignore
 
 PaginationParams: TypeAlias = _LimitOffsetParams
 

--- a/services/api-server/src/simcore_service_api_server/models/pagination.py
+++ b/services/api-server/src/simcore_service_api_server/models/pagination.py
@@ -9,10 +9,9 @@ Usage:
 from collections.abc import Sequence
 from typing import Any, ClassVar, Generic, TypeAlias, TypeVar
 
-from fastapi_pagination.limit_offset import LimitOffsetParams
-from fastapi_pagination.links.limit_offset import (
-    LimitOffsetPage as _FastApiLimitOffsetPage,
-)
+from fastapi_pagination.customization import CustomizedPage, UseParamsFields
+from fastapi_pagination.limit_offset import LimitOffsetPage as _LimitOffsetPage
+from fastapi_pagination.limit_offset import LimitOffsetParams as _LimitOffsetParams
 from models_library.rest_pagination import (
     DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
     MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
@@ -23,16 +22,21 @@ from pydantic.generics import GenericModel
 
 T = TypeVar("T")
 
-# NOTE: same pagination limits and defaults as web-server
-Page = _FastApiLimitOffsetPage.with_custom_options(
-    limit=Field(
-        DEFAULT_NUMBER_OF_ITEMS_PER_PAGE, ge=1, le=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE
-    )
-)
+
+# NOTE: same pagination limits and defaults as web-server,
+# otherwise it is more difficult to sync
+Page = CustomizedPage[
+    _LimitOffsetPage[T],
+    UseParamsFields(
+        limit=Field(
+            DEFAULT_NUMBER_OF_ITEMS_PER_PAGE, ge=1, le=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE
+        )
+    ),
+]
 # NOTE: Renamed to make shorter clients name models
 Page.__name__ = "Page"
 
-PaginationParams: TypeAlias = LimitOffsetParams
+PaginationParams: TypeAlias = _LimitOffsetParams
 
 
 class OnePage(GenericModel, Generic[T]):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Enhancements to Customization in `fastapi_pagination` and Fix for `limit` Query Parameter Customization

- ⬆️ Upgrades `fastapi_pagination` page by removing version limit in `constraints.txt`
-  ♻️🐛 Uses new  `CustomizedPage` to customise query parameters and name of the `Page` model. We also replace `Field` by `Query` to avoid error reported in `constraints.txt`  (`AttributeError: 'FieldInfo' object has no attribute 'in_'`). @giancarloromeo I believe this is also causing the same issues we see in https://github.com/ITISFoundation/osparc-simcore/issues/6511. 

**REMINDER**: @giancarloromeo when this is merged into `master`, do not forget to resync your branches with `master` so you get this change.

## Related issue/s

- Supports https://github.com/ITISFoundation/osparc-simcore/issues/6511 
- Part of https://github.com/ITISFoundation/osparc-simcore/issues/4481


## How to test

```
cd services/api-service
make install-dev
make test-dev-unit
```

## Dev-ops checklist
None