### PR TITLE
🎨 Serialize Colors as HEX

### DIFF
--- a/packages/models-library/src/models_library/projects_nodes_ui.py
+++ b/packages/models-library/src/models_library/projects_nodes_ui.py
@@ -16,6 +16,6 @@ class Position(BaseModel):
 
 
 class Marker(BaseModel):
-    color: Annotated[Color, PlainSerializer(str), Field(...)]
+    color: Annotated[Color, PlainSerializer(Color.as_hex), Field(...)]
 
     model_config = ConfigDict(extra="forbid")

--- a/packages/models-library/src/models_library/projects_ui.py
+++ b/packages/models-library/src/models_library/projects_ui.py
@@ -31,7 +31,7 @@ class Slideshow(_SlideshowRequired, total=False):
 
 class Annotation(BaseModel):
     type: Literal["note", "rect", "text"] = Field(...)
-    color: Annotated[Color, PlainSerializer(str), Field(...)]
+    color: Annotated[Color, PlainSerializer(Color.as_hex), Field(...)]
     attributes: dict = Field(..., description="svg attributes")
     model_config = ConfigDict(
         extra="forbid",

--- a/packages/models-library/tests/test_projects_nodes_ui.py
+++ b/packages/models-library/tests/test_projects_nodes_ui.py
@@ -1,8 +1,11 @@
+import pytest
 from models_library.projects_nodes_ui import Marker
 from pydantic_extra_types.color import Color
 
 
-def test_marker_serialization():
-    m = Marker(color=Color("#b7e28d"))
-
-    assert m.model_dump_json() == '{"color":"#b7e28d"}'
+@pytest.mark.parametrize(
+    "color_str,expected_color_str", [("#b7e28d", "#b7e28d"), ("Cyan", "#0ff")]
+)
+def test_marker_color_serialized_to_hex(color_str, expected_color_str):
+    m = Marker(color=Color(color_str))
+    assert m.model_dump_json() == f'{{"color":"{expected_color_str}"}}'

--- a/packages/models-library/tests/test_projects_ui.py
+++ b/packages/models-library/tests/test_projects_ui.py
@@ -1,0 +1,14 @@
+import pytest
+from models_library.projects_ui import Annotation
+from pydantic_extra_types.color import Color
+
+
+@pytest.mark.parametrize(
+    "color_str,expected_color_str", [("#b7e28d", "#b7e28d"), ("Cyan", "#0ff")]
+)
+def test_annotation_color_serialized_to_hex(color_str, expected_color_str):
+    m = Annotation(type="text", color=Color(color_str), attributes={})
+    assert (
+        m.model_dump_json()
+        == f'{{"type":"text","color":"{expected_color_str}","attributes":{{}}}}'
+    )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
Colors are now **always** serialized in HEX format:

Example:
```
"#b7e28d" => "#b7e28d"
"Cyan" =>  "#0ff"
```

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->
- Relates to: #6162 

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [X] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
