### PR TITLE
🐛 [Frontend] Fix: Download logs with newlines (Firefox)

### DIFF
--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -804,11 +804,10 @@ qx.Class.define("osparc.utils.Utils", {
               loadedCb();
             }
             const blob = new Blob([xhr.response]);
-            const urlBlob = window.URL.createObjectURL(blob);
             if (!fileName) {
               fileName = this.self().filenameFromContentDisposition(xhr);
             }
-            this.self().downloadContent(urlBlob, fileName);
+            this.self().downloadBlobContent(blob, fileName);
             resolve();
           } else {
             reject(xhr);
@@ -820,9 +819,9 @@ qx.Class.define("osparc.utils.Utils", {
       });
     },
 
-    downloadContent: function(content, filename = "file") {
+    downloadBlobContent: function(blob, filename = "file") {
       let downloadAnchorNode = document.createElement("a");
-      downloadAnchorNode.setAttribute("href", content);
+      downloadAnchorNode.setAttribute("href", window.URL.createObjectURL(blob));
       downloadAnchorNode.setAttribute("download", filename);
       downloadAnchorNode.click();
       downloadAnchorNode.remove();

--- a/services/static-webserver/client/source/class/osparc/widget/logger/LoggerView.js
+++ b/services/static-webserver/client/source/class/osparc/widget/logger/LoggerView.js
@@ -317,9 +317,10 @@ qx.Class.define("osparc.widget.logger.LoggerView", {
     },
 
     __getLogsString: function() {
+      const newLine = "\r\n";
       let logs = "";
       this.__loggerModel.getFilteredRows().forEach(rowData => {
-        logs += this.self().printRow(rowData) + "\n";
+        logs += this.self().printRow(rowData) + newLine;
       });
       return logs;
     },

--- a/services/static-webserver/client/source/class/osparc/widget/logger/LoggerView.js
+++ b/services/static-webserver/client/source/class/osparc/widget/logger/LoggerView.js
@@ -317,7 +317,7 @@ qx.Class.define("osparc.widget.logger.LoggerView", {
     },
 
     __getLogsString: function() {
-      const newLine = "\r\n";
+      const newLine = "\n";
       let logs = "";
       this.__loggerModel.getFilteredRows().forEach(rowData => {
         logs += this.self().printRow(rowData) + newLine;
@@ -339,7 +339,8 @@ qx.Class.define("osparc.widget.logger.LoggerView", {
 
     downloadLogs: function() {
       const logs = this.__getLogsString();
-      osparc.utils.Utils.downloadContent("data:text/plain;charset=utf-8," + logs, "logs.log");
+      const blob = new Blob([logs], {type: "text/plain"});
+      osparc.utils.Utils.downloadBlobContent(blob, "logs.log");
     },
 
     debug: function(nodeId, msg = "") {


### PR DESCRIPTION
## What do these changes do?

When Downloading the log file in Firefox wasn't adding any newlines. This PR fixes it.

![DownloadLogsFF](https://github.com/user-attachments/assets/aa368749-26a7-458d-8904-818d89a1d3b8)


## Related issue/s

- fixes https://github.com/ITISFoundation/osparc-simcore/issues/6074


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
