### PR TITLE
🎨Dask sidecar: use reproducible zipfile library

### DIFF
--- a/services/dask-sidecar/requirements/_base.in
+++ b/services/dask-sidecar/requirements/_base.in
@@ -26,3 +26,4 @@ fsspec[http, s3] # sub types needed as we acces http and s3 here
 lz4 # for compression
 pydantic[email,dotenv]
 prometheus_client
+repro-zipfile

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -325,7 +325,9 @@ referencing==0.29.3
     #   jsonschema
     #   jsonschema-specifications
 repro-zipfile==0.3.1
-    # via -r requirements/../../../packages/service-library/requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/_base.in
 requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
 rich==13.7.1

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
@@ -12,7 +12,7 @@ from typing import Any, Final, TypedDict, cast
 import aiofiles
 import aiofiles.tempfile
 import fsspec  # type: ignore[import-untyped]
-import repro_zipfile
+import repro_zipfile  # type: ignore[import-untyped]
 from pydantic import ByteSize, FileUrl, parse_obj_as
 from pydantic.networks import AnyUrl
 from servicelib.logging_utils import LogLevelInt, LogMessageStr

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
@@ -5,13 +5,14 @@ import mimetypes
 import time
 import zipfile
 from collections.abc import Awaitable, Callable
-from io import BytesIO
+from io import IOBase
 from pathlib import Path
 from typing import Any, Final, TypedDict, cast
 
 import aiofiles
 import aiofiles.tempfile
 import fsspec  # type: ignore[import-untyped]
+import repro_zipfile
 from pydantic import ByteSize, FileUrl, parse_obj_as
 from pydantic.networks import AnyUrl
 from servicelib.logging_utils import LogLevelInt, LogMessageStr
@@ -33,7 +34,7 @@ def _file_progress_cb(
     log_publishing_cb: LogPublishingCB,
     text_prefix: str,
     main_loop: asyncio.AbstractEventLoop,
-    **kwargs,
+    **kwargs,  # noqa: ARG001
 ):
     asyncio.run_coroutine_threadsafe(
         log_publishing_cb(
@@ -78,7 +79,7 @@ def _s3fs_settings_from_s3_settings(s3_settings: S3Settings) -> S3FsSettingsDict
     return s3fs_settings
 
 
-def _file_chunk_streamer(src: BytesIO, dst: BytesIO):
+def _file_chunk_streamer(src: IOBase, dst: IOBase):
     data = src.read(CHUNK_SIZE)
     segment_len = dst.write(data)
     return (data, segment_len)
@@ -98,6 +99,8 @@ async def _copy_file(
     with fsspec.open(src_url, mode="rb", **src_storage_kwargs) as src_fp, fsspec.open(
         dst_url, "wb", **dst_storage_kwargs
     ) as dst_fp:
+        assert isinstance(src_fp, IOBase)  # nosec
+        assert isinstance(dst_fp, IOBase)  # nosec
         file_size = getattr(src_fp, "size", None)
         data_read = True
         total_data_written = 0
@@ -159,7 +162,7 @@ async def pull_file_from_remote(
     if src_mime_type == _ZIP_MIME_TYPE and target_mime_type != _ZIP_MIME_TYPE:
         await log_publishing_cb(f"Uncompressing '{dst_path.name}'...", logging.INFO)
         logger.debug("%s is a zip file and will be now uncompressed", dst_path)
-        with zipfile.ZipFile(dst_path, "r") as zip_obj:
+        with repro_zipfile.ReproducibleZipFile(dst_path, "r") as zip_obj:
             await asyncio.get_event_loop().run_in_executor(
                 None, zip_obj.extractall, dst_path.parents[0]
             )
@@ -248,7 +251,8 @@ async def push_file_to_remote(
                 f"Compressing '{src_path.name}' to '{archive_file_path.name}'...",
                 logging.INFO,
             )
-            with zipfile.ZipFile(
+
+            with repro_zipfile.ReproducibleZipFile(
                 archive_file_path, mode="w", compression=zipfile.ZIP_STORED
             ) as zfp:
                 await asyncio.get_event_loop().run_in_executor(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
as explained in https://github.com/ITISFoundation/osparc-simcore/issues/6244 this PR makes sure we use deterministic Zipping when uploading files from the dask-sidecar.

### Driving test
`test_push_file_to_remote_creates_reproducible_zip_archive`

### Important note:
The test shows that the current implementation already created deterministic zip files (e.g. hash of 2 zips containing the same files created at different time points are the same). Nevertheless, since the computational backend currently allows to pass only 1 file and the services are actually responsible for creating their own zip files, this is probably mostly useless at the moment.

When we allow to have folders to be compressed by the dask-sidecar this might prove useful.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
