### PR TITLE
🐛 Fix Color serialization in Pydantic v2

### DIFF
--- a/packages/models-library/src/models_library/projects_nodes_ui.py
+++ b/packages/models-library/src/models_library/projects_nodes_ui.py
@@ -2,7 +2,9 @@
     Models node UI (legacy model, use instead projects.ui.py)
 """
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer
 from pydantic_extra_types.color import Color
 
 
@@ -14,6 +16,6 @@ class Position(BaseModel):
 
 
 class Marker(BaseModel):
-    color: Color = Field(...)
+    color: Annotated[Color, PlainSerializer(str), Field(...)]
 
     model_config = ConfigDict(extra="forbid")

--- a/packages/models-library/src/models_library/projects_ui.py
+++ b/packages/models-library/src/models_library/projects_ui.py
@@ -2,9 +2,9 @@
     Models Front-end UI
 """
 
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, field_validator
 from pydantic_extra_types.color import Color
 from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
     TypedDict,
@@ -31,7 +31,7 @@ class Slideshow(_SlideshowRequired, total=False):
 
 class Annotation(BaseModel):
     type: Literal["note", "rect", "text"] = Field(...)
-    color: Color = Field(...)
+    color: Annotated[Color, PlainSerializer(str), Field(...)]
     attributes: dict = Field(..., description="svg attributes")
     model_config = ConfigDict(
         extra="forbid",

--- a/packages/models-library/tests/test_projects_nodes_ui.py
+++ b/packages/models-library/tests/test_projects_nodes_ui.py
@@ -1,0 +1,8 @@
+from models_library.projects_nodes_ui import Marker
+from pydantic_extra_types.color import Color
+
+
+def test_marker_serialization():
+    m = Marker(color=Color("#b7e28d"))
+
+    assert m.model_dump_json() == '{"color":"#b7e28d"}'


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
Fix a serialization issue with `Color` fields in Pydantic v2.


In Web Server logs:
```
  File "/home/scu/.venv/lib/python3.11/site-packages/simcore_service_webserver/projects/_crud_handlers.py", line 223, in list_projects

    text=page.model_dump_json(**RESPONSE_MODEL_POLICY),

         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/scu/.venv/lib/python3.11/site-packages/pydantic/main.py", line 441, in model_dump_json

    return self.__pydantic_serializer__.to_json(

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

pydantic_core._pydantic_core.PydanticSerializationError: Unable to serialize unknown type: <class 'pydantic_extra_types.color.Color'>
```

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
