### PR TITLE
♻️ Migrates folders and workspaces repositories to asyncpg

### DIFF
--- a/services/web/server/src/simcore_service_webserver/folders/_folders_api.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_folders_api.py
@@ -262,7 +262,7 @@ async def update_folder(
 
     folder_db = await folders_db.update(
         app,
-        folder_id=folder_id,
+        folders_id_or_ids=folder_id,
         name=name,
         parent_folder_id=parent_folder_id,
         product_name=product_name,

--- a/services/web/server/src/simcore_service_webserver/folders/_folders_db.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_folders_db.py
@@ -221,7 +221,7 @@ async def get_for_user_or_workspace(
         return FolderDB.from_orm(row)
 
 
-async def _update_impl(
+async def update(
     app: web.Application,
     connection: AsyncConnection | None = None,
     *,
@@ -263,53 +263,6 @@ async def _update_impl(
         if row is None:
             raise FolderNotFoundError(reason=f"Folder {folders_id_or_ids} not found.")
         return FolderDB.from_orm(row)
-
-
-async def update_batch(
-    app: web.Application,
-    connection: AsyncConnection | None = None,
-    *folder_id: FolderID,
-    product_name: ProductName,
-    # updatable columns
-    name: str | UnSet = _unset,
-    parent_folder_id: FolderID | None | UnSet = _unset,
-    trashed_at: datetime | None | UnSet = _unset,
-    trashed_explicitly: bool | UnSet = _unset,
-) -> FolderDB:
-    return await _update_impl(
-        app=app,
-        connection=connection,
-        folders_id_or_ids=set(folder_id),
-        product_name=product_name,
-        name=name,
-        parent_folder_id=parent_folder_id,
-        trashed_at=trashed_at,
-        trashed_explicitly=trashed_explicitly,
-    )
-
-
-async def update(
-    app: web.Application,
-    connection: AsyncConnection | None = None,
-    *,
-    folder_id: FolderID,
-    product_name: ProductName,
-    # updatable columns
-    name: str | UnSet = _unset,
-    parent_folder_id: FolderID | None | UnSet = _unset,
-    trashed_at: datetime | None | UnSet = _unset,
-    trashed_explicitly: bool | UnSet = _unset,
-) -> FolderDB:
-    return await _update_impl(
-        app=app,
-        connection=connection,
-        folders_id_or_ids=folder_id,
-        product_name=product_name,
-        name=name,
-        parent_folder_id=parent_folder_id,
-        trashed_at=trashed_at,
-        trashed_explicitly=trashed_explicitly,
-    )
 
 
 async def delete_recursively(

--- a/services/web/server/src/simcore_service_webserver/folders/_trash_api.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_trash_api.py
@@ -63,7 +63,7 @@ async def _folders_db_update(
     # EXPLICIT un/trash
     await _folders_db.update(
         app,
-        folder_id=folder_id,
+        folders_id_or_ids=folder_id,
         product_name=product_name,
         trashed_at=trashed_at,
         trashed_explicitly=trashed_at is not None,
@@ -79,9 +79,9 @@ async def _folders_db_update(
     }
 
     if child_folders:
-        await _folders_db.update_batch(
+        await _folders_db.update(
             app,
-            *child_folders,
+            folders_id_or_ids=child_folders,
             product_name=product_name,
             trashed_at=trashed_at,
             trashed_explicitly=False,

--- a/services/web/server/src/simcore_service_webserver/workspaces/_groups_db.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_groups_db.py
@@ -55,7 +55,7 @@ async def create_workspace_group(
     delete: bool,
 ) -> WorkspaceGroupGetDB:
     async with transaction_context(get_asyncpg_engine(app), connection) as conn:
-        result = await conn.execute(
+        result = await conn.stream(
             workspaces_access_rights.insert()
             .values(
                 workspace_id=workspace_id,
@@ -68,7 +68,7 @@ async def create_workspace_group(
             )
             .returning(literal_column("*"))
         )
-        row = result.first()
+        row = await result.first()
         return WorkspaceGroupGetDB.from_orm(row)
 
 
@@ -120,8 +120,8 @@ async def get_workspace_group(
     )
 
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
-        result = await conn.execute(stmt)
-        row = result.first()
+        result = await conn.stream(stmt)
+        row = await result.first()
         if row is None:
             raise WorkspaceGroupNotFoundError(
                 workspace_id=workspace_id, group_id=group_id
@@ -140,7 +140,7 @@ async def update_workspace_group(
     delete: bool,
 ) -> WorkspaceGroupGetDB:
     async with transaction_context(get_asyncpg_engine(app), connection) as conn:
-        result = await conn.execute(
+        result = await conn.stream(
             workspaces_access_rights.update()
             .values(
                 read=read,
@@ -153,7 +153,7 @@ async def update_workspace_group(
             )
             .returning(literal_column("*"))
         )
-        row = result.first()
+        row = await result.first()
         if row is None:
             raise WorkspaceGroupNotFoundError(
                 workspace_id=workspace_id, group_id=group_id

--- a/services/web/server/src/simcore_service_webserver/workspaces/_groups_db.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_groups_db.py
@@ -92,9 +92,8 @@ async def list_workspace_groups(
     )
 
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
-        result = await conn.execute(stmt)
-        rows = result.fetchall() or []
-        return [WorkspaceGroupGetDB.from_orm(row) for row in rows]
+        result = await conn.stream(stmt)
+        return [WorkspaceGroupGetDB.from_orm(row) async for row in result]
 
 
 async def get_workspace_group(

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_db.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_db.py
@@ -160,13 +160,12 @@ async def list_workspaces_for_user(
         count_result = await conn.execute(count_query)
         total_count = count_result.scalar()
 
-        result = await conn.execute(list_query)
-        rows = result.fetchall() or []
-        results: list[UserWorkspaceAccessRightsDB] = [
-            UserWorkspaceAccessRightsDB.from_orm(row) for row in rows
+        result = await conn.stream(list_query)
+        workspaces: list[UserWorkspaceAccessRightsDB] = [
+            UserWorkspaceAccessRightsDB.from_orm(row) async for row in result
         ]
 
-        return cast(int, total_count), results
+        return cast(int, total_count), workspaces
 
 
 async def get_workspace_for_user(

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_db.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_db.py
@@ -161,11 +161,11 @@ async def list_workspaces_for_user(
         total_count = count_result.scalar()
 
         result = await conn.stream(list_query)
-        workspaces: list[UserWorkspaceAccessRightsDB] = [
+        items: list[UserWorkspaceAccessRightsDB] = [
             UserWorkspaceAccessRightsDB.from_orm(row) async for row in result
         ]
 
-        return cast(int, total_count), workspaces
+        return cast(int, total_count), items
 
 
 async def get_workspace_for_user(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This PR migrates the `folders` and `workspaces` repository layers to the new `asyncpg` engine. It also leverages the new `utils_repo` helpers to support building unit-of-work context managers.


## Related issue/s

- Preparation to create units-of-work for ITISFoundation/osparc-issues#468
- Part of https://github.com/ITISFoundation/osparc-simcore/issues/4529


## How to test

```
cd services/web/server
make install-dev
make test-dev-unit
```

## Dev-ops checklist
NOne