### PR TITLE
  🎨 web-server api: ordering parameters and simplified openapi specs for complex query parameters

### DIFF
--- a/api/specs/web-server/_common.py
+++ b/api/specs/web-server/_common.py
@@ -63,10 +63,8 @@ def as_query(model_class: type[BaseModel]) -> type[BaseModel]:
                 example=kwargs.get("example_json"),
             )
             default_value = json_dumps(default_value) if default_value else None
-            fields[field_name] = (field_type, Query(default=default_value, **kwargs))
-        else:
-            # Regular fields
-            fields[field_name] = (field_type, Query(default=default_value, **kwargs))
+
+        fields[field_name] = (field_type, Query(default=default_value, **kwargs))
 
     new_model_name = f"{model_class.__name__}Query"
     return create_model(new_model_name, **fields)

--- a/api/specs/web-server/_common.py
+++ b/api/specs/web-server/_common.py
@@ -120,6 +120,9 @@ def assert_handler_signature_against_model(
         for field in model_cls.__fields__.values()
     ]
 
-    assert {p.name for p in implemented_params}.issubset(  # nosec
-        {p.name for p in specs_params}
-    ), f"Entrypoint {handler} does not implement OAS"
+    implemented_names = {p.name for p in implemented_params}
+    specified_names = {p.name for p in specs_params}
+
+    if not implemented_names.issubset(specified_names):
+        msg = f"Entrypoint {handler} does not implement OAS: {implemented_names} not in {specified_names}"
+        raise AssertionError(msg)

--- a/api/specs/web-server/_common.py
+++ b/api/specs/web-server/_common.py
@@ -8,13 +8,65 @@ from pathlib import Path
 from typing import Any, ClassVar, NamedTuple
 
 import yaml
-from fastapi import FastAPI
+from fastapi import FastAPI, Query
 from models_library.basic_types import LogLevel
-from pydantic import BaseModel, Field
+from models_library.utils.json_serialization import json_dumps
+from pydantic import BaseModel, Field, create_model
 from pydantic.fields import FieldInfo
 from servicelib.fastapi.openapi import override_fastapi_openapi_method
 
 CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
+
+
+def _create_json_type(**schema_extras):
+    class _Json(str):
+        __slots__ = ()
+
+        @classmethod
+        def __modify_schema__(cls, field_schema: dict[str, Any]) -> None:
+            # openapi.json schema is corrected here
+            field_schema.update(type="string", format="json-string")
+            if schema_extras:
+                field_schema.update(schema_extras)
+
+    return _Json
+
+
+def as_query(model_class: type[BaseModel]) -> type[BaseModel]:
+    fields = {}
+    for field_name, model_field in model_class.__fields__.items():
+
+        field_type = model_field.type_
+        default_value = model_field.default
+
+        kwargs = {
+            "alias": model_field.field_info.alias,
+            "title": model_field.field_info.title,
+            "description": model_field.field_info.description,
+            "gt": model_field.field_info.gt,
+            "ge": model_field.field_info.ge,
+            "lt": model_field.field_info.lt,
+            "le": model_field.field_info.le,
+            "min_length": model_field.field_info.min_length,
+            "max_length": model_field.field_info.max_length,
+            "regex": model_field.field_info.regex,
+            **model_field.field_info.extra,
+        }
+
+        if issubclass(field_type, BaseModel):
+            # Complex fields
+            field_type = _create_json_type(
+                description=kwargs["description"],
+                example=kwargs.get("example_json"),
+            )
+            default_value = json_dumps(default_value) if default_value else None
+            fields[field_name] = (field_type, Query(default=default_value, **kwargs))
+        else:
+            # Regular fields
+            fields[field_name] = (field_type, Query(default=default_value, **kwargs))
+
+    new_model_name = f"{model_class.__name__}Query"
+    return create_model(new_model_name, **fields)
 
 
 class Log(BaseModel):

--- a/api/specs/web-server/_common.py
+++ b/api/specs/web-server/_common.py
@@ -25,7 +25,10 @@ def _create_json_type(**schema_extras):
         @classmethod
         def __modify_schema__(cls, field_schema: dict[str, Any]) -> None:
             # openapi.json schema is corrected here
-            field_schema.update(type="string", format="json-string")
+            field_schema.update(
+                type="string",
+                # format="json-string" NOTE: we need to get rid of openapi-core in web-server before using this!
+            )
             if schema_extras:
                 field_schema.update(schema_extras)
 

--- a/api/specs/web-server/_folders.py
+++ b/api/specs/web-server/_folders.py
@@ -48,7 +48,7 @@ async def create_folder(
     response_model=Envelope[list[FolderGet]],
 )
 async def list_folders(
-    _q: Annotated[as_query(FoldersListQueryParams), Depends()],
+    _query: Annotated[as_query(FoldersListQueryParams), Depends()],
 ):
     ...
 
@@ -58,7 +58,7 @@ async def list_folders(
     response_model=Envelope[list[FolderGet]],
 )
 async def list_folders_full_search(
-    _q: Annotated[as_query(FolderSearchQueryParams), Depends()],
+    _query: Annotated[as_query(FolderSearchQueryParams), Depends()],
 ):
     ...
 
@@ -68,7 +68,7 @@ async def list_folders_full_search(
     response_model=Envelope[FolderGet],
 )
 async def get_folder(
-    _p: Annotated[FoldersPathParams, Depends()],
+    _path: Annotated[FoldersPathParams, Depends()],
 ):
     ...
 
@@ -78,7 +78,7 @@ async def get_folder(
     response_model=Envelope[FolderGet],
 )
 async def replace_folder(
-    _p: Annotated[FoldersPathParams, Depends()],
+    _path: Annotated[FoldersPathParams, Depends()],
     _b: PutFolderBodyParams,
 ):
     ...
@@ -89,6 +89,6 @@ async def replace_folder(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_folder(
-    _p: Annotated[FoldersPathParams, Depends()],
+    _path: Annotated[FoldersPathParams, Depends()],
 ):
     ...

--- a/api/specs/web-server/_folders.py
+++ b/api/specs/web-server/_folders.py
@@ -9,46 +9,20 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, status
 from models_library.api_schemas_webserver.folders_v2 import (
     CreateFolderBodyParams,
     FolderGet,
     PutFolderBodyParams,
 )
-from models_library.folders import FolderID
 from models_library.generics import Envelope
-from models_library.rest_base import RequestParameters
 from models_library.rest_pagination import PageQueryParameters
-from models_library.workspaces import WorkspaceID
-from pydantic import Json
 from simcore_service_webserver._meta import API_VTAG
 from simcore_service_webserver.folders._models import (
-    FolderFilters,
-    FolderOrderQueryParamsOpenApi,
+    FolderListFullSearchQueryParams,
+    FoldersListQueryParams,
     FoldersPathParams,
 )
-
-
-class _ListExtraQueryParams(RequestParameters):
-    workspace_id: WorkspaceID | None = None
-    folder_id: FolderID | None = None
-
-
-class _FiltersQueryParams(RequestParameters):
-    filters: Annotated[
-        Json | None,
-        Query(description=FolderFilters.schema_json(indent=1)),
-    ] = None
-
-
-class _ListQueryParams(  # type: ignore
-    FolderOrderQueryParamsOpenApi,
-    _FiltersQueryParams,
-    PageQueryParameters,
-    _ListExtraQueryParams,
-):
-    ...
-
 
 router = APIRouter(
     prefix=f"/{API_VTAG}",
@@ -72,7 +46,7 @@ async def create_folder(_b: CreateFolderBodyParams):
     response_model=Envelope[list[FolderGet]],
 )
 async def list_folders(
-    _q: Annotated[_ListQueryParams, Depends()],
+    _q: Annotated[FoldersListQueryParams, Depends()],
 ):
     ...
 
@@ -82,19 +56,8 @@ async def list_folders(
     response_model=Envelope[list[FolderGet]],
 )
 async def list_folders_full_search(
-    params: Annotated[PageQueryParameters, Depends()],
-    text: str | None = None,
-    order_by: Annotated[
-        Json,
-        Query(
-            description="Order by field (modified_at|name|description) and direction (asc|desc). The default sorting order is ascending.",
-            example='{"field": "name", "direction": "desc"}',
-        ),
-    ] = '{"field": "modified_at", "direction": "desc"}',
-    filters: Annotated[
-        Json | None,
-        Query(description=FolderFilters.schema_json(indent=1)),
-    ] = None,
+    _p: Annotated[PageQueryParameters, Depends()],
+    _q: Annotated[FolderListFullSearchQueryParams, Depends()],
 ):
     ...
 

--- a/api/specs/web-server/_folders.py
+++ b/api/specs/web-server/_folders.py
@@ -24,7 +24,7 @@ from pydantic import Json
 from simcore_service_webserver._meta import API_VTAG
 from simcore_service_webserver.folders._models import (
     FolderFilters,
-    FolderSortJsonQueryParams,
+    FolderSortQueryParamsOpenApi,
     FoldersPathParams,
 )
 
@@ -41,8 +41,8 @@ class _FiltersQueryParams(RequestParameters):
     ] = None
 
 
-class _ListQueryParams(
-    FolderSortJsonQueryParams,
+class _ListQueryParams(  # type: ignore
+    FolderSortQueryParamsOpenApi,
     _FiltersQueryParams,
     PageQueryParameters,
     _ScopeQueryParams,

--- a/api/specs/web-server/_folders.py
+++ b/api/specs/web-server/_folders.py
@@ -9,6 +9,7 @@
 
 from typing import Annotated
 
+from _common import as_query
 from fastapi import APIRouter, Depends, status
 from models_library.api_schemas_webserver.folders_v2 import (
     CreateFolderBodyParams,
@@ -48,7 +49,7 @@ async def create_folder(
     response_model=Envelope[list[FolderGet]],
 )
 async def list_folders(
-    _q: Annotated[FoldersListQueryParams, Depends()],
+    _q: Annotated[as_query(FoldersListQueryParams), Depends()],
 ):
     ...
 
@@ -59,7 +60,7 @@ async def list_folders(
 )
 async def list_folders_full_search(
     _p: Annotated[PageQueryParameters, Depends()],
-    _q: Annotated[FolderSearchQueryParams, Depends()],
+    _q: Annotated[as_query(FolderSearchQueryParams), Depends()],
 ):
     ...
 

--- a/api/specs/web-server/_folders.py
+++ b/api/specs/web-server/_folders.py
@@ -17,7 +17,6 @@ from models_library.api_schemas_webserver.folders_v2 import (
     PutFolderBodyParams,
 )
 from models_library.generics import Envelope
-from models_library.rest_pagination import PageQueryParameters
 from simcore_service_webserver._meta import API_VTAG
 from simcore_service_webserver.folders._models import (
     FolderSearchQueryParams,
@@ -59,7 +58,6 @@ async def list_folders(
     response_model=Envelope[list[FolderGet]],
 )
 async def list_folders_full_search(
-    _p: Annotated[PageQueryParameters, Depends()],
     _q: Annotated[as_query(FolderSearchQueryParams), Depends()],
 ):
     ...

--- a/api/specs/web-server/_folders.py
+++ b/api/specs/web-server/_folders.py
@@ -24,12 +24,12 @@ from pydantic import Json
 from simcore_service_webserver._meta import API_VTAG
 from simcore_service_webserver.folders._models import (
     FolderFilters,
-    FolderSortQueryParamsOpenApi,
+    FolderOrderQueryParamsOpenApi,
     FoldersPathParams,
 )
 
 
-class _ScopeQueryParams(RequestParameters):
+class _ListExtraQueryParams(RequestParameters):
     workspace_id: WorkspaceID | None = None
     folder_id: FolderID | None = None
 
@@ -42,10 +42,10 @@ class _FiltersQueryParams(RequestParameters):
 
 
 class _ListQueryParams(  # type: ignore
-    FolderSortQueryParamsOpenApi,
+    FolderOrderQueryParamsOpenApi,
     _FiltersQueryParams,
     PageQueryParameters,
-    _ScopeQueryParams,
+    _ListExtraQueryParams,
 ):
     ...
 

--- a/api/specs/web-server/_folders.py
+++ b/api/specs/web-server/_folders.py
@@ -19,7 +19,7 @@ from models_library.generics import Envelope
 from models_library.rest_pagination import PageQueryParameters
 from simcore_service_webserver._meta import API_VTAG
 from simcore_service_webserver.folders._models import (
-    FolderListFullSearchQueryParams,
+    FolderSearchQueryParams,
     FoldersListQueryParams,
     FoldersPathParams,
 )
@@ -37,7 +37,9 @@ router = APIRouter(
     response_model=Envelope[FolderGet],
     status_code=status.HTTP_201_CREATED,
 )
-async def create_folder(_b: CreateFolderBodyParams):
+async def create_folder(
+    _b: CreateFolderBodyParams,
+):
     ...
 
 
@@ -57,7 +59,7 @@ async def list_folders(
 )
 async def list_folders_full_search(
     _p: Annotated[PageQueryParameters, Depends()],
-    _q: Annotated[FolderListFullSearchQueryParams, Depends()],
+    _q: Annotated[FolderSearchQueryParams, Depends()],
 ):
     ...
 
@@ -66,7 +68,9 @@ async def list_folders_full_search(
     "/folders/{folder_id}",
     response_model=Envelope[FolderGet],
 )
-async def get_folder(_path: Annotated[FoldersPathParams, Depends()]):
+async def get_folder(
+    _p: Annotated[FoldersPathParams, Depends()],
+):
     ...
 
 
@@ -75,7 +79,8 @@ async def get_folder(_path: Annotated[FoldersPathParams, Depends()]):
     response_model=Envelope[FolderGet],
 )
 async def replace_folder(
-    _path: Annotated[FoldersPathParams, Depends()], _body: PutFolderBodyParams
+    _p: Annotated[FoldersPathParams, Depends()],
+    _b: PutFolderBodyParams,
 ):
     ...
 
@@ -84,5 +89,7 @@ async def replace_folder(
     "/folders/{folder_id}",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def delete_folder(_path: Annotated[FoldersPathParams, Depends()]):
+async def delete_folder(
+    _p: Annotated[FoldersPathParams, Depends()],
+):
     ...

--- a/api/specs/web-server/_folders.py
+++ b/api/specs/web-server/_folders.py
@@ -38,7 +38,7 @@ router = APIRouter(
     status_code=status.HTTP_201_CREATED,
 )
 async def create_folder(
-    _b: CreateFolderBodyParams,
+    _body: CreateFolderBodyParams,
 ):
     ...
 
@@ -79,7 +79,7 @@ async def get_folder(
 )
 async def replace_folder(
     _path: Annotated[FoldersPathParams, Depends()],
-    _b: PutFolderBodyParams,
+    _body: PutFolderBodyParams,
 ):
     ...
 

--- a/api/specs/web-server/_groups.py
+++ b/api/specs/web-server/_groups.py
@@ -48,7 +48,7 @@ async def list_groups():
     response_model=Envelope[GroupGet],
     status_code=status.HTTP_201_CREATED,
 )
-async def create_group(_b: GroupCreate):
+async def create_group(_body: GroupCreate):
     """
     Creates an organization group
     """
@@ -58,7 +58,7 @@ async def create_group(_b: GroupCreate):
     "/groups/{gid}",
     response_model=Envelope[GroupGet],
 )
-async def get_group(_p: Annotated[_GroupPathParams, Depends()]):
+async def get_group(_path: Annotated[_GroupPathParams, Depends()]):
     """
     Get an organization group
     """
@@ -69,8 +69,8 @@ async def get_group(_p: Annotated[_GroupPathParams, Depends()]):
     response_model=Envelope[GroupGet],
 )
 async def update_group(
-    _p: Annotated[_GroupPathParams, Depends()],
-    _b: GroupUpdate,
+    _path: Annotated[_GroupPathParams, Depends()],
+    _body: GroupUpdate,
 ):
     """
     Updates organization groups
@@ -81,7 +81,7 @@ async def update_group(
     "/groups/{gid}",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def delete_group(_p: Annotated[_GroupPathParams, Depends()]):
+async def delete_group(_path: Annotated[_GroupPathParams, Depends()]):
     """
     Deletes organization groups
     """
@@ -91,7 +91,7 @@ async def delete_group(_p: Annotated[_GroupPathParams, Depends()]):
     "/groups/{gid}/users",
     response_model=Envelope[list[GroupUserGet]],
 )
-async def get_all_group_users(_p: Annotated[_GroupPathParams, Depends()]):
+async def get_all_group_users(_path: Annotated[_GroupPathParams, Depends()]):
     """
     Gets users in organization groups
     """
@@ -102,8 +102,8 @@ async def get_all_group_users(_p: Annotated[_GroupPathParams, Depends()]):
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def add_group_user(
-    _p: Annotated[_GroupPathParams, Depends()],
-    _b: GroupUserAdd,
+    _path: Annotated[_GroupPathParams, Depends()],
+    _body: GroupUserAdd,
 ):
     """
     Adds a user to an organization group
@@ -115,7 +115,7 @@ async def add_group_user(
     response_model=Envelope[GroupUserGet],
 )
 async def get_group_user(
-    _p: Annotated[_GroupUserPathParams, Depends()],
+    _path: Annotated[_GroupUserPathParams, Depends()],
 ):
     """
     Gets specific user in an organization group
@@ -127,8 +127,8 @@ async def get_group_user(
     response_model=Envelope[GroupUserGet],
 )
 async def update_group_user(
-    _p: Annotated[_GroupUserPathParams, Depends()],
-    _b: GroupUserUpdate,
+    _path: Annotated[_GroupUserPathParams, Depends()],
+    _body: GroupUserUpdate,
 ):
     """
     Updates user (access-rights) to an organization group
@@ -140,7 +140,7 @@ async def update_group_user(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_group_user(
-    _p: Annotated[_GroupUserPathParams, Depends()],
+    _path: Annotated[_GroupUserPathParams, Depends()],
 ):
     """
     Removes a user from an organization group
@@ -157,8 +157,8 @@ async def delete_group_user(
     response_model=Envelope[dict[str, Any]],
 )
 async def get_group_classifiers(
-    _p: Annotated[_GroupPathParams, Depends()],
-    _q: Annotated[_ClassifiersQuery, Depends()],
+    _path: Annotated[_GroupPathParams, Depends()],
+    _query: Annotated[_ClassifiersQuery, Depends()],
 ):
     ...
 

--- a/api/specs/web-server/_projects_crud.py
+++ b/api/specs/web-server/_projects_crud.py
@@ -27,7 +27,7 @@ from models_library.generics import Envelope
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.rest_base import RequestParameters
-from models_library.rest_pagination import Page
+from models_library.rest_pagination import Page, PageQueryParameters
 from pydantic import Json
 from simcore_service_webserver._meta import API_VTAG
 from simcore_service_webserver.projects._common_models import ProjectPathParams
@@ -44,9 +44,10 @@ class _FiltersQueryParams(RequestParameters):
 
 
 class _ListQueryParams(  # type: ignore
-    ProjectListExtraQueryParams,
     ProjectListOrderParamsOpenApi,
     _FiltersQueryParams,
+    PageQueryParameters,
+    ProjectListExtraQueryParams,
 ):
     ...
 

--- a/api/specs/web-server/_projects_crud.py
+++ b/api/specs/web-server/_projects_crud.py
@@ -33,9 +33,9 @@ from simcore_service_webserver._meta import API_VTAG
 from simcore_service_webserver.projects._common_models import ProjectPathParams
 from simcore_service_webserver.projects._crud_handlers import ProjectCreateParams
 from simcore_service_webserver.projects._crud_handlers_models import (
+    ProjectListExtraQueryParams,
     ProjectListFullSearchParams,
-    ProjectListParams,
-    ProjectListSortParamsOpenApi,
+    ProjectListOrderParamsOpenApi,
 )
 
 
@@ -44,7 +44,8 @@ class _FiltersQueryParams(RequestParameters):
 
 
 class _ListQueryParams(  # type: ignore
-    ProjectListSortParamsOpenApi,
+    ProjectListExtraQueryParams,
+    ProjectListOrderParamsOpenApi,
     _FiltersQueryParams,
 ):
     ...
@@ -89,7 +90,6 @@ async def create_project(
     response_model=Page[ProjectListItem],
 )
 async def list_projects(
-    _p: Annotated[ProjectListParams, Depends()],
     _q: Annotated[_ListQueryParams, Depends()],
 ):
     ...

--- a/api/specs/web-server/_projects_crud.py
+++ b/api/specs/web-server/_projects_crud.py
@@ -70,7 +70,7 @@ class _ProjectCreateHeaderParams(BaseModel):
 )
 async def create_project(
     _h: Annotated[_ProjectCreateHeaderParams, Depends()],
-    _p: Annotated[ProjectCreateParams, Depends()],
+    _path: Annotated[ProjectCreateParams, Depends()],
     _b: ProjectCreateNew | ProjectCopyOverride,
 ):
     ...
@@ -81,7 +81,7 @@ async def create_project(
     response_model=Page[ProjectListItem],
 )
 async def list_projects(
-    _q: Annotated[as_query(ProjectsListQueryParams), Depends()],
+    _query: Annotated[as_query(ProjectsListQueryParams), Depends()],
 ):
     ...
 
@@ -91,7 +91,7 @@ async def list_projects(
     response_model=Envelope[ProjectGet],
 )
 async def get_active_project(
-    _q: Annotated[ProjectActiveQueryParams, Depends()],
+    _query: Annotated[ProjectActiveQueryParams, Depends()],
 ):
     ...
 
@@ -101,7 +101,7 @@ async def get_active_project(
     response_model=Envelope[ProjectGet],
 )
 async def get_project(
-    _p: Annotated[ProjectPathParams, Depends()],
+    _path: Annotated[ProjectPathParams, Depends()],
 ):
     ...
 
@@ -112,7 +112,7 @@ async def get_project(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def patch_project(
-    _p: Annotated[ProjectPathParams, Depends()],
+    _path: Annotated[ProjectPathParams, Depends()],
     _b: ProjectPatch,
 ):
     ...
@@ -123,7 +123,7 @@ async def patch_project(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_project(
-    _p: Annotated[ProjectPathParams, Depends()],
+    _path: Annotated[ProjectPathParams, Depends()],
 ):
     ...
 
@@ -134,7 +134,7 @@ async def delete_project(
     status_code=status.HTTP_201_CREATED,
 )
 async def clone_project(
-    _p: Annotated[ProjectPathParams, Depends()],
+    _path: Annotated[ProjectPathParams, Depends()],
 ):
     ...
 
@@ -144,7 +144,7 @@ async def clone_project(
     response_model=Page[ProjectListItem],
 )
 async def list_projects_full_search(
-    _q: Annotated[as_query(ProjectsSearchQueryParams), Depends()],
+    _query: Annotated[as_query(ProjectsSearchQueryParams), Depends()],
 ):
     ...
 
@@ -155,6 +155,6 @@ async def list_projects_full_search(
     status_code=status.HTTP_200_OK,
 )
 async def get_project_inactivity(
-    _p: Annotated[ProjectPathParams, Depends()],
+    _path: Annotated[ProjectPathParams, Depends()],
 ):
     ...

--- a/api/specs/web-server/_projects_crud.py
+++ b/api/specs/web-server/_projects_crud.py
@@ -86,10 +86,10 @@ async def create_project(
     response_model=Page[ProjectListItem],
 )
 async def list_projects(
-    _xq: Annotated[ListProjectsExtraQueryParams, Depends()],
-    _oq: Annotated[_OrderQueryParams, Depends()],
-    _fq: Annotated[_FiltersQueryParams, Depends()],
-    _pq: Annotated[PageQueryParameters, Depends()],
+    _qo: Annotated[_OrderQueryParams, Depends()],
+    _qf: Annotated[_FiltersQueryParams, Depends()],
+    _qp: Annotated[PageQueryParameters, Depends()],
+    _qx: Annotated[ListProjectsExtraQueryParams, Depends()],
 ):
     ...
 

--- a/api/specs/web-server/_projects_crud.py
+++ b/api/specs/web-server/_projects_crud.py
@@ -47,7 +47,9 @@ router = APIRouter(
 
 
 class _ProjectCreateHeaderParams(BaseModel):
-    x_simcore_user_agent: Annotated[str | None, Header()] = "undefined"
+    x_simcore_user_agent: Annotated[
+        str | None, Header(description="Optional simcore user agent")
+    ] = "undefined"
     x_simcore_parent_project_uuid: Annotated[
         ProjectID | None,
         Header(

--- a/api/specs/web-server/_projects_crud.py
+++ b/api/specs/web-server/_projects_crud.py
@@ -33,9 +33,9 @@ from simcore_service_webserver._meta import API_VTAG
 from simcore_service_webserver.projects._common_models import ProjectPathParams
 from simcore_service_webserver.projects._crud_handlers import ProjectCreateParams
 from simcore_service_webserver.projects._crud_handlers_models import (
-    ProjectListExtraQueryParams,
-    ProjectListFullSearchParams,
-    ProjectListOrderParamsOpenApi,
+    ListProjectsExtraQueryParams,
+    ListProjectsOrderParamsOpenApi,
+    SearchProjectExtraQueryParams,
 )
 
 
@@ -43,12 +43,7 @@ class _FiltersQueryParams(RequestParameters):
     filters: Annotated[Json | None, Query()] = None
 
 
-class _ListQueryParams(  # type: ignore
-    ProjectListOrderParamsOpenApi,
-    _FiltersQueryParams,
-    PageQueryParameters,
-    ProjectListExtraQueryParams,
-):
+class _OrderQueryParams(ListProjectsOrderParamsOpenApi):
     ...
 
 
@@ -91,7 +86,10 @@ async def create_project(
     response_model=Page[ProjectListItem],
 )
 async def list_projects(
-    _q: Annotated[_ListQueryParams, Depends()],
+    _xq: Annotated[ListProjectsExtraQueryParams, Depends()],
+    _oq: Annotated[_OrderQueryParams, Depends()],
+    _fq: Annotated[_FiltersQueryParams, Depends()],
+    _pq: Annotated[PageQueryParameters, Depends()],
 ):
     ...
 
@@ -142,10 +140,10 @@ async def clone_project(
 
 @router.get(
     "/projects:search",
-    response_model=Page[ProjectListFullSearchParams],
+    response_model=Page[SearchProjectExtraQueryParams],
 )
 async def list_projects_full_search(
-    _params: Annotated[ProjectListFullSearchParams, Depends()],
+    _params: Annotated[SearchProjectExtraQueryParams, Depends()],
     order_by: Annotated[
         Json,
         Query(

--- a/api/specs/web-server/_projects_crud.py
+++ b/api/specs/web-server/_projects_crud.py
@@ -71,7 +71,7 @@ class _ProjectCreateHeaderParams(BaseModel):
 async def create_project(
     _h: Annotated[_ProjectCreateHeaderParams, Depends()],
     _path: Annotated[ProjectCreateParams, Depends()],
-    _b: ProjectCreateNew | ProjectCopyOverride,
+    _body: ProjectCreateNew | ProjectCopyOverride,
 ):
     ...
 
@@ -113,7 +113,7 @@ async def get_project(
 )
 async def patch_project(
     _path: Annotated[ProjectPathParams, Depends()],
-    _b: ProjectPatch,
+    _body: ProjectPatch,
 ):
     ...
 

--- a/api/specs/web-server/_projects_crud.py
+++ b/api/specs/web-server/_projects_crud.py
@@ -11,6 +11,7 @@ This OAS are the source of truth
 
 from typing import Annotated
 
+from _common import as_query
 from fastapi import APIRouter, Depends, Header, status
 from models_library.api_schemas_directorv2.dynamic_services import (
     GetProjectInactivityResponse,
@@ -80,7 +81,7 @@ async def create_project(
     response_model=Page[ProjectListItem],
 )
 async def list_projects(
-    _q: Annotated[ProjectsListQueryParams, Depends()],
+    _q: Annotated[as_query(ProjectsListQueryParams), Depends()],
 ):
     ...
 
@@ -143,7 +144,7 @@ async def clone_project(
     response_model=Page[ProjectListItem],
 )
 async def list_projects_full_search(
-    _q: Annotated[ProjectsSearchQueryParams, Depends()],
+    _q: Annotated[as_query(ProjectsSearchQueryParams), Depends()],
 ):
     ...
 

--- a/api/specs/web-server/_resource_usage.py
+++ b/api/specs/web-server/_resource_usage.py
@@ -135,7 +135,7 @@ async def get_pricing_plan(
     tags=["admin"],
 )
 async def create_pricing_plan(
-    _b: CreatePricingPlanBodyParams,
+    _body: CreatePricingPlanBodyParams,
 ):
     ...
 
@@ -148,7 +148,7 @@ async def create_pricing_plan(
 )
 async def update_pricing_plan(
     _path: Annotated[PricingPlanGetPathParams, Depends()],
-    _b: UpdatePricingPlanBodyParams,
+    _body: UpdatePricingPlanBodyParams,
 ):
     ...
 
@@ -176,7 +176,7 @@ async def get_pricing_unit(
 )
 async def create_pricing_unit(
     _path: Annotated[PricingPlanGetPathParams, Depends()],
-    _b: CreatePricingUnitBodyParams,
+    _body: CreatePricingUnitBodyParams,
 ):
     ...
 
@@ -189,7 +189,7 @@ async def create_pricing_unit(
 )
 async def update_pricing_unit(
     _path: Annotated[PricingUnitGetPathParams, Depends()],
-    _b: UpdatePricingUnitBodyParams,
+    _body: UpdatePricingUnitBodyParams,
 ):
     ...
 
@@ -217,6 +217,6 @@ async def list_connected_services_to_pricing_plan(
 )
 async def connect_service_to_pricing_plan(
     _path: Annotated[PricingPlanGetPathParams, Depends()],
-    _b: ConnectServiceToPricingPlanBodyParams,
+    _body: ConnectServiceToPricingPlanBodyParams,
 ):
     ...

--- a/api/specs/web-server/_resource_usage.py
+++ b/api/specs/web-server/_resource_usage.py
@@ -11,7 +11,6 @@ This OAS are the source of truth
 
 from typing import Annotated
 
-from _common import assert_handler_signature_against_model
 from fastapi import APIRouter, Depends, Query, status
 from models_library.api_schemas_resource_usage_tracker.service_runs import (
     OsparcCreditsAggregatedByServiceGet,
@@ -30,8 +29,6 @@ from models_library.api_schemas_webserver.resource_usage import (
 )
 from models_library.generics import Envelope
 from models_library.resource_tracker import (
-    PricingPlanId,
-    PricingUnitId,
     ServicesAggregatedUsagesTimePeriod,
     ServicesAggregatedUsagesType,
 )
@@ -68,14 +65,6 @@ class _OrderQueryParams(ListResourceUsagesOrderQueryParamsOpenApi):
     ...
 
 
-class _ListQueryParams(  # type: ignore
-    _OrderQueryParams,
-    _FiltersQueryParams,
-    PageQueryParameters,
-):
-    ...
-
-
 router = APIRouter(prefix=f"/{API_VTAG}")
 
 
@@ -87,7 +76,9 @@ router = APIRouter(prefix=f"/{API_VTAG}")
     tags=["usage"],
 )
 async def list_resource_usage_services(
-    _q: Annotated[_ListQueryParams, Depends()],
+    _qo: Annotated[_OrderQueryParams, Depends()],
+    _qf: Annotated[_FiltersQueryParams, Depends()],
+    _qp: Annotated[PageQueryParameters, Depends()],
     wallet_id: Annotated[WalletID | None, Query] = None,
 ):
     ...
@@ -104,7 +95,7 @@ async def list_osparc_credits_aggregated_usages(
     aggregated_by: ServicesAggregatedUsagesType,
     time_period: ServicesAggregatedUsagesTimePeriod,
     wallet_id: Annotated[WalletID, Query],
-    _q: Annotated[PageQueryParameters, Depends()],
+    _qp: Annotated[PageQueryParameters, Depends()],
 ):
     ...
 
@@ -122,8 +113,8 @@ async def list_osparc_credits_aggregated_usages(
     "user services (user and product are taken from context, optionally wallet_id parameter might be provided).",
 )
 async def export_resource_usage_services(
-    _oq: Annotated[_OrderQueryParams, Depends()],
-    _fq: Annotated[_FiltersQueryParams, Depends()],
+    _qo: Annotated[_OrderQueryParams, Depends()],
+    _qf: Annotated[_FiltersQueryParams, Depends()],
     wallet_id: Annotated[WalletID | None, Query] = None,
 ):
     ...
@@ -136,14 +127,9 @@ async def export_resource_usage_services(
     tags=["pricing-plans"],
 )
 async def get_pricing_plan_unit(
-    pricing_plan_id: PricingPlanId, pricing_unit_id: PricingUnitId
+    _p: Annotated[_GetPricingPlanUnitPathParams, Depends()],
 ):
     ...
-
-
-assert_handler_signature_against_model(
-    get_pricing_plan_unit, _GetPricingPlanUnitPathParams
-)
 
 
 ## Pricing plans for Admin panel
@@ -167,12 +153,9 @@ async def list_pricing_plans():
     tags=["admin"],
 )
 async def get_pricing_plan(
-    pricing_plan_id: PricingPlanId,
+    _p: Annotated[_GetPricingPlanPathParams, Depends()],
 ):
     ...
-
-
-assert_handler_signature_against_model(get_pricing_plan, _GetPricingPlanPathParams)
 
 
 @router.post(
@@ -194,13 +177,10 @@ async def create_pricing_plan(
     tags=["admin"],
 )
 async def update_pricing_plan(
-    pricing_plan_id: PricingPlanId,
+    _p: Annotated[_GetPricingPlanPathParams, Depends()],
     _b: UpdatePricingPlanBodyParams,
 ):
     ...
-
-
-assert_handler_signature_against_model(update_pricing_plan, _GetPricingPlanPathParams)
 
 
 ## Pricing units for Admin panel
@@ -213,13 +193,9 @@ assert_handler_signature_against_model(update_pricing_plan, _GetPricingPlanPathP
     tags=["admin"],
 )
 async def get_pricing_unit(
-    pricing_plan_id: PricingPlanId,
-    pricing_unit_id: PricingUnitId,
+    _p: Annotated[_GetPricingUnitPathParams, Depends()],
 ):
     ...
-
-
-assert_handler_signature_against_model(get_pricing_unit, _GetPricingUnitPathParams)
 
 
 @router.post(
@@ -229,13 +205,10 @@ assert_handler_signature_against_model(get_pricing_unit, _GetPricingUnitPathPara
     tags=["admin"],
 )
 async def create_pricing_unit(
-    pricing_plan_id: PricingPlanId,
+    _p: Annotated[_GetPricingPlanPathParams, Depends()],
     _b: CreatePricingUnitBodyParams,
 ):
     ...
-
-
-assert_handler_signature_against_model(create_pricing_unit, _GetPricingPlanPathParams)
 
 
 @router.put(
@@ -245,14 +218,10 @@ assert_handler_signature_against_model(create_pricing_unit, _GetPricingPlanPathP
     tags=["admin"],
 )
 async def update_pricing_unit(
-    pricing_plan_id: PricingPlanId,
-    pricing_unit_id: PricingUnitId,
+    _p: Annotated[_GetPricingUnitPathParams, Depends()],
     _b: UpdatePricingUnitBodyParams,
 ):
     ...
-
-
-assert_handler_signature_against_model(update_pricing_unit, _GetPricingUnitPathParams)
 
 
 ## Pricing Plans to Service Admin panel
@@ -265,12 +234,9 @@ assert_handler_signature_against_model(update_pricing_unit, _GetPricingUnitPathP
     tags=["admin"],
 )
 async def list_connected_services_to_pricing_plan(
-    pricing_plan_id: PricingPlanId,
+    _p: Annotated[_GetPricingPlanPathParams, Depends()],
 ):
     ...
-
-
-assert_handler_signature_against_model(update_pricing_unit, _GetPricingPlanPathParams)
 
 
 @router.post(
@@ -280,10 +246,7 @@ assert_handler_signature_against_model(update_pricing_unit, _GetPricingPlanPathP
     tags=["admin"],
 )
 async def connect_service_to_pricing_plan(
-    pricing_plan_id: PricingPlanId,
+    _p: Annotated[_GetPricingPlanPathParams, Depends()],
     _b: ConnectServiceToPricingPlanBodyParams,
 ):
     ...
-
-
-assert_handler_signature_against_model(update_pricing_unit, _GetPricingPlanPathParams)

--- a/api/specs/web-server/_resource_usage.py
+++ b/api/specs/web-server/_resource_usage.py
@@ -11,7 +11,7 @@ This OAS are the source of truth
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, status
 from models_library.api_schemas_resource_usage_tracker.service_runs import (
     OsparcCreditsAggregatedByServiceGet,
 )
@@ -28,42 +28,19 @@ from models_library.api_schemas_webserver.resource_usage import (
     UpdatePricingUnitBodyParams,
 )
 from models_library.generics import Envelope
-from models_library.resource_tracker import (
-    ServicesAggregatedUsagesTimePeriod,
-    ServicesAggregatedUsagesType,
-)
-from models_library.rest_base import RequestParameters
-from models_library.rest_pagination import PageQueryParameters
-from models_library.wallets import WalletID
-from pydantic import Json
 from simcore_service_webserver._meta import API_VTAG
 from simcore_service_webserver.resource_usage._pricing_plans_admin_handlers import (
-    _GetPricingPlanPathParams,
-    _GetPricingUnitPathParams,
+    PricingPlanGetPathParams,
+    PricingUnitGetPathParams,
 )
 from simcore_service_webserver.resource_usage._pricing_plans_handlers import (
-    _GetPricingPlanUnitPathParams,
+    PricingPlanUnitGetPathParams,
 )
 from simcore_service_webserver.resource_usage._service_runs_handlers import (
-    ListResourceUsagesOrderQueryParamsOpenApi,
+    ServicesAggregatedUsagesListQueryParams,
+    ServicesResourceUsagesListQueryParams,
+    ServicesResourceUsagesReportQueryParams,
 )
-
-
-class _FiltersQueryParams(RequestParameters):
-    filters: Annotated[
-        Json | None,
-        Query(
-            description="Filters to process on the resource usages list, encoded as JSON. "
-            "Currently supports the filtering of 'started_at' field with 'from' and 'until' parameters in <yyyy-mm-dd> ISO 8601 format. "
-            "The date range specified is inclusive.",
-            example='{"started_at": {"from": "yyyy-mm-dd", "until": "yyyy-mm-dd"}}',
-        ),
-    ] = None
-
-
-class _OrderQueryParams(ListResourceUsagesOrderQueryParamsOpenApi):
-    ...
-
 
 router = APIRouter(prefix=f"/{API_VTAG}")
 
@@ -76,10 +53,7 @@ router = APIRouter(prefix=f"/{API_VTAG}")
     tags=["usage"],
 )
 async def list_resource_usage_services(
-    _qo: Annotated[_OrderQueryParams, Depends()],
-    _qf: Annotated[_FiltersQueryParams, Depends()],
-    _qp: Annotated[PageQueryParameters, Depends()],
-    wallet_id: Annotated[WalletID | None, Query] = None,
+    _q: Annotated[ServicesResourceUsagesListQueryParams, Depends()],
 ):
     ...
 
@@ -92,10 +66,7 @@ async def list_resource_usage_services(
     tags=["usage"],
 )
 async def list_osparc_credits_aggregated_usages(
-    aggregated_by: ServicesAggregatedUsagesType,
-    time_period: ServicesAggregatedUsagesTimePeriod,
-    wallet_id: Annotated[WalletID, Query],
-    _qp: Annotated[PageQueryParameters, Depends()],
+    _q: Annotated[ServicesAggregatedUsagesListQueryParams, Depends()]
 ):
     ...
 
@@ -113,9 +84,7 @@ async def list_osparc_credits_aggregated_usages(
     "user services (user and product are taken from context, optionally wallet_id parameter might be provided).",
 )
 async def export_resource_usage_services(
-    _qo: Annotated[_OrderQueryParams, Depends()],
-    _qf: Annotated[_FiltersQueryParams, Depends()],
-    wallet_id: Annotated[WalletID | None, Query] = None,
+    _q: Annotated[ServicesResourceUsagesReportQueryParams, Depends()]
 ):
     ...
 
@@ -127,7 +96,7 @@ async def export_resource_usage_services(
     tags=["pricing-plans"],
 )
 async def get_pricing_plan_unit(
-    _p: Annotated[_GetPricingPlanUnitPathParams, Depends()],
+    _p: Annotated[PricingPlanUnitGetPathParams, Depends()],
 ):
     ...
 
@@ -153,7 +122,7 @@ async def list_pricing_plans():
     tags=["admin"],
 )
 async def get_pricing_plan(
-    _p: Annotated[_GetPricingPlanPathParams, Depends()],
+    _p: Annotated[PricingPlanGetPathParams, Depends()],
 ):
     ...
 
@@ -177,7 +146,7 @@ async def create_pricing_plan(
     tags=["admin"],
 )
 async def update_pricing_plan(
-    _p: Annotated[_GetPricingPlanPathParams, Depends()],
+    _p: Annotated[PricingPlanGetPathParams, Depends()],
     _b: UpdatePricingPlanBodyParams,
 ):
     ...
@@ -193,7 +162,7 @@ async def update_pricing_plan(
     tags=["admin"],
 )
 async def get_pricing_unit(
-    _p: Annotated[_GetPricingUnitPathParams, Depends()],
+    _p: Annotated[PricingUnitGetPathParams, Depends()],
 ):
     ...
 
@@ -205,7 +174,7 @@ async def get_pricing_unit(
     tags=["admin"],
 )
 async def create_pricing_unit(
-    _p: Annotated[_GetPricingPlanPathParams, Depends()],
+    _p: Annotated[PricingPlanGetPathParams, Depends()],
     _b: CreatePricingUnitBodyParams,
 ):
     ...
@@ -218,7 +187,7 @@ async def create_pricing_unit(
     tags=["admin"],
 )
 async def update_pricing_unit(
-    _p: Annotated[_GetPricingUnitPathParams, Depends()],
+    _p: Annotated[PricingUnitGetPathParams, Depends()],
     _b: UpdatePricingUnitBodyParams,
 ):
     ...
@@ -234,7 +203,7 @@ async def update_pricing_unit(
     tags=["admin"],
 )
 async def list_connected_services_to_pricing_plan(
-    _p: Annotated[_GetPricingPlanPathParams, Depends()],
+    _p: Annotated[PricingPlanGetPathParams, Depends()],
 ):
     ...
 
@@ -246,7 +215,7 @@ async def list_connected_services_to_pricing_plan(
     tags=["admin"],
 )
 async def connect_service_to_pricing_plan(
-    _p: Annotated[_GetPricingPlanPathParams, Depends()],
+    _p: Annotated[PricingPlanGetPathParams, Depends()],
     _b: ConnectServiceToPricingPlanBodyParams,
 ):
     ...

--- a/api/specs/web-server/_resource_usage.py
+++ b/api/specs/web-server/_resource_usage.py
@@ -54,7 +54,7 @@ router = APIRouter(prefix=f"/{API_VTAG}")
     tags=["usage"],
 )
 async def list_resource_usage_services(
-    _q: Annotated[as_query(ServicesResourceUsagesListQueryParams), Depends()],
+    _query: Annotated[as_query(ServicesResourceUsagesListQueryParams), Depends()],
 ):
     ...
 
@@ -67,7 +67,7 @@ async def list_resource_usage_services(
     tags=["usage"],
 )
 async def list_osparc_credits_aggregated_usages(
-    _q: Annotated[as_query(ServicesAggregatedUsagesListQueryParams), Depends()]
+    _query: Annotated[as_query(ServicesAggregatedUsagesListQueryParams), Depends()]
 ):
     ...
 
@@ -85,7 +85,7 @@ async def list_osparc_credits_aggregated_usages(
     "user services (user and product are taken from context, optionally wallet_id parameter might be provided).",
 )
 async def export_resource_usage_services(
-    _q: Annotated[as_query(ServicesResourceUsagesReportQueryParams), Depends()]
+    _query: Annotated[as_query(ServicesResourceUsagesReportQueryParams), Depends()]
 ):
     ...
 
@@ -97,7 +97,7 @@ async def export_resource_usage_services(
     tags=["pricing-plans"],
 )
 async def get_pricing_plan_unit(
-    _p: Annotated[PricingPlanUnitGetPathParams, Depends()],
+    _path: Annotated[PricingPlanUnitGetPathParams, Depends()],
 ):
     ...
 
@@ -123,7 +123,7 @@ async def list_pricing_plans():
     tags=["admin"],
 )
 async def get_pricing_plan(
-    _p: Annotated[PricingPlanGetPathParams, Depends()],
+    _path: Annotated[PricingPlanGetPathParams, Depends()],
 ):
     ...
 
@@ -147,7 +147,7 @@ async def create_pricing_plan(
     tags=["admin"],
 )
 async def update_pricing_plan(
-    _p: Annotated[PricingPlanGetPathParams, Depends()],
+    _path: Annotated[PricingPlanGetPathParams, Depends()],
     _b: UpdatePricingPlanBodyParams,
 ):
     ...
@@ -163,7 +163,7 @@ async def update_pricing_plan(
     tags=["admin"],
 )
 async def get_pricing_unit(
-    _p: Annotated[PricingUnitGetPathParams, Depends()],
+    _path: Annotated[PricingUnitGetPathParams, Depends()],
 ):
     ...
 
@@ -175,7 +175,7 @@ async def get_pricing_unit(
     tags=["admin"],
 )
 async def create_pricing_unit(
-    _p: Annotated[PricingPlanGetPathParams, Depends()],
+    _path: Annotated[PricingPlanGetPathParams, Depends()],
     _b: CreatePricingUnitBodyParams,
 ):
     ...
@@ -188,7 +188,7 @@ async def create_pricing_unit(
     tags=["admin"],
 )
 async def update_pricing_unit(
-    _p: Annotated[PricingUnitGetPathParams, Depends()],
+    _path: Annotated[PricingUnitGetPathParams, Depends()],
     _b: UpdatePricingUnitBodyParams,
 ):
     ...
@@ -204,7 +204,7 @@ async def update_pricing_unit(
     tags=["admin"],
 )
 async def list_connected_services_to_pricing_plan(
-    _p: Annotated[PricingPlanGetPathParams, Depends()],
+    _path: Annotated[PricingPlanGetPathParams, Depends()],
 ):
     ...
 
@@ -216,7 +216,7 @@ async def list_connected_services_to_pricing_plan(
     tags=["admin"],
 )
 async def connect_service_to_pricing_plan(
-    _p: Annotated[PricingPlanGetPathParams, Depends()],
+    _path: Annotated[PricingPlanGetPathParams, Depends()],
     _b: ConnectServiceToPricingPlanBodyParams,
 ):
     ...

--- a/api/specs/web-server/_resource_usage.py
+++ b/api/specs/web-server/_resource_usage.py
@@ -11,6 +11,7 @@ This OAS are the source of truth
 
 from typing import Annotated
 
+from _common import as_query
 from fastapi import APIRouter, Depends, status
 from models_library.api_schemas_resource_usage_tracker.service_runs import (
     OsparcCreditsAggregatedByServiceGet,
@@ -53,7 +54,7 @@ router = APIRouter(prefix=f"/{API_VTAG}")
     tags=["usage"],
 )
 async def list_resource_usage_services(
-    _q: Annotated[ServicesResourceUsagesListQueryParams, Depends()],
+    _q: Annotated[as_query(ServicesResourceUsagesListQueryParams), Depends()],
 ):
     ...
 
@@ -66,7 +67,7 @@ async def list_resource_usage_services(
     tags=["usage"],
 )
 async def list_osparc_credits_aggregated_usages(
-    _q: Annotated[ServicesAggregatedUsagesListQueryParams, Depends()]
+    _q: Annotated[as_query(ServicesAggregatedUsagesListQueryParams), Depends()]
 ):
     ...
 
@@ -84,7 +85,7 @@ async def list_osparc_credits_aggregated_usages(
     "user services (user and product are taken from context, optionally wallet_id parameter might be provided).",
 )
 async def export_resource_usage_services(
-    _q: Annotated[ServicesResourceUsagesReportQueryParams, Depends()]
+    _q: Annotated[as_query(ServicesResourceUsagesReportQueryParams), Depends()]
 ):
     ...
 

--- a/api/specs/web-server/_trash.py
+++ b/api/specs/web-server/_trash.py
@@ -48,8 +48,8 @@ _extra_tags: list[str | Enum] = ["projects"]
     },
 )
 def trash_project(
-    _p: Annotated[ProjectPathParams, Depends()],
-    _q: Annotated[RemoveQueryParams, Depends()],
+    _path: Annotated[ProjectPathParams, Depends()],
+    _query: Annotated[RemoveQueryParams, Depends()],
 ):
     ...
 
@@ -60,7 +60,7 @@ def trash_project(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 def untrash_project(
-    _p: Annotated[ProjectPathParams, Depends()],
+    _path: Annotated[ProjectPathParams, Depends()],
 ):
     ...
 
@@ -81,8 +81,8 @@ _extra_tags = ["folders"]
     },
 )
 def trash_folder(
-    _p: Annotated[FoldersPathParams, Depends()],
-    _q: Annotated[RemoveQueryParams_duplicated, Depends()],
+    _path: Annotated[FoldersPathParams, Depends()],
+    _query: Annotated[RemoveQueryParams_duplicated, Depends()],
 ):
     ...
 
@@ -93,6 +93,6 @@ def trash_folder(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 def untrash_folder(
-    _p: Annotated[FoldersPathParams, Depends()],
+    _path: Annotated[FoldersPathParams, Depends()],
 ):
     ...

--- a/packages/models-library/src/models_library/rest_base.py
+++ b/packages/models-library/src/models_library/rest_base.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel, Extra
+
+
+class RequestParameters(BaseModel):
+    """
+    Base model for any type of request parameters,
+    i.e. context, path, query, headers
+    """
+
+    def as_params(self, **export_options) -> dict[str, str]:
+        data = self.dict(**export_options)
+        return {k: f"{v}" for k, v in data.items()}
+
+
+class StrictRequestParameters(RequestParameters):
+    """Use a base class for context, path and query parameters"""
+
+    class Config:
+        extra = Extra.forbid  # strict

--- a/packages/models-library/src/models_library/rest_ordering.py
+++ b/packages/models-library/src/models_library/rest_ordering.py
@@ -1,8 +1,11 @@
 from enum import Enum
+from typing import Any, ClassVar
 
-from pydantic import BaseModel, Field
+from models_library.utils.json_serialization import json_dumps, json_loads
+from pydantic import BaseModel, Field, Json, validator
 
 from .basic_types import IDStr
+from .rest_base import RequestParameters
 
 
 class OrderDirection(str, Enum):
@@ -11,10 +14,105 @@ class OrderDirection(str, Enum):
 
 
 class OrderBy(BaseModel):
-    """inspired by Google AIP https://google.aip.dev/132#ordering"""
-
-    field: IDStr = Field()
-    direction: OrderDirection = Field(default=OrderDirection.ASC)
+    # Based on https://google.aip.dev/132#ordering
+    field: IDStr = Field(..., description="field name identifier")
+    direction: OrderDirection = Field(
+        default=OrderDirection.ASC,
+        description=(
+            f"As [A,B,C,...] if `{OrderDirection.ASC.value}`"
+            f" or [Z,Y,X, ...] if `{OrderDirection.DESC.value}`"
+        ),
+    )
 
     class Config:
         extra = "forbid"
+        schema_extra: ClassVar[dict[str, Any]] = {
+            "example": {"field": "some_field_name", "direction": "desc"}
+        }
+
+
+class _BaseOrderByQueryParams(RequestParameters):
+    order_by: OrderBy | None = None
+
+
+def create_order_by_query_model_classes(
+    *,
+    sortable_fields: set[str],
+    default_order_by: OrderBy,
+    override_direction_default: bool = False,
+) -> tuple[type[_BaseOrderByQueryParams], type[BaseModel]]:
+    """
+    Factory to create an uniform model used as ordering parameters in a query
+
+    Returns the validation
+    """
+
+    assert default_order_by.field in sortable_fields  # nosec
+
+    msg_field_options = "|".join(sorted(sortable_fields))
+    msg_direction_options = "|".join(sorted(OrderDirection))
+    order_by_example: dict[str, Any] = OrderBy.Config.schema_extra["example"]
+
+    class _OrderByJsonable(OrderBy):
+        direction: OrderDirection = Field(
+            default=default_order_by.direction
+            if override_direction_default
+            else OrderBy.__fields__["direction"].default,
+            description=OrderBy.__fields__["direction"].field_info.description,
+        )
+
+        @classmethod
+        def __modify_schema__(cls, field_schema: dict[str, Any]) -> None:
+            # openapi.json schema is corrected here
+            field_schema.update(
+                type="string",
+                format="json-string",
+                default=json_dumps(default_order_by),
+                example=json_dumps(order_by_example),
+                title="Order By",
+            )
+
+        @validator("field", allow_reuse=True)
+        @classmethod
+        def _check_if_sortable_field(cls, v):
+            if v not in sortable_fields:
+                msg = (
+                    f"We do not support ordering by provided field '{v}'. "
+                    f"Fields supported are {msg_field_options}."
+                )
+                raise ValueError(msg)
+            return v
+
+    description = (
+        f"Order by field ({msg_field_options}) and direction ({msg_direction_options}). "
+        f"The default sorting order is '{default_order_by.direction.value}' on '{default_order_by.field}'."
+    )
+
+    class _RequestValidatorModel(_BaseOrderByQueryParams):
+        # Used in rest handler for verification
+        order_by: _OrderByJsonable = Field(
+            default=default_order_by,
+            description=description,
+        )
+
+        @validator("order_by", allow_reuse=True, pre=True)
+        @classmethod
+        def _pre_parse_if_json(cls, v):
+            if isinstance(v, str):
+                # can raise a JsonEncoderError(TypeError)
+                return json_loads(v)
+            return v
+
+    class _OpenapiModel(BaseModel):
+        # Used to produce nice openapi.json specs
+        order_by: Json = Field(
+            default=json_dumps(default_order_by),
+            description=description,
+        )
+
+        class Config:
+            schema_extra: ClassVar[dict[str, Any]] = {
+                "title": "Order By Parameters",
+            }
+
+    return _RequestValidatorModel, _OpenapiModel

--- a/packages/models-library/src/models_library/rest_ordering.py
+++ b/packages/models-library/src/models_library/rest_ordering.py
@@ -77,12 +77,13 @@ def create_ordering_query_model_classes(
                     f"Fields supported are {msg_field_options}."
                 )
                 raise ValueError(msg)
+            return v
 
         @validator("field", allow_reuse=True, always=True)
         @classmethod
         def _post_rename_order_by_field_as_db_column(cls, v):
             # API field name -> DB column_name
-            return ordering_fields_api_to_column_map.get(v, v)
+            return ordering_fields_api_to_column_map.get(v) or v
 
     order_by_example: dict[str, Any] = OrderBy.Config.schema_extra["example"]
     order_by_example_json = json_dumps(order_by_example)

--- a/packages/models-library/src/models_library/rest_ordering.py
+++ b/packages/models-library/src/models_library/rest_ordering.py
@@ -51,7 +51,7 @@ def create_ordering_query_model_classes(
     msg_direction_options = "|".join(sorted(OrderDirection))
 
     class _OrderBy(OrderBy):
-        @validator("field", allow_reuse=True)
+        @validator("field", allow_reuse=True, always=True)
         @classmethod
         def _check_if_ordering_field(cls, v):
             if v not in ordering_fields:

--- a/packages/models-library/src/models_library/rest_ordering.py
+++ b/packages/models-library/src/models_library/rest_ordering.py
@@ -36,7 +36,7 @@ class _BaseOrderByQueryParams(RequestParameters):
     order_by: OrderBy | None = None
 
 
-def create_order_by_query_model_classes(
+def create_ordering_query_model_classes(
     *,
     sortable_fields: set[str],
     default_order_by: OrderBy,

--- a/packages/models-library/src/models_library/rest_ordering.py
+++ b/packages/models-library/src/models_library/rest_ordering.py
@@ -54,9 +54,8 @@ def create_ordering_query_model_classes(
     msg_field_options = "|".join(sorted(ordering_fields))
     msg_direction_options = "|".join(sorted(OrderDirection))
     description = (
-        f"Order by field ({msg_field_options}) and direction ({msg_direction_options}). "
-        f"The default sorting order is '{default.direction.value}' on '{default.field}'."
-        f"For instance order_by={json_dumps(order_by_example)}"
+        f"Order by field (`{msg_field_options}`) and direction (`{msg_direction_options}`). "
+        f"The default sorting order is `{default.direction.value}` on `{default.field}`."
     )
 
     class _OrderBy(OrderBy):
@@ -78,9 +77,12 @@ def create_ordering_query_model_classes(
                 raise ValueError(msg)
             return v
 
-    class _RequestValidatorModel(_BaseOrderByQueryParams):
-        # Used in rest handler for verification
-        order_by: _OrderBy = Field(default=default)
+    class _OrderQueryParams(_BaseOrderByQueryParams):
+        order_by: _OrderBy = Field(
+            default=default,
+            description=description,
+            example_json=json_dumps(order_by_example),
+        )
 
         _pre_parse_string = validator("order_by", allow_reuse=True, pre=True)(
             load_if_json_encoded_pre_validator
@@ -104,4 +106,4 @@ def create_ordering_query_model_classes(
         # Used to produce nice openapi.json specs
         order_by: _OrderByJson = Field(default=json_dumps(default))
 
-    return _RequestValidatorModel, _OpenApiModel
+    return _OrderQueryParams, _OpenApiModel

--- a/packages/models-library/src/models_library/rest_ordering.py
+++ b/packages/models-library/src/models_library/rest_ordering.py
@@ -50,9 +50,9 @@ def create_ordering_query_model_classes(
             will be automatically translated to their corresponding database
             column names for seamless integration with database queries.
     """
-    ordering_fields_api_to_column_map = ordering_fields_api_to_column_map or {}
+    _ordering_fields_api_to_column_map = ordering_fields_api_to_column_map or {}
 
-    assert set(ordering_fields_api_to_column_map.keys()).issubset(  # nosec
+    assert set(_ordering_fields_api_to_column_map.keys()).issubset(  # nosec
         ordering_fields
     )
 
@@ -62,7 +62,7 @@ def create_ordering_query_model_classes(
     msg_direction_options = "|".join(sorted(OrderDirection))
 
     class _OrderBy(OrderBy):
-        class Config(OrderBy.Config):
+        class Config:
             schema_extra: ClassVar[dict[str, Any]] = {
                 "example": {
                     "field": next(iter(ordering_fields)),
@@ -85,7 +85,7 @@ def create_ordering_query_model_classes(
                 raise ValueError(msg)
 
             # API field name -> DB column_name conversion
-            return ordering_fields_api_to_column_map.get(v) or v
+            return _ordering_fields_api_to_column_map.get(v) or v
 
     order_by_example: dict[str, Any] = _OrderBy.Config.schema_extra["example"]
     order_by_example_json = json_dumps(order_by_example)

--- a/packages/models-library/src/models_library/rest_ordering.py
+++ b/packages/models-library/src/models_library/rest_ordering.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field, validator
 
 from .basic_types import IDStr
 from .rest_base import RequestParameters
-from .utils.common_validators import load_if_json_encoded_pre_validator
+from .utils.common_validators import parse_json_pre_validator
 
 
 class OrderDirection(str, Enum):
@@ -77,7 +77,7 @@ def create_ordering_query_model_classes(
         )
 
         _pre_parse_string = validator("order_by", allow_reuse=True, pre=True)(
-            load_if_json_encoded_pre_validator
+            parse_json_pre_validator
         )
 
     return _OrderQueryParams

--- a/packages/models-library/src/models_library/rest_pagination.py
+++ b/packages/models-library/src/models_library/rest_pagination.py
@@ -13,6 +13,7 @@ from pydantic import (
 )
 from pydantic.generics import GenericModel
 
+from .rest_base import RequestParameters
 from .utils.common_validators import none_to_empty_list_pre_validator
 
 # Default limit values
@@ -29,7 +30,7 @@ class PageLimitInt(ConstrainedInt):
 DEFAULT_NUMBER_OF_ITEMS_PER_PAGE: Final[PageLimitInt] = parse_obj_as(PageLimitInt, 20)
 
 
-class PageQueryParameters(BaseModel):
+class PageQueryParameters(RequestParameters):
     """Use as pagination options in query parameters"""
 
     limit: PageLimitInt = Field(

--- a/packages/models-library/src/models_library/utils/common_validators.py
+++ b/packages/models-library/src/models_library/utils/common_validators.py
@@ -20,6 +20,8 @@ import functools
 import operator
 from typing import Any
 
+from orjson import JSONDecodeError
+
 from .json_serialization import json_loads
 
 
@@ -41,10 +43,13 @@ def none_to_empty_list_pre_validator(value: Any):
     return value
 
 
-def load_if_json_encoded_pre_validator(value: Any):
+def parse_json_pre_validator(value: Any):
     if isinstance(value, str):
-        # raises JsonEncoderError which is a TypeError
-        return json_loads(value)
+        try:
+            return json_loads(value)
+        except JSONDecodeError as err:
+            msg = f"Invalid JSON {value=}: {err}"
+            raise TypeError(msg) from err
     return value
 
 

--- a/packages/models-library/src/models_library/utils/common_validators.py
+++ b/packages/models-library/src/models_library/utils/common_validators.py
@@ -20,6 +20,8 @@ import functools
 import operator
 from typing import Any
 
+from .json_serialization import json_loads
+
 
 def empty_str_to_none_pre_validator(value: Any):
     if isinstance(value, str) and value.strip() == "":
@@ -36,6 +38,13 @@ def none_to_empty_str_pre_validator(value: Any):
 def none_to_empty_list_pre_validator(value: Any):
     if value is None:
         return []
+    return value
+
+
+def load_if_json_encoded_pre_validator(value: Any):
+    if isinstance(value, str):
+        # raises JsonEncoderError which is a TypeError
+        return json_loads(value)
     return value
 
 

--- a/packages/models-library/tests/test_rest_ordering.py
+++ b/packages/models-library/tests/test_rest_ordering.py
@@ -1,0 +1,173 @@
+import pytest
+from models_library.basic_types import IDStr
+from models_library.rest_ordering import (
+    OrderBy,
+    OrderDirection,
+    create_order_by_query_model_classes,
+)
+from models_library.utils.json_serialization import json_dumps
+from pydantic import BaseModel, Extra, Field, Json, ValidationError, validator
+
+
+class ReferenceSortQueryParamsClass(BaseModel):
+    # NOTE: this class is a copy of `FolderListSortParams` from
+    # services/web/server/src/simcore_service_webserver/folders/_models.py
+    # and used as a reference in these tests to ensure the same functionality
+
+    # pylint: disable=unsubscriptable-object
+    order_by: Json[OrderBy] = Field(
+        default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
+        description="Order by field (modified_at|name|description) and direction (asc|desc). The default sorting order is ascending.",
+        example='{"field": "name", "direction": "desc"}',
+        alias="order_by",
+    )
+
+    @validator("order_by", check_fields=False)
+    @classmethod
+    def _validate_order_by_field(cls, v):
+        if v.field not in {
+            "modified_at",
+            "name",
+            "description",
+        }:
+            msg = f"We do not support ordering by provided field {v.field}"
+            raise ValueError(msg)
+        if v.field == "modified_at":
+            v.field = "modified"
+        return v
+
+    class Config:
+        extra = Extra.forbid
+
+
+def test_order_by_query_model_class_factory():
+    BaseOrderByQueryModel, _ = create_order_by_query_model_classes(
+        sortable_fields={"modified", "name", "description"},
+        default_order_by=OrderBy(
+            field=IDStr("modified"), direction=OrderDirection.DESC
+        ),
+    )
+
+    # inherits to add extra post-validator
+    class OrderByQueryParamsModel(BaseOrderByQueryModel):
+        @validator("order_by", pre=True)
+        @classmethod
+        def _validate_order_by_field(cls, v):
+            # Adds aliases!?
+            if v and v.get("field") == "modified_at":
+                v["field"] = "modified"
+            return v
+
+    # normal
+    data = {"order_by": {"field": "modified_at", "direction": "asc"}}
+    model = OrderByQueryParamsModel.parse_obj(data)
+
+    assert model.order_by
+    assert model.order_by.dict() == {"field": "modified", "direction": "asc"}
+
+    # test against reference
+    expected = ReferenceSortQueryParamsClass.parse_obj(
+        {"order_by": json_dumps({"field": "modified_at", "direction": "asc"})}
+    )
+    assert expected.dict() == model.dict()
+
+
+def test_order_by_query_model_class__fails_with_invalid_fields():
+
+    OrderByQueryParamsModel, _ = create_order_by_query_model_classes(
+        sortable_fields={"modified", "name", "description"},
+        default_order_by=OrderBy(
+            field=IDStr("modified"), direction=OrderDirection.DESC
+        ),
+    )
+
+    # fails with invalid field to sort
+    with pytest.raises(ValidationError) as err_info:
+        OrderByQueryParamsModel.parse_obj({"order_by": {"field": "INVALID"}})
+
+    error = err_info.value.errors()[0]
+
+    assert error["type"] == "value_error"
+    assert "INVALID" in error["msg"]
+    assert error["loc"] == ("order_by", "field")
+
+
+def test_order_by_query_model_class__fails_with_invalid_direction():
+    OrderByQueryParamsModel, _ = create_order_by_query_model_classes(
+        sortable_fields={"modified", "name", "description"},
+        default_order_by=OrderBy(
+            field=IDStr("modified"), direction=OrderDirection.DESC
+        ),
+    )
+
+    with pytest.raises(ValidationError) as err_info:
+        OrderByQueryParamsModel.parse_obj(
+            {"order_by": {"field": "modified", "direction": "INVALID"}}
+        )
+
+    error = err_info.value.errors()[0]
+
+    assert error["type"] == "type_error.enum"
+    assert error["loc"] == ("order_by", "direction")
+
+
+@pytest.mark.parametrize("override_direction_default", [True, False])
+def test_order_by_query_model_class__defaults(override_direction_default: bool):
+
+    OrderByQueryParamsModel, _ = create_order_by_query_model_classes(
+        sortable_fields={"modified", "name", "description"},
+        default_order_by=OrderBy(
+            field=IDStr("modified"), direction=OrderDirection.DESC
+        ),
+        override_direction_default=override_direction_default,
+    )
+
+    # checks  all defaults
+    model = OrderByQueryParamsModel()
+    assert model.order_by
+    assert model.order_by.field == "modified"
+    assert model.order_by.direction == OrderDirection.DESC
+
+    # partial defaults
+    model = OrderByQueryParamsModel.parse_obj({"order_by": {"field": "name"}})
+    assert model.order_by
+    assert model.order_by.field == "name"
+    assert (
+        model.order_by.direction == OrderDirection.DESC
+        if override_direction_default
+        else OrderBy.__fields__["direction"].default
+    )
+
+    # direction alone is invalid
+    with pytest.raises(ValidationError) as err_info:
+        OrderByQueryParamsModel.parse_obj({"order_by": {"direction": "asc"}})
+
+    error = err_info.value.errors()[0]
+    assert error["loc"] == ("order_by", "field")
+    assert error["type"] == "value_error.missing"
+
+
+def test_order_by_query_model_class__openapi():
+
+    _, OrderByQueryParamsModelOAS = create_order_by_query_model_classes(
+        sortable_fields={"modified", "name", "description"},
+        default_order_by=OrderBy(
+            field=IDStr("modified"), direction=OrderDirection.DESC
+        ),
+    )
+
+    print(OrderByQueryParamsModelOAS.schema_json(indent=1))
+
+    assert OrderByQueryParamsModelOAS.schema() == {
+        "title": "Order By Parameters",
+        "type": "object",
+        "properties": {
+            "order_by": {
+                "title": "Order By",
+                "description": "Order by field (description|modified|name) and direction (asc|desc). The default sorting order is 'desc' on 'modified'.",
+                "default": '{"field":"modified","direction":"desc"}',
+                "type": "string",
+                "format": "json-string",
+            }
+        },
+    }

--- a/packages/models-library/tests/test_rest_ordering.py
+++ b/packages/models-library/tests/test_rest_ordering.py
@@ -104,12 +104,13 @@ def test_ordering_query_model_class__defaults():
     OrderQueryParamsModel = create_ordering_query_model_classes(
         ordering_fields={"modified", "name", "description"},
         default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
+        ordering_fields_api_to_column_map={"modified": "modified_at"},
     )
 
     # checks  all defaults
     model = OrderQueryParamsModel()
     assert model.order_by
-    assert model.order_by.field == "modified"
+    assert model.order_by.field == "modified_at"  # NOTE that this was mapped!
     assert model.order_by.direction == OrderDirection.DESC
 
     # partial defaults

--- a/packages/models-library/tests/test_rest_ordering.py
+++ b/packages/models-library/tests/test_rest_ordering.py
@@ -147,7 +147,7 @@ def test_order_by_query_model_class__defaults(override_direction_default: bool):
     assert error["type"] == "value_error.missing"
 
 
-def test_order_by_query_model_class__openapi():
+def test_order_by_query_model_class__openapi_generator():
 
     _, OrderByQueryParamsModelOAS = create_order_by_query_model_classes(
         sortable_fields={"modified", "name", "description"},
@@ -158,16 +158,12 @@ def test_order_by_query_model_class__openapi():
 
     print(OrderByQueryParamsModelOAS.schema_json(indent=1))
 
-    assert OrderByQueryParamsModelOAS.schema() == {
-        "title": "Order By Parameters",
-        "type": "object",
-        "properties": {
-            "order_by": {
-                "title": "Order By",
-                "description": "Order by field (description|modified|name) and direction (asc|desc). The default sorting order is 'desc' on 'modified'.",
-                "default": '{"field":"modified","direction":"desc"}',
-                "type": "string",
-                "format": "json-string",
-            }
-        },
-    }
+    schema = OrderByQueryParamsModelOAS.schema()
+
+    assert schema["type"] == "object"
+    assert "order_by" in schema["properties"]
+
+    assert schema["properties"]["order_by"]["type"] == "string"
+    assert schema["properties"]["order_by"]["format"] == "json-string"
+    assert schema["properties"]["order_by"].get("description")
+    assert schema["properties"]["order_by"].get("title")

--- a/packages/models-library/tests/test_rest_ordering.py
+++ b/packages/models-library/tests/test_rest_ordering.py
@@ -42,10 +42,8 @@ class ReferenceOrderQueryParamsClass(BaseModel):
 
 def test_ordering_query_model_class_factory():
     BaseOrderingQueryModel, _ = create_ordering_query_model_classes(
-        sortable_fields={"modified", "name", "description"},
-        default_order_by=OrderBy(
-            field=IDStr("modified"), direction=OrderDirection.DESC
-        ),
+        ordering_fields={"modified", "name", "description"},
+        default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
     )
 
     # inherits to add extra post-validator
@@ -75,10 +73,8 @@ def test_ordering_query_model_class_factory():
 def test_ordering_query_model_class__fails_with_invalid_fields():
 
     OrderQueryParamsModel, _ = create_ordering_query_model_classes(
-        sortable_fields={"modified", "name", "description"},
-        default_order_by=OrderBy(
-            field=IDStr("modified"), direction=OrderDirection.DESC
-        ),
+        ordering_fields={"modified", "name", "description"},
+        default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
     )
 
     # fails with invalid field to sort
@@ -94,10 +90,8 @@ def test_ordering_query_model_class__fails_with_invalid_fields():
 
 def test_ordering_query_model_class__fails_with_invalid_direction():
     OrderQueryParamsModel, _ = create_ordering_query_model_classes(
-        sortable_fields={"modified", "name", "description"},
-        default_order_by=OrderBy(
-            field=IDStr("modified"), direction=OrderDirection.DESC
-        ),
+        ordering_fields={"modified", "name", "description"},
+        default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
     )
 
     with pytest.raises(ValidationError) as err_info:
@@ -115,10 +109,8 @@ def test_ordering_query_model_class__fails_with_invalid_direction():
 def test_ordering_query_model_class__defaults(override_direction_default: bool):
 
     OrderQueryParamsModel, _ = create_ordering_query_model_classes(
-        sortable_fields={"modified", "name", "description"},
-        default_order_by=OrderBy(
-            field=IDStr("modified"), direction=OrderDirection.DESC
-        ),
+        ordering_fields={"modified", "name", "description"},
+        default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
         override_direction_default=override_direction_default,
     )
 
@@ -150,10 +142,8 @@ def test_ordering_query_model_class__defaults(override_direction_default: bool):
 def test_ordering_query_model_class__openapi_generator():
 
     _, OrderQueryParamsModelOpenApi = create_ordering_query_model_classes(
-        sortable_fields={"modified", "name", "description"},
-        default_order_by=OrderBy(
-            field=IDStr("modified"), direction=OrderDirection.DESC
-        ),
+        ordering_fields={"modified", "name", "description"},
+        default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
     )
 
     print(OrderQueryParamsModelOpenApi.schema_json(indent=1))

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/assert_checks.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/assert_checks.py
@@ -82,13 +82,13 @@ def _do_assert_error(
 
     assert is_error(expected_status_code)
 
-    assert len(error["errors"]) == 1
-
-    err = error["errors"][0]
+    assert len(error["errors"]) >= 1
     if expected_msg:
-        assert expected_msg in err["message"]
+        messages = [detail["message"] for detail in error["errors"]]
+        assert expected_msg in messages
 
     if expected_error_code:
-        assert expected_error_code == err["code"]
+        codes = [detail["code"] for detail in error["errors"]]
+        assert expected_error_code in codes
 
     return data, error

--- a/packages/service-library/src/servicelib/aiohttp/requests_validation.py
+++ b/packages/service-library/src/servicelib/aiohttp/requests_validation.py
@@ -14,7 +14,7 @@ from typing import TypeAlias, TypeVar, Union
 
 from aiohttp import web
 from models_library.utils.json_serialization import json_dumps
-from pydantic import BaseModel, Extra, ValidationError, parse_obj_as
+from pydantic import BaseModel, ValidationError, parse_obj_as
 
 from ..mimetype_constants import MIMETYPE_APPLICATION_JSON
 from . import status
@@ -22,17 +22,6 @@ from . import status
 ModelClass = TypeVar("ModelClass", bound=BaseModel)
 ModelOrListOrDictType = TypeVar("ModelOrListOrDictType", bound=BaseModel | list | dict)
 UnionOfModelTypes: TypeAlias = Union[type[ModelClass], type[ModelClass]]  # noqa: UP007
-
-
-class RequestParams(BaseModel):
-    ...
-
-
-class StrictRequestParams(BaseModel):
-    """Use a base class for context, path and query parameters"""
-
-    class Config:
-        extra = Extra.forbid  # strict
 
 
 @contextmanager

--- a/packages/service-library/src/servicelib/fastapi/openapi.py
+++ b/packages/service-library/src/servicelib/fastapi/openapi.py
@@ -25,7 +25,7 @@ _OAS_DEVELOPMENT_SERVER = {
 }
 
 
-def get_common_oas_options(is_devel_mode: bool) -> dict[str, Any]:
+def get_common_oas_options(*, is_devel_mode: bool) -> dict[str, Any]:
     """common OAS options for FastAPI constructor"""
     servers: list[dict[str, Any]] = [
         _OAS_DEFAULT_SERVER,

--- a/packages/service-library/tests/aiohttp/test_requests_validation.py
+++ b/packages/service-library/tests/aiohttp/test_requests_validation.py
@@ -363,7 +363,7 @@ async def test_parse_request_with_invalid_headers_params(
 
 def test_parse_request_query_parameters_as_with_order_by_query_models():
 
-    OrderByModel = create_ordering_query_model_classes(
+    OrderQueryModel = create_ordering_query_model_classes(
         ordering_fields={"modified", "name"}, default=OrderBy(field="name")
     )
 
@@ -373,12 +373,5 @@ def test_parse_request_query_parameters_as_with_order_by_query_models():
 
     request = make_mocked_request("GET", path=f"{url}")
 
-    query_params = parse_request_query_parameters_as(OrderByModel, request)
+    query_params = parse_request_query_parameters_as(OrderQueryModel, request)
     assert query_params.order_by == expected
-
-    expected_schema = {"type": "string", "format": "json-string"}
-    assert {
-        k: v
-        for k, v in OrderByModel.schema()["properties"]["order_by"]
-        if k in expected
-    } == expected_schema

--- a/packages/service-library/tests/aiohttp/test_requests_validation.py
+++ b/packages/service-library/tests/aiohttp/test_requests_validation.py
@@ -14,7 +14,7 @@ from models_library.rest_base import RequestParameters, StrictRequestParameters
 from models_library.rest_ordering import (
     OrderBy,
     OrderDirection,
-    create_order_by_query_model_classes,
+    create_ordering_query_model_classes,
 )
 from models_library.utils.json_serialization import json_dumps
 from pydantic import BaseModel, Field
@@ -363,7 +363,7 @@ async def test_parse_request_with_invalid_headers_params(
 
 def test_parse_request_query_parameters_as_with_order_by_query_models():
 
-    OrderByModel, OrderByModelOAS = create_order_by_query_model_classes(
+    OrderByModel, OrderByModelOAS = create_ordering_query_model_classes(
         sortable_fields={"modified", "name"}, default_order_by=OrderBy(field="name")
     )
 

--- a/packages/service-library/tests/aiohttp/test_requests_validation.py
+++ b/packages/service-library/tests/aiohttp/test_requests_validation.py
@@ -364,7 +364,7 @@ async def test_parse_request_with_invalid_headers_params(
 def test_parse_request_query_parameters_as_with_order_by_query_models():
 
     OrderByModel, OrderByModelOAS = create_ordering_query_model_classes(
-        sortable_fields={"modified", "name"}, default_order_by=OrderBy(field="name")
+        ordering_fields={"modified", "name"}, default=OrderBy(field="name")
     )
 
     expected = OrderBy(field="name", direction=OrderDirection.ASC)

--- a/packages/service-library/tests/aiohttp/test_requests_validation.py
+++ b/packages/service-library/tests/aiohttp/test_requests_validation.py
@@ -363,7 +363,7 @@ async def test_parse_request_with_invalid_headers_params(
 
 def test_parse_request_query_parameters_as_with_order_by_query_models():
 
-    OrderByModel, _ = create_ordering_query_model_classes(
+    OrderByModel = create_ordering_query_model_classes(
         ordering_fields={"modified", "name"}, default=OrderBy(field="name")
     )
 

--- a/packages/service-library/tests/aiohttp/test_requests_validation.py
+++ b/packages/service-library/tests/aiohttp/test_requests_validation.py
@@ -363,7 +363,7 @@ async def test_parse_request_with_invalid_headers_params(
 
 def test_parse_request_query_parameters_as_with_order_by_query_models():
 
-    OrderByModel, OrderByModelOAS = create_ordering_query_model_classes(
+    OrderByModel, _ = create_ordering_query_model_classes(
         ordering_fields={"modified", "name"}, default=OrderBy(field="name")
     )
 

--- a/packages/service-library/tests/fastapi/test_request_decorators.py
+++ b/packages/service-library/tests/fastapi/test_request_decorators.py
@@ -6,9 +6,10 @@ import asyncio
 import subprocess
 import sys
 import time
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Callable, Iterator, NamedTuple
+from typing import NamedTuple
 
 import pytest
 import requests

--- a/services/agent/src/simcore_service_agent/core/application.py
+++ b/services/agent/src/simcore_service_agent/core/application.py
@@ -48,7 +48,7 @@ def create_app() -> FastAPI:
         description=SUMMARY,
         version=f"{VERSION}",
         openapi_url=f"/api/{API_VTAG}/openapi.json",
-        **get_common_oas_options(settings.SC_BOOT_MODE.is_devel_mode()),
+        **get_common_oas_options(is_devel_mode=settings.SC_BOOT_MODE.is_devel_mode()),
     )
     override_fastapi_openapi_method(app)
     app.state.settings = settings

--- a/services/director-v2/src/simcore_service_director_v2/core/application.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/application.py
@@ -132,7 +132,7 @@ def create_base_app(settings: AppSettings | None = None) -> FastAPI:
         description=SUMMARY,
         version=API_VERSION,
         openapi_url=f"/api/{API_VTAG}/openapi.json",
-        **get_common_oas_options(settings.SC_BOOT_MODE.is_devel_mode()),
+        **get_common_oas_options(is_devel_mode=settings.SC_BOOT_MODE.is_devel_mode()),
     )
     override_fastapi_openapi_method(app)
     app.state.settings = settings

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
@@ -142,7 +142,7 @@ def create_base_app() -> FastAPI:
         description=SUMMARY,
         version=API_VERSION,
         openapi_url=f"/api/{API_VTAG}/openapi.json",
-        **get_common_oas_options(settings.SC_BOOT_MODE.is_devel_mode()),
+        **get_common_oas_options(is_devel_mode=settings.SC_BOOT_MODE.is_devel_mode()),
     )
     override_fastapi_openapi_method(app)
     app.state.settings = settings

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -2684,6 +2684,23 @@ paths:
       parameters:
       - required: false
         schema:
+          title: Filters
+          type: string
+          description: Custom filter query parameter encoded as JSON
+        name: filters
+        in: query
+      - required: false
+        schema:
+          title: Order By
+          type: string
+          description: Order by field (`description|modified|name`) and direction
+            (`asc|desc`). The default sorting order is `{"field":"modified","direction":"desc"}`.
+          default: '{"field":"modified","direction":"desc"}'
+          example: '{"field":"some_field_name","direction":"desc"}'
+        name: order_by
+        in: query
+      - required: false
+        schema:
           title: Limit
           exclusiveMaximum: true
           minimum: 1
@@ -2699,23 +2716,6 @@ paths:
           type: integer
           default: 0
         name: offset
-        in: query
-      - required: false
-        schema:
-          title: Filters
-          type: string
-          description: Custom filter query parameter encoded as JSON
-        name: filters
-        in: query
-      - required: false
-        schema:
-          title: Order By
-          type: string
-          description: Order by field (`description|modified|name`) and direction
-            (`asc|desc`). The default sorting order is `{"field":"modified","direction":"desc"}`.
-          default: '{"field":"modified","direction":"desc"}'
-          example: '{"field":"some_field_name","direction":"desc"}'
-        name: order_by
         in: query
       - required: false
         schema:

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -2601,6 +2601,14 @@ paths:
       parameters:
       - required: false
         schema:
+          title: Workspace Id
+          exclusiveMinimum: true
+          type: integer
+          minimum: 0
+        name: workspace_id
+        in: query
+      - required: false
+        schema:
           title: Folder Id
           exclusiveMinimum: true
           type: integer
@@ -2609,22 +2617,21 @@ paths:
         in: query
       - required: false
         schema:
-          title: Workspace Id
-          exclusiveMinimum: true
+          title: Limit
+          exclusiveMaximum: true
+          minimum: 1
           type: integer
-          minimum: 0
-        name: workspace_id
+          default: 20
+          maximum: 50
+        name: limit
         in: query
-      - description: Order by field (modified_at|name|description) and direction (asc|desc).
-          The default sorting order is ascending.
-        required: false
+      - required: false
         schema:
-          title: Order By
-          description: Order by field (modified_at|name|description) and direction
-            (asc|desc). The default sorting order is ascending.
-          default: '{"field": "modified_at", "direction": "desc"}'
-        example: '{"field": "name", "direction": "desc"}'
-        name: order_by
+          title: Offset
+          minimum: 0
+          type: integer
+          default: 0
+        name: offset
         in: query
       - description: "{\n \"title\": \"FolderFilters\",\n \"description\": \"Encoded\
           \ as JSON. Each available filter can have its own logic (should be well\
@@ -2649,21 +2656,13 @@ paths:
         in: query
       - required: false
         schema:
-          title: Limit
-          exclusiveMaximum: true
-          minimum: 1
-          type: integer
-          default: 20
-          maximum: 50
-        name: limit
-        in: query
-      - required: false
-        schema:
-          title: Offset
-          minimum: 0
-          type: integer
-          default: 0
-        name: offset
+          title: Order By
+          type: string
+          description: Order by field (description|modified|name) and direction (asc|desc).
+            The default sorting order is 'desc' on 'modified'.For instance order_by={"field":"some_field_name","direction":"desc"}
+          format: json-string
+          default: '{"field":"modified","direction":"desc"}'
+        name: order_by
         in: query
       responses:
         '200':
@@ -3136,56 +3135,6 @@ paths:
       summary: List Projects
       operationId: list_projects
       parameters:
-      - description: Order by field (type|uuid|name|description|prj_owner|creation_date|last_change_date)
-          and direction (asc|desc). The default sorting order is ascending.
-        required: false
-        schema:
-          title: Order By
-          description: Order by field (type|uuid|name|description|prj_owner|creation_date|last_change_date)
-            and direction (asc|desc). The default sorting order is ascending.
-          default: '{"field": "last_change_date", "direction": "desc"}'
-        example: '{"field": "last_change_date", "direction": "desc"}'
-        name: order_by
-        in: query
-      - description: "{\n \"title\": \"ProjectFilters\",\n \"description\": \"Encoded\
-          \ as JSON. Each available filter can have its own logic (should be well\
-          \ documented)\\nInspired by Docker API https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerList.\"\
-          ,\n \"type\": \"object\",\n \"properties\": {\n  \"trashed\": {\n   \"title\"\
-          : \"Trashed\",\n   \"description\": \"Set to true to list trashed, false\
-          \ to list non-trashed (default), None to list all\",\n   \"default\": false,\n\
-          \   \"type\": \"boolean\"\n  }\n }\n}"
-        required: false
-        schema:
-          title: Filters
-          type: string
-          description: "{\n \"title\": \"ProjectFilters\",\n \"description\": \"Encoded\
-            \ as JSON. Each available filter can have its own logic (should be well\
-            \ documented)\\nInspired by Docker API https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerList.\"\
-            ,\n \"type\": \"object\",\n \"properties\": {\n  \"trashed\": {\n   \"\
-            title\": \"Trashed\",\n   \"description\": \"Set to true to list trashed,\
-            \ false to list non-trashed (default), None to list all\",\n   \"default\"\
-            : false,\n   \"type\": \"boolean\"\n  }\n }\n}"
-          format: json-string
-        name: filters
-        in: query
-      - required: false
-        schema:
-          title: Limit
-          exclusiveMaximum: true
-          minimum: 1
-          type: integer
-          default: 20
-          maximum: 50
-        name: limit
-        in: query
-      - required: false
-        schema:
-          title: Offset
-          minimum: 0
-          type: integer
-          default: 0
-        name: offset
-        in: query
       - required: false
         schema:
           allOf:
@@ -3222,6 +3171,42 @@ paths:
           type: integer
           minimum: 0
         name: workspace_id
+        in: query
+      - required: false
+        schema:
+          title: Limit
+          exclusiveMaximum: true
+          minimum: 1
+          type: integer
+          default: 20
+          maximum: 50
+        name: limit
+        in: query
+      - required: false
+        schema:
+          title: Offset
+          minimum: 0
+          type: integer
+          default: 0
+        name: offset
+        in: query
+      - required: false
+        schema:
+          title: Filters
+          type: string
+          format: json-string
+        name: filters
+        in: query
+      - required: false
+        schema:
+          title: Order By
+          type: string
+          description: Order by field (creation_date|description|last_change_date|name|prj_owner|type|uuid)
+            and direction (asc|desc). The default sorting order is 'desc' on 'last_change_date'.For
+            instance order_by={"field":"some_field_name","direction":"desc"}
+          format: json-string
+          default: '{"field":"last_change_date","direction":"desc"}'
+        name: order_by
         in: query
       responses:
         '200':
@@ -3297,7 +3282,7 @@ paths:
         content:
           application/json:
             schema:
-              title: ' Create'
+              title: ' B'
               anyOf:
               - $ref: '#/components/schemas/ProjectCreateNew'
               - $ref: '#/components/schemas/ProjectCopyOverride'
@@ -4649,16 +4634,31 @@ paths:
         are taken from context, optionally wallet_id parameter might be provided).
       operationId: list_resource_usage_services
       parameters:
-      - description: Order by field (wallet_id|wallet_name|user_id|project_id|project_name|node_id|node_name|service_key|service_version|service_type|started_at|stopped_at|service_run_status|credit_cost|transaction_status)
-          and direction (asc|desc). The default sorting order is ascending.
-        required: false
+      - required: false
         schema:
-          title: Order By
-          description: Order by field (wallet_id|wallet_name|user_id|project_id|project_name|node_id|node_name|service_key|service_version|service_type|started_at|stopped_at|service_run_status|credit_cost|transaction_status)
-            and direction (asc|desc). The default sorting order is ascending.
-          default: '{"field": "started_at", "direction": "desc"}'
-        example: '{"field": "started_at", "direction": "desc"}'
-        name: order_by
+          title: Wallet Id
+          exclusiveMinimum: true
+          type: integer
+          minimum: 0
+        name: wallet_id
+        in: query
+      - required: false
+        schema:
+          title: Limit
+          exclusiveMaximum: true
+          minimum: 1
+          type: integer
+          default: 20
+          maximum: 50
+        name: limit
+        in: query
+      - required: false
+        schema:
+          title: Offset
+          minimum: 0
+          type: integer
+          default: 0
+        name: offset
         in: query
       - description: Filters to process on the resource usages list, encoded as JSON.
           Currently supports the filtering of 'started_at' field with 'from' and 'until'
@@ -4678,26 +4678,14 @@ paths:
         in: query
       - required: false
         schema:
-          title: Wallet Id
-          exclusiveMinimum: true
-          type: integer
-          minimum: 0
-        name: wallet_id
-        in: query
-      - required: false
-        schema:
-          title: Limit
-          type: integer
-          default: 20
-        name: limit
-        in: query
-      - required: false
-        schema:
-          title: Offset
-          minimum: 0
-          type: integer
-          default: 0
-        name: offset
+          title: Order By
+          type: string
+          description: Order by field (credit_cost|node_id|node_name|project_id|project_name|root_parent_project_id|root_parent_project_name|service_key|service_run_status|service_type|service_version|started_at|stopped_at|transaction_status|user_email|user_id|wallet_id|wallet_name)
+            and direction (asc|desc). The default sorting order is 'desc' on 'started_at'.For
+            instance order_by={"field":"some_field_name","direction":"desc"}
+          format: json-string
+          default: '{"field":"started_at","direction":"desc"}'
+        name: order_by
         in: query
       responses:
         '200':
@@ -4736,8 +4724,11 @@ paths:
       - required: false
         schema:
           title: Limit
+          exclusiveMaximum: true
+          minimum: 1
           type: integer
           default: 20
+          maximum: 50
         name: limit
         in: query
       - required: false
@@ -4766,30 +4757,38 @@ paths:
       parameters:
       - required: false
         schema:
-          title: Order By
-          default: '{"field": "started_at", "direction": "desc"}'
-        example: '{"field": "started_at", "direction": "desc"}'
-        name: order_by
-        in: query
-      - description: Order by field (wallet_id|wallet_name|user_id|project_id|project_name|node_id|node_name|service_key|service_version|service_type|started_at|stopped_at|service_run_status|credit_cost|transaction_status)
-          and direction (asc|desc). The default sorting order is ascending.
-        required: false
-        schema:
-          title: Filters
-          type: string
-          description: Order by field (wallet_id|wallet_name|user_id|project_id|project_name|node_id|node_name|service_key|service_version|service_type|started_at|stopped_at|service_run_status|credit_cost|transaction_status)
-            and direction (asc|desc). The default sorting order is ascending.
-          format: json-string
-        example: '{"started_at": {"from": "yyyy-mm-dd", "until": "yyyy-mm-dd"}}'
-        name: filters
-        in: query
-      - required: false
-        schema:
           title: Wallet Id
           exclusiveMinimum: true
           type: integer
           minimum: 0
         name: wallet_id
+        in: query
+      - required: false
+        schema:
+          title: Order By
+          type: string
+          description: Order by field (credit_cost|node_id|node_name|project_id|project_name|root_parent_project_id|root_parent_project_name|service_key|service_run_status|service_type|service_version|started_at|stopped_at|transaction_status|user_email|user_id|wallet_id|wallet_name)
+            and direction (asc|desc). The default sorting order is 'desc' on 'started_at'.For
+            instance order_by={"field":"some_field_name","direction":"desc"}
+          format: json-string
+          default: '{"field":"started_at","direction":"desc"}'
+        name: order_by
+        in: query
+      - description: Filters to process on the resource usages list, encoded as JSON.
+          Currently supports the filtering of 'started_at' field with 'from' and 'until'
+          parameters in <yyyy-mm-dd> ISO 8601 format. The date range specified is
+          inclusive.
+        required: false
+        schema:
+          title: Filters
+          type: string
+          description: Filters to process on the resource usages list, encoded as
+            JSON. Currently supports the filtering of 'started_at' field with 'from'
+            and 'until' parameters in <yyyy-mm-dd> ISO 8601 format. The date range
+            specified is inclusive.
+          format: json-string
+        example: '{"started_at": {"from": "yyyy-mm-dd", "until": "yyyy-mm-dd"}}'
+        name: filters
         in: query
       responses:
         '302':

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -3137,6 +3137,42 @@ paths:
       parameters:
       - required: false
         schema:
+          title: Order By
+          type: string
+          description: Order by field (creation_date|description|last_change_date|name|prj_owner|type|uuid)
+            and direction (asc|desc). The default sorting order is 'desc' on 'last_change_date'.For
+            instance order_by={"field":"some_field_name","direction":"desc"}
+          format: json-string
+          default: '{"field":"last_change_date","direction":"desc"}'
+        name: order_by
+        in: query
+      - required: false
+        schema:
+          title: Filters
+          type: string
+          format: json-string
+        name: filters
+        in: query
+      - required: false
+        schema:
+          title: Limit
+          exclusiveMaximum: true
+          minimum: 1
+          type: integer
+          default: 20
+          maximum: 50
+        name: limit
+        in: query
+      - required: false
+        schema:
+          title: Offset
+          minimum: 0
+          type: integer
+          default: 0
+        name: offset
+        in: query
+      - required: false
+        schema:
           allOf:
           - $ref: '#/components/schemas/ProjectTypeAPI'
           default: all
@@ -3171,42 +3207,6 @@ paths:
           type: integer
           minimum: 0
         name: workspace_id
-        in: query
-      - required: false
-        schema:
-          title: Limit
-          exclusiveMaximum: true
-          minimum: 1
-          type: integer
-          default: 20
-          maximum: 50
-        name: limit
-        in: query
-      - required: false
-        schema:
-          title: Offset
-          minimum: 0
-          type: integer
-          default: 0
-        name: offset
-        in: query
-      - required: false
-        schema:
-          title: Filters
-          type: string
-          format: json-string
-        name: filters
-        in: query
-      - required: false
-        schema:
-          title: Order By
-          type: string
-          description: Order by field (creation_date|description|last_change_date|name|prj_owner|type|uuid)
-            and direction (asc|desc). The default sorting order is 'desc' on 'last_change_date'.For
-            instance order_by={"field":"some_field_name","direction":"desc"}
-          format: json-string
-          default: '{"field":"last_change_date","direction":"desc"}'
-        name: order_by
         in: query
       responses:
         '200':
@@ -3450,7 +3450,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Page_ProjectListFullSearchParams_'
+                $ref: '#/components/schemas/Page_SearchProjectExtraQueryParams_'
   /v0/projects/{project_id}/inactivity:
     get:
       tags:
@@ -4644,21 +4644,14 @@ paths:
         in: query
       - required: false
         schema:
-          title: Limit
-          exclusiveMaximum: true
-          minimum: 1
-          type: integer
-          default: 20
-          maximum: 50
-        name: limit
-        in: query
-      - required: false
-        schema:
-          title: Offset
-          minimum: 0
-          type: integer
-          default: 0
-        name: offset
+          title: Order By
+          type: string
+          description: Order by field (credit_cost|node_id|node_name|project_id|project_name|root_parent_project_id|root_parent_project_name|service_key|service_run_status|service_type|service_version|started_at|stopped_at|transaction_status|user_email|user_id|wallet_id|wallet_name)
+            and direction (asc|desc). The default sorting order is 'desc' on 'started_at'.For
+            instance order_by={"field":"some_field_name","direction":"desc"}
+          format: json-string
+          default: '{"field":"started_at","direction":"desc"}'
+        name: order_by
         in: query
       - description: Filters to process on the resource usages list, encoded as JSON.
           Currently supports the filtering of 'started_at' field with 'from' and 'until'
@@ -4678,14 +4671,21 @@ paths:
         in: query
       - required: false
         schema:
-          title: Order By
-          type: string
-          description: Order by field (credit_cost|node_id|node_name|project_id|project_name|root_parent_project_id|root_parent_project_name|service_key|service_run_status|service_type|service_version|started_at|stopped_at|transaction_status|user_email|user_id|wallet_id|wallet_name)
-            and direction (asc|desc). The default sorting order is 'desc' on 'started_at'.For
-            instance order_by={"field":"some_field_name","direction":"desc"}
-          format: json-string
-          default: '{"field":"started_at","direction":"desc"}'
-        name: order_by
+          title: Limit
+          exclusiveMaximum: true
+          minimum: 1
+          type: integer
+          default: 20
+          maximum: 50
+        name: limit
+        in: query
+      - required: false
+        schema:
+          title: Offset
+          minimum: 0
+          type: integer
+          default: 0
+        name: offset
         in: query
       responses:
         '200':
@@ -9904,25 +9904,6 @@ components:
             $ref: '#/components/schemas/ProjectIterationResultItem'
       additionalProperties: false
       description: Paginated response model of ItemTs
-    Page_ProjectListFullSearchParams_:
-      title: Page[ProjectListFullSearchParams]
-      required:
-      - _meta
-      - _links
-      - data
-      type: object
-      properties:
-        _meta:
-          $ref: '#/components/schemas/PageMetaInfoLimitOffset'
-        _links:
-          $ref: '#/components/schemas/PageLinks'
-        data:
-          title: Data
-          type: array
-          items:
-            $ref: '#/components/schemas/ProjectListFullSearchParams'
-      additionalProperties: false
-      description: Paginated response model of ItemTs
     Page_ProjectListItem_:
       title: Page[ProjectListItem]
       required:
@@ -9959,6 +9940,25 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RepoApiModel'
+      additionalProperties: false
+      description: Paginated response model of ItemTs
+    Page_SearchProjectExtraQueryParams_:
+      title: Page[SearchProjectExtraQueryParams]
+      required:
+      - _meta
+      - _links
+      - data
+      type: object
+      properties:
+        _meta:
+          $ref: '#/components/schemas/PageMetaInfoLimitOffset'
+        _links:
+          $ref: '#/components/schemas/PageLinks'
+        data:
+          title: Data
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchProjectExtraQueryParams'
       additionalProperties: false
       description: Paginated response model of ItemTs
     ParentMetaProjectRef:
@@ -10786,37 +10786,6 @@ components:
           format: uri
         results:
           $ref: '#/components/schemas/ExtractedResults'
-    ProjectListFullSearchParams:
-      title: ProjectListFullSearchParams
-      type: object
-      properties:
-        limit:
-          title: Limit
-          exclusiveMaximum: true
-          minimum: 1
-          type: integer
-          description: maximum number of items to return (pagination)
-          default: 20
-          maximum: 50
-        offset:
-          title: Offset
-          minimum: 0
-          type: integer
-          description: index to the first item to return (pagination)
-          default: 0
-        text:
-          title: Text
-          maxLength: 100
-          type: string
-          description: Multi column full text search, across all folders and workspaces
-          example: My Project
-        tag_ids:
-          title: Tag Ids
-          type: string
-          description: Search by tag ID (multiple tag IDs may be provided separated
-            by column)
-          example: 1,3
-      description: Use as pagination options in query parameters
     ProjectListItem:
       title: ProjectListItem
       required:
@@ -11547,6 +11516,37 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/Worker'
+    SearchProjectExtraQueryParams:
+      title: SearchProjectExtraQueryParams
+      type: object
+      properties:
+        limit:
+          title: Limit
+          exclusiveMaximum: true
+          minimum: 1
+          type: integer
+          description: maximum number of items to return (pagination)
+          default: 20
+          maximum: 50
+        offset:
+          title: Offset
+          minimum: 0
+          type: integer
+          description: index to the first item to return (pagination)
+          default: 0
+        text:
+          title: Text
+          maxLength: 100
+          type: string
+          description: Multi column full text search, across all folders and workspaces
+          example: My Project
+        tag_ids:
+          title: Tag Ids
+          type: string
+          description: Search by tag ID (multiple tag IDs may be provided separated
+            by column)
+          example: 1,3
+      description: Use as pagination options in query parameters
     SelectBox:
       title: SelectBox
       required:

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -2604,7 +2604,6 @@ paths:
           title: Filters
           type: string
           description: Custom filter query parameter encoded as JSON
-          format: json-string
         name: filters
         in: query
       - required: false
@@ -2613,7 +2612,6 @@ paths:
           type: string
           description: Order by field (`description|modified|name`) and direction
             (`asc|desc`). The default sorting order is `{"field":"modified","direction":"desc"}`.
-          format: json-string
           default: '{"field":"modified","direction":"desc"}'
           example: '{"field":"some_field_name","direction":"desc"}'
         name: order_by
@@ -2707,7 +2705,6 @@ paths:
           title: Filters
           type: string
           description: Custom filter query parameter encoded as JSON
-          format: json-string
         name: filters
         in: query
       - required: false
@@ -2716,7 +2713,6 @@ paths:
           type: string
           description: Order by field (`description|modified|name`) and direction
             (`asc|desc`). The default sorting order is `{"field":"modified","direction":"desc"}`.
-          format: json-string
           default: '{"field":"modified","direction":"desc"}'
           example: '{"field":"some_field_name","direction":"desc"}'
         name: order_by
@@ -3153,7 +3149,6 @@ paths:
           title: Filters
           type: string
           description: Custom filter query parameter encoded as JSON
-          format: json-string
         name: filters
         in: query
       - required: false
@@ -3162,7 +3157,6 @@ paths:
           type: string
           description: Order by field (`creation_date|description|last_change_date|name|prj_owner|type|uuid`)
             and direction (`asc|desc`). The default sorting order is `{"field":"last_change_date","direction":"desc"}`.
-          format: json-string
           default: '{"field":"last_change_date","direction":"desc"}'
           example: '{"field":"some_field_name","direction":"desc"}'
         name: order_by
@@ -3384,7 +3378,6 @@ paths:
           type: string
           description: Order by field (`creation_date|description|last_change_date|name|prj_owner|type|uuid`)
             and direction (`asc|desc`). The default sorting order is `{"field":"last_change_date","direction":"desc"}`.
-          format: json-string
           default: '{"field":"last_change_date","direction":"desc"}'
           example: '{"field":"some_field_name","direction":"desc"}'
         name: order_by
@@ -4394,7 +4387,7 @@ paths:
         '403':
           description: ProjectInvalidRightsError
         '404':
-          description: UserDefaultWalletNotFoundError, ProjectNotFoundError
+          description: ProjectNotFoundError, UserDefaultWalletNotFoundError
         '409':
           description: ProjectTooManyProjectOpenedError
         '422':
@@ -4616,7 +4609,6 @@ paths:
           type: string
           description: Order by field (`credit_cost|node_id|node_name|project_id|project_name|root_parent_project_id|root_parent_project_name|service_key|service_run_status|service_type|service_version|started_at|stopped_at|transaction_status|user_email|user_id|wallet_id|wallet_name`)
             and direction (`asc|desc`). The default sorting order is `{"field":"started_at","direction":"desc"}`.
-          format: json-string
           default: '{"field":"started_at","direction":"desc"}'
           example: '{"field":"some_field_name","direction":"desc"}'
         name: order_by
@@ -4637,7 +4629,6 @@ paths:
             JSON. Currently supports the filtering of 'started_at' field with 'from'
             and 'until' parameters in <yyyy-mm-dd> ISO 8601 format. The date range
             specified is inclusive.
-          format: json-string
         name: filters
         in: query
       - required: false
@@ -4732,7 +4723,6 @@ paths:
           type: string
           description: Order by field (`credit_cost|node_id|node_name|project_id|project_name|root_parent_project_id|root_parent_project_name|service_key|service_run_status|service_type|service_version|started_at|stopped_at|transaction_status|user_email|user_id|wallet_id|wallet_name`)
             and direction (`asc|desc`). The default sorting order is `{"field":"started_at","direction":"desc"}`.
-          format: json-string
           default: '{"field":"started_at","direction":"desc"}'
           example: '{"field":"some_field_name","direction":"desc"}'
         name: order_by
@@ -4753,7 +4743,6 @@ paths:
             JSON. Currently supports the filtering of 'started_at' field with 'from'
             and 'until' parameters in <yyyy-mm-dd> ISO 8601 format. The date range
             specified is inclusive.
-          format: json-string
         name: filters
         in: query
       responses:

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -3220,10 +3220,12 @@ paths:
           default: false
         name: hidden
         in: query
-      - required: false
+      - description: Optional simcore user agent
+        required: false
         schema:
           title: X-Simcore-User-Agent
           type: string
+          description: Optional simcore user agent
           default: undefined
         name: x-simcore-user-agent
         in: header
@@ -3253,7 +3255,7 @@ paths:
         content:
           application/json:
             schema:
-              title: ' B'
+              title: ' Body'
               anyOf:
               - $ref: '#/components/schemas/ProjectCreateNew'
               - $ref: '#/components/schemas/ProjectCopyOverride'
@@ -4387,7 +4389,7 @@ paths:
         '403':
           description: ProjectInvalidRightsError
         '404':
-          description: ProjectNotFoundError, UserDefaultWalletNotFoundError
+          description: UserDefaultWalletNotFoundError, ProjectNotFoundError
         '409':
           description: ProjectTooManyProjectOpenedError
         '422':

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -2601,19 +2601,22 @@ paths:
       parameters:
       - required: false
         schema:
-          title: Workspace Id
-          exclusiveMinimum: true
-          type: integer
-          minimum: 0
-        name: workspace_id
+          title: Filters
+          type: string
+          description: Custom filter query parameter encoded as JSON
+          format: json-string
+        name: filters
         in: query
       - required: false
         schema:
-          title: Folder Id
-          exclusiveMinimum: true
-          type: integer
-          minimum: 0
-        name: folder_id
+          title: Order By
+          type: string
+          description: Order by field (`description|modified|name`) and direction
+            (`asc|desc`). The default sorting order is `{"field":"modified","direction":"desc"}`.
+          format: json-string
+          default: '{"field":"modified","direction":"desc"}'
+          example: '{"field":"some_field_name","direction":"desc"}'
+        name: order_by
         in: query
       - required: false
         schema:
@@ -2633,36 +2636,21 @@ paths:
           default: 0
         name: offset
         in: query
-      - description: "{\n \"title\": \"FolderFilters\",\n \"description\": \"Encoded\
-          \ as JSON. Each available filter can have its own logic (should be well\
-          \ documented)\\nInspired by Docker API https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerList.\"\
-          ,\n \"type\": \"object\",\n \"properties\": {\n  \"trashed\": {\n   \"title\"\
-          : \"Trashed\",\n   \"description\": \"Set to true to list trashed, false\
-          \ to list non-trashed (default), None to list all\",\n   \"default\": false,\n\
-          \   \"type\": \"boolean\"\n  }\n }\n}"
-        required: false
+      - required: false
         schema:
-          title: Filters
-          type: string
-          description: "{\n \"title\": \"FolderFilters\",\n \"description\": \"Encoded\
-            \ as JSON. Each available filter can have its own logic (should be well\
-            \ documented)\\nInspired by Docker API https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerList.\"\
-            ,\n \"type\": \"object\",\n \"properties\": {\n  \"trashed\": {\n   \"\
-            title\": \"Trashed\",\n   \"description\": \"Set to true to list trashed,\
-            \ false to list non-trashed (default), None to list all\",\n   \"default\"\
-            : false,\n   \"type\": \"boolean\"\n  }\n }\n}"
-          format: json-string
-        name: filters
+          title: Folder Id
+          exclusiveMinimum: true
+          type: integer
+          minimum: 0
+        name: folder_id
         in: query
       - required: false
         schema:
-          title: Order By
-          type: string
-          description: Order by field (description|modified|name) and direction (asc|desc).
-            The default sorting order is 'desc' on 'modified'.For instance order_by={"field":"some_field_name","direction":"desc"}
-          format: json-string
-          default: '{"field":"modified","direction":"desc"}'
-        name: order_by
+          title: Workspace Id
+          exclusiveMinimum: true
+          type: integer
+          minimum: 0
+        name: workspace_id
         in: query
       responses:
         '200':
@@ -2698,44 +2686,6 @@ paths:
       parameters:
       - required: false
         schema:
-          title: Text
-          type: string
-        name: text
-        in: query
-      - description: Order by field (modified_at|name|description) and direction (asc|desc).
-          The default sorting order is ascending.
-        required: false
-        schema:
-          title: Order By
-          description: Order by field (modified_at|name|description) and direction
-            (asc|desc). The default sorting order is ascending.
-          default: '{"field": "modified_at", "direction": "desc"}'
-        example: '{"field": "name", "direction": "desc"}'
-        name: order_by
-        in: query
-      - description: "{\n \"title\": \"FolderFilters\",\n \"description\": \"Encoded\
-          \ as JSON. Each available filter can have its own logic (should be well\
-          \ documented)\\nInspired by Docker API https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerList.\"\
-          ,\n \"type\": \"object\",\n \"properties\": {\n  \"trashed\": {\n   \"title\"\
-          : \"Trashed\",\n   \"description\": \"Set to true to list trashed, false\
-          \ to list non-trashed (default), None to list all\",\n   \"default\": false,\n\
-          \   \"type\": \"boolean\"\n  }\n }\n}"
-        required: false
-        schema:
-          title: Filters
-          type: string
-          description: "{\n \"title\": \"FolderFilters\",\n \"description\": \"Encoded\
-            \ as JSON. Each available filter can have its own logic (should be well\
-            \ documented)\\nInspired by Docker API https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerList.\"\
-            ,\n \"type\": \"object\",\n \"properties\": {\n  \"trashed\": {\n   \"\
-            title\": \"Trashed\",\n   \"description\": \"Set to true to list trashed,\
-            \ false to list non-trashed (default), None to list all\",\n   \"default\"\
-            : false,\n   \"type\": \"boolean\"\n  }\n }\n}"
-          format: json-string
-        name: filters
-        in: query
-      - required: false
-        schema:
           title: Limit
           exclusiveMaximum: true
           minimum: 1
@@ -2751,6 +2701,32 @@ paths:
           type: integer
           default: 0
         name: offset
+        in: query
+      - required: false
+        schema:
+          title: Filters
+          type: string
+          description: Custom filter query parameter encoded as JSON
+          format: json-string
+        name: filters
+        in: query
+      - required: false
+        schema:
+          title: Order By
+          type: string
+          description: Order by field (`description|modified|name`) and direction
+            (`asc|desc`). The default sorting order is `{"field":"modified","direction":"desc"}`.
+          format: json-string
+          default: '{"field":"modified","direction":"desc"}'
+          example: '{"field":"some_field_name","direction":"desc"}'
+        name: order_by
+        in: query
+      - required: false
+        schema:
+          title: Text
+          maxLength: 100
+          type: string
+        name: text
         in: query
       responses:
         '200':
@@ -3137,42 +3113,6 @@ paths:
       parameters:
       - required: false
         schema:
-          title: Order By
-          type: string
-          description: Order by field (creation_date|description|last_change_date|name|prj_owner|type|uuid)
-            and direction (asc|desc). The default sorting order is 'desc' on 'last_change_date'.For
-            instance order_by={"field":"some_field_name","direction":"desc"}
-          format: json-string
-          default: '{"field":"last_change_date","direction":"desc"}'
-        name: order_by
-        in: query
-      - required: false
-        schema:
-          title: Filters
-          type: string
-          format: json-string
-        name: filters
-        in: query
-      - required: false
-        schema:
-          title: Limit
-          exclusiveMaximum: true
-          minimum: 1
-          type: integer
-          default: 20
-          maximum: 50
-        name: limit
-        in: query
-      - required: false
-        schema:
-          title: Offset
-          minimum: 0
-          type: integer
-          default: 0
-        name: offset
-        in: query
-      - required: false
-        schema:
           allOf:
           - $ref: '#/components/schemas/ProjectTypeAPI'
           default: all
@@ -3207,6 +3147,43 @@ paths:
           type: integer
           minimum: 0
         name: workspace_id
+        in: query
+      - required: false
+        schema:
+          title: Filters
+          type: string
+          description: Custom filter query parameter encoded as JSON
+          format: json-string
+        name: filters
+        in: query
+      - required: false
+        schema:
+          title: Order By
+          type: string
+          description: Order by field (`creation_date|description|last_change_date|name|prj_owner|type|uuid`)
+            and direction (`asc|desc`). The default sorting order is `{"field":"last_change_date","direction":"desc"}`.
+          format: json-string
+          default: '{"field":"last_change_date","direction":"desc"}'
+          example: '{"field":"some_field_name","direction":"desc"}'
+        name: order_by
+        in: query
+      - required: false
+        schema:
+          title: Limit
+          exclusiveMaximum: true
+          minimum: 1
+          type: integer
+          default: 20
+          maximum: 50
+        name: limit
+        in: query
+      - required: false
+        schema:
+          title: Offset
+          minimum: 0
+          type: integer
+          default: 0
+        name: offset
         in: query
       responses:
         '200':
@@ -3401,16 +3378,15 @@ paths:
       summary: List Projects Full Search
       operationId: list_projects_full_search
       parameters:
-      - description: Order by field (type|uuid|name|description|prj_owner|creation_date|last_change_date)
-          and direction (asc|desc). The default sorting order is ascending.
-        required: false
+      - required: false
         schema:
           title: Order By
-          description: Order by field (type|uuid|name|description|prj_owner|creation_date|last_change_date)
-            and direction (asc|desc). The default sorting order is ascending.
-          default:
-          - '{"field": "last_change_date", "direction": "desc"}'
-        example: '{"field": "last_change_date", "direction": "desc"}'
+          type: string
+          description: Order by field (`creation_date|description|last_change_date|name|prj_owner|type|uuid`)
+            and direction (`asc|desc`). The default sorting order is `{"field":"last_change_date","direction":"desc"}`.
+          format: json-string
+          default: '{"field":"last_change_date","direction":"desc"}'
+          example: '{"field":"some_field_name","direction":"desc"}'
         name: order_by
         in: query
       - required: false
@@ -3450,7 +3426,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Page_SearchProjectExtraQueryParams_'
+                $ref: '#/components/schemas/Page_ProjectListItem_'
   /v0/projects/{project_id}/inactivity:
     get:
       tags:
@@ -4636,6 +4612,17 @@ paths:
       parameters:
       - required: false
         schema:
+          title: Order By
+          type: string
+          description: Order by field (`credit_cost|node_id|node_name|project_id|project_name|root_parent_project_id|root_parent_project_name|service_key|service_run_status|service_type|service_version|started_at|stopped_at|transaction_status|user_email|user_id|wallet_id|wallet_name`)
+            and direction (`asc|desc`). The default sorting order is `{"field":"started_at","direction":"desc"}`.
+          format: json-string
+          default: '{"field":"started_at","direction":"desc"}'
+          example: '{"field":"some_field_name","direction":"desc"}'
+        name: order_by
+        in: query
+      - required: false
+        schema:
           title: Wallet Id
           exclusiveMinimum: true
           type: integer
@@ -4644,21 +4631,6 @@ paths:
         in: query
       - required: false
         schema:
-          title: Order By
-          type: string
-          description: Order by field (credit_cost|node_id|node_name|project_id|project_name|root_parent_project_id|root_parent_project_name|service_key|service_run_status|service_type|service_version|started_at|stopped_at|transaction_status|user_email|user_id|wallet_id|wallet_name)
-            and direction (asc|desc). The default sorting order is 'desc' on 'started_at'.For
-            instance order_by={"field":"some_field_name","direction":"desc"}
-          format: json-string
-          default: '{"field":"started_at","direction":"desc"}'
-        name: order_by
-        in: query
-      - description: Filters to process on the resource usages list, encoded as JSON.
-          Currently supports the filtering of 'started_at' field with 'from' and 'until'
-          parameters in <yyyy-mm-dd> ISO 8601 format. The date range specified is
-          inclusive.
-        required: false
-        schema:
           title: Filters
           type: string
           description: Filters to process on the resource usages list, encoded as
@@ -4666,7 +4638,6 @@ paths:
             and 'until' parameters in <yyyy-mm-dd> ISO 8601 format. The date range
             specified is inclusive.
           format: json-string
-        example: '{"started_at": {"from": "yyyy-mm-dd", "until": "yyyy-mm-dd"}}'
         name: filters
         in: query
       - required: false
@@ -4703,24 +4674,6 @@ paths:
         be provided).
       operationId: list_osparc_credits_aggregated_usages
       parameters:
-      - required: true
-        schema:
-          $ref: '#/components/schemas/ServicesAggregatedUsagesType'
-        name: aggregated_by
-        in: query
-      - required: true
-        schema:
-          $ref: '#/components/schemas/ServicesAggregatedUsagesTimePeriod'
-        name: time_period
-        in: query
-      - required: true
-        schema:
-          title: Wallet Id
-          exclusiveMinimum: true
-          type: integer
-          minimum: 0
-        name: wallet_id
-        in: query
       - required: false
         schema:
           title: Limit
@@ -4738,6 +4691,24 @@ paths:
           type: integer
           default: 0
         name: offset
+        in: query
+      - required: false
+        schema:
+          $ref: '#/components/schemas/ServicesAggregatedUsagesType'
+        name: aggregated_by
+        in: query
+      - required: false
+        schema:
+          $ref: '#/components/schemas/ServicesAggregatedUsagesTimePeriod'
+        name: time_period
+        in: query
+      - required: false
+        schema:
+          title: Wallet Id
+          exclusiveMinimum: true
+          type: integer
+          minimum: 0
+        name: wallet_id
         in: query
       responses:
         '200':
@@ -4757,6 +4728,17 @@ paths:
       parameters:
       - required: false
         schema:
+          title: Order By
+          type: string
+          description: Order by field (`credit_cost|node_id|node_name|project_id|project_name|root_parent_project_id|root_parent_project_name|service_key|service_run_status|service_type|service_version|started_at|stopped_at|transaction_status|user_email|user_id|wallet_id|wallet_name`)
+            and direction (`asc|desc`). The default sorting order is `{"field":"started_at","direction":"desc"}`.
+          format: json-string
+          default: '{"field":"started_at","direction":"desc"}'
+          example: '{"field":"some_field_name","direction":"desc"}'
+        name: order_by
+        in: query
+      - required: false
+        schema:
           title: Wallet Id
           exclusiveMinimum: true
           type: integer
@@ -4765,21 +4747,6 @@ paths:
         in: query
       - required: false
         schema:
-          title: Order By
-          type: string
-          description: Order by field (credit_cost|node_id|node_name|project_id|project_name|root_parent_project_id|root_parent_project_name|service_key|service_run_status|service_type|service_version|started_at|stopped_at|transaction_status|user_email|user_id|wallet_id|wallet_name)
-            and direction (asc|desc). The default sorting order is 'desc' on 'started_at'.For
-            instance order_by={"field":"some_field_name","direction":"desc"}
-          format: json-string
-          default: '{"field":"started_at","direction":"desc"}'
-        name: order_by
-        in: query
-      - description: Filters to process on the resource usages list, encoded as JSON.
-          Currently supports the filtering of 'started_at' field with 'from' and 'until'
-          parameters in <yyyy-mm-dd> ISO 8601 format. The date range specified is
-          inclusive.
-        required: false
-        schema:
           title: Filters
           type: string
           description: Filters to process on the resource usages list, encoded as
@@ -4787,7 +4754,6 @@ paths:
             and 'until' parameters in <yyyy-mm-dd> ISO 8601 format. The date range
             specified is inclusive.
           format: json-string
-        example: '{"started_at": {"from": "yyyy-mm-dd", "until": "yyyy-mm-dd"}}'
         name: filters
         in: query
       responses:
@@ -9942,25 +9908,6 @@ components:
             $ref: '#/components/schemas/RepoApiModel'
       additionalProperties: false
       description: Paginated response model of ItemTs
-    Page_SearchProjectExtraQueryParams_:
-      title: Page[SearchProjectExtraQueryParams]
-      required:
-      - _meta
-      - _links
-      - data
-      type: object
-      properties:
-        _meta:
-          $ref: '#/components/schemas/PageMetaInfoLimitOffset'
-        _links:
-          $ref: '#/components/schemas/PageLinks'
-        data:
-          title: Data
-          type: array
-          items:
-            $ref: '#/components/schemas/SearchProjectExtraQueryParams'
-      additionalProperties: false
-      description: Paginated response model of ItemTs
     ParentMetaProjectRef:
       title: ParentMetaProjectRef
       required:
@@ -11516,37 +11463,6 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/Worker'
-    SearchProjectExtraQueryParams:
-      title: SearchProjectExtraQueryParams
-      type: object
-      properties:
-        limit:
-          title: Limit
-          exclusiveMaximum: true
-          minimum: 1
-          type: integer
-          description: maximum number of items to return (pagination)
-          default: 20
-          maximum: 50
-        offset:
-          title: Offset
-          minimum: 0
-          type: integer
-          description: index to the first item to return (pagination)
-          default: 0
-        text:
-          title: Text
-          maxLength: 100
-          type: string
-          description: Multi column full text search, across all folders and workspaces
-          example: My Project
-        tag_ids:
-          title: Tag Ids
-          type: string
-          description: Search by tag ID (multiple tag IDs may be provided separated
-            by column)
-          example: 1,3
-      description: Use as pagination options in query parameters
     SelectBox:
       title: SelectBox
       required:

--- a/services/web/server/src/simcore_service_webserver/api_keys/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/api_keys/_handlers.py
@@ -3,18 +3,15 @@ import logging
 from aiohttp import web
 from aiohttp.web import RouteTableDef
 from models_library.api_schemas_webserver.auth import ApiKeyCreate
-from models_library.rest_base import RequestParameters
-from models_library.users import UserID
-from pydantic import Field
 from servicelib.aiohttp import status
 from servicelib.aiohttp.requests_validation import parse_request_body_as
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
 from simcore_postgres_database.errors import DatabaseError
 from simcore_service_webserver.security.decorators import permission_required
 
-from .._constants import RQ_PRODUCT_KEY, RQT_USERID_KEY
 from .._meta import API_VTAG
 from ..login.decorators import login_required
+from ..models import RequestContext
 from ..utils_aiohttp import envelope_json_response
 from . import _api
 
@@ -24,16 +21,11 @@ _logger = logging.getLogger(__name__)
 routes = RouteTableDef()
 
 
-class _RequestContext(RequestParameters):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
-    product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
-
-
 @routes.get(f"/{API_VTAG}/auth/api-keys", name="list_api_keys")
 @login_required
 @permission_required("user.apikey.*")
 async def list_api_keys(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     api_keys_names = await _api.list_api_keys(
         request.app,
         user_id=req_ctx.user_id,
@@ -46,7 +38,7 @@ async def list_api_keys(request: web.Request):
 @login_required
 @permission_required("user.apikey.*")
 async def create_api_key(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     new = await parse_request_body_as(ApiKeyCreate, request)
     try:
         data = await _api.create_api_key(
@@ -68,7 +60,7 @@ async def create_api_key(request: web.Request):
 @login_required
 @permission_required("user.apikey.*")
 async def delete_api_key(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
 
     # NOTE: SEE https://github.com/ITISFoundation/osparc-simcore/issues/4920
     body = await request.json()

--- a/services/web/server/src/simcore_service_webserver/api_keys/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/api_keys/_handlers.py
@@ -3,10 +3,11 @@ import logging
 from aiohttp import web
 from aiohttp.web import RouteTableDef
 from models_library.api_schemas_webserver.auth import ApiKeyCreate
+from models_library.rest_base import RequestParameters
 from models_library.users import UserID
 from pydantic import Field
 from servicelib.aiohttp import status
-from servicelib.aiohttp.requests_validation import RequestParams, parse_request_body_as
+from servicelib.aiohttp.requests_validation import parse_request_body_as
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
 from simcore_postgres_database.errors import DatabaseError
 from simcore_service_webserver.security.decorators import permission_required
@@ -23,7 +24,7 @@ _logger = logging.getLogger(__name__)
 routes = RouteTableDef()
 
 
-class _RequestContext(RequestParams):
+class _RequestContext(RequestParameters):
     user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
     product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 

--- a/services/web/server/src/simcore_service_webserver/clusters/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/clusters/_handlers.py
@@ -10,15 +10,13 @@ from models_library.api_schemas_webserver.clusters import (
     ClusterPathParams,
     ClusterPing,
 )
-from models_library.users import UserID
-from pydantic import BaseModel, Field, parse_obj_as
+from pydantic import parse_obj_as
 from servicelib.aiohttp import status
 from servicelib.aiohttp.requests_validation import (
     parse_request_body_as,
     parse_request_path_parameters_as,
 )
 from servicelib.aiohttp.typing_extension import Handler
-from servicelib.request_keys import RQT_USERID_KEY
 
 from .._meta import api_version_prefix
 from ..director_v2 import api as director_v2_api
@@ -29,6 +27,7 @@ from ..director_v2.exceptions import (
     DirectorServiceError,
 )
 from ..login.decorators import login_required
+from ..models import RequestContext
 from ..security.decorators import permission_required
 from ..utils_aiohttp import envelope_json_response
 
@@ -58,15 +57,6 @@ def _handle_cluster_exceptions(handler: Handler):
 
 
 #
-# API components/schemas
-#
-
-
-class _RequestContext(BaseModel):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
-
-
-#
 # API handlers
 #
 
@@ -78,7 +68,7 @@ routes = web.RouteTableDef()
 @permission_required("clusters.create")
 @_handle_cluster_exceptions
 async def create_cluster(request: web.Request) -> web.Response:
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     new_cluster = await parse_request_body_as(ClusterCreate, request)
 
     created_cluster = await director_v2_api.create_cluster(
@@ -94,7 +84,7 @@ async def create_cluster(request: web.Request) -> web.Response:
 @permission_required("clusters.read")
 @_handle_cluster_exceptions
 async def list_clusters(request: web.Request) -> web.Response:
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
 
     clusters = await director_v2_api.list_clusters(
         app=request.app,
@@ -109,7 +99,7 @@ async def list_clusters(request: web.Request) -> web.Response:
 @permission_required("clusters.read")
 @_handle_cluster_exceptions
 async def get_cluster(request: web.Request) -> web.Response:
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(ClusterPathParams, request)
 
     cluster = await director_v2_api.get_cluster(
@@ -126,7 +116,7 @@ async def get_cluster(request: web.Request) -> web.Response:
 @permission_required("clusters.write")
 @_handle_cluster_exceptions
 async def update_cluster(request: web.Request) -> web.Response:
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(ClusterPathParams, request)
     cluster_patch = await parse_request_body_as(ClusterPatch, request)
 
@@ -146,7 +136,7 @@ async def update_cluster(request: web.Request) -> web.Response:
 @permission_required("clusters.delete")
 @_handle_cluster_exceptions
 async def delete_cluster(request: web.Request) -> web.Response:
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(ClusterPathParams, request)
 
     await director_v2_api.delete_cluster(
@@ -165,7 +155,7 @@ async def delete_cluster(request: web.Request) -> web.Response:
 @permission_required("clusters.read")
 @_handle_cluster_exceptions
 async def get_cluster_details(request: web.Request) -> web.Response:
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(ClusterPathParams, request)
 
     cluster_details = await director_v2_api.get_cluster_details(
@@ -199,7 +189,7 @@ async def ping_cluster(request: web.Request) -> web.Response:
 @permission_required("clusters.read")
 @_handle_cluster_exceptions
 async def ping_cluster_cluster_id(request: web.Request) -> web.Response:
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(ClusterPathParams, request)
 
     await director_v2_api.ping_specific_cluster(

--- a/services/web/server/src/simcore_service_webserver/director_v2/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2/_handlers.py
@@ -26,6 +26,7 @@ from .._constants import RQ_PRODUCT_KEY
 from .._meta import API_VTAG as VTAG
 from ..db.plugin import get_database_engine
 from ..login.decorators import login_required
+from ..models import RequestContext
 from ..products import api as products_api
 from ..security.decorators import permission_required
 from ..users.exceptions import UserDefaultWalletNotFoundError

--- a/services/web/server/src/simcore_service_webserver/director_v2/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2/_handlers.py
@@ -22,7 +22,6 @@ from simcore_postgres_database.utils_groups_extra_properties import (
     GroupExtraPropertiesRepo,
 )
 
-from .._constants import RQ_PRODUCT_KEY
 from .._meta import API_VTAG as VTAG
 from ..db.plugin import get_database_engine
 from ..login.decorators import login_required
@@ -42,11 +41,6 @@ _logger = logging.getLogger(__name__)
 
 
 routes = web.RouteTableDef()
-
-
-class RequestContext(BaseModel):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
-    product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
 class _ComputationStarted(BaseModel):

--- a/services/web/server/src/simcore_service_webserver/folders/_folders_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_folders_handlers.py
@@ -28,7 +28,7 @@ from . import _folders_api
 from ._exceptions_handlers import handle_plugin_requests_exceptions
 from ._models import (
     FolderFilters,
-    FolderListFullSearchQueryParams,
+    FolderSearchQueryParams,
     FoldersListQueryParams,
     FoldersPathParams,
     FoldersRequestContext,
@@ -106,8 +106,8 @@ async def list_folders(request: web.Request):
 @handle_plugin_requests_exceptions
 async def list_folders_full_search(request: web.Request):
     req_ctx = FoldersRequestContext.parse_obj(request)
-    query_params: FolderListFullSearchQueryParams = parse_request_query_parameters_as(
-        FolderListFullSearchQueryParams, request
+    query_params: FolderSearchQueryParams = parse_request_query_parameters_as(
+        FolderSearchQueryParams, request
     )
 
     if not query_params.filters:

--- a/services/web/server/src/simcore_service_webserver/folders/_folders_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_folders_handlers.py
@@ -28,8 +28,8 @@ from . import _folders_api
 from ._exceptions_handlers import handle_plugin_requests_exceptions
 from ._models import (
     FolderFilters,
-    FolderListFullSearchWithJsonStrQueryParams,
-    FolderListWithJsonStrQueryParams,
+    FolderListFullSearchQueryParams,
+    FoldersListQueryParams,
     FoldersPathParams,
     FoldersRequestContext,
 )
@@ -66,8 +66,8 @@ async def create_folder(request: web.Request):
 @handle_plugin_requests_exceptions
 async def list_folders(request: web.Request):
     req_ctx = FoldersRequestContext.parse_obj(request)
-    query_params: FolderListWithJsonStrQueryParams = parse_request_query_parameters_as(
-        FolderListWithJsonStrQueryParams, request
+    query_params: FoldersListQueryParams = parse_request_query_parameters_as(
+        FoldersListQueryParams, request
     )
 
     if not query_params.filters:
@@ -106,10 +106,8 @@ async def list_folders(request: web.Request):
 @handle_plugin_requests_exceptions
 async def list_folders_full_search(request: web.Request):
     req_ctx = FoldersRequestContext.parse_obj(request)
-    query_params: FolderListFullSearchWithJsonStrQueryParams = (
-        parse_request_query_parameters_as(
-            FolderListFullSearchWithJsonStrQueryParams, request
-        )
+    query_params: FolderListFullSearchQueryParams = parse_request_query_parameters_as(
+        FolderListFullSearchQueryParams, request
     )
 
     if not query_params.filters:

--- a/services/web/server/src/simcore_service_webserver/folders/_models.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_models.py
@@ -42,7 +42,7 @@ class FolderFilters(Filters):
 
 (
     _FolderSortQueryParams,
-    FolderSortJsonQueryParams,
+    FolderSortQueryParamsOpenApi,
 ) = create_order_by_query_model_classes(
     sortable_fields={"modified", "name", "description"},
     default_order_by=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),

--- a/services/web/server/src/simcore_service_webserver/folders/_models.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_models.py
@@ -46,6 +46,7 @@ _FolderOrderQueryParams: type[RequestParameters] = create_ordering_query_model_c
         "name",
     },
     default=OrderBy(field=IDStr("modified_at"), direction=OrderDirection.DESC),
+    ordering_fields_api_to_column_map={"modified_at": "modified"},
 )
 
 
@@ -72,13 +73,6 @@ class FoldersListQueryParams(
     _null_or_none_str_to_none_validator2 = validator(
         "workspace_id", allow_reuse=True, pre=True
     )(null_or_none_str_to_none_validator)
-
-    @validator("order_by", always=True)
-    @classmethod
-    def _post_rename_order_by_field_as_db_column(cls, v):
-        if v.field == "modified_at":  # API field
-            v.field = "modified"  # DB column
-        return v
 
 
 class FolderSearchQueryParams(

--- a/services/web/server/src/simcore_service_webserver/folders/_models.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_models.py
@@ -40,14 +40,14 @@ class FolderFilters(Filters):
     )
 
 
-_FolderOrderQueryParams = create_ordering_query_model_classes(
+_FolderOrderQueryParams: type[RequestParameters] = create_ordering_query_model_classes(
     ordering_fields={"modified", "name", "description"},
     default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
 )
 
 
 class FoldersListQueryParams(
-    PageQueryParameters, _FolderOrderQueryParams, FiltersQueryParameters[FolderFilters]
+    PageQueryParameters, _FolderOrderQueryParams, FiltersQueryParameters[FolderFilters]  # type: ignore[misc, valid-type]
 ):
     folder_id: FolderID | None = Field(
         default=None,
@@ -72,7 +72,7 @@ class FoldersListQueryParams(
 
 
 class FolderSearchQueryParams(
-    PageQueryParameters, _FolderOrderQueryParams, FiltersQueryParameters[FolderFilters]
+    PageQueryParameters, _FolderOrderQueryParams, FiltersQueryParameters[FolderFilters]  # type: ignore[misc, valid-type]
 ):
     text: str | None = Field(
         default=None,

--- a/services/web/server/src/simcore_service_webserver/folders/_models.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_models.py
@@ -41,8 +41,11 @@ class FolderFilters(Filters):
 
 
 _FolderOrderQueryParams: type[RequestParameters] = create_ordering_query_model_classes(
-    ordering_fields={"modified", "name", "description"},
-    default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
+    ordering_fields={
+        "modified_at",
+        "name",
+    },
+    default=OrderBy(field=IDStr("modified_at"), direction=OrderDirection.DESC),
 )
 
 
@@ -69,6 +72,13 @@ class FoldersListQueryParams(
     _null_or_none_str_to_none_validator2 = validator(
         "workspace_id", allow_reuse=True, pre=True
     )(null_or_none_str_to_none_validator)
+
+    @validator("order_by", always=True)
+    @classmethod
+    def _post_rename_order_by_field_as_db_column(cls, v):
+        if v.field == "modified_at":  # API field
+            v.field = "modified"  # DB column
+        return v
 
 
 class FolderSearchQueryParams(

--- a/services/web/server/src/simcore_service_webserver/folders/_models.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_models.py
@@ -41,8 +41,8 @@ class FolderFilters(Filters):
 
 
 (
-    _FolderSortQueryParams,
-    FolderSortQueryParamsOpenApi,
+    _FolderOrderQueryParams,
+    FolderOrderQueryParamsOpenApi,
 ) = create_ordering_query_model_classes(
     sortable_fields={"modified", "name", "description"},
     default_order_by=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
@@ -50,7 +50,7 @@ class FolderFilters(Filters):
 
 
 class FolderListWithJsonStrQueryParams(
-    PageQueryParameters, _FolderSortQueryParams, FiltersQueryParameters[FolderFilters]
+    PageQueryParameters, _FolderOrderQueryParams, FiltersQueryParameters[FolderFilters]
 ):
     folder_id: FolderID | None = Field(
         default=None,
@@ -75,7 +75,7 @@ class FolderListWithJsonStrQueryParams(
 
 
 class FolderListFullSearchWithJsonStrQueryParams(
-    PageQueryParameters, _FolderSortQueryParams, FiltersQueryParameters[FolderFilters]
+    PageQueryParameters, _FolderOrderQueryParams, FiltersQueryParameters[FolderFilters]
 ):
     text: str | None = Field(
         default=None,

--- a/services/web/server/src/simcore_service_webserver/folders/_models.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_models.py
@@ -33,9 +33,6 @@ class FoldersPathParams(StrictRequestParameters):
     folder_id: FolderID
 
 
-# QUERY ----------
-
-
 class FolderFilters(Filters):
     trashed: bool | None = Field(
         default=False,
@@ -43,7 +40,7 @@ class FolderFilters(Filters):
     )
 
 
-(_FolderOrderQueryParams, _,) = create_ordering_query_model_classes(
+_FolderOrderQueryParams, _ = create_ordering_query_model_classes(
     ordering_fields={"modified", "name", "description"},
     default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
 )
@@ -74,7 +71,7 @@ class FoldersListQueryParams(
     )(null_or_none_str_to_none_validator)
 
 
-class FolderListFullSearchQueryParams(
+class FolderSearchQueryParams(
     PageQueryParameters, _FolderOrderQueryParams, FiltersQueryParameters[FolderFilters]
 ):
     text: str | None = Field(

--- a/services/web/server/src/simcore_service_webserver/folders/_models.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_models.py
@@ -2,6 +2,7 @@ import logging
 
 from models_library.basic_types import IDStr
 from models_library.folders import FolderID
+from models_library.rest_base import RequestParameters, StrictRequestParameters
 from models_library.rest_filters import Filters, FiltersQueryParameters
 from models_library.rest_ordering import OrderBy, OrderDirection
 from models_library.rest_pagination import PageQueryParameters
@@ -12,7 +13,6 @@ from models_library.utils.common_validators import (
 )
 from models_library.workspaces import WorkspaceID
 from pydantic import BaseModel, Extra, Field, Json, validator
-from servicelib.aiohttp.requests_validation import RequestParams, StrictRequestParams
 from servicelib.request_keys import RQT_USERID_KEY
 
 from .._constants import RQ_PRODUCT_KEY
@@ -20,12 +20,12 @@ from .._constants import RQ_PRODUCT_KEY
 _logger = logging.getLogger(__name__)
 
 
-class FoldersRequestContext(RequestParams):
+class FoldersRequestContext(RequestParameters):
     user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
     product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
-class FoldersPathParams(StrictRequestParams):
+class FoldersPathParams(StrictRequestParameters):
     folder_id: FolderID
 
 

--- a/services/web/server/src/simcore_service_webserver/folders/_models.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_models.py
@@ -33,6 +33,9 @@ class FoldersPathParams(StrictRequestParameters):
     folder_id: FolderID
 
 
+# QUERY ----------
+
+
 class FolderFilters(Filters):
     trashed: bool | None = Field(
         default=False,
@@ -40,16 +43,13 @@ class FolderFilters(Filters):
     )
 
 
-(
-    _FolderOrderQueryParams,
-    FolderOrderQueryParamsOpenApi,
-) = create_ordering_query_model_classes(
-    sortable_fields={"modified", "name", "description"},
-    default_order_by=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
+(_FolderOrderQueryParams, _,) = create_ordering_query_model_classes(
+    ordering_fields={"modified", "name", "description"},
+    default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
 )
 
 
-class FolderListWithJsonStrQueryParams(
+class FoldersListQueryParams(
     PageQueryParameters, _FolderOrderQueryParams, FiltersQueryParameters[FolderFilters]
 ):
     folder_id: FolderID | None = Field(
@@ -74,7 +74,7 @@ class FolderListWithJsonStrQueryParams(
     )(null_or_none_str_to_none_validator)
 
 
-class FolderListFullSearchWithJsonStrQueryParams(
+class FolderListFullSearchQueryParams(
     PageQueryParameters, _FolderOrderQueryParams, FiltersQueryParameters[FolderFilters]
 ):
     text: str | None = Field(

--- a/services/web/server/src/simcore_service_webserver/folders/_models.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_models.py
@@ -7,7 +7,7 @@ from models_library.rest_filters import Filters, FiltersQueryParameters
 from models_library.rest_ordering import (
     OrderBy,
     OrderDirection,
-    create_order_by_query_model_classes,
+    create_ordering_query_model_classes,
 )
 from models_library.rest_pagination import PageQueryParameters
 from models_library.users import UserID
@@ -43,7 +43,7 @@ class FolderFilters(Filters):
 (
     _FolderSortQueryParams,
     FolderSortQueryParamsOpenApi,
-) = create_order_by_query_model_classes(
+) = create_ordering_query_model_classes(
     sortable_fields={"modified", "name", "description"},
     default_order_by=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
 )

--- a/services/web/server/src/simcore_service_webserver/folders/_models.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_models.py
@@ -40,7 +40,7 @@ class FolderFilters(Filters):
     )
 
 
-_FolderOrderQueryParams, _ = create_ordering_query_model_classes(
+_FolderOrderQueryParams = create_ordering_query_model_classes(
     ordering_fields={"modified", "name", "description"},
     default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
 )

--- a/services/web/server/src/simcore_service_webserver/long_running_tasks.py
+++ b/services/web/server/src/simcore_service_webserver/long_running_tasks.py
@@ -1,6 +1,7 @@
 from functools import wraps
 
 from aiohttp import web
+from models_library.rest_base import RequestParameters
 from models_library.users import UserID
 from models_library.utils.fastapi_encoders import jsonable_encoder
 from pydantic import Field
@@ -8,7 +9,6 @@ from servicelib.aiohttp.long_running_tasks._constants import (
     RQT_LONG_RUNNING_TASKS_CONTEXT_KEY,
 )
 from servicelib.aiohttp.long_running_tasks.server import setup
-from servicelib.aiohttp.requests_validation import RequestParams
 from servicelib.aiohttp.typing_extension import Handler
 from servicelib.request_keys import RQT_USERID_KEY
 
@@ -17,7 +17,7 @@ from ._meta import API_VTAG
 from .login.decorators import login_required
 
 
-class _RequestContext(RequestParams):
+class _RequestContext(RequestParameters):
     user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
     product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 

--- a/services/web/server/src/simcore_service_webserver/long_running_tasks.py
+++ b/services/web/server/src/simcore_service_webserver/long_running_tasks.py
@@ -1,25 +1,16 @@
 from functools import wraps
 
 from aiohttp import web
-from models_library.rest_base import RequestParameters
-from models_library.users import UserID
 from models_library.utils.fastapi_encoders import jsonable_encoder
-from pydantic import Field
 from servicelib.aiohttp.long_running_tasks._constants import (
     RQT_LONG_RUNNING_TASKS_CONTEXT_KEY,
 )
 from servicelib.aiohttp.long_running_tasks.server import setup
 from servicelib.aiohttp.typing_extension import Handler
-from servicelib.request_keys import RQT_USERID_KEY
 
-from ._constants import RQ_PRODUCT_KEY
 from ._meta import API_VTAG
 from .login.decorators import login_required
-
-
-class _RequestContext(RequestParameters):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
-    product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
+from .models import RequestContext
 
 
 def _webserver_request_context_decorator(handler: Handler):
@@ -28,7 +19,7 @@ def _webserver_request_context_decorator(handler: Handler):
         request: web.Request,
     ) -> web.StreamResponse:
         """this task context callback tries to get the user_id from the query if available"""
-        req_ctx = _RequestContext.parse_obj(request)
+        req_ctx = RequestContext.parse_obj(request)
         request[RQT_LONG_RUNNING_TASKS_CONTEXT_KEY] = jsonable_encoder(req_ctx)
         return await handler(request)
 

--- a/services/web/server/src/simcore_service_webserver/models.py
+++ b/services/web/server/src/simcore_service_webserver/models.py
@@ -1,0 +1,11 @@
+from models_library.rest_base import RequestParameters
+from models_library.users import UserID
+from pydantic import Field
+from servicelib.request_keys import RQT_USERID_KEY
+
+from ._constants import RQ_PRODUCT_KEY
+
+
+class RequestContext(RequestParameters):
+    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
+    product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]

--- a/services/web/server/src/simcore_service_webserver/products/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/products/_handlers.py
@@ -4,13 +4,10 @@ from typing import Literal
 from aiohttp import web
 from models_library.api_schemas_webserver.product import GetCreditPrice, GetProduct
 from models_library.basic_types import IDStr
+from models_library.rest_base import RequestParameters, StrictRequestParameters
 from models_library.users import UserID
 from pydantic import Extra, Field
-from servicelib.aiohttp.requests_validation import (
-    RequestParams,
-    StrictRequestParams,
-    parse_request_path_parameters_as,
-)
+from servicelib.aiohttp.requests_validation import parse_request_path_parameters_as
 from servicelib.request_keys import RQT_USERID_KEY
 from simcore_service_webserver.utils_aiohttp import envelope_json_response
 
@@ -27,7 +24,7 @@ routes = web.RouteTableDef()
 _logger = logging.getLogger(__name__)
 
 
-class _ProductsRequestContext(RequestParams):
+class _ProductsRequestContext(RequestParameters):
     user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
     product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
@@ -49,7 +46,7 @@ async def _get_current_product_price(request: web.Request):
     return envelope_json_response(credit_price)
 
 
-class _ProductsRequestParams(StrictRequestParams):
+class _ProductsRequestParams(StrictRequestParameters):
     product_name: IDStr | Literal["current"]
 
 

--- a/services/web/server/src/simcore_service_webserver/products/_invitations_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/products/_invitations_handlers.py
@@ -6,9 +6,10 @@ from models_library.api_schemas_webserver.product import (
     GenerateInvitation,
     InvitationGenerated,
 )
+from models_library.rest_base import RequestParameters
 from models_library.users import UserID
 from pydantic import Field
-from servicelib.aiohttp.requests_validation import RequestParams, parse_request_body_as
+from servicelib.aiohttp.requests_validation import parse_request_body_as
 from servicelib.request_keys import RQT_USERID_KEY
 from simcore_service_webserver.utils_aiohttp import envelope_json_response
 from yarl import URL
@@ -26,7 +27,7 @@ routes = web.RouteTableDef()
 _logger = logging.getLogger(__name__)
 
 
-class _ProductsRequestContext(RequestParams):
+class _ProductsRequestContext(RequestParameters):
     user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
     product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 

--- a/services/web/server/src/simcore_service_webserver/projects/_common_models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_common_models.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Extra, Field
 
 from ..models import RequestContext
 
-assert RequestContext  # nosec
+assert RequestContext.__name__  # nosec
 
 
 class ProjectPathParams(BaseModel):

--- a/services/web/server/src/simcore_service_webserver/projects/_common_models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_common_models.py
@@ -5,16 +5,11 @@ Standard methods or CRUD that states for Create+Read(Get&List)+Update+Delete
 """
 
 from models_library.projects import ProjectID
-from models_library.users import UserID
 from pydantic import BaseModel, Extra, Field
-from servicelib.request_keys import RQT_USERID_KEY
 
-from .._constants import RQ_PRODUCT_KEY
+from ..models import RequestContext
 
-
-class RequestContext(BaseModel):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
-    product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
+assert RequestContext  # nosec
 
 
 class ProjectPathParams(BaseModel):
@@ -29,3 +24,6 @@ class RemoveQueryParams(BaseModel):
     force: bool = Field(
         default=False, description="Force removal (even if resource is active)"
     )
+
+
+__all__: tuple[str, ...] = ("RequestContext",)

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_handlers.py
@@ -56,7 +56,7 @@ from ._crud_handlers_models import (
     ProjectCreateParams,
     ProjectFilters,
     ProjectListFullSearchWithJsonStrParams,
-    ProjectListWithJsonStrParams,
+    ProjectListQueryParams,
 )
 from ._permalink_api import update_or_pop_permalink_in_project
 from .exceptions import (
@@ -188,8 +188,8 @@ async def list_projects(request: web.Request):
 
     """
     req_ctx = RequestContext.parse_obj(request)
-    query_params: ProjectListWithJsonStrParams = parse_request_query_parameters_as(
-        ProjectListWithJsonStrParams, request
+    query_params: ProjectListQueryParams = parse_request_query_parameters_as(
+        ProjectListQueryParams, request
     )
 
     if not query_params.filters:

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_handlers.py
@@ -51,12 +51,12 @@ from ..workspaces.errors import WorkspaceAccessForbiddenError, WorkspaceNotFound
 from . import _crud_api_create, _crud_api_read, projects_api
 from ._common_models import ProjectPathParams, RequestContext
 from ._crud_handlers_models import (
+    ListProjectsQueryParams,
     ProjectActiveParams,
     ProjectCreateHeaders,
     ProjectCreateParams,
     ProjectFilters,
-    ProjectListFullSearchWithJsonStrParams,
-    ProjectListQueryParams,
+    SearchProjectsQueryParams,
 )
 from ._permalink_api import update_or_pop_permalink_in_project
 from .exceptions import (
@@ -188,8 +188,8 @@ async def list_projects(request: web.Request):
 
     """
     req_ctx = RequestContext.parse_obj(request)
-    query_params: ProjectListQueryParams = parse_request_query_parameters_as(
-        ProjectListQueryParams, request
+    query_params: ListProjectsQueryParams = parse_request_query_parameters_as(
+        ListProjectsQueryParams, request
     )
 
     if not query_params.filters:
@@ -233,10 +233,8 @@ async def list_projects(request: web.Request):
 @_handle_projects_exceptions
 async def list_projects_full_search(request: web.Request):
     req_ctx = RequestContext.parse_obj(request)
-    query_params: ProjectListFullSearchWithJsonStrParams = (
-        parse_request_query_parameters_as(
-            ProjectListFullSearchWithJsonStrParams, request
-        )
+    query_params: SearchProjectsQueryParams = parse_request_query_parameters_as(
+        SearchProjectsQueryParams, request
     )
     tag_ids_list = query_params.tag_ids_list()
 

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_handlers.py
@@ -51,12 +51,12 @@ from ..workspaces.errors import WorkspaceAccessForbiddenError, WorkspaceNotFound
 from . import _crud_api_create, _crud_api_read, projects_api
 from ._common_models import ProjectPathParams, RequestContext
 from ._crud_handlers_models import (
-    ListProjectsQueryParams,
-    ProjectActiveParams,
+    ProjectActiveQueryParams,
     ProjectCreateHeaders,
     ProjectCreateParams,
     ProjectFilters,
-    SearchProjectsQueryParams,
+    ProjectsListQueryParams,
+    ProjectsSearchQueryParams,
 )
 from ._permalink_api import update_or_pop_permalink_in_project
 from .exceptions import (
@@ -188,8 +188,8 @@ async def list_projects(request: web.Request):
 
     """
     req_ctx = RequestContext.parse_obj(request)
-    query_params: ListProjectsQueryParams = parse_request_query_parameters_as(
-        ListProjectsQueryParams, request
+    query_params: ProjectsListQueryParams = parse_request_query_parameters_as(
+        ProjectsListQueryParams, request
     )
 
     if not query_params.filters:
@@ -233,8 +233,8 @@ async def list_projects(request: web.Request):
 @_handle_projects_exceptions
 async def list_projects_full_search(request: web.Request):
     req_ctx = RequestContext.parse_obj(request)
-    query_params: SearchProjectsQueryParams = parse_request_query_parameters_as(
-        SearchProjectsQueryParams, request
+    query_params: ProjectsSearchQueryParams = parse_request_query_parameters_as(
+        ProjectsSearchQueryParams, request
     )
     tag_ids_list = query_params.tag_ids_list()
 
@@ -281,8 +281,8 @@ async def get_active_project(request: web.Request) -> web.Response:
         web.HTTPNotFound: If active project is not found
     """
     req_ctx = RequestContext.parse_obj(request)
-    query_params: ProjectActiveParams = parse_request_query_parameters_as(
-        ProjectActiveParams, request
+    query_params: ProjectActiveQueryParams = parse_request_query_parameters_as(
+        ProjectActiveQueryParams, request
     )
 
     try:

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
@@ -102,8 +102,8 @@ class ProjectFilters(Filters):
 
 
 (
-    ProjectListOrderParams,
-    ProjectListOrderParamsOpenApi,
+    ListProjectsOrderParams,
+    ListProjectsOrderParamsOpenApi,
 ) = create_ordering_query_model_classes(
     sortable_fields={
         "type",
@@ -120,7 +120,7 @@ class ProjectFilters(Filters):
 )
 
 
-class ProjectListExtraQueryParams(RequestParameters):
+class ListProjectsExtraQueryParams(RequestParameters):
     project_type: ProjectTypeAPI = Field(default=ProjectTypeAPI.all, alias="type")
     show_hidden: bool = Field(
         default=False, description="includes projects marked as hidden in the listing"
@@ -156,11 +156,11 @@ class ProjectListExtraQueryParams(RequestParameters):
     )(null_or_none_str_to_none_validator)
 
 
-class ProjectListQueryParams(
+class ListProjectsQueryParams(
     PageQueryParameters,
-    ProjectListOrderParams,
+    ListProjectsOrderParams,
     FiltersQueryParameters[ProjectFilters],
-    ProjectListExtraQueryParams,
+    ListProjectsExtraQueryParams,
 ):
     ...
 
@@ -169,7 +169,7 @@ class ProjectActiveParams(BaseModel):
     client_session_id: str
 
 
-class ProjectListFullSearchParams(PageQueryParameters):
+class SearchProjectExtraQueryParams(PageQueryParameters):
     text: str | None = Field(
         default=None,
         description="Multi column full text search, across all folders and workspaces",
@@ -187,9 +187,7 @@ class ProjectListFullSearchParams(PageQueryParameters):
     )
 
 
-class ProjectListFullSearchWithJsonStrParams(
-    ProjectListFullSearchParams, ProjectListOrderParams
-):
+class SearchProjectsQueryParams(SearchProjectExtraQueryParams, ListProjectsOrderParams):
     def tag_ids_list(self) -> list[int]:
         try:
             # Split the tag_ids by commas and map them to integers

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
@@ -105,7 +105,7 @@ class ProjectFilters(Filters):
     ListProjectsOrderParams,
     ListProjectsOrderParamsOpenApi,
 ) = create_ordering_query_model_classes(
-    sortable_fields={
+    ordering_fields={
         "type",
         "uuid",
         "name",
@@ -114,9 +114,7 @@ class ProjectFilters(Filters):
         "creation_date",
         "last_change_date",
     },
-    default_order_by=OrderBy(
-        field=IDStr("last_change_date"), direction=OrderDirection.DESC
-    ),
+    default=OrderBy(field=IDStr("last_change_date"), direction=OrderDirection.DESC),
 )
 
 

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
@@ -153,7 +153,7 @@ class ProjectsListExtraQueryParams(RequestParameters):
 
 class ProjectsListQueryParams(
     PageQueryParameters,
-    ProjectsListOrderParams,
+    ProjectsListOrderParams,  # type: ignore[misc, valid-type]
     FiltersQueryParameters[ProjectFilters],
     ProjectsListExtraQueryParams,
 ):
@@ -182,7 +182,9 @@ class ProjectSearchExtraQueryParams(PageQueryParameters):
     )
 
 
-class ProjectsSearchQueryParams(ProjectSearchExtraQueryParams, ProjectsListOrderParams):
+class ProjectsSearchQueryParams(
+    ProjectSearchExtraQueryParams, ProjectsListOrderParams  # type: ignore[misc, valid-type]
+):
     def tag_ids_list(self) -> list[int]:
         try:
             # Split the tag_ids by commas and map them to integers

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
@@ -101,7 +101,7 @@ class ProjectFilters(Filters):
     )
 
 
-(ProjectsListOrderParams, _) = create_ordering_query_model_classes(
+ProjectsListOrderParams, _ = create_ordering_query_model_classes(
     ordering_fields={
         "type",
         "uuid",

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
@@ -101,7 +101,7 @@ class ProjectFilters(Filters):
     )
 
 
-ProjectsListOrderParams, _ = create_ordering_query_model_classes(
+ProjectsListOrderParams = create_ordering_query_model_classes(
     ordering_fields={
         "type",
         "uuid",

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
@@ -158,9 +158,9 @@ class ProjectListExtraQueryParams(RequestParameters):
 
 class ProjectListQueryParams(
     PageQueryParameters,
-    ProjectListExtraQueryParams,
     ProjectListOrderParams,
     FiltersQueryParameters[ProjectFilters],
+    ProjectListExtraQueryParams,
 ):
     ...
 

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_handlers_models.py
@@ -101,10 +101,7 @@ class ProjectFilters(Filters):
     )
 
 
-(
-    ListProjectsOrderParams,
-    ListProjectsOrderParamsOpenApi,
-) = create_ordering_query_model_classes(
+(ProjectsListOrderParams, _) = create_ordering_query_model_classes(
     ordering_fields={
         "type",
         "uuid",
@@ -118,7 +115,7 @@ class ProjectFilters(Filters):
 )
 
 
-class ListProjectsExtraQueryParams(RequestParameters):
+class ProjectsListExtraQueryParams(RequestParameters):
     project_type: ProjectTypeAPI = Field(default=ProjectTypeAPI.all, alias="type")
     show_hidden: bool = Field(
         default=False, description="includes projects marked as hidden in the listing"
@@ -154,20 +151,20 @@ class ListProjectsExtraQueryParams(RequestParameters):
     )(null_or_none_str_to_none_validator)
 
 
-class ListProjectsQueryParams(
+class ProjectsListQueryParams(
     PageQueryParameters,
-    ListProjectsOrderParams,
+    ProjectsListOrderParams,
     FiltersQueryParameters[ProjectFilters],
-    ListProjectsExtraQueryParams,
+    ProjectsListExtraQueryParams,
 ):
     ...
 
 
-class ProjectActiveParams(BaseModel):
+class ProjectActiveQueryParams(BaseModel):
     client_session_id: str
 
 
-class SearchProjectExtraQueryParams(PageQueryParameters):
+class ProjectSearchExtraQueryParams(PageQueryParameters):
     text: str | None = Field(
         default=None,
         description="Multi column full text search, across all folders and workspaces",
@@ -185,7 +182,7 @@ class SearchProjectExtraQueryParams(PageQueryParameters):
     )
 
 
-class SearchProjectsQueryParams(SearchProjectExtraQueryParams, ListProjectsOrderParams):
+class ProjectsSearchQueryParams(ProjectSearchExtraQueryParams, ProjectsListOrderParams):
     def tag_ids_list(self) -> list[int]:
         try:
             # Split the tag_ids by commas and map them to integers

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_pricing_plans_admin_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_pricing_plans_admin_handlers.py
@@ -19,6 +19,7 @@ from models_library.resource_tracker import (
     PricingUnitWithCostCreate,
     PricingUnitWithCostUpdate,
 )
+from models_library.rest_base import StrictRequestParameters
 from models_library.users import UserID
 from pydantic import BaseModel, Extra, Field
 from servicelib.aiohttp.requests_validation import (
@@ -70,7 +71,7 @@ routes = web.RouteTableDef()
 ## Admin Pricing Plan endpoints
 
 
-class _GetPricingPlanPathParams(BaseModel):
+class PricingPlanGetPathParams(StrictRequestParameters):
     pricing_plan_id: PricingPlanId
 
     class Config:
@@ -117,7 +118,7 @@ async def list_pricing_plans(request: web.Request):
 @_handle_pricing_plan_admin_exceptions
 async def get_pricing_plan(request: web.Request):
     req_ctx = _RequestContext.parse_obj(request)
-    path_params = parse_request_path_parameters_as(_GetPricingPlanPathParams, request)
+    path_params = parse_request_path_parameters_as(PricingPlanGetPathParams, request)
 
     pricing_plan_get = await admin_api.get_pricing_plan(
         app=request.app,
@@ -125,7 +126,8 @@ async def get_pricing_plan(request: web.Request):
         pricing_plan_id=path_params.pricing_plan_id,
     )
     if pricing_plan_get.pricing_units is None:
-        raise ValueError("Pricing plan units should not be None")
+        msg = "Pricing plan units should not be None"
+        raise ValueError(msg)
 
     webserver_admin_pricing_plan_get = PricingPlanAdminGet(
         pricing_plan_id=pricing_plan_get.pricing_plan_id,
@@ -209,7 +211,7 @@ async def create_pricing_plan(request: web.Request):
 @_handle_pricing_plan_admin_exceptions
 async def update_pricing_plan(request: web.Request):
     req_ctx = _RequestContext.parse_obj(request)
-    path_params = parse_request_path_parameters_as(_GetPricingPlanPathParams, request)
+    path_params = parse_request_path_parameters_as(PricingPlanGetPathParams, request)
     body_params = await parse_request_body_as(UpdatePricingPlanBodyParams, request)
 
     _data = PricingPlanUpdate(
@@ -253,7 +255,7 @@ async def update_pricing_plan(request: web.Request):
 ## Admin Pricing Unit endpoints
 
 
-class _GetPricingUnitPathParams(BaseModel):
+class PricingUnitGetPathParams(BaseModel):
     pricing_plan_id: PricingPlanId
     pricing_unit_id: PricingUnitId
 
@@ -270,7 +272,7 @@ class _GetPricingUnitPathParams(BaseModel):
 @_handle_pricing_plan_admin_exceptions
 async def get_pricing_unit(request: web.Request):
     req_ctx = _RequestContext.parse_obj(request)
-    path_params = parse_request_path_parameters_as(_GetPricingUnitPathParams, request)
+    path_params = parse_request_path_parameters_as(PricingUnitGetPathParams, request)
 
     pricing_unit_get = await admin_api.get_pricing_unit(
         app=request.app,
@@ -300,7 +302,7 @@ async def get_pricing_unit(request: web.Request):
 @_handle_pricing_plan_admin_exceptions
 async def create_pricing_unit(request: web.Request):
     req_ctx = _RequestContext.parse_obj(request)
-    path_params = parse_request_path_parameters_as(_GetPricingPlanPathParams, request)
+    path_params = parse_request_path_parameters_as(PricingPlanGetPathParams, request)
     body_params = await parse_request_body_as(CreatePricingUnitBodyParams, request)
 
     _data = PricingUnitWithCostCreate(
@@ -339,7 +341,7 @@ async def create_pricing_unit(request: web.Request):
 @_handle_pricing_plan_admin_exceptions
 async def update_pricing_unit(request: web.Request):
     req_ctx = _RequestContext.parse_obj(request)
-    path_params = parse_request_path_parameters_as(_GetPricingUnitPathParams, request)
+    path_params = parse_request_path_parameters_as(PricingUnitGetPathParams, request)
     body_params = await parse_request_body_as(UpdatePricingUnitBodyParams, request)
 
     _data = PricingUnitWithCostUpdate(
@@ -381,7 +383,7 @@ async def update_pricing_unit(request: web.Request):
 @_handle_pricing_plan_admin_exceptions
 async def list_connected_services_to_pricing_plan(request: web.Request):
     req_ctx = _RequestContext.parse_obj(request)
-    path_params = parse_request_path_parameters_as(_GetPricingPlanPathParams, request)
+    path_params = parse_request_path_parameters_as(PricingPlanGetPathParams, request)
 
     connected_services_list = await admin_api.list_connected_services_to_pricing_plan(
         app=request.app,
@@ -410,7 +412,7 @@ async def list_connected_services_to_pricing_plan(request: web.Request):
 @_handle_pricing_plan_admin_exceptions
 async def connect_service_to_pricing_plan(request: web.Request):
     req_ctx = _RequestContext.parse_obj(request)
-    path_params = parse_request_path_parameters_as(_GetPricingPlanPathParams, request)
+    path_params = parse_request_path_parameters_as(PricingPlanGetPathParams, request)
     body_params = await parse_request_body_as(
         ConnectServiceToPricingPlanBodyParams, request
     )

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_pricing_plans_admin_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_pricing_plans_admin_handlers.py
@@ -20,19 +20,17 @@ from models_library.resource_tracker import (
     PricingUnitWithCostUpdate,
 )
 from models_library.rest_base import StrictRequestParameters
-from models_library.users import UserID
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Extra
 from servicelib.aiohttp.requests_validation import (
     parse_request_body_as,
     parse_request_path_parameters_as,
 )
 from servicelib.aiohttp.typing_extension import Handler
 from servicelib.rabbitmq._errors import RPCServerError
-from servicelib.request_keys import RQT_USERID_KEY
 
-from .._constants import RQ_PRODUCT_KEY
 from .._meta import API_VTAG as VTAG
 from ..login.decorators import login_required
+from ..models import RequestContext
 from ..security.decorators import permission_required
 from ..utils_aiohttp import envelope_json_response
 from . import _pricing_plans_admin_api as admin_api
@@ -54,11 +52,6 @@ def _handle_pricing_plan_admin_exceptions(handler: Handler):
             raise RPCServerError from exc
 
     return wrapper
-
-
-class _RequestContext(BaseModel):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
-    product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
 #
@@ -86,7 +79,7 @@ class PricingPlanGetPathParams(StrictRequestParameters):
 @permission_required("resource-usage.write")
 @_handle_pricing_plan_admin_exceptions
 async def list_pricing_plans(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
 
     pricing_plans_list = await admin_api.list_pricing_plans(
         app=request.app,
@@ -117,7 +110,7 @@ async def list_pricing_plans(request: web.Request):
 @permission_required("resource-usage.write")
 @_handle_pricing_plan_admin_exceptions
 async def get_pricing_plan(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(PricingPlanGetPathParams, request)
 
     pricing_plan_get = await admin_api.get_pricing_plan(
@@ -161,7 +154,7 @@ async def get_pricing_plan(request: web.Request):
 @permission_required("resource-usage.write")
 @_handle_pricing_plan_admin_exceptions
 async def create_pricing_plan(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     body_params = await parse_request_body_as(CreatePricingPlanBodyParams, request)
 
     _data = PricingPlanCreate(
@@ -210,7 +203,7 @@ async def create_pricing_plan(request: web.Request):
 @permission_required("resource-usage.write")
 @_handle_pricing_plan_admin_exceptions
 async def update_pricing_plan(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(PricingPlanGetPathParams, request)
     body_params = await parse_request_body_as(UpdatePricingPlanBodyParams, request)
 
@@ -271,7 +264,7 @@ class PricingUnitGetPathParams(BaseModel):
 @permission_required("resource-usage.write")
 @_handle_pricing_plan_admin_exceptions
 async def get_pricing_unit(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(PricingUnitGetPathParams, request)
 
     pricing_unit_get = await admin_api.get_pricing_unit(
@@ -301,7 +294,7 @@ async def get_pricing_unit(request: web.Request):
 @permission_required("resource-usage.write")
 @_handle_pricing_plan_admin_exceptions
 async def create_pricing_unit(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(PricingPlanGetPathParams, request)
     body_params = await parse_request_body_as(CreatePricingUnitBodyParams, request)
 
@@ -340,7 +333,7 @@ async def create_pricing_unit(request: web.Request):
 @permission_required("resource-usage.write")
 @_handle_pricing_plan_admin_exceptions
 async def update_pricing_unit(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(PricingUnitGetPathParams, request)
     body_params = await parse_request_body_as(UpdatePricingUnitBodyParams, request)
 
@@ -382,7 +375,7 @@ async def update_pricing_unit(request: web.Request):
 @permission_required("resource-usage.write")
 @_handle_pricing_plan_admin_exceptions
 async def list_connected_services_to_pricing_plan(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(PricingPlanGetPathParams, request)
 
     connected_services_list = await admin_api.list_connected_services_to_pricing_plan(
@@ -411,7 +404,7 @@ async def list_connected_services_to_pricing_plan(request: web.Request):
 @permission_required("resource-usage.write")
 @_handle_pricing_plan_admin_exceptions
 async def connect_service_to_pricing_plan(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(PricingPlanGetPathParams, request)
     body_params = await parse_request_body_as(
         ConnectServiceToPricingPlanBodyParams, request

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_pricing_plans_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_pricing_plans_handlers.py
@@ -4,15 +4,12 @@ from aiohttp import web
 from models_library.api_schemas_webserver.resource_usage import PricingUnitGet
 from models_library.resource_tracker import PricingPlanId, PricingUnitId
 from models_library.rest_base import StrictRequestParameters
-from models_library.users import UserID
-from pydantic import BaseModel, Field
 from servicelib.aiohttp.requests_validation import parse_request_path_parameters_as
 from servicelib.aiohttp.typing_extension import Handler
-from servicelib.request_keys import RQT_USERID_KEY
 
-from .._constants import RQ_PRODUCT_KEY
 from .._meta import API_VTAG as VTAG
 from ..login.decorators import login_required
+from ..models import RequestContext
 from ..security.decorators import permission_required
 from ..utils_aiohttp import envelope_json_response
 from ..wallets.errors import WalletAccessForbiddenError
@@ -35,11 +32,6 @@ def _handle_resource_usage_exceptions(handler: Handler):
     return wrapper
 
 
-class _RequestContext(BaseModel):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
-    product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
-
-
 routes = web.RouteTableDef()
 
 
@@ -56,7 +48,7 @@ class PricingPlanUnitGetPathParams(StrictRequestParameters):
 @permission_required("resource-usage.read")
 @_handle_resource_usage_exceptions
 async def get_pricing_plan_unit(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(
         PricingPlanUnitGetPathParams, request
     )

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_pricing_plans_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_pricing_plans_handlers.py
@@ -3,8 +3,9 @@ import functools
 from aiohttp import web
 from models_library.api_schemas_webserver.resource_usage import PricingUnitGet
 from models_library.resource_tracker import PricingPlanId, PricingUnitId
+from models_library.rest_base import StrictRequestParameters
 from models_library.users import UserID
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Field
 from servicelib.aiohttp.requests_validation import parse_request_path_parameters_as
 from servicelib.aiohttp.typing_extension import Handler
 from servicelib.request_keys import RQT_USERID_KEY
@@ -42,12 +43,9 @@ class _RequestContext(BaseModel):
 routes = web.RouteTableDef()
 
 
-class _GetPricingPlanUnitPathParams(BaseModel):
+class PricingPlanUnitGetPathParams(StrictRequestParameters):
     pricing_plan_id: PricingPlanId
     pricing_unit_id: PricingUnitId
-
-    class Config:
-        extra = Extra.forbid
 
 
 @routes.get(
@@ -60,7 +58,7 @@ class _GetPricingPlanUnitPathParams(BaseModel):
 async def get_pricing_plan_unit(request: web.Request):
     req_ctx = _RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(
-        _GetPricingPlanUnitPathParams, request
+        PricingPlanUnitGetPathParams, request
     )
 
     pricing_unit_get = await api.get_pricing_plan_unit(

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_pricing_plans_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_pricing_plans_handlers.py
@@ -39,10 +39,6 @@ class _RequestContext(BaseModel):
     product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
-#
-# API handlers
-#
-
 routes = web.RouteTableDef()
 
 

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
@@ -12,7 +12,6 @@ from models_library.resource_tracker import (
     ServicesAggregatedUsagesTimePeriod,
     ServicesAggregatedUsagesType,
 )
-from models_library.rest_base import RequestParameters
 from models_library.rest_ordering import (
     OrderBy,
     OrderDirection,
@@ -20,18 +19,16 @@ from models_library.rest_ordering import (
 )
 from models_library.rest_pagination import Page, PageQueryParameters
 from models_library.rest_pagination_utils import paginate_data
-from models_library.users import UserID
 from models_library.wallets import WalletID
 from pydantic import Extra, Field, Json, parse_obj_as, validator
 from servicelib.aiohttp.requests_validation import parse_request_query_parameters_as
 from servicelib.aiohttp.typing_extension import Handler
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
-from servicelib.request_keys import RQT_USERID_KEY
 from servicelib.rest_constants import RESPONSE_MODEL_POLICY
 
-from .._constants import RQ_PRODUCT_KEY
 from .._meta import API_VTAG as VTAG
 from ..login.decorators import login_required
+from ..models import RequestContext
 from ..security.decorators import permission_required
 from ..wallets.errors import WalletAccessForbiddenError
 from . import _service_runs_api as api
@@ -51,11 +48,6 @@ def _handle_resource_usage_exceptions(handler: Handler):
             raise web.HTTPForbidden(reason=f"{exc}") from exc
 
     return wrapper
-
-
-class _RequestContext(RequestParameters):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
-    product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
 _ResorceUsagesListOrderQueryParams = create_ordering_query_model_classes(
@@ -133,7 +125,7 @@ routes = web.RouteTableDef()
 @permission_required("resource-usage.read")
 @_handle_resource_usage_exceptions
 async def list_resource_usage_services(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     query_params: ServicesResourceUsagesListQueryParams = (
         parse_request_query_parameters_as(
             ServicesResourceUsagesListQueryParams, request
@@ -174,7 +166,7 @@ async def list_resource_usage_services(request: web.Request):
 @permission_required("resource-usage.read")
 @_handle_resource_usage_exceptions
 async def list_osparc_credits_aggregated_usages(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     query_params: ServicesAggregatedUsagesListQueryParams = (
         parse_request_query_parameters_as(
             ServicesAggregatedUsagesListQueryParams, request
@@ -214,7 +206,7 @@ async def list_osparc_credits_aggregated_usages(request: web.Request):
 @permission_required("resource-usage.read")
 @_handle_resource_usage_exceptions
 async def export_resource_usage_services(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     query_params: ServicesResourceUsagesReportQueryParams = (
         parse_request_query_parameters_as(
             ServicesResourceUsagesReportQueryParams, request

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
@@ -67,7 +67,7 @@ class _RequestContext(RequestParameters):
     ListResourceUsagesOrderQueryParams,
     ListResourceUsagesOrderQueryParamsOpenApi,
 ) = create_ordering_query_model_classes(
-    sortable_fields={
+    ordering_fields={
         "wallet_id",
         "wallet_name",
         "user_id",
@@ -87,7 +87,7 @@ class _RequestContext(RequestParameters):
         "credit_cost",
         "transaction_status",
     },
-    default_order_by=OrderBy(field=IDStr("started_at"), direction=OrderDirection.DESC),
+    default=OrderBy(field=IDStr("started_at"), direction=OrderDirection.DESC),
 )
 
 

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
@@ -93,9 +93,9 @@ class ServicesResourceUsagesReportQueryParams(
 
     @validator("order_by", always=True)
     @classmethod
-    def _post_rename_order_by_field(cls, v):
-        if v.field == "credit_cost":
-            v.field = "osparc_credits"
+    def _post_rename_order_by_field_as_db_column(cls, v):
+        if v.field == "credit_cost":  # API field
+            v.field = "osparc_credits"  # DB column
         return v
 
     class Config:

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
@@ -12,6 +12,7 @@ from models_library.resource_tracker import (
     ServicesAggregatedUsagesTimePeriod,
     ServicesAggregatedUsagesType,
 )
+from models_library.rest_base import RequestParameters
 from models_library.rest_ordering import (
     OrderBy,
     OrderDirection,
@@ -50,7 +51,9 @@ def _handle_resource_usage_exceptions(handler: Handler):
     return wrapper
 
 
-_ResorceUsagesListOrderQueryParams = create_ordering_query_model_classes(
+_ResorceUsagesListOrderQueryParams: type[
+    RequestParameters
+] = create_ordering_query_model_classes(
     ordering_fields={
         "wallet_id",
         "wallet_name",
@@ -75,7 +78,9 @@ _ResorceUsagesListOrderQueryParams = create_ordering_query_model_classes(
 )
 
 
-class ServicesResourceUsagesReportQueryParams(_ResorceUsagesListOrderQueryParams):
+class ServicesResourceUsagesReportQueryParams(
+    _ResorceUsagesListOrderQueryParams  # type: ignore[misc, valid-type]
+):
     wallet_id: WalletID | None = Field(default=None)
     filters: (
         Json[ServiceResourceUsagesFilters]  # pylint: disable=unsubscriptable-object

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
@@ -21,7 +21,7 @@ from models_library.rest_ordering import (
 from models_library.rest_pagination import Page, PageQueryParameters
 from models_library.rest_pagination_utils import paginate_data
 from models_library.wallets import WalletID
-from pydantic import Extra, Field, Json, parse_obj_as, validator
+from pydantic import Extra, Field, Json, parse_obj_as
 from servicelib.aiohttp.requests_validation import parse_request_query_parameters_as
 from servicelib.aiohttp.typing_extension import Handler
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
@@ -75,6 +75,9 @@ _ResorceUsagesListOrderQueryParams: type[
         "transaction_status",
     },
     default=OrderBy(field=IDStr("started_at"), direction=OrderDirection.DESC),
+    ordering_fields_api_to_column_map={
+        "credit_cost": "osparc_credits",
+    },
 )
 
 
@@ -90,13 +93,6 @@ class ServicesResourceUsagesReportQueryParams(
         description="Filters to process on the resource usages list, encoded as JSON. Currently supports the filtering of 'started_at' field with 'from' and 'until' parameters in <yyyy-mm-dd> ISO 8601 format. The date range specified is inclusive.",
         example='{"started_at": {"from": "yyyy-mm-dd", "until": "yyyy-mm-dd"}}',
     )
-
-    @validator("order_by", always=True)
-    @classmethod
-    def _post_rename_order_by_field_as_db_column(cls, v):
-        if v.field == "credit_cost":  # API field
-            v.field = "osparc_credits"  # DB column
-        return v
 
     class Config:
         extra = Extra.forbid

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
@@ -58,7 +58,7 @@ class _RequestContext(RequestParameters):
     product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
-_ResorceUsagesListOrderQueryParams, _ = create_ordering_query_model_classes(
+_ResorceUsagesListOrderQueryParams = create_ordering_query_model_classes(
     ordering_fields={
         "wallet_id",
         "wallet_name",

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
@@ -12,7 +12,12 @@ from models_library.resource_tracker import (
     ServicesAggregatedUsagesTimePeriod,
     ServicesAggregatedUsagesType,
 )
-from models_library.rest_ordering import OrderBy, OrderDirection
+from models_library.rest_base import RequestParameters
+from models_library.rest_ordering import (
+    OrderBy,
+    OrderDirection,
+    create_ordering_query_model_classes,
+)
 from models_library.rest_pagination import (
     DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
     MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
@@ -22,15 +27,7 @@ from models_library.rest_pagination import (
 from models_library.rest_pagination_utils import paginate_data
 from models_library.users import UserID
 from models_library.wallets import WalletID
-from pydantic import (
-    BaseModel,
-    Extra,
-    Field,
-    Json,
-    NonNegativeInt,
-    parse_obj_as,
-    validator,
-)
+from pydantic import Extra, Field, Json, NonNegativeInt, parse_obj_as, validator
 from servicelib.aiohttp.requests_validation import parse_request_query_parameters_as
 from servicelib.aiohttp.typing_extension import Handler
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
@@ -61,21 +58,41 @@ def _handle_resource_usage_exceptions(handler: Handler):
     return wrapper
 
 
-class _RequestContext(BaseModel):
+class _RequestContext(RequestParameters):
     user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
     product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
-ORDER_BY_DESCRIPTION = "Order by field (wallet_id|wallet_name|user_id|project_id|project_name|node_id|node_name|service_key|service_version|service_type|started_at|stopped_at|service_run_status|credit_cost|transaction_status) and direction (asc|desc). The default sorting order is ascending."
+(
+    ListResourceUsagesOrderQueryParams,
+    ListResourceUsagesOrderQueryParamsOpenApi,
+) = create_ordering_query_model_classes(
+    sortable_fields={
+        "wallet_id",
+        "wallet_name",
+        "user_id",
+        "user_email",
+        "project_id",
+        "project_name",
+        "node_id",
+        "node_name",
+        "root_parent_project_id",
+        "root_parent_project_name",
+        "service_key",
+        "service_version",
+        "service_type",
+        "started_at",
+        "stopped_at",
+        "service_run_status",
+        "credit_cost",
+        "transaction_status",
+    },
+    default_order_by=OrderBy(field=IDStr("started_at"), direction=OrderDirection.DESC),
+)
 
 
-class _ListServicesResourceUsagesQueryParams(BaseModel):
+class _ListServicesResourceUsagesQueryParams(ListResourceUsagesOrderQueryParams):
     wallet_id: WalletID | None = Field(default=None)
-    order_by: Json[OrderBy] = Field(  # pylint: disable=unsubscriptable-object
-        default=OrderBy(field=IDStr("started_at"), direction=OrderDirection.DESC),
-        description=ORDER_BY_DESCRIPTION,
-        example='{"field": "started_at", "direction": "desc"}',
-    )
     filters: (
         Json[ServiceResourceUsagesFilters]  # pylint: disable=unsubscriptable-object
         | None
@@ -85,30 +102,9 @@ class _ListServicesResourceUsagesQueryParams(BaseModel):
         example='{"started_at": {"from": "yyyy-mm-dd", "until": "yyyy-mm-dd"}}',
     )
 
-    @validator("order_by", allow_reuse=True)
+    @validator("order_by")
     @classmethod
-    def validate_order_by_field(cls, v):
-        if v.field not in {
-            "wallet_id",
-            "wallet_name",
-            "user_id",
-            "user_email",
-            "project_id",
-            "project_name",
-            "node_id",
-            "node_name",
-            "root_parent_project_id",
-            "root_parent_project_name",
-            "service_key",
-            "service_version",
-            "service_type",
-            "started_at",
-            "stopped_at",
-            "service_run_status",
-            "credit_cost",
-            "transaction_status",
-        }:
-            raise ValueError(f"We do not support ordering by provided field {v.field}")
+    def _post_rename_order_by_field(cls, v):
         if v.field == "credit_cost":
             v.field = "osparc_credits"
         return v

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_service_runs_handlers.py
@@ -91,7 +91,7 @@ class ServicesResourceUsagesReportQueryParams(
         example='{"started_at": {"from": "yyyy-mm-dd", "until": "yyyy-mm-dd"}}',
     )
 
-    @validator("order_by")
+    @validator("order_by", always=True)
     @classmethod
     def _post_rename_order_by_field(cls, v):
         if v.field == "credit_cost":

--- a/services/web/server/src/simcore_service_webserver/tags/schemas.py
+++ b/services/web/server/src/simcore_service_webserver/tags/schemas.py
@@ -2,18 +2,18 @@ import re
 from datetime import datetime
 
 from models_library.api_schemas_webserver._base import InputSchema, OutputSchema
+from models_library.rest_base import RequestParameters, StrictRequestParameters
 from models_library.users import GroupID, UserID
 from pydantic import ConstrainedStr, Field, PositiveInt
-from servicelib.aiohttp.requests_validation import RequestParams, StrictRequestParams
 from servicelib.request_keys import RQT_USERID_KEY
 from simcore_postgres_database.utils_tags import TagDict
 
 
-class TagRequestContext(RequestParams):
+class TagRequestContext(RequestParameters):
     user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
 
 
-class TagPathParams(StrictRequestParams):
+class TagPathParams(StrictRequestParameters):
     tag_id: PositiveInt
 
 

--- a/services/web/server/src/simcore_service_webserver/users/_preferences_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/users/_preferences_handlers.py
@@ -5,32 +5,23 @@ from models_library.api_schemas_webserver.users_preferences import (
     PatchPathParams,
     PatchRequestBody,
 )
-from models_library.products import ProductName
-from models_library.users import UserID
-from pydantic import BaseModel, Field
 from servicelib.aiohttp import status
 from servicelib.aiohttp.requests_validation import (
     parse_request_body_as,
     parse_request_path_parameters_as,
 )
 from servicelib.aiohttp.typing_extension import Handler
-from servicelib.request_keys import RQT_USERID_KEY
 from simcore_postgres_database.utils_user_preferences import (
     CouldNotCreateOrUpdateUserPreferenceError,
 )
 
-from .._constants import RQ_PRODUCT_KEY
 from .._meta import API_VTAG
 from ..login.decorators import login_required
+from ..models import RequestContext
 from . import _preferences_api
 from .exceptions import FrontendUserPreferenceIsNotDefinedError
 
 routes = web.RouteTableDef()
-
-
-class _RequestContext(BaseModel):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
-    product_name: ProductName = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
 def _handle_users_exceptions(handler: Handler):
@@ -55,7 +46,7 @@ def _handle_users_exceptions(handler: Handler):
 @login_required
 @_handle_users_exceptions
 async def set_frontend_preference(request: web.Request) -> web.Response:
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     req_body = await parse_request_body_as(PatchRequestBody, request)
     req_path_params = parse_request_path_parameters_as(PatchPathParams, request)
 

--- a/services/web/server/src/simcore_service_webserver/wallets/_groups_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_groups_handlers.py
@@ -6,20 +6,19 @@ import functools
 import logging
 
 from aiohttp import web
-from models_library.users import GroupID, UserID
+from models_library.users import GroupID
 from models_library.wallets import WalletID
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Extra
 from servicelib.aiohttp import status
 from servicelib.aiohttp.requests_validation import (
     parse_request_body_as,
     parse_request_path_parameters_as,
 )
 from servicelib.aiohttp.typing_extension import Handler
-from servicelib.request_keys import RQT_USERID_KEY
 
-from .._constants import RQ_PRODUCT_KEY
 from .._meta import api_version_prefix as VTAG
 from ..login.decorators import login_required
+from ..models import RequestContext
 from ..security.decorators import permission_required
 from ..utils_aiohttp import envelope_json_response
 from . import _groups_api
@@ -28,11 +27,6 @@ from ._handlers import WalletsPathParams
 from .errors import WalletAccessForbiddenError, WalletGroupNotFoundError
 
 _logger = logging.getLogger(__name__)
-
-
-class _RequestContext(BaseModel):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
-    product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
 def _handle_wallets_groups_exceptions(handler: Handler):
@@ -81,7 +75,7 @@ class _WalletsGroupsBodyParams(BaseModel):
 @permission_required("wallets.*")
 @_handle_wallets_groups_exceptions
 async def create_wallet_group(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(_WalletsGroupsPathParams, request)
     body_params = await parse_request_body_as(_WalletsGroupsBodyParams, request)
 
@@ -104,7 +98,7 @@ async def create_wallet_group(request: web.Request):
 @permission_required("wallets.*")
 @_handle_wallets_groups_exceptions
 async def list_wallet_groups(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(WalletsPathParams, request)
 
     wallets: list[
@@ -127,7 +121,7 @@ async def list_wallet_groups(request: web.Request):
 @permission_required("wallets.*")
 @_handle_wallets_groups_exceptions
 async def update_wallet_group(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(_WalletsGroupsPathParams, request)
     body_params = await parse_request_body_as(_WalletsGroupsBodyParams, request)
 
@@ -151,7 +145,7 @@ async def update_wallet_group(request: web.Request):
 @permission_required("wallets.*")
 @_handle_wallets_groups_exceptions
 async def delete_wallet_group(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(_WalletsGroupsPathParams, request)
 
     await _groups_api.delete_wallet_group(

--- a/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_handlers.py
@@ -9,12 +9,11 @@ from models_library.api_schemas_webserver.wallets import (
     WalletGetWithAvailableCredits,
 )
 from models_library.error_codes import create_error_code
+from models_library.rest_base import RequestParameters, StrictRequestParameters
 from models_library.users import UserID
 from models_library.wallets import WalletID
 from pydantic import Field
 from servicelib.aiohttp.requests_validation import (
-    RequestParams,
-    StrictRequestParams,
     parse_request_body_as,
     parse_request_path_parameters_as,
 )
@@ -106,19 +105,18 @@ def handle_wallets_exceptions(handler: Handler):
     return wrapper
 
 
-#
 # wallets COLLECTION -------------------------
 #
 
 routes = web.RouteTableDef()
 
 
-class WalletsRequestContext(RequestParams):
+class WalletsRequestContext(RequestParameters):
     user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
     product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
-class WalletsPathParams(StrictRequestParams):
+class WalletsPathParams(StrictRequestParameters):
     wallet_id: WalletID
 
 

--- a/services/web/server/src/simcore_service_webserver/workspaces/_groups_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_groups_handlers.py
@@ -6,20 +6,19 @@ import functools
 import logging
 
 from aiohttp import web
-from models_library.users import GroupID, UserID
+from models_library.users import GroupID
 from models_library.workspaces import WorkspaceID
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Extra
 from servicelib.aiohttp import status
 from servicelib.aiohttp.requests_validation import (
     parse_request_body_as,
     parse_request_path_parameters_as,
 )
 from servicelib.aiohttp.typing_extension import Handler
-from servicelib.request_keys import RQT_USERID_KEY
 
-from .._constants import RQ_PRODUCT_KEY
 from .._meta import api_version_prefix as VTAG
 from ..login.decorators import login_required
+from ..models import RequestContext
 from ..security.decorators import permission_required
 from ..utils_aiohttp import envelope_json_response
 from . import _groups_api
@@ -28,11 +27,6 @@ from ._workspaces_handlers import WorkspacesPathParams
 from .errors import WorkspaceAccessForbiddenError, WorkspaceGroupNotFoundError
 
 _logger = logging.getLogger(__name__)
-
-
-class _RequestContext(BaseModel):
-    user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
-    product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
 def _handle_workspaces_groups_exceptions(handler: Handler):
@@ -82,7 +76,7 @@ class _WorkspacesGroupsBodyParams(BaseModel):
 @permission_required("workspaces.*")
 @_handle_workspaces_groups_exceptions
 async def create_workspace_group(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(_WorkspacesGroupsPathParams, request)
     body_params = await parse_request_body_as(_WorkspacesGroupsBodyParams, request)
 
@@ -105,7 +99,7 @@ async def create_workspace_group(request: web.Request):
 @permission_required("workspaces.*")
 @_handle_workspaces_groups_exceptions
 async def list_workspace_groups(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(WorkspacesPathParams, request)
 
     workspaces: list[
@@ -128,7 +122,7 @@ async def list_workspace_groups(request: web.Request):
 @permission_required("workspaces.*")
 @_handle_workspaces_groups_exceptions
 async def replace_workspace_group(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(_WorkspacesGroupsPathParams, request)
     body_params = await parse_request_body_as(_WorkspacesGroupsBodyParams, request)
 
@@ -152,7 +146,7 @@ async def replace_workspace_group(request: web.Request):
 @permission_required("workspaces.*")
 @_handle_workspaces_groups_exceptions
 async def delete_workspace_group(request: web.Request):
-    req_ctx = _RequestContext.parse_obj(request)
+    req_ctx = RequestContext.parse_obj(request)
     path_params = parse_request_path_parameters_as(_WorkspacesGroupsPathParams, request)
 
     await _groups_api.delete_workspace_group(

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
@@ -89,9 +89,11 @@ class WorkspacesListQueryParams(
     PageQueryParameters,
     WorkspacesListOrderQueryParams,  # type: ignore[misc, valid-type]
 ):
-    @validator("order_by", check_fields=False)
+    @validator("order_by", check_fields=False, always=True)
     @classmethod
     def _post_rename_order_by_field(cls, v):
+        # NOTE: PC->MD this is very error-prone (e.g. w/ defaults).
+        # Rather create a map to a db interface
         if v.field == "modified_at":
             v.field = "modified"
         return v

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
@@ -73,10 +73,7 @@ class WorkspacesPathParams(StrictRequestParameters):
     workspace_id: WorkspaceID
 
 
-(
-    WorkspacesListOrderQueryParams,
-    WorkspacesListOrderQueryParamsOpenApi,
-) = create_ordering_query_model_classes(
+WorkspacesListOrderQueryParams = create_ordering_query_model_classes(
     ordering_fields={
         "modified_at",
         "name",

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
@@ -19,7 +19,7 @@ from models_library.rest_pagination import Page, PageQueryParameters
 from models_library.rest_pagination_utils import paginate_data
 from models_library.users import UserID
 from models_library.workspaces import WorkspaceID
-from pydantic import Field, parse_obj_as, validator
+from pydantic import Field, parse_obj_as
 from servicelib.aiohttp import status
 from servicelib.aiohttp.requests_validation import (
     parse_request_body_as,
@@ -81,6 +81,7 @@ WorkspacesListOrderQueryParams: type[
         "name",
     },
     default=OrderBy(field=IDStr("modified_at"), direction=OrderDirection.DESC),
+    ordering_fields_api_to_column_map={"modified_at": "modified"},
 )
 
 
@@ -88,14 +89,7 @@ class WorkspacesListQueryParams(
     PageQueryParameters,
     WorkspacesListOrderQueryParams,  # type: ignore[misc, valid-type]
 ):
-    @validator("order_by", always=True)
-    @classmethod
-    def _post_rename_order_by_field_as_db_column(cls, v):
-        # NOTE: PC->MD this is very error-prone (e.g. w/ defaults).
-        # Rather create a map to a db interface
-        if v.field == "modified_at":  # API field
-            v.field = "modified"  # DB column
-        return v
+    ...
 
 
 @routes.post(f"/{VTAG}/workspaces", name="create_workspace")

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
@@ -73,7 +73,9 @@ class WorkspacesPathParams(StrictRequestParameters):
     workspace_id: WorkspaceID
 
 
-WorkspacesListOrderQueryParams = create_ordering_query_model_classes(
+WorkspacesListOrderQueryParams: type[
+    RequestParameters
+] = create_ordering_query_model_classes(
     ordering_fields={
         "modified_at",
         "name",
@@ -83,7 +85,10 @@ WorkspacesListOrderQueryParams = create_ordering_query_model_classes(
 )
 
 
-class WorkspacesListQueryParams(PageQueryParameters, WorkspacesListOrderQueryParams):
+class WorkspacesListQueryParams(
+    PageQueryParameters,
+    WorkspacesListOrderQueryParams,  # type: ignore[misc, valid-type]
+):
     @validator("order_by", check_fields=False)
     @classmethod
     def _post_rename_order_by_field(cls, v):

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
@@ -77,12 +77,12 @@ class WorkspacesPathParams(StrictRequestParameters):
     WorkspacesListOrderQueryParams,
     WorkspacesListOrderQueryParamsOpenApi,
 ) = create_ordering_query_model_classes(
-    sortable_fields={
+    ordering_fields={
         "modified_at",
         "name",
         "description",
     },
-    default_order_by=OrderBy(field=IDStr("modified_at"), direction=OrderDirection.DESC),
+    default=OrderBy(field=IDStr("modified_at"), direction=OrderDirection.DESC),
 )
 
 

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
@@ -9,6 +9,7 @@ from models_library.api_schemas_webserver.workspaces import (
     WorkspaceGetPage,
 )
 from models_library.basic_types import IDStr
+from models_library.rest_base import RequestParameters, StrictRequestParameters
 from models_library.rest_ordering import OrderBy, OrderDirection
 from models_library.rest_pagination import Page, PageQueryParameters
 from models_library.rest_pagination_utils import paginate_data
@@ -17,8 +18,6 @@ from models_library.workspaces import WorkspaceID
 from pydantic import Extra, Field, Json, parse_obj_as, validator
 from servicelib.aiohttp import status
 from servicelib.aiohttp.requests_validation import (
-    RequestParams,
-    StrictRequestParams,
     parse_request_body_as,
     parse_request_path_parameters_as,
     parse_request_query_parameters_as,
@@ -61,12 +60,12 @@ def handle_workspaces_exceptions(handler: Handler):
 routes = web.RouteTableDef()
 
 
-class WorkspacesRequestContext(RequestParams):
+class WorkspacesRequestContext(RequestParameters):
     user_id: UserID = Field(..., alias=RQT_USERID_KEY)  # type: ignore[literal-required]
     product_name: str = Field(..., alias=RQ_PRODUCT_KEY)  # type: ignore[literal-required]
 
 
-class WorkspacesPathParams(StrictRequestParams):
+class WorkspacesPathParams(StrictRequestParameters):
     workspace_id: WorkspaceID
 
 

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_handlers.py
@@ -79,7 +79,6 @@ WorkspacesListOrderQueryParams: type[
     ordering_fields={
         "modified_at",
         "name",
-        "description",
     },
     default=OrderBy(field=IDStr("modified_at"), direction=OrderDirection.DESC),
 )
@@ -89,13 +88,13 @@ class WorkspacesListQueryParams(
     PageQueryParameters,
     WorkspacesListOrderQueryParams,  # type: ignore[misc, valid-type]
 ):
-    @validator("order_by", check_fields=False, always=True)
+    @validator("order_by", always=True)
     @classmethod
-    def _post_rename_order_by_field(cls, v):
+    def _post_rename_order_by_field_as_db_column(cls, v):
         # NOTE: PC->MD this is very error-prone (e.g. w/ defaults).
         # Rather create a map to a db interface
-        if v.field == "modified_at":
-            v.field = "modified"
+        if v.field == "modified_at":  # API field
+            v.field = "modified"  # DB column
         return v
 
 

--- a/services/web/server/tests/unit/with_dbs/03/resource_usage/test_usage_services__list.py
+++ b/services/web/server/tests/unit/with_dbs/03/resource_usage/test_usage_services__list.py
@@ -26,8 +26,8 @@ from simcore_service_webserver.db.models import UserRole
 
 _SERVICE_RUN_GET = ServiceRunPage(
     items=[
-        ServiceRunGet(
-            **{
+        ServiceRunGet.parse_obj(
+            {
                 "service_run_id": "comp_1_5c2110be-441b-11ee-a0e8-02420a000040_1",
                 "wallet_id": 1,
                 "wallet_name": "the super wallet!",
@@ -55,12 +55,11 @@ _SERVICE_RUN_GET = ServiceRunPage(
 
 @pytest.fixture
 def mock_list_usage_services(mocker: MockerFixture) -> tuple:
-    mock_list_usage = mocker.patch(
+    return mocker.patch(
         "simcore_service_webserver.resource_usage._service_runs_api.service_runs.get_service_run_page",
         spec=True,
         return_value=_SERVICE_RUN_GET,
     )
-    return mock_list_usage
 
 
 @pytest.fixture()
@@ -79,7 +78,10 @@ def setup_wallets_db(
             .returning(sa.literal_column("*"))
         )
         row = result.fetchone()
+        assert row
+
         yield cast(int, row[0])
+
         con.execute(wallets.delete())
 
 
@@ -160,6 +162,8 @@ async def test_list_service_usage_with_order_by_query_param(
     setup_wallets_db,
     mock_list_usage_services,
 ):
+    assert client.app
+
     # without any additional query parameter
     url = client.app.router["list_resource_usage_services"].url_for()
     resp = await client.get(f"{url}")
@@ -237,9 +241,13 @@ async def test_list_service_usage_with_order_by_query_param(
     _, error = await assert_status(resp, status.HTTP_422_UNPROCESSABLE_ENTITY)
     assert mock_list_usage_services.called
     assert error["status"] == status.HTTP_422_UNPROCESSABLE_ENTITY
-    assert error["errors"][0]["message"].startswith(
-        "value is not a valid enumeration member"
-    )
+
+    errors = {(e["code"], e["field"]) for e in error["errors"]}
+    assert {
+        ("value_error", "order_by.field"),
+        ("type_error.enum", "order_by.direction"),
+    } == errors
+    assert len(errors) == 2
 
     # without field
     _filter = {"direction": "asc"}
@@ -253,6 +261,8 @@ async def test_list_service_usage_with_order_by_query_param(
     assert mock_list_usage_services.called
     assert error["status"] == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert error["errors"][0]["message"].startswith("field required")
+    assert error["errors"][0]["code"] == "value_error.missing"
+    assert error["errors"][0]["field"] == "order_by.field"
 
 
 @pytest.mark.parametrize("user_role", [(UserRole.USER)])
@@ -262,6 +272,8 @@ async def test_list_service_usage_with_filters_query_param(
     setup_wallets_db,
     mock_list_usage_services,
 ):
+    assert client.app
+
     # with unable to decode filter query parameter
     url = (
         client.app.router["list_resource_usage_services"]

--- a/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces.py
+++ b/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces.py
@@ -8,6 +8,7 @@ from http import HTTPStatus
 import pytest
 from aiohttp.test_utils import TestClient
 from models_library.api_schemas_webserver.workspaces import WorkspaceGet
+from models_library.rest_ordering import OrderDirection
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import (
@@ -17,6 +18,26 @@ from pytest_simcore.helpers.webserver_parametrizations import (
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.projects.models import ProjectDict
+from simcore_service_webserver.workspaces._workspaces_handlers import (
+    WorkspacesListQueryParams,
+)
+
+
+def test_workspaces_order_query_model_post_validator():
+
+    # on default
+    query_params = WorkspacesListQueryParams.parse_obj({})
+    assert query_params.order_by
+    assert query_params.order_by.field == "modified"
+    assert query_params.order_by.direction == OrderDirection.DESC
+
+    # on partial default
+    query_params = WorkspacesListQueryParams.parse_obj(
+        {"order_by": {"field": "modified_at"}}
+    )
+    assert query_params.order_by
+    assert query_params.order_by.field == "modified"
+    assert query_params.order_by.direction == OrderDirection.ASC
 
 
 @pytest.mark.parametrize(*standard_role_response(), ids=str)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

 [![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/ITISFoundation/osparc-simcore/57f2044cb3ffce6f99ab36b415a8139d04f2c3ae/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml) [![Swagger UI](https://img.shields.io/badge/OpenAPI-Swagger_UI-85ea2d?logo=swagger)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/ITISFoundation/osparc-simcore/57f2044cb3ffce6f99ab36b415a8139d04f2c3ae/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
Unifies and simplifies ordering queries. For instance, list `folders`  is displayed as
![image](https://github.com/user-attachments/assets/38db3ca4-8d2f-48d4-b3a2-cdff19626aa2)
from this **coded openapi specification**
```python
@router.get(
    "/folders",
    response_model=Envelope[list[FolderGet]],
)
async def list_folders(
    _q: Annotated[as_query(FolderListQueryParams), Depends()],
):
    ...    
```

#### ♻️ Unified `ordering` query parameters
- SEE `packages/models-library/src/models_library/rest_ordering.py`
- Introduced a factory function to streamline the handling of ordering parameters, ensuring flexibility for customization per case.
- Refactored existing resources (folders, projects, ...) to adopt the unified approach for defining ordering parameters.
- Established a naming convention for models: `$(ResourceName)$(OperationName)OrderQueryParams` (e.g., `FoldersListOrderQueryParams`).

#### ♻️ Simplified handling of complex query parameters (i.e. JSON-encoded)
- Unified the logic with a **single class** for both OpenAPI specification generation and request validation.
    - Includes the helper function `as_query` for ease of use
- Improved implementation in `api/specs/web-server` to reduce complexity and potential errors.. E.g. openapi specs are simply defined using one model per "group" of parameters
- Note that it uses [dependency injection shortcuts](https://fastapi.tiangolo.com/tutorial/dependencies/classes-as-dependencies/?h=depends%28%29#type-annotation-vs-depends) to expand all fields in the model as (path `_p`/ query `_q`) parameters.

## Related issue/s

- Preparations to include ordering in ITISFoundation/osparc-issues#468


## How to test

Driving test
```
cd pakcages/models-library
make install-dev
pytest -vv tests/test_rest_ordering
```


## Dev-ops

None