### PR TITLE
🐛 Fixed webserver API endpoints

### DIFF
--- a/packages/models-library/src/models_library/api_schemas_webserver/projects.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects.py
@@ -33,8 +33,8 @@ from .permalinks import ProjectPermalink
 class ProjectCreateNew(InputSchema):
     uuid: ProjectID | None = None  # NOTE: suggested uuid! but could be different!
     name: str
-    description: str | None
-    thumbnail: HttpUrl | None
+    description: str | None = None
+    thumbnail: HttpUrl | None = None
     workbench: NodesDict
     access_rights: dict[GroupIDStr, AccessRights]
     tags: list[int] = Field(default_factory=list)
@@ -55,8 +55,8 @@ class ProjectCreateNew(InputSchema):
 # NOTE: based on OVERRIDABLE_DOCUMENT_KEYS
 class ProjectCopyOverride(InputSchema):
     name: str
-    description: str | None
-    thumbnail: HttpUrl | None
+    description: str | None = None
+    thumbnail: HttpUrl | None = None
     prj_owner: LowerCaseEmailStr
 
     _empty_is_none = field_validator("thumbnail", mode="before")(

--- a/packages/models-library/src/models_library/api_schemas_webserver/projects_nodes.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects_nodes.py
@@ -19,7 +19,7 @@ __all__: tuple[str, ...] = ("ServiceResourcesDict",)
 class NodeCreate(InputSchemaWithoutCamelCase):
     service_key: ServiceKey
     service_version: ServiceVersion
-    service_id: str | None
+    service_id: str | None = None
 
 
 BootOptions: TypeAlias = dict


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Endpoints for creating a node and creating a new project did had some optional parameters that were not respected.

After the Pydantic v2 migration, these became mandatory, which was wrong. Aligned with what the OpenAPI spec (and the frontend) require.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
