### PR TITLE
All errors in dynamic-sidecar inherit from `OsparcErrorMixin`

### DIFF
--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/docker_utils.py
@@ -50,7 +50,13 @@ async def get_volume_by_label(label: str, run_id: RunID) -> dict[str, Any]:
         volumes = data["Volumes"]
         _logger.debug("volumes query for label=%s volumes=%s", label, volumes)
         if len(volumes) != 1:
-            raise VolumeNotFoundError(label, run_id, volumes)
+            raise VolumeNotFoundError(
+                volume_count=len(volumes),
+                source_label=label,
+                run_id=run_id,
+                volume_names=" ".join(v.get("Name", "UNKNOWN") for v in volumes),
+                status_code=http_status.HTTP_404_NOT_FOUND,
+            )
         volume_details: dict[str, Any] = volumes[0]
         return volume_details
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/error_handlers.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/error_handlers.py
@@ -12,7 +12,7 @@ async def http_error_handler(
 ) -> JSONResponse:
     return JSONResponse(
         content=jsonable_encoder({"errors": [exception.message]}),
-        status_code=exception.status_code,
+        status_code=exception.status_code,  # type:ignore[attr-defined]
     )
 
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/errors.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/errors.py
@@ -1,53 +1,30 @@
-from typing import Any
-
 from common_library.errors_classes import OsparcErrorMixin
-from fastapi import status
-from models_library.services import RunID
 
 
-class BaseDynamicSidecarError(Exception):
+class BaseDynamicSidecarError(OsparcErrorMixin, Exception):
     """Used as base for all exceptions"""
-
-    def __init__(
-        self, nessage: str, status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR
-    ) -> None:
-        self.message: str = nessage
-        self.status_code: int = status_code
-        super().__init__(nessage)
 
 
 class VolumeNotFoundError(BaseDynamicSidecarError):
-    def __init__(
-        self, source_label: str, run_id: RunID, volumes: list[dict[str, Any]]
-    ) -> None:
-        super().__init__(
-            f"Expected 1 got {len(volumes)} volumes labels with {source_label=}, {run_id=}: "
-            f"Found {' '.join(v.get('Name', 'UNKNOWN') for v in volumes)}",
-            status_code=status.HTTP_404_NOT_FOUND,
-        )
+    msg_template = (
+        "Expected 1 got {volume_count} volumes labels with "
+        "source_label={source_label}, run_id={run_id}: Found {volume_names}"
+    )
 
 
 class UnexpectedDockerError(BaseDynamicSidecarError):
-    def __init__(self, message: str, status_code: int) -> None:
-        super().__init__(
-            f"An unexpected Docker error occurred {status_code=}, {message=}",
-            status_code=status_code,
-        )
+    msg_template = "An unexpected Docker error occurred status_code={status_code}, message={message}"
 
 
-class BaseError(OsparcErrorMixin, BaseDynamicSidecarError):
-    ...
-
-
-class ContainerExecContainerNotFoundError(BaseError):
+class ContainerExecContainerNotFoundError(BaseDynamicSidecarError):
     msg_template = "Container '{container_name}' was not found"
 
 
-class ContainerExecTimeoutError(BaseError):
+class ContainerExecTimeoutError(BaseDynamicSidecarError):
     msg_template = "Timed out after {timeout} while executing: '{command}'"
 
 
-class ContainerExecCommandFailedError(BaseError):
+class ContainerExecCommandFailedError(BaseDynamicSidecarError):
     msg_template = (
         "Command '{command}' exited with code '{exit_code}'"
         "and output: '{command_result}'"

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/settings.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/settings.py
@@ -2,7 +2,7 @@ import warnings
 from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
-from typing import cast
+from typing import Annotated, cast
 
 from common_library.pydantic_validators import validate_numeric_string_as_timedelta
 from models_library.basic_types import BootModeEnum, PortInt
@@ -53,10 +53,13 @@ class SystemMonitorSettings(BaseCustomSettings):
 
 
 class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
-    SC_BOOT_MODE: BootModeEnum = Field(
-        ...,
-        description="boot mode helps determine if in development mode or normal operation",
-    )
+    SC_BOOT_MODE: Annotated[
+        BootModeEnum,
+        Field(
+            ...,
+            description="boot mode helps determine if in development mode or normal operation",
+        ),
+    ]
 
     DYNAMIC_SIDECAR_DY_VOLUMES_MOUNT_DIR: Path = Field(
         ...,

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/settings.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/settings.py
@@ -2,10 +2,10 @@ import warnings
 from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
-from typing import Annotated, cast
+from typing import cast
 
 from common_library.pydantic_validators import validate_numeric_string_as_timedelta
-from models_library.basic_types import BootModeEnum, PortInt
+from models_library.basic_types import PortInt
 from models_library.callbacks_mapping import CallbacksMapping
 from models_library.products import ProductName
 from models_library.projects import ProjectID
@@ -21,8 +21,8 @@ from pydantic import (
     field_validator,
 )
 from servicelib.logging_utils_filtering import LoggerName, MessageSubstring
+from settings_library.application import BaseApplicationSettings
 from settings_library.aws_s3_cli import AwsS3CliSettings
-from settings_library.base import BaseCustomSettings
 from settings_library.docker_registry import RegistrySettings
 from settings_library.node_ports import StorageAuthSettings
 from settings_library.postgres import PostgresSettings
@@ -35,7 +35,7 @@ from settings_library.tracing import TracingSettings
 from settings_library.utils_logging import MixinLoggingSettings
 
 
-class ResourceTrackingSettings(BaseCustomSettings):
+class ResourceTrackingSettings(BaseApplicationSettings):
     RESOURCE_TRACKING_HEARTBEAT_INTERVAL: timedelta = Field(
         default=DEFAULT_RESOURCE_USAGE_HEARTBEAT_INTERVAL,
         description="each time the status of the service is propagated",
@@ -46,20 +46,13 @@ class ResourceTrackingSettings(BaseCustomSettings):
     )
 
 
-class SystemMonitorSettings(BaseCustomSettings):
+class SystemMonitorSettings(BaseApplicationSettings):
     DY_SIDECAR_SYSTEM_MONITOR_TELEMETRY_ENABLE: bool = Field(
         default=False, description="enabled/disabled disk usage monitoring"
     )
 
 
-class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
-    SC_BOOT_MODE: Annotated[
-        BootModeEnum,
-        Field(
-            ...,
-            description="boot mode helps determine if in development mode or normal operation",
-        ),
-    ]
+class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
 
     DYNAMIC_SIDECAR_DY_VOLUMES_MOUNT_DIR: Path = Field(
         ...,

--- a/services/dynamic-sidecar/tests/unit/test_api_rest_containers.py
+++ b/services/dynamic-sidecar/tests/unit/test_api_rest_containers.py
@@ -480,7 +480,7 @@ async def test_container_docker_error(
     def _expected_error_string(status_code: int) -> dict[str, Any]:
         return {
             "errors": [
-                f"An unexpected Docker error occurred status_code={status_code}, message='aiodocker_mocked_error'"
+                f"An unexpected Docker error occurred status_code={status_code}, message=aiodocker_mocked_error"
             ]
         }
 

--- a/services/dynamic-sidecar/tests/unit/test_core_errors.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_errors.py
@@ -1,0 +1,35 @@
+# pylint:disable=broad-exception-caught
+# pylint:disable=no-member
+
+from simcore_service_dynamic_sidecar.core.errors import (
+    UnexpectedDockerError,
+    VolumeNotFoundError,
+)
+from starlette import status
+
+
+def test_legacy_interface_unexpected_docker_error():
+    message = "some_message"
+    status_code = 42
+    try:
+        raise UnexpectedDockerError(  # noqa: TRY301
+            message=message, status_code=status_code
+        )
+    except Exception as e:
+        print(e)
+        assert e.status_code == status_code  # noqa: PT017
+        assert message in e.message  # noqa: PT017
+
+
+def test_legacy_interface_volume_not_found_error():
+    try:
+        raise VolumeNotFoundError(  # noqa: TRY301
+            source_label="some", run_id="run_id", volumes=[{}, {"Name": "a_volume"}]
+        )
+    except Exception as e:
+        print(e)
+        assert (  # noqa: PT017
+            e.message
+            == "Expected 1 got 2 volumes labels with source_label='some', run_id='run_id': Found UNKNOWN a_volume"
+        )
+        assert e.status_code == status.HTTP_404_NOT_FOUND  # noqa: PT017

--- a/services/dynamic-sidecar/tests/unit/test_core_errors.py
+++ b/services/dynamic-sidecar/tests/unit/test_core_errors.py
@@ -23,13 +23,20 @@ def test_legacy_interface_unexpected_docker_error():
 
 def test_legacy_interface_volume_not_found_error():
     try:
+        volumes = [{}, {"Name": "a_volume"}]
+        volume_names = " ".join(v.get("Name", "UNKNOWN") for v in volumes)
+
         raise VolumeNotFoundError(  # noqa: TRY301
-            source_label="some", run_id="run_id", volumes=[{}, {"Name": "a_volume"}]
+            volume_count=len(volumes),
+            source_label="some",
+            run_id="run_id",
+            volume_names=volume_names,
+            status_code=status.HTTP_404_NOT_FOUND,
         )
     except Exception as e:
         print(e)
         assert (  # noqa: PT017
             e.message
-            == "Expected 1 got 2 volumes labels with source_label='some', run_id='run_id': Found UNKNOWN a_volume"
+            == "Expected 1 got 2 volumes labels with source_label=some, run_id=run_id: Found UNKNOWN a_volume"
         )
         assert e.status_code == status.HTTP_404_NOT_FOUND  # noqa: PT017


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Refactored errors in dynamic-sidecar thy all inherit from `OsparcErrorMixin`.
Makes all pylint checks pass.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->

- fixes https://github.com/ITISFoundation/osparc-simcore/issues/6757

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
