### PR TITLE
🔨 Fix: e2e Performance Tests in CI

### DIFF
--- a/tests/performance/Makefile
+++ b/tests/performance/Makefile
@@ -29,6 +29,7 @@ __check_defined = \
       $(error Undefined $1$(if $2, ($2))))
 
 
+
 .PHONY: build
 build: ## builds distributed osparc locust docker image
 	docker \
@@ -43,6 +44,8 @@ build: ## builds distributed osparc locust docker image
 push:
 	docker push itisfoundation/locust:$(LOCUST_VERSION)
 
+
+
 .PHONY: down
 down: ## stops and removes osparc locust containers
 	docker compose --file docker-compose.yml down
@@ -55,6 +58,8 @@ test: ## runs osparc locust. Locust and test configuration are specified in ENV_
 		echo "Created docker network $(NETWORK_NAME)"; \
 	fi
 	docker compose --file docker-compose.yml up --scale worker=4 --exit-code-from=master
+
+
 
 .PHONY: dashboards-up dashboards-down
 
@@ -69,6 +74,8 @@ dashboards-up: ## Create Grafana dashboard for inspecting locust results. See da
 dashboards-down:
 	@locust-compose down
 
+
+
 .PHONY: install-ci install-dev
 
 install-dev:
@@ -81,4 +88,4 @@ install-ci:
 .PHONY: config
 config:
 	@$(call check_defined, input, please define inputs when calling $@ - e.g. ```make $@ input="--help"```)
-	@uv run locust_settings.py $(input) | tee .env
+	@uv run locust_settings.py $(input) | tee "${ENV_FILE}"

--- a/tests/performance/Makefile
+++ b/tests/performance/Makefile
@@ -12,7 +12,8 @@ export ENV_FILE
 NETWORK_NAME=dashboards_timenet
 
 # UTILS
-get_my_ip := $(shell (hostname --all-ip-addresses || hostname -i) 2>/dev/null | cut --delimiter=" " --fields=1)
+# NOTE: keep short arguments for `cut` so it works in both BusyBox (alpine) AND Ubuntu
+get_my_ip := $(shell (hostname --all-ip-addresses || hostname -i) 2>/dev/null | cut -d " " -f 1)
 
 # Check that given variables are set and all have non-empty values,
 # die with an error otherwise.

--- a/tests/performance/locust_files/platform_ping_test.py
+++ b/tests/performance/locust_files/platform_ping_test.py
@@ -19,7 +19,7 @@ logging.basicConfig(level=logging.INFO)
 assert locust_plugins  # nosec
 
 
-class LocustAuth(BaseSettings):
+class MonitoringBasicAuth(BaseSettings):
     SC_USER_NAME: str = Field(default=..., examples=["<your username>"])
     SC_PASSWORD: str = Field(default=..., examples=["<your password>"])
 
@@ -27,7 +27,7 @@ class LocustAuth(BaseSettings):
 class WebApiUser(FastHttpUser):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        _auth = LocustAuth()
+        _auth = MonitoringBasicAuth()
         self.auth = (
             _auth.SC_USER_NAME,
             _auth.SC_PASSWORD,

--- a/tests/performance/locust_settings.py
+++ b/tests/performance/locust_settings.py
@@ -1,10 +1,21 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "parse",
+#     "pydantic",
+#     "pydantic-settings",
+# ]
+# ///
 # pylint: disable=unused-argument
 # pylint: disable=no-self-use
 # pylint: disable=no-name-in-module
 
+import importlib.util
+import inspect
 import json
 from datetime import timedelta
 from pathlib import Path
+from types import ModuleType
 from typing import Final
 
 from parse import Result, parse
@@ -24,6 +35,37 @@ _TEST_DIR: Final[Path] = Path(__file__).parent.resolve()
 _LOCUST_FILES_DIR: Final[Path] = _TEST_DIR / "locust_files"
 assert _TEST_DIR.is_dir()
 assert _LOCUST_FILES_DIR.is_dir()
+
+
+def _check_load_and_instantiate_settings_classes(file_path: str):
+    module_name = Path(file_path).stem
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        msg = f"Invalid {file_path=}"
+        raise ValueError(msg)
+
+    module: ModuleType = importlib.util.module_from_spec(spec)
+
+    # Execute the module in its own namespace
+    try:
+        spec.loader.exec_module(module)
+    except Exception as e:
+        msg = f"Failed to load module {module_name} from {file_path}"
+        raise ValueError(msg) from e
+
+    # Filter subclasses of BaseSettings
+    settings_classes = [
+        obj
+        for _, obj in inspect.getmembers(module, inspect.isclass)
+        if issubclass(obj, BaseSettings) and obj is not BaseSettings
+    ]
+
+    for settings_class in settings_classes:
+        try:
+            settings_class()
+        except Exception as e:
+            msg = f"Missing env vars for {settings_class.__name__} in {file_path=}: {e}"
+            raise ValueError(msg) from e
 
 
 class LocustSettings(BaseSettings):
@@ -87,6 +129,10 @@ class LocustSettings(BaseSettings):
         if not v.is_relative_to(_LOCUST_FILES_DIR):
             msg = f"{v} must be a test file relative to {_LOCUST_FILES_DIR}"
             raise ValueError(msg)
+
+        # NOTE: CHECK that all the env-vars are defined for this test
+        # _check_load_and_instantiate_settings_classes(f"{v}")
+
         return v.relative_to(_TEST_DIR)
 
     @field_serializer("LOCUST_RUN_TIME")

--- a/tests/performance/locust_settings.py
+++ b/tests/performance/locust_settings.py
@@ -44,8 +44,8 @@ class LocustSettings(BaseSettings):
     LOCUST_RUN_TIME: timedelta
     LOCUST_SPAWN_RATE: PositiveInt = Field(default=20)
 
-    # Options for Timescale + Grafana Dashboards
-    # SEE https://github.com/SvenskaSpel/locust-plugins/blob/master/locust_plugins/timescale/
+    # Timescale: Log and graph results using TimescaleDB and Grafana dashboards
+    # SEE https://github.com/SvenskaSpel/locust-plugins/tree/master/locust_plugins/dashboards
     #
     LOCUST_TIMESCALE: NonNegativeInt = Field(
         default=1,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?


This PR addresses the failure of performance tests to run in the CI environment after an e2e upgrade in Python.

- **Dependency Injection**: Adjusted `.env` generation as `make config` was producing an empty file. Now, dependencies are injected into `locust_settings.py` using `uv add --script ...`, allowing it to run as a standalone script.
- **CLI Argument Fix**: Corrected `cut` command arguments to ensure proper execution
- **Environment Variable Validation**: Added initial checks for additional required environment variables.



## Related issue/s

- portal e2e failures since `docker:latest` updated and installs new version of python

## How to test


## Dev-ops
None