### PR TITLE
🎨 Allow to have multiple consumers for the same queue in 1 application and allow to optionally define queue name

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
+# pylint: disable=protected-access
 
 import asyncio
 import logging
@@ -130,10 +131,3 @@ async def rabbitmq_rpc_client(
     yield _creator
     # cleanup, properly close the clients
     await asyncio.gather(*(client.close() for client in created_clients))
-
-
-async def rabbitmq_client(create_rabbitmq_client):
-    # NOTE: Legacy fixture
-    # Use create_rabbitmq_client instead of rabbitmq_client
-    # SEE docs/coding-conventions.md::CC4
-    return create_rabbitmq_client

--- a/packages/service-library/src/servicelib/rabbitmq/__init__.py
+++ b/packages/service-library/src/servicelib/rabbitmq/__init__.py
@@ -8,13 +8,16 @@ from ._errors import (
     RPCNotInitializedError,
     RPCServerError,
 )
-from ._models import ConsumerTag, QueueName
+from ._models import ConsumerTag, ExchangeName, QueueName
 from ._rpc_router import RPCRouter
 from ._utils import is_rabbitmq_responsive, wait_till_rabbitmq_responsive
 
 __all__: tuple[str, ...] = (
     "BIND_TO_ALL_TOPICS",
+    "ConsumerTag",
+    "ExchangeName",
     "is_rabbitmq_responsive",
+    "QueueName",
     "RabbitMQClient",
     "RabbitMQRPCClient",
     "RemoteMethodNotRegisteredError",
@@ -24,8 +27,6 @@ __all__: tuple[str, ...] = (
     "RPCRouter",
     "RPCServerError",
     "wait_till_rabbitmq_responsive",
-    "QueueName",
-    "ConsumerTag",
 )
 
 # nopycln: file

--- a/packages/service-library/src/servicelib/rabbitmq/__init__.py
+++ b/packages/service-library/src/servicelib/rabbitmq/__init__.py
@@ -8,6 +8,7 @@ from ._errors import (
     RPCNotInitializedError,
     RPCServerError,
 )
+from ._models import ConsumerTag, QueueName
 from ._rpc_router import RPCRouter
 from ._utils import is_rabbitmq_responsive, wait_till_rabbitmq_responsive
 
@@ -23,6 +24,8 @@ __all__: tuple[str, ...] = (
     "RPCRouter",
     "RPCServerError",
     "wait_till_rabbitmq_responsive",
+    "QueueName",
+    "ConsumerTag",
 )
 
 # nopycln: file

--- a/packages/service-library/src/servicelib/rabbitmq/_models.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_models.py
@@ -1,5 +1,5 @@
 from collections.abc import Awaitable, Callable
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeAlias
 
 from models_library.basic_types import ConstrainedStr
 from models_library.rabbitmq_basic_types import (
@@ -10,6 +10,9 @@ from models_library.rabbitmq_basic_types import (
 from pydantic import TypeAdapter
 
 MessageHandler = Callable[[Any], Awaitable[bool]]
+
+QueueName: TypeAlias = str
+ConsumerTag: TypeAlias = str
 
 
 class RabbitMessage(Protocol):

--- a/packages/service-library/src/servicelib/rabbitmq/_models.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_models.py
@@ -11,8 +11,10 @@ from pydantic import TypeAdapter
 
 MessageHandler = Callable[[Any], Awaitable[bool]]
 
+ExchangeName: TypeAlias = str
 QueueName: TypeAlias = str
 ConsumerTag: TypeAlias = str
+TopicName: TypeAlias = str
 
 
 class RabbitMessage(Protocol):

--- a/packages/service-library/src/servicelib/rabbitmq/_utils.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_utils.py
@@ -68,6 +68,7 @@ async def declare_queue(
     exchange_name: str,
     *,
     exclusive_queue: bool,
+    non_exclusive_queue_name: str | None,
     arguments: dict[str, Any] | None = None,
     message_ttl: NonNegativeInt = RABBIT_QUEUE_MESSAGE_DEFAULT_TTL_MS,
 ) -> aio_pika.abc.AbstractRobustQueue:
@@ -78,11 +79,11 @@ async def declare_queue(
         "durable": True,
         "exclusive": exclusive_queue,
         "arguments": default_arguments,
-        "name": f"{get_rabbitmq_client_unique_name(client_name)}_{exchange_name}_exclusive",
+        "name": f"{get_rabbitmq_client_unique_name(client_name)}_{non_exclusive_queue_name or exchange_name}_exclusive",
     }
     if not exclusive_queue:
         # NOTE: setting a name will ensure multiple instance will take their data here
-        queue_parameters |= {"name": exchange_name}
+        queue_parameters |= {"name": non_exclusive_queue_name or exchange_name}
 
     # NOTE: if below line raises something similar to ``ChannelPreconditionFailed: PRECONDITION_FAILED``
     # most likely someone changed the signature of the queues (parameters etc...)

--- a/packages/service-library/src/servicelib/rabbitmq/_utils.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_utils.py
@@ -13,6 +13,7 @@ from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_fixed
 
 from ..logging_utils import log_context
+from ._models import QueueName
 
 _logger = logging.getLogger(__file__)
 
@@ -65,10 +66,9 @@ def get_rabbitmq_client_unique_name(base_name: str) -> str:
 async def declare_queue(
     channel: aio_pika.RobustChannel,
     client_name: str,
-    exchange_name: str,
+    queue_name: QueueName,
     *,
     exclusive_queue: bool,
-    non_exclusive_queue_name: str | None,
     arguments: dict[str, Any] | None = None,
     message_ttl: NonNegativeInt = RABBIT_QUEUE_MESSAGE_DEFAULT_TTL_MS,
 ) -> aio_pika.abc.AbstractRobustQueue:
@@ -79,11 +79,11 @@ async def declare_queue(
         "durable": True,
         "exclusive": exclusive_queue,
         "arguments": default_arguments,
-        "name": f"{get_rabbitmq_client_unique_name(client_name)}_{non_exclusive_queue_name or exchange_name}_exclusive",
+        "name": f"{get_rabbitmq_client_unique_name(client_name)}_{queue_name}_exclusive",
     }
     if not exclusive_queue:
         # NOTE: setting a name will ensure multiple instance will take their data here
-        queue_parameters |= {"name": non_exclusive_queue_name or exchange_name}
+        queue_parameters |= {"name": queue_name}
 
     # NOTE: if below line raises something similar to ``ChannelPreconditionFailed: PRECONDITION_FAILED``
     # most likely someone changed the signature of the queues (parameters etc...)

--- a/services/api-server/src/simcore_service_api_server/services/log_streaming.py
+++ b/services/api-server/src/simcore_service_api_server/services/log_streaming.py
@@ -10,15 +10,15 @@ from models_library.users import UserID
 from pydantic import NonNegativeInt
 from servicelib.logging_errors import create_troubleshotting_log_kwargs
 from servicelib.logging_utils import log_catch
-from servicelib.rabbitmq import RabbitMQClient
-from simcore_service_api_server.exceptions.backend_errors import BaseBackEndError
-from simcore_service_api_server.models.schemas.errors import ErrorGet
+from servicelib.rabbitmq import QueueName, RabbitMQClient
 
 from .._constants import MSG_INTERNAL_ERROR_USER_FRIENDLY_TEMPLATE
+from ..exceptions.backend_errors import BaseBackEndError
 from ..exceptions.log_streaming_errors import (
     LogStreamerNotRegisteredError,
     LogStreamerRegistionConflictError,
 )
+from ..models.schemas.errors import ErrorGet
 from ..models.schemas.jobs import JobID, JobLog
 from .director_v2 import DirectorV2Api
 
@@ -31,10 +31,10 @@ class LogDistributor:
     def __init__(self, rabbitmq_client: RabbitMQClient):
         self._rabbit_client = rabbitmq_client
         self._log_streamers: dict[JobID, Queue[JobLog]] = {}
-        self._queue_name: str
+        self._queue_name: QueueName
 
     async def setup(self):
-        self._queue_name = await self._rabbit_client.subscribe(
+        self._queue_name, _ = await self._rabbit_client.subscribe(
             LoggerRabbitMessage.get_channel_name(),
             self._distribute_logs,
             exclusive_queue=True,
@@ -123,7 +123,7 @@ class LogStreamer:
                         self._queue.get(), timeout=self._log_check_timeout
                     )
                     yield log.model_dump_json() + _NEW_LINE
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     done = await self._project_done()
 
         except BaseBackEndError as exc:

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -585,6 +585,7 @@ def unneeded_instance_type(
     return random_type
 
 
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize(
     "expected_buffer_params",
     [

--- a/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_comp_scheduler_dask_scheduler.py
@@ -558,7 +558,7 @@ async def instrumentation_rabbit_client_parser(
 ) -> AsyncIterator[mock.AsyncMock]:
     client = create_rabbitmq_client("instrumentation_pytest_consumer")
     mock = mocker.AsyncMock(return_value=True)
-    queue_name = await client.subscribe(
+    queue_name, _ = await client.subscribe(
         InstrumentationRabbitMessage.get_channel_name(), mock
     )
     yield mock
@@ -571,7 +571,7 @@ async def resource_tracking_rabbit_client_parser(
 ) -> AsyncIterator[mock.AsyncMock]:
     client = create_rabbitmq_client("resource_tracking_pytest_consumer")
     mock = mocker.AsyncMock(return_value=True)
-    queue_name = await client.subscribe(
+    queue_name, _ = await client.subscribe(
         RabbitResourceTrackingBaseMessage.get_channel_name(), mock
     )
     yield mock

--- a/services/efs-guardian/src/simcore_service_efs_guardian/services/process_messages_setup.py
+++ b/services/efs-guardian/src/simcore_service_efs_guardian/services/process_messages_setup.py
@@ -25,7 +25,7 @@ _EFS_MESSAGE_TTL_IN_MS = 2 * _HOUR
 async def _subscribe_to_rabbitmq(app) -> str:
     with log_context(_logger, logging.INFO, msg="Subscribing to rabbitmq channel"):
         rabbit_client: RabbitMQClient = get_rabbitmq_client(app)
-        subscribed_queue: str = await rabbit_client.subscribe(
+        subscribed_queue, _ = await rabbit_client.subscribe(
             DynamicServiceRunningMessage.get_channel_name(),
             message_handler=functools.partial(
                 process_dynamic_service_running_message, app

--- a/services/payments/src/simcore_service_payments/services/auto_recharge_listener.py
+++ b/services/payments/src/simcore_service_payments/services/auto_recharge_listener.py
@@ -4,7 +4,7 @@ import logging
 from fastapi import FastAPI
 from models_library.rabbitmq_messages import WalletCreditsMessage
 from servicelib.logging_utils import log_context
-from servicelib.rabbitmq import RabbitMQClient
+from servicelib.rabbitmq import ConsumerTag, QueueName
 
 from .auto_recharge_process_message import process_message
 from .rabbitmq import get_rabbitmq_client
@@ -12,36 +12,36 @@ from .rabbitmq import get_rabbitmq_client
 _logger = logging.getLogger(__name__)
 
 
-async def _subscribe_to_rabbitmq(app) -> str:
+async def _subscribe_to_rabbitmq(app) -> tuple[QueueName, ConsumerTag]:
     with log_context(_logger, logging.INFO, msg="Subscribing to rabbitmq channel"):
-        rabbit_client: RabbitMQClient = get_rabbitmq_client(app)
-        subscribed_queue: str = await rabbit_client.subscribe(
+        rabbit_client = get_rabbitmq_client(app)
+        return await rabbit_client.subscribe(
             WalletCreditsMessage.get_channel_name(),
             message_handler=functools.partial(process_message, app),
             exclusive_queue=False,
             topics=["#"],
         )
-        return subscribed_queue
 
 
-async def _unsubscribe_consumer(app) -> None:
+async def _unsubscribe_consumer(
+    app, queue_name: QueueName, consumer_tag: ConsumerTag
+) -> None:
     with log_context(_logger, logging.INFO, msg="Unsubscribing from rabbitmq queue"):
-        rabbit_client: RabbitMQClient = get_rabbitmq_client(app)
-        await rabbit_client.unsubscribe_consumer(
-            WalletCreditsMessage.get_channel_name(),
-        )
+        rabbit_client = get_rabbitmq_client(app)
+        await rabbit_client.unsubscribe_consumer(queue_name, consumer_tag)
 
 
 def setup_auto_recharge_listener(app: FastAPI):
-    async def _on_startup():
+    async def _on_startup() -> None:
         app.state.auto_recharge_rabbitmq_consumer = await _subscribe_to_rabbitmq(app)
 
-    async def _on_shutdown():
+    async def _on_shutdown() -> None:
         assert app.state.auto_recharge_rabbitmq_consumer  # nosec
+        assert isinstance(app.state.auto_recharge_rabbitmq_consumer, tuple)  # nosec
         if app.state.rabbitmq_client:
             # NOTE: We want to have persistent queue, therefore we will unsubscribe only consumer
-            await _unsubscribe_consumer(app)
-        app.state.auto_recharge_rabbitmq_constumer = None
+            await _unsubscribe_consumer(app, *app.state.auto_recharge_rabbitmq_consumer)
+        app.state.auto_recharge_rabbitmq_consumer = None
 
     app.add_event_handler("startup", _on_startup)
     app.add_event_handler("shutdown", _on_shutdown)

--- a/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/process_message_running_service_setup.py
+++ b/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/process_message_running_service_setup.py
@@ -20,7 +20,7 @@ _RUT_MESSAGE_TTL_IN_MS = 2 * 60 * 60 * 1000  # 2 hours
 async def _subscribe_to_rabbitmq(app) -> str:
     with log_context(_logger, logging.INFO, msg="Subscribing to rabbitmq channel"):
         rabbit_client: RabbitMQClient = get_rabbitmq_client(app)
-        subscribed_queue: str = await rabbit_client.subscribe(
+        subscribed_queue, _ = await rabbit_client.subscribe(
             RabbitResourceTrackingBaseMessage.get_channel_name(),
             message_handler=functools.partial(process_message, app),
             exclusive_queue=False,

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
@@ -65,12 +65,10 @@ async def _convert_to_node_update_event(
 
 
 async def _progress_message_parser(app: web.Application, data: bytes) -> bool:
-    rabbit_message: (
-        ProgressRabbitMessageNode | ProgressRabbitMessageProject
-    ) = TypeAdapter(
-        ProgressRabbitMessageNode | ProgressRabbitMessageProject
-    ).validate_json(
-        data
+    rabbit_message: ProgressRabbitMessageNode | ProgressRabbitMessageProject = (
+        TypeAdapter(
+            ProgressRabbitMessageNode | ProgressRabbitMessageProject
+        ).validate_json(data)
     )
     message: SocketMessageDict | None = None
     if isinstance(rabbit_message, ProgressRabbitMessageProject):
@@ -183,7 +181,7 @@ async def _unsubscribe_from_rabbitmq(app) -> None:
         await logged_gather(
             *(
                 rabbit_client.unsubscribe(queue_name)
-                for queue_name in app[_APP_RABBITMQ_CONSUMERS_KEY].values()
+                for queue_name, _ in app[_APP_RABBITMQ_CONSUMERS_KEY].values()
             ),
         )
 

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_nonexclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_nonexclusive_queue_consumers.py
@@ -59,8 +59,8 @@ async def _unsubscribe_from_rabbitmq(app) -> None:
         rabbit_client: RabbitMQClient = get_rabbitmq_client(app)
         await logged_gather(
             *(
-                rabbit_client.unsubscribe_consumer(queue_name)
-                for queue_name in app[_APP_RABBITMQ_CONSUMERS_KEY].values()
+                rabbit_client.unsubscribe_consumer(*queue_consumer_map)
+                for queue_consumer_map in app[_APP_RABBITMQ_CONSUMERS_KEY].values()
             ),
         )
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
Before:
- The RabbitMQ consumer was setup with a name unique to the application, but this prevents from having multiple ones in the same application
After:
- the ConsumerTag is returned when subscribing to a Exchange/Queue
- unsubscribing a consumer from a Queue requires the ConsumerTag,
- Fixes unsubscribing when the connection to the RabbitMQ service is already shutdown,
- Upgraded derived services
- After discussion with @matusdrobuliak66 adds option for non-exclusive queues to define a specific queue name

## Related issue/s
- required by https://github.com/ITISFoundation/osparc-simcore/pull/6736
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
