### PR TITLE
✅ Extends test_EC2_INSTANCES_ALLOWED_TYPES_empty_not_allowed

### DIFF
--- a/services/autoscaling/tests/unit/test_core_settings.py
+++ b/services/autoscaling/tests/unit/test_core_settings.py
@@ -208,10 +208,16 @@ def test_EC2_INSTANCES_ALLOWED_TYPES_empty_not_allowed(  # noqa: N802
 
     # now as part of AUTOSCALING_EC2_INSTANCES: EC2InstancesSettings | None
     assert os.environ["AUTOSCALING_EC2_INSTANCES"] == "{}"
+
+    with pytest.raises(ValidationError) as err_info:
+        ApplicationSettings.create_from_envs(AUTOSCALING_EC2_INSTANCES={})
+
+    before = err_info.value.errors()
+
     with pytest.raises(ValidationError) as err_info:
         ApplicationSettings.create_from_envs()
 
-    assert err_info.value.errors()
+    assert err_info.value.errors() == before
 
     # removing any value for AUTOSCALING_EC2_INSTANCES
     monkeypatch.delenv("AUTOSCALING_EC2_INSTANCES")

--- a/services/autoscaling/tests/unit/test_core_settings.py
+++ b/services/autoscaling/tests/unit/test_core_settings.py
@@ -228,6 +228,7 @@ def test_EC2_INSTANCES_ALLOWED_TYPES_empty_not_allowed_without_main_field_env_va
     app_environment: EnvVarsDict, monkeypatch: pytest.MonkeyPatch
 ):
     monkeypatch.delenv("AUTOSCALING_EC2_INSTANCES")
+    monkeypatch.setenv("EC2_INSTANCES_ALLOWED_TYPES", "{}")
 
     # removing any value for AUTOSCALING_EC2_INSTANCES
     settings = ApplicationSettings.create_from_envs()


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

In PR https://github.com/ITISFoundation/osparc-simcore/pull/6701, the test `test_EC2_INSTANCES_ALLOWED_TYPES_empty_not_allowed` fails with the new Pydantic version, but it unexpectedly passes with the previous version. This PR modifies the test to highlight a bug in our `BaseCustomsSettings` logic when using Pydantic v1. 

The bug originates from a workaround initially applied by @YuryHrytsuk on the refactoring of docker-compose environments  (this is also related to this change https://github.com/ITISFoundation/osparc-ops-environments/issues/866), which involved using an empty dictionary `{}` as an environment variable value to simulate an "unset" state. This workaround impacts fields set with `auto-default-factory=True`, where empty dicts `{}` mark fields as `UNSET`.

In particular, this test case focuses on the field `ApplicationSettings.AUTOSCALING_EC2_INSTANCES: EC2InstancesSettings | None`, which is a **nullable** field with an auto-default factory. The `test_EC2_INSTANCES_ALLOWED_TYPES_empty_not_allowed` test expects the auto-default factory to return `None`. Instead, it raises a `ValidationError` because `AUTOSCALING_EC2_INSTANCES={}` is misinterpreted as a valid assignment instead of as an unset state.

This PR enhances `test_EC2_INSTANCES_ALLOWED_TYPES_empty_not_allowed` to establish a foundation for the migration to Pydantic v2, as outlined in PR  https://github.com/ITISFoundation/osparc-simcore/pull/6701. In this migration, we **will address the issue by enforcing that `AUTOSCALING_EC2_INSTANCES={}` is treated as an explicit assignment rather than an "unset" sentinel.**


## Related issue/s

- https://github.com/ITISFoundation/osparc-simcore/pull/6701

## How to test

```
cd services/autoscaling
make install-dev
pytest -vv tests/unit -k test_EC2_INSTANCES_ALLOWED_TYPES_empty_not_allowed
```

## Dev-ops


