### PR TITLE
♻️ Changing == by is_ in sqlalchemy queries

### DIFF
--- a/scripts/maintenance/migrate_project/src/db.py
+++ b/scripts/maintenance/migrate_project/src/db.py
@@ -48,7 +48,7 @@ def _get_project(connection: Connection, project_uuid: UUID) -> ResultProxy:
 def _get_hidden_project(connection: Connection, prj_owner: int) -> ResultProxy:
     return connection.execute(
         select(projects).where(
-            and_(projects.c.prj_owner == prj_owner, projects.c.hidden == True)
+            and_(projects.c.prj_owner == prj_owner, projects.c.hidden.is_(True))
         )
     )
 
@@ -61,7 +61,7 @@ def _get_file_meta_data_without_soft_links(
             and_(
                 file_meta_data.c.node_id == f"{node_uuid}",
                 file_meta_data.c.project_id == f"{project_id}",
-                file_meta_data.c.is_soft_link != True,
+                file_meta_data.c.is_soft_link.is_not(True),
             )
         )
     )

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_catalog.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_catalog.py
@@ -97,7 +97,7 @@ async def iter_latest_product_services(
             )
             & (services_meta_data.c.deprecated.is_(None))
             & (services_access_rights.c.gid == EVERYONE_GROUP_ID)
-            & (services_access_rights.c.execute_access == True)
+            & (services_access_rights.c.execute_access.is_(True))
             & (services_access_rights.c.product_name == product_name)
         )
     )
@@ -161,7 +161,7 @@ async def validate_requested_service(
             sa.select(services_consume_filetypes.c.is_guest_allowed)
             .where(
                 (services_consume_filetypes.c.service_key == service_key)
-                & (services_consume_filetypes.c.is_guest_allowed == True)
+                & (services_consume_filetypes.c.is_guest_allowed.is_(True))
             )
             .limit(1)
         )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

I've encountered an issue several times where **ruff automatically converts expressions like `x == True` to `x is True`**. This becomes problematic in SQLAlchemy queries when expressions like `table.c.x == True` are involved, as ruff will transform it to `table.c.x is True`. While this is syntactically valid, it produces **a different SQL query** 


```python
import sqlalchemy as sa
from simcore_postgres_database.models.file_meta_data import *
from simcore_postgres_database.utils import *

wrong = sa.select(file_meta_data.c.file_id).where(file_meta_data.c.is_soft_link is True)  # WRONG
right = sa.select(file_meta_data.c.file_id).where(file_meta_data.c.is_soft_link.is_(True) ) # RIGHT

print( as_postgres_sql_query_str(wrong) )
print( as_postgres_sql_query_str(right) )
```
creates
```sql
SELECT file_meta_data.file_id 
FROM file_meta_data 
WHERE false
```
which will never return anything  (wrong!) and
```sql
SELECT file_meta_data.file_id 
FROM file_meta_data 
WHERE file_meta_data.is_soft_link IS true
```
which is the correct filter 


I've noticed this bug on multiple occasions and, to prevent it from reoccurring, I've created this PR to update all such occurrences in our repository. This PR also serves as a reminder.

### Suggestion

To avoid issues in your SQLAlchemy queries, 
- use `table.c.x.is_(True)` instead of `table.c.x == True`.
- use `table.c.x.is_not(True)` instead of `table.c.x != True`.
- analogously with `False` and `None` (when nullable).


## Related issue/s

Maintenance.

## How to test

None

## Dev-ops checklist

None
