### PR TITLE
⬆️ Maintenance: upgrades `invitations` service requirements

### DIFF
--- a/services/invitations/openapi.json
+++ b/services/invitations/openapi.json
@@ -286,9 +286,6 @@
           },
           "invitation_url": {
             "type": "string",
-            "maxLength": 2083,
-            "minLength": 1,
-            "format": "uri",
             "title": "Invitation Url",
             "description": "Invitation link"
           }
@@ -437,9 +434,6 @@
           },
           "docs_url": {
             "type": "string",
-            "maxLength": 2083,
-            "minLength": 1,
-            "format": "uri",
             "title": "Docs Url"
           }
         },

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -1,14 +1,16 @@
-aio-pika==9.4.1
+aio-pika==9.5.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiocache==0.12.2
+aiocache==0.12.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiodebug==2.3.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiodocker==0.21.0
+aiodocker==0.24.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiofiles==23.2.1
+aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiohttp==3.9.3
+aiohappyeyeballs==2.4.3
+    # via aiohttp
+aiohttp==3.11.7
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -23,13 +25,13 @@ aiohttp==3.9.3
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   aiodocker
-aiormq==6.8.0
+aiormq==6.8.1
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.7.0
     # via pydantic
-anyio==4.3.0
+anyio==4.6.2.post1
     # via
     #   fast-depends
     #   faststream
@@ -43,12 +45,12 @@ arrow==1.3.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
-certifi==2024.2.2
+certifi==2024.8.30
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -65,15 +67,15 @@ certifi==2024.2.2
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via
     #   typer
     #   uvicorn
-cryptography==42.0.5
+cryptography==43.0.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -88,44 +90,45 @@ cryptography==42.0.5
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
-deprecated==1.2.14
+deprecated==1.2.15
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
-dnspython==2.6.1
+dnspython==2.7.0
     # via email-validator
-email-validator==2.1.1
+email-validator==2.2.0
     # via pydantic
+exceptiongroup==1.2.2
+    # via aio-pika
 fast-depends==2.4.12
     # via faststream
 fastapi==0.115.5
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-    #   prometheus-fastapi-instrumentator
-faststream==0.5.28
+faststream==0.5.30
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-googleapis-common-protos==1.65.0
+googleapis-common-protos==1.66.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.66.0
+grpcio==1.68.0
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.4
+httpcore==1.0.7
     # via httpx
-httptools==0.6.1
+httptools==0.6.4
     # via uvicorn
-httpx==0.27.0
+httpx==0.27.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -140,30 +143,30 @@ httpx==0.27.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-idna==3.6
+idna==3.10
     # via
     #   anyio
     #   email-validator
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.0.0
+importlib-metadata==8.5.0
     # via opentelemetry-api
-jsonschema==4.21.1
+jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
 markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.26.0
+opentelemetry-api==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -176,58 +179,59 @@ opentelemetry-api==1.26.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.26.0
+opentelemetry-exporter-otlp==1.28.2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.26.0
+opentelemetry-exporter-otlp-proto-common==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.26.0
+opentelemetry-exporter-otlp-proto-grpc==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.26.0
+opentelemetry-exporter-otlp-proto-http==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.47b0
+opentelemetry-instrumentation==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-asgi==0.47b0
+opentelemetry-instrumentation-asgi==0.49b2
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-fastapi==0.47b0
+opentelemetry-instrumentation-fastapi==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.47b0
+opentelemetry-instrumentation-httpx==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-redis==0.47b0
+opentelemetry-instrumentation-redis==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.47b0
+opentelemetry-instrumentation-requests==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.26.0
+opentelemetry-proto==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.26.0
+opentelemetry-sdk==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.47b0
+opentelemetry-semantic-conventions==0.49b2
     # via
+    #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.47b0
+opentelemetry-util-http==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
-orjson==3.10.0
+orjson==3.10.12
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -249,25 +253,31 @@ orjson==3.10.0
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-packaging==24.0
-    # via -r requirements/_base.in
+packaging==24.2
+    # via
+    #   -r requirements/_base.in
+    #   opentelemetry-instrumentation
 pamqp==3.3.0
     # via aiormq
-prometheus-client==0.20.0
+prometheus-client==0.21.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   prometheus-fastapi-instrumentator
-prometheus-fastapi-instrumentator==6.1.0
+prometheus-fastapi-instrumentator==7.0.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-protobuf==4.25.4
+propcache==0.2.0
+    # via
+    #   aiohttp
+    #   yarl
+protobuf==5.28.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.0.0
+psutil==6.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pydantic==2.9.2
+pydantic==2.10.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -296,9 +306,9 @@ pydantic==2.9.2
     #   fastapi
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.23.4
+pydantic-core==2.27.1
     # via pydantic
-pydantic-extra-types==2.9.0
+pydantic-extra-types==2.10.0
     # via
     #   -r requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -314,9 +324,9 @@ pydantic-settings==2.6.1
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-pygments==2.17.2
+pygments==2.18.0
     # via rich
-pyinstrument==4.6.2
+pyinstrument==5.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via arrow
@@ -324,7 +334,7 @@ python-dotenv==1.0.1
     # via
     #   pydantic-settings
     #   uvicorn
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -340,7 +350,7 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   uvicorn
-redis==5.0.4
+redis==5.2.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -355,26 +365,23 @@ redis==5.0.4
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-referencing==0.29.3
+referencing==0.35.1
     # via
-    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   jsonschema
     #   jsonschema-specifications
 repro-zipfile==0.3.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
-rich==13.7.1
+rich==13.9.4
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.18.0
+rpds-py==0.21.0
     # via
     #   jsonschema
     #   referencing
-setuptools==74.0.0
-    # via opentelemetry-instrumentation
 shellingham==1.5.4
     # via typer
 six==1.16.0
@@ -383,7 +390,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-starlette==0.41.2
+starlette==0.41.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -398,28 +405,29 @@ starlette==0.41.2
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   fastapi
-tenacity==8.5.0
+    #   prometheus-fastapi-instrumentator
+tenacity==9.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-toolz==0.12.1
+toolz==1.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-tqdm==4.66.2
+tqdm==4.67.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.12.3
+typer==0.13.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
-types-python-dateutil==2.9.0.20240316
+types-python-dateutil==2.9.0.20241003
     # via arrow
-typing-extensions==4.10.0
+typing-extensions==4.12.2
     # via
     #   aiodebug
-    #   aiodocker
     #   fastapi
     #   faststream
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
+    #   pydantic-extra-types
     #   typer
 urllib3==2.2.3
     # via
@@ -436,25 +444,27 @@ urllib3==2.2.3
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.29.0
+uvicorn==0.32.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-uvloop==0.19.0
+uvloop==0.21.0
     # via uvicorn
-watchfiles==0.21.0
+watchfiles==1.0.0
     # via uvicorn
-websockets==12.0
+websockets==14.1
     # via uvicorn
-wrapt==1.16.0
+wrapt==1.17.0
     # via
     #   deprecated
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
-yarl==1.9.4
+yarl==1.18.0
     # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.20.1
+zipp==3.21.0
     # via importlib-metadata

--- a/services/invitations/requirements/_test.txt
+++ b/services/invitations/requirements/_test.txt
@@ -1,46 +1,46 @@
-anyio==4.3.0
+anyio==4.6.2.post1
     # via
     #   -c requirements/_base.txt
     #   httpx
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -c requirements/_base.txt
     #   hypothesis
-certifi==2024.2.2
+certifi==2024.8.30
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   httpcore
     #   httpx
-coverage==7.6.1
+coverage==7.6.8
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-faker==29.0.0
+faker==33.0.0
     # via -r requirements/_test.in
 h11==0.14.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==1.0.4
+httpcore==1.0.7
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.27.0
+httpx==0.27.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-hypothesis==6.112.1
+hypothesis==6.119.4
     # via -r requirements/_test.in
-idna==3.6
+idna==3.10
     # via
     #   -c requirements/_base.txt
     #   anyio
     #   httpx
 iniconfig==2.0.0
     # via pytest
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   pytest
@@ -57,7 +57,7 @@ pytest-asyncio==0.23.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r requirements/_test.in
 pytest-runner==6.0.1
     # via -r requirements/_test.in
@@ -82,5 +82,9 @@ sniffio==1.3.1
     #   httpx
 sortedcontainers==2.4.0
     # via hypothesis
-termcolor==2.4.0
+termcolor==2.5.0
     # via pytest-sugar
+typing-extensions==4.12.2
+    # via
+    #   -c requirements/_base.txt
+    #   faker

--- a/services/invitations/requirements/_tools.txt
+++ b/services/invitations/requirements/_tools.txt
@@ -1,8 +1,8 @@
-astroid==3.3.4
+astroid==3.3.5
     # via pylint
-black==24.8.0
+black==24.10.0
     # via -r requirements/../../../requirements/devenv.txt
-build==1.2.2
+build==1.2.2.post1
     # via pip-tools
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -13,13 +13,13 @@ click==8.1.7
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-dill==0.3.8
+dill==0.3.9
     # via pylint
-distlib==0.3.8
+distlib==0.3.9
     # via virtualenv
 filelock==3.16.1
     # via virtualenv
-identify==2.6.1
+identify==2.6.3
     # via pre-commit
 isort==5.13.2
     # via
@@ -27,7 +27,7 @@ isort==5.13.2
     #   pylint
 mccabe==0.7.0
     # via pylint
-mypy==1.12.0
+mypy==1.13.0
     # via -r requirements/../../../requirements/devenv.txt
 mypy-extensions==1.0.0
     # via
@@ -35,7 +35,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -43,7 +43,7 @@ packaging==24.0
     #   build
 pathspec==0.12.1
     # via black
-pip==24.2
+pip==24.3.1
     # via pip-tools
 pip-tools==7.4.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -52,35 +52,34 @@ platformdirs==4.3.6
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.8.0
+pre-commit==4.0.1
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.3.0
+pylint==3.3.1
     # via -r requirements/../../../requirements/devenv.txt
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   pre-commit
     #   watchdog
-ruff==0.6.7
+ruff==0.8.0
     # via -r requirements/../../../requirements/devenv.txt
-setuptools==74.0.0
-    # via
-    #   -c requirements/_base.txt
-    #   pip-tools
+setuptools==75.6.0
+    # via pip-tools
 tomlkit==0.13.2
     # via pylint
-typing-extensions==4.10.0
+typing-extensions==4.12.2
     # via
     #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.26.5
+virtualenv==20.28.0
     # via pre-commit
-watchdog==5.0.2
+watchdog==6.0.0
     # via -r requirements/_tools.in
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

- #packages before ~ 94
- #packages after ~ 97

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.4.1           | 9.5.0      | *minor*    | 1 | invitations⬆️ |
|   2 | aiocache                  | 0.12.2          | 0.12.3     |            | 1 | invitations⬆️ |
|   3 | aiodocker                 | 0.21.0          | 0.24.0     | *minor*    | 1 | invitations⬆️ |
|   4 | aiofiles                  | 23.2.1          | 24.1.0     | **MAJOR**  | 1 | invitations⬆️ |
|   5 | aiohttp                   | 3.9.3           | 3.11.7     | *minor*    | 1 | invitations⬆️ |
|   6 | aiormq                    | 6.8.0           | 6.8.1      |            | 1 | invitations⬆️ |
|   7 | anyio                     | 4.3.0           | 4.6.2.post1 | *minor*    | 2 | invitations⬆️🧪 |
|   8 | astroid                   | 3.3.4           | 3.3.5      |            | 1 | invitations🔧 |
|   9 | attrs                     | 23.2.0          | 24.2.0     | **MAJOR**  | 2 | invitations⬆️🧪 |
|  10 | black                     | 24.8.0          | 24.10.0    | *minor*    | 1 | invitations🔧 |
|  11 | build                     | 1.2.2           | 1.2.2.post1 |            | 1 | invitations🔧 |
|  12 | certifi                   | 2024.2.2        | 2024.8.30  | *minor*    | 2 | invitations⬆️🧪 |
|  13 | cffi                      | 1.16.0          | 1.17.1     | *minor*    | 1 | invitations⬆️ |
|  14 | charset-normalizer        | 3.3.2           | 3.4.0      | *minor*    | 1 | invitations⬆️ |
|  15 | coverage                  | 7.6.1           | 7.6.8      |            | 1 | invitations🧪 |
|  16 | cryptography              | 42.0.5          | 43.0.3     | **MAJOR**  | 1 | invitations⬆️ |
|  17 | deprecated                | 1.2.14          | 1.2.15     |            | 1 | invitations⬆️ |
|  18 | dill                      | 0.3.8           | 0.3.9      |            | 1 | invitations🔧 |
|  19 | distlib                   | 0.3.8           | 0.3.9      |            | 1 | invitations🔧 |
|  20 | dnspython                 | 2.6.1           | 2.7.0      | *minor*    | 1 | invitations⬆️ |
|  21 | email-validator           | 2.1.1           | 2.2.0      | *minor*    | 1 | invitations⬆️ |
|  22 | faker                     | 29.0.0          | 33.0.0     | **MAJOR**  | 1 | invitations🧪 |
|  23 | faststream                | 0.5.28          | 0.5.30     |            | 1 | invitations⬆️ |
|  24 | frozenlist                | 1.4.1           | 1.5.0      | *minor*    | 1 | invitations⬆️ |
|  25 | googleapis-common-protos  | 1.65.0          | 1.66.0     | *minor*    | 1 | invitations⬆️ |
|  26 | grpcio                    | 1.66.0          | 1.68.0     | *minor*    | 1 | invitations⬆️ |
|  27 | httpcore                  | 1.0.4           | 1.0.7      |            | 2 | invitations⬆️🧪 |
|  28 | httptools                 | 0.6.1           | 0.6.4      |            | 1 | invitations⬆️ |
|  29 | httpx                     | 0.27.0          | 0.27.2     |            | 2 | invitations⬆️🧪 |
|  30 | hypothesis                | 6.112.1         | 6.119.4    | *minor*    | 1 | invitations🧪 |
|  31 | identify                  | 2.6.1           | 2.6.3      |            | 1 | invitations🔧 |
|  32 | idna                      | 3.6             | 3.10       | *minor*    | 2 | invitations⬆️🧪 |
|  33 | importlib-metadata        | 8.0.0           | 8.5.0      | *minor*    | 1 | invitations⬆️ |
|  34 | jsonschema                | 4.21.1          | 4.23.0     | *minor*    | 1 | invitations⬆️ |
|  35 | jsonschema-specifications | 2023.7.1        | 2024.10.1  | **MAJOR**  | 1 | invitations⬆️ |
|  36 | multidict                 | 6.0.5           | 6.1.0      | *minor*    | 1 | invitations⬆️ |
|  37 | mypy                      | 1.12.0          | 1.13.0     | *minor*    | 1 | invitations🔧 |
|  38 | opentelemetry-api         | 1.26.0          | 1.28.2     | *minor*    | 1 | invitations⬆️ |
|  39 | opentelemetry-exporter-otlp | 1.26.0          | 1.28.2     | *minor*    | 1 | invitations⬆️ |
|  40 | opentelemetry-exporter-otlp-proto-common | 1.26.0          | 1.28.2     | *minor*    | 1 | invitations⬆️ |
|  41 | opentelemetry-exporter-otlp-proto-grpc | 1.26.0          | 1.28.2     | *minor*    | 1 | invitations⬆️ |
|  42 | opentelemetry-exporter-otlp-proto-http | 1.26.0          | 1.28.2     | *minor*    | 1 | invitations⬆️ |
|  43 | opentelemetry-instrumentation | 0.47            | 0.49       | *minor*    | 1 | invitations⬆️ |
|  44 | opentelemetry-instrumentation-asgi | 0.47            | 0.49       | *minor*    | 1 | invitations⬆️ |
|  45 | opentelemetry-instrumentation-fastapi | 0.47            | 0.49       | *minor*    | 1 | invitations⬆️ |
|  46 | opentelemetry-instrumentation-httpx | 0.47            | 0.49       | *minor*    | 1 | invitations⬆️ |
|  47 | opentelemetry-instrumentation-redis | 0.47            | 0.49       | *minor*    | 1 | invitations⬆️ |
|  48 | opentelemetry-instrumentation-requests | 0.47            | 0.49       | *minor*    | 1 | invitations⬆️ |
|  49 | opentelemetry-proto       | 1.26.0          | 1.28.2     | *minor*    | 1 | invitations⬆️ |
|  50 | opentelemetry-sdk         | 1.26.0          | 1.28.2     | *minor*    | 1 | invitations⬆️ |
|  51 | opentelemetry-semantic-conventions | 0.47            | 0.49       | *minor*    | 1 | invitations⬆️ |
|  52 | opentelemetry-util-http   | 0.47            | 0.49       | *minor*    | 1 | invitations⬆️ |
|  53 | orjson                    | 3.10.0          | 3.10.12    |            | 1 | invitations⬆️ |
|  54 | packaging                 | 24.0            | 24.2       | *minor*    | 3 | invitations⬆️🧪🔧 |
|  55 | pip                       | 24.2            | 24.3.1     | *minor*    | 1 | invitations🔧 |
|  56 | pre-commit                | 3.8.0           | 4.0.1      | **MAJOR**  | 1 | invitations🔧 |
|  57 | prometheus-client         | 0.20.0          | 0.21.0     | *minor*    | 1 | invitations⬆️ |
|  58 | prometheus-fastapi-instrumentator | 6.1.0           | 7.0.0      | **MAJOR**  | 1 | invitations⬆️ |
|  59 | protobuf                  | 4.25.4          | 5.28.3     | **MAJOR**  | 1 | invitations⬆️ |
|  60 | psutil                    | 6.0.0           | 6.1.0      | *minor*    | 1 | invitations⬆️ |
|  61 | pycparser                 | 2.21            | 2.22       | *minor*    | 1 | invitations⬆️ |
|  62 | pydantic                  | 2.9.2           | 2.10.2     | *minor*    | 1 | invitations⬆️ |
|  63 | pydantic-core             | 2.23.4          | 2.27.1     | *minor*    | 1 | invitations⬆️ |
|  64 | pydantic-extra-types      | 2.9.0           | 2.10.0     | *minor*    | 1 | invitations⬆️ |
|  65 | pygments                  | 2.17.2          | 2.18.0     | *minor*    | 1 | invitations⬆️ |
|  66 | pyinstrument              | 4.6.2           | 5.0.0      | **MAJOR**  | 1 | invitations⬆️ |
|  67 | pylint                    | 3.3.0           | 3.3.1      |            | 1 | invitations🔧 |
|  68 | pyproject-hooks           | 1.1.0           | 1.2.0      | *minor*    | 1 | invitations🔧 |
|  69 | pytest-cov                | 5.0.0           | 6.0.0      | **MAJOR**  | 1 | invitations🧪 |
|  70 | pyyaml                    | 6.0.1           | 6.0.2      |            | 2 | invitations⬆️🔧 |
|  71 | redis                     | 5.0.4           | 5.2.0      | *minor*    | 1 | invitations⬆️ |
|  72 | referencing               | 0.29.3          | 0.35.1     | *minor*    | 1 | invitations⬆️ |
|  73 | rich                      | 13.7.1          | 13.9.4     | *minor*    | 1 | invitations⬆️ |
|  74 | rpds-py                   | 0.18.0          | 0.21.0     | *minor*    | 1 | invitations⬆️ |
|  75 | ruff                      | 0.6.7           | 0.8.0      | *minor*    | 1 | invitations🔧 |
|  76 | setuptools                | 74.0.0          | 75.6.0     | **MAJOR**  | 2 | invitations⬆️🔧 |
|  77 | starlette                 | 0.41.2          | 0.41.3     |            | 1 | invitations⬆️ |
|  78 | tenacity                  | 8.5.0           | 9.0.0      | **MAJOR**  | 1 | invitations⬆️ |
|  79 | termcolor                 | 2.4.0           | 2.5.0      | *minor*    | 1 | invitations🧪 |
|  80 | toolz                     | 0.12.1          | 1.0.0      | **MAJOR**  | 1 | invitations⬆️ |
|  81 | tqdm                      | 4.66.2          | 4.67.1     | *minor*    | 1 | invitations⬆️ |
|  82 | typer                     | 0.12.3          | 0.13.1     | *minor*    | 1 | invitations⬆️ |
|  83 | types-python-dateutil     | 2.9.0.20240316  | 2.9.0.20241003 |            | 1 | invitations⬆️ |
|  84 | typing-extensions         | 4.10.0          | 4.12.2     | *minor*    | 2 | invitations⬆️🔧 |
|  85 | uvicorn                   | 0.29.0          | 0.32.1     | *minor*    | 1 | invitations⬆️ |
|  86 | uvloop                    | 0.19.0          | 0.21.0     | *minor*    | 1 | invitations⬆️ |
|  87 | virtualenv                | 20.26.5         | 20.28.0    | *minor*    | 1 | invitations🔧 |
|  88 | watchdog                  | 5.0.2           | 6.0.0      | **MAJOR**  | 1 | invitations🔧 |
|  89 | watchfiles                | 0.21.0          | 1.0.0      | **MAJOR**  | 1 | invitations⬆️ |
|  90 | websockets                | 12.0            | 14.1       | **MAJOR**  | 1 | invitations⬆️ |
|  91 | wheel                     | 0.44.0          | 0.45.1     | *minor*    | 1 | invitations🔧 |
|  92 | wrapt                     | 1.16.0          | 1.17.0     | *minor*    | 1 | invitations⬆️ |
|  93 | yarl                      | 1.9.4           | 1.18.0     | *minor*    | 1 | invitations⬆️ |
|  94 | zipp                      | 3.20.1          | 3.21.0     | *minor*    | 1 | invitations⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency
