### PR TITLE
🐛 [Frontend] Fix: Avoid null parameters in requests

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -1249,6 +1249,12 @@ qx.Class.define("osparc.data.Resources", {
      * @param {Object} options Collections of options (pollTask, resolveWResponse, timeout, timeoutRetries)
      */
     fetch: function(resource, endpoint, params = {}, options = {}) {
+      if (params === null) {
+        params = {};
+      }
+      if (options === null) {
+        options = {};
+      }
       return new Promise((resolve, reject) => {
         if (this.self().resources[resource] == null) {
           reject(Error(`Error while fetching ${resource}: the resource is not defined`));

--- a/services/static-webserver/client/source/class/osparc/desktop/organizations/OrganizationsList.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/organizations/OrganizationsList.js
@@ -180,7 +180,7 @@ qx.Class.define("osparc.desktop.organizations.OrganizationsList", {
       orgsModel.removeAll();
 
       const useCache = false;
-      osparc.data.Resources.get("organizations", null, useCache)
+      osparc.data.Resources.get("organizations", {}, useCache)
         .then(async respOrgs => {
           const orgs = respOrgs["organizations"];
           const promises = await orgs.map(async org => {


### PR DESCRIPTION
## What do these changes do?

Found in the organizations list. Fix: make them empty objects

Bug:
![Bug](https://github.com/user-attachments/assets/d1831a71-a10d-444a-9a79-fbfe9fdedd8d)


Fixed:
![Fixed](https://github.com/user-attachments/assets/596320a2-bacf-4307-a491-99e9c2ce0465)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
