### PR TITLE
🎨 [Frontend] Show EFS data storage

### DIFF
--- a/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
@@ -96,6 +96,7 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
 
       let prevDiskUsageState = this.__prevDiskUsageStateList.find(isMatchingNodeId);
       if (prevDiskUsageState === undefined) {
+        // Initialize it
         this.__prevDiskUsageStateList.push({
           nodeId: id,
           state: "NORMAL"
@@ -115,11 +116,17 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
       }
 
       const diskHostUsage = data.usage["HOST"]
-      const diskVolsUsage = "STATE_VOLUMES" in data.usage ? data.usage["STATE_VOLUMES"] : null;
-      let message;
-      const freeSpace = osparc.utils.Utils.bytesToSize(diskHostUsage.free);
-      const warningLevel = this.__getWarningLevel(diskHostUsage.free);
+      let freeSpace = osparc.utils.Utils.bytesToSize(diskHostUsage.free);
+      let warningLevel = this.__getWarningLevel(diskHostUsage.free);
+
+      if ("STATE_VOLUMES" in data.usage) {
+        const diskVolsUsage = data.usage["STATE_VOLUMES"];
+        const freeVolsSpace = osparc.utils.Utils.bytesToSize(diskVolsUsage.free);
+        const volsWarningLevel = this.__getWarningLevel(diskVolsUsage.free);
+      }
+
       const objIndex = this.__prevDiskUsageStateList.findIndex((obj => obj.nodeId === id));
+      let message;
       switch (warningLevel) {
         case "CRITICAL":
           if (shouldDisplayMessage(prevDiskUsageState, warningLevel)) {

--- a/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
@@ -65,7 +65,7 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
       }
     },
 
-    getDiskUsage: function(freeSpace) {
+    __getWarningLevel: function(freeSpace) {
       const lowDiskSpacePreferencesSettings = osparc.Preferences.getInstance();
       this.__lowDiskThreshold = lowDiskSpacePreferencesSettings.getLowDiskSpaceThreshold();
       const warningSize = osparc.utils.Utils.gBToBytes(this.__lowDiskThreshold); // 5 GB Default
@@ -96,8 +96,6 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
       }
 
       let prevDiskUsageState = this.__prevDiskUsageStateList.find(isMatchingNodeId);
-
-      const warningLevel = this.getDiskUsage(diskUsage.free);
       if (prevDiskUsageState === undefined) {
         this.__prevDiskUsageStateList.push({
           nodeId: id,
@@ -119,7 +117,7 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
       }
 
       let message;
-
+      const warningLevel = this.__getWarningLevel(diskHostUsage.free);
       const objIndex = this.__prevDiskUsageStateList.findIndex((obj => obj.nodeId === id));
       switch (warningLevel) {
         case "CRITICAL":

--- a/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
@@ -87,13 +87,15 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
         return;
       }
 
-      const diskUsage = data.usage["HOST"]
       function isMatchingNodeId({nodeId}) {
         return nodeId === id;
       }
       function shouldDisplayMessage(prevDiskUsageState, warningLevel) {
         return prevDiskUsageState && prevDiskUsageState.nodeId === id && prevDiskUsageState.state !== warningLevel
       }
+
+      const diskHostUsage = data.usage["HOST"]
+      const diskVolsUsage = "STATE_VOLUMES" in data.usage ? data.usage["STATE_VOLUMES"] : null;
 
       let prevDiskUsageState = this.__prevDiskUsageStateList.find(isMatchingNodeId);
       if (prevDiskUsageState === undefined) {
@@ -102,7 +104,7 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
           state: "NORMAL"
         })
       }
-      const freeSpace = osparc.utils.Utils.bytesToSize(diskUsage.free);
+      const freeSpace = osparc.utils.Utils.bytesToSize(diskHostUsage.free);
 
       const store = osparc.store.Store.getInstance();
       const currentStudy = store.getCurrentStudy();

--- a/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
@@ -94,9 +94,6 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
         return prevDiskUsageState && prevDiskUsageState.nodeId === id && prevDiskUsageState.state !== warningLevel
       }
 
-      const diskHostUsage = data.usage["HOST"]
-      const diskVolsUsage = "STATE_VOLUMES" in data.usage ? data.usage["STATE_VOLUMES"] : null;
-
       let prevDiskUsageState = this.__prevDiskUsageStateList.find(isMatchingNodeId);
       if (prevDiskUsageState === undefined) {
         this.__prevDiskUsageStateList.push({
@@ -104,21 +101,23 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
           state: "NORMAL"
         })
       }
-      const freeSpace = osparc.utils.Utils.bytesToSize(diskHostUsage.free);
 
       const store = osparc.store.Store.getInstance();
       const currentStudy = store.getCurrentStudy();
       if (!currentStudy) {
         return;
       }
-      const node = currentStudy.getWorkbench().getNode(id);
 
+      const node = currentStudy.getWorkbench().getNode(id);
       const nodeName = node ? node.getLabel() : null;
       if (nodeName === null) {
         return;
       }
 
+      const diskHostUsage = data.usage["HOST"]
+      const diskVolsUsage = "STATE_VOLUMES" in data.usage ? data.usage["STATE_VOLUMES"] : null;
       let message;
+      const freeSpace = osparc.utils.Utils.bytesToSize(diskHostUsage.free);
       const warningLevel = this.__getWarningLevel(diskHostUsage.free);
       const objIndex = this.__prevDiskUsageStateList.findIndex((obj => obj.nodeId === id));
       switch (warningLevel) {

--- a/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/DiskUsageController.js
@@ -34,7 +34,7 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
     this.__socket.on("serviceDiskUsage", data => {
       if (data["node_id"] && this.__callbacks[data["node_id"]]) {
         //  notify
-        this.setDiskUsageNotificationToUI(data);
+        this.__evaluateDisplayMessage(data);
         this.__callbacks[data["node_id"]].forEach(cb => {
           cb(data);
         })
@@ -81,7 +81,7 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
       return warningLevel
     },
 
-    setDiskUsageNotificationToUI: function(data) {
+    __evaluateDisplayMessage: function(data) {
       const id = data["node_id"];
       if (!this.__callbacks[id]) {
         return;
@@ -121,8 +121,11 @@ qx.Class.define("osparc.workbench.DiskUsageController", {
 
       if ("STATE_VOLUMES" in data.usage) {
         const diskVolsUsage = data.usage["STATE_VOLUMES"];
-        const freeVolsSpace = osparc.utils.Utils.bytesToSize(diskVolsUsage.free);
-        const volsWarningLevel = this.__getWarningLevel(diskVolsUsage.free);
+        if (diskVolsUsage["used_percent"] > diskHostUsage["used_percent"]) {
+          // "STATE_VOLUMES" is more critical so it takes over
+          freeSpace = osparc.utils.Utils.bytesToSize(diskVolsUsage.free);
+          warningLevel = this.__getWarningLevel(diskVolsUsage.free);
+        }
       }
 
       const objIndex = this.__prevDiskUsageStateList.findIndex((obj => obj.nodeId === id));

--- a/services/static-webserver/client/source/class/osparc/workbench/DiskUsageIndicator.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/DiskUsageIndicator.js
@@ -74,7 +74,6 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
             allowShrinkY: false,
             allowGrowX: true,
             allowGrowY: false,
-            toolTipText: this.tr("Disk usage")
           });
           this._add(control)
           break;
@@ -156,16 +155,32 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
         return;
       }
 
-      const usage = diskUsage["usage"]["HOST"]
-      const color1 = this.__getIndicatorColor(usage.free);
-      const progress = `${usage["used_percent"]}%`;
-      const labelDiskSize = osparc.utils.Utils.bytesToSize(usage.free);
+      const diskHostUsage = diskUsage["usage"]["HOST"]
+      let color1 = this.__getIndicatorColor(diskHostUsage.free);
+      let progress = `${diskHostUsage["used_percent"]}%`;
+      let labelDiskSize = osparc.utils.Utils.bytesToSize(diskHostUsage.free);
+      let toolTipText = this.tr("Disk usage");
+      if ("STATE_VOLUMES" in diskUsage["usage"]) {
+        const diskVolsUsage = diskUsage["usage"]["STATE_VOLUMES"];
+        if (diskVolsUsage["used_percent"] > diskHostUsage["used_percent"]) {
+          // "STATE_VOLUMES" is more critical so it takes over
+          color1 = this.__getIndicatorColor(diskVolsUsage.free);
+          progress = `${diskVolsUsage["used_percent"]}%`;
+          labelDiskSize = osparc.utils.Utils.bytesToSize(diskVolsUsage.free);
+        }
+        toolTipText = this.tr("Disk usage") + "<br>";
+        toolTipText += this.tr("Data storage: ") + osparc.utils.Utils.bytesToSize(diskVolsUsage.free) + "<br>";
+        toolTipText += this.tr("I/O storage: ") + osparc.utils.Utils.bytesToSize(diskHostUsage.free) + "<br>";
+      }
       const bgColor = qx.theme.manager.Color.getInstance().resolve("tab_navigation_bar_background_color");
       const color2 = qx.theme.manager.Color.getInstance().resolve("progressive-progressbar-background");
       indicator.getContentElement().setStyles({
         "background-color": bgColor,
         "background": `linear-gradient(90deg, ${color1} ${progress}, ${color2} ${progress})`,
         "border-color": color1
+      });
+      indicator.set({
+        toolTipText
       });
 
       const indicatorLabel = this.getChildControl("disk-indicator-label");


### PR DESCRIPTION
## What do these changes do?

This PR follows https://github.com/ITISFoundation/osparc-simcore/pull/6520

When the EFS storage is enabled, the backend sends two different data storage information: "HOST" and "STATE_VOLUMES".

This information (so far "HOST" only) goes into a progress bar above the iframe and it's also displayed in the NodeUI, so that users are aware of their data storage used.

In this PR, the most critical (most ``used_percentage``) data storage will be shown in the indicators, and the tooltip will show all the available information.

## Related issue/s

- related to https://github.com/ITISFoundation/osparc-simcore/issues/6411


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
