### PR TITLE
 ⬆️ upgrades `iter_model_examples_in_module` to enable all example tests

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
+++ b/packages/pytest-simcore/src/pytest_simcore/pydantic_models.py
@@ -82,21 +82,20 @@ def iter_model_examples_in_module(module: object) -> Iterator[ModelExample]:
     for model_name, model_cls in inspect.getmembers(module, _is_model_cls):
         assert model_name  # nosec
         if (
-            (config_cls := model_cls.model_config)
-            and inspect.isclass(config_cls)
-            and is_strict_inner(model_cls, config_cls)
-            and (schema_extra := getattr(config_cls, "schema_extra", {}))
-            and isinstance(schema_extra, dict)
+            (model_config := model_cls.model_config)
+            and isinstance(model_config, dict)
+            and (json_schema_extra := model_config.get("json_schema_extra", {}))
+            and isinstance(json_schema_extra, dict)
         ):
-            if "example" in schema_extra:
+            if "example" in json_schema_extra:
                 yield ModelExample(
                     model_cls=model_cls,
                     example_name="example",
-                    example_data=schema_extra["example"],
+                    example_data=json_schema_extra["example"],
                 )
 
-            elif "examples" in schema_extra:
-                for index, example in enumerate(schema_extra["examples"]):
+            elif "examples" in json_schema_extra:
+                for index, example in enumerate(json_schema_extra["examples"]):
                     yield ModelExample(
                         model_cls=model_cls,
                         example_name=f"examples_{index}",
@@ -120,10 +119,10 @@ def model_cls_examples(model_cls: type[BaseModel]) -> dict[str, dict[str, Any]]:
         "SEE https://pydantic-docs.helpmanual.io/usage/schema/#schema-customization"
     )
 
+    json_schema_extra: dict = model_cls.model_config.get("json_schema_extra", {})
+
     # checks exampleS setup in schema_extra
-    examples_list = copy.deepcopy(
-        model_cls.model_config["json_schema_extra"].get("examples", [])
-    )
+    examples_list = copy.deepcopy(json_schema_extra.get("examples", []))
     assert isinstance(examples_list, list), (
         "OpenAPI and json-schema differ regarding the format for exampleS."
         "The former is a dict and the latter an array. "
@@ -132,15 +131,12 @@ def model_cls_examples(model_cls: type[BaseModel]) -> dict[str, dict[str, Any]]:
         "SEE https://swagger.io/docs/specification/adding-examples/"
     )
 
-    # check example in schema_extra
-    example = copy.deepcopy(model_cls.model_config["json_schema_extra"].get("example"))
-
     # collect all examples and creates fixture -> {example-name: example, ...}
     examples = {
-        f"{model_cls.__name__}.example[{index}]": example
-        for index, example in enumerate(examples_list)
+        f"{model_cls.__name__}.example[{index}]": example_
+        for index, example_ in enumerate(examples_list)
     }
-    if example:
+    if example := copy.deepcopy(json_schema_extra.get("example")):
         examples[f"{model_cls.__name__}.example"] = example
 
     return examples


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This PR resolves the issue where tests validating examples were previously skipped due to an incomplete upgrade of `iter_model_examples_in_module`. 

NOte that most likely your tests on examples will fail due to the following: Pydantic 2 behavior, which now enforces that fields cannot have `None` as a default unless explicitly declared as nullable (i.e., `field: Type | None`). This update ensures compatibility with these stricter type requirements.

NOTE: when approved, I will force-merge into the branch so we can review the example tests separately.

## Related issue/s

- Part of #4481 


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

