### PR TITLE
⬆️Upgrade dask related libraries and services (⚠️🚨)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -22,6 +22,7 @@ component_management:
     statuses:
       - type: project
         target: auto
+        threshold: 1%
         branches:
           - "!master"
   individual_components:

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -348,15 +348,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/webserver.bash test_with_db 01
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-webserver-02:
     needs: changes
@@ -393,15 +390,12 @@ jobs:
       - name: test
         run: ./ci/github/unit-testing/webserver.bash test_with_db 02
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-webserver-03:
     needs: changes
@@ -438,15 +432,12 @@ jobs:
       - name: test
         run: ./ci/github/unit-testing/webserver.bash test_with_db 03
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-webserver-04:
       needs: changes
@@ -531,15 +522,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/storage.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-agent:
     needs: changes
@@ -581,15 +569,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/agent.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-api:
     needs: changes
@@ -626,15 +611,12 @@ jobs:
       - name: test
         run: ./ci/github/unit-testing/api.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-api-server:
     needs: changes
@@ -677,15 +659,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/api-server.bash openapi-diff
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-autoscaling:
     needs: changes
@@ -725,15 +704,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/autoscaling.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-catalog:
     needs: changes
@@ -779,15 +755,12 @@ jobs:
           name: ${{ github.job }}_docker_logs
           path: ./services/catalog/test_failures
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-clusters-keeper:
     needs: changes
@@ -838,15 +811,12 @@ jobs:
           pushd services/clusters-keeper && \
           make test-ci-unit
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-datcore-adapter:
     needs: changes
@@ -892,15 +862,12 @@ jobs:
           name: ${{ github.job }}_docker_logs
           path: ./services/datcore-adapter/test_failures
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-director:
     needs: changes
@@ -946,15 +913,12 @@ jobs:
           name: ${{ github.job }}_docker_logs
           path: ./services/director/test_failures
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-director-v2:
     needs: changes
@@ -1000,15 +964,12 @@ jobs:
           name: ${{ github.job }}_docker_logs
           path: ./services/director-v2/test_failures
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-aws-library:
     needs: changes
@@ -1048,15 +1009,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/aws-library.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-dask-task-models-library:
     needs: changes
@@ -1096,15 +1054,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dask-task-models-library.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-dask-sidecar:
     needs: changes
@@ -1144,15 +1099,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dask-sidecar.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-payments:
     needs: changes
@@ -1192,15 +1144,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/payments.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-dynamic-scheduler:
     needs: changes
@@ -1240,15 +1189,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dynamic-scheduler.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-resource-usage-tracker:
     needs: changes
@@ -1298,15 +1244,12 @@ jobs:
           pushd services/resource-usage-tracker && \
           make test-ci-unit
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-dynamic-sidecar:
     needs: changes
@@ -1346,15 +1289,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dynamic-sidecar.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-efs-guardian:
     needs: changes
@@ -1405,15 +1345,12 @@ jobs:
           pushd services/efs-guardian && \
           make test-ci-unit
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-python-linting:
     needs: changes
@@ -1488,15 +1425,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/postgres-database.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-invitations:
     needs: changes
@@ -1536,15 +1470,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/invitations.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-service-integration:
     needs: changes
@@ -1584,15 +1515,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/service-integration.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-service-library:
     needs: changes
@@ -1632,15 +1560,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/service-library.bash test_all
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-settings-library:
     needs: changes
@@ -1680,15 +1605,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/settings-library.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-models-library:
     needs: changes
@@ -1727,15 +1649,12 @@ jobs:
       - name: test
         run: ./ci/github/unit-testing/models-library.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-common-library:
     needs: changes
@@ -1818,15 +1737,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/notifications-library.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-test-simcore-sdk:
     needs: changes
@@ -1868,15 +1784,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/simcore-sdk.bash test
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittests #optional
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   unit-tests:
     # NOTE: this is a github required status check!
@@ -1983,6 +1896,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/webserver.bash clean_up
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2046,6 +1960,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/webserver.bash clean_up
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2109,6 +2024,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/director-v2.bash clean_up
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2181,6 +2097,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/director-v2.bash clean_up
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2246,6 +2163,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/dynamic-sidecar.bash clean_up
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2309,6 +2227,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/simcore-sdk.bash clean_up
       - uses: codecov/codecov-action@v5
+        if: ${{ !cancelled }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -348,7 +348,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/webserver.bash test_with_db 01
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -390,7 +390,7 @@ jobs:
       - name: test
         run: ./ci/github/unit-testing/webserver.bash test_with_db 02
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -432,7 +432,7 @@ jobs:
       - name: test
         run: ./ci/github/unit-testing/webserver.bash test_with_db 03
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -522,7 +522,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/storage.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -569,7 +569,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/agent.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -611,7 +611,7 @@ jobs:
       - name: test
         run: ./ci/github/unit-testing/api.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -659,7 +659,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/api-server.bash openapi-diff
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -704,7 +704,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/autoscaling.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -755,7 +755,7 @@ jobs:
           name: ${{ github.job }}_docker_logs
           path: ./services/catalog/test_failures
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -811,7 +811,7 @@ jobs:
           pushd services/clusters-keeper && \
           make test-ci-unit
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -862,7 +862,7 @@ jobs:
           name: ${{ github.job }}_docker_logs
           path: ./services/datcore-adapter/test_failures
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -913,7 +913,7 @@ jobs:
           name: ${{ github.job }}_docker_logs
           path: ./services/director/test_failures
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -964,7 +964,7 @@ jobs:
           name: ${{ github.job }}_docker_logs
           path: ./services/director-v2/test_failures
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1009,7 +1009,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/aws-library.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1054,7 +1054,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dask-task-models-library.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1099,7 +1099,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dask-sidecar.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1144,7 +1144,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/payments.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1189,7 +1189,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dynamic-scheduler.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1244,7 +1244,7 @@ jobs:
           pushd services/resource-usage-tracker && \
           make test-ci-unit
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1289,7 +1289,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dynamic-sidecar.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1345,7 +1345,7 @@ jobs:
           pushd services/efs-guardian && \
           make test-ci-unit
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1425,7 +1425,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/postgres-database.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1470,7 +1470,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/invitations.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1515,7 +1515,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/service-integration.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1560,7 +1560,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/service-library.bash test_all
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1605,7 +1605,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/settings-library.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1649,7 +1649,7 @@ jobs:
       - name: test
         run: ./ci/github/unit-testing/models-library.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1737,7 +1737,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/notifications-library.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1784,7 +1784,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/simcore-sdk.bash test
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1896,7 +1896,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/webserver.bash clean_up
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1960,7 +1960,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/webserver.bash clean_up
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2024,7 +2024,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/director-v2.bash clean_up
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2097,7 +2097,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/director-v2.bash clean_up
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2163,7 +2163,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/dynamic-sidecar.bash clean_up
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2227,7 +2227,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/simcore-sdk.bash clean_up
       - uses: codecov/codecov-action@v5
-        if: ${{ !cancelled }}
+        if: ${{ !cancelled() }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -347,7 +347,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/webserver.bash test_with_db 01
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -392,7 +392,7 @@ jobs:
         run: ./ci/github/unit-testing/webserver.bash install
       - name: test
         run: ./ci/github/unit-testing/webserver.bash test_with_db 02
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -437,7 +437,7 @@ jobs:
         run: ./ci/github/unit-testing/webserver.bash install
       - name: test
         run: ./ci/github/unit-testing/webserver.bash test_with_db 03
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -482,7 +482,7 @@ jobs:
           run: ./ci/github/unit-testing/webserver.bash install
         - name: test
           run: ./ci/github/unit-testing/webserver.bash test_with_db 04
-        - uses: codecov/codecov-action@v5.0.7
+        - uses: codecov/codecov-action@v5
           env:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           with:
@@ -530,7 +530,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/storage.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -580,7 +580,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/agent.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -625,7 +625,7 @@ jobs:
         run: ./ci/github/unit-testing/api.bash install
       - name: test
         run: ./ci/github/unit-testing/api.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -676,7 +676,7 @@ jobs:
       - name: OAS backwards compatibility check
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/api-server.bash openapi-diff
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -724,7 +724,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/autoscaling.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -778,7 +778,7 @@ jobs:
         with:
           name: ${{ github.job }}_docker_logs
           path: ./services/catalog/test_failures
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -837,7 +837,7 @@ jobs:
           source .venv/bin/activate && \
           pushd services/clusters-keeper && \
           make test-ci-unit
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -891,7 +891,7 @@ jobs:
         with:
           name: ${{ github.job }}_docker_logs
           path: ./services/datcore-adapter/test_failures
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -945,7 +945,7 @@ jobs:
         with:
           name: ${{ github.job }}_docker_logs
           path: ./services/director/test_failures
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -999,7 +999,7 @@ jobs:
         with:
           name: ${{ github.job }}_docker_logs
           path: ./services/director-v2/test_failures
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1047,7 +1047,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/aws-library.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1095,7 +1095,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dask-task-models-library.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1143,7 +1143,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dask-sidecar.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1191,7 +1191,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/payments.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1239,7 +1239,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dynamic-scheduler.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1297,7 +1297,7 @@ jobs:
           source .venv/bin/activate && \
           pushd services/resource-usage-tracker && \
           make test-ci-unit
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1345,7 +1345,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/dynamic-sidecar.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1404,7 +1404,7 @@ jobs:
           source .venv/bin/activate && \
           pushd services/efs-guardian && \
           make test-ci-unit
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1487,7 +1487,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/postgres-database.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1535,7 +1535,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/invitations.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1583,7 +1583,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/service-integration.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1631,7 +1631,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/service-library.bash test_all
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1679,7 +1679,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/settings-library.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1726,7 +1726,7 @@ jobs:
         run: ./ci/github/unit-testing/models-library.bash typecheck
       - name: test
         run: ./ci/github/unit-testing/models-library.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1774,7 +1774,7 @@ jobs:
         run: ./ci/github/unit-testing/common-library.bash typecheck
       - name: test
         run: ./ci/github/unit-testing/common-library.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         with:
           flags: unittests #optional
 
@@ -1817,7 +1817,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/notifications-library.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1867,7 +1867,7 @@ jobs:
       - name: test
         if: ${{ !cancelled() }}
         run: ./ci/github/unit-testing/simcore-sdk.bash test
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1982,7 +1982,7 @@ jobs:
       - name: cleanup
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/webserver.bash clean_up
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2045,7 +2045,7 @@ jobs:
       - name: cleanup
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/webserver.bash clean_up
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2108,7 +2108,7 @@ jobs:
       - name: cleanup
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/director-v2.bash clean_up
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2180,7 +2180,7 @@ jobs:
       - name: cleanup
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/director-v2.bash clean_up
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2245,7 +2245,7 @@ jobs:
       - name: cleanup
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/dynamic-sidecar.bash clean_up
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -2308,7 +2308,7 @@ jobs:
       - name: cleanup
         if: ${{ !cancelled() }}
         run: ./ci/github/integration-testing/simcore-sdk.bash clean_up
-      - uses: codecov/codecov-action@v5.0.7
+      - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -128,13 +128,13 @@ rich==13.9.4
     # via
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.22.1
+rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
 shellingham==1.5.4
     # via typer
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 sortedcontainers==2.4.0
     # via distributed
@@ -147,9 +147,9 @@ toolz==1.0.0
     #   partd
 tornado==6.4.2
     # via distributed
-typer==0.15.0
+typer==0.15.1
     # via -r requirements/../../../packages/settings-library/requirements/_base.in
-types-python-dateutil==2.9.0.20241003
+types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
     # via

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -15,11 +15,11 @@ cloudpickle==3.1.0
     # via
     #   dask
     #   distributed
-dask==2024.11.2
+dask==2024.12.0
     # via
     #   -r requirements/_base.in
     #   distributed
-distributed==2024.11.2
+distributed==2024.12.0
     # via dask
 dnspython==2.7.0
     # via email-validator
@@ -76,7 +76,7 @@ partd==1.4.2
     # via dask
 psutil==6.1.0
     # via distributed
-pydantic==2.10.2
+pydantic==2.10.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -128,7 +128,7 @@ rich==13.9.4
     # via
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.21.0
+rpds-py==0.22.1
     # via
     #   jsonschema
     #   referencing
@@ -147,7 +147,7 @@ toolz==1.0.0
     #   partd
 tornado==6.4.2
     # via distributed
-typer==0.14.0
+typer==0.15.0
     # via -r requirements/../../../packages/settings-library/requirements/_base.in
 types-python-dateutil==2.9.0.20241003
     # via arrow

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -11,21 +11,21 @@ click==8.1.7
     #   dask
     #   distributed
     #   typer
-cloudpickle==3.0.0
+cloudpickle==3.1.0
     # via
     #   dask
     #   distributed
-dask==2024.9.0
+dask==2024.11.2
     # via
     #   -r requirements/_base.in
     #   distributed
-distributed==2024.9.0
+distributed==2024.11.2
     # via dask
-dnspython==2.6.1
+dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
     # via pydantic
-fsspec==2024.9.0
+fsspec==2024.10.0
     # via dask
 idna==3.10
     # via email-validator
@@ -42,7 +42,7 @@ jinja2==3.1.4
     #   distributed
 jsonschema==4.23.0
     # via -r requirements/../../../packages/models-library/requirements/_base.in
-jsonschema-specifications==2023.12.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
 locket==1.0.0
     # via
@@ -50,13 +50,13 @@ locket==1.0.0
     #   partd
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.1.0
     # via distributed
-orjson==3.10.7
+orjson==3.10.12
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -68,15 +68,15 @@ orjson==3.10.7
     #   -r requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-packaging==24.1
+packaging==24.2
     # via
     #   dask
     #   distributed
 partd==1.4.2
     # via dask
-psutil==6.0.0
+psutil==6.1.0
     # via distributed
-pydantic==2.10.3
+pydantic==2.10.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -94,7 +94,7 @@ pydantic==2.10.3
     #   pydantic-settings
 pydantic-core==2.27.1
     # via pydantic
-pydantic-extra-types==2.9.0
+pydantic-extra-types==2.10.0
     # via
     #   -r requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -124,11 +124,11 @@ referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-rich==13.8.1
+rich==13.9.4
     # via
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.20.0
+rpds-py==0.21.0
     # via
     #   jsonschema
     #   referencing
@@ -140,21 +140,22 @@ sortedcontainers==2.4.0
     # via distributed
 tblib==3.0.0
     # via distributed
-toolz==0.12.1
+toolz==1.0.0
     # via
     #   dask
     #   distributed
     #   partd
-tornado==6.4.1
+tornado==6.4.2
     # via distributed
-typer==0.12.5
+typer==0.14.0
     # via -r requirements/../../../packages/settings-library/requirements/_base.in
-types-python-dateutil==2.9.0.20240906
+types-python-dateutil==2.9.0.20241003
     # via arrow
 typing-extensions==4.12.2
     # via
     #   pydantic
     #   pydantic-core
+    #   pydantic-extra-types
     #   typer
 urllib3==2.2.3
     # via
@@ -167,5 +168,5 @@ urllib3==2.2.3
     #   distributed
 zict==3.0.0
     # via distributed
-zipp==3.20.2
+zipp==3.21.0
     # via importlib-metadata

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -59,7 +59,7 @@ pyyaml==6.0.2
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-six==1.16.0
+six==1.17.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -25,7 +25,7 @@ pluggy==1.5.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio

--- a/packages/dask-task-models-library/requirements/_test.txt
+++ b/packages/dask-task-models-library/requirements/_test.txt
@@ -1,26 +1,26 @@
-appdirs==1.4.4
-    # via pint
-coverage==7.6.1
+coverage==7.6.8
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-faker==29.0.0
+faker==33.1.0
     # via -r requirements/_test.in
 flexcache==0.3
     # via pint
-flexparser==0.3.1
+flexparser==0.4
     # via pint
 icdiff==2.0.7
     # via pytest-icdiff
 iniconfig==2.0.0
     # via pytest
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   pytest
     #   pytest-sugar
-pint==0.24.3
+pint==0.24.4
     # via -r requirements/_test.in
+platformdirs==4.3.6
+    # via pint
 pluggy==1.5.0
     # via pytest
 pprintpp==0.4.0
@@ -38,7 +38,7 @@ pytest-asyncio==0.23.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r requirements/_test.in
 pytest-icdiff==0.9
     # via -r requirements/_test.in
@@ -63,11 +63,12 @@ six==1.16.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil
-termcolor==2.4.0
+termcolor==2.5.0
     # via pytest-sugar
 typing-extensions==4.12.2
     # via
     #   -c requirements/_base.txt
+    #   faker
     #   flexcache
     #   flexparser
     #   pint

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -55,7 +55,7 @@ platformdirs==4.3.6
     #   virtualenv
 pre-commit==4.0.1
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.3.1
+pylint==3.3.2
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.2.0
     # via

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -67,7 +67,7 @@ pyyaml==6.0.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.8.1
+ruff==0.8.2
     # via -r requirements/../../../requirements/devenv.txt
 setuptools==75.6.0
     # via pip-tools

--- a/packages/dask-task-models-library/requirements/_tools.txt
+++ b/packages/dask-task-models-library/requirements/_tools.txt
@@ -1,8 +1,8 @@
-astroid==3.3.4
+astroid==3.3.5
     # via pylint
-black==24.8.0
+black==24.10.0
     # via -r requirements/../../../requirements/devenv.txt
-build==1.2.2
+build==1.2.2.post1
     # via pip-tools
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -13,13 +13,13 @@ click==8.1.7
     #   -c requirements/_base.txt
     #   black
     #   pip-tools
-dill==0.3.8
+dill==0.3.9
     # via pylint
-distlib==0.3.8
+distlib==0.3.9
     # via virtualenv
 filelock==3.16.1
     # via virtualenv
-identify==2.6.1
+identify==2.6.3
     # via pre-commit
 isort==5.13.2
     # via
@@ -27,7 +27,7 @@ isort==5.13.2
     #   pylint
 mccabe==0.7.0
     # via pylint
-mypy==1.12.0
+mypy==1.13.0
     # via -r requirements/../../../requirements/devenv.txt
 mypy-extensions==1.0.0
     # via
@@ -35,7 +35,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -43,20 +43,21 @@ packaging==24.1
     #   build
 pathspec==0.12.1
     # via black
-pip==24.2
+pip==24.3.1
     # via pip-tools
 pip-tools==7.4.1
     # via -r requirements/../../../requirements/devenv.txt
 platformdirs==4.3.6
     # via
+    #   -c requirements/_test.txt
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.8.0
+pre-commit==4.0.1
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.3.0
+pylint==3.3.1
     # via -r requirements/../../../requirements/devenv.txt
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
@@ -66,9 +67,9 @@ pyyaml==6.0.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.6.7
+ruff==0.8.1
     # via -r requirements/../../../requirements/devenv.txt
-setuptools==75.1.0
+setuptools==75.6.0
     # via pip-tools
 tomlkit==0.13.2
     # via pylint
@@ -77,7 +78,7 @@ typing-extensions==4.12.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.26.5
+virtualenv==20.28.0
     # via pre-commit
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools

--- a/packages/pytest-simcore/src/pytest_simcore/dask_scheduler.py
+++ b/packages/pytest-simcore/src/pytest_simcore/dask_scheduler.py
@@ -72,6 +72,7 @@ async def dask_spec_local_cluster(
         asynchronous=True,
         name="pytest_dask_spec_local_cluster",
     ) as cluster:
+        print("Cluster dashboard link: ", cluster.dashboard_link)
         scheduler_address = URL(cluster.scheduler_address)
         monkeypatch.setenv(
             "COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_URL",

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -332,6 +332,10 @@ opentelemetry-instrumentation-fastapi==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
+opentelemetry-instrumentation-logging==0.49b2
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-redis==0.49b2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -131,12 +131,12 @@ click==8.1.7
     #   distributed
     #   typer
     #   uvicorn
-cloudpickle==3.0.0
+cloudpickle==3.1.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-dask==2024.5.1
+dask==2024.11.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/_base.in
@@ -147,7 +147,7 @@ deprecated==1.2.14
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
-distributed==2024.5.1
+distributed==2024.11.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -170,7 +170,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.5.0
+fsspec==2024.10.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -220,7 +220,7 @@ idna==3.7
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==7.1.0
+importlib-metadata==8.5.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -272,7 +272,7 @@ locket==1.0.0
     #   partd
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   jinja2
@@ -286,7 +286,7 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.26.0
+opentelemetry-api==1.28.2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -303,19 +303,19 @@ opentelemetry-api==1.26.0
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.26.0
+opentelemetry-exporter-otlp==1.28.2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.26.0
+opentelemetry-exporter-otlp-proto-common==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.26.0
+opentelemetry-exporter-otlp-proto-grpc==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.26.0
+opentelemetry-exporter-otlp-proto-http==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.47b0
+opentelemetry-instrumentation==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-botocore
@@ -324,41 +324,38 @@ opentelemetry-instrumentation==0.47b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-asgi==0.47b0
+opentelemetry-instrumentation-asgi==0.49b2
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-botocore==0.47b0
+opentelemetry-instrumentation-botocore==0.49b2
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.47b0
+opentelemetry-instrumentation-fastapi==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.47b0
+opentelemetry-instrumentation-httpx==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-logging==0.47b0
+opentelemetry-instrumentation-redis==0.49b2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.47b0
-    # via
-    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.47b0
+opentelemetry-instrumentation-requests==0.49b2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.1
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.26.0
+opentelemetry-proto==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.26.0
+opentelemetry-sdk==1.28.2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.47b0
+opentelemetry-semantic-conventions==0.49b2
     # via
+    #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
@@ -366,7 +363,7 @@ opentelemetry-semantic-conventions==0.47b0
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.47b0
+opentelemetry-util-http==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -414,12 +411,13 @@ orjson==3.10.3
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/_base.in
     #   dask
     #   distributed
+    #   opentelemetry-instrumentation
 pamqp==3.3.0
     # via aiormq
 partd==1.4.2
@@ -432,11 +430,11 @@ prometheus-client==0.20.0
     #   prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-protobuf==4.25.4
+protobuf==5.29.0
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.0.0
+psutil==6.1.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -537,7 +535,7 @@ python-dateutil==2.9.0.post0
     #   botocore
 python-dotenv==1.0.1
     # via pydantic-settings
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -619,8 +617,6 @@ rpds-py==0.18.1
     #   referencing
 s3transfer==0.10.1
     # via boto3
-setuptools==74.0.0
-    # via opentelemetry-instrumentation
 sh==2.0.6
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 shellingham==1.5.4
@@ -670,7 +666,7 @@ tenacity==8.5.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-toolz==0.12.1
+toolz==1.0.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -678,7 +674,7 @@ toolz==0.12.1
     #   dask
     #   distributed
     #   partd
-tornado==6.4
+tornado==6.4.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
@@ -755,6 +751,7 @@ wrapt==1.16.0
     #   aiobotocore
     #   deprecated
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 yarl==1.9.4
     # via
@@ -767,7 +764,7 @@ zict==3.0.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-zipp==3.18.2
+zipp==3.21.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   importlib-metadata

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -136,7 +136,7 @@ cloudpickle==3.1.0
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-dask==2024.11.2
+dask==2024.12.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/_base.in
@@ -147,7 +147,7 @@ deprecated==1.2.14
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
-distributed==2024.11.2
+distributed==2024.12.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -147,7 +147,7 @@ lazy-object-proxy==1.10.0
     # via openapi-spec-validator
 lupa==2.2
     # via fakeredis
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   -c requirements/_base.txt
     #   jinja2
@@ -164,7 +164,7 @@ openapi-spec-validator==0.7.1
     # via moto
 orderly-set==5.2.2
     # via deepdiff
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   pytest
@@ -177,7 +177,7 @@ ply==3.11
     # via jsonpath-ng
 pprintpp==0.4.0
     # via pytest-icdiff
-psutil==6.0.0
+psutil==6.1.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -228,7 +228,7 @@ python-dotenv==1.0.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -273,9 +273,7 @@ s3transfer==0.10.1
     #   -c requirements/_base.txt
     #   boto3
 setuptools==74.0.0
-    # via
-    #   -c requirements/_base.txt
-    #   moto
+    # via moto
 six==1.16.0
     # via
     #   -c requirements/_base.txt

--- a/services/autoscaling/requirements/_tools.txt
+++ b/services/autoscaling/requirements/_tools.txt
@@ -36,7 +36,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -61,7 +61,7 @@ pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -72,7 +72,6 @@ ruff==0.6.7
     # via -r requirements/../../../requirements/devenv.txt
 setuptools==74.0.0
     # via
-    #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pip-tools
 tomlkit==0.13.2

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -134,7 +134,7 @@ cloudpickle==3.1.0
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-dask==2024.11.2
+dask==2024.12.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/_base.in
@@ -145,7 +145,7 @@ deprecated==1.2.14
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
-distributed==2024.11.2
+distributed==2024.12.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -129,12 +129,12 @@ click==8.1.7
     #   distributed
     #   typer
     #   uvicorn
-cloudpickle==3.0.0
+cloudpickle==3.1.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-dask==2024.5.1
+dask==2024.11.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/_base.in
@@ -145,7 +145,7 @@ deprecated==1.2.14
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
-distributed==2024.5.1
+distributed==2024.11.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -168,7 +168,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.5.0
+fsspec==2024.10.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -218,7 +218,7 @@ idna==3.7
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==7.1.0
+importlib-metadata==8.5.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -270,7 +270,7 @@ locket==1.0.0
     #   partd
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   jinja2
@@ -284,7 +284,7 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.26.0
+opentelemetry-api==1.28.2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -301,19 +301,19 @@ opentelemetry-api==1.26.0
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.26.0
+opentelemetry-exporter-otlp==1.28.2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.26.0
+opentelemetry-exporter-otlp-proto-common==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.26.0
+opentelemetry-exporter-otlp-proto-grpc==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.26.0
+opentelemetry-exporter-otlp-proto-http==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.47b0
+opentelemetry-instrumentation==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-botocore
@@ -322,41 +322,38 @@ opentelemetry-instrumentation==0.47b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-asgi==0.47b0
+opentelemetry-instrumentation-asgi==0.49b2
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-botocore==0.47b0
+opentelemetry-instrumentation-botocore==0.49b2
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.47b0
+opentelemetry-instrumentation-fastapi==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.47b0
+opentelemetry-instrumentation-httpx==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-logging==0.47b0
+opentelemetry-instrumentation-redis==0.49b2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.47b0
-    # via
-    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.47b0
+opentelemetry-instrumentation-requests==0.49b2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.1
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.26.0
+opentelemetry-proto==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.26.0
+opentelemetry-sdk==1.28.2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.47b0
+opentelemetry-semantic-conventions==0.49b2
     # via
+    #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
@@ -364,7 +361,7 @@ opentelemetry-semantic-conventions==0.47b0
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.47b0
+opentelemetry-util-http==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -412,12 +409,13 @@ orjson==3.10.3
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/_base.in
     #   dask
     #   distributed
+    #   opentelemetry-instrumentation
 pamqp==3.3.0
     # via aiormq
 partd==1.4.2
@@ -430,11 +428,11 @@ prometheus-client==0.20.0
     #   prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-protobuf==4.25.4
+protobuf==5.29.0
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.0.0
+psutil==6.1.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -535,7 +533,7 @@ python-dateutil==2.9.0.post0
     #   botocore
 python-dotenv==1.0.1
     # via pydantic-settings
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -617,8 +615,6 @@ rpds-py==0.18.1
     #   referencing
 s3transfer==0.10.1
     # via boto3
-setuptools==74.0.0
-    # via opentelemetry-instrumentation
 sh==2.0.6
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 shellingham==1.5.4
@@ -668,7 +664,7 @@ tenacity==8.5.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-toolz==0.12.1
+toolz==1.0.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -676,7 +672,7 @@ toolz==0.12.1
     #   dask
     #   distributed
     #   partd
-tornado==6.4
+tornado==6.4.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
@@ -753,6 +749,7 @@ wrapt==1.16.0
     #   aiobotocore
     #   deprecated
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 yarl==1.9.4
     # via
@@ -765,7 +762,7 @@ zict==3.0.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-zipp==3.18.2
+zipp==3.21.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   importlib-metadata

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -330,6 +330,10 @@ opentelemetry-instrumentation-fastapi==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
+opentelemetry-instrumentation-logging==0.49b2
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-redis==0.49b2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -163,7 +163,7 @@ lazy-object-proxy==1.10.0
     # via openapi-spec-validator
 lupa==2.2
     # via fakeredis
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   -c requirements/_base.txt
     #   jinja2
@@ -185,7 +185,7 @@ openapi-spec-validator==0.7.1
     # via moto
 orderly-set==5.2.2
     # via deepdiff
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   pytest
@@ -197,7 +197,7 @@ pluggy==1.5.0
     # via pytest
 ply==3.11
     # via jsonpath-ng
-psutil==6.0.0
+psutil==6.1.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -242,7 +242,7 @@ python-dotenv==1.0.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -287,9 +287,7 @@ s3transfer==0.10.1
     #   -c requirements/_base.txt
     #   boto3
 setuptools==74.0.0
-    # via
-    #   -c requirements/_base.txt
-    #   moto
+    # via moto
 six==1.16.0
     # via
     #   -c requirements/_base.txt

--- a/services/clusters-keeper/requirements/_tools.txt
+++ b/services/clusters-keeper/requirements/_tools.txt
@@ -36,7 +36,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -61,7 +61,7 @@ pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -72,7 +72,6 @@ ruff==0.6.7
     # via -r requirements/../../../requirements/devenv.txt
 setuptools==74.0.0
     # via
-    #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pip-tools
 tomlkit==0.13.2

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -16,7 +16,7 @@ aiofiles==24.1.0
     #   -r requirements/_base.in
 aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.11.9
+aiohttp==3.11.10
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -48,7 +48,7 @@ aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.7.0
     # via pydantic
-anyio==4.6.2.post1
+anyio==4.7.0
     # via
     #   fast-depends
     #   faststream
@@ -125,7 +125,7 @@ exceptiongroup==1.2.2
     # via aio-pika
 fast-depends==2.4.12
     # via faststream
-faststream==0.5.31
+faststream==0.5.33
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 frozenlist==1.5.0
     # via
@@ -233,6 +233,8 @@ opentelemetry-instrumentation==0.49b2
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+opentelemetry-instrumentation-logging==0.49b2
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-redis==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.49b2
@@ -307,7 +309,7 @@ propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
-protobuf==5.29.0
+protobuf==5.29.1
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
@@ -315,7 +317,7 @@ psutil==6.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   distributed
-pydantic==2.10.2
+pydantic==2.10.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -454,7 +456,7 @@ rich==13.9.4
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.22.1
+rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
@@ -462,7 +464,7 @@ s3fs==2024.10.0
     # via fsspec
 shellingham==1.5.4
     # via typer
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
     # via anyio
@@ -484,16 +486,17 @@ tornado==6.4.2
     #   distributed
 tqdm==4.67.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.15.0
+typer==0.15.1
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-types-python-dateutil==2.9.0.20241003
+types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
     # via
     #   aiodebug
+    #   anyio
     #   faststream
     #   opentelemetry-sdk
     #   pydantic

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -315,7 +315,7 @@ psutil==6.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   distributed
-pydantic==2.10.3
+pydantic==2.10.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -1,20 +1,22 @@
-aio-pika==9.4.1
+aio-pika==9.5.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiobotocore==2.13.0
+aiobotocore==2.15.2
     # via s3fs
-aiocache==0.12.2
+aiocache==0.12.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiodebug==2.3.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiodocker==0.21.0
+aiodocker==0.24.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiofiles==23.2.1
+aiofiles==24.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiohttp==3.9.5
+aiohappyeyeballs==2.4.3
+    # via aiohttp
+aiohttp==3.11.8
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -38,15 +40,15 @@ aiohttp==3.9.5
     #   aiodocker
     #   fsspec
     #   s3fs
-aioitertools==0.11.0
+aioitertools==0.12.0
     # via aiobotocore
-aiormq==6.8.0
+aiormq==6.8.1
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.7.0
     # via pydantic
-anyio==4.3.0
+anyio==4.6.2.post1
     # via
     #   fast-depends
     #   faststream
@@ -56,18 +58,18 @@ arrow==1.3.0
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
-blosc==1.11.1
+blosc==1.11.2
     # via -r requirements/_base.in
-bokeh==3.4.1
+bokeh==3.6.1
     # via dask
-botocore==1.34.106
+botocore==1.35.36
     # via aiobotocore
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -88,63 +90,66 @@ certifi==2024.7.4
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via
     #   dask
     #   distributed
     #   typer
-cloudpickle==3.0.0
+cloudpickle==3.1.0
     # via
     #   dask
     #   distributed
-contourpy==1.2.1
+contourpy==1.3.1
     # via bokeh
-dask==2024.5.1
+dask==2024.11.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
     #   -r requirements/_base.in
     #   distributed
-deprecated==1.2.14
+deprecated==1.2.15
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
-distributed==2024.5.1
-    # via dask
-dnspython==2.6.1
+distributed==2024.11.2
+    # via
+    #   dask
+dnspython==2.7.0
     # via email-validator
-email-validator==2.1.1
+email-validator==2.2.0
     # via pydantic
+exceptiongroup==1.2.2
+    # via aio-pika
 fast-depends==2.4.12
     # via faststream
 faststream==0.5.31
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.5.0
+fsspec==2024.10.0
     # via
     #   -r requirements/_base.in
     #   dask
     #   s3fs
-googleapis-common-protos==1.65.0
+googleapis-common-protos==1.66.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.66.0
+grpcio==1.68.0
     # via opentelemetry-exporter-otlp-proto-grpc
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   email-validator
     #   requests
     #   yarl
-importlib-metadata==7.1.0
+importlib-metadata==8.5.0
     # via
     #   dask
     #   opentelemetry-api
@@ -173,12 +178,12 @@ jinja2==3.1.4
     #   distributed
 jmespath==1.0.1
     # via botocore
-jsonschema==4.22.0
+jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
 locket==1.0.0
     # via
@@ -188,22 +193,22 @@ lz4==4.3.3
     # via -r requirements/_base.in
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.1.0
     # via distributed
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-numpy==1.26.4
+numpy==2.1.3
     # via
     #   bokeh
     #   contourpy
     #   pandas
-opentelemetry-api==1.26.0
+opentelemetry-api==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -214,45 +219,44 @@ opentelemetry-api==1.26.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.26.0
+opentelemetry-exporter-otlp==1.28.2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.26.0
+opentelemetry-exporter-otlp-proto-common==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.26.0
+opentelemetry-exporter-otlp-proto-grpc==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.26.0
+opentelemetry-exporter-otlp-proto-http==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.47b0
+opentelemetry-instrumentation==0.49b2
     # via
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-logging==0.47b0
+opentelemetry-instrumentation-redis==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.47b0
+opentelemetry-instrumentation-requests==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.47b0
-    # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.26.0
+opentelemetry-proto==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.26.0
+opentelemetry-sdk==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.47b0
+opentelemetry-semantic-conventions==0.49b2
     # via
+    #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.47b0
+opentelemetry-util-http==0.49b2
     # via opentelemetry-instrumentation-requests
-orjson==3.10.3
+orjson==3.10.12
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -284,26 +288,31 @@ orjson==3.10.3
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-packaging==24.0
+packaging==24.2
     # via
     #   bokeh
     #   dask
     #   distributed
+    #   opentelemetry-instrumentation
 pamqp==3.3.0
     # via aiormq
-pandas==2.2.2
+pandas==2.2.3
     # via bokeh
 partd==1.4.2
     # via dask
-pillow==10.3.0
+pillow==11.0.0
     # via bokeh
-prometheus-client==0.20.0
+prometheus-client==0.21.0
     # via -r requirements/_base.in
-protobuf==4.25.4
+propcache==0.2.0
+    # via
+    #   aiohttp
+    #   yarl
+protobuf==5.29.0
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.0.0
+psutil==6.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   distributed
@@ -350,7 +359,7 @@ pydantic==2.10.2
     #   pydantic-settings
 pydantic-core==2.27.1
     # via pydantic
-pydantic-extra-types==2.9.0
+pydantic-extra-types==2.10.0
     # via
     #   -r requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -374,7 +383,7 @@ pydantic-settings==2.6.1
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
 pygments==2.18.0
     # via rich
-pyinstrument==4.6.2
+pyinstrument==5.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via
@@ -383,9 +392,9 @@ python-dateutil==2.9.0.post0
     #   pandas
 python-dotenv==1.0.1
     # via pydantic-settings
-pytz==2024.1
+pytz==2024.2
     # via pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -409,7 +418,7 @@ pyyaml==6.0.1
     #   bokeh
     #   dask
     #   distributed
-redis==5.0.4
+redis==5.2.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -430,7 +439,7 @@ redis==5.0.4
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-referencing==0.29.3
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -440,20 +449,18 @@ repro-zipfile==0.3.1
     #   -r requirements/_base.in
 requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
-rich==13.7.1
+rich==13.9.4
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.18.1
+rpds-py==0.21.0
     # via
     #   jsonschema
     #   referencing
-s3fs==2024.5.0
+s3fs==2024.10.0
     # via fsspec
-setuptools==74.0.0
-    # via opentelemetry-instrumentation
 shellingham==1.5.4
     # via typer
 six==1.16.0
@@ -464,37 +471,37 @@ sortedcontainers==2.4.0
     # via distributed
 tblib==3.0.0
     # via distributed
-tenacity==8.5.0
+tenacity==9.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-toolz==0.12.1
+toolz==1.0.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
     #   partd
-tornado==6.4
+tornado==6.4.2
     # via
     #   bokeh
     #   distributed
-tqdm==4.66.4
+tqdm==4.67.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.12.3
+typer==0.14.0
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-types-python-dateutil==2.9.0.20240316
+types-python-dateutil==2.9.0.20241003
     # via arrow
 typing-extensions==4.12.2
     # via
     #   aiodebug
-    #   aiodocker
     #   faststream
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
+    #   pydantic-extra-types
     #   typer
-tzdata==2024.1
+tzdata==2024.2
     # via pandas
 urllib3==2.2.3
     # via
@@ -519,15 +526,15 @@ urllib3==2.2.3
     #   botocore
     #   distributed
     #   requests
-wrapt==1.16.0
+wrapt==1.17.0
     # via
     #   aiobotocore
     #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-redis
-xyzservices==2024.4.0
+xyzservices==2024.9.0
     # via bokeh
-yarl==1.9.4
+yarl==1.18.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aio-pika
@@ -535,5 +542,5 @@ yarl==1.9.4
     #   aiormq
 zict==3.0.0
     # via distributed
-zipp==3.18.2
+zipp==3.21.0
     # via importlib-metadata

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -1,4 +1,4 @@
-aio-pika==9.5.1
+aio-pika==9.5.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiobotocore==2.15.2
     # via s3fs
@@ -14,9 +14,9 @@ aiofiles==24.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.11.8
+aiohttp==3.11.9
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -65,7 +65,7 @@ attrs==24.2.0
     #   referencing
 blosc==1.11.2
     # via -r requirements/_base.in
-bokeh==3.6.1
+bokeh==3.6.2
     # via dask
 botocore==1.35.36
     # via aiobotocore
@@ -103,7 +103,7 @@ cloudpickle==3.1.0
     #   distributed
 contourpy==1.3.1
     # via bokeh
-dask==2024.11.2
+dask==2024.12.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
@@ -115,9 +115,8 @@ deprecated==1.2.15
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
-distributed==2024.11.2
-    # via
-    #   dask
+distributed==2024.12.0
+    # via dask
 dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
@@ -141,7 +140,7 @@ googleapis-common-protos==1.66.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.68.0
+grpcio==1.68.1
     # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.10
     # via
@@ -302,9 +301,9 @@ partd==1.4.2
     # via dask
 pillow==11.0.0
     # via bokeh
-prometheus-client==0.21.0
+prometheus-client==0.21.1
     # via -r requirements/_base.in
-propcache==0.2.0
+propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
@@ -316,7 +315,7 @@ psutil==6.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   distributed
-pydantic==2.10.2
+pydantic==2.10.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -455,7 +454,7 @@ rich==13.9.4
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.21.0
+rpds-py==0.22.1
     # via
     #   jsonschema
     #   referencing
@@ -485,7 +484,7 @@ tornado==6.4.2
     #   distributed
 tqdm==4.67.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.14.0
+typer==0.15.0
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
@@ -534,7 +533,7 @@ wrapt==1.17.0
     #   opentelemetry-instrumentation-redis
 xyzservices==2024.9.0
     # via bokeh
-yarl==1.18.0
+yarl==1.18.3
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aio-pika

--- a/services/dask-sidecar/requirements/_dask-distributed.txt
+++ b/services/dask-sidecar/requirements/_dask-distributed.txt
@@ -12,12 +12,12 @@ cloudpickle==3.1.0
     #   -c requirements/./_base.txt
     #   dask
     #   distributed
-dask==2024.11.2
+dask==2024.12.0
     # via
     #   -c requirements/./_base.txt
     #   -r requirements/_dask-distributed.in
     #   distributed
-distributed==2024.11.2
+distributed==2024.12.0
     # via
     #   -c requirements/./_base.txt
     #   dask

--- a/services/dask-sidecar/requirements/_dask-distributed.txt
+++ b/services/dask-sidecar/requirements/_dask-distributed.txt
@@ -1,4 +1,4 @@
-blosc==1.11.1
+blosc==1.11.2
     # via
     #   -c requirements/./_base.txt
     #   -r requirements/_dask-distributed.in
@@ -7,25 +7,25 @@ click==8.1.7
     #   -c requirements/./_base.txt
     #   dask
     #   distributed
-cloudpickle==3.0.0
+cloudpickle==3.1.0
     # via
     #   -c requirements/./_base.txt
     #   dask
     #   distributed
-dask==2024.5.1
+dask==2024.11.2
     # via
     #   -c requirements/./_base.txt
     #   -r requirements/_dask-distributed.in
     #   distributed
-distributed==2024.5.1
+distributed==2024.11.2
     # via
     #   -c requirements/./_base.txt
     #   dask
-fsspec==2024.5.0
+fsspec==2024.10.0
     # via
     #   -c requirements/./_base.txt
     #   dask
-importlib-metadata==7.1.0
+importlib-metadata==8.5.0
     # via
     #   -c requirements/./_base.txt
     #   dask
@@ -42,7 +42,7 @@ lz4==4.3.3
     # via
     #   -c requirements/./_base.txt
     #   -r requirements/_dask-distributed.in
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   -c requirements/./_base.txt
     #   jinja2
@@ -50,11 +50,11 @@ msgpack==1.1.0
     # via
     #   -c requirements/./_base.txt
     #   distributed
-numpy==1.26.4
+numpy==2.1.3
     # via
     #   -c requirements/./_base.txt
     #   -r requirements/_dask-distributed.in
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/./_base.txt
     #   dask
@@ -63,11 +63,11 @@ partd==1.4.2
     # via
     #   -c requirements/./_base.txt
     #   dask
-psutil==6.0.0
+psutil==6.1.0
     # via
     #   -c requirements/./_base.txt
     #   distributed
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/./_base.txt
     #   dask
@@ -80,13 +80,13 @@ tblib==3.0.0
     # via
     #   -c requirements/./_base.txt
     #   distributed
-toolz==0.12.1
+toolz==1.0.0
     # via
     #   -c requirements/./_base.txt
     #   dask
     #   distributed
     #   partd
-tornado==6.4
+tornado==6.4.2
     # via
     #   -c requirements/./_base.txt
     #   distributed
@@ -98,7 +98,7 @@ zict==3.0.0
     # via
     #   -c requirements/./_base.txt
     #   distributed
-zipp==3.18.2
+zipp==3.21.0
     # via
     #   -c requirements/./_base.txt
     #   importlib-metadata

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -4,38 +4,38 @@ annotated-types==0.7.0
     #   pydantic
 antlr4-python3-runtime==4.13.2
     # via moto
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-aws-sam-translator==1.89.0
+aws-sam-translator==1.94.0
     # via cfn-lint
 aws-xray-sdk==2.14.0
     # via moto
-blinker==1.8.2
+blinker==1.9.0
     # via flask
-boto3==1.34.106
+boto3==1.35.36
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.34.106
+botocore==1.35.36
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   requests
 cffi==1.17.1
     # via cryptography
-cfn-lint==1.10.3
+cfn-lint==1.20.1
     # via moto
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via
     #   -c requirements/_base.txt
     #   requests
@@ -43,11 +43,11 @@ click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   flask
-coverage==7.6.1
+coverage==7.6.8
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-cryptography==43.0.1
+cryptography==44.0.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   joserfc
@@ -57,19 +57,19 @@ docker==7.1.0
     # via
     #   -r requirements/_test.in
     #   moto
-faker==29.0.0
+faker==33.1.0
     # via -r requirements/_test.in
-flask==3.0.3
+flask==3.1.0
     # via
     #   flask-cors
     #   moto
 flask-cors==5.0.0
     # via moto
-graphql-core==3.2.4
+graphql-core==3.2.5
     # via moto
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.7
+idna==3.10
     # via
     #   -c requirements/_base.txt
     #   requests
@@ -94,47 +94,47 @@ jsondiff==2.2.1
     # via moto
 jsonpatch==1.33
     # via cfn-lint
-jsonpath-ng==1.6.1
+jsonpath-ng==1.7.0
     # via moto
 jsonpointer==3.0.0
     # via jsonpatch
-jsonschema==4.22.0
+jsonschema==4.23.0
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
+    #   jsonschema-spec
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.3
+jsonschema-spec==0.1.3
     # via openapi-spec-validator
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
-    #   openapi-schema-validator
 lazy-object-proxy==1.10.0
     # via openapi-spec-validator
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.0.15
+moto==5.0.21
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
-networkx==3.3
+networkx==3.4.2
     # via cfn-lint
-openapi-schema-validator==0.6.2
+openapi-schema-validator==0.4.3
     # via openapi-spec-validator
-openapi-spec-validator==0.7.1
+openapi-spec-validator==0.5.5
     # via moto
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   pytest
     #   pytest-sugar
 pathable==0.4.3
-    # via jsonschema-path
+    # via jsonschema-spec
 pluggy==1.5.0
     # via pytest
 ply==3.11
@@ -154,11 +154,11 @@ pydantic-core==2.27.1
     # via
     #   -c requirements/_base.txt
     #   pydantic
-pyftpdlib==2.0.0
+pyftpdlib==2.0.1
     # via pytest-localftpserver
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via pytest-localftpserver
-pyparsing==3.1.4
+pyparsing==3.2.0
     # via moto
 pytest==8.3.3
     # via
@@ -174,7 +174,7 @@ pytest-asyncio==0.23.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r requirements/_test.in
 pytest-icdiff==0.9
     # via -r requirements/_test.in
@@ -196,45 +196,41 @@ python-dotenv==1.0.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   cfn-lint
     #   jsondiff
-    #   jsonschema-path
+    #   jsonschema-spec
     #   moto
     #   responses
-referencing==0.29.3
+referencing==0.35.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
-    #   jsonschema-path
     #   jsonschema-specifications
-regex==2024.9.11
+regex==2024.11.6
     # via cfn-lint
 requests==2.32.3
     # via
     #   -c requirements/_base.txt
     #   docker
-    #   jsonschema-path
     #   moto
     #   responses
 responses==0.25.3
     # via moto
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.18.1
+rpds-py==0.21.0
     # via
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.2
+s3transfer==0.10.4
     # via boto3
-setuptools==74.0.0
-    # via
-    #   -c requirements/_base.txt
-    #   moto
+setuptools==75.6.0
+    # via moto
 six==1.16.0
     # via
     #   -c requirements/_base.txt
@@ -242,7 +238,7 @@ six==1.16.0
     #   rfc3339-validator
 sympy==1.13.3
     # via cfn-lint
-termcolor==2.4.0
+termcolor==2.5.0
     # via pytest-sugar
 types-aiofiles==24.1.0.20240626
     # via -r requirements/_test.in
@@ -251,6 +247,8 @@ typing-extensions==4.12.2
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   cfn-lint
+    #   faker
+    #   jsonschema-spec
     #   pydantic
     #   pydantic-core
 urllib3==2.2.3
@@ -261,13 +259,13 @@ urllib3==2.2.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.0.4
+werkzeug==3.1.3
     # via
     #   flask
     #   moto
-wrapt==1.16.0
+wrapt==1.17.0
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
-xmltodict==0.13.0
+xmltodict==0.14.2
     # via moto

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -145,7 +145,7 @@ py-partiql-parser==0.5.6
     # via moto
 pycparser==2.22
     # via cffi
-pydantic==2.10.3
+pydantic==2.10.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -145,7 +145,7 @@ py-partiql-parser==0.5.6
     # via moto
 pycparser==2.22
     # via cffi
-pydantic==2.10.2
+pydantic==2.10.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -222,7 +222,7 @@ responses==0.25.3
     # via moto
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.22.1
+rpds-py==0.22.3
     # via
     #   -c requirements/_base.txt
     #   jsonschema
@@ -231,7 +231,7 @@ s3transfer==0.10.4
     # via boto3
 setuptools==75.6.0
     # via moto
-six==1.16.0
+six==1.17.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -33,7 +33,7 @@ certifi==2024.8.30
     #   requests
 cffi==1.17.1
     # via cryptography
-cfn-lint==1.20.1
+cfn-lint==1.20.2
     # via moto
 charset-normalizer==3.4.0
     # via
@@ -88,7 +88,7 @@ jmespath==1.0.1
     #   -c requirements/_base.txt
     #   boto3
     #   botocore
-joserfc==1.0.0
+joserfc==1.0.1
     # via moto
 jsondiff==2.2.1
     # via moto
@@ -118,7 +118,7 @@ markupsafe==3.0.2
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.0.21
+moto==5.0.22
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
@@ -145,7 +145,7 @@ py-partiql-parser==0.5.6
     # via moto
 pycparser==2.22
     # via cffi
-pydantic==2.10.2
+pydantic==2.10.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -160,7 +160,7 @@ pyopenssl==24.3.0
     # via pytest-localftpserver
 pyparsing==3.2.0
     # via moto
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio
@@ -222,7 +222,7 @@ responses==0.25.3
     # via moto
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.21.0
+rpds-py==0.22.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -55,7 +55,7 @@ platformdirs==4.3.6
     #   virtualenv
 pre-commit==4.0.1
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.3.1
+pylint==3.3.2
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.2.0
     # via

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -68,7 +68,7 @@ pyyaml==6.0.2
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.8.1
+ruff==0.8.2
     # via -r requirements/../../../requirements/devenv.txt
 setuptools==75.6.0
     # via

--- a/services/dask-sidecar/requirements/_tools.txt
+++ b/services/dask-sidecar/requirements/_tools.txt
@@ -1,8 +1,8 @@
-astroid==3.3.4
+astroid==3.3.5
     # via pylint
-black==24.8.0
+black==24.10.0
     # via -r requirements/../../../requirements/devenv.txt
-build==1.2.2
+build==1.2.2.post1
     # via pip-tools
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -14,13 +14,13 @@ click==8.1.7
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-dill==0.3.8
+dill==0.3.9
     # via pylint
-distlib==0.3.8
+distlib==0.3.9
     # via virtualenv
 filelock==3.16.1
     # via virtualenv
-identify==2.6.1
+identify==2.6.3
     # via pre-commit
 isort==5.13.2
     # via
@@ -28,7 +28,7 @@ isort==5.13.2
     #   pylint
 mccabe==0.7.0
     # via pylint
-mypy==1.12.0
+mypy==1.13.0
     # via -r requirements/../../../requirements/devenv.txt
 mypy-extensions==1.0.0
     # via
@@ -36,7 +36,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -44,7 +44,7 @@ packaging==24.0
     #   build
 pathspec==0.12.1
     # via black
-pip==24.2
+pip==24.3.1
     # via pip-tools
 pip-tools==7.4.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -53,26 +53,25 @@ platformdirs==4.3.6
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.8.0
+pre-commit==4.0.1
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.3.0
+pylint==3.3.1
     # via -r requirements/../../../requirements/devenv.txt
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.6.7
+ruff==0.8.1
     # via -r requirements/../../../requirements/devenv.txt
-setuptools==74.0.0
+setuptools==75.6.0
     # via
-    #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pip-tools
 tomlkit==0.13.2
@@ -82,9 +81,9 @@ typing-extensions==4.12.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.26.5
+virtualenv==20.28.0
     # via pre-commit
-watchdog==5.0.2
+watchdog==6.0.0
     # via -r requirements/_tools.in
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -163,7 +163,7 @@ cloudpickle==3.1.0
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-dask==2024.11.2
+dask==2024.12.0
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
@@ -174,7 +174,7 @@ deprecated==1.2.14
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
-distributed==2024.11.2
+distributed==2024.12.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -448,6 +448,10 @@ opentelemetry-instrumentation-fastapi==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
+opentelemetry-instrumentation-logging==0.49b2
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-redis==0.49b2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -108,7 +108,7 @@ attrs==23.2.0
     #   referencing
 bidict==0.23.1
     # via python-socketio
-blosc==1.11.1
+blosc==1.11.2
     # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
 certifi==2024.2.2
     # via
@@ -158,12 +158,12 @@ click==8.1.7
     #   distributed
     #   typer
     #   uvicorn
-cloudpickle==3.0.0
+cloudpickle==3.1.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-dask==2024.5.1
+dask==2024.11.2
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
@@ -174,7 +174,7 @@ deprecated==1.2.14
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
-distributed==2024.5.1
+distributed==2024.11.2
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -205,7 +205,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.5.0
+fsspec==2024.10.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -272,7 +272,7 @@ idna==3.7
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==7.1.0
+importlib-metadata==8.5.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
@@ -373,7 +373,7 @@ mako==1.3.5
     #   alembic
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   jinja2
@@ -391,9 +391,9 @@ multidict==6.0.5
     #   yarl
 networkx==3.3
     # via -r requirements/_base.in
-numpy==1.26.4
+numpy==2.1.3
     # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
-opentelemetry-api==1.27.0
+opentelemetry-api==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -411,19 +411,19 @@ opentelemetry-api==1.27.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.27.0
+opentelemetry-exporter-otlp==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.27.0
+opentelemetry-exporter-otlp-proto-common==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.27.0
+opentelemetry-exporter-otlp-proto-grpc==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.27.0
+opentelemetry-exporter-otlp-proto-http==1.28.2
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.48b0
+opentelemetry-instrumentation==0.49b2
     # via
     #   opentelemetry-instrumentation-aiopg
     #   opentelemetry-instrumentation-asgi
@@ -434,45 +434,42 @@ opentelemetry-instrumentation==0.48b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aiopg==0.48b0
+opentelemetry-instrumentation-aiopg==0.49b2
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.48b0
+opentelemetry-instrumentation-asgi==0.49b2
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.48b0
+opentelemetry-instrumentation-asyncpg==0.49b2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-opentelemetry-instrumentation-dbapi==0.48b0
+opentelemetry-instrumentation-dbapi==0.49b2
     # via opentelemetry-instrumentation-aiopg
-opentelemetry-instrumentation-fastapi==0.48b0
+opentelemetry-instrumentation-fastapi==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.48b0
+opentelemetry-instrumentation-httpx==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-logging==0.48b0
+opentelemetry-instrumentation-redis==0.49b2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.48b0
+opentelemetry-instrumentation-requests==0.49b2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.48b0
-    # via
-    #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.27.0
+opentelemetry-proto==1.28.2
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.27.0
+opentelemetry-sdk==1.28.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.48b0
+opentelemetry-semantic-conventions==0.49b2
     # via
+    #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-dbapi
@@ -481,7 +478,7 @@ opentelemetry-semantic-conventions==0.48b0
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.48b0
+opentelemetry-util-http==0.49b2
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -549,12 +546,13 @@ orjson==3.10.3
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/_base.in
     #   fastapi
-packaging==24.0
+packaging==24.2
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
+    #   opentelemetry-instrumentation
 pamqp==3.3.0
     # via aiormq
 partd==1.4.2
@@ -569,11 +567,11 @@ prometheus-client==0.20.0
     #   prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-protobuf==4.25.4
+protobuf==5.29.0
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.0.0
+psutil==6.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -715,7 +713,7 @@ python-multipart==0.0.9
     # via fastapi
 python-socketio==5.11.2
     # via -r requirements/_base.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -821,8 +819,6 @@ rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
-setuptools==74.0.0
-    # via opentelemetry-instrumentation
 shellingham==1.5.4
     # via typer
 simple-websocket==1.0.0
@@ -924,7 +920,7 @@ tenacity==8.5.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-toolz==0.12.1
+toolz==1.0.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -932,7 +928,7 @@ toolz==0.12.1
     #   dask
     #   distributed
     #   partd
-tornado==6.4
+tornado==6.4.2
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
@@ -1059,6 +1055,7 @@ wrapt==1.16.0
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aiopg
     #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 wsproto==1.2.0
     # via simple-websocket
@@ -1075,7 +1072,7 @@ zict==3.0.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-zipp==3.18.2
+zipp==3.21.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   importlib-metadata

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -76,14 +76,12 @@ contourpy==1.3.0
     # via bokeh
 coverage==7.6.1
     # via pytest-cov
-
-dask==2024.11.2
+dask==2024.12.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   distributed
-
-distributed==2024.11.2
+distributed==2024.12.0
     # via
     #   -c requirements/_base.txt
     #   dask
@@ -296,7 +294,6 @@ tornado==6.4.2
     #   -c requirements/_base.txt
     #   bokeh
     #   distributed
-
 types-networkx==3.4.2.20241115
     # via -r requirements/_test.in
 types-psycopg2==2.9.21.20240819

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -67,7 +67,7 @@ click==8.1.7
     #   -c requirements/_base.txt
     #   dask
     #   distributed
-cloudpickle==3.0.0
+cloudpickle==3.1.0
     # via
     #   -c requirements/_base.txt
     #   dask
@@ -76,12 +76,14 @@ contourpy==1.3.0
     # via bokeh
 coverage==7.6.1
     # via pytest-cov
-dask==2024.5.1
+
+dask==2024.11.2
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   distributed
-distributed==2024.5.1
+
+distributed==2024.11.2
     # via
     #   -c requirements/_base.txt
     #   dask
@@ -98,7 +100,7 @@ frozenlist==1.4.1
     #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
-fsspec==2024.5.0
+fsspec==2024.10.0
     # via
     #   -c requirements/_base.txt
     #   dask
@@ -128,7 +130,7 @@ idna==3.7
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==7.1.0
+importlib-metadata==8.5.0
     # via
     #   -c requirements/_base.txt
     #   dask
@@ -155,7 +157,7 @@ mako==1.3.5
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   alembic
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via
     #   -c requirements/_base.txt
     #   jinja2
@@ -174,14 +176,14 @@ mypy==1.12.0
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
-numpy==1.26.4
+numpy==2.1.3
     # via
     #   -c requirements/_base.txt
     #   bokeh
     #   contourpy
     #   pandas
     #   types-networkx
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   bokeh
@@ -204,7 +206,7 @@ pluggy==1.5.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
-psutil==6.0.0
+psutil==6.1.0
     # via
     #   -c requirements/_base.txt
     #   distributed
@@ -241,7 +243,7 @@ python-dateutil==2.9.0.post0
     #   pandas
 pytz==2024.2
     # via pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -283,18 +285,19 @@ tblib==3.0.0
     # via
     #   -c requirements/_base.txt
     #   distributed
-toolz==0.12.1
+toolz==1.0.0
     # via
     #   -c requirements/_base.txt
     #   dask
     #   distributed
     #   partd
-tornado==6.4
+tornado==6.4.2
     # via
     #   -c requirements/_base.txt
     #   bokeh
     #   distributed
-types-networkx==3.2.1.20240918
+
+types-networkx==3.4.2.20241115
     # via -r requirements/_test.in
 types-psycopg2==2.9.21.20240819
     # via -r requirements/_test.in
@@ -332,7 +335,7 @@ zict==3.0.0
     # via
     #   -c requirements/_base.txt
     #   distributed
-zipp==3.18.2
+zipp==3.21.0
     # via
     #   -c requirements/_base.txt
     #   importlib-metadata

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -39,7 +39,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.0
+packaging==24.2
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
@@ -64,7 +64,7 @@ pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -74,9 +74,7 @@ pyyaml==6.0.1
 ruff==0.6.7
     # via -r requirements/../../../requirements/devenv.txt
 setuptools==74.0.0
-    # via
-    #   -c requirements/_base.txt
-    #   pip-tools
+    # via pip-tools
 tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass, field
 from http.client import HTTPException
-from typing import Any, cast
+from typing import Any, Final, cast
 
 import dask.typing
 import distributed
@@ -99,7 +99,7 @@ _DASK_TASK_STATUS_DASK_CLIENT_TASK_STATE_MAP: dict[
 }
 
 
-_DASK_DEFAULT_TIMEOUT_S = 1
+_DASK_DEFAULT_TIMEOUT_S: Final[int] = 1
 
 
 _UserCallbackInSepThread = Callable[[], None]
@@ -451,9 +451,9 @@ class DaskClient:
             )
             if dask_status == "erred":
                 # find out if this was a cancellation
-                exception = await distributed.Future(job_id).exception(
-                    timeout=_DASK_DEFAULT_TIMEOUT_S
-                )
+                exception = await distributed.Future(
+                    job_id, client=self.backend.client
+                ).exception(timeout=_DASK_DEFAULT_TIMEOUT_S)
                 assert isinstance(exception, Exception)  # nosec
 
                 if isinstance(exception, TaskCancelledError):

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -535,6 +535,7 @@ class DaskClient:
             await dask_utils.wrap_client_async_routine(
                 self.backend.client.unpublish_dataset(name=job_id)
             )
+            distributed.Variable(job_id, client=self.backend.client).delete()
         except KeyError:
             _logger.warning("Unknown task cannot be unpublished: %s", f"{job_id=}")
 

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -613,7 +613,9 @@ async def test_computation_task_is_persisted_on_dask_scheduler(
     )
     assert published_computation_task[0].node_id in image_params.fake_tasks
     # creating a new future shows that it is not done????
-    assert not distributed.Future(published_computation_task[0].job_id).done()
+    assert not distributed.Future(
+        published_computation_task[0].job_id, client=dask_client.backend.client
+    ).done()
 
     # as the task is published on the dask-scheduler when sending, it shall still be published on the dask scheduler
     list_of_persisted_datasets = await dask_client.backend.client.list_datasets()  # type: ignore
@@ -636,7 +638,9 @@ async def test_computation_task_is_persisted_on_dask_scheduler(
     assert isinstance(task_result, TaskOutputData)
     assert task_result.get("some_output_key") == 123
     # try to create another future and this one is already done
-    assert distributed.Future(published_computation_task[0].job_id).done()
+    assert distributed.Future(
+        published_computation_task[0].job_id, client=dask_client.backend.client
+    ).done()
 
 
 async def test_abort_computation_tasks(
@@ -1022,7 +1026,9 @@ async def test_get_tasks_status(
 
     assert published_computation_task[0].node_id in cpu_image.fake_tasks
     # let's get a dask future for the task here so dask will not remove the task from the scheduler at the end
-    computation_future = distributed.Future(key=published_computation_task[0].job_id)
+    computation_future = distributed.Future(
+        key=published_computation_task[0].job_id, client=dask_client.backend.client
+    )
     assert computation_future
 
     await _assert_wait_for_task_status(

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -9,7 +9,6 @@ import functools
 import traceback
 from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
 from dataclasses import dataclass
-from inspect import isawaitable
 from typing import Any, NoReturn, cast
 from unittest import mock
 from uuid import uuid4


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- Upgrade dask-models-library (full-upgrade)
- Upgrade dask-sidecar (full upgrade)
- Upgrade director-v2 (sync upgrade - dask)
- Upgrade autoscaling (sync upgrade - dask)
- Upgrade clusters-keeper (sync upgrade - dask)

## Bonus
- fixed codecov upload of reports, also for integration tests

### highlights of dask upgrades:
- new dask version: 2024.12.0
- since 2024.7.0: Pub/Sub mechanism is deprecated [https://docs.dask.org/en/stable/changelog.html#publish-subscribe-apis-deprecated](https://docs.dask.org/en/stable/changelog.html#publish-subscribe-apis-deprecated) -> this is annoying and will need replacements
- [Dask changelog](https://docs.dask.org/en/stable/changelog.html#changelog)

## Important for release (⚠️ devops)
- whenever the dask library changes it is important that all dask-related services are in sync,
- client/scheduler/workers - python versions, dask versions, serialization library dependencies versions
--> **any private cluster must be stopped prior to deploying!!!!**

###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 129
- #packages after ~ 132

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.4.1           | 9.5.3      | *minor*    | 1 | dask-sidecar⬆️ |
|   2 | aiobotocore               | 2.13.0          | 2.15.2     | *minor*    | 1 | dask-sidecar⬆️ |
|   3 | aiocache                  | 0.12.2          | 0.12.3     |            | 1 | dask-sidecar⬆️ |
|   4 | aiodocker                 | 0.21.0          | 0.24.0     | *minor*    | 1 | dask-sidecar⬆️ |
|   5 | aiofiles                  | 23.2.1          | 24.1.0     | **MAJOR**  | 1 | dask-sidecar⬆️ |
|   6 | aiohttp                   | 3.9.5           | 3.11.10    | *minor*    | 1 | dask-sidecar⬆️ |
|   7 | aioitertools              | 0.11.0          | 0.12.0     | *minor*    | 1 | dask-sidecar⬆️ |
|   8 | aiormq                    | 6.8.0           | 6.8.1      |            | 1 | dask-sidecar⬆️ |
|   9 | anyio                     | 4.3.0           | 4.7.0      | *minor*    | 1 | dask-sidecar⬆️ |
|  10 | appdirs                   | 1.4.4           | 🗑️ removed |  | 1 | dask-task-models-library🧪 |
|  11 | astroid                   | 3.3.4           | 3.3.5      |            | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
|  12 | attrs                     | 23.2.0          | 24.2.0     | **MAJOR**  | 2 | dask-sidecar⬆️🧪 |
|  13 | aws-sam-translator        | 1.89.0          | 1.94.0     | *minor*    | 1 | dask-sidecar🧪 |
|  14 | black                     | 24.8.0          | 24.10.0    | *minor*    | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
|  15 | blinker                   | 1.8.2           | 1.9.0      | *minor*    | 1 | dask-sidecar🧪 |
|  16 | blosc                     | 1.11.1          | 1.11.2     |            | 3 | dask-sidecar⬆️⬆️</br>director-v2⬆️ |
|  17 | bokeh                     | 3.4.1           | 3.6.2      | *minor*    | 1 | dask-sidecar⬆️ |
|  18 | boto3                     | 1.34.106        | 1.35.36    | *minor*    | 1 | dask-sidecar🧪 |
|  19 | botocore                  | 1.34.106        | 1.35.36    | *minor*    | 2 | dask-sidecar⬆️🧪 |
|  20 | build                     | 1.2.2           | 1.2.2.post1 |            | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
|  21 | certifi                   | 2024.7.4        | 2024.8.30  | *minor*    | 2 | dask-sidecar⬆️🧪 |
|  22 | cfn-lint                  | 1.10.3          | 1.20.2     | *minor*    | 1 | dask-sidecar🧪 |
|  23 | charset-normalizer        | 3.3.2           | 3.4.0      | *minor*    | 2 | dask-sidecar⬆️🧪 |
|  24 | cloudpickle               | 3.0.0           | 3.1.0      | *minor*    | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪 |
|  25 | contourpy                 | 1.2.1           | 1.3.1      | *minor*    | 1 | dask-sidecar⬆️ |
|  26 | coverage                  | 7.6.1           | 7.6.8      |            | 2 | dask-sidecar🧪</br>dask-task-models-library🧪 |
|  27 | cryptography              | 43.0.1          | 44.0.0     | **MAJOR**  | 1 | dask-sidecar🧪 |
|  28 | dask                      | 2024.5.1, 2024.9.0 | 2024.12.0  | *minor*    | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪 |
|  29 | deprecated                | 1.2.14          | 1.2.15     |            | 1 | dask-sidecar⬆️ |
|  30 | dill                      | 0.3.8           | 0.3.9      |            | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
|  31 | distlib                   | 0.3.8           | 0.3.9      |            | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
|  32 | distributed               | 2024.5.1, 2024.9.0 | 2024.12.0  | *minor*    | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪 |
|  33 | dnspython                 | 2.6.1           | 2.7.0      | *minor*    | 2 | dask-sidecar⬆️</br>dask-task-models-library🧪 |
|  34 | email-validator           | 2.1.1           | 2.2.0      | *minor*    | 1 | dask-sidecar⬆️ |
|  35 | faker                     | 29.0.0          | 33.1.0     | **MAJOR**  | 2 | dask-sidecar🧪</br>dask-task-models-library🧪 |
|  36 | faststream                | 0.5.31          | 0.5.33     |            | 1 | dask-sidecar⬆️ |
|  37 | flask                     | 3.0.3           | 3.1.0      | *minor*    | 1 | dask-sidecar🧪 |
|  38 | flexparser                | 0.3.1           | 0.4        | *minor*    | 1 | dask-task-models-library🧪 |
|  39 | frozenlist                | 1.4.1           | 1.5.0      | *minor*    | 1 | dask-sidecar⬆️ |
|  40 | fsspec                    | 2024.5.0, 2024.9.0 | 2024.10.0  | *minor*    | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪 |
|  41 | googleapis-common-protos  | 1.65.0          | 1.66.0     | *minor*    | 1 | dask-sidecar⬆️ |
|  42 | graphql-core              | 3.2.4           | 3.2.5      |            | 1 | dask-sidecar🧪 |
|  43 | grpcio                    | 1.66.0          | 1.68.1     | *minor*    | 1 | dask-sidecar⬆️ |
|  44 | identify                  | 2.6.1           | 2.6.3      |            | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
|  45 | idna                      | 3.7             | 3.10       | *minor*    | 2 | dask-sidecar⬆️🧪 |
|  46 | importlib-metadata        | 7.1.0           | 8.5.0      | **MAJOR**  | 6 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>director-v2⬆️🧪 |
|  47 | joserfc                   | 1.0.0           | 1.0.1      |            | 1 | dask-sidecar🧪 |
|  48 | jsonpath-ng               | 1.6.1           | 1.7.0      | *minor*    | 1 | dask-sidecar🧪 |
|  49 | jsonschema                | 4.22.0          | 4.23.0     | *minor*    | 2 | dask-sidecar⬆️🧪 |
|  50 | jsonschema-path           | 0.3.3           | 🗑️ removed |  | 1 | dask-sidecar🧪 |
|  51 | jsonschema-specifications | 2023.12.1, 2023.7.1 | 2024.10.1  | **MAJOR**  | 3 | dask-sidecar⬆️🧪</br>dask-task-models-library🧪 |
|  52 | markupsafe                | 2.1.5           | 3.0.2      | **MAJOR**  | 10 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️⬆️🧪</br>dask-task-models-library🧪</br>director-v2⬆️🧪 |
|  53 | moto                      | 5.0.15          | 5.0.22     |            | 1 | dask-sidecar🧪 |
|  54 | multidict                 | 6.0.5           | 6.1.0      | *minor*    | 1 | dask-sidecar⬆️ |
|  55 | mypy                      | 1.12.0          | 1.13.0     | *minor*    | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
|  56 | networkx                  | 3.3             | 3.4.2      | *minor*    | 1 | dask-sidecar🧪 |
|  57 | numpy                     | 1.26.4          | 2.1.3      | **MAJOR**  | 4 | dask-sidecar⬆️⬆️</br>director-v2⬆️🧪 |
|  58 | openapi-schema-validator  | 0.6.2           | 0.4.3      | 🔥 downgrade | 1 | dask-sidecar🧪 |
|  59 | openapi-spec-validator    | 0.7.1           | 0.5.5      | 🔥 downgrade | 1 | dask-sidecar🧪 |
|  60 | opentelemetry-api         | 1.27.0, 1.26.0  | 1.28.2     | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  61 | opentelemetry-exporter-otlp | 1.27.0, 1.26.0  | 1.28.2     | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  62 | opentelemetry-exporter-otlp-proto-common | 1.27.0, 1.26.0  | 1.28.2     | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  63 | opentelemetry-exporter-otlp-proto-grpc | 1.27.0, 1.26.0  | 1.28.2     | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  64 | opentelemetry-exporter-otlp-proto-http | 1.27.0, 1.26.0  | 1.28.2     | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  65 | opentelemetry-instrumentation | 0.48, 0.47      | 0.49       | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  66 | opentelemetry-instrumentation-aiopg | 0.48            | 0.49       | *minor*    | 1 | director-v2⬆️ |
|  67 | opentelemetry-instrumentation-asgi | 0.48, 0.47      | 0.49       | *minor*    | 3 | autoscaling⬆️</br>clusters-keeper⬆️</br>director-v2⬆️ |
|  68 | opentelemetry-instrumentation-asyncpg | 0.48            | 0.49       | *minor*    | 1 | director-v2⬆️ |
|  69 | opentelemetry-instrumentation-botocore | 0.47            | 0.49       | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  70 | opentelemetry-instrumentation-dbapi | 0.48            | 0.49       | *minor*    | 1 | director-v2⬆️ |
|  71 | opentelemetry-instrumentation-fastapi | 0.48, 0.47      | 0.49       | *minor*    | 3 | autoscaling⬆️</br>clusters-keeper⬆️</br>director-v2⬆️ |
|  72 | opentelemetry-instrumentation-httpx | 0.48, 0.47      | 0.49       | *minor*    | 3 | autoscaling⬆️</br>clusters-keeper⬆️</br>director-v2⬆️ |
|  73 | opentelemetry-instrumentation-logging | 0.48, 0.47      | 0.49       | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  74 | opentelemetry-instrumentation-redis | 0.48, 0.47      | 0.49       | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  75 | opentelemetry-instrumentation-requests | 0.48, 0.47      | 0.49       | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  76 | opentelemetry-proto       | 1.27.0, 1.26.0  | 1.28.2     | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  77 | opentelemetry-sdk         | 1.27.0, 1.26.0  | 1.28.2     | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  78 | opentelemetry-semantic-conventions | 0.48, 0.47      | 0.49       | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  79 | opentelemetry-util-http   | 0.48, 0.47      | 0.49       | *minor*    | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  80 | orjson                    | 3.10.7, 3.10.3  | 3.10.12    |            | 2 | dask-sidecar⬆️</br>dask-task-models-library🧪 |
|  81 | packaging                 | 24.0, 24.1      | 24.2       | *minor*    | 16 | autoscaling⬆️🧪🔧</br>clusters-keeper⬆️🧪🔧</br>dask-sidecar⬆️⬆️🧪🔧</br>dask-task-models-library🧪🧪🔧</br>director-v2⬆️🧪🔧 |
|  82 | pandas                    | 2.2.2           | 2.2.3      |            | 1 | dask-sidecar⬆️ |
|  83 | pillow                    | 10.3.0          | 11.0.0     | **MAJOR**  | 1 | dask-sidecar⬆️ |
|  84 | pint                      | 0.24.3          | 0.24.4     |            | 1 | dask-task-models-library🧪 |
|  85 | pip                       | 24.2            | 24.3.1     | *minor*    | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
|  86 | pre-commit                | 3.8.0           | 4.0.1      | **MAJOR**  | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
|  87 | prometheus-client         | 0.20.0          | 0.21.1     | *minor*    | 1 | dask-sidecar⬆️ |
|  88 | protobuf                  | 4.25.4          | 5.29.0,5.29.1 | **MAJOR**  | 4 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2⬆️ |
|  89 | psutil                    | 6.0.0           | 6.1.0      | *minor*    | 9 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪 |
|  90 | pydantic                  | 2.10.2          | 2.10.3     |            | 2 | dask-sidecar⬆️🧪 |
|  91 | pydantic-extra-types      | 2.9.0           | 2.10.0     | *minor*    | 2 | dask-sidecar⬆️</br>dask-task-models-library🧪 |
|  92 | pyftpdlib                 | 2.0.0           | 2.0.1      |            | 1 | dask-sidecar🧪 |
|  93 | pyinstrument              | 4.6.2           | 5.0.0      | **MAJOR**  | 1 | dask-sidecar⬆️ |
|  94 | pylint                    | 3.3.0           | 3.3.2      |            | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
|  95 | pyopenssl                 | 24.2.1          | 24.3.0     | *minor*    | 1 | dask-sidecar🧪 |
|  96 | pyparsing                 | 3.1.4           | 3.2.0      | *minor*    | 1 | dask-sidecar🧪 |
|  97 | pyproject-hooks           | 1.1.0           | 1.2.0      | *minor*    | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
|  98 | pytest                    | 8.3.3           | 8.3.4      |            | 2 | dask-sidecar🧪</br>dask-task-models-library🧪 |
|  99 | pytest-cov                | 5.0.0           | 6.0.0      | **MAJOR**  | 2 | dask-sidecar🧪</br>dask-task-models-library🧪 |
| 100 | pytz                      | 2024.1          | 2024.2     | *minor*    | 1 | dask-sidecar⬆️ |
| 101 | pyyaml                    | 6.0.1           | 6.0.2      |            | 13 | autoscaling⬆️🧪🔧</br>clusters-keeper⬆️🧪🔧</br>dask-sidecar⬆️⬆️🧪🔧</br>director-v2⬆️🧪🔧 |
| 102 | redis                     | 5.0.4           | 5.2.0      | *minor*    | 1 | dask-sidecar⬆️ |
| 103 | referencing               | 0.29.3          | 0.35.1     | *minor*    | 2 | dask-sidecar⬆️🧪 |
| 104 | regex                     | 2024.9.11       | 2024.11.6  | *minor*    | 1 | dask-sidecar🧪 |
| 105 | rich                      | 13.8.1, 13.7.1  | 13.9.4     | *minor*    | 2 | dask-sidecar⬆️</br>dask-task-models-library🧪 |
| 106 | rpds-py                   | 0.18.1, 0.20.0  | 0.22.3     | *minor*    | 3 | dask-sidecar⬆️🧪</br>dask-task-models-library🧪 |
| 107 | ruff                      | 0.6.7           | 0.8.2      | *minor*    | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
| 108 | s3fs                      | 2024.5.0        | 2024.10.0  | *minor*    | 1 | dask-sidecar⬆️ |
| 109 | s3transfer                | 0.10.2          | 0.10.4     |            | 1 | dask-sidecar🧪 |
| 110 | setuptools                | 75.1.0, 74.0.0  | 75.6.0     | *minor*    | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️🧪🔧</br>dask-task-models-library🔧</br>director-v2⬆️ |
| 111 | six                       | 1.16.0          | 1.17.0     | *minor*    | 4 | dask-sidecar⬆️🧪</br>dask-task-models-library🧪🧪 |
| 112 | tenacity                  | 8.5.0           | 9.0.0      | **MAJOR**  | 1 | dask-sidecar⬆️ |
| 113 | termcolor                 | 2.4.0           | 2.5.0      | *minor*    | 2 | dask-sidecar🧪</br>dask-task-models-library🧪 |
| 114 | toolz                     | 0.12.1          | 1.0.0      | **MAJOR**  | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪 |
| 115 | tornado                   | 6.4, 6.4.1      | 6.4.2      |            | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪 |
| 116 | tqdm                      | 4.66.4          | 4.67.1     | *minor*    | 1 | dask-sidecar⬆️ |
| 117 | typer                     | 0.12.3, 0.12.5  | 0.15.1     | *minor*    | 2 | dask-sidecar⬆️</br>dask-task-models-library🧪 |
| 118 | types-networkx            | 3.2.1.20240918  | 3.4.2.20241115 | *minor*    | 1 | director-v2🧪 |
| 119 | types-python-dateutil     | 2.9.0.20240316, 2.9.0.20240906 | 2.9.0.20241206 |            | 2 | dask-sidecar⬆️</br>dask-task-models-library🧪 |
| 120 | tzdata                    | 2024.1          | 2024.2     | *minor*    | 1 | dask-sidecar⬆️ |
| 121 | virtualenv                | 20.26.5         | 20.28.0    | *minor*    | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
| 122 | watchdog                  | 5.0.2           | 6.0.0      | **MAJOR**  | 1 | dask-sidecar🔧 |
| 123 | werkzeug                  | 3.0.4           | 3.1.3      | *minor*    | 1 | dask-sidecar🧪 |
| 124 | wheel                     | 0.44.0          | 0.45.1     | *minor*    | 2 | dask-sidecar🔧</br>dask-task-models-library🔧 |
| 125 | wrapt                     | 1.16.0          | 1.17.0     | *minor*    | 2 | dask-sidecar⬆️🧪 |
| 126 | xmltodict                 | 0.13.0          | 0.14.2     | *minor*    | 1 | dask-sidecar🧪 |
| 127 | xyzservices               | 2024.4.0        | 2024.9.0   | *minor*    | 1 | dask-sidecar⬆️ |
| 128 | yarl                      | 1.9.4           | 1.18.3     | *minor*    | 1 | dask-sidecar⬆️ |
| 129 | zipp                      | 3.20.2, 3.18.2  | 3.21.0     | *minor*    | 7 | autoscaling⬆️</br>clusters-keeper⬆️</br>dask-sidecar⬆️⬆️</br>dask-task-models-library🧪</br>director-v2⬆️🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency