### PR TITLE
⬆️ Maintenance: bump all dependencies for `dynamic-scheduler` service

### DIFF
--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -1,16 +1,16 @@
-aio-pika==9.4.3
+aio-pika==9.5.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.12.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiodebug==2.3.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiodocker==0.23.0
+aiodocker==0.24.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.10
+aiohttp==3.11.7
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -31,7 +31,7 @@ aiormq==6.8.1
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
-alembic==1.13.3
+alembic==1.14.0
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
 annotated-types==0.7.0
     # via pydantic
@@ -50,9 +50,7 @@ arrow==1.3.0
     #   -r requirements/_base.in
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
-async-timeout==4.0.3
-    # via asyncpg
-asyncpg==0.29.0
+asyncpg==0.30.0
     # via sqlalchemy
 attrs==24.2.0
     # via
@@ -86,7 +84,7 @@ click==8.1.7
     # via
     #   typer
     #   uvicorn
-deprecated==1.2.14
+deprecated==1.2.15
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -96,34 +94,36 @@ dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
     # via pydantic
+exceptiongroup==1.2.2
+    # via aio-pika
 fast-depends==2.4.12
     # via faststream
 fastapi==0.115.5
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-faststream==0.5.28
+faststream==0.5.30
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-googleapis-common-protos==1.65.0
+googleapis-common-protos==1.66.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 greenlet==3.1.1
     # via sqlalchemy
-grpcio==1.67.0
+grpcio==1.68.0
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
     #   wsproto
-httpcore==1.0.6
+httpcore==1.0.7
     # via httpx
-httptools==0.6.2
+httptools==0.6.4
     # via uvicorn
 httpx==0.27.2
     # via
@@ -150,15 +150,15 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.4.0
+importlib-metadata==8.5.0
     # via opentelemetry-api
 jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
-mako==1.3.5
+mako==1.3.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -177,7 +177,7 @@ mako==1.3.5
     #   alembic
 markdown-it-py==3.0.0
     # via rich
-markupsafe==3.0.1
+markupsafe==3.0.2
     # via mako
 mdurl==0.1.2
     # via markdown-it-py
@@ -185,7 +185,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.27.0
+opentelemetry-api==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -199,17 +199,17 @@ opentelemetry-api==1.27.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.27.0
+opentelemetry-exporter-otlp==1.28.2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.27.0
+opentelemetry-exporter-otlp-proto-common==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.27.0
+opentelemetry-exporter-otlp-proto-grpc==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.27.0
+opentelemetry-exporter-otlp-proto-http==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.48b0
+opentelemetry-instrumentation==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
@@ -217,30 +217,31 @@ opentelemetry-instrumentation==0.48b0
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-asgi==0.48b0
+opentelemetry-instrumentation-asgi==0.49b2
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.48b0
+opentelemetry-instrumentation-asyncpg==0.49b2
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.48b0
+opentelemetry-instrumentation-fastapi==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.48b0
+opentelemetry-instrumentation-httpx==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-redis==0.48b0
+opentelemetry-instrumentation-redis==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.48b0
+opentelemetry-instrumentation-requests==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.27.0
+opentelemetry-proto==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.27.0
+opentelemetry-sdk==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.48b0
+opentelemetry-semantic-conventions==0.49b2
     # via
+    #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
@@ -248,13 +249,13 @@ opentelemetry-semantic-conventions==0.48b0
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.48b0
+opentelemetry-util-http==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
-orjson==3.10.7
+orjson==3.10.12
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -279,8 +280,10 @@ orjson==3.10.7
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-packaging==24.1
-    # via -r requirements/_base.in
+packaging==24.2
+    # via
+    #   -r requirements/_base.in
+    #   opentelemetry-instrumentation
 pamqp==3.3.0
     # via aiormq
 prometheus-client==0.21.0
@@ -290,16 +293,18 @@ prometheus-client==0.21.0
 prometheus-fastapi-instrumentator==7.0.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 propcache==0.2.0
-    # via yarl
-protobuf==4.25.5
+    # via
+    #   aiohttp
+    #   yarl
+protobuf==5.28.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.0.0
+psutil==6.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 psycopg2-binary==2.9.10
     # via sqlalchemy
-pydantic==2.9.2
+pydantic==2.10.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -332,9 +337,9 @@ pydantic==2.9.2
     #   fastapi
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.23.4
+pydantic-core==2.27.1
     # via pydantic
-pydantic-extra-types==2.9.0
+pydantic-extra-types==2.10.0
     # via
     #   -r requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -383,7 +388,7 @@ pyyaml==6.0.2
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   uvicorn
-redis==5.1.1
+redis==5.2.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -400,26 +405,23 @@ redis==5.1.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-referencing==0.29.3
+referencing==0.35.1
     # via
-    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   jsonschema
     #   jsonschema-specifications
 repro-zipfile==0.3.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
-rich==13.9.2
+rich==13.9.4
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.20.0
+rpds-py==0.21.0
     # via
     #   jsonschema
     #   referencing
-setuptools==75.2.0
-    # via opentelemetry-instrumentation
 shellingham==1.5.4
     # via typer
 simple-websocket==1.1.0
@@ -448,7 +450,7 @@ sqlalchemy==1.4.54
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   alembic
-starlette==0.40.0
+starlette==0.41.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -470,9 +472,9 @@ tenacity==9.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 toolz==1.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-tqdm==4.66.5
+tqdm==4.67.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.12.5
+typer==0.13.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
@@ -488,6 +490,7 @@ typing-extensions==4.12.2
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
+    #   pydantic-extra-types
     #   typer
 u-msgpack-python==2.8.0
     # via -r requirements/_base.in
@@ -508,28 +511,30 @@ urllib3==2.2.3
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.32.0
+uvicorn==0.32.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
 uvloop==0.21.0
     # via uvicorn
-watchfiles==0.24.0
+watchfiles==1.0.0
     # via uvicorn
-websockets==13.1
+websockets==14.1
     # via uvicorn
-wrapt==1.16.0
+wrapt==1.17.0
     # via
     #   deprecated
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 wsproto==1.2.0
     # via simple-websocket
-yarl==1.15.3
+yarl==1.18.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.20.2
+zipp==3.21.0
     # via importlib-metadata

--- a/services/dynamic-scheduler/requirements/_test.txt
+++ b/services/dynamic-scheduler/requirements/_test.txt
@@ -15,19 +15,19 @@ charset-normalizer==3.4.0
     # via
     #   -c requirements/_base.txt
     #   requests
-coverage==7.6.3
+coverage==7.6.8
     # via
     #   -r requirements/_test.in
     #   pytest-cov
 docker==7.1.0
     # via -r requirements/_test.in
-faker==30.4.0
+faker==33.0.0
     # via -r requirements/_test.in
 h11==0.14.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==1.0.6
+httpcore==1.0.7
     # via
     #   -c requirements/_base.txt
     #   httpx
@@ -46,7 +46,7 @@ idna==3.10
     #   requests
 iniconfig==2.0.0
     # via pytest
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   pytest
@@ -67,7 +67,7 @@ pytest-asyncio==0.23.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r requirements/_test.in
 pytest-icdiff==0.9
     # via -r requirements/_test.in

--- a/services/dynamic-scheduler/requirements/_tools.txt
+++ b/services/dynamic-scheduler/requirements/_tools.txt
@@ -19,7 +19,7 @@ distlib==0.3.9
     # via virtualenv
 filelock==3.16.1
     # via virtualenv
-identify==2.6.1
+identify==2.6.3
     # via pre-commit
 isort==5.13.2
     # via
@@ -27,7 +27,7 @@ isort==5.13.2
     #   pylint
 mccabe==0.7.0
     # via pylint
-mypy==1.12.0
+mypy==1.13.0
     # via -r requirements/../../../requirements/devenv.txt
 mypy-extensions==1.0.0
     # via
@@ -35,7 +35,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -43,7 +43,7 @@ packaging==24.1
     #   build
 pathspec==0.12.1
     # via black
-pip==24.2
+pip==24.3.1
     # via pip-tools
 pip-tools==7.4.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -65,12 +65,10 @@ pyyaml==6.0.2
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   pre-commit
-ruff==0.6.9
+ruff==0.8.0
     # via -r requirements/../../../requirements/devenv.txt
-setuptools==75.2.0
-    # via
-    #   -c requirements/_base.txt
-    #   pip-tools
+setuptools==75.6.0
+    # via pip-tools
 tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
@@ -78,7 +76,7 @@ typing-extensions==4.12.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.26.6
+virtualenv==20.28.0
     # via pre-commit
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 0
- #packages after ~ 0

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 101

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.1.2, 9.4.1, 9.4.2, 9.4.3, 9.5.0 | 9.4.1, 9.4.3              |                           |
|   2 | aioboto3                  | 13.1.0, 13.1.1, 13.2.0    | 13.1.1, 13.2.0            |                           |
|   3 | aiobotocore               | 2.13.0, 2.13.1, 2.15.2    | 2.13.1, 2.15.2            |                           |
|   4 | aiocache                  | 0.11.1, 0.12.2, 0.12.3    | 0.12.2                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.21.0, 0.22.1, 0.22.2, 0.23.0, 0.24.0 | 0.21.0, 0.23.0            |                           |
|   7 | aiofiles                  | 0.8.0, 23.2.1, 24.1.0     | 23.2.1, 24.1.0            |                           |
|   8 | aiohappyeyeballs          | 2.3.4, 2.4.0, 2.4.3       | 2.3.4, 2.4.0, 2.4.3       |                           |
|   9 | aiohttp                   | 3.8.5, 3.9.3, 3.9.5, 3.10.0, 3.10.5, 3.10.10, 3.11.7 | 3.8.5, 3.9.3, 3.9.5, 3.10.0, 3.10.5, 3.10.10 |                           |
|  10 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  11 | aiohttp-security          | 0.4.0                     |                           |                           |
|  12 | aiohttp-session           | 2.11.0                    |                           |                           |
|  13 | aiohttp-swagger           | 1.0.16                    |                           |                           |
|  14 | aioitertools              | 0.11.0, 0.12.0            | 0.12.0                    |                           |
|  15 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  16 | aioprocessing             | 2.0.1                     |                           |                           |
|  17 | aioresponses              |                           | 0.7.6                     |                           |
|  18 | aiormq                    | 6.7.6, 6.8.0, 6.8.1       | 6.8.0, 6.8.1              |                           |
|  19 | aiosignal                 | 1.2.0, 1.3.1              | 1.2.0, 1.3.1              |                           |
|  20 | aiosmtplib                | 1.1.6, 3.0.2              |                           |                           |
|  21 | alembic                   | 1.8.1, 1.13.1, 1.13.2, 1.13.3, 1.14.0 | 1.8.1, 1.13.1, 1.13.3     |                           |
|  22 | annotated-types           | 0.7.0                     | 0.7.0                     |                           |
|  23 | antlr4-python3-runtime    |                           | 4.13.2                    |                           |
|  24 | anyio                     | 4.3.0, 4.4.0, 4.6.0, 4.6.2.post1 | 4.3.0, 4.4.0, 4.6.0, 4.6.2.post1 |                           |
|  25 | appdirs                   | 1.4.4                     | 1.4.4                     |                           |
|  26 | arrow                     | 1.2.3, 1.3.0              | 1.3.0                     |                           |
|  27 | asgi-lifespan             |                           | 2.1.0                     |                           |
|  28 | asgiref                   | 3.8.1                     |                           |                           |
|  29 | astroid                   |                           |                           | 3.3.4, 3.3.5              |
|  30 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  31 | async-timeout             | 4.0.3                     | 4.0.3                     |                           |
|  32 | asyncpg                   | 0.27.0, 0.29.0, 0.30.0    | 0.27.0, 0.29.0            |                           |
|  33 | asyncpg-stubs             |                           | 0.27.1                    |                           |
|  34 | attrs                     | 21.4.0, 23.2.0, 24.2.0    | 21.4.0, 23.2.0, 24.2.0    |                           |
|  35 | aws-sam-translator        |                           | 1.55.0, 1.89.0, 1.91.0    |                           |
|  36 | aws-xray-sdk              |                           | 2.14.0                    |                           |
|  37 | bidict                    | 0.22.0, 0.23.1            | 0.23.1                    |                           |
|  38 | binaryornot               | 0.4.4                     |                           |                           |
|  39 | black                     |                           |                           | 24.8.0, 24.10.0           |
|  40 | blinker                   |                           | 1.8.2                     |                           |
|  41 | blosc                     | 1.11.1                    |                           |                           |
|  42 | bokeh                     | 3.4.1                     | 3.5.2                     |                           |
|  43 | boto3                     | 1.34.75, 1.34.131, 1.35.36 | 1.34.106, 1.34.131, 1.35.25, 1.35.36 |                           |
|  44 | boto3-stubs               |                           | 1.35.25                   |                           |
|  45 | botocore                  | 1.34.75, 1.34.106, 1.34.131, 1.35.36 | 1.34.106, 1.34.131, 1.35.25, 1.35.36, 1.35.50 |                           |
|  46 | botocore-stubs            | 1.34.69, 1.34.94, 1.35.25, 1.35.43 | 1.34.94, 1.35.25          |                           |
|  47 | build                     |                           |                           | 1.2.2, 1.2.2.post1        |
|  48 | bump2version              |                           |                           | 1.0.1                     |
|  49 | captcha                   | 0.5.0                     |                           |                           |
|  50 | certifi                   | 2023.7.22, 2024.2.2, 2024.7.4, 2024.8.30 | 2023.7.22, 2024.2.2, 2024.7.4, 2024.8.30 |                           |
|  51 | cffi                      | 1.16.0, 1.17.1            | 1.16.0, 1.17.1            |                           |
|  52 | cfgv                      |                           |                           | 3.4.0                     |
|  53 | cfn-lint                  |                           | 0.72.0, 1.10.3, 1.15.0, 1.16.1, 1.17.1 |                           |
|  54 | change-case               |                           |                           | 0.5.2                     |
|  55 | chardet                   | 5.2.0                     |                           |                           |
|  56 | charset-normalizer        | 2.0.12, 3.3.2, 3.4.0      | 2.0.12, 3.3.2, 3.4.0      |                           |
|  57 | click                     | 8.1.3, 8.1.7              | 8.1.3, 8.1.7              | 8.1.3, 8.1.7              |
|  58 | cloudpickle               | 3.0.0                     | 3.0.0                     |                           |
|  59 | colorlog                  | 6.8.2                     | 6.8.2                     |                           |
|  60 | contourpy                 | 1.2.0, 1.2.1              | 1.3.0                     |                           |
|  61 | cookiecutter              | 2.6.0                     |                           |                           |
|  62 | coverage                  |                           | 7.6.1, 7.6.3, 7.6.8       |                           |
|  63 | cryptography              | 41.0.7, 42.0.5, 42.0.7, 43.0.0 | 42.0.5, 43.0.1            |                           |
|  64 | cycler                    | 0.12.1                    |                           |                           |
|  65 | dask                      | 2024.5.1, 2024.9.0        | 2024.5.1                  |                           |
|  66 | dask-gateway              | 2024.1.0                  | 2024.1.0                  |                           |
|  67 | dask-gateway-server       | 2023.1.1                  | 2023.1.1                  |                           |
|  68 | dateparser                | 1.2.0                     |                           |                           |
|  69 | debugpy                   |                           | 1.8.5, 1.8.7              |                           |
|  70 | deepdiff                  |                           | 8.0.1                     |                           |
|  71 | deprecated                | 1.2.14, 1.2.15            | 1.2.14                    |                           |
|  72 | dill                      |                           |                           | 0.3.8, 0.3.9              |
|  73 | distlib                   |                           |                           | 0.3.8, 0.3.9              |
|  74 | distributed               | 2024.5.1, 2024.9.0        | 2024.5.1                  |                           |
|  75 | dnspython                 | 2.2.1, 2.6.1, 2.7.0       | 2.6.1                     |                           |
|  76 | docker                    | 7.1.0                     | 7.1.0                     |                           |
|  77 | ecdsa                     | 0.19.0                    | 0.19.0                    |                           |
|  78 | email-validator           | 2.1.1, 2.2.0              | 2.2.0                     |                           |
|  79 | et-xmlfile                | 1.1.0                     |                           |                           |
|  80 | exceptiongroup            | 1.2.2                     |                           |                           |
|  81 | execnet                   |                           | 2.1.1                     |                           |
|  82 | faker                     | 19.6.1                    | 19.6.1, 29.0.0, 30.3.0, 30.4.0, 30.6.0, 30.8.2, 33.0.0 |                           |
|  83 | fakeredis                 |                           | 2.24.1, 2.25.1            |                           |
|  84 | fast-depends              | 2.4.2, 2.4.12             | 2.4.12                    |                           |
|  85 | fastapi                   | 0.115.5                   |                           |                           |
|  86 | fastapi-cli               | 0.0.5                     |                           |                           |
|  87 | fastapi-pagination        | 0.12.31                   |                           |                           |
|  88 | faststream                | 0.5.28, 0.5.30            | 0.5.28                    |                           |
|  89 | filelock                  |                           |                           | 3.16.1                    |
|  90 | flaky                     |                           | 3.8.1                     |                           |
|  91 | flask                     |                           | 2.1.3, 3.0.3              |                           |
|  92 | flask-cors                |                           | 5.0.0                     |                           |
|  93 | flexcache                 | 0.3                       | 0.3                       |                           |
|  94 | flexparser                | 0.3.1                     | 0.3.1                     |                           |
|  95 | fonttools                 | 4.50.0                    |                           |                           |
|  96 | frozenlist                | 1.4.1, 1.5.0              | 1.4.1, 1.5.0              |                           |
|  97 | fsspec                    | 2024.5.0, 2024.9.0        | 2024.5.0                  |                           |
|  98 | googleapis-common-protos  | 1.65.0, 1.66.0            | 1.65.0                    |                           |
|  99 | graphql-core              |                           | 3.2.4, 3.2.5              |                           |
| 100 | greenlet                  | 2.0.2, 3.0.3, 3.1.1       | 2.0.2, 3.0.3, 3.1.1       |                           |
| 101 | grpcio                    | 1.66.0, 1.66.1, 1.67.0, 1.68.0 | 1.66.1                    |                           |
| 102 | gunicorn                  | 23.0.0                    |                           |                           |
| 103 | h11                       | 0.14.0                    | 0.14.0                    |                           |
| 104 | h2                        | 4.1.0                     |                           |                           |
| 105 | hpack                     | 4.0.0                     |                           |                           |
| 106 | httmock                   | 1.4.0                     |                           |                           |
| 107 | httpcore                  | 1.0.4, 1.0.5, 1.0.6, 1.0.7 | 1.0.4, 1.0.5, 1.0.6, 1.0.7 |                           |
| 108 | httptools                 | 0.6.1, 0.6.4              |                           |                           |
| 109 | httpx                     | 0.27.0, 0.27.2            | 0.27.0, 0.27.2            |                           |
| 110 | hyperframe                | 6.0.1                     |                           |                           |
| 111 | hypothesis                |                           | 6.91.0, 6.112.1           |                           |
| 112 | icdiff                    |                           | 2.0.7                     |                           |
| 113 | identify                  |                           |                           | 2.6.1, 2.6.3              |
| 114 | idna                      | 3.3, 3.6, 3.7, 3.10       | 3.3, 3.6, 3.7, 3.10       |                           |
| 115 | importlib-metadata        | 7.1.0, 8.0.0, 8.4.0, 8.5.0 | 7.1.0, 8.4.0              |                           |
| 116 | iniconfig                 | 2.0.0                     | 2.0.0                     |                           |
| 117 | inotify                   |                           |                           | 0.2.10                    |
| 118 | isort                     |                           |                           | 5.13.2                    |
| 119 | itsdangerous              | 2.1.2, 2.2.0              | 2.1.2, 2.2.0              |                           |
| 120 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 121 | jinja2                    | 3.1.2, 3.1.3, 3.1.4       | 3.1.3, 3.1.4              | 3.1.3                     |
| 122 | jinja2-time               | 0.2.0                     |                           |                           |
| 123 | jmespath                  | 1.0.1                     | 1.0.1                     |                           |
| 124 | joserfc                   |                           | 1.0.0                     |                           |
| 125 | jschema-to-python         |                           | 1.2.3                     |                           |
| 126 | json2html                 | 1.3.0                     |                           |                           |
| 127 | jsondiff                  | 2.0.0                     | 2.2.1                     |                           |
| 128 | jsonpatch                 |                           | 1.33                      |                           |
| 129 | jsonpath-ng               |                           | 1.6.1, 1.7.0              |                           |
| 130 | jsonpickle                |                           | 3.3.0                     |                           |
| 131 | jsonpointer               |                           | 3.0.0                     |                           |
| 132 | jsonref                   |                           | 1.1.0                     |                           |
| 133 | jsonschema                | 3.2.0, 4.21.1, 4.22.0, 4.23.0 | 3.2.0, 4.21.1, 4.22.0, 4.23.0 |                           |
| 134 | jsonschema-path           |                           | 0.3.2, 0.3.3              |                           |
| 135 | jsonschema-specifications | 2023.7.1, 2023.12.1, 2024.10.1 | 2023.7.1, 2023.12.1       |                           |
| 136 | junit-xml                 |                           | 1.9                       |                           |
| 137 | kiwisolver                | 1.4.5                     |                           |                           |
| 138 | lazy-object-proxy         |                           | 1.10.0                    |                           |
| 139 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 140 | lupa                      |                           | 2.2                       |                           |
| 141 | lz4                       | 4.3.3                     | 4.3.3                     |                           |
| 142 | mako                      | 1.2.2, 1.3.2, 1.3.5, 1.3.6 | 1.2.2, 1.3.2, 1.3.5       |                           |
| 143 | markdown-it-py            | 3.0.0                     | 3.0.0                     | 3.0.0                     |
| 144 | markupsafe                | 2.1.1, 2.1.5, 3.0.1, 3.0.2 | 2.1.1, 2.1.5, 3.0.1       | 2.1.5                     |
| 145 | matplotlib                | 3.8.3                     |                           |                           |
| 146 | mccabe                    |                           |                           | 0.7.0                     |
| 147 | mdurl                     | 0.1.2                     | 0.1.2                     | 0.1.2                     |
| 148 | moto                      |                           | 4.0.1, 5.0.15, 5.0.17     |                           |
| 149 | mpmath                    |                           | 1.3.0                     |                           |
| 150 | msgpack                   | 1.1.0                     | 1.1.0                     |                           |
| 151 | multidict                 | 6.0.5, 6.1.0              | 6.0.5, 6.1.0              |                           |
| 152 | mypy                      |                           | 1.12.0                    | 1.11.2, 1.12.0, 1.13.0    |
| 153 | mypy-extensions           |                           | 1.0.0                     | 1.0.0                     |
| 154 | nest-asyncio              | 1.6.0                     |                           |                           |
| 155 | networkx                  | 3.3                       | 2.8.8, 3.3, 3.4.1         |                           |
| 156 | nodeenv                   |                           |                           | 1.9.1                     |
| 157 | nose                      |                           |                           | 1.3.7                     |
| 158 | numpy                     | 1.26.4                    | 1.26.4, 2.1.1             |                           |
| 159 | openapi-schema-validator  |                           | 0.2.3, 0.6.2              |                           |
| 160 | openapi-spec-validator    |                           | 0.4.0, 0.7.1              |                           |
| 161 | openpyxl                  | 3.0.9                     |                           |                           |
| 162 | opentelemetry-api         | 1.26.0, 1.27.0, 1.28.1, 1.28.2 | 1.27.0                    |                           |
| 163 | opentelemetry-exporter-otlp | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 164 | opentelemetry-exporter-otlp-proto-common | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 165 | opentelemetry-exporter-otlp-proto-grpc | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 166 | opentelemetry-exporter-otlp-proto-http | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 167 | opentelemetry-instrumentation | 0.47b0, 0.48b0, 0.49b1, 0.49b2 | 0.48b0                    |                           |
| 168 | opentelemetry-instrumentation-aiohttp-client | 0.47b0, 0.48b0            |                           |                           |
| 169 | opentelemetry-instrumentation-aiohttp-server | 0.47b0, 0.48b0            |                           |                           |
| 170 | opentelemetry-instrumentation-aiopg | 0.47b0, 0.48b0            | 0.48b0                    |                           |
| 171 | opentelemetry-instrumentation-asgi | 0.47b0, 0.48b0, 0.49b2    |                           |                           |
| 172 | opentelemetry-instrumentation-asyncpg | 0.47b0, 0.48b0, 0.49b1, 0.49b2 | 0.48b0                    |                           |
| 173 | opentelemetry-instrumentation-botocore | 0.47b0, 0.48b0            |                           |                           |
| 174 | opentelemetry-instrumentation-dbapi | 0.47b0, 0.48b0            | 0.48b0                    |                           |
| 175 | opentelemetry-instrumentation-fastapi | 0.47b0, 0.48b0, 0.49b2    |                           |                           |
| 176 | opentelemetry-instrumentation-httpx | 0.47b0, 0.48b0, 0.49b2    |                           |                           |
| 177 | opentelemetry-instrumentation-redis | 0.47b0, 0.48b0, 0.49b2    | 0.48b0                    |                           |
| 178 | opentelemetry-instrumentation-requests | 0.47b0, 0.48b0, 0.49b2    | 0.48b0                    |                           |
| 179 | opentelemetry-propagator-aws-xray | 1.0.1, 1.0.2              |                           |                           |
| 180 | opentelemetry-proto       | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 181 | opentelemetry-sdk         | 1.26.0, 1.27.0, 1.28.2    | 1.27.0                    |                           |
| 182 | opentelemetry-semantic-conventions | 0.47b0, 0.48b0, 0.49b1, 0.49b2 | 0.48b0                    |                           |
| 183 | opentelemetry-util-http   | 0.47b0, 0.48b0, 0.49b2    | 0.48b0                    |                           |
| 184 | ordered-set               | 4.1.0                     |                           |                           |
| 185 | orderly-set               |                           | 5.2.2                     |                           |
| 186 | orjson                    | 3.10.0, 3.10.3, 3.10.6, 3.10.7, 3.10.10, 3.10.11, 3.10.12 | 3.10.7                    |                           |
| 187 | osparc                    | 0.6.6                     |                           |                           |
| 188 | osparc-client             | 0.6.6                     |                           |                           |
| 189 | packaging                 | 24.0, 24.1, 24.2          | 24.0, 24.1, 24.2          | 24.0, 24.1, 24.2          |
| 190 | pamqp                     | 3.2.1, 3.3.0              | 3.3.0                     |                           |
| 191 | pandas                    | 2.2.1, 2.2.2              | 2.2.3                     |                           |
| 192 | parse                     | 1.20.2                    | 1.20.2                    |                           |
| 193 | partd                     | 1.4.2                     | 1.4.2                     |                           |
| 194 | passlib                   | 1.7.4                     |                           |                           |
| 195 | pathable                  |                           | 0.4.3                     |                           |
| 196 | pathspec                  |                           |                           | 0.12.1                    |
| 197 | pbr                       |                           | 6.1.0                     |                           |
| 198 | pillow                    | 10.2.0, 10.3.0            | 10.4.0                    |                           |
| 199 | pint                      | 0.24.3                    | 0.24.3                    |                           |
| 200 | pip                       |                           | 24.3.1                    | 24.2, 24.3.1              |
| 201 | pip-tools                 |                           |                           | 7.4.1                     |
| 202 | platformdirs              |                           |                           | 4.3.6                     |
| 203 | playwright                |                           | 1.47.0                    |                           |
| 204 | pluggy                    | 1.5.0                     | 1.5.0                     |                           |
| 205 | ply                       |                           | 3.11                      |                           |
| 206 | pprintpp                  |                           | 0.4.0                     |                           |
| 207 | pre-commit                |                           |                           | 3.8.0, 4.0.0, 4.0.1       |
| 208 | prometheus-api-client     | 0.5.5                     |                           |                           |
| 209 | prometheus-client         | 0.14.1, 0.20.0, 0.21.0    |                           |                           |
| 210 | prometheus-fastapi-instrumentator | 6.1.0, 7.0.0              |                           |                           |
| 211 | propcache                 | 0.2.0                     | 0.2.0                     |                           |
| 212 | protobuf                  | 4.25.4, 4.25.5, 5.28.3    | 4.25.5                    |                           |
| 213 | psutil                    | 6.0.0, 6.1.0              | 6.0.0, 6.1.0              |                           |
| 214 | psycopg2-binary           | 2.9.6, 2.9.9, 2.9.10      | 2.9.9                     |                           |
| 215 | ptvsd                     |                           | 4.3.2                     |                           |
| 216 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 217 | py-partiql-parser         |                           | 0.5.6                     |                           |
| 218 | pyasn1                    | 0.6.0                     | 0.6.1                     |                           |
| 219 | pycountry                 | 23.12.11                  |                           |                           |
| 220 | pycparser                 | 2.21, 2.22                | 2.22                      |                           |
| 221 | pydantic                  | 2.9.2, 2.10.2             | 2.9.2                     |                           |
| 222 | pydantic-core             | 2.23.4, 2.27.1            | 2.23.4                    |                           |
| 223 | pydantic-extra-types      | 2.9.0, 2.10.0             | 2.9.0                     |                           |
| 224 | pydantic-settings         | 2.5.2, 2.6.1              | 2.6.1                     |                           |
| 225 | pyee                      |                           | 12.0.0                    |                           |
| 226 | pyftpdlib                 |                           | 2.0.0                     |                           |
| 227 | pygments                  | 2.15.1, 2.17.2, 2.18.0    | 2.18.0                    | 2.18.0                    |
| 228 | pyinstrument              | 4.6.1, 4.6.2, 4.7.3, 5.0.0 | 4.6.2, 4.7.3              |                           |
| 229 | pyjwt                     | 2.4.0                     |                           |                           |
| 230 | pylint                    |                           |                           | 3.3.0, 3.3.1              |
| 231 | pyopenssl                 |                           | 24.2.1                    |                           |
| 232 | pyparsing                 | 3.1.2                     | 3.1.2, 3.1.4, 3.2.0       |                           |
| 233 | pyproject-hooks           |                           |                           | 1.1.0, 1.2.0              |
| 234 | pyrsistent                | 0.18.1, 0.20.0            | 0.18.1, 0.20.0            |                           |
| 235 | pytest                    | 8.3.3                     | 8.3.3                     |                           |
| 236 | pytest-aiohttp            |                           | 1.0.5                     |                           |
| 237 | pytest-asyncio            |                           | 0.21.2, 0.23.8            |                           |
| 238 | pytest-base-url           |                           | 2.1.0                     |                           |
| 239 | pytest-benchmark          |                           | 4.0.0                     |                           |
| 240 | pytest-cov                |                           | 5.0.0, 6.0.0              |                           |
| 241 | pytest-docker             |                           | 3.1.1                     |                           |
| 242 | pytest-html               |                           | 4.1.1                     |                           |
| 243 | pytest-icdiff             |                           | 0.9                       |                           |
| 244 | pytest-instafail          |                           | 0.5.0                     |                           |
| 245 | pytest-localftpserver     |                           | 1.3.2                     |                           |
| 246 | pytest-metadata           |                           | 3.1.1                     |                           |
| 247 | pytest-mock               |                           | 3.14.0                    |                           |
| 248 | pytest-playwright         |                           | 0.5.2                     |                           |
| 249 | pytest-runner             |                           | 6.0.1                     |                           |
| 250 | pytest-sugar              |                           | 1.0.0                     |                           |
| 251 | pytest-xdist              |                           | 3.6.1                     |                           |
| 252 | python-dateutil           | 2.8.2, 2.9.0.post0        | 2.8.2, 2.9.0.post0        |                           |
| 253 | python-dotenv             | 1.0.1                     | 1.0.1                     |                           |
| 254 | python-engineio           | 4.3.4, 4.9.0, 4.9.1, 4.10.1 | 4.9.1                     |                           |
| 255 | python-jose               | 3.3.0                     | 3.3.0                     |                           |
| 256 | python-magic              | 0.4.25, 0.4.27            |                           |                           |
| 257 | python-multipart          | 0.0.9                     |                           |                           |
| 258 | python-slugify            | 8.0.4                     | 8.0.4                     |                           |
| 259 | python-socketio           | 5.8.0, 5.11.2, 5.11.3, 5.11.4 | 5.11.3                    |                           |
| 260 | pytz                      | 2022.1, 2024.1            | 2024.2                    |                           |
| 261 | pyyaml                    | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              |
| 262 | redis                     | 5.0.4, 5.1.1, 5.2.0       | 5.0.4, 5.1.1              |                           |
| 263 | referencing               | 0.29.3, 0.35.1            | 0.8.11, 0.29.3, 0.35.1    |                           |
| 264 | regex                     | 2023.12.25                | 2023.12.25, 2024.9.11     |                           |
| 265 | repro-zipfile             | 0.3.1                     | 0.3.1                     |                           |
| 266 | requests                  | 2.32.2, 2.32.3            | 2.32.2, 2.32.3            |                           |
| 267 | requests-mock             |                           | 1.12.1                    |                           |
| 268 | responses                 |                           | 0.25.3                    |                           |
| 269 | respx                     |                           | 0.21.1                    |                           |
| 270 | rfc3339-validator         |                           | 0.1.4                     |                           |
| 271 | rich                      | 13.4.2, 13.7.1, 13.8.1, 13.9.2, 13.9.4 | 13.8.1                    | 13.8.1                    |
| 272 | rpds-py                   | 0.18.0, 0.18.1, 0.19.1, 0.20.0, 0.21.0 | 0.18.0, 0.18.1, 0.20.0    |                           |
| 273 | rsa                       | 4.9                       | 4.9                       |                           |
| 274 | ruff                      |                           |                           | 0.6.7, 0.6.9, 0.7.0, 0.8.0 |
| 275 | s3fs                      | 2024.5.0                  |                           |                           |
| 276 | s3transfer                | 0.10.1, 0.10.2, 0.10.3    | 0.10.1, 0.10.2, 0.10.3    |                           |
| 277 | sarif-om                  |                           | 1.0.4                     |                           |
| 278 | setproctitle              | 1.3.3                     |                           |                           |
| 279 | setuptools                | 69.1.1, 69.2.0, 74.0.0, 75.1.0, 75.2.0 | 69.1.1, 69.2.0, 74.0.0, 75.1.0, 75.2.0 | 69.1.1, 69.2.0, 74.0.0, 75.1.0, 75.2.0, 75.6.0 |
| 280 | sh                        | 2.0.6, 2.0.7, 2.1.0       |                           |                           |
| 281 | shellingham               | 1.5.4                     | 1.5.4                     | 1.5.4                     |
| 282 | shortuuid                 | 1.0.13                    |                           |                           |
| 283 | simple-websocket          | 1.0.0, 1.1.0              | 1.0.0                     |                           |
| 284 | six                       | 1.16.0                    | 1.16.0                    |                           |
| 285 | sniffio                   | 1.3.1                     | 1.3.1                     |                           |
| 286 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 287 | sqlalchemy                | 1.4.47, 1.4.52, 1.4.53, 1.4.54 | 1.4.47, 1.4.52, 1.4.53, 1.4.54 |                           |
| 288 | sqlalchemy2-stubs         |                           | 0.0.2a38                  |                           |
| 289 | sshpubkeys                |                           | 3.3.1                     |                           |
| 290 | starlette                 | 0.40.0, 0.41.0, 0.41.2, 0.41.3 |                           |                           |
| 291 | sympy                     |                           | 1.13.3                    |                           |
| 292 | tblib                     | 3.0.0                     | 3.0.0                     |                           |
| 293 | tenacity                  | 8.5.0, 9.0.0              | 8.5.0, 9.0.0              |                           |
| 294 | termcolor                 |                           | 2.4.0, 2.5.0              |                           |
| 295 | text-unidecode            | 1.3                       | 1.3                       |                           |
| 296 | tomlkit                   |                           |                           | 0.13.2                    |
| 297 | toolz                     | 0.12.0, 0.12.1, 1.0.0     | 0.12.1                    |                           |
| 298 | tornado                   | 6.4, 6.4.1                | 6.4                       |                           |
| 299 | tqdm                      | 4.64.0, 4.66.2, 4.66.4, 4.66.5, 4.67.1 | 4.66.5                    |                           |
| 300 | traitlets                 | 5.14.3                    | 5.14.3                    |                           |
| 301 | twilio                    | 7.12.0                    |                           |                           |
| 302 | typer                     | 0.12.3, 0.12.5, 0.13.1    | 0.12.5                    | 0.12.5                    |
| 303 | types-aioboto3            |                           | 13.1.1                    |                           |
| 304 | types-aiobotocore         | 2.12.1, 2.13.0, 2.15.1, 2.15.2 | 2.13.0, 2.15.1            |                           |
| 305 | types-aiobotocore-ec2     | 2.12.1, 2.12.3, 2.13.0, 2.15.1, 2.15.2 | 2.13.0                    |                           |
| 306 | types-aiobotocore-iam     |                           | 2.13.3                    |                           |
| 307 | types-aiobotocore-s3      | 2.12.1, 2.13.0, 2.15.1, 2.15.2 | 2.13.0, 2.15.1            |                           |
| 308 | types-aiobotocore-ssm     | 2.12.3, 2.13.0, 2.13.1, 2.15.1, 2.15.2 | 2.13.0                    |                           |
| 309 | types-aiofiles            |                           | 24.1.0.20240626           |                           |
| 310 | types-awscrt              | 0.20.5, 0.20.9, 0.21.5, 0.22.0 | 0.20.9, 0.21.5            |                           |
| 311 | types-boto3               |                           | 1.0.2                     |                           |
| 312 | types-botocore            |                           | 1.0.2                     |                           |
| 313 | types-cachetools          |                           |                           | 5.5.0.20240820            |
| 314 | types-docker              |                           | 7.1.0.20240827            |                           |
| 315 | types-jsonschema          |                           | 4.23.0.20240813           |                           |
| 316 | types-networkx            |                           | 3.2.1.20240918            |                           |
| 317 | types-openpyxl            |                           | 3.1.5.20240918            |                           |
| 318 | types-passlib             |                           | 1.7.7.20240819            |                           |
| 319 | types-psutil              |                           | 6.0.0.20240901            |                           |
| 320 | types-psycopg2            |                           | 2.9.21.20240819           |                           |
| 321 | types-pyasn1              |                           | 0.6.0.20240913            |                           |
| 322 | types-python-dateutil     | 2.9.0.20240316, 2.9.0.20240906, 2.9.0.20241003 | 2.9.0.20240906            |                           |
| 323 | types-python-jose         |                           | 3.3.4.20240106            |                           |
| 324 | types-pyyaml              |                           | 6.0.12.20240917           |                           |
| 325 | types-requests            |                           | 2.32.0.20240914           |                           |
| 326 | types-s3transfer          |                           | 0.10.2                    |                           |
| 327 | types-tqdm                |                           | 4.66.0.20240417           |                           |
| 328 | typing-extensions         | 4.10.0, 4.11.0, 4.12.0, 4.12.2 | 4.10.0, 4.11.0, 4.12.0, 4.12.2 | 4.10.0, 4.11.0, 4.12.0, 4.12.2 |
| 329 | tzdata                    | 2024.1                    | 2024.2                    |                           |
| 330 | tzlocal                   | 5.2                       |                           |                           |
| 331 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 332 | ujson                     | 5.5.0, 5.9.0, 5.10.0      |                           |                           |
| 333 | urllib3                   | 2.2.3                     | 2.2.3                     |                           |
| 334 | uvicorn                   | 0.29.0, 0.30.4, 0.32.0, 0.32.1 |                           |                           |
| 335 | uvloop                    | 0.19.0, 0.21.0            |                           |                           |
| 336 | virtualenv                |                           |                           | 20.26.5, 20.26.6, 20.27.0, 20.28.0 |
| 337 | watchdog                  | 4.0.0                     |                           | 5.0.2, 5.0.3              |
| 338 | watchfiles                | 0.21.0, 0.22.0, 1.0.0     |                           |                           |
| 339 | websockets                | 12.0, 14.1                | 13.1                      |                           |
| 340 | werkzeug                  | 2.1.2, 3.0.2              | 2.1.2, 3.0.2, 3.0.4       |                           |
| 341 | wheel                     |                           |                           | 0.44.0, 0.45.1            |
| 342 | wrapt                     | 1.16.0, 1.17.0            | 1.16.0                    |                           |
| 343 | wsproto                   | 1.2.0                     | 1.2.0                     |                           |
| 344 | xmltodict                 |                           | 0.13.0, 0.14.2            |                           |
| 345 | xyzservices               | 2024.4.0                  | 2024.9.0                  |                           |
| 346 | yarl                      | 1.9.4, 1.12.1, 1.15.3, 1.15.4, 1.18.0 | 1.9.4, 1.12.1, 1.15.3, 1.15.4 |                           |
| 347 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 348 | zipp                      | 3.18.2, 3.20.1, 3.20.2, 3.21.0 | 3.18.2, 3.20.2            |                           |


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
