### PR TITLE
Is468/mark trash api as dev

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,6 +18,7 @@ flag_management:
 
 component_management:
   default_rules:
+    carryforward: true
     statuses:
       - type: project
         target: auto

--- a/services/web/server/src/simcore_service_webserver/projects/_trash_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_trash_handlers.py
@@ -14,6 +14,7 @@ from servicelib.logging_errors import create_troubleshotting_log_kwargs
 from servicelib.status_codes_utils import is_5xx_server_error
 
 from .._meta import API_VTAG as VTAG
+from ..application_settings_utils import requires_dev_feature_enabled
 from ..login.decorators import get_user_id, login_required
 from ..products.api import get_product_name
 from ..projects._common_models import ProjectPathParams
@@ -102,6 +103,7 @@ routes = web.RouteTableDef()
 
 
 @routes.delete(f"/{VTAG}/trash", name="empty_trash")
+@requires_dev_feature_enabled
 @login_required
 @permission_required("project.delete")
 @_handle_request_exceptions
@@ -117,6 +119,7 @@ async def empty_trash(request: web.Request):
 
 
 @routes.post(f"/{VTAG}/projects/{{project_id}}:trash", name="trash_project")
+@requires_dev_feature_enabled
 @login_required
 @permission_required("project.delete")
 @_handle_request_exceptions
@@ -140,6 +143,7 @@ async def trash_project(request: web.Request):
 
 
 @routes.post(f"/{VTAG}/projects/{{project_id}}:untrash", name="untrash_project")
+@requires_dev_feature_enabled
 @login_required
 @permission_required("project.delete")
 @_handle_request_exceptions

--- a/services/web/server/tests/unit/with_dbs/03/test_trash.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_trash.py
@@ -18,10 +18,21 @@ from models_library.api_schemas_webserver.projects import ProjectGet, ProjectLis
 from models_library.rest_pagination import Page
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
+from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
+from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.helpers.webserver_login import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.projects.models import ProjectDict
+
+
+@pytest.fixture
+def app_environment(
+    app_environment: EnvVarsDict, monkeypatch: pytest.MonkeyPatch
+) -> EnvVarsDict:
+    return app_environment | setenvs_from_dict(
+        monkeypatch, {"WEBSERVER_DEV_FEATURES_ENABLED": "1"}
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

- ♻️ Marks new web API entrypoints in https://github.com/ITISFoundation/osparc-simcore/pull/6579 as dev features i.e. can only be used with `WEBSERVER_DEV_FEATURES_ENABLED=1`
- 🔨 updates `.codecov.yaml` to avoid false positives in CI

## Related issue/s

- Follows up from https://github.com/ITISFoundation/osparc-simcore/pull/6579
- Part of https://github.com/ITISFoundation/osparc-issues/issues/468

## How to test
```
cd services/web/server
make install-dev
pytest -vv tests/unit/with_dbs/03/test_trash.py
```

## Dev-ops checklist

None