### PR TITLE
🎨🐛 Enh/fix: frontend knows about ``trashedAt``

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/Folder.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Folder.js
@@ -37,6 +37,7 @@ qx.Class.define("osparc.data.model.Folder", {
       owner: folderData.owner,
       createdAt: new Date(folderData.createdAt),
       lastModified: new Date(folderData.modifiedAt),
+      trashedAt: folderData.trashedAt ? new Date(folderData.trashedAt) : this.getTrashedAt(),
     });
   },
 
@@ -95,7 +96,13 @@ qx.Class.define("osparc.data.model.Folder", {
       nullable: true,
       init: null,
       event: "changeLastModified"
-    }
+    },
+
+    trashedAt: {
+      check: "Date",
+      nullable: true,
+      init: null,
+    },
   },
 
   statics: {

--- a/services/static-webserver/client/source/class/osparc/data/model/Study.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Study.js
@@ -58,7 +58,8 @@ qx.Class.define("osparc.data.model.Study", {
       state: studyData.state || this.getState(),
       quality: studyData.quality || this.getQuality(),
       permalink: studyData.permalink || this.getPermalink(),
-      dev: studyData.dev || this.getDev()
+      dev: studyData.dev || this.getDev(),
+      trashedAt: studyData.trashedAt ? new Date(studyData.trashedAt) : this.getTrashedAt(),
     });
 
     const wbData = studyData.workbench || this.getWorkbench();
@@ -209,7 +210,13 @@ qx.Class.define("osparc.data.model.Study", {
       nullable: true,
       event: "changeReadOnly",
       init: true
-    }
+    },
+
+    trashedAt: {
+      check: "Date",
+      nullable: true,
+      init: null,
+    },
     // ------ ignore for serializing ------
   },
 
@@ -218,7 +225,8 @@ qx.Class.define("osparc.data.model.Study", {
       "permalink",
       "state",
       "pipelineRunning",
-      "readOnly"
+      "readOnly",
+      "trashedAt",
     ],
 
     IgnoreModelizationProps: [

--- a/services/static-webserver/client/source/class/osparc/store/Folders.js
+++ b/services/static-webserver/client/source/class/osparc/store/Folders.js
@@ -141,6 +141,8 @@ qx.Class.define("osparc.store.Folders", {
             folder.set("createdAt", new Date(folderData["createdAt"]));
           } else if (key === "modifiedAt") {
             folder.set("lastModified", new Date(folderData["modifiedAt"]));
+          } else if (key === "trashedAt") {
+            folder.set("trashedAt", new Date(folderData["trashedAt"]));
           } else {
             folder.set(key, folderData[key]);
           }


### PR DESCRIPTION
## What do these changes do?

The backend is already providing the ``trashedAt`` property, while the frontend [doesn't yet know](https://github.com/ITISFoundation/osparc-simcore/pull/6590/) how to handle it.

This PR brings some "Trash bin" logic to the frontend to make it compatible with the current frontend.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
