### PR TITLE
🐛 [e2e] Study Options: Open button

### DIFF
--- a/services/opentelemetry-collector-config.yaml
+++ b/services/opentelemetry-collector-config.yaml
@@ -13,10 +13,16 @@ service:
     traces:
       receivers: [otlp]
       exporters: [otlphttp]
-      processors: [batch,probabilistic_sampler]
+      processors: [batch,probabilistic_sampler,filter/drop_healthcheck]
 processors:
   batch:
     timeout: 5s
     send_batch_size: ${TRACING_OPENTELEMETRY_COLLECTOR_BATCH_SIZE}
   probabilistic_sampler:
     sampling_percentage: ${TRACING_OPENTELEMETRY_COLLECTOR_SAMPLING_PERCENTAGE}
+  filter/drop_healthcheck:
+    error_mode: ignore
+    traces:
+      span:
+        - attributes["http.route"] == "healthcheck_readiness_probe"
+        - attributes["db.statement"] == "PING" and attributes["db.system"] == "redis"

--- a/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
+++ b/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
@@ -142,6 +142,7 @@ qx.Class.define("osparc.study.StudyOptions", {
           control = osparc.desktop.credits.Utils.createWalletSelector("read").set({
             allowGrowX: false
           });
+          control.addListener("changeSelection", () => this.__evaluateOpenButton());
           this.getChildControl("wallet-selector-layout").add(control);
           break;
         case "advanced-layout":
@@ -278,13 +279,11 @@ qx.Class.define("osparc.study.StudyOptions", {
           }
         });
       }
-
-      this.__evaluateOpenButton();
     },
 
     __evaluateOpenButton: function() {
       const hasTitle = Boolean(this.getChildControl("title-field").getValue());
-      const walletSelected = Boolean(this.getWallet());
+      const walletSelected = Boolean(this.getChildControl("wallet-selector").getSelection());
       this.getChildControl("open-button").setEnabled(hasTitle && walletSelected);
     },
 

--- a/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
+++ b/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
@@ -130,6 +130,7 @@ qx.Class.define("osparc.study.StudyOptions", {
           control = new qx.ui.form.TextField().set({
             maxWidth: 220
           });
+          control.addListener("changeValue", () => this.__evaluateOpenButton());
           osparc.utils.Utils.setIdToWidget(control, "studyTitleField");
           this.getChildControl("title-layout").add(control);
           break;
@@ -227,7 +228,8 @@ qx.Class.define("osparc.study.StudyOptions", {
             minWidth: 150,
             maxWidth: 150,
             height: 35,
-            center: true
+            center: true,
+            enabled: false,
           });
           osparc.utils.Utils.setIdToWidget(control, "openWithResources");
           this.getChildControl("buttons-layout").addAt(control, 1);
@@ -277,7 +279,13 @@ qx.Class.define("osparc.study.StudyOptions", {
         });
       }
 
-      this.getChildControl("open-button").setEnabled(Boolean(wallet));
+      this.__evaluateOpenButton();
+    },
+
+    __evaluateOpenButton: function() {
+      const hasTitle = Boolean(this.getChildControl("title-field").getValue());
+      const walletSelected = Boolean(this.getWallet());
+      this.getChildControl("open-button").setEnabled(hasTitle && walletSelected);
     },
 
     __buildLayout: function() {

--- a/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
+++ b/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
@@ -292,6 +292,8 @@ qx.Class.define("osparc.study.StudyOptions", {
       this.__buildTopSummaryLayout();
       this.__buildOptionsLayout();
       this.__buildButtons();
+
+      this.__evaluateOpenButton();
     },
 
     __buildTopSummaryLayout: function() {

--- a/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
+++ b/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
@@ -283,7 +283,7 @@ qx.Class.define("osparc.study.StudyOptions", {
 
     __evaluateOpenButton: function() {
       const hasTitle = Boolean(this.getChildControl("title-field").getValue());
-      const walletSelected = Boolean(this.getChildControl("wallet-selector").getSelection());
+      const walletSelected = Boolean(this.getChildControl("wallet-selector").getSelection().length);
       this.getChildControl("open-button").setEnabled(hasTitle && walletSelected);
     },
 

--- a/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
+++ b/services/static-webserver/client/source/class/osparc/study/StudyOptions.js
@@ -130,6 +130,7 @@ qx.Class.define("osparc.study.StudyOptions", {
           control = new qx.ui.form.TextField().set({
             maxWidth: 220
           });
+          osparc.utils.Utils.setIdToWidget(control, "studyTitleField");
           this.getChildControl("title-layout").add(control);
           break;
         case "wallet-selector-layout":

--- a/tests/e2e-playwright/tests/conftest.py
+++ b/tests/e2e-playwright/tests/conftest.py
@@ -404,18 +404,6 @@ def log_in_and_out(
         page.wait_for_timeout(500)
 
 
-def _open_with_resources(page: Page, click_it: bool):
-    page.wait_for_function(
-        """element => element.value === 'asdf'""",
-        arg=page.get_by_test_id("studyTitleField"),
-    )
-    # Open project with default resources
-    open_with_resources_button = page.get_by_test_id("openWithResources")
-    if click_it:
-        open_with_resources_button.click()
-    return open_with_resources_button
-
-
 @pytest.fixture
 def create_new_project_and_delete(
     page: Page,
@@ -462,7 +450,7 @@ def create_new_project_and_delete(
                     if template_id is not None:
                         if is_product_billable:
                             open_button.click()
-                            open_button = _open_with_resources(page, False)
+                            open_button = page.get_by_test_id("openWithResources")
                         # it returns a Long Running Task
                         with page.expect_response(
                             re.compile(rf"/projects\?from_study\={template_id}")
@@ -507,10 +495,16 @@ def create_new_project_and_delete(
                     else:
                         open_button.click()
                         if is_product_billable:
-                            _open_with_resources(page, True)
+                            open_with_resources_button = page.get_by_test_id(
+                                "openWithResources"
+                            )
+                            open_with_resources_button.click()
                             open_with_resources_clicked = True
                 if is_product_billable and not open_with_resources_clicked:
-                    _open_with_resources(page, True)
+                    open_with_resources_button = page.get_by_test_id(
+                        "openWithResources"
+                    )
+                    open_with_resources_button.click()
             project_data = response_info.value.json()
             assert project_data
             project_uuid = project_data["data"]["uuid"]

--- a/tests/e2e-playwright/tests/conftest.py
+++ b/tests/e2e-playwright/tests/conftest.py
@@ -450,6 +450,7 @@ def create_new_project_and_delete(
                     if template_id is not None:
                         if is_product_billable:
                             open_button.click()
+                            # Open project with default resources
                             open_button = page.get_by_test_id("openWithResources")
                         # it returns a Long Running Task
                         with page.expect_response(
@@ -495,16 +496,14 @@ def create_new_project_and_delete(
                     else:
                         open_button.click()
                         if is_product_billable:
-                            open_with_resources_button = page.get_by_test_id(
-                                "openWithResources"
-                            )
-                            open_with_resources_button.click()
+                            # Open project with default resources
+                            open_button = page.get_by_test_id("openWithResources")
+                            open_button.click()
                             open_with_resources_clicked = True
                 if is_product_billable and not open_with_resources_clicked:
-                    open_with_resources_button = page.get_by_test_id(
-                        "openWithResources"
-                    )
-                    open_with_resources_button.click()
+                    # Open project with default resources
+                    open_button = page.get_by_test_id("openWithResources")
+                    open_button.click()
             project_data = response_info.value.json()
             assert project_data
             project_uuid = project_data["data"]["uuid"]


### PR DESCRIPTION
## What do these changes do?

The Open button in the Study Options view now depends on the title and selected wallet: if both are not set it will be disabled.

Sometimes the e2e would fail because playwright was opening the Study before the title was set.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
