### PR TITLE
WIP: Is4481/fix settings tests

### DIFF
--- a/packages/settings-library/src/settings_library/base.py
+++ b/packages/settings-library/src/settings_library/base.py
@@ -15,9 +15,9 @@ from pydantic_settings import (
 
 _logger = logging.getLogger(__name__)
 
-_DEFAULTS_TO_NONE_MSG: Final[
+_DEFAULTS_TO_NONE_FSTRING: Final[
     str
-] = "%s auto_default_from_env unresolved, defaulting to None"
+] = "{field_name} auto_default_from_env unresolved, defaulting to None"
 
 
 class DefaultFromEnvFactoryError(ValueError):
@@ -40,10 +40,8 @@ def _create_settings_from_env(field_name: str, info: FieldInfo):
         except ValidationError as err:
             if is_nullable(info):
                 # e.g. Optional[PostgresSettings] would warn if defaults to None
-                _logger.warning(
-                    _DEFAULTS_TO_NONE_MSG,
-                    field_name,
-                )
+                msg = _DEFAULTS_TO_NONE_FSTRING.format(field_name=field_name)
+                _logger.warning(msg)
                 return None
             _logger.warning("Validation errors=%s", err.errors())
             raise DefaultFromEnvFactoryError(errors=err.errors()) from err
@@ -56,6 +54,9 @@ def _is_auto_default_from_env_enabled(field: FieldInfo) -> bool:
         field.json_schema_extra is not None
         and field.json_schema_extra.get("auto_default_from_env", False)  # type: ignore[union-attr]
     )
+
+
+ENABLED: Final = {}
 
 
 class EnvSettingsWithAutoDefaultSource(EnvSettingsSource):
@@ -86,7 +87,7 @@ class EnvSettingsWithAutoDefaultSource(EnvSettingsSource):
             _is_auto_default_from_env_enabled(field)
             and field.default_factory
             and field.default is None
-            and prepared_value == {}
+            and prepared_value == ENABLED
         ):
             prepared_value = field.default_factory()
         return prepared_value

--- a/packages/settings-library/src/settings_library/base.py
+++ b/packages/settings-library/src/settings_library/base.py
@@ -15,7 +15,7 @@ from pydantic_settings import (
 
 _logger = logging.getLogger(__name__)
 
-_DEFAULTS_TO_NONE_FSTRING: Final[
+_AUTO_DEFAULT_FACTORY_RESOLVES_TO_NONE_FSTRING: Final[
     str
 ] = "{field_name} auto_default_from_env unresolved, defaulting to None"
 
@@ -40,7 +40,9 @@ def _create_settings_from_env(field_name: str, info: FieldInfo):
         except ValidationError as err:
             if is_nullable(info):
                 # e.g. Optional[PostgresSettings] would warn if defaults to None
-                msg = _DEFAULTS_TO_NONE_FSTRING.format(field_name=field_name)
+                msg = _AUTO_DEFAULT_FACTORY_RESOLVES_TO_NONE_FSTRING.format(
+                    field_name=field_name
+                )
                 _logger.warning(msg)
                 return None
             _logger.warning("Validation errors=%s", err.errors())

--- a/packages/settings-library/tests/test_base.py
+++ b/packages/settings-library/tests/test_base.py
@@ -17,7 +17,7 @@ from pytest_mock import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_envfile
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.base import (
-    _DEFAULTS_TO_NONE_FSTRING,
+    _AUTO_DEFAULT_FACTORY_RESOLVES_TO_NONE_FSTRING,
     BaseCustomSettings,
     DefaultFromEnvFactoryError,
 )
@@ -224,7 +224,9 @@ def test_auto_default_to_none_logs_a_warning(
     # Defaulting to None also logs a warning
     assert logger_warn.call_count == 1
     assert (
-        _DEFAULTS_TO_NONE_FSTRING.format(field_name="VALUE_NULLABLE_DEFAULT_ENV")
+        _AUTO_DEFAULT_FACTORY_RESOLVES_TO_NONE_FSTRING.format(
+            field_name="VALUE_NULLABLE_DEFAULT_ENV"
+        )
         in logger_warn.call_args[0][0]
     )
 

--- a/packages/settings-library/tests/test_base.py
+++ b/packages/settings-library/tests/test_base.py
@@ -17,7 +17,7 @@ from pytest_mock import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_envfile
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.base import (
-    _DEFAULTS_TO_NONE_MSG,
+    _DEFAULTS_TO_NONE_FSTRING,
     BaseCustomSettings,
     DefaultFromEnvFactoryError,
 )
@@ -223,7 +223,10 @@ def test_auto_default_to_none_logs_a_warning(
 
     # Defaulting to None also logs a warning
     assert logger_warn.call_count == 1
-    assert _DEFAULTS_TO_NONE_MSG in logger_warn.call_args[0][0]
+    assert (
+        _DEFAULTS_TO_NONE_FSTRING.format(field_name="VALUE_NULLABLE_DEFAULT_ENV")
+        in logger_warn.call_args[0][0]
+    )
 
 
 def test_auto_default_to_not_none(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Addresses failures in `autoscaling/tests/unit/test_core_settings.py`

- 

## Related issue/s

- Part of #4481 


## How to test

```
cd services/autoscaling
make install-dev
pytest -vv tests/unit/test_core_settings.py
```

## Dev-ops
NOne