### PR TITLE
⬆️ Upgrades deprecated pydantic calls repo-wide

### DIFF
--- a/api/specs/director/schemas/scripts/create_node-meta-schema.py
+++ b/api/specs/director/schemas/scripts/create_node-meta-schema.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import jsonref
+from common_library.json_serialization import json_dumps
 from models_library.services import ServiceMetaDataPublished
 
 CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
@@ -15,7 +16,7 @@ CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve(
 
 if __name__ == "__main__":
     with Path.open(CURRENT_DIR.parent / "node-meta-v0.0.1-pydantic.json", "w") as f:
-        schema = ServiceMetaDataPublished.schema_json()
+        schema = json_dumps(ServiceMetaDataPublished.model_json_schema())
         schema_without_ref = jsonref.loads(schema)
 
         json.dump(schema_without_ref, f, indent=2)

--- a/api/specs/director/schemas/scripts/create_project-schema.py
+++ b/api/specs/director/schemas/scripts/create_project-schema.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import jsonref
+from common_library.json_serialization import json_dumps
 from models_library.projects import Project
 
 CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
@@ -17,7 +18,7 @@ if __name__ == "__main__":
     with Path.open(
         CURRENT_DIR.parent / "common/schemas/project-v0.0.1-pydantic.json", "w"
     ) as f:
-        schema = Project.schema_json()
+        schema = json_dumps(Project.model_json_schema())
         schema_without_ref = jsonref.loads(schema)
 
         json.dump(schema_without_ref, f, indent=2)

--- a/packages/models-library/Makefile
+++ b/packages/models-library/Makefile
@@ -49,13 +49,6 @@ tests-ci: ## runs unit tests [ci-mode]
     -m "not heavy_load" \
 		$(CURDIR)/tests
 
-.PHONY: project-jsonschema.ignore.json
-project-jsonschema.ignore.json: ## creates project-v0.0.1.json for DEV purposes
-	python3 -c "from models_library.projects import Project; print(Project.schema_json(indent=2))" > $@
-
-.PHONY: service-jsonschema.ignore.json
-node-meta-jsonschema.ignore.json: ## creates node-meta-v0.0.1.json for DEV purposes
-	python3 -c "from models_library.services import ServiceDockerData as cls; print(cls.schema_json(indent=2))" > $@
 
 DOCKER_API_VERSION ?= 1.41
 .PHONY: docker_rest_api.py

--- a/packages/models-library/src/models_library/function_services_catalog/services/iter_sensitivity.py
+++ b/packages/models-library/src/models_library/function_services_catalog/services/iter_sensitivity.py
@@ -2,7 +2,7 @@ from collections.abc import Iterator
 from copy import deepcopy
 from typing import Any
 
-from pydantic import schema_of
+from pydantic import TypeAdapter
 
 from ...projects_nodes import OutputID, OutputsDict
 from ...services import ServiceMetaDataPublished, ServiceType
@@ -10,7 +10,10 @@ from ...services_constants import LATEST_INTEGRATION_VERSION
 from .._key_labels import FUNCTION_SERVICE_KEY_PREFIX
 from .._utils import EN, OM, FunctionServices, create_fake_thumbnail_url
 
-LIST_NUMBERS_SCHEMA: dict[str, Any] = schema_of(list[float], title="list[number]")
+LIST_NUMBERS_SCHEMA: dict[str, Any] = {
+    **TypeAdapter(list[float]).json_schema(),
+    "title": "list[number]",
+}
 
 
 META = ServiceMetaDataPublished.model_validate(

--- a/packages/models-library/src/models_library/utils/common_validators.py
+++ b/packages/models-library/src/models_library/utils/common_validators.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from common_library.json_serialization import json_loads
 from orjson import JSONDecodeError
+from pydantic import BaseModel
 
 
 def empty_str_to_none_pre_validator(value: Any):
@@ -102,8 +103,8 @@ def create__check_only_one_is_set__root_validator(alternative_field_names: list[
     SEE test_uid_or_email_are_set.py for more details
     """
 
-    def _validator(cls, values):
-        assert set(alternative_field_names).issubset(cls.__fields__)  # nosec
+    def _validator(cls: type[BaseModel], values):
+        assert set(alternative_field_names).issubset(cls.model_fields)  # nosec
 
         got = {
             field_name: getattr(values, field_name)

--- a/packages/models-library/src/models_library/utils/services_io.py
+++ b/packages/models-library/src/models_library/utils/services_io.py
@@ -2,7 +2,7 @@ import mimetypes
 from copy import deepcopy
 from typing import Any, Literal
 
-from pydantic import schema_of
+from pydantic import TypeAdapter
 
 from ..services import ServiceInput, ServiceOutput
 from ..services_regex import PROPERTY_TYPE_TO_PYTHON_TYPE_MAP
@@ -10,8 +10,12 @@ from ..services_regex import PROPERTY_TYPE_TO_PYTHON_TYPE_MAP
 PortKindStr = Literal["input", "output"]
 JsonSchemaDict = dict[str, Any]
 
+
 _PROPERTY_TYPE_TO_SCHEMAS = {
-    property_type: schema_of(python_type, title=property_type.capitalize())
+    property_type: {
+        **TypeAdapter(python_type).json_schema(),
+        "title": property_type.capitalize(),
+    }
     for property_type, python_type in PROPERTY_TYPE_TO_PYTHON_TYPE_MAP.items()
 }
 

--- a/packages/models-library/tests/test__models_fit_schemas.py
+++ b/packages/models-library/tests/test__models_fit_schemas.py
@@ -2,10 +2,10 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 # pylint:disable=protected-access
-import json
 from collections.abc import Callable
 
 import pytest
+from common_library.json_serialization import json_loads
 from models_library.projects import Project
 from models_library.services import ServiceMetaDataPublished
 from pydantic.main import BaseModel
@@ -28,7 +28,7 @@ def test_generated_schema_same_as_original(
     # TODO: create instead a fixture that returns a Callable and do these checks
     # on separate test_* files that follow the same package submodule's hierarchy
     #
-    generated_schema = json.loads(pydantic_model.schema_json(indent=2))
+    generated_schema = json_loads(pydantic_model.model_json_schema(), indent=2)
     original_schema = json_schema_dict(original_json_schema)
 
     # NOTE: A change is considered an addition when the destination schema has become more permissive relative to the source schema. For example {"type": "string"} -> {"type": ["string", "number"]}.

--- a/packages/models-library/tests/test__pydantic_models.py
+++ b/packages/models-library/tests/test__pydantic_models.py
@@ -9,9 +9,10 @@ check some "corner cases" or critical setups with pydantic model such that:
 from typing import Any, Union, get_args, get_origin
 
 import pytest
+from common_library.json_serialization import json_dumps
 from models_library.projects_nodes import InputTypes, OutputTypes
 from models_library.projects_nodes_io import SimCoreFileLink
-from pydantic import BaseModel, Field, ValidationError, schema_json_of
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 from pydantic.types import Json
 from pydantic.version import version_short
 
@@ -37,7 +38,9 @@ def test_json_type():
         data_schema: Json
 
     # notice that this is a raw string!
-    jsonschema_of_x = schema_json_of(list[int], title="schema[x]")
+    jsonschema_of_x = json_dumps(
+        {**TypeAdapter(list[int]).json_schema(), "title": "schema[x]"}
+    )
     assert isinstance(jsonschema_of_x, str)
 
     x_annotation = ArgumentAnnotation(name="x", data_schema=jsonschema_of_x)

--- a/packages/models-library/tests/test_service_settings_labels.py
+++ b/packages/models-library/tests/test_service_settings_labels.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from pprint import pformat
 from typing import Any, Final, NamedTuple
 
+import pydantic_core
 import pytest
 from models_library.basic_types import PortInt
 from models_library.osparc_variable_identifier import (
@@ -32,7 +33,6 @@ from models_library.service_settings_nat_rule import (
 from models_library.services_resources import DEFAULT_SINGLE_SERVICE_NAME
 from models_library.utils.string_substitution import TextTemplate
 from pydantic import BaseModel, TypeAdapter, ValidationError
-from pydantic.json import pydantic_encoder
 
 
 class _Parametrization(NamedTuple):
@@ -560,7 +560,7 @@ def test_can_parse_labels_with_osparc_identifiers(
 
 def servicelib__json_serialization__json_dumps(obj: Any, **kwargs):
     # Analogous to 'models_library.utils.json_serialization.json_dumps'
-    return json.dumps(obj, default=pydantic_encoder, **kwargs)
+    return json.dumps(obj, default=pydantic_core.to_jsonable_python, **kwargs)
 
 
 def test_resolving_some_service_labels_at_load_time(

--- a/packages/models-library/tests/test_services_io.py
+++ b/packages/models-library/tests/test_services_io.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 
 import yaml
+from common_library.json_serialization import json_dumps
 from models_library.services import ServiceInput, ServiceMetaDataPublished
 from pint import Unit, UnitRegistry
 
@@ -13,7 +14,7 @@ def test_service_port_units(tests_data_dir: Path):
     ureg = UnitRegistry()
 
     data = yaml.safe_load((tests_data_dir / "metadata-sleeper-2.0.2.yaml").read_text())
-    print(ServiceMetaDataPublished.schema_json(indent=2))
+    print(json_dumps(ServiceMetaDataPublished.model_json_schema(), indent=2))
 
     service_meta = ServiceMetaDataPublished.model_validate(data)
     assert service_meta.inputs

--- a/packages/models-library/tests/test_sidecar_volumes.py
+++ b/packages/models-library/tests/test_sidecar_volumes.py
@@ -13,5 +13,5 @@ def test_volume_state_equality_does_not_use_last_changed(status: VolumeStatus):
     # NOTE: `last_changed` is initialized with the utc datetime
     #  at the moment of the creation of the object.
     assert VolumeState(status=status) == VolumeState(status=status)
-    schema_property_count = len(VolumeState.schema()["properties"])
+    schema_property_count = len(VolumeState.model_json_schema()["properties"])
     assert len(VolumeState(status=status).model_dump()) == schema_property_count

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/faker_catalog.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/faker_catalog.py
@@ -32,7 +32,6 @@ def create_service_out2(**overrides):
     # https://github.com/ITISFoundation/osparc-simcore/blob/master/services/catalog/src/simcore_service_catalog/models/schemas/services.py
     #
     # docker exec -it $(docker ps --filter="ancestor=local/catalog:development" -q)
-    # python -c "from simcore_service_catalog.models.schemas.services import ServiceOut;print(ServiceOut.schema_json(indent=2))" > services/catalog/ignore-schema.json
     # put file in https://json-schema-faker.js.org/ and get fake output
     #
 

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_port_mapping.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_port_mapping.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 from models_library.services import ServiceInput
-from pydantic import Field, ValidationError, schema_of
+from pydantic import Field, TypeAdapter, ValidationError
 from simcore_sdk.node_ports_v2 import exceptions
 from simcore_sdk.node_ports_v2.port import Port
 from simcore_sdk.node_ports_v2.ports_mapping import InputsList, OutputsList
@@ -74,10 +74,11 @@ def test_io_ports_are_not_aliases():
 @pytest.fixture
 def fake_port_meta() -> dict[str, Any]:
     """Service port metadata: defines a list of non-negative numbers"""
-    schema = schema_of(
-        list[Annotated[float, Field(ge=0)]],
-        title="list[non-negative number]",
-    )
+    schema = {
+        **TypeAdapter(list[Annotated[float, Field(ge=0)]]).json_schema(),
+        "title": "list[non-negative number]",
+    }
+
     schema.update(
         description="Port with an array of numbers",
         x_unit="millimeter",


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Based on the `PydanticDeprecatedSince20` warnings shown in the model-library tests, I upgrades repo-wise some pydantic calls



## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26

  If openapi changes are provided, optionally point to the swagger editor with new changes
  Example [openapi.json specs](https://editor.swagger.io/?url=https://raw.githubusercontent.com/<github-username>/osparc-simcore/is1133/create-api-for-creation-of-pricing-plan/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml)
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
