### PR TITLE
♻️ `aiohttp` deprecation: Using `web.json_response` to return `2XX` responses instead of raising `HttpException`

### DIFF
--- a/services/storage/src/simcore_service_storage/handlers_simcore_s3.py
+++ b/services/storage/src/simcore_service_storage/handlers_simcore_s3.py
@@ -18,7 +18,6 @@ from servicelib.aiohttp.requests_validation import (
     parse_request_query_parameters_as,
 )
 from servicelib.logging_utils import log_context
-from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
 from settings_library.s3 import S3Settings
 
 from . import sts
@@ -79,8 +78,8 @@ async def _copy_folders_from_project(
             task_progress=task_progress,
         )
 
-    raise web.HTTPCreated(
-        text=json_dumps(body.destination), content_type=MIMETYPE_APPLICATION_JSON
+    return web.json_response(
+        text=json_dumps(body.destination), status=status.HTTP_201_CREATED
     )
 
 

--- a/services/storage/src/simcore_service_storage/handlers_simcore_s3.py
+++ b/services/storage/src/simcore_service_storage/handlers_simcore_s3.py
@@ -159,6 +159,11 @@ async def search_files(request: web.Request) -> web.Response:
     )
 
     return web.json_response(
-        {"data": [jsonable_encoder(FileMetaDataGet(**d.model_dump())) for d in data]},
+        {
+            "data": [
+                jsonable_encoder(FileMetaDataGet(**d.model_dump()), exclude_unset=True)
+                for d in data
+            ]
+        },
         dumps=json_dumps,
     )

--- a/services/storage/src/simcore_service_storage/handlers_simcore_s3.py
+++ b/services/storage/src/simcore_service_storage/handlers_simcore_s3.py
@@ -79,7 +79,9 @@ async def _copy_folders_from_project(
         )
 
     return web.json_response(
-        text=json_dumps(body.destination), status=status.HTTP_201_CREATED
+        {"data": jsonable_encoder(body.destination)},
+        status=status.HTTP_201_CREATED,
+        dumps=json_dumps,
     )
 
 

--- a/services/storage/src/simcore_service_storage/handlers_simcore_s3.py
+++ b/services/storage/src/simcore_service_storage/handlers_simcore_s3.py
@@ -159,11 +159,6 @@ async def search_files(request: web.Request) -> web.Response:
     )
 
     return web.json_response(
-        {
-            "data": [
-                jsonable_encoder(FileMetaDataGet(**d.model_dump()), exclude_unset=True)
-                for d in data
-            ]
-        },
+        {"data": [jsonable_encoder(FileMetaDataGet(**d.model_dump())) for d in data]},
         dumps=json_dumps,
     )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

`aiohttp` [deprecated **returning** `HttpException`](https://docs.aiohttp.org/en/stable/web_quickstart.html#exceptions). Moreover, raising non-error creates false negatives as in the example below where `201` (Created) was shown as an error in our tracing

Jaeger captures these exceptions as errors in storage:
![image](https://github.com/user-attachments/assets/b112953b-d0b5-4248-a16c-b01f73b60da6)


## Related issue/s

- Analogous to https://github.com/ITISFoundation/osparc-simcore/pull/6563
- Maintenance


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops 
None