### PR TITLE
 🎨  webserver's trash flag

### DIFF
--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -271,18 +271,27 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
     WEBSERVER_CLUSTERS: bool = False
     WEBSERVER_DB_LISTENER: bool = True
     WEBSERVER_FOLDERS: bool = True
-    WEBSERVER_WORKSPACES: bool = True
     WEBSERVER_GROUPS: bool = True
     WEBSERVER_META_MODELING: bool = True
     WEBSERVER_NOTIFICATIONS: bool = Field(default=True)
     WEBSERVER_PRODUCTS: bool = True
+    WEBSERVER_PROFILING: bool = False
     WEBSERVER_PUBLICATIONS: bool = True
     WEBSERVER_REMOTE_DEBUG: bool = True
     WEBSERVER_SOCKETIO: bool = True
     WEBSERVER_TAGS: bool = True
+    WEBSERVER_TRASH: Annotated[
+        bool,
+        Field(
+            description="Currently only used to enable/disable front-end",
+            validation_alias=AliasChoices(
+                "WEBSERVER_TRASH", "WEBSERVER_DEV_FEATURES_ENABLED"
+            ),
+        ),
+    ] = False
     WEBSERVER_VERSION_CONTROL: bool = True
     WEBSERVER_WALLETS: bool = True
-    WEBSERVER_PROFILING: bool = False
+    WEBSERVER_WORKSPACES: bool = True
 
     #
     WEBSERVER_SECURITY: bool = Field(
@@ -376,6 +385,7 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
             "WEBSERVER_META_MODELING",
             "WEBSERVER_PAYMENTS",
             "WEBSERVER_SCICRUNCH",
+            "WEBSERVER_TRASH",
             "WEBSERVER_VERSION_CONTROL",
         }
         return [_ for _ in public_plugin_candidates if not self.is_enabled(_)]

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -323,6 +323,7 @@ class ApplicationSettings(BaseCustomSettings, MixinLoggingSettings):
         # TODO: consider mark as dev-feature in field extras of Config attr.
         # Then they can be automtically advertised
         "WEBSERVER_META_MODELING",
+        "WEBSERVER_TRASH",
         "WEBSERVER_VERSION_CONTROL",
         mode="before",
     )

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -103,6 +103,25 @@ def test_settings_to_client_statics_plugins(
     assert set(statics["pluginsDisabled"]) == (disable_plugins | {"WEBSERVER_CLUSTERS"})
 
 
+@pytest.mark.parametrize("is_dev_feature_enabled", [True, False])
+def test_settings_to_client_statics_for_webserver_trash(
+    is_dev_feature_enabled: bool,
+    mock_webserver_service_environment: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv(
+        "WEBSERVER_DEV_FEATURES_ENABLED", f"{is_dev_feature_enabled}".lower()
+    )
+
+    settings = ApplicationSettings.create_from_envs()
+    statics = settings.to_client_statics()
+
+    if is_dev_feature_enabled:
+        assert "WEBSERVER_TRASH" not in set(statics["pluginsDisabled"])
+    else:
+        assert "WEBSERVER_TRASH" in set(statics["pluginsDisabled"])
+
+
 def test_avoid_sensitive_info_in_public(app_settings: ApplicationSettings):
     # avoids display of sensitive info
     assert not any("pass" in key for key in app_settings.public_dict())


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

- Adds `WEBSERVER_TRASH` flag to indicate whether the trash functionality is available or not. 
- Since currently it is under development, it is aliased to `WEBSERVER_DEV_FEATURES_ENABLED` 
- The front-end can get this information via `GET /static-frontend-data.json`
![image](https://github.com/user-attachments/assets/7aa30448-4cb9-4c74-8ae5-ba1eba145453)


## Related issue/s

- Needed before merging https://github.com/ITISFoundation/osparc-simcore/pull/6590
- Part of ITISFoundation/osparc-issues#468

## How to test

```
cd services/web/server
make install-dev
pytest -vv tests/unit/isolated -k test_settings_to_client_statics_for_webserver_trash.py
```


## Dev-ops 

None