### PR TITLE
🐛 [Frontend] TIP: New plan after creating its template

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -763,8 +763,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
 
             newStudyBtn.addListener("execute", () => {
               newStudyBtn.setValue(false);
-              // do not use cached templates
-              osparc.data.Resources.get("templates", {}, false)
+              osparc.data.Resources.get("templates")
                 .then(templates => {
                   if (templates) {
                     const newStudies = new osparc.dashboard.NewStudies(newStudiesData[product]);

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -766,7 +766,6 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
               // do not use cached templates
               osparc.data.Resources.get("templates", {}, false)
                 .then(templates => {
-                  console.log("templates", templates);
                   if (templates) {
                     const newStudies = new osparc.dashboard.NewStudies(newStudiesData[product]);
                     newStudies.addListener("templatesLoaded", () => {

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -721,7 +721,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
           break;
         case "tis":
         case "tiplite":
-          this.__addTIPPlusButtons();
+          this.__addTIPPlusButton();
           break;
         case "s4l":
         case "s4lacad":
@@ -745,24 +745,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       this._resourcesContainer.addNonResourceCard(newStudyBtn);
     },
 
-    __addTIPPlusButtons: function() {
-      osparc.data.Resources.get("templates")
-        .then(templates => {
-          if (templates) {
-            osparc.utils.Utils.fetchJSON("/resource/osparc/new_studies.json")
-              .then(newStudiesData => {
-                const product = osparc.product.Utils.getProductName()
-                if (product in newStudiesData) {
-                  const mode = this._resourcesContainer.getMode();
-                  const title = this.tr("New Plan");
-                  const newStudyBtn = (mode === "grid") ? new osparc.dashboard.GridButtonNew(title) : new osparc.dashboard.ListButtonNew(title);
-                  newStudyBtn.setCardKey("new-study");
-                  newStudyBtn.subscribeToFilterGroup("searchBarFilter");
-                  osparc.utils.Utils.setIdToWidget(newStudyBtn, "newStudyBtn");
-                  this._resourcesContainer.addNonResourceCard(newStudyBtn);
-                  newStudyBtn.addListener("execute", () => {
-                    newStudyBtn.setValue(false);
-
+    __addTIPPlusButton: function() {
                     const newStudies = new osparc.dashboard.NewStudies(newStudiesData[product]);
                     newStudies.addListener("templatesLoaded", () => {
                       newStudies.setGroupBy("category");

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -746,6 +746,28 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     },
 
     __addTIPPlusButton: function() {
+      const mode = this._resourcesContainer.getMode();
+      const title = this.tr("New Plan");
+      const newStudyBtn = (mode === "grid") ? new osparc.dashboard.GridButtonNew(title) : new osparc.dashboard.ListButtonNew(title);
+      newStudyBtn.setCardKey("new-study");
+      newStudyBtn.subscribeToFilterGroup("searchBarFilter");
+      osparc.utils.Utils.setIdToWidget(newStudyBtn, "newStudyBtn");
+      this._resourcesContainer.addNonResourceCard(newStudyBtn);
+      newStudyBtn.setEnabled(false);
+
+      osparc.utils.Utils.fetchJSON("/resource/osparc/new_studies.json")
+        .then(newStudiesData => {
+          const product = osparc.product.Utils.getProductName()
+          if (product in newStudiesData) {
+            newStudyBtn.setEnabled(true);
+
+            newStudyBtn.addListener("execute", () => {
+              newStudyBtn.setValue(false);
+              // do not use cached templates
+              osparc.data.Resources.get("templates", {}, false)
+                .then(templates => {
+                  console.log("templates", templates);
+                  if (templates) {
                     const newStudies = new osparc.dashboard.NewStudies(newStudiesData[product]);
                     newStudies.addListener("templatesLoaded", () => {
                       newStudies.setGroupBy("category");
@@ -764,9 +786,9 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
                       });
                       osparc.utils.Utils.setIdToWidget(win, "newStudiesWindow");
                     });
-                  });
-                }
-              });
+                  }
+                });
+            });
           }
         });
     },

--- a/services/static-webserver/client/source/class/osparc/info/StudyLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/StudyLarge.js
@@ -324,6 +324,10 @@ qx.Class.define("osparc.info.StudyLarge", {
           studyData["resourceType"] = this.__isTemplate ? "template" : "study";
           this.fireDataEvent("updateStudy", studyData);
           qx.event.message.Bus.getInstance().dispatchByName("updateStudy", studyData);
+          if (this.__isTemplate) {
+            // reload templates
+            osparc.data.Resources.get("templates", {}, false)
+          }
         })
         .catch(err => {
           console.error(err);


### PR DESCRIPTION
## What do these changes do?

The main plus button loads all the required information when the application loads. That's why if a mapped template becomes available after the start up, it wouldn't be available in the New Plans. This PR fixes this case.

New Plans after creating its template:
![PlusButtons](https://github.com/user-attachments/assets/7582870b-b8c7-400d-81aa-6daa1917c25a)

New Plans after renaming to the expected mapped name:
![PlusButtons](https://github.com/user-attachments/assets/f956ef22-39ba-4158-8495-7c5adbdbf7d9)

## Related issue/s

- closes https://github.com/ITISFoundation/osparc-issues/issues/1718

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
