### PR TITLE
🎨 Enables trash in web-api

### DIFF
--- a/services/web/server/src/simcore_service_webserver/folders/_trash_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_trash_handlers.py
@@ -8,7 +8,6 @@ from servicelib.aiohttp.requests_validation import (
 )
 
 from .._meta import API_VTAG as VTAG
-from ..application_settings_utils import requires_dev_feature_enabled
 from ..login.decorators import get_user_id, login_required
 from ..products.api import get_product_name
 from ..security.decorators import permission_required
@@ -23,7 +22,6 @@ routes = web.RouteTableDef()
 
 
 @routes.post(f"/{VTAG}/folders/{{folder_id}}:trash", name="trash_folder")
-@requires_dev_feature_enabled
 @login_required
 @permission_required("folder.delete")
 @handle_plugin_requests_exceptions
@@ -47,7 +45,6 @@ async def trash_folder(request: web.Request):
 
 
 @routes.post(f"/{VTAG}/folders/{{folder_id}}:untrash", name="untrash_folder")
-@requires_dev_feature_enabled
 @login_required
 @permission_required("folder.delete")
 @handle_plugin_requests_exceptions

--- a/services/web/server/src/simcore_service_webserver/projects/_trash_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_trash_handlers.py
@@ -8,7 +8,6 @@ from servicelib.aiohttp.requests_validation import (
 )
 
 from .._meta import API_VTAG as VTAG
-from ..application_settings_utils import requires_dev_feature_enabled
 from ..exceptions_handlers import (
     ExceptionToHttpErrorMap,
     HttpErrorInfo,
@@ -57,7 +56,6 @@ routes = web.RouteTableDef()
 
 
 @routes.delete(f"/{VTAG}/trash", name="empty_trash")
-@requires_dev_feature_enabled
 @login_required
 @permission_required("project.delete")
 @_handle_exceptions
@@ -73,7 +71,6 @@ async def empty_trash(request: web.Request):
 
 
 @routes.post(f"/{VTAG}/projects/{{project_id}}:trash", name="trash_project")
-@requires_dev_feature_enabled
 @login_required
 @permission_required("project.delete")
 @_handle_exceptions
@@ -98,7 +95,6 @@ async def trash_project(request: web.Request):
 
 
 @routes.post(f"/{VTAG}/projects/{{project_id}}:untrash", name="untrash_project")
-@requires_dev_feature_enabled
 @login_required
 @permission_required("project.delete")
 @_handle_exceptions

--- a/services/web/server/src/simcore_service_webserver/workspaces/_trash_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_trash_handlers.py
@@ -8,7 +8,6 @@ from servicelib.aiohttp.requests_validation import (
 )
 
 from .._meta import API_VTAG as VTAG
-from ..application_settings_utils import requires_dev_feature_enabled
 from ..login.decorators import get_user_id, login_required
 from ..products.api import get_product_name
 from ..security.decorators import permission_required
@@ -23,7 +22,6 @@ routes = web.RouteTableDef()
 
 
 @routes.post(f"/{VTAG}/workspaces/{{workspace_id}}:trash", name="trash_workspace")
-@requires_dev_feature_enabled
 @login_required
 @permission_required("workspaces.*")
 @handle_plugin_requests_exceptions
@@ -47,7 +45,6 @@ async def trash_workspace(request: web.Request):
 
 
 @routes.post(f"/{VTAG}/workspaces/{{workspace_id}}:untrash", name="untrash_workspace")
-@requires_dev_feature_enabled
 @login_required
 @permission_required("workspaces.*")
 @handle_plugin_requests_exceptions

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -106,7 +106,7 @@ def test_settings_to_client_statics_plugins(
 @pytest.mark.parametrize("is_dev_feature_enabled", [True, False])
 @pytest.mark.parametrize(
     "plugin_name",
-    ["WEBSERVER_META_MODELING", "WEBSERVER_VERSION_CONTROL", "WEBSERVER_CLUSTERS"]
+    ["WEBSERVER_META_MODELING", "WEBSERVER_VERSION_CONTROL"]
     # NOTE: this is the list in _enable_only_if_dev_features_allowed
 )
 def test_disabled_plugins_settings_to_client_statics(

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -104,10 +104,16 @@ def test_settings_to_client_statics_plugins(
 
 
 @pytest.mark.parametrize("is_dev_feature_enabled", [True, False])
-def test_settings_to_client_statics_for_webserver_trash(
+@pytest.mark.parametrize(
+    "plugin_name",
+    ["WEBSERVER_META_MODELING", "WEBSERVER_VERSION_CONTROL", "WEBSERVER_CLUSTERS"]
+    # NOTE: this is the list in _enable_only_if_dev_features_allowed
+)
+def test_disabled_plugins_settings_to_client_statics(
     is_dev_feature_enabled: bool,
     mock_webserver_service_environment: EnvVarsDict,
     monkeypatch: pytest.MonkeyPatch,
+    plugin_name: str,
 ):
     monkeypatch.setenv(
         "WEBSERVER_DEV_FEATURES_ENABLED", f"{is_dev_feature_enabled}".lower()
@@ -116,10 +122,11 @@ def test_settings_to_client_statics_for_webserver_trash(
     settings = ApplicationSettings.create_from_envs()
     statics = settings.to_client_statics()
 
+    # checks whether it is shown to the front-end depending on the value of WEBSERVER_DEV_FEATURES_ENABLED
     if is_dev_feature_enabled:
-        assert "WEBSERVER_TRASH" not in set(statics["pluginsDisabled"])
+        assert plugin_name not in set(statics["pluginsDisabled"])
     else:
-        assert "WEBSERVER_TRASH" in set(statics["pluginsDisabled"])
+        assert plugin_name in set(statics["pluginsDisabled"])
 
 
 def test_avoid_sensitive_info_in_public(app_settings: ApplicationSettings):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Enables trash entrypoitns in web-api


## Related issue/s

- Enables ITISFoundation/osparc-issues#468
- Unblocks https://github.com/ITISFoundation/osparc-simcore/pull/6590


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

None