### PR TITLE
⬆️Fast depends: update version due to syntax breaking change

### DIFF
--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -81,7 +81,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.2.0
     # via pydantic
-fast-depends==2.4.11
+fast-depends==2.4.12
     # via faststream
 faststream==0.5.23
     # via -r requirements/../../../packages/service-library/requirements/_base.in

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -53,7 +53,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.2.0
     # via pydantic
-fast-depends==2.4.11
+fast-depends==2.4.12
     # via faststream
 faststream==0.5.23
     # via -r requirements/_base.in

--- a/packages/service-library/src/servicelib/deferred_tasks/_utils.py
+++ b/packages/service-library/src/servicelib/deferred_tasks/_utils.py
@@ -30,8 +30,6 @@ def stop_retry_for_unintended_errors(func):
                 f"Please check code at: '{func.__module__}.{func.__name__}'"
             )
             _logger.exception(msg)
-            # NOTE: the new version of fast-depends allows to pass a parameter until then we keep it simple
-            # raise RejectMessage(reason=msg) from e
-            raise RejectMessage from e
+            raise RejectMessage(reason=msg) from e
 
     return wrapper

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -79,7 +79,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.2.0
     # via pydantic
-fast-depends==2.4.11
+fast-depends==2.4.12
     # via faststream
 faststream==0.5.23
     # via -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -70,7 +70,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.2.0
     # via pydantic
-fast-depends==2.4.11
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -136,7 +136,7 @@ email-validator==2.1.1
     # via
     #   fastapi
     #   pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -129,7 +129,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -81,7 +81,7 @@ email-validator==2.1.1
     # via
     #   fastapi
     #   pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -127,7 +127,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -106,7 +106,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 faststream==0.5.10
     # via -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -77,7 +77,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -154,7 +154,7 @@ email-validator==2.1.1
     # via
     #   fastapi
     #   pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -78,7 +78,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -120,7 +120,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -78,7 +78,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -95,7 +95,7 @@ ecdsa==0.19.0
     # via python-jose
 email-validator==2.2.0
     # via pydantic
-fast-depends==2.4.7
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -126,7 +126,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 fastapi==0.99.1
     # via

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -125,7 +125,7 @@ dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via pydantic
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 faststream==0.5.10
     # via

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -160,7 +160,7 @@ et-xmlfile==1.1.0
     # via openpyxl
 faker==19.6.1
     # via -r requirements/_base.in
-fast-depends==2.4.2
+fast-depends==2.4.12
     # via faststream
 faststream==0.5.10
     # via

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -117,7 +117,7 @@ docker==7.1.0
     #   -r requirements/_test.in
 email-validator==2.2.0
     # via pydantic
-fast-depends==2.4.11
+fast-depends==2.4.12
     # via faststream
 faststream==0.5.23
     # via


### PR DESCRIPTION
###
reverted change from https://github.com/ITISFoundation/osparc-simcore/pull/6575

###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 1
- #packages after ~ 1

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | fast-depends              | 2.4.11, 2.4.2, 2.4.7 | 2.4.12     |            | 19 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>invitations⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>swarm-deploy🧪</br>web⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

