### PR TITLE
⬆️ Maintenance: upgrades `payments` service requirements

### DIFF
--- a/services/payments/gateway/openapi.json
+++ b/services/payments/gateway/openapi.json
@@ -14,24 +14,31 @@
     "operationId": "init_payment",
     "parameters": [
      {
+      "name": "x-init-api-secret",
+      "in": "header",
       "required": false,
       "schema": {
-       "type": "string",
+       "anyOf": [
+        {
+         "type": "string"
+        },
+        {
+         "type": "null"
+        }
+       ],
        "title": "X-Init-Api-Secret"
-      },
-      "name": "x-init-api-secret",
-      "in": "header"
+      }
      }
     ],
     "requestBody": {
+     "required": true,
      "content": {
       "application/json": {
        "schema": {
         "$ref": "#/components/schemas/InitPayment"
        }
       }
-     },
-     "required": true
+     }
     },
     "responses": {
      "200": {
@@ -45,14 +52,14 @@
       }
      },
      "4XX": {
-      "description": "Client Error",
       "content": {
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/ErrorModel"
         }
        }
-      }
+      },
+      "description": "Client Error"
      }
     }
    }
@@ -66,15 +73,15 @@
     "operationId": "get_payment_form",
     "parameters": [
      {
+      "name": "id",
+      "in": "query",
       "required": true,
       "schema": {
        "type": "string",
-       "maxLength": 50,
        "minLength": 1,
+       "maxLength": 100,
        "title": "Id"
-      },
-      "name": "id",
-      "in": "query"
+      }
      }
     ],
     "responses": {
@@ -89,14 +96,14 @@
       }
      },
      "4XX": {
-      "description": "Client Error",
       "content": {
        "text/html": {
         "schema": {
          "type": "string"
         }
        }
-      }
+      },
+      "description": "Client Error"
      }
     }
    }
@@ -110,24 +117,31 @@
     "operationId": "cancel_payment",
     "parameters": [
      {
+      "name": "x-init-api-secret",
+      "in": "header",
       "required": false,
       "schema": {
-       "type": "string",
+       "anyOf": [
+        {
+         "type": "string"
+        },
+        {
+         "type": "null"
+        }
+       ],
        "title": "X-Init-Api-Secret"
-      },
-      "name": "x-init-api-secret",
-      "in": "header"
+      }
      }
     ],
     "requestBody": {
+     "required": true,
      "content": {
       "application/json": {
        "schema": {
         "$ref": "#/components/schemas/PaymentInitiated"
        }
       }
-     },
-     "required": true
+     }
     },
     "responses": {
      "200": {
@@ -141,14 +155,14 @@
       }
      },
      "4XX": {
-      "description": "Client Error",
       "content": {
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/ErrorModel"
         }
        }
-      }
+      },
+      "description": "Client Error"
      }
     }
    }
@@ -162,24 +176,31 @@
     "operationId": "init_payment_method",
     "parameters": [
      {
+      "name": "x-init-api-secret",
+      "in": "header",
       "required": false,
       "schema": {
-       "type": "string",
+       "anyOf": [
+        {
+         "type": "string"
+        },
+        {
+         "type": "null"
+        }
+       ],
        "title": "X-Init-Api-Secret"
-      },
-      "name": "x-init-api-secret",
-      "in": "header"
+      }
      }
     ],
     "requestBody": {
+     "required": true,
      "content": {
       "application/json": {
        "schema": {
         "$ref": "#/components/schemas/InitPaymentMethod"
        }
       }
-     },
-     "required": true
+     }
     },
     "responses": {
      "200": {
@@ -193,14 +214,14 @@
       }
      },
      "4XX": {
-      "description": "Client Error",
       "content": {
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/ErrorModel"
         }
        }
-      }
+      },
+      "description": "Client Error"
      }
     }
    }
@@ -214,15 +235,15 @@
     "operationId": "get_form_payment_method",
     "parameters": [
      {
+      "name": "id",
+      "in": "query",
       "required": true,
       "schema": {
        "type": "string",
-       "maxLength": 50,
        "minLength": 1,
+       "maxLength": 100,
        "title": "Id"
-      },
-      "name": "id",
-      "in": "query"
+      }
      }
     ],
     "responses": {
@@ -237,14 +258,14 @@
       }
      },
      "4XX": {
-      "description": "Client Error",
       "content": {
        "text/html": {
         "schema": {
          "type": "string"
         }
        }
-      }
+      },
+      "description": "Client Error"
      }
     }
    }
@@ -258,24 +279,31 @@
     "operationId": "batch_get_payment_methods",
     "parameters": [
      {
+      "name": "x-init-api-secret",
+      "in": "header",
       "required": false,
       "schema": {
-       "type": "string",
+       "anyOf": [
+        {
+         "type": "string"
+        },
+        {
+         "type": "null"
+        }
+       ],
        "title": "X-Init-Api-Secret"
-      },
-      "name": "x-init-api-secret",
-      "in": "header"
+      }
      }
     ],
     "requestBody": {
+     "required": true,
      "content": {
       "application/json": {
        "schema": {
         "$ref": "#/components/schemas/BatchGetPaymentMethods"
        }
       }
-     },
-     "required": true
+     }
     },
     "responses": {
      "200": {
@@ -289,14 +317,14 @@
       }
      },
      "4XX": {
-      "description": "Client Error",
       "content": {
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/ErrorModel"
         }
        }
-      }
+      },
+      "description": "Client Error"
      }
     }
    }
@@ -310,24 +338,31 @@
     "operationId": "get_payment_method",
     "parameters": [
      {
+      "name": "id",
+      "in": "path",
       "required": true,
       "schema": {
        "type": "string",
-       "maxLength": 50,
        "minLength": 1,
+       "maxLength": 100,
        "title": "Id"
-      },
-      "name": "id",
-      "in": "path"
+      }
      },
      {
+      "name": "x-init-api-secret",
+      "in": "header",
       "required": false,
       "schema": {
-       "type": "string",
+       "anyOf": [
+        {
+         "type": "string"
+        },
+        {
+         "type": "null"
+        }
+       ],
        "title": "X-Init-Api-Secret"
-      },
-      "name": "x-init-api-secret",
-      "in": "header"
+      }
      }
     ],
     "responses": {
@@ -352,14 +387,14 @@
       }
      },
      "4XX": {
-      "description": "Client Error",
       "content": {
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/ErrorModel"
         }
        }
-      }
+      },
+      "description": "Client Error"
      }
     }
    },
@@ -371,24 +406,31 @@
     "operationId": "delete_payment_method",
     "parameters": [
      {
+      "name": "id",
+      "in": "path",
       "required": true,
       "schema": {
        "type": "string",
-       "maxLength": 50,
        "minLength": 1,
+       "maxLength": 100,
        "title": "Id"
-      },
-      "name": "id",
-      "in": "path"
+      }
      },
      {
+      "name": "x-init-api-secret",
+      "in": "header",
       "required": false,
       "schema": {
-       "type": "string",
+       "anyOf": [
+        {
+         "type": "string"
+        },
+        {
+         "type": "null"
+        }
+       ],
        "title": "X-Init-Api-Secret"
-      },
-      "name": "x-init-api-secret",
-      "in": "header"
+      }
      }
     ],
     "responses": {
@@ -396,14 +438,14 @@
       "description": "Successful Response"
      },
      "4XX": {
-      "description": "Client Error",
       "content": {
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/ErrorModel"
         }
        }
-      }
+      },
+      "description": "Client Error"
      }
     }
    }
@@ -417,35 +459,42 @@
     "operationId": "pay_with_payment_method",
     "parameters": [
      {
+      "name": "id",
+      "in": "path",
       "required": true,
       "schema": {
        "type": "string",
-       "maxLength": 50,
        "minLength": 1,
+       "maxLength": 100,
        "title": "Id"
-      },
-      "name": "id",
-      "in": "path"
+      }
      },
      {
+      "name": "x-init-api-secret",
+      "in": "header",
       "required": false,
       "schema": {
-       "type": "string",
+       "anyOf": [
+        {
+         "type": "string"
+        },
+        {
+         "type": "null"
+        }
+       ],
        "title": "X-Init-Api-Secret"
-      },
-      "name": "x-init-api-secret",
-      "in": "header"
+      }
      }
     ],
     "requestBody": {
+     "required": true,
      "content": {
       "application/json": {
        "schema": {
         "$ref": "#/components/schemas/InitPayment"
        }
       }
-     },
-     "required": true
+     }
     },
     "responses": {
      "200": {
@@ -459,14 +508,14 @@
       }
      },
      "4XX": {
-      "description": "Client Error",
       "content": {
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/ErrorModel"
         }
        }
-      }
+      },
+      "description": "Client Error"
      }
     }
    }
@@ -481,50 +530,93 @@
       "title": "Success"
      },
      "message": {
-      "type": "string",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Message"
      },
      "provider_payment_id": {
-      "type": "string",
-      "maxLength": 50,
-      "minLength": 1,
+      "anyOf": [
+       {
+        "type": "string",
+        "maxLength": 100,
+        "minLength": 1
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Provider Payment Id",
       "description": "Payment ID from the provider (e.g. stripe payment ID)"
      },
      "invoice_url": {
-      "type": "string",
-      "maxLength": 2083,
-      "minLength": 1,
-      "format": "uri",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Invoice Url",
       "description": "Link to invoice is required when success=true"
      },
      "invoice_pdf": {
-      "type": "string",
-      "maxLength": 2083,
-      "minLength": 1,
-      "format": "uri",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Invoice Pdf",
       "description": "Link to invoice PDF"
      },
      "stripe_invoice_id": {
-      "type": "string",
-      "maxLength": 50,
-      "minLength": 1,
+      "anyOf": [
+       {
+        "type": "string",
+        "maxLength": 100,
+        "minLength": 1
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Stripe Invoice Id",
       "description": "Stripe invoice ID"
      },
      "stripe_customer_id": {
-      "type": "string",
-      "maxLength": 50,
-      "minLength": 1,
+      "anyOf": [
+       {
+        "type": "string",
+        "maxLength": 100,
+        "minLength": 1
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Stripe Customer Id",
-      "description": "Customer invoice ID"
+      "description": "Stripe customer ID"
      },
      "payment_id": {
-      "type": "string",
-      "maxLength": 50,
-      "minLength": 1,
+      "anyOf": [
+       {
+        "type": "string",
+        "maxLength": 100,
+        "minLength": 1
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Payment Id",
       "description": "Payment ID from the gateway"
      }
@@ -535,10 +627,10 @@
     ],
     "title": "AckPaymentWithPaymentMethod",
     "example": {
-     "success": true,
-     "provider_payment_id": "pi_123ABC",
      "invoice_url": "https://invoices.com/id=12345",
-     "payment_id": "D19EE68B-B007-4B61-A8BC-32B7115FB244"
+     "payment_id": "D19EE68B-B007-4B61-A8BC-32B7115FB244",
+     "provider_payment_id": "pi_123ABC",
+     "success": true
     }
    },
    "BatchGetPaymentMethods": {
@@ -546,7 +638,7 @@
      "payment_methods_ids": {
       "items": {
        "type": "string",
-       "maxLength": 50,
+       "maxLength": 100,
        "minLength": 1
       },
       "type": "array",
@@ -566,7 +658,14 @@
       "title": "Message"
      },
      "exception": {
-      "type": "string",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Exception"
      },
      "file": {
@@ -577,17 +676,34 @@
        },
        {
         "type": "string"
+       },
+       {
+        "type": "null"
        }
       ],
       "title": "File"
      },
      "line": {
-      "type": "integer",
+      "anyOf": [
+       {
+        "type": "integer"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Line"
      },
      "trace": {
-      "items": {},
-      "type": "array",
+      "anyOf": [
+       {
+        "items": {},
+        "type": "array"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Trace"
      }
     },
@@ -601,28 +717,63 @@
     "properties": {
      "id": {
       "type": "string",
-      "maxLength": 50,
+      "maxLength": 100,
       "minLength": 1,
       "title": "Id"
      },
      "card_holder_name": {
-      "type": "string",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Card Holder Name"
      },
      "card_number_masked": {
-      "type": "string",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Card Number Masked"
      },
      "card_type": {
-      "type": "string",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Card Type"
      },
      "expiration_month": {
-      "type": "integer",
+      "anyOf": [
+       {
+        "type": "integer"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Expiration Month"
      },
      "expiration_year": {
-      "type": "integer",
+      "anyOf": [
+       {
+        "type": "integer"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Expiration Year"
      },
      "created": {
@@ -641,24 +792,39 @@
    "InitPayment": {
     "properties": {
      "amount_dollars": {
-      "type": "number",
-      "exclusiveMaximum": true,
-      "exclusiveMinimum": true,
-      "title": "Amount Dollars",
-      "maximum": 1000000.0,
-      "minimum": 0.0
+      "anyOf": [
+       {
+        "type": "number",
+        "exclusiveMaximum": true,
+        "exclusiveMinimum": true,
+        "maximum": 1000000.0,
+        "minimum": 0.0
+       },
+       {
+        "type": "string"
+       }
+      ],
+      "title": "Amount Dollars"
      },
      "credits": {
-      "type": "number",
-      "exclusiveMaximum": true,
-      "exclusiveMinimum": true,
+      "anyOf": [
+       {
+        "type": "number",
+        "exclusiveMaximum": true,
+        "exclusiveMinimum": true,
+        "maximum": 1000000.0,
+        "minimum": 0.0
+       },
+       {
+        "type": "string"
+       }
+      ],
       "title": "Credits",
-      "maximum": 1000000.0,
-      "minimum": 0.0
+      "describe": "This is equal to `quantity` field in Stripe"
      },
      "user_name": {
       "type": "string",
-      "maxLength": 50,
+      "maxLength": 100,
       "minLength": 1,
       "title": "User Name"
      },
@@ -668,24 +834,20 @@
       "title": "User Email"
      },
      "user_address": {
-      "$ref": "#/components/schemas/UserAddress"
+      "$ref": "#/components/schemas/UserInvoiceAddress"
      },
      "wallet_name": {
       "type": "string",
-      "maxLength": 50,
+      "maxLength": 100,
       "minLength": 1,
       "title": "Wallet Name"
      },
      "stripe_price_id": {
       "type": "string",
-      "maxLength": 50,
-      "minLength": 1,
       "title": "Stripe Price Id"
      },
      "stripe_tax_rate_id": {
       "type": "string",
-      "maxLength": 50,
-      "minLength": 1,
       "title": "Stripe Tax Rate Id"
      },
      "stripe_tax_exempt_value": {
@@ -711,15 +873,13 @@
     "properties": {
      "method": {
       "type": "string",
-      "enum": [
-       "CC"
-      ],
+      "const": "CC",
       "title": "Method",
       "default": "CC"
      },
      "user_name": {
       "type": "string",
-      "maxLength": 50,
+      "maxLength": 100,
       "minLength": 1,
       "title": "User Name"
      },
@@ -730,7 +890,7 @@
      },
      "wallet_name": {
       "type": "string",
-      "maxLength": 50,
+      "maxLength": 100,
       "minLength": 1,
       "title": "Wallet Name"
      }
@@ -747,7 +907,14 @@
    "PaymentCancelled": {
     "properties": {
      "message": {
-      "type": "string",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Message"
      }
     },
@@ -758,7 +925,7 @@
     "properties": {
      "payment_id": {
       "type": "string",
-      "maxLength": 50,
+      "maxLength": 100,
       "minLength": 1,
       "title": "Payment Id"
      }
@@ -773,7 +940,7 @@
     "properties": {
      "payment_method_id": {
       "type": "string",
-      "maxLength": 50,
+      "maxLength": 100,
       "minLength": 1,
       "title": "Payment Method Id"
      }
@@ -807,37 +974,65 @@
      "none",
      "reverse"
     ],
-    "title": "StripeTaxExempt",
-    "description": "An enumeration."
+    "title": "StripeTaxExempt"
    },
-   "UserAddress": {
+   "UserInvoiceAddress": {
     "properties": {
      "line1": {
-      "type": "string",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Line1"
      },
      "state": {
-      "type": "string",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "State"
      },
      "postal_code": {
-      "type": "string",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "Postal Code"
      },
      "city": {
-      "type": "string",
+      "anyOf": [
+       {
+        "type": "string"
+       },
+       {
+        "type": "null"
+       }
+      ],
       "title": "City"
      },
      "country": {
       "type": "string",
-      "title": "Country"
+      "title": "Country",
+      "description": "Currently validated in webserver via pycountry library. Two letter country code alpha_2 expected."
      }
     },
     "type": "object",
     "required": [
      "country"
     ],
-    "title": "UserAddress"
+    "title": "UserInvoiceAddress"
    }
   }
  }

--- a/services/payments/openapi.json
+++ b/services/payments/openapi.json
@@ -449,9 +449,6 @@
           },
           "docs_url": {
             "type": "string",
-            "maxLength": 2083,
-            "minLength": 1,
-            "format": "uri",
             "title": "Docs Url"
           }
         },
@@ -507,9 +504,6 @@
           },
           "token_type": {
             "type": "string",
-            "enum": [
-              "bearer"
-            ],
             "const": "bearer",
             "title": "Token Type"
           }

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -147,7 +147,7 @@ httpcore==1.0.7
     # via httpx
 httptools==0.6.4
     # via uvicorn
-httpx==0.28.0
+httpx==0.27.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -499,7 +499,9 @@ six==1.16.0
     #   ecdsa
     #   python-dateutil
 sniffio==1.3.1
-    # via anyio
+    # via
+    #   anyio
+    #   httpx
 sqlalchemy==1.4.54
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -1,4 +1,4 @@
-aio-pika==9.5.0
+aio-pika==9.5.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.12.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
@@ -10,7 +10,7 @@ aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.11.7
+aiohttp==3.11.8
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -87,7 +87,7 @@ click==8.1.7
     # via
     #   typer
     #   uvicorn
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -147,7 +147,7 @@ httpcore==1.0.7
     # via httpx
 httptools==0.6.4
     # via uvicorn
-httpx==0.27.2
+httpx==0.28.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -337,7 +337,7 @@ propcache==0.2.0
     # via
     #   aiohttp
     #   yarl
-protobuf==5.28.3
+protobuf==5.29.0
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
@@ -499,9 +499,7 @@ six==1.16.0
     #   ecdsa
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 sqlalchemy==1.4.54
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -1,16 +1,16 @@
-aio-pika==9.4.2
+aio-pika==9.5.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiocache==0.12.2
+aiocache==0.12.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiodebug==2.3.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiodocker==0.22.2
+aiodocker==0.24.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiohappyeyeballs==2.3.4
+aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.0
+aiohttp==3.11.7
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -27,17 +27,17 @@ aiohttp==3.10.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   aiodocker
-aiormq==6.8.0
+aiormq==6.8.1
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
 aiosmtplib==3.0.2
     # via -r requirements/_base.in
-alembic==1.13.2
+alembic==1.14.0
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
 annotated-types==0.7.0
     # via pydantic
-anyio==4.4.0
+anyio==4.6.2.post1
     # via
     #   fast-depends
     #   faststream
@@ -51,18 +51,16 @@ arrow==1.3.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
-async-timeout==4.0.3
-    # via asyncpg
-asyncpg==0.29.0
+asyncpg==0.30.0
     # via sqlalchemy
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
 bidict==0.23.1
     # via python-socketio
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -81,15 +79,15 @@ certifi==2024.7.4
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via
     #   typer
     #   uvicorn
-cryptography==43.0.0
+cryptography==43.0.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -106,49 +104,50 @@ cryptography==43.0.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
-deprecated==1.2.14
+deprecated==1.2.15
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
-dnspython==2.6.1
+dnspython==2.7.0
     # via email-validator
 ecdsa==0.19.0
     # via python-jose
 email-validator==2.2.0
     # via pydantic
+exceptiongroup==1.2.2
+    # via aio-pika
 fast-depends==2.4.12
     # via faststream
 fastapi==0.115.5
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-    #   prometheus-fastapi-instrumentator
-faststream==0.5.28
+faststream==0.5.30
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-googleapis-common-protos==1.65.0
+googleapis-common-protos==1.66.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-greenlet==3.0.3
+greenlet==3.1.1
     # via sqlalchemy
-grpcio==1.66.0
+grpcio==1.68.0
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
     #   wsproto
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httptools==0.6.1
+httptools==0.6.4
     # via uvicorn
-httpx==0.27.0
+httpx==0.27.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -166,14 +165,14 @@ httpx==0.27.0
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   email-validator
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.0.0
+importlib-metadata==8.5.0
     # via opentelemetry-api
 jinja2==3.1.4
     # via
@@ -196,9 +195,9 @@ jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
-mako==1.3.5
+mako==1.3.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -217,17 +216,17 @@ mako==1.3.5
     #   alembic
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   jinja2
     #   mako
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.27.0
+opentelemetry-api==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -241,17 +240,17 @@ opentelemetry-api==1.27.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.27.0
+opentelemetry-exporter-otlp==1.28.2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.27.0
+opentelemetry-exporter-otlp-proto-common==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.27.0
+opentelemetry-exporter-otlp-proto-grpc==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.27.0
+opentelemetry-exporter-otlp-proto-http==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.48b0
+opentelemetry-instrumentation==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
@@ -259,30 +258,31 @@ opentelemetry-instrumentation==0.48b0
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-asgi==0.48b0
+opentelemetry-instrumentation-asgi==0.49b2
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.48b0
+opentelemetry-instrumentation-asyncpg==0.49b2
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.48b0
+opentelemetry-instrumentation-fastapi==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.48b0
+opentelemetry-instrumentation-httpx==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-redis==0.48b0
+opentelemetry-instrumentation-redis==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.48b0
+opentelemetry-instrumentation-requests==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.27.0
+opentelemetry-proto==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.27.0
+opentelemetry-sdk==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.48b0
+opentelemetry-semantic-conventions==0.49b2
     # via
+    #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
@@ -290,13 +290,13 @@ opentelemetry-semantic-conventions==0.48b0
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.48b0
+opentelemetry-util-http==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
-orjson==3.10.6
+orjson==3.10.12
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -321,31 +321,37 @@ orjson==3.10.6
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-packaging==24.1
-    # via -r requirements/_base.in
+packaging==24.2
+    # via
+    #   -r requirements/_base.in
+    #   opentelemetry-instrumentation
 pamqp==3.3.0
     # via aiormq
-prometheus-client==0.20.0
+prometheus-client==0.21.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   prometheus-fastapi-instrumentator
-prometheus-fastapi-instrumentator==6.1.0
+prometheus-fastapi-instrumentator==7.0.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-protobuf==4.25.4
+propcache==0.2.0
+    # via
+    #   aiohttp
+    #   yarl
+protobuf==5.28.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.0.0
+psutil==6.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.10
     # via sqlalchemy
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   python-jose
     #   rsa
 pycparser==2.22
     # via cffi
-pydantic==2.9.2
+pydantic==2.10.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -378,9 +384,9 @@ pydantic==2.9.2
     #   fastapi
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.23.4
+pydantic-core==2.27.1
     # via pydantic
-pydantic-extra-types==2.9.0
+pydantic-extra-types==2.10.0
     # via
     #   -r requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -399,7 +405,7 @@ pydantic-settings==2.6.1
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
 pygments==2.18.0
     # via rich
-pyinstrument==4.6.2
+pyinstrument==5.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via arrow
@@ -407,15 +413,15 @@ python-dotenv==1.0.1
     # via
     #   pydantic-settings
     #   uvicorn
-python-engineio==4.9.1
+python-engineio==4.10.1
     # via python-socketio
 python-jose==3.3.0
     # via -r requirements/_base.in
-python-multipart==0.0.9
+python-multipart==0.0.17
     # via -r requirements/_base.in
-python-socketio==5.11.3
+python-socketio==5.11.4
     # via -r requirements/_base.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -433,7 +439,7 @@ pyyaml==6.0.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   uvicorn
-redis==5.0.4
+redis==5.2.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -450,21 +456,20 @@ redis==5.0.4
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-referencing==0.29.3
+referencing==0.35.1
     # via
-    #   -c requirements/../../../packages/service-library/requirements/./constraints.txt
     #   jsonschema
     #   jsonschema-specifications
 repro-zipfile==0.3.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
-rich==13.7.1
+rich==13.9.4
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.19.1
+rpds-py==0.21.0
     # via
     #   jsonschema
     #   referencing
@@ -485,11 +490,9 @@ rsa==4.9
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   python-jose
-setuptools==74.0.0
-    # via opentelemetry-instrumentation
 shellingham==1.5.4
     # via typer
-simple-websocket==1.0.0
+simple-websocket==1.1.0
     # via python-engineio
 six==1.16.0
     # via
@@ -499,7 +502,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-sqlalchemy==1.4.53
+sqlalchemy==1.4.54
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -517,7 +520,7 @@ sqlalchemy==1.4.53
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   alembic
-starlette==0.40.0
+starlette==0.41.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -534,18 +537,19 @@ starlette==0.40.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   fastapi
+    #   prometheus-fastapi-instrumentator
 tenacity==9.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-toolz==0.12.1
+toolz==1.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-tqdm==4.66.4
+tqdm==4.67.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.12.3
+typer==0.13.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
-types-python-dateutil==2.9.0.20240316
+types-python-dateutil==2.9.0.20241003
     # via arrow
 typing-extensions==4.12.2
     # via
@@ -556,6 +560,7 @@ typing-extensions==4.12.2
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
+    #   pydantic-extra-types
     #   typer
 urllib3==2.2.3
     # via
@@ -574,28 +579,30 @@ urllib3==2.2.3
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.30.4
+uvicorn==0.32.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-uvloop==0.19.0
+uvloop==0.21.0
     # via uvicorn
-watchfiles==0.22.0
+watchfiles==1.0.0
     # via uvicorn
-websockets==12.0
+websockets==14.1
     # via uvicorn
-wrapt==1.16.0
+wrapt==1.17.0
     # via
     #   deprecated
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 wsproto==1.2.0
     # via simple-websocket
-yarl==1.9.4
+yarl==1.18.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.20.1
+zipp==3.21.0
     # via importlib-metadata

--- a/services/payments/requirements/_test.txt
+++ b/services/payments/requirements/_test.txt
@@ -1,8 +1,8 @@
-aiohappyeyeballs==2.3.4
+aiohappyeyeballs==2.4.3
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.10.0
+aiohttp==3.11.7
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -11,13 +11,13 @@ aiosignal==1.3.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-anyio==4.4.0
+anyio==4.6.2.post1
     # via
     #   -c requirements/_base.txt
     #   httpx
 asgi-lifespan==2.1.0
     # via -r requirements/_test.in
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -25,31 +25,31 @@ bidict==0.23.1
     # via
     #   -c requirements/_base.txt
     #   python-socketio
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via
     #   -c requirements/_base.txt
     #   requests
-coverage==7.6.1
+coverage==7.6.8
     # via
     #   -r requirements/_test.in
     #   pytest-cov
 docker==7.1.0
     # via -r requirements/_test.in
-faker==29.0.0
+faker==33.0.0
     # via -r requirements/_test.in
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
-greenlet==3.0.3
+greenlet==3.1.1
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
@@ -58,18 +58,18 @@ h11==0.14.0
     #   -c requirements/_base.txt
     #   httpcore
     #   wsproto
-httpcore==1.0.5
+httpcore==1.0.7
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.27.0
+httpx==0.27.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   respx
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.7
+idna==3.10
     # via
     #   -c requirements/_base.txt
     #   anyio
@@ -80,16 +80,16 @@ iniconfig==2.0.0
     # via pytest
 jsonref==1.1.0
     # via -r requirements/_test.in
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-mypy==1.12.0
+mypy==1.13.0
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   pytest
@@ -98,6 +98,11 @@ pluggy==1.5.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
+propcache==0.2.0
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   yarl
 pytest==8.3.3
     # via
     #   -r requirements/_test.in
@@ -110,7 +115,7 @@ pytest-asyncio==0.23.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r requirements/_test.in
 pytest-icdiff==0.9
     # via -r requirements/_test.in
@@ -128,11 +133,11 @@ python-dotenv==1.0.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-python-engineio==4.9.1
+python-engineio==4.10.1
     # via
     #   -c requirements/_base.txt
     #   python-socketio
-python-socketio==5.11.3
+python-socketio==5.11.4
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -142,7 +147,7 @@ requests==2.32.3
     #   docker
 respx==0.21.1
     # via -r requirements/_test.in
-simple-websocket==1.0.0
+simple-websocket==1.1.0
     # via
     #   -c requirements/_base.txt
     #   python-engineio
@@ -156,14 +161,14 @@ sniffio==1.3.1
     #   anyio
     #   asgi-lifespan
     #   httpx
-sqlalchemy==1.4.53
+sqlalchemy==1.4.54
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
 sqlalchemy2-stubs==0.0.2a38
     # via sqlalchemy
-termcolor==2.4.0
+termcolor==2.5.0
     # via pytest-sugar
 types-aiofiles==24.1.0.20240626
     # via -r requirements/_test.in
@@ -176,6 +181,7 @@ types-pyyaml==6.0.12.20240917
 typing-extensions==4.12.2
     # via
     #   -c requirements/_base.txt
+    #   faker
     #   mypy
     #   sqlalchemy2-stubs
 urllib3==2.2.3
@@ -188,7 +194,7 @@ wsproto==1.2.0
     # via
     #   -c requirements/_base.txt
     #   simple-websocket
-yarl==1.9.4
+yarl==1.18.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/services/payments/requirements/_test.txt
+++ b/services/payments/requirements/_test.txt
@@ -2,7 +2,7 @@ aiohappyeyeballs==2.4.3
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.7
+aiohttp==3.11.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -42,7 +42,7 @@ coverage==7.6.8
     #   pytest-cov
 docker==7.1.0
     # via -r requirements/_test.in
-faker==33.0.0
+faker==33.1.0
     # via -r requirements/_test.in
 frozenlist==1.5.0
     # via
@@ -62,7 +62,7 @@ httpcore==1.0.7
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.27.2
+httpx==0.28.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -160,7 +160,6 @@ sniffio==1.3.1
     #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
-    #   httpx
 sqlalchemy==1.4.54
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/payments/requirements/_test.txt
+++ b/services/payments/requirements/_test.txt
@@ -62,7 +62,7 @@ httpcore==1.0.7
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.28.0
+httpx==0.27.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -160,6 +160,7 @@ sniffio==1.3.1
     #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
+    #   httpx
 sqlalchemy==1.4.54
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/payments/requirements/_tools.txt
+++ b/services/payments/requirements/_tools.txt
@@ -1,8 +1,8 @@
-astroid==3.3.4
+astroid==3.3.5
     # via pylint
-black==24.8.0
+black==24.10.0
     # via -r requirements/../../../requirements/devenv.txt
-build==1.2.2
+build==1.2.2.post1
     # via pip-tools
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -13,13 +13,13 @@ click==8.1.7
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-dill==0.3.8
+dill==0.3.9
     # via pylint
-distlib==0.3.8
+distlib==0.3.9
     # via virtualenv
 filelock==3.16.1
     # via virtualenv
-identify==2.6.1
+identify==2.6.3
     # via pre-commit
 isort==5.13.2
     # via
@@ -27,7 +27,7 @@ isort==5.13.2
     #   pylint
 mccabe==0.7.0
     # via pylint
-mypy==1.12.0
+mypy==1.13.0
     # via
     #   -c requirements/_test.txt
     #   -r requirements/../../../requirements/devenv.txt
@@ -38,7 +38,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -46,7 +46,7 @@ packaging==24.1
     #   build
 pathspec==0.12.1
     # via black
-pip==24.2
+pip==24.3.1
     # via pip-tools
 pip-tools==7.4.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -55,25 +55,23 @@ platformdirs==4.3.6
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.8.0
+pre-commit==4.0.1
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.3.0
+pylint==3.3.1
     # via -r requirements/../../../requirements/devenv.txt
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   pre-commit
-ruff==0.6.7
+ruff==0.8.0
     # via -r requirements/../../../requirements/devenv.txt
-setuptools==74.0.0
-    # via
-    #   -c requirements/_base.txt
-    #   pip-tools
+setuptools==75.6.0
+    # via pip-tools
 tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
@@ -81,7 +79,7 @@ typing-extensions==4.12.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.26.5
+virtualenv==20.28.0
     # via pre-commit
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools

--- a/services/payments/src/simcore_service_payments/core/settings.py
+++ b/services/payments/src/simcore_service_payments/core/settings.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from typing import Annotated
 
 from models_library.basic_types import NonNegativeDecimal
 from pydantic import (
@@ -95,20 +96,27 @@ class ApplicationSettings(_BaseApplicationSettings):
     )
     PAYMENTS_ACCESS_TOKEN_EXPIRE_MINUTES: PositiveFloat = Field(default=30)
 
-    PAYMENTS_AUTORECHARGE_MIN_BALANCE_IN_CREDITS: NonNegativeDecimal = Field(
-        default=100,
-        description="Minimum balance in credits to top-up for auto-recharge",
-    )
+    PAYMENTS_AUTORECHARGE_MIN_BALANCE_IN_CREDITS: Annotated[
+        NonNegativeDecimal,
+        Field(
+            description="Minimum balance in credits to top-up for auto-recharge",
+        ),
+    ]
 
-    PAYMENTS_AUTORECHARGE_DEFAULT_TOP_UP_AMOUNT: NonNegativeDecimal = Field(
-        default=100,
-        description="Default value in USD on the amount to top-up for auto-recharge (`top_up_amount_in_usd`)",
-    )
+    PAYMENTS_AUTORECHARGE_DEFAULT_TOP_UP_AMOUNT: Annotated[
+        NonNegativeDecimal,
+        Field(
+            description="Default value in USD on the amount to top-up for auto-recharge (`top_up_amount_in_usd`)",
+        ),
+    ]
 
-    PAYMENTS_AUTORECHARGE_DEFAULT_MONTHLY_LIMIT: NonNegativeDecimal | None = Field(
-        default=10000,
-        description="Default value in USD for the montly limit for auto-recharge (`monthly_limit_in_usd`)",
-    )
+    PAYMENTS_AUTORECHARGE_DEFAULT_MONTHLY_LIMIT: Annotated[
+        NonNegativeDecimal | None,
+        Field(
+            description="Default value in USD for the montly limit for auto-recharge (`monthly_limit_in_usd`)",
+        ),
+    ]
+
     PAYMENTS_AUTORECHARGE_ENABLED: bool = Field(
         default=False,
         description="Based on this variable is the auto recharge functionality in Payment service enabled",

--- a/services/payments/src/simcore_service_payments/core/settings.py
+++ b/services/payments/src/simcore_service_payments/core/settings.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from functools import cached_property
 from typing import Annotated
 
@@ -101,21 +102,21 @@ class ApplicationSettings(_BaseApplicationSettings):
         Field(
             description="Minimum balance in credits to top-up for auto-recharge",
         ),
-    ]
+    ] = Decimal(100)
 
     PAYMENTS_AUTORECHARGE_DEFAULT_TOP_UP_AMOUNT: Annotated[
         NonNegativeDecimal,
         Field(
             description="Default value in USD on the amount to top-up for auto-recharge (`top_up_amount_in_usd`)",
         ),
-    ]
+    ] = Decimal(100)
 
     PAYMENTS_AUTORECHARGE_DEFAULT_MONTHLY_LIMIT: Annotated[
         NonNegativeDecimal | None,
         Field(
             description="Default value in USD for the montly limit for auto-recharge (`monthly_limit_in_usd`)",
         ),
-    ]
+    ] = Decimal(10_000)
 
     PAYMENTS_AUTORECHARGE_ENABLED: bool = Field(
         default=False,

--- a/services/payments/src/simcore_service_payments/models/schemas/acknowledgements.py
+++ b/services/payments/src/simcore_service_payments/models/schemas/acknowledgements.py
@@ -1,5 +1,5 @@
 # mypy: disable-error-code=truthy-function
-from typing import Any
+from typing import Annotated, Any
 
 from models_library.api_schemas_webserver.wallets import PaymentID, PaymentMethodID
 from models_library.basic_types import IDStr
@@ -110,9 +110,10 @@ class AckPaymentWithPaymentMethod(_BaseAckPayment):
     # I decided to separate it for clarity in the OAS since in payments
     # w/ payment-method the field `saved` will never be provided,
 
-    payment_id: PaymentID = Field(
-        default=None, description="Payment ID from the gateway"
-    )
+    payment_id: Annotated[
+        PaymentID | None, Field(description="Payment ID from the gateway")
+    ] = None
+
     model_config = ConfigDict(
         json_schema_extra={
             "example": {

--- a/services/payments/tests/unit/test_services_payments__get_invoice.py
+++ b/services/payments/tests/unit/test_services_payments__get_invoice.py
@@ -18,7 +18,6 @@ from models_library.payments import StripeInvoiceID
 from models_library.users import UserID
 from models_library.wallets import WalletID
 from pydantic import HttpUrl
-from pydantic_core import Url
 from pytest_simcore.helpers.faker_factories import random_payment_transaction
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
@@ -119,4 +118,4 @@ async def test_get_payment_invoice_url(
         payment_id=populate_payment_transaction_db,
     )
     assert invoice_url
-    assert isinstance(invoice_url, Url)
+    assert isinstance(invoice_url, HttpUrl)

--- a/services/payments/tests/unit/test_services_payments_gateway.py
+++ b/services/payments/tests/unit/test_services_payments_gateway.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 from faker import Faker
 from fastapi import FastAPI, status
+from httpx import ASGITransport
 from models_library.payments import UserInvoiceAddress
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
 from respx import MockRouter
@@ -218,7 +219,7 @@ async def test_payments_gateway_error_exception():
     async def _go():
         with _raise_as_payments_gateway_error(operation_id="foo"):
             async with httpx.AsyncClient(
-                app=FastAPI(),
+                transport=ASGITransport(app=FastAPI()),
                 base_url="http://payments.testserver.io",
             ) as client:
                 response = await client.post("/foo", params={"x": "3"}, json={"y": 12})


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- #packages before ~ 100
- #packages after ~ 101

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.4.2           | 9.5.1      | *minor*    | 1 | payments⬆️ |
|   2 | aiocache                  | 0.12.2          | 0.12.3     |            | 1 | payments⬆️ |
|   3 | aiodocker                 | 0.22.2          | 0.24.0     | *minor*    | 1 | payments⬆️ |
|   4 | aiohappyeyeballs          | 2.3.4           | 2.4.3      | *minor*    | 2 | payments⬆️🧪 |
|   5 | aiohttp                   | 3.10.0          | 3.11.8     | *minor*    | 2 | payments⬆️🧪 |
|   6 | aiormq                    | 6.8.0           | 6.8.1      |            | 1 | payments⬆️ |
|   7 | alembic                   | 1.13.2          | 1.14.0     | *minor*    | 1 | payments⬆️ |
|   8 | anyio                     | 4.4.0           | 4.6.2.post1 | *minor*    | 2 | payments⬆️🧪 |
|   9 | astroid                   | 3.3.4           | 3.3.5      |            | 1 | payments🔧 |
|  10 | async-timeout             | 4.0.3           | 🗑️ removed |  | 1 | payments⬆️ |
|  11 | asyncpg                   | 0.29.0          | 0.30.0     | *minor*    | 1 | payments⬆️ |
|  12 | attrs                     | 23.2.0          | 24.2.0     | **MAJOR**  | 2 | payments⬆️🧪 |
|  13 | black                     | 24.8.0          | 24.10.0    | *minor*    | 1 | payments🔧 |
|  14 | build                     | 1.2.2           | 1.2.2.post1 |            | 1 | payments🔧 |
|  15 | certifi                   | 2024.7.4        | 2024.8.30  | *minor*    | 2 | payments⬆️🧪 |
|  16 | cffi                      | 1.16.0          | 1.17.1     | *minor*    | 1 | payments⬆️ |
|  17 | charset-normalizer        | 3.3.2           | 3.4.0      | *minor*    | 2 | payments⬆️🧪 |
|  18 | coverage                  | 7.6.1           | 7.6.8      |            | 1 | payments🧪 |
|  19 | cryptography              | 43.0.0          | 44.0.0     | **MAJOR**  | 1 | payments⬆️ |
|  20 | deprecated                | 1.2.14          | 1.2.15     |            | 1 | payments⬆️ |
|  21 | dill                      | 0.3.8           | 0.3.9      |            | 1 | payments🔧 |
|  22 | distlib                   | 0.3.8           | 0.3.9      |            | 1 | payments🔧 |
|  23 | dnspython                 | 2.6.1           | 2.7.0      | *minor*    | 1 | payments⬆️ |
|  24 | faker                     | 29.0.0          | 33.1.0     | **MAJOR**  | 1 | payments🧪 |
|  25 | faststream                | 0.5.28          | 0.5.30     |            | 1 | payments⬆️ |
|  26 | frozenlist                | 1.4.1           | 1.5.0      | *minor*    | 2 | payments⬆️🧪 |
|  27 | googleapis-common-protos  | 1.65.0          | 1.66.0     | *minor*    | 1 | payments⬆️ |
|  28 | greenlet                  | 3.0.3           | 3.1.1      | *minor*    | 2 | payments⬆️🧪 |
|  29 | grpcio                    | 1.66.0          | 1.68.0     | *minor*    | 1 | payments⬆️ |
|  30 | httpcore                  | 1.0.5           | 1.0.7      |            | 2 | payments⬆️🧪 |
|  31 | httptools                 | 0.6.1           | 0.6.4      |            | 1 | payments⬆️ |
|  32 | httpx                     | 0.27.0          | 0.27.2     |            | 2 | payments⬆️🧪 |
|  33 | identify                  | 2.6.1           | 2.6.3      |            | 1 | payments🔧 |
|  34 | idna                      | 3.7             | 3.10       | *minor*    | 2 | payments⬆️🧪 |
|  35 | importlib-metadata        | 8.0.0           | 8.5.0      | *minor*    | 1 | payments⬆️ |
|  36 | jsonschema-specifications | 2023.7.1        | 2024.10.1  | **MAJOR**  | 1 | payments⬆️ |
|  37 | mako                      | 1.3.5           | 1.3.6      |            | 1 | payments⬆️ |
|  38 | markupsafe                | 2.1.5           | 3.0.2      | **MAJOR**  | 1 | payments⬆️ |
|  39 | multidict                 | 6.0.5           | 6.1.0      | *minor*    | 2 | payments⬆️🧪 |
|  40 | mypy                      | 1.12.0          | 1.13.0     | *minor*    | 2 | payments🧪🔧 |
|  41 | opentelemetry-api         | 1.27.0          | 1.28.2     | *minor*    | 1 | payments⬆️ |
|  42 | opentelemetry-exporter-otlp | 1.27.0          | 1.28.2     | *minor*    | 1 | payments⬆️ |
|  43 | opentelemetry-exporter-otlp-proto-common | 1.27.0          | 1.28.2     | *minor*    | 1 | payments⬆️ |
|  44 | opentelemetry-exporter-otlp-proto-grpc | 1.27.0          | 1.28.2     | *minor*    | 1 | payments⬆️ |
|  45 | opentelemetry-exporter-otlp-proto-http | 1.27.0          | 1.28.2     | *minor*    | 1 | payments⬆️ |
|  46 | opentelemetry-instrumentation | 0.48            | 0.49       | *minor*    | 1 | payments⬆️ |
|  47 | opentelemetry-instrumentation-asgi | 0.48            | 0.49       | *minor*    | 1 | payments⬆️ |
|  48 | opentelemetry-instrumentation-asyncpg | 0.48            | 0.49       | *minor*    | 1 | payments⬆️ |
|  49 | opentelemetry-instrumentation-fastapi | 0.48            | 0.49       | *minor*    | 1 | payments⬆️ |
|  50 | opentelemetry-instrumentation-httpx | 0.48            | 0.49       | *minor*    | 1 | payments⬆️ |
|  51 | opentelemetry-instrumentation-redis | 0.48            | 0.49       | *minor*    | 1 | payments⬆️ |
|  52 | opentelemetry-instrumentation-requests | 0.48            | 0.49       | *minor*    | 1 | payments⬆️ |
|  53 | opentelemetry-proto       | 1.27.0          | 1.28.2     | *minor*    | 1 | payments⬆️ |
|  54 | opentelemetry-sdk         | 1.27.0          | 1.28.2     | *minor*    | 1 | payments⬆️ |
|  55 | opentelemetry-semantic-conventions | 0.48            | 0.49       | *minor*    | 1 | payments⬆️ |
|  56 | opentelemetry-util-http   | 0.48            | 0.49       | *minor*    | 1 | payments⬆️ |
|  57 | orjson                    | 3.10.6          | 3.10.12    |            | 1 | payments⬆️ |
|  58 | packaging                 | 24.1            | 24.2       | *minor*    | 3 | payments⬆️🧪🔧 |
|  59 | pip                       | 24.2            | 24.3.1     | *minor*    | 1 | payments🔧 |
|  60 | pre-commit                | 3.8.0           | 4.0.1      | **MAJOR**  | 1 | payments🔧 |
|  61 | prometheus-client         | 0.20.0          | 0.21.0     | *minor*    | 1 | payments⬆️ |
|  62 | prometheus-fastapi-instrumentator | 6.1.0           | 7.0.0      | **MAJOR**  | 1 | payments⬆️ |
|  63 | protobuf                  | 4.25.4          | 5.29.0     | **MAJOR**  | 1 | payments⬆️ |
|  64 | psutil                    | 6.0.0           | 6.1.0      | *minor*    | 1 | payments⬆️ |
|  65 | psycopg2-binary           | 2.9.9           | 2.9.10     |            | 1 | payments⬆️ |
|  66 | pyasn1                    | 0.6.0           | 0.6.1      |            | 1 | payments⬆️ |
|  67 | pydantic                  | 2.9.2           | 2.10.2     | *minor*    | 1 | payments⬆️ |
|  68 | pydantic-core             | 2.23.4          | 2.27.1     | *minor*    | 1 | payments⬆️ |
|  69 | pydantic-extra-types      | 2.9.0           | 2.10.0     | *minor*    | 1 | payments⬆️ |
|  70 | pyinstrument              | 4.6.2           | 5.0.0      | **MAJOR**  | 1 | payments⬆️ |
|  71 | pylint                    | 3.3.0           | 3.3.1      |            | 1 | payments🔧 |
|  72 | pyproject-hooks           | 1.1.0           | 1.2.0      | *minor*    | 1 | payments🔧 |
|  73 | pytest-cov                | 5.0.0           | 6.0.0      | **MAJOR**  | 1 | payments🧪 |
|  74 | python-engineio           | 4.9.1           | 4.10.1     | *minor*    | 2 | payments⬆️🧪 |
|  75 | python-multipart          | 0.0.9           | 0.0.17     |            | 1 | payments⬆️ |
|  76 | python-socketio           | 5.11.3          | 5.11.4     |            | 2 | payments⬆️🧪 |
|  77 | pyyaml                    | 6.0.1           | 6.0.2      |            | 2 | payments⬆️🔧 |
|  78 | redis                     | 5.0.4           | 5.2.0      | *minor*    | 1 | payments⬆️ |
|  79 | referencing               | 0.29.3          | 0.35.1     | *minor*    | 1 | payments⬆️ |
|  80 | rich                      | 13.7.1          | 13.9.4     | *minor*    | 1 | payments⬆️ |
|  81 | rpds-py                   | 0.19.1          | 0.21.0     | *minor*    | 1 | payments⬆️ |
|  82 | ruff                      | 0.6.7           | 0.8.0      | *minor*    | 1 | payments🔧 |
|  83 | setuptools                | 74.0.0          | 75.6.0     | **MAJOR**  | 2 | payments⬆️🔧 |
|  84 | simple-websocket          | 1.0.0           | 1.1.0      | *minor*    | 2 | payments⬆️🧪 |
|  85 | sqlalchemy                | 1.4.53          | 1.4.54     |            | 2 | payments⬆️🧪 |
|  86 | starlette                 | 0.40.0          | 0.41.3     | *minor*    | 1 | payments⬆️ |
|  87 | termcolor                 | 2.4.0           | 2.5.0      | *minor*    | 1 | payments🧪 |
|  88 | toolz                     | 0.12.1          | 1.0.0      | **MAJOR**  | 1 | payments⬆️ |
|  89 | tqdm                      | 4.66.4          | 4.67.1     | *minor*    | 1 | payments⬆️ |
|  90 | typer                     | 0.12.3          | 0.13.1     | *minor*    | 1 | payments⬆️ |
|  91 | types-python-dateutil     | 2.9.0.20240316  | 2.9.0.20241003 |            | 1 | payments⬆️ |
|  92 | uvicorn                   | 0.30.4          | 0.32.1     | *minor*    | 1 | payments⬆️ |
|  93 | uvloop                    | 0.19.0          | 0.21.0     | *minor*    | 1 | payments⬆️ |
|  94 | virtualenv                | 20.26.5         | 20.28.0    | *minor*    | 1 | payments🔧 |
|  95 | watchfiles                | 0.22.0          | 1.0.0      | **MAJOR**  | 1 | payments⬆️ |
|  96 | websockets                | 12.0            | 14.1       | **MAJOR**  | 1 | payments⬆️ |
|  97 | wheel                     | 0.44.0          | 0.45.1     | *minor*    | 1 | payments🔧 |
|  98 | wrapt                     | 1.16.0          | 1.17.0     | *minor*    | 1 | payments⬆️ |
|  99 | yarl                      | 1.9.4           | 1.18.0     | *minor*    | 2 | payments⬆️🧪 |
| 100 | zipp                      | 3.20.1          | 3.21.0     | *minor*    | 1 | payments⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency