### PR TITLE
🎨  api-server's LogStreamerRegistionConflictError not logged as a server error anymore

### DIFF
--- a/services/api-server/src/simcore_service_api_server/exceptions/handlers/_log_streaming_errors.py
+++ b/services/api-server/src/simcore_service_api_server/exceptions/handlers/_log_streaming_errors.py
@@ -4,7 +4,7 @@ from starlette.responses import JSONResponse
 
 from ..log_streaming_errors import (
     LogStreamerNotRegisteredError,
-    LogStreamerRegistionConflictError,
+    LogStreamerRegistrationConflictError,
     LogStreamingBaseError,
 )
 from ._utils import create_error_json_response
@@ -18,7 +18,7 @@ async def log_handling_error_handler(request: Request, exc: Exception) -> JSONRe
     status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR
     if isinstance(exc, LogStreamerNotRegisteredError):
         status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-    elif isinstance(exc, LogStreamerRegistionConflictError):
+    elif isinstance(exc, LogStreamerRegistrationConflictError):
         status_code = status.HTTP_409_CONFLICT
 
     return create_error_json_response(msg, status_code=status_code)

--- a/services/api-server/src/simcore_service_api_server/exceptions/log_streaming_errors.py
+++ b/services/api-server/src/simcore_service_api_server/exceptions/log_streaming_errors.py
@@ -9,5 +9,5 @@ class LogStreamerNotRegisteredError(LogStreamingBaseError):
     msg_template = "{msg}"
 
 
-class LogStreamerRegistionConflictError(LogStreamingBaseError):
+class LogStreamerRegistrationConflictError(LogStreamingBaseError):
     msg_template = "A stream was already connected to {job_id}. Only a single stream can be connected at the time"

--- a/services/api-server/src/simcore_service_api_server/services/log_streaming.py
+++ b/services/api-server/src/simcore_service_api_server/services/log_streaming.py
@@ -127,9 +127,10 @@ class LogStreamer:
                     done = await self._project_done()
 
         except (BaseBackEndError, LogStreamerRegistionConflictError) as exc:
-            _logger.info("%s: %s", exc.code, f"{exc}")
+            error_msg = f"{exc}"
 
-            yield ErrorGet(errors=[f"{exc}"]).model_dump_json() + _NEW_LINE
+            _logger.info("%s: %s", exc.code, error_msg)
+            yield ErrorGet(errors=[error_msg]).model_dump_json() + _NEW_LINE
 
         except Exception as exc:  # pylint: disable=W0718
             error_code = create_error_code(exc)

--- a/services/api-server/src/simcore_service_api_server/services/log_streaming.py
+++ b/services/api-server/src/simcore_service_api_server/services/log_streaming.py
@@ -127,7 +127,7 @@ class LogStreamer:
                     done = await self._project_done()
 
         except (BaseBackEndError, LogStreamerRegistionConflictError) as exc:
-            _logger.info("%s", f"{exc}")
+            _logger.info("%s: %s", exc.code, f"{exc}")
 
             yield ErrorGet(errors=[f"{exc}"]).model_dump_json() + _NEW_LINE
 

--- a/services/api-server/src/simcore_service_api_server/services/log_streaming.py
+++ b/services/api-server/src/simcore_service_api_server/services/log_streaming.py
@@ -16,7 +16,7 @@ from .._constants import MSG_INTERNAL_ERROR_USER_FRIENDLY_TEMPLATE
 from ..exceptions.backend_errors import BaseBackEndError
 from ..exceptions.log_streaming_errors import (
     LogStreamerNotRegisteredError,
-    LogStreamerRegistionConflictError,
+    LogStreamerRegistrationConflictError,
 )
 from ..models.schemas.errors import ErrorGet
 from ..models.schemas.jobs import JobID, JobLog
@@ -70,7 +70,7 @@ class LogDistributor:
 
     async def register(self, job_id: JobID, queue: Queue[JobLog]):
         if job_id in self._log_streamers:
-            raise LogStreamerRegistionConflictError(job_id=job_id)
+            raise LogStreamerRegistrationConflictError(job_id=job_id)
         self._log_streamers[job_id] = queue
         await self._rabbit_client.add_topics(
             LoggerRabbitMessage.get_channel_name(), topics=[f"{job_id}.*"]
@@ -126,7 +126,7 @@ class LogStreamer:
                 except TimeoutError:
                     done = await self._project_done()
 
-        except (BaseBackEndError, LogStreamerRegistionConflictError) as exc:
+        except (BaseBackEndError, LogStreamerRegistrationConflictError) as exc:
             error_msg = f"{exc}"
 
             _logger.info("%s: %s", exc.code, error_msg)

--- a/services/api-server/tests/unit/test_services_rabbitmq.py
+++ b/services/api-server/tests/unit/test_services_rabbitmq.py
@@ -45,7 +45,7 @@ from simcore_service_api_server.services.director_v2 import (
 from simcore_service_api_server.services.log_streaming import (
     LogDistributor,
     LogStreamer,
-    LogStreamerRegistionConflictError,
+    LogStreamerRegistrationConflictError,
 )
 from tenacity import AsyncRetrying, retry_if_not_exception_type, stop_after_delay
 
@@ -219,7 +219,7 @@ async def test_one_job_multiple_registrations(
         pass
 
     await log_distributor.register(project_id, _)
-    with pytest.raises(LogStreamerRegistionConflictError):
+    with pytest.raises(LogStreamerRegistrationConflictError):
         await log_distributor.register(project_id, _)
     await log_distributor.deregister(project_id)
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

- api-server's LogStreamerRegistionConflictError is a client error and must not be logged as a server error.

## Related issue/s

- resolves https://github.com/ITISFoundation/osparc-simcore/issues/6714

## How to test


## Dev-ops checklist

None