### PR TITLE
🐛 [Frontend] Fix Service browser

### DIFF
--- a/services/static-webserver/client/source/class/osparc/store/Services.js
+++ b/services/static-webserver/client/source/class/osparc/store/Services.js
@@ -59,7 +59,7 @@ qx.Class.define("osparc.store.Services", {
               let serviceLatest = servicesLatest[key];
               if (excludeFrontend && key.includes("simcore/services/frontend/")) {
                 // do not add frontend services
-                return;
+                continue;
               }
               if (excludeDeprecated && serviceLatest["retired"]) {
                 // first check if a previous version of this service isn't retired
@@ -74,7 +74,7 @@ qx.Class.define("osparc.store.Services", {
                 }
                 if (serviceLatest["retired"]) {
                   // do not add retired services
-                  return;
+                  continue;
                 }
               }
               servicesList.push(serviceLatest);

--- a/services/static-webserver/client/source/class/osparc/store/Services.js
+++ b/services/static-webserver/client/source/class/osparc/store/Services.js
@@ -68,6 +68,7 @@ qx.Class.define("osparc.store.Services", {
                 for (let j=0; j<versions.length; j++) {
                   const version = versions[j];
                   if (!this.servicesCached[key][version]["retired"]) {
+                    // one older non retired version found
                     serviceLatest = await this.getService(key, version);
                     break;
                   }

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -720,12 +720,14 @@ qx.Class.define("osparc.utils.Utils", {
       if (!+bytes) {
         return "0 Bytes";
       }
-      const k = 1000;
-      const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
-      const dm = decimals < 0 ? 0 : decimals;
 
-      const i = Math.floor(Math.log(bytes) / Math.log(k))
-      return `${isDecimalCollapsed ? parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) : (bytes / Math.pow(k, i)).toFixed(dm)} ${sizes[i]}`
+      const k = 1000;
+      const dm = decimals < 0 ? 0 : decimals;
+      const i = Math.floor(Math.log(bytes) / Math.log(k));
+      const value = (bytes / Math.pow(k, i)).toFixed(dm);
+      const metrics = ["Bytes", "kB", "MB", "GB", "TB"];
+      const metric = i < metrics.length ? metrics[i] : "";
+      return `${isDecimalCollapsed ? parseFloat(value) : value} ${metric}`
     },
 
     bytesToGB: function(bytes) {


### PR DESCRIPTION
## What do these changes do?

- [x] Fix the Service Browser listing.
- [x] Fix the ``undefined`` unit in the Disk Usage's tooltip

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
