### PR TITLE
⬆️ Maintenance: bump all dependencies for `agent` service

### DIFF
--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -1,10 +1,10 @@
-aio-pika==9.4.3
+aio-pika==9.5.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.12.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiodebug==2.3.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiodocker==0.23.0
+aiodocker==0.24.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
@@ -12,7 +12,7 @@ aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.10
+aiohttp==3.11.7
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -74,7 +74,7 @@ click==8.1.7
     # via
     #   typer
     #   uvicorn
-deprecated==1.2.14
+deprecated==1.2.15
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -84,29 +84,31 @@ dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
     # via pydantic
+exceptiongroup==1.2.2
+    # via aio-pika
 fast-depends==2.4.12
     # via faststream
 fastapi==0.115.5
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-faststream==0.5.28
+faststream==0.5.30
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-googleapis-common-protos==1.65.0
+googleapis-common-protos==1.66.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.67.0
+grpcio==1.68.0
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.6
+httpcore==1.0.7
     # via httpx
 httpx==0.27.2
     # via
@@ -130,13 +132,13 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.4.0
+importlib-metadata==8.5.0
     # via opentelemetry-api
 jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
 markdown-it-py==3.0.0
     # via rich
@@ -146,7 +148,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.27.0
+opentelemetry-api==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -159,58 +161,59 @@ opentelemetry-api==1.27.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.27.0
+opentelemetry-exporter-otlp==1.28.2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.27.0
+opentelemetry-exporter-otlp-proto-common==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.27.0
+opentelemetry-exporter-otlp-proto-grpc==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.27.0
+opentelemetry-exporter-otlp-proto-http==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.48b0
+opentelemetry-instrumentation==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-asgi==0.48b0
+opentelemetry-instrumentation-asgi==0.49b2
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-fastapi==0.48b0
+opentelemetry-instrumentation-fastapi==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.48b0
+opentelemetry-instrumentation-httpx==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-redis==0.48b0
+opentelemetry-instrumentation-redis==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.48b0
+opentelemetry-instrumentation-requests==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.27.0
+opentelemetry-proto==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.27.0
+opentelemetry-sdk==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.48b0
+opentelemetry-semantic-conventions==0.49b2
     # via
+    #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.48b0
+opentelemetry-util-http==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
-orjson==3.10.7
+orjson==3.10.12
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -232,8 +235,10 @@ orjson==3.10.7
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-packaging==24.1
-    # via -r requirements/_base.in
+packaging==24.2
+    # via
+    #   -r requirements/_base.in
+    #   opentelemetry-instrumentation
 pamqp==3.3.0
     # via aiormq
 prometheus-client==0.21.0
@@ -243,14 +248,16 @@ prometheus-client==0.21.0
 prometheus-fastapi-instrumentator==7.0.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 propcache==0.2.0
-    # via yarl
-protobuf==4.25.5
+    # via
+    #   aiohttp
+    #   yarl
+protobuf==5.28.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.0.0
+psutil==6.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-pydantic==2.9.2
+pydantic==2.10.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -280,9 +287,9 @@ pydantic==2.9.2
     #   fastapi
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.23.4
+pydantic-core==2.27.1
     # via pydantic
-pydantic-extra-types==2.9.0
+pydantic-extra-types==2.10.0
     # via
     #   -r requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -321,7 +328,7 @@ pyyaml==6.0.2
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-redis==5.1.1
+redis==5.2.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -336,26 +343,23 @@ redis==5.1.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-referencing==0.29.3
+referencing==0.35.1
     # via
-    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   jsonschema
     #   jsonschema-specifications
 repro-zipfile==0.3.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
-rich==13.9.2
+rich==13.9.4
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.20.0
+rpds-py==0.21.0
     # via
     #   jsonschema
     #   referencing
-setuptools==75.2.0
-    # via opentelemetry-instrumentation
 shellingham==1.5.4
     # via typer
 six==1.16.0
@@ -364,7 +368,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-starlette==0.40.0
+starlette==0.41.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -384,9 +388,9 @@ tenacity==9.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 toolz==1.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-tqdm==4.66.5
+tqdm==4.67.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.12.5
+typer==0.13.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
@@ -400,6 +404,7 @@ typing-extensions==4.12.2
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
+    #   pydantic-extra-types
     #   typer
 urllib3==2.2.3
     # via
@@ -416,19 +421,21 @@ urllib3==2.2.3
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.32.0
+uvicorn==0.32.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-wrapt==1.16.0
+wrapt==1.17.0
     # via
     #   deprecated
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
-yarl==1.15.3
+yarl==1.18.0
     # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.20.2
+zipp==3.21.0
     # via importlib-metadata

--- a/services/agent/requirements/_test.txt
+++ b/services/agent/requirements/_test.txt
@@ -10,7 +10,7 @@ aiohappyeyeballs==2.4.3
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.10.10
+aiohttp==3.11.7
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -39,11 +39,11 @@ attrs==24.2.0
     #   aiohttp
     #   jsonschema
     #   referencing
-aws-sam-translator==1.91.0
+aws-sam-translator==1.94.0
     # via cfn-lint
 aws-xray-sdk==2.14.0
     # via moto
-blinker==1.8.2
+blinker==1.9.0
     # via flask
 boto3==1.35.36
     # via
@@ -66,7 +66,7 @@ certifi==2024.8.30
     #   requests
 cffi==1.17.1
     # via cryptography
-cfn-lint==1.16.1
+cfn-lint==1.20.0
     # via moto
 charset-normalizer==3.4.0
     # via
@@ -76,26 +76,26 @@ click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   flask
-coverage==7.6.3
+coverage==7.6.8
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-cryptography==43.0.1
+cryptography==43.0.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   joserfc
     #   moto
 docker==7.1.0
     # via moto
-faker==30.4.0
+faker==33.0.0
     # via -r requirements/_test.in
-flask==3.0.3
+flask==3.1.0
     # via
     #   flask-cors
     #   moto
 flask-cors==5.0.0
     # via moto
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -106,7 +106,7 @@ h11==0.14.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==1.0.6
+httpcore==1.0.7
     # via
     #   -c requirements/_base.txt
     #   httpx
@@ -149,22 +149,22 @@ jsonschema==4.23.0
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
+    #   jsonschema-spec
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.3
+jsonschema-spec==0.1.3
     # via openapi-spec-validator
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
-    #   openapi-schema-validator
 lazy-object-proxy==1.10.0
     # via openapi-spec-validator
-markupsafe==3.0.1
+markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto==5.0.17
+moto==5.0.21
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
@@ -173,18 +173,18 @@ multidict==6.1.0
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-networkx==3.4.1
+networkx==3.4.2
     # via cfn-lint
-openapi-schema-validator==0.6.2
+openapi-schema-validator==0.4.3
     # via openapi-spec-validator
-openapi-spec-validator==0.7.1
+openapi-spec-validator==0.5.5
     # via moto
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   pytest
 pathable==0.4.3
-    # via jsonschema-path
+    # via jsonschema-spec
 pluggy==1.5.0
     # via pytest
 ply==3.11
@@ -192,17 +192,18 @@ ply==3.11
 propcache==0.2.0
     # via
     #   -c requirements/_base.txt
+    #   aiohttp
     #   yarl
 py-partiql-parser==0.5.6
     # via moto
 pycparser==2.22
     # via cffi
-pydantic==2.9.2
+pydantic==2.10.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aws-sam-translator
-pydantic-core==2.23.4
+pydantic-core==2.27.1
     # via
     #   -c requirements/_base.txt
     #   pydantic
@@ -218,7 +219,7 @@ pytest-asyncio==0.23.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r requirements/_test.in
 pytest-mock==3.14.0
     # via -r requirements/_test.in
@@ -240,39 +241,35 @@ pyyaml==6.0.2
     #   -c requirements/_base.txt
     #   cfn-lint
     #   jsondiff
-    #   jsonschema-path
+    #   jsonschema-spec
     #   moto
     #   responses
-referencing==0.29.3
+referencing==0.35.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
-    #   jsonschema-path
     #   jsonschema-specifications
-regex==2024.9.11
+regex==2024.11.6
     # via cfn-lint
 requests==2.32.3
     # via
     #   -c requirements/_base.txt
     #   docker
-    #   jsonschema-path
     #   moto
     #   responses
 responses==0.25.3
     # via moto
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.20.0
+rpds-py==0.21.0
     # via
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via boto3
-setuptools==75.2.0
-    # via
-    #   -c requirements/_base.txt
-    #   moto
+setuptools==75.6.0
+    # via moto
 six==1.16.0
     # via
     #   -c requirements/_base.txt
@@ -292,6 +289,7 @@ typing-extensions==4.12.2
     #   aws-sam-translator
     #   cfn-lint
     #   faker
+    #   jsonschema-spec
     #   pydantic
     #   pydantic-core
 urllib3==2.2.3
@@ -302,18 +300,18 @@ urllib3==2.2.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.0.4
+werkzeug==3.1.3
     # via
     #   flask
     #   moto
-wrapt==1.16.0
+wrapt==1.17.0
     # via
     #   -c requirements/_base.txt
     #   aiobotocore
     #   aws-xray-sdk
 xmltodict==0.14.2
     # via moto
-yarl==1.15.3
+yarl==1.18.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/services/agent/requirements/_tools.txt
+++ b/services/agent/requirements/_tools.txt
@@ -20,7 +20,7 @@ distlib==0.3.9
     # via virtualenv
 filelock==3.16.1
     # via virtualenv
-identify==2.6.1
+identify==2.6.3
     # via pre-commit
 isort==5.13.2
     # via
@@ -28,7 +28,7 @@ isort==5.13.2
     #   pylint
 mccabe==0.7.0
     # via pylint
-mypy==1.12.0
+mypy==1.13.0
     # via -r requirements/../../../requirements/devenv.txt
 mypy-extensions==1.0.0
     # via
@@ -36,7 +36,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -44,7 +44,7 @@ packaging==24.1
     #   build
 pathspec==0.12.1
     # via black
-pip==24.2
+pip==24.3.1
     # via pip-tools
 pip-tools==7.4.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -67,11 +67,10 @@ pyyaml==6.0.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.6.9
+ruff==0.8.0
     # via -r requirements/../../../requirements/devenv.txt
-setuptools==75.2.0
+setuptools==75.6.0
     # via
-    #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pip-tools
 tomlkit==0.13.2
@@ -81,7 +80,7 @@ typing-extensions==4.12.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.26.6
+virtualenv==20.28.0
     # via pre-commit
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools

--- a/services/agent/src/simcore_service_agent/core/settings.py
+++ b/services/agent/src/simcore_service_agent/core/settings.py
@@ -12,7 +12,7 @@ from settings_library.utils_logging import MixinLoggingSettings
 
 class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
     LOGLEVEL: LogLevel = Field(
-        LogLevel.WARNING.value,
+        LogLevel.WARNING,
         validation_alias=AliasChoices(
             "AGENT_LOGLEVEL",
             "LOG_LEVEL",


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 68
- #packages after ~ 69

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.4.3           | 9.5.0      | *minor*    | 1 | agent⬆️ |
|   2 | aiodocker                 | 0.23.0          | 0.24.0     | *minor*    | 1 | agent⬆️ |
|   3 | aiohttp                   | 3.10.10         | 3.11.7     | *minor*    | 2 | agent⬆️🧪 |
|   4 | aws-sam-translator        | 1.91.0          | 1.94.0     | *minor*    | 1 | agent🧪 |
|   5 | blinker                   | 1.8.2           | 1.9.0      | *minor*    | 1 | agent🧪 |
|   6 | cfn-lint                  | 1.16.1          | 1.20.0     | *minor*    | 1 | agent🧪 |
|   7 | coverage                  | 7.6.3           | 7.6.8      |            | 1 | agent🧪 |
|   8 | cryptography              | 43.0.1          | 43.0.3     |            | 1 | agent🧪 |
|   9 | deprecated                | 1.2.14          | 1.2.15     |            | 1 | agent⬆️ |
|  10 | faker                     | 30.4.0          | 33.0.0     | **MAJOR**  | 1 | agent🧪 |
|  11 | faststream                | 0.5.28          | 0.5.30     |            | 1 | agent⬆️ |
|  12 | flask                     | 3.0.3           | 3.1.0      | *minor*    | 1 | agent🧪 |
|  13 | frozenlist                | 1.4.1           | 1.5.0      | *minor*    | 2 | agent⬆️🧪 |
|  14 | googleapis-common-protos  | 1.65.0          | 1.66.0     | *minor*    | 1 | agent⬆️ |
|  15 | grpcio                    | 1.67.0          | 1.68.0     | *minor*    | 1 | agent⬆️ |
|  16 | httpcore                  | 1.0.6           | 1.0.7      |            | 2 | agent⬆️🧪 |
|  17 | identify                  | 2.6.1           | 2.6.3      |            | 1 | agent🔧 |
|  18 | importlib-metadata        | 8.4.0           | 8.5.0      | *minor*    | 1 | agent⬆️ |
|  19 | jsonschema-path           | 0.3.3           | 🗑️ removed |  | 1 | agent🧪 |
|  20 | jsonschema-specifications | 2023.7.1        | 2024.10.1  | **MAJOR**  | 2 | agent⬆️🧪 |
|  21 | markupsafe                | 3.0.1           | 3.0.2      |            | 1 | agent🧪 |
|  22 | moto                      | 5.0.17          | 5.0.21     |            | 1 | agent🧪 |
|  23 | mypy                      | 1.12.0          | 1.13.0     | *minor*    | 1 | agent🔧 |
|  24 | networkx                  | 3.4.1           | 3.4.2      |            | 1 | agent🧪 |
|  25 | openapi-schema-validator  | 0.6.2           | 0.4.3      | 🔥 downgrade | 1 | agent🧪 |
|  26 | openapi-spec-validator    | 0.7.1           | 0.5.5      | 🔥 downgrade | 1 | agent🧪 |
|  27 | opentelemetry-api         | 1.27.0          | 1.28.2     | *minor*    | 1 | agent⬆️ |
|  28 | opentelemetry-exporter-otlp | 1.27.0          | 1.28.2     | *minor*    | 1 | agent⬆️ |
|  29 | opentelemetry-exporter-otlp-proto-common | 1.27.0          | 1.28.2     | *minor*    | 1 | agent⬆️ |
|  30 | opentelemetry-exporter-otlp-proto-grpc | 1.27.0          | 1.28.2     | *minor*    | 1 | agent⬆️ |
|  31 | opentelemetry-exporter-otlp-proto-http | 1.27.0          | 1.28.2     | *minor*    | 1 | agent⬆️ |
|  32 | opentelemetry-instrumentation | 0.48            | 0.49       | *minor*    | 1 | agent⬆️ |
|  33 | opentelemetry-instrumentation-asgi | 0.48            | 0.49       | *minor*    | 1 | agent⬆️ |
|  34 | opentelemetry-instrumentation-fastapi | 0.48            | 0.49       | *minor*    | 1 | agent⬆️ |
|  35 | opentelemetry-instrumentation-httpx | 0.48            | 0.49       | *minor*    | 1 | agent⬆️ |
|  36 | opentelemetry-instrumentation-redis | 0.48            | 0.49       | *minor*    | 1 | agent⬆️ |
|  37 | opentelemetry-instrumentation-requests | 0.48            | 0.49       | *minor*    | 1 | agent⬆️ |
|  38 | opentelemetry-proto       | 1.27.0          | 1.28.2     | *minor*    | 1 | agent⬆️ |
|  39 | opentelemetry-sdk         | 1.27.0          | 1.28.2     | *minor*    | 1 | agent⬆️ |
|  40 | opentelemetry-semantic-conventions | 0.48            | 0.49       | *minor*    | 1 | agent⬆️ |
|  41 | opentelemetry-util-http   | 0.48            | 0.49       | *minor*    | 1 | agent⬆️ |
|  42 | orjson                    | 3.10.7          | 3.10.12    |            | 1 | agent⬆️ |
|  43 | packaging                 | 24.1            | 24.2       | *minor*    | 3 | agent⬆️🧪🔧 |
|  44 | pip                       | 24.2            | 24.3.1     | *minor*    | 1 | agent🔧 |
|  45 | protobuf                  | 4.25.5          | 5.28.3     | **MAJOR**  | 1 | agent⬆️ |
|  46 | psutil                    | 6.0.0           | 6.1.0      | *minor*    | 1 | agent⬆️ |
|  47 | pydantic                  | 2.9.2           | 2.10.2     | *minor*    | 2 | agent⬆️🧪 |
|  48 | pydantic-core             | 2.23.4          | 2.27.1     | *minor*    | 2 | agent⬆️🧪 |
|  49 | pydantic-extra-types      | 2.9.0           | 2.10.0     | *minor*    | 1 | agent⬆️ |
|  50 | pytest-cov                | 5.0.0           | 6.0.0      | **MAJOR**  | 1 | agent🧪 |
|  51 | redis                     | 5.1.1           | 5.2.0      | *minor*    | 1 | agent⬆️ |
|  52 | referencing               | 0.29.3          | 0.35.1     | *minor*    | 2 | agent⬆️🧪 |
|  53 | regex                     | 2024.9.11       | 2024.11.6  | *minor*    | 1 | agent🧪 |
|  54 | rich                      | 13.9.2          | 13.9.4     |            | 1 | agent⬆️ |
|  55 | rpds-py                   | 0.20.0          | 0.21.0     | *minor*    | 2 | agent⬆️🧪 |
|  56 | ruff                      | 0.6.9           | 0.8.0      | *minor*    | 1 | agent🔧 |
|  57 | s3transfer                | 0.10.3          | 0.10.4     |            | 1 | agent🧪 |
|  58 | setuptools                | 75.2.0          | 75.6.0     | *minor*    | 3 | agent⬆️🧪🔧 |
|  59 | starlette                 | 0.40.0          | 0.41.3     | *minor*    | 1 | agent⬆️ |
|  60 | tqdm                      | 4.66.5          | 4.67.1     | *minor*    | 1 | agent⬆️ |
|  61 | typer                     | 0.12.5          | 0.13.1     | *minor*    | 1 | agent⬆️ |
|  62 | uvicorn                   | 0.32.0          | 0.32.1     |            | 1 | agent⬆️ |
|  63 | virtualenv                | 20.26.6         | 20.28.0    | *minor*    | 1 | agent🔧 |
|  64 | werkzeug                  | 3.0.4           | 3.1.3      | *minor*    | 1 | agent🧪 |
|  65 | wheel                     | 0.44.0          | 0.45.1     | *minor*    | 1 | agent🔧 |
|  66 | wrapt                     | 1.16.0          | 1.17.0     | *minor*    | 2 | agent⬆️🧪 |
|  67 | yarl                      | 1.15.3          | 1.18.0     | *minor*    | 2 | agent⬆️🧪 |
|  68 | zipp                      | 3.20.2          | 3.21.0     | *minor*    | 1 | agent⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 101

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.1.2, 9.4.1, 9.4.2, 9.4.3, 9.5.0 | 9.4.1, 9.4.3              |                           |
|   2 | aioboto3                  | 13.1.0, 13.1.1, 13.2.0    | 13.1.1, 13.2.0            |                           |
|   3 | aiobotocore               | 2.13.0, 2.13.1, 2.15.2    | 2.13.1, 2.15.2            |                           |
|   4 | aiocache                  | 0.11.1, 0.12.2, 0.12.3    | 0.12.2                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.21.0, 0.22.1, 0.22.2, 0.23.0, 0.24.0 | 0.21.0, 0.23.0            |                           |
|   7 | aiofiles                  | 0.8.0, 23.2.1, 24.1.0     | 23.2.1, 24.1.0            |                           |
|   8 | aiohappyeyeballs          | 2.3.4, 2.4.0, 2.4.3       | 2.3.4, 2.4.0, 2.4.3       |                           |
|   9 | aiohttp                   | 3.8.5, 3.9.3, 3.9.5, 3.10.0, 3.10.5, 3.10.10, 3.11.7 | 3.8.5, 3.9.3, 3.9.5, 3.10.0, 3.10.5, 3.10.10, 3.11.7 |                           |
|  10 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  11 | aiohttp-security          | 0.4.0                     |                           |                           |
|  12 | aiohttp-session           | 2.11.0                    |                           |                           |
|  13 | aiohttp-swagger           | 1.0.16                    |                           |                           |
|  14 | aioitertools              | 0.11.0, 0.12.0            | 0.12.0                    |                           |
|  15 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  16 | aioprocessing             | 2.0.1                     |                           |                           |
|  17 | aioresponses              |                           | 0.7.6                     |                           |
|  18 | aiormq                    | 6.7.6, 6.8.0, 6.8.1       | 6.8.0, 6.8.1              |                           |
|  19 | aiosignal                 | 1.2.0, 1.3.1              | 1.2.0, 1.3.1              |                           |
|  20 | aiosmtplib                | 1.1.6, 3.0.2              |                           |                           |
|  21 | alembic                   | 1.8.1, 1.13.1, 1.13.2, 1.13.3 | 1.8.1, 1.13.1, 1.13.3     |                           |
|  22 | annotated-types           | 0.7.0                     | 0.7.0                     |                           |
|  23 | antlr4-python3-runtime    |                           | 4.13.2                    |                           |
|  24 | anyio                     | 4.3.0, 4.4.0, 4.6.0, 4.6.2.post1 | 4.3.0, 4.4.0, 4.6.0, 4.6.2.post1 |                           |
|  25 | appdirs                   | 1.4.4                     | 1.4.4                     |                           |
|  26 | arrow                     | 1.2.3, 1.3.0              | 1.3.0                     |                           |
|  27 | asgi-lifespan             |                           | 2.1.0                     |                           |
|  28 | asgiref                   | 3.8.1                     |                           |                           |
|  29 | astroid                   |                           |                           | 3.3.4, 3.3.5              |
|  30 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  31 | async-timeout             | 4.0.3                     | 4.0.3                     |                           |
|  32 | asyncpg                   | 0.27.0, 0.29.0            | 0.27.0, 0.29.0            |                           |
|  33 | asyncpg-stubs             |                           | 0.27.1                    |                           |
|  34 | attrs                     | 21.4.0, 23.2.0, 24.2.0    | 21.4.0, 23.2.0, 24.2.0    |                           |
|  35 | aws-sam-translator        |                           | 1.55.0, 1.89.0, 1.91.0, 1.94.0 |                           |
|  36 | aws-xray-sdk              |                           | 2.14.0                    |                           |
|  37 | bidict                    | 0.22.0, 0.23.1            | 0.23.1                    |                           |
|  38 | binaryornot               | 0.4.4                     |                           |                           |
|  39 | black                     |                           |                           | 24.8.0, 24.10.0           |
|  40 | blinker                   |                           | 1.8.2, 1.9.0              |                           |
|  41 | blosc                     | 1.11.1                    |                           |                           |
|  42 | bokeh                     | 3.4.1                     | 3.5.2                     |                           |
|  43 | boto3                     | 1.34.75, 1.34.131, 1.35.36 | 1.34.106, 1.34.131, 1.35.25, 1.35.36 |                           |
|  44 | boto3-stubs               |                           | 1.35.25                   |                           |
|  45 | botocore                  | 1.34.75, 1.34.106, 1.34.131, 1.35.36 | 1.34.106, 1.34.131, 1.35.25, 1.35.36, 1.35.50 |                           |
|  46 | botocore-stubs            | 1.34.69, 1.34.94, 1.35.25, 1.35.43 | 1.34.94, 1.35.25          |                           |
|  47 | build                     |                           |                           | 1.2.2, 1.2.2.post1        |
|  48 | bump2version              |                           |                           | 1.0.1                     |
|  49 | captcha                   | 0.5.0                     |                           |                           |
|  50 | certifi                   | 2023.7.22, 2024.2.2, 2024.7.4, 2024.8.30 | 2023.7.22, 2024.2.2, 2024.7.4, 2024.8.30 |                           |
|  51 | cffi                      | 1.16.0, 1.17.1            | 1.16.0, 1.17.1            |                           |
|  52 | cfgv                      |                           |                           | 3.4.0                     |
|  53 | cfn-lint                  |                           | 0.72.0, 1.10.3, 1.15.0, 1.17.1, 1.20.0 |                           |
|  54 | change-case               |                           |                           | 0.5.2                     |
|  55 | chardet                   | 5.2.0                     |                           |                           |
|  56 | charset-normalizer        | 2.0.12, 3.3.2, 3.4.0      | 2.0.12, 3.3.2, 3.4.0      |                           |
|  57 | click                     | 8.1.3, 8.1.7              | 8.1.3, 8.1.7              | 8.1.3, 8.1.7              |
|  58 | cloudpickle               | 3.0.0                     | 3.0.0                     |                           |
|  59 | colorlog                  | 6.8.2                     | 6.8.2                     |                           |
|  60 | contourpy                 | 1.2.0, 1.2.1              | 1.3.0                     |                           |
|  61 | cookiecutter              | 2.6.0                     |                           |                           |
|  62 | coverage                  |                           | 7.6.1, 7.6.3, 7.6.8       |                           |
|  63 | cryptography              | 41.0.7, 42.0.5, 42.0.7, 43.0.0 | 42.0.5, 43.0.1, 43.0.3    |                           |
|  64 | cycler                    | 0.12.1                    |                           |                           |
|  65 | dask                      | 2024.5.1, 2024.9.0        | 2024.5.1                  |                           |
|  66 | dask-gateway              | 2024.1.0                  | 2024.1.0                  |                           |
|  67 | dask-gateway-server       | 2023.1.1                  | 2023.1.1                  |                           |
|  68 | dateparser                | 1.2.0                     |                           |                           |
|  69 | debugpy                   |                           | 1.8.5, 1.8.7              |                           |
|  70 | deepdiff                  |                           | 8.0.1                     |                           |
|  71 | deprecated                | 1.2.14, 1.2.15            | 1.2.14                    |                           |
|  72 | dill                      |                           |                           | 0.3.8, 0.3.9              |
|  73 | distlib                   |                           |                           | 0.3.8, 0.3.9              |
|  74 | distributed               | 2024.5.1, 2024.9.0        | 2024.5.1                  |                           |
|  75 | dnspython                 | 2.2.1, 2.6.1, 2.7.0       | 2.6.1                     |                           |
|  76 | docker                    | 7.1.0                     | 7.1.0                     |                           |
|  77 | ecdsa                     | 0.19.0                    | 0.19.0                    |                           |
|  78 | email-validator           | 2.1.1, 2.2.0              | 2.2.0                     |                           |
|  79 | et-xmlfile                | 1.1.0                     |                           |                           |
|  80 | exceptiongroup            | 1.2.2                     |                           |                           |
|  81 | execnet                   |                           | 2.1.1                     |                           |
|  82 | faker                     | 19.6.1                    | 19.6.1, 29.0.0, 30.3.0, 30.4.0, 30.6.0, 30.8.2, 33.0.0 |                           |
|  83 | fakeredis                 |                           | 2.24.1, 2.25.1            |                           |
|  84 | fast-depends              | 2.4.2, 2.4.12             | 2.4.12                    |                           |
|  85 | fastapi                   | 0.115.5                   |                           |                           |
|  86 | fastapi-cli               | 0.0.5                     |                           |                           |
|  87 | fastapi-pagination        | 0.12.31                   |                           |                           |
|  88 | faststream                | 0.5.28, 0.5.30            | 0.5.28                    |                           |
|  89 | filelock                  |                           |                           | 3.16.1                    |
|  90 | flaky                     |                           | 3.8.1                     |                           |
|  91 | flask                     |                           | 2.1.3, 3.0.3, 3.1.0       |                           |
|  92 | flask-cors                |                           | 5.0.0                     |                           |
|  93 | flexcache                 | 0.3                       | 0.3                       |                           |
|  94 | flexparser                | 0.3.1                     | 0.3.1                     |                           |
|  95 | fonttools                 | 4.50.0                    |                           |                           |
|  96 | frozenlist                | 1.4.1, 1.5.0              | 1.4.1, 1.5.0              |                           |
|  97 | fsspec                    | 2024.5.0, 2024.9.0        | 2024.5.0                  |                           |
|  98 | googleapis-common-protos  | 1.65.0, 1.66.0            | 1.65.0                    |                           |
|  99 | graphql-core              |                           | 3.2.4, 3.2.5              |                           |
| 100 | greenlet                  | 2.0.2, 3.0.3, 3.1.1       | 2.0.2, 3.0.3, 3.1.1       |                           |
| 101 | grpcio                    | 1.66.0, 1.66.1, 1.67.0, 1.68.0 | 1.66.1                    |                           |
| 102 | gunicorn                  | 23.0.0                    |                           |                           |
| 103 | h11                       | 0.14.0                    | 0.14.0                    |                           |
| 104 | h2                        | 4.1.0                     |                           |                           |
| 105 | hpack                     | 4.0.0                     |                           |                           |
| 106 | httmock                   | 1.4.0                     |                           |                           |
| 107 | httpcore                  | 1.0.4, 1.0.5, 1.0.6, 1.0.7 | 1.0.4, 1.0.5, 1.0.6, 1.0.7 |                           |
| 108 | httptools                 | 0.6.1, 0.6.2              |                           |                           |
| 109 | httpx                     | 0.27.0, 0.27.2            | 0.27.0, 0.27.2            |                           |
| 110 | hyperframe                | 6.0.1                     |                           |                           |
| 111 | hypothesis                |                           | 6.91.0, 6.112.1           |                           |
| 112 | icdiff                    |                           | 2.0.7                     |                           |
| 113 | identify                  |                           |                           | 2.6.1, 2.6.3              |
| 114 | idna                      | 3.3, 3.6, 3.7, 3.10       | 3.3, 3.6, 3.7, 3.10       |                           |
| 115 | importlib-metadata        | 7.1.0, 8.0.0, 8.4.0, 8.5.0 | 7.1.0, 8.4.0              |                           |
| 116 | iniconfig                 | 2.0.0                     | 2.0.0                     |                           |
| 117 | inotify                   |                           |                           | 0.2.10                    |
| 118 | isort                     |                           |                           | 5.13.2                    |
| 119 | itsdangerous              | 2.1.2, 2.2.0              | 2.1.2, 2.2.0              |                           |
| 120 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 121 | jinja2                    | 3.1.2, 3.1.3, 3.1.4       | 3.1.3, 3.1.4              | 3.1.3                     |
| 122 | jinja2-time               | 0.2.0                     |                           |                           |
| 123 | jmespath                  | 1.0.1                     | 1.0.1                     |                           |
| 124 | joserfc                   |                           | 1.0.0                     |                           |
| 125 | jschema-to-python         |                           | 1.2.3                     |                           |
| 126 | json2html                 | 1.3.0                     |                           |                           |
| 127 | jsondiff                  | 2.0.0                     | 2.2.1                     |                           |
| 128 | jsonpatch                 |                           | 1.33                      |                           |
| 129 | jsonpath-ng               |                           | 1.6.1, 1.7.0              |                           |
| 130 | jsonpickle                |                           | 3.3.0                     |                           |
| 131 | jsonpointer               |                           | 3.0.0                     |                           |
| 132 | jsonref                   |                           | 1.1.0                     |                           |
| 133 | jsonschema                | 3.2.0, 4.21.1, 4.22.0, 4.23.0 | 3.2.0, 4.21.1, 4.22.0, 4.23.0 |                           |
| 134 | jsonschema-path           |                           | 0.3.2, 0.3.3              |                           |
| 135 | jsonschema-spec           |                           | 0.1.3                     |                           |
| 136 | jsonschema-specifications | 2023.7.1, 2023.12.1, 2024.10.1 | 2023.7.1, 2023.12.1, 2024.10.1 |                           |
| 137 | junit-xml                 |                           | 1.9                       |                           |
| 138 | kiwisolver                | 1.4.5                     |                           |                           |
| 139 | lazy-object-proxy         |                           | 1.10.0                    |                           |
| 140 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 141 | lupa                      |                           | 2.2                       |                           |
| 142 | lz4                       | 4.3.3                     | 4.3.3                     |                           |
| 143 | mako                      | 1.2.2, 1.3.2, 1.3.5       | 1.2.2, 1.3.2, 1.3.5       |                           |
| 144 | markdown-it-py            | 3.0.0                     | 3.0.0                     | 3.0.0                     |
| 145 | markupsafe                | 2.1.1, 2.1.5, 3.0.1       | 2.1.1, 2.1.5, 3.0.1, 3.0.2 | 2.1.5                     |
| 146 | matplotlib                | 3.8.3                     |                           |                           |
| 147 | mccabe                    |                           |                           | 0.7.0                     |
| 148 | mdurl                     | 0.1.2                     | 0.1.2                     | 0.1.2                     |
| 149 | moto                      |                           | 4.0.1, 5.0.15, 5.0.17, 5.0.21 |                           |
| 150 | mpmath                    |                           | 1.3.0                     |                           |
| 151 | msgpack                   | 1.1.0                     | 1.1.0                     |                           |
| 152 | multidict                 | 6.0.5, 6.1.0              | 6.0.5, 6.1.0              |                           |
| 153 | mypy                      |                           | 1.12.0                    | 1.11.2, 1.12.0, 1.13.0    |
| 154 | mypy-extensions           |                           | 1.0.0                     | 1.0.0                     |
| 155 | nest-asyncio              | 1.6.0                     |                           |                           |
| 156 | networkx                  | 3.3                       | 2.8.8, 3.3, 3.4.1, 3.4.2  |                           |
| 157 | nodeenv                   |                           |                           | 1.9.1                     |
| 158 | nose                      |                           |                           | 1.3.7                     |
| 159 | numpy                     | 1.26.4                    | 1.26.4, 2.1.1             |                           |
| 160 | openapi-schema-validator  |                           | 0.2.3, 0.4.3, 0.6.2       |                           |
| 161 | openapi-spec-validator    |                           | 0.4.0, 0.5.5, 0.7.1       |                           |
| 162 | openpyxl                  | 3.0.9                     |                           |                           |
| 163 | opentelemetry-api         | 1.26.0, 1.27.0, 1.28.1, 1.28.2 | 1.27.0                    |                           |
| 164 | opentelemetry-exporter-otlp | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 165 | opentelemetry-exporter-otlp-proto-common | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 166 | opentelemetry-exporter-otlp-proto-grpc | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 167 | opentelemetry-exporter-otlp-proto-http | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 168 | opentelemetry-instrumentation | 0.47b0, 0.48b0, 0.49b1, 0.49b2 | 0.48b0                    |                           |
| 169 | opentelemetry-instrumentation-aiohttp-client | 0.47b0, 0.48b0            |                           |                           |
| 170 | opentelemetry-instrumentation-aiohttp-server | 0.47b0, 0.48b0            |                           |                           |
| 171 | opentelemetry-instrumentation-aiopg | 0.47b0, 0.48b0            | 0.48b0                    |                           |
| 172 | opentelemetry-instrumentation-asgi | 0.47b0, 0.48b0, 0.49b2    |                           |                           |
| 173 | opentelemetry-instrumentation-asyncpg | 0.47b0, 0.48b0, 0.49b1    | 0.48b0                    |                           |
| 174 | opentelemetry-instrumentation-botocore | 0.47b0, 0.48b0            |                           |                           |
| 175 | opentelemetry-instrumentation-dbapi | 0.47b0, 0.48b0            | 0.48b0                    |                           |
| 176 | opentelemetry-instrumentation-fastapi | 0.47b0, 0.48b0, 0.49b2    |                           |                           |
| 177 | opentelemetry-instrumentation-httpx | 0.47b0, 0.48b0, 0.49b2    |                           |                           |
| 178 | opentelemetry-instrumentation-redis | 0.47b0, 0.48b0, 0.49b2    | 0.48b0                    |                           |
| 179 | opentelemetry-instrumentation-requests | 0.47b0, 0.48b0, 0.49b2    | 0.48b0                    |                           |
| 180 | opentelemetry-propagator-aws-xray | 1.0.1, 1.0.2              |                           |                           |
| 181 | opentelemetry-proto       | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 182 | opentelemetry-sdk         | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 183 | opentelemetry-semantic-conventions | 0.47b0, 0.48b0, 0.49b1, 0.49b2 | 0.48b0                    |                           |
| 184 | opentelemetry-util-http   | 0.47b0, 0.48b0, 0.49b2    | 0.48b0                    |                           |
| 185 | ordered-set               | 4.1.0                     |                           |                           |
| 186 | orderly-set               |                           | 5.2.2                     |                           |
| 187 | orjson                    | 3.10.0, 3.10.3, 3.10.6, 3.10.7, 3.10.10, 3.10.11, 3.10.12 | 3.10.7                    |                           |
| 188 | osparc                    | 0.6.6                     |                           |                           |
| 189 | osparc-client             | 0.6.6                     |                           |                           |
| 190 | packaging                 | 24.0, 24.1, 24.2          | 24.0, 24.1, 24.2          | 24.0, 24.1, 24.2          |
| 191 | pamqp                     | 3.2.1, 3.3.0              | 3.3.0                     |                           |
| 192 | pandas                    | 2.2.1, 2.2.2              | 2.2.3                     |                           |
| 193 | parse                     | 1.20.2                    | 1.20.2                    |                           |
| 194 | partd                     | 1.4.2                     | 1.4.2                     |                           |
| 195 | passlib                   | 1.7.4                     |                           |                           |
| 196 | pathable                  |                           | 0.4.3                     |                           |
| 197 | pathspec                  |                           |                           | 0.12.1                    |
| 198 | pbr                       |                           | 6.1.0                     |                           |
| 199 | pillow                    | 10.2.0, 10.3.0            | 10.4.0                    |                           |
| 200 | pint                      | 0.24.3                    | 0.24.3                    |                           |
| 201 | pip                       |                           | 24.3.1                    | 24.2, 24.3.1              |
| 202 | pip-tools                 |                           |                           | 7.4.1                     |
| 203 | platformdirs              |                           |                           | 4.3.6                     |
| 204 | playwright                |                           | 1.47.0                    |                           |
| 205 | pluggy                    | 1.5.0                     | 1.5.0                     |                           |
| 206 | ply                       |                           | 3.11                      |                           |
| 207 | pprintpp                  |                           | 0.4.0                     |                           |
| 208 | pre-commit                |                           |                           | 3.8.0, 4.0.0, 4.0.1       |
| 209 | prometheus-api-client     | 0.5.5                     |                           |                           |
| 210 | prometheus-client         | 0.14.1, 0.20.0, 0.21.0    |                           |                           |
| 211 | prometheus-fastapi-instrumentator | 6.1.0, 7.0.0              |                           |                           |
| 212 | propcache                 | 0.2.0                     | 0.2.0                     |                           |
| 213 | protobuf                  | 4.25.4, 4.25.5, 5.28.3    | 4.25.5                    |                           |
| 214 | psutil                    | 6.0.0, 6.1.0              | 6.0.0, 6.1.0              |                           |
| 215 | psycopg2-binary           | 2.9.6, 2.9.9, 2.9.10      | 2.9.9                     |                           |
| 216 | ptvsd                     |                           | 4.3.2                     |                           |
| 217 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 218 | py-partiql-parser         |                           | 0.5.6                     |                           |
| 219 | pyasn1                    | 0.6.0                     | 0.6.1                     |                           |
| 220 | pycountry                 | 23.12.11                  |                           |                           |
| 221 | pycparser                 | 2.21, 2.22                | 2.22                      |                           |
| 222 | pydantic                  | 2.9.2, 2.10.2             | 2.9.2, 2.10.2             |                           |
| 223 | pydantic-core             | 2.23.4, 2.27.1            | 2.23.4, 2.27.1            |                           |
| 224 | pydantic-extra-types      | 2.9.0, 2.10.0             | 2.9.0                     |                           |
| 225 | pydantic-settings         | 2.5.2, 2.6.1              | 2.6.1                     |                           |
| 226 | pyee                      |                           | 12.0.0                    |                           |
| 227 | pyftpdlib                 |                           | 2.0.0                     |                           |
| 228 | pygments                  | 2.15.1, 2.17.2, 2.18.0    | 2.18.0                    | 2.18.0                    |
| 229 | pyinstrument              | 4.6.1, 4.6.2, 4.7.3, 5.0.0 | 4.6.2, 4.7.3              |                           |
| 230 | pyjwt                     | 2.4.0                     |                           |                           |
| 231 | pylint                    |                           |                           | 3.3.0, 3.3.1              |
| 232 | pyopenssl                 |                           | 24.2.1                    |                           |
| 233 | pyparsing                 | 3.1.2                     | 3.1.2, 3.1.4, 3.2.0       |                           |
| 234 | pyproject-hooks           |                           |                           | 1.1.0, 1.2.0              |
| 235 | pyrsistent                | 0.18.1, 0.20.0            | 0.18.1, 0.20.0            |                           |
| 236 | pytest                    | 8.3.3                     | 8.3.3                     |                           |
| 237 | pytest-aiohttp            |                           | 1.0.5                     |                           |
| 238 | pytest-asyncio            |                           | 0.21.2, 0.23.8            |                           |
| 239 | pytest-base-url           |                           | 2.1.0                     |                           |
| 240 | pytest-benchmark          |                           | 4.0.0                     |                           |
| 241 | pytest-cov                |                           | 5.0.0, 6.0.0              |                           |
| 242 | pytest-docker             |                           | 3.1.1                     |                           |
| 243 | pytest-html               |                           | 4.1.1                     |                           |
| 244 | pytest-icdiff             |                           | 0.9                       |                           |
| 245 | pytest-instafail          |                           | 0.5.0                     |                           |
| 246 | pytest-localftpserver     |                           | 1.3.2                     |                           |
| 247 | pytest-metadata           |                           | 3.1.1                     |                           |
| 248 | pytest-mock               |                           | 3.14.0                    |                           |
| 249 | pytest-playwright         |                           | 0.5.2                     |                           |
| 250 | pytest-runner             |                           | 6.0.1                     |                           |
| 251 | pytest-sugar              |                           | 1.0.0                     |                           |
| 252 | pytest-xdist              |                           | 3.6.1                     |                           |
| 253 | python-dateutil           | 2.8.2, 2.9.0.post0        | 2.8.2, 2.9.0.post0        |                           |
| 254 | python-dotenv             | 1.0.1                     | 1.0.1                     |                           |
| 255 | python-engineio           | 4.3.4, 4.9.0, 4.9.1, 4.10.1 | 4.9.1                     |                           |
| 256 | python-jose               | 3.3.0                     | 3.3.0                     |                           |
| 257 | python-magic              | 0.4.25, 0.4.27            |                           |                           |
| 258 | python-multipart          | 0.0.9                     |                           |                           |
| 259 | python-slugify            | 8.0.4                     | 8.0.4                     |                           |
| 260 | python-socketio           | 5.8.0, 5.11.2, 5.11.3, 5.11.4 | 5.11.3                    |                           |
| 261 | pytz                      | 2022.1, 2024.1            | 2024.2                    |                           |
| 262 | pyyaml                    | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              |
| 263 | redis                     | 5.0.4, 5.1.1, 5.2.0       | 5.0.4, 5.1.1              |                           |
| 264 | referencing               | 0.29.3, 0.35.1            | 0.8.11, 0.29.3, 0.35.1    |                           |
| 265 | regex                     | 2023.12.25                | 2023.12.25, 2024.9.11, 2024.11.6 |                           |
| 266 | repro-zipfile             | 0.3.1                     | 0.3.1                     |                           |
| 267 | requests                  | 2.32.2, 2.32.3            | 2.32.2, 2.32.3            |                           |
| 268 | requests-mock             |                           | 1.12.1                    |                           |
| 269 | responses                 |                           | 0.25.3                    |                           |
| 270 | respx                     |                           | 0.21.1                    |                           |
| 271 | rfc3339-validator         |                           | 0.1.4                     |                           |
| 272 | rich                      | 13.4.2, 13.7.1, 13.8.1, 13.9.2, 13.9.4 | 13.8.1                    | 13.8.1                    |
| 273 | rpds-py                   | 0.18.0, 0.18.1, 0.19.1, 0.20.0, 0.21.0 | 0.18.0, 0.18.1, 0.20.0, 0.21.0 |                           |
| 274 | rsa                       | 4.9                       | 4.9                       |                           |
| 275 | ruff                      |                           |                           | 0.6.7, 0.6.9, 0.7.0, 0.8.0 |
| 276 | s3fs                      | 2024.5.0                  |                           |                           |
| 277 | s3transfer                | 0.10.1, 0.10.2, 0.10.3    | 0.10.1, 0.10.2, 0.10.3, 0.10.4 |                           |
| 278 | sarif-om                  |                           | 1.0.4                     |                           |
| 279 | setproctitle              | 1.3.3                     |                           |                           |
| 280 | setuptools                | 69.1.1, 69.2.0, 74.0.0, 75.1.0, 75.2.0 | 69.1.1, 69.2.0, 74.0.0, 75.1.0, 75.2.0, 75.6.0 | 69.1.1, 69.2.0, 74.0.0, 75.1.0, 75.2.0, 75.6.0 |
| 281 | sh                        | 2.0.6, 2.0.7, 2.1.0       |                           |                           |
| 282 | shellingham               | 1.5.4                     | 1.5.4                     | 1.5.4                     |
| 283 | shortuuid                 | 1.0.13                    |                           |                           |
| 284 | simple-websocket          | 1.0.0, 1.1.0              | 1.0.0                     |                           |
| 285 | six                       | 1.16.0                    | 1.16.0                    |                           |
| 286 | sniffio                   | 1.3.1                     | 1.3.1                     |                           |
| 287 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 288 | sqlalchemy                | 1.4.47, 1.4.52, 1.4.53, 1.4.54 | 1.4.47, 1.4.52, 1.4.53, 1.4.54 |                           |
| 289 | sqlalchemy2-stubs         |                           | 0.0.2a38                  |                           |
| 290 | sshpubkeys                |                           | 3.3.1                     |                           |
| 291 | starlette                 | 0.40.0, 0.41.0, 0.41.2, 0.41.3 |                           |                           |
| 292 | sympy                     |                           | 1.13.3                    |                           |
| 293 | tblib                     | 3.0.0                     | 3.0.0                     |                           |
| 294 | tenacity                  | 8.5.0, 9.0.0              | 8.5.0, 9.0.0              |                           |
| 295 | termcolor                 |                           | 2.4.0, 2.5.0              |                           |
| 296 | text-unidecode            | 1.3                       | 1.3                       |                           |
| 297 | tomlkit                   |                           |                           | 0.13.2                    |
| 298 | toolz                     | 0.12.0, 0.12.1, 1.0.0     | 0.12.1                    |                           |
| 299 | tornado                   | 6.4, 6.4.1                | 6.4                       |                           |
| 300 | tqdm                      | 4.64.0, 4.66.2, 4.66.4, 4.66.5, 4.67.1 | 4.66.5                    |                           |
| 301 | traitlets                 | 5.14.3                    | 5.14.3                    |                           |
| 302 | twilio                    | 7.12.0                    |                           |                           |
| 303 | typer                     | 0.12.3, 0.12.5, 0.13.1    | 0.12.5                    | 0.12.5                    |
| 304 | types-aioboto3            |                           | 13.1.1                    |                           |
| 305 | types-aiobotocore         | 2.12.1, 2.13.0, 2.15.1, 2.15.2 | 2.13.0, 2.15.1            |                           |
| 306 | types-aiobotocore-ec2     | 2.12.1, 2.12.3, 2.13.0, 2.15.1, 2.15.2 | 2.13.0                    |                           |
| 307 | types-aiobotocore-iam     |                           | 2.13.3                    |                           |
| 308 | types-aiobotocore-s3      | 2.12.1, 2.13.0, 2.15.1, 2.15.2 | 2.13.0, 2.15.1            |                           |
| 309 | types-aiobotocore-ssm     | 2.12.3, 2.13.0, 2.13.1, 2.15.1, 2.15.2 | 2.13.0                    |                           |
| 310 | types-aiofiles            |                           | 24.1.0.20240626           |                           |
| 311 | types-awscrt              | 0.20.5, 0.20.9, 0.21.5, 0.22.0 | 0.20.9, 0.21.5            |                           |
| 312 | types-boto3               |                           | 1.0.2                     |                           |
| 313 | types-botocore            |                           | 1.0.2                     |                           |
| 314 | types-cachetools          |                           |                           | 5.5.0.20240820            |
| 315 | types-docker              |                           | 7.1.0.20240827            |                           |
| 316 | types-jsonschema          |                           | 4.23.0.20240813           |                           |
| 317 | types-networkx            |                           | 3.2.1.20240918            |                           |
| 318 | types-openpyxl            |                           | 3.1.5.20240918            |                           |
| 319 | types-passlib             |                           | 1.7.7.20240819            |                           |
| 320 | types-psutil              |                           | 6.0.0.20240901            |                           |
| 321 | types-psycopg2            |                           | 2.9.21.20240819           |                           |
| 322 | types-pyasn1              |                           | 0.6.0.20240913            |                           |
| 323 | types-python-dateutil     | 2.9.0.20240316, 2.9.0.20240906, 2.9.0.20241003 | 2.9.0.20240906            |                           |
| 324 | types-python-jose         |                           | 3.3.4.20240106            |                           |
| 325 | types-pyyaml              |                           | 6.0.12.20240917           |                           |
| 326 | types-requests            |                           | 2.32.0.20240914           |                           |
| 327 | types-s3transfer          |                           | 0.10.2                    |                           |
| 328 | types-tqdm                |                           | 4.66.0.20240417           |                           |
| 329 | typing-extensions         | 4.10.0, 4.11.0, 4.12.0, 4.12.2 | 4.10.0, 4.11.0, 4.12.0, 4.12.2 | 4.10.0, 4.11.0, 4.12.0, 4.12.2 |
| 330 | tzdata                    | 2024.1                    | 2024.2                    |                           |
| 331 | tzlocal                   | 5.2                       |                           |                           |
| 332 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 333 | ujson                     | 5.5.0, 5.9.0, 5.10.0      |                           |                           |
| 334 | urllib3                   | 2.2.3                     | 2.2.3                     |                           |
| 335 | uvicorn                   | 0.29.0, 0.30.4, 0.32.0, 0.32.1 |                           |                           |
| 336 | uvloop                    | 0.19.0, 0.21.0            |                           |                           |
| 337 | virtualenv                |                           |                           | 20.26.5, 20.26.6, 20.27.0, 20.28.0 |
| 338 | watchdog                  | 4.0.0                     |                           | 5.0.2, 5.0.3              |
| 339 | watchfiles                | 0.21.0, 0.22.0, 0.24.0    |                           |                           |
| 340 | websockets                | 12.0, 13.1                | 13.1                      |                           |
| 341 | werkzeug                  | 2.1.2, 3.0.2              | 2.1.2, 3.0.2, 3.0.4, 3.1.3 |                           |
| 342 | wheel                     |                           |                           | 0.44.0, 0.45.1            |
| 343 | wrapt                     | 1.16.0, 1.17.0            | 1.16.0, 1.17.0            |                           |
| 344 | wsproto                   | 1.2.0                     | 1.2.0                     |                           |
| 345 | xmltodict                 |                           | 0.13.0, 0.14.2            |                           |
| 346 | xyzservices               | 2024.4.0                  | 2024.9.0                  |                           |
| 347 | yarl                      | 1.9.4, 1.12.1, 1.15.3, 1.15.4, 1.18.0 | 1.9.4, 1.12.1, 1.15.4, 1.18.0 |                           |
| 348 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 349 | zipp                      | 3.18.2, 3.20.1, 3.20.2, 3.21.0 | 3.18.2, 3.20.2            |                           |



## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
