### PR TITLE
🐛 [Frontend] Reuse ``client_session_id`` from socket's query instead of creating a new one

### DIFF
--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -1033,11 +1033,13 @@ qx.Class.define("osparc.utils.Utils", {
     // Function that creates a unique tabId even for duplicated tabs
     getClientSessionID: function() {
       const getUniqueSessionId = () => {
-        const uuid = osparc.utils.Utils.uuidV4();
+        // before creating a new one, check if the websocket has it set
+        const webSocket = osparc.wrapper.WebSocket.getInstance().getSocket();
+        const clientSessionId = webSocket ? webSocket.io.engine.opts.query["client_session_id"] : osparc.utils.Utils.uuidV4();
         // Set window.name. This property is persistent on window reloads, but it doesn't get copied in a duplicated tab
-        window.name = uuid;
-        sessionStorage.setItem("clientsessionid", uuid);
-        return uuid;
+        window.name = clientSessionId;
+        sessionStorage.setItem("clientsessionid", clientSessionId);
+        return clientSessionId;
       };
 
       let uniqueSessionId = sessionStorage.getItem("clientsessionid");


### PR DESCRIPTION
## What do these changes do?

After logging in, the frontend creates a ``client_session_id`` used by the websocket and some projects related request headers. This ``client_session_id`` is kept in the ``sessionStorage`` of the borwser.

If somehow this one gets deleted or disappears, whenever it's required, the frontend will create a new one that will be only used by the projects related requests, the websocket after reconnecting it will keep the previous ``client_session_id``. This misalignment makes the Garbage Collector kill services that are started with this new session id.

This PR fixes this scenario by checking (and reusing) if the websocket has a ``client_session_id`` before creating a new one.

![ReuseSocketSessionId](https://github.com/user-attachments/assets/2332f7ad-b02f-4a5d-bde1-a387438f6a81)


## Related issue/s

- fixes https://github.com/ITISFoundation/osparc-simcore/issues/6087

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
