### PR TITLE
Uses typing_extensions.TypedDict in all instances used in pydantic models AND fixes with migration of rest_ordering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@ Makefile                                  @pcrespov @sanderegg
 /ci/                                      @sanderegg @pcrespov
 /docs/                                    @pcrespov
 /packages/common-library/                 @giancarloromeo
-/packages/models-library/                 @sanderegg @pcrespov @matusdrobuliak66
+/packages/models-library/                 @sanderegg @pcrespov @matusdrobuliak66 @giancarloromeo
 /packages/postgres-database/              @matusdrobuliak66
 /packages/pytest-simcore/                 @pcrespov @sanderegg
 /packages/service-integration/            @pcrespov @sanderegg @GitHK

--- a/packages/models-library/src/models_library/boot_options.py
+++ b/packages/models-library/src/models_library/boot_options.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, ConfigDict, ValidationInfo, field_validator
-from typing_extensions import TypedDict
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 from .basic_types import EnvVarKey
 

--- a/packages/models-library/src/models_library/projects_ui.py
+++ b/packages/models-library/src/models_library/projects_ui.py
@@ -6,7 +6,9 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic_extra_types.color import Color
-from typing_extensions import TypedDict
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 from .projects_nodes_io import NodeID, NodeIDStr
 from .projects_nodes_ui import Marker, Position

--- a/packages/models-library/src/models_library/rest_base.py
+++ b/packages/models-library/src/models_library/rest_base.py
@@ -8,7 +8,7 @@ class RequestParameters(BaseModel):
     """
 
     def as_params(self, **export_options) -> dict[str, str]:
-        data = self.dict(**export_options)
+        data = self.model_dump(**export_options)
         return {k: f"{v}" for k, v in data.items()}
 
 

--- a/packages/models-library/src/models_library/rest_pagination_utils.py
+++ b/packages/models-library/src/models_library/rest_pagination_utils.py
@@ -1,9 +1,11 @@
 from math import ceil
 from typing import Any, Protocol, runtime_checkable
-from typing_extensions import TypedDict
 
 from common_library.pydantic_networks_extension import AnyHttpUrlLegacy
 from pydantic import TypeAdapter
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 from .rest_pagination import PageLinks, PageMetaInfoLimitOffset
 
@@ -70,7 +72,9 @@ def paginate_data(
     """
     last_page = ceil(total / limit) - 1
 
-    data = [item.model_dump() if hasattr(item, "model_dump") else item for item in chunk]
+    data = [
+        item.model_dump() if hasattr(item, "model_dump") else item for item in chunk
+    ]
 
     return PageDict(
         _meta=PageMetaInfoLimitOffset(

--- a/packages/models-library/src/models_library/socketio.py
+++ b/packages/models-library/src/models_library/socketio.py
@@ -1,6 +1,8 @@
 from typing import Any
 
-from typing_extensions import TypedDict
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 
 class SocketMessageDict(TypedDict):

--- a/packages/models-library/src/models_library/socketio.py
+++ b/packages/models-library/src/models_library/socketio.py
@@ -1,4 +1,6 @@
-from typing import Any, TypedDict
+from typing import Any
+
+from typing_extensions import TypedDict
 
 
 class SocketMessageDict(TypedDict):

--- a/packages/models-library/src/models_library/utils/common_validators.py
+++ b/packages/models-library/src/models_library/utils/common_validators.py
@@ -48,7 +48,7 @@ def parse_json_pre_validator(value: Any):
             return json_loads(value)
         except JSONDecodeError as err:
             msg = f"Invalid JSON {value=}: {err}"
-            raise TypeError(msg) from err
+            raise ValueError(msg) from err
     return value
 
 

--- a/packages/models-library/tests/test_rest_ordering.py
+++ b/packages/models-library/tests/test_rest_ordering.py
@@ -151,3 +151,22 @@ def test_ordering_query_model_with_map():
     model = OrderQueryParamsModel.model_validate({"order_by": {"field": "modified"}})
     assert model.order_by
     assert model.order_by.field == "some_db_column_name"
+
+
+def test_ordering_query_parse_json_pre_validator():
+
+    OrderQueryParamsModel = create_ordering_query_model_classes(
+        ordering_fields={"modified", "name"},
+        default=OrderBy(field=IDStr("modified"), direction=OrderDirection.DESC),
+    )
+
+    bad_json_value = ",invalid json"
+    with pytest.raises(ValidationError) as err_info:
+        OrderQueryParamsModel.model_validate({"order_by": bad_json_value})
+
+    exc = err_info.value
+    assert exc.error_count() == 1
+    error = exc.errors()[0]
+    assert error["loc"] == ("order_by",)
+    assert error["type"] == "value_error"
+    assert error["input"] == bad_json_value

--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -11,7 +11,9 @@ from typing import Literal
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
-from typing_extensions import TypedDict
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 from .base import metadata
 from .groups import groups

--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -9,7 +9,9 @@ from typing import Any, Protocol
 import arrow
 from aiohttp import web
 from pydantic import TypeAdapter
-from typing_extensions import TypedDict
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 from .application_keys import APP_CONFIG_KEY, APP_SETTINGS_KEY
 

--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -4,11 +4,12 @@ import logging
 from collections.abc import Callable
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Protocol, TypedDict
+from typing import Any, Protocol
 
 import arrow
 from aiohttp import web
 from pydantic import TypeAdapter
+from typing_extensions import TypedDict
 
 from .application_keys import APP_CONFIG_KEY, APP_SETTINGS_KEY
 

--- a/packages/service-library/src/servicelib/rest_constants.py
+++ b/packages/service-library/src/servicelib/rest_constants.py
@@ -2,7 +2,9 @@
 
 from typing import Final
 
-from typing_extensions import TypedDict
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 
 class PydanticExportParametersDict(TypedDict):

--- a/packages/service-library/src/servicelib/rest_constants.py
+++ b/packages/service-library/src/servicelib/rest_constants.py
@@ -1,6 +1,8 @@
 # SEE https://pydantic-docs.helpmanual.io/usage/exporting_models/#modeldict
 
-from typing import Final, TypedDict
+from typing import Final
+
+from typing_extensions import TypedDict
 
 
 class PydanticExportParametersDict(TypedDict):

--- a/packages/service-library/tests/aiohttp/test_requests_validation.py
+++ b/packages/service-library/tests/aiohttp/test_requests_validation.py
@@ -371,9 +371,9 @@ def test_parse_request_query_parameters_as_with_order_by_query_models():
 
     expected = OrderBy(field="name", direction=OrderDirection.ASC)
 
-    url = URL("/test").with_query(order_by=expected.json())
+    url = URL("/test").with_query(order_by=expected.model_dump_json())
 
     request = make_mocked_request("GET", path=f"{url}")
 
     query_params = parse_request_query_parameters_as(OrderQueryModel, request)
-    assert query_params.order_by == expected
+    assert query_params.order_by.model_dump() == expected.model_dump()

--- a/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
@@ -8,7 +8,9 @@ from models_library.projects_state import RunningState
 from models_library.users import UserID
 from pydantic import BaseModel, ConfigDict, PositiveInt, field_validator
 from simcore_postgres_database.models.comp_pipeline import StateType
-from typing_extensions import TypedDict
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 from ..utils.db import DB_TO_RUNNING_STATE
 

--- a/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
@@ -14,12 +14,14 @@
 """
 
 import logging
-from typing import TypedDict
 
 import redis.asyncio as aioredis
 from aiohttp import web
 from models_library.basic_types import UUIDStr
 from servicelib.redis_utils import handle_redis_returns_union_types
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 from ..redis import get_redis_resources_client
 from ._constants import APP_CLIENT_SOCKET_REGISTRY_KEY

--- a/services/web/server/src/simcore_service_webserver/rest/healthcheck.py
+++ b/services/web/server/src/simcore_service_webserver/rest/healthcheck.py
@@ -47,10 +47,13 @@ Taken from https://docs.docker.com/engine/reference/builder/#healthcheck
 import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
-from typing import TypeAlias, TypedDict
+from typing import TypeAlias
 
 from aiohttp import web
 from aiosignal import Signal
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 from .._constants import APP_SETTINGS_KEY
 

--- a/services/web/server/src/simcore_service_webserver/security/_authz_access_model.py
+++ b/services/web/server/src/simcore_service_webserver/security/_authz_access_model.py
@@ -10,7 +10,7 @@ import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TypeAlias
+from typing import TypeAlias, TypedDict
 
 from models_library.products import ProductName
 from models_library.users import UserID

--- a/services/web/server/src/simcore_service_webserver/security/_authz_access_model.py
+++ b/services/web/server/src/simcore_service_webserver/security/_authz_access_model.py
@@ -10,7 +10,7 @@ import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TypeAlias, TypedDict
+from typing import TypeAlias
 
 from models_library.products import ProductName
 from models_library.users import UserID

--- a/services/web/server/src/simcore_service_webserver/security/_authz_access_roles.py
+++ b/services/web/server/src/simcore_service_webserver/security/_authz_access_roles.py
@@ -5,9 +5,10 @@
 """
 
 
-from typing import TypedDict
-
 from simcore_postgres_database.models.users import UserRole
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 
 class PermissionDict(TypedDict, total=False):

--- a/services/web/server/src/simcore_service_webserver/session/access_policies.py
+++ b/services/web/server/src/simcore_service_webserver/session/access_policies.py
@@ -3,13 +3,16 @@ import logging
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Final, TypedDict
+from typing import Final
 
 from aiohttp import web
 from aiohttp_session import Session
 from pydantic import PositiveInt, validate_call
 from servicelib.aiohttp import status
 from servicelib.aiohttp.typing_extension import Handler
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 from .api import get_session
 from .settings import SessionSettings, get_plugin_settings

--- a/services/web/server/src/simcore_service_webserver/statics/settings.py
+++ b/services/web/server/src/simcore_service_webserver/statics/settings.py
@@ -2,13 +2,16 @@
 
     Typically dumped in statics.json
 """
-from typing import Any, TypedDict
+from typing import Any
 
 import pycountry
 from aiohttp import web
 from models_library.utils.change_case import snake_to_camel
 from pydantic import AliasChoices, AnyHttpUrl, Field, TypeAdapter
 from settings_library.base import BaseCustomSettings
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 from .._constants import APP_SETTINGS_KEY
 

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_projects_permalinks.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_projects_permalinks.py
@@ -1,5 +1,4 @@
 import logging
-from typing import TypedDict
 
 import sqlalchemy as sa
 from aiohttp import web
@@ -7,6 +6,9 @@ from models_library.projects import ProjectID, ProjectIDStr
 from pydantic import HttpUrl, TypeAdapter
 from simcore_postgres_database.models.project_to_groups import project_to_groups
 from simcore_postgres_database.models.projects import ProjectType, projects
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 from ..db.plugin import get_database_engine
 from ..projects.api import ProjectPermalink, register_permalink_factory

--- a/services/web/server/src/simcore_service_webserver/utils.py
+++ b/services/web/server/src/simcore_service_webserver/utils.py
@@ -16,7 +16,9 @@ from typing import Any
 import orjson
 from common_library.error_codes import ErrorCodeStr
 from models_library.basic_types import SHA1Str
-from typing_extensions import TypedDict
+from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    TypedDict,
+)
 
 _CURRENT_DIR = (
     Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

All `TypedDict` used in pydantic models for `python <3.12` should use the backport library `typing_extensions`

SEE https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict

NOTE that we should not always import from the backport library `typing_extensions` but only those `TypedDict` used inside models.

----

- Fixes some remaining issue with migration of `rest_ordering.py` in https://github.com/ITISFoundation/osparc-simcore/pull/6763/files
   - Fixes wrong exception raised in parse_json_pre_validator pydantic validator
   - Fixes tests

## Related issue/s

- https://github.com/ITISFoundation/osparc-simcore/issues/4481


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
