### PR TITLE
⬆️Full upgrade autoscaling/clusters-keeper

### DIFF
--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -1,12 +1,12 @@
-aio-pika==9.4.1
+aio-pika==9.5.3
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==13.1.0
+aioboto3==13.2.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-aiobotocore==2.13.1
+aiobotocore==2.15.2
     # via aioboto3
-aiocache==0.12.2
+aiocache==0.12.3
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/_base.in
@@ -16,17 +16,19 @@ aiodebug==2.3.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiodocker==0.21.0
+aiodocker==0.24.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiofiles==23.2.1
+aiofiles==24.1.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aioboto3
-aiohttp==3.9.5
+aiohappyeyeballs==2.4.4
+    # via aiohttp
+aiohttp==3.11.10
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -54,15 +56,15 @@ aiohttp==3.9.5
     #   -c requirements/../../../requirements/constraints.txt
     #   aiobotocore
     #   aiodocker
-aioitertools==0.11.0
+aioitertools==0.12.0
     # via aiobotocore
-aiormq==6.8.0
+aiormq==6.8.1
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.7.0
     # via pydantic
-anyio==4.3.0
+anyio==4.7.0
     # via
     #   fast-depends
     #   faststream
@@ -79,21 +81,21 @@ arrow==1.3.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.34.131
+boto3==1.35.36
     # via aiobotocore
-botocore==1.34.131
+botocore==1.35.36
     # via
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.34.94
+botocore-stubs==1.35.76
     # via types-aiobotocore
-certifi==2024.2.2
+certifi==2024.8.30
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -122,7 +124,7 @@ certifi==2024.2.2
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via
@@ -141,7 +143,7 @@ dask==2024.12.0
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/_base.in
     #   distributed
-deprecated==1.2.14
+deprecated==1.2.15
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -151,22 +153,23 @@ distributed==2024.12.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-dnspython==2.6.1
+dnspython==2.7.0
     # via email-validator
-email-validator==2.1.1
+email-validator==2.2.0
     # via pydantic
+exceptiongroup==1.2.2
+    # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.5
+fastapi==0.115.6
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-    #   prometheus-fastapi-instrumentator
-faststream==0.5.31
+faststream==0.5.33
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
@@ -174,19 +177,19 @@ fsspec==2024.10.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-googleapis-common-protos==1.65.0
+googleapis-common-protos==1.66.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.66.0
+grpcio==1.68.1
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.28.0
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -213,7 +216,7 @@ httpx==0.27.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   email-validator
@@ -257,13 +260,13 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.22.0
+jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
 locket==1.0.0
     # via
@@ -282,7 +285,7 @@ msgpack==1.1.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
@@ -344,7 +347,7 @@ opentelemetry-instrumentation-requests==0.49b2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-propagator-aws-xray==1.0.1
+opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
 opentelemetry-proto==1.28.2
     # via
@@ -373,7 +376,7 @@ opentelemetry-util-http==0.49b2
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
-orjson==3.10.3
+orjson==3.10.12
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -428,13 +431,17 @@ partd==1.4.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-prometheus-client==0.20.0
+prometheus-client==0.21.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   prometheus-fastapi-instrumentator
-prometheus-fastapi-instrumentator==6.1.0
+prometheus-fastapi-instrumentator==7.0.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-protobuf==5.29.0
+propcache==0.2.1
+    # via
+    #   aiohttp
+    #   yarl
+protobuf==5.29.1
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
@@ -444,7 +451,7 @@ psutil==6.1.0
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   distributed
-pydantic==2.10.2
+pydantic==2.10.3
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -499,7 +506,7 @@ pydantic==2.10.2
     #   pydantic-settings
 pydantic-core==2.27.1
     # via pydantic
-pydantic-extra-types==2.9.0
+pydantic-extra-types==2.10.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -529,7 +536,7 @@ pydantic-settings==2.6.1
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
 pygments==2.18.0
     # via rich
-pyinstrument==4.6.2
+pyinstrument==5.0.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -570,7 +577,7 @@ pyyaml==6.0.2
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
-redis==5.0.4
+redis==5.2.1
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -598,7 +605,7 @@ redis==5.0.4
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-referencing==0.29.3
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -608,34 +615,32 @@ repro-zipfile==0.3.1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
-rich==13.7.1
+rich==13.9.4
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.18.1
+rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.1
+s3transfer==0.10.4
     # via boto3
-sh==2.0.6
+sh==2.1.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 shellingham==1.5.4
     # via typer
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 sortedcontainers==2.4.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-starlette==0.41.2
+starlette==0.41.3
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -662,11 +667,12 @@ starlette==0.41.2
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   fastapi
+    #   prometheus-fastapi-instrumentator
 tblib==3.0.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-tenacity==8.5.0
+tenacity==9.0.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -682,37 +688,38 @@ tornado==6.4.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-tqdm==4.66.4
+tqdm==4.67.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.12.3
+typer==0.15.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-types-aiobotocore==2.13.0
+types-aiobotocore==2.15.2.post3
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-types-aiobotocore-ec2==2.13.0
+types-aiobotocore-ec2==2.15.2
     # via types-aiobotocore
-types-aiobotocore-s3==2.13.0
+types-aiobotocore-s3==2.15.2.post1
     # via types-aiobotocore
-types-aiobotocore-ssm==2.13.0
+types-aiobotocore-ssm==2.15.2
     # via types-aiobotocore
-types-awscrt==0.20.9
+types-awscrt==0.23.3
     # via botocore-stubs
-types-python-dateutil==2.9.0.20240316
+types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
     # via
     #   aiodebug
-    #   aiodocker
+    #   anyio
     #   fastapi
     #   faststream
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
+    #   pydantic-extra-types
     #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
@@ -748,16 +755,16 @@ urllib3==2.2.3
     #   botocore
     #   distributed
     #   requests
-uvicorn==0.29.0
+uvicorn==0.32.1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-wrapt==1.16.0
+wrapt==1.17.0
     # via
     #   aiobotocore
     #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
-yarl==1.9.4
+yarl==1.18.3
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/autoscaling/requirements/_test.in
+++ b/services/autoscaling/requirements/_test.in
@@ -18,6 +18,7 @@ deepdiff
 docker
 faker
 fakeredis[lua]
+flaky
 httpx
 moto[server]
 psutil

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -75,6 +75,8 @@ faker==33.1.0
     # via -r requirements/_test.in
 fakeredis==2.26.1
     # via -r requirements/_test.in
+flaky==3.8.1
+    # via -r requirements/_test.in
 flask==3.1.0
     # via
     #   flask-cors

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -4,40 +4,40 @@ annotated-types==0.7.0
     #   pydantic
 antlr4-python3-runtime==4.13.2
     # via moto
-anyio==4.3.0
+anyio==4.7.0
     # via
     #   -c requirements/_base.txt
     #   httpx
 asgi-lifespan==2.1.0
     # via -r requirements/_test.in
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-aws-sam-translator==1.89.0
+aws-sam-translator==1.94.0
     # via cfn-lint
 aws-xray-sdk==2.14.0
     # via moto
-blinker==1.8.2
+blinker==1.9.0
     # via flask
-boto3==1.34.131
+boto3==1.35.36
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.34.131
+botocore==1.35.36
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
-botocore-stubs==1.34.94
+botocore-stubs==1.35.76
     # via
     #   -c requirements/_base.txt
     #   types-aiobotocore
-certifi==2024.2.2
+certifi==2024.8.30
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -46,9 +46,9 @@ certifi==2024.2.2
     #   requests
 cffi==1.17.1
     # via cryptography
-cfn-lint==1.10.3
+cfn-lint==1.20.2
     # via moto
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via
     #   -c requirements/_base.txt
     #   requests
@@ -56,11 +56,11 @@ click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   flask
-coverage==7.6.1
+coverage==7.6.9
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-cryptography==43.0.1
+cryptography==44.0.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   joserfc
@@ -71,27 +71,27 @@ docker==7.1.0
     # via
     #   -r requirements/_test.in
     #   moto
-faker==29.0.0
+faker==33.1.0
     # via -r requirements/_test.in
-fakeredis==2.24.1
+fakeredis==2.26.1
     # via -r requirements/_test.in
-flask==3.0.3
+flask==3.1.0
     # via
     #   flask-cors
     #   moto
 flask-cors==5.0.0
     # via moto
-graphql-core==3.2.4
+graphql-core==3.2.5
     # via moto
 h11==0.14.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.27.0
+httpx==0.28.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -99,7 +99,7 @@ httpx==0.27.0
     #   respx
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.7
+idna==3.10
     # via
     #   -c requirements/_base.txt
     #   anyio
@@ -120,29 +120,29 @@ jmespath==1.0.1
     #   -c requirements/_base.txt
     #   boto3
     #   botocore
-joserfc==1.0.0
+joserfc==1.0.1
     # via moto
 jsondiff==2.2.1
     # via moto
 jsonpatch==1.33
     # via cfn-lint
-jsonpath-ng==1.6.1
+jsonpath-ng==1.7.0
     # via moto
 jsonpointer==3.0.0
     # via jsonpatch
-jsonschema==4.22.0
+jsonschema==4.23.0
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
+    #   jsonschema-spec
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.3
+jsonschema-spec==0.1.3
     # via openapi-spec-validator
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
-    #   openapi-schema-validator
 lazy-object-proxy==1.10.0
     # via openapi-spec-validator
 lupa==2.2
@@ -152,15 +152,15 @@ markupsafe==3.0.2
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.0.15
+moto==5.0.22
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
-networkx==3.3
+networkx==3.4.2
     # via cfn-lint
-openapi-schema-validator==0.6.2
+openapi-schema-validator==0.4.3
     # via openapi-spec-validator
-openapi-spec-validator==0.7.1
+openapi-spec-validator==0.5.5
     # via moto
 orderly-set==5.2.2
     # via deepdiff
@@ -170,7 +170,7 @@ packaging==24.2
     #   pytest
     #   pytest-sugar
 pathable==0.4.3
-    # via jsonschema-path
+    # via jsonschema-spec
 pluggy==1.5.0
     # via pytest
 ply==3.11
@@ -185,7 +185,7 @@ py-partiql-parser==0.5.6
     # via moto
 pycparser==2.22
     # via cffi
-pydantic==2.10.2
+pydantic==2.10.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -194,9 +194,9 @@ pydantic-core==2.27.1
     # via
     #   -c requirements/_base.txt
     #   pydantic
-pyparsing==3.1.4
+pyparsing==3.2.0
     # via moto
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio
@@ -208,7 +208,7 @@ pytest-asyncio==0.23.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r requirements/_test.in
 pytest-icdiff==0.9
     # via -r requirements/_test.in
@@ -234,27 +234,25 @@ pyyaml==6.0.2
     #   -c requirements/_base.txt
     #   cfn-lint
     #   jsondiff
-    #   jsonschema-path
+    #   jsonschema-spec
     #   moto
     #   responses
-redis==5.0.4
+redis==5.2.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   fakeredis
-referencing==0.29.3
+referencing==0.35.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
-    #   jsonschema-path
     #   jsonschema-specifications
-regex==2024.9.11
+regex==2024.11.6
     # via cfn-lint
 requests==2.32.3
     # via
     #   -c requirements/_base.txt
     #   docker
-    #   jsonschema-path
     #   moto
     #   responses
 responses==0.25.3
@@ -263,18 +261,18 @@ respx==0.21.1
     # via -r requirements/_test.in
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.18.1
+rpds-py==0.22.3
     # via
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.1
+s3transfer==0.10.4
     # via
     #   -c requirements/_base.txt
     #   boto3
-setuptools==74.0.0
+setuptools==75.6.0
     # via moto
-six==1.16.0
+six==1.17.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil
@@ -284,34 +282,33 @@ sniffio==1.3.1
     #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
-    #   httpx
 sortedcontainers==2.4.0
     # via
     #   -c requirements/_base.txt
     #   fakeredis
 sympy==1.13.3
     # via cfn-lint
-termcolor==2.4.0
+termcolor==2.5.0
     # via pytest-sugar
-types-aiobotocore==2.13.0
+types-aiobotocore==2.15.2.post3
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-types-aiobotocore-ec2==2.13.0
+types-aiobotocore-ec2==2.15.2
     # via
     #   -c requirements/_base.txt
     #   types-aiobotocore
-types-aiobotocore-iam==2.13.3
+types-aiobotocore-iam==2.15.2
     # via types-aiobotocore
-types-aiobotocore-s3==2.13.0
+types-aiobotocore-s3==2.15.2.post1
     # via
     #   -c requirements/_base.txt
     #   types-aiobotocore
-types-aiobotocore-ssm==2.13.0
+types-aiobotocore-ssm==2.15.2
     # via
     #   -c requirements/_base.txt
     #   types-aiobotocore
-types-awscrt==0.20.9
+types-awscrt==0.23.3
     # via
     #   -c requirements/_base.txt
     #   botocore-stubs
@@ -320,8 +317,11 @@ types-pyyaml==6.0.12.20240917
 typing-extensions==4.12.2
     # via
     #   -c requirements/_base.txt
+    #   anyio
     #   aws-sam-translator
     #   cfn-lint
+    #   faker
+    #   jsonschema-spec
     #   pydantic
     #   pydantic-core
     #   types-aiobotocore
@@ -337,13 +337,13 @@ urllib3==2.2.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.0.4
+werkzeug==3.1.3
     # via
     #   flask
     #   moto
-wrapt==1.16.0
+wrapt==1.17.0
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
-xmltodict==0.13.0
+xmltodict==0.14.2
     # via moto

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -154,7 +154,7 @@ markupsafe==3.0.2
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.0.22
+moto==5.0.15
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy

--- a/services/autoscaling/requirements/_tools.txt
+++ b/services/autoscaling/requirements/_tools.txt
@@ -1,8 +1,8 @@
-astroid==3.3.4
+astroid==3.3.5
     # via pylint
-black==24.8.0
+black==24.10.0
     # via -r requirements/../../../requirements/devenv.txt
-build==1.2.2
+build==1.2.2.post1
     # via pip-tools
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -14,13 +14,13 @@ click==8.1.7
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-dill==0.3.8
+dill==0.3.9
     # via pylint
-distlib==0.3.8
+distlib==0.3.9
     # via virtualenv
 filelock==3.16.1
     # via virtualenv
-identify==2.6.1
+identify==2.6.3
     # via pre-commit
 isort==5.13.2
     # via
@@ -28,7 +28,7 @@ isort==5.13.2
     #   pylint
 mccabe==0.7.0
     # via pylint
-mypy==1.12.0
+mypy==1.13.0
     # via -r requirements/../../../requirements/devenv.txt
 mypy-extensions==1.0.0
     # via
@@ -44,7 +44,7 @@ packaging==24.2
     #   build
 pathspec==0.12.1
     # via black
-pip==24.2
+pip==24.3.1
     # via pip-tools
 pip-tools==7.4.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -53,11 +53,11 @@ platformdirs==4.3.6
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.8.0
+pre-commit==4.0.1
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.3.0
+pylint==3.3.2
     # via -r requirements/../../../requirements/devenv.txt
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
@@ -68,9 +68,9 @@ pyyaml==6.0.2
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.6.7
+ruff==0.8.2
     # via -r requirements/../../../requirements/devenv.txt
-setuptools==74.0.0
+setuptools==75.6.0
     # via
     #   -c requirements/_test.txt
     #   pip-tools
@@ -81,9 +81,9 @@ typing-extensions==4.12.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.26.5
+virtualenv==20.28.0
     # via pre-commit
-watchdog==5.0.2
+watchdog==6.0.0
     # via -r requirements/_tools.in
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -419,7 +419,7 @@ def service_monitored_labels(
 @pytest.fixture
 async def async_client(initialized_app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
     async with httpx.AsyncClient(
-        app=initialized_app,
+        transport=httpx.ASGITransport(app=initialized_app),
         base_url=f"http://{initialized_app.title}.testserver.io",
         headers={"Content-Type": "application/json"},
     ) as client:

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -1,12 +1,12 @@
-aio-pika==9.4.1
+aio-pika==9.5.3
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==13.1.0
+aioboto3==13.2.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-aiobotocore==2.13.1
+aiobotocore==2.15.2
     # via aioboto3
-aiocache==0.12.2
+aiocache==0.12.3
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/_base.in
@@ -15,16 +15,18 @@ aiodebug==2.3.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiodocker==0.21.0
+aiodocker==0.24.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiofiles==23.2.1
+aiofiles==24.1.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aioboto3
-aiohttp==3.9.5
+aiohappyeyeballs==2.4.4
+    # via aiohttp
+aiohttp==3.11.10
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -52,15 +54,15 @@ aiohttp==3.9.5
     #   -c requirements/../../../requirements/constraints.txt
     #   aiobotocore
     #   aiodocker
-aioitertools==0.11.0
+aioitertools==0.12.0
     # via aiobotocore
-aiormq==6.8.0
+aiormq==6.8.1
     # via aio-pika
 aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.7.0
     # via pydantic
-anyio==4.3.0
+anyio==4.7.0
     # via
     #   fast-depends
     #   faststream
@@ -77,21 +79,21 @@ arrow==1.3.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.34.131
+boto3==1.35.36
     # via aiobotocore
-botocore==1.34.131
+botocore==1.35.36
     # via
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.34.94
+botocore-stubs==1.35.76
     # via types-aiobotocore
-certifi==2024.2.2
+certifi==2024.8.30
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -120,7 +122,7 @@ certifi==2024.2.2
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via
@@ -139,7 +141,7 @@ dask==2024.12.0
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   -r requirements/_base.in
     #   distributed
-deprecated==1.2.14
+deprecated==1.2.15
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -149,22 +151,23 @@ distributed==2024.12.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-dnspython==2.6.1
+dnspython==2.7.0
     # via email-validator
-email-validator==2.1.1
+email-validator==2.2.0
     # via pydantic
+exceptiongroup==1.2.2
+    # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.5
+fastapi==0.115.6
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
-    #   prometheus-fastapi-instrumentator
-faststream==0.5.31
+faststream==0.5.33
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
@@ -172,19 +175,19 @@ fsspec==2024.10.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-googleapis-common-protos==1.65.0
+googleapis-common-protos==1.66.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.66.0
+grpcio==1.68.1
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.28.0
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -211,7 +214,7 @@ httpx==0.27.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   email-validator
@@ -255,13 +258,13 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.22.0
+jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
 locket==1.0.0
     # via
@@ -280,7 +283,7 @@ msgpack==1.1.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
@@ -342,7 +345,7 @@ opentelemetry-instrumentation-requests==0.49b2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-propagator-aws-xray==1.0.1
+opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
 opentelemetry-proto==1.28.2
     # via
@@ -371,7 +374,7 @@ opentelemetry-util-http==0.49b2
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
-orjson==3.10.3
+orjson==3.10.12
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -426,13 +429,17 @@ partd==1.4.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-prometheus-client==0.20.0
+prometheus-client==0.21.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   prometheus-fastapi-instrumentator
-prometheus-fastapi-instrumentator==6.1.0
+prometheus-fastapi-instrumentator==7.0.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-protobuf==5.29.0
+propcache==0.2.1
+    # via
+    #   aiohttp
+    #   yarl
+protobuf==5.29.1
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
@@ -442,7 +449,7 @@ psutil==6.1.0
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   distributed
-pydantic==2.10.2
+pydantic==2.10.3
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -497,7 +504,7 @@ pydantic==2.10.2
     #   pydantic-settings
 pydantic-core==2.27.1
     # via pydantic
-pydantic-extra-types==2.9.0
+pydantic-extra-types==2.10.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -527,7 +534,7 @@ pydantic-settings==2.6.1
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
 pygments==2.18.0
     # via rich
-pyinstrument==4.6.2
+pyinstrument==5.0.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -568,7 +575,7 @@ pyyaml==6.0.2
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
-redis==5.0.4
+redis==5.2.1
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -596,7 +603,7 @@ redis==5.0.4
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-referencing==0.29.3
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -606,34 +613,32 @@ repro-zipfile==0.3.1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
-rich==13.7.1
+rich==13.9.4
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.18.1
+rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.1
+s3transfer==0.10.4
     # via boto3
-sh==2.0.6
+sh==2.1.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 shellingham==1.5.4
     # via typer
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 sortedcontainers==2.4.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-starlette==0.41.2
+starlette==0.41.3
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -660,11 +665,12 @@ starlette==0.41.2
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   fastapi
+    #   prometheus-fastapi-instrumentator
 tblib==3.0.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-tenacity==8.5.0
+tenacity==9.0.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -680,37 +686,38 @@ tornado==6.4.2
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-tqdm==4.66.4
+tqdm==4.67.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.12.3
+typer==0.15.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-types-aiobotocore==2.13.0
+types-aiobotocore==2.15.2.post3
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-types-aiobotocore-ec2==2.13.0
+types-aiobotocore-ec2==2.15.2
     # via types-aiobotocore
-types-aiobotocore-s3==2.13.0
+types-aiobotocore-s3==2.15.2.post1
     # via types-aiobotocore
-types-aiobotocore-ssm==2.13.1
+types-aiobotocore-ssm==2.15.2
     # via types-aiobotocore
-types-awscrt==0.20.9
+types-awscrt==0.23.3
     # via botocore-stubs
-types-python-dateutil==2.9.0.20240316
+types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
     # via
     #   aiodebug
-    #   aiodocker
+    #   anyio
     #   fastapi
     #   faststream
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
+    #   pydantic-extra-types
     #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
@@ -746,16 +753,16 @@ urllib3==2.2.3
     #   botocore
     #   distributed
     #   requests
-uvicorn==0.29.0
+uvicorn==0.32.1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-wrapt==1.16.0
+wrapt==1.17.0
     # via
     #   aiobotocore
     #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
-yarl==1.9.4
+yarl==1.18.3
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -1,8 +1,12 @@
-aiodocker==0.21.0
+aiodocker==0.24.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-aiohttp==3.9.5
+aiohappyeyeballs==2.4.4
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+aiohttp==3.11.10
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -17,37 +21,37 @@ annotated-types==0.7.0
     #   pydantic
 antlr4-python3-runtime==4.13.2
     # via moto
-anyio==4.3.0
+anyio==4.7.0
     # via
     #   -c requirements/_base.txt
     #   httpx
 asgi-lifespan==2.1.0
     # via -r requirements/_test.in
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   jsonschema
     #   referencing
-aws-sam-translator==1.89.0
+aws-sam-translator==1.94.0
     # via cfn-lint
 aws-xray-sdk==2.14.0
     # via moto
-blinker==1.8.2
+blinker==1.9.0
     # via flask
-boto3==1.34.131
+boto3==1.35.36
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.34.131
+botocore==1.35.36
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
-certifi==2024.2.2
+certifi==2024.8.30
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -56,9 +60,9 @@ certifi==2024.2.2
     #   requests
 cffi==1.17.1
     # via cryptography
-cfn-lint==1.10.3
+cfn-lint==1.20.2
     # via moto
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via
     #   -c requirements/_base.txt
     #   requests
@@ -66,16 +70,16 @@ click==8.1.7
     # via
     #   -c requirements/_base.txt
     #   flask
-coverage==7.6.1
+coverage==7.6.9
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-cryptography==43.0.1
+cryptography==44.0.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   joserfc
     #   moto
-debugpy==1.8.5
+debugpy==1.8.9
     # via -r requirements/_test.in
 deepdiff==8.0.1
     # via -r requirements/_test.in
@@ -83,38 +87,38 @@ docker==7.1.0
     # via
     #   -r requirements/_test.in
     #   moto
-faker==29.0.0
+faker==33.1.0
     # via -r requirements/_test.in
-fakeredis==2.24.1
+fakeredis==2.26.1
     # via -r requirements/_test.in
-flask==3.0.3
+flask==3.1.0
     # via
     #   flask-cors
     #   moto
 flask-cors==5.0.0
     # via moto
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
-graphql-core==3.2.4
+graphql-core==3.2.5
     # via moto
 h11==0.14.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.27.0
+httpx==0.28.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   respx
-idna==3.7
+idna==3.10
     # via
     #   -c requirements/_base.txt
     #   anyio
@@ -136,29 +140,29 @@ jmespath==1.0.1
     #   -c requirements/_base.txt
     #   boto3
     #   botocore
-joserfc==1.0.0
+joserfc==1.0.1
     # via moto
 jsondiff==2.2.1
     # via moto
 jsonpatch==1.33
     # via cfn-lint
-jsonpath-ng==1.6.1
+jsonpath-ng==1.7.0
     # via moto
 jsonpointer==3.0.0
     # via jsonpatch
-jsonschema==4.22.0
+jsonschema==4.23.0
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
+    #   jsonschema-spec
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.3
+jsonschema-spec==0.1.3
     # via openapi-spec-validator
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
-    #   openapi-schema-validator
 lazy-object-proxy==1.10.0
     # via openapi-spec-validator
 lupa==2.2
@@ -168,20 +172,20 @@ markupsafe==3.0.2
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.0.15
+moto==5.0.22
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-networkx==3.3
+networkx==3.4.2
     # via cfn-lint
-openapi-schema-validator==0.6.2
+openapi-schema-validator==0.4.3
     # via openapi-spec-validator
-openapi-spec-validator==0.7.1
+openapi-spec-validator==0.5.5
     # via moto
 orderly-set==5.2.2
     # via deepdiff
@@ -192,11 +196,16 @@ packaging==24.2
 parse==1.20.2
     # via -r requirements/_test.in
 pathable==0.4.3
-    # via jsonschema-path
+    # via jsonschema-spec
 pluggy==1.5.0
     # via pytest
 ply==3.11
     # via jsonpath-ng
+propcache==0.2.1
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   yarl
 psutil==6.1.0
     # via
     #   -c requirements/_base.txt
@@ -205,7 +214,7 @@ py-partiql-parser==0.5.6
     # via moto
 pycparser==2.22
     # via cffi
-pydantic==2.10.2
+pydantic==2.10.3
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -214,9 +223,9 @@ pydantic-core==2.27.1
     # via
     #   -c requirements/_base.txt
     #   pydantic
-pyparsing==3.1.4
+pyparsing==3.2.0
     # via moto
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio
@@ -226,7 +235,7 @@ pytest-asyncio==0.23.8
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r requirements/_test.in
 pytest-mock==3.14.0
     # via -r requirements/_test.in
@@ -248,27 +257,25 @@ pyyaml==6.0.2
     #   -c requirements/_base.txt
     #   cfn-lint
     #   jsondiff
-    #   jsonschema-path
+    #   jsonschema-spec
     #   moto
     #   responses
-redis==5.0.4
+redis==5.2.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   fakeredis
-referencing==0.29.3
+referencing==0.35.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
-    #   jsonschema-path
     #   jsonschema-specifications
-regex==2024.9.11
+regex==2024.11.6
     # via cfn-lint
 requests==2.32.3
     # via
     #   -c requirements/_base.txt
     #   docker
-    #   jsonschema-path
     #   moto
     #   responses
 responses==0.25.3
@@ -277,18 +284,18 @@ respx==0.21.1
     # via -r requirements/_test.in
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.18.1
+rpds-py==0.22.3
     # via
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.1
+s3transfer==0.10.4
     # via
     #   -c requirements/_base.txt
     #   boto3
-setuptools==74.0.0
+setuptools==75.6.0
     # via moto
-six==1.16.0
+six==1.17.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil
@@ -298,7 +305,6 @@ sniffio==1.3.1
     #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
-    #   httpx
 sortedcontainers==2.4.0
     # via
     #   -c requirements/_base.txt
@@ -310,9 +316,11 @@ types-pyyaml==6.0.12.20240917
 typing-extensions==4.12.2
     # via
     #   -c requirements/_base.txt
-    #   aiodocker
+    #   anyio
     #   aws-sam-translator
     #   cfn-lint
+    #   faker
+    #   jsonschema-spec
     #   pydantic
     #   pydantic-core
 urllib3==2.2.3
@@ -323,17 +331,17 @@ urllib3==2.2.3
     #   docker
     #   requests
     #   responses
-werkzeug==3.0.4
+werkzeug==3.1.3
     # via
     #   flask
     #   moto
-wrapt==1.16.0
+wrapt==1.17.0
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
-xmltodict==0.13.0
+xmltodict==0.14.2
     # via moto
-yarl==1.9.4
+yarl==1.18.3
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/services/clusters-keeper/requirements/_tools.txt
+++ b/services/clusters-keeper/requirements/_tools.txt
@@ -1,8 +1,8 @@
-astroid==3.3.4
+astroid==3.3.5
     # via pylint
-black==24.8.0
+black==24.10.0
     # via -r requirements/../../../requirements/devenv.txt
-build==1.2.2
+build==1.2.2.post1
     # via pip-tools
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -14,13 +14,13 @@ click==8.1.7
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-dill==0.3.8
+dill==0.3.9
     # via pylint
-distlib==0.3.8
+distlib==0.3.9
     # via virtualenv
 filelock==3.16.1
     # via virtualenv
-identify==2.6.1
+identify==2.6.3
     # via pre-commit
 isort==5.13.2
     # via
@@ -28,7 +28,7 @@ isort==5.13.2
     #   pylint
 mccabe==0.7.0
     # via pylint
-mypy==1.12.0
+mypy==1.13.0
     # via -r requirements/../../../requirements/devenv.txt
 mypy-extensions==1.0.0
     # via
@@ -44,7 +44,7 @@ packaging==24.2
     #   build
 pathspec==0.12.1
     # via black
-pip==24.2
+pip==24.3.1
     # via pip-tools
 pip-tools==7.4.1
     # via -r requirements/../../../requirements/devenv.txt
@@ -53,11 +53,11 @@ platformdirs==4.3.6
     #   black
     #   pylint
     #   virtualenv
-pre-commit==3.8.0
+pre-commit==4.0.1
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.3.0
+pylint==3.3.2
     # via -r requirements/../../../requirements/devenv.txt
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
@@ -68,9 +68,9 @@ pyyaml==6.0.2
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.6.7
+ruff==0.8.2
     # via -r requirements/../../../requirements/devenv.txt
-setuptools==74.0.0
+setuptools==75.6.0
     # via
     #   -c requirements/_test.txt
     #   pip-tools
@@ -81,9 +81,9 @@ typing-extensions==4.12.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.26.5
+virtualenv==20.28.0
     # via pre-commit
-watchdog==5.0.2
+watchdog==6.0.0
     # via -r requirements/_tools.in
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools

--- a/services/clusters-keeper/tests/unit/conftest.py
+++ b/services/clusters-keeper/tests/unit/conftest.py
@@ -262,7 +262,7 @@ def app_settings(initialized_app: FastAPI) -> ApplicationSettings:
 @pytest.fixture
 async def async_client(initialized_app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
     async with httpx.AsyncClient(
-        app=initialized_app,
+        transport=httpx.ASGITransport(app=initialized_app),
         base_url=f"http://{initialized_app.title}.testserver.io",
         headers={"Content-Type": "application/json"},
     ) as client:


### PR DESCRIPTION
###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 99
- #packages after ~ 102

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.4.1           | 9.5.3      | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|   2 | aioboto3                  | 13.1.0          | 13.2.0     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|   3 | aiobotocore               | 2.13.1          | 2.15.2     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|   4 | aiocache                  | 0.12.2          | 0.12.3     |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|   5 | aiodocker                 | 0.21.0          | 0.24.0     | *minor*    | 3 | autoscaling⬆️</br>clusters-keeper⬆️🧪 |
|   6 | aiofiles                  | 23.2.1          | 24.1.0     | **MAJOR**  | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|   7 | aiohttp                   | 3.9.5           | 3.11.10    | *minor*    | 3 | autoscaling⬆️</br>clusters-keeper⬆️🧪 |
|   8 | aioitertools              | 0.11.0          | 0.12.0     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|   9 | aiormq                    | 6.8.0           | 6.8.1      |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  10 | anyio                     | 4.3.0           | 4.7.0      | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  11 | astroid                   | 3.3.4           | 3.3.5      |            | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  12 | attrs                     | 23.2.0          | 24.2.0     | **MAJOR**  | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  13 | aws-sam-translator        | 1.89.0          | 1.94.0     | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  14 | black                     | 24.8.0          | 24.10.0    | *minor*    | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  15 | blinker                   | 1.8.2           | 1.9.0      | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  16 | boto3                     | 1.34.131        | 1.35.36    | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  17 | botocore                  | 1.34.131        | 1.35.36    | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  18 | botocore-stubs            | 1.34.94         | 1.35.76    | *minor*    | 3 | autoscaling⬆️🧪</br>clusters-keeper⬆️ |
|  19 | build                     | 1.2.2           | 1.2.2.post1 |            | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  20 | certifi                   | 2024.2.2        | 2024.8.30  | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  21 | cfn-lint                  | 1.10.3          | 1.20.2     | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  22 | charset-normalizer        | 3.3.2           | 3.4.0      | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  23 | coverage                  | 7.6.1           | 7.6.9      |            | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  24 | cryptography              | 43.0.1          | 44.0.0     | **MAJOR**  | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  25 | debugpy                   | 1.8.5           | 1.8.9      |            | 1 | clusters-keeper🧪 |
|  26 | deprecated                | 1.2.14          | 1.2.15     |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  27 | dill                      | 0.3.8           | 0.3.9      |            | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  28 | distlib                   | 0.3.8           | 0.3.9      |            | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  29 | dnspython                 | 2.6.1           | 2.7.0      | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  30 | email-validator           | 2.1.1           | 2.2.0      | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  31 | faker                     | 29.0.0          | 33.1.0     | **MAJOR**  | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  32 | fakeredis                 | 2.24.1          | 2.26.1     | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  33 | fastapi                   | 0.115.5         | 0.115.6    |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  34 | faststream                | 0.5.31          | 0.5.33     |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  35 | flask                     | 3.0.3           | 3.1.0      | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  36 | frozenlist                | 1.4.1           | 1.5.0      | *minor*    | 3 | autoscaling⬆️</br>clusters-keeper⬆️🧪 |
|  37 | googleapis-common-protos  | 1.65.0          | 1.66.0     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  38 | graphql-core              | 3.2.4           | 3.2.5      |            | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  39 | grpcio                    | 1.66.0          | 1.68.1     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  40 | httpcore                  | 1.0.5           | 1.0.7      |            | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  41 | httpx                     | 0.27.0          | 0.28.0     | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  42 | identify                  | 2.6.1           | 2.6.3      |            | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  43 | idna                      | 3.7             | 3.10       | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  44 | joserfc                   | 1.0.0           | 1.0.1      |            | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  45 | jsonpath-ng               | 1.6.1           | 1.7.0      | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  46 | jsonschema                | 4.22.0          | 4.23.0     | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  47 | jsonschema-path           | 0.3.3           | 🗑️ removed |  | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  48 | jsonschema-specifications | 2023.7.1        | 2024.10.1  | **MAJOR**  | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  49 | moto                      | 5.0.15          | 5.0.22     |            | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  50 | multidict                 | 6.0.5           | 6.1.0      | *minor*    | 3 | autoscaling⬆️</br>clusters-keeper⬆️🧪 |
|  51 | mypy                      | 1.12.0          | 1.13.0     | *minor*    | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  52 | networkx                  | 3.3             | 3.4.2      | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  53 | openapi-schema-validator  | 0.6.2           | 0.4.3      | 🔥 downgrade | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  54 | openapi-spec-validator    | 0.7.1           | 0.5.5      | 🔥 downgrade | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  55 | opentelemetry-propagator-aws-xray | 1.0.1           | 1.0.2      |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  56 | orjson                    | 3.10.3          | 3.10.12    |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  57 | pip                       | 24.2            | 24.3.1     | *minor*    | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  58 | pre-commit                | 3.8.0           | 4.0.1      | **MAJOR**  | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  59 | prometheus-client         | 0.20.0          | 0.21.1     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  60 | prometheus-fastapi-instrumentator | 6.1.0           | 7.0.0      | **MAJOR**  | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  61 | protobuf                  | 5.29.0          | 5.29.1     |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  62 | pydantic                  | 2.10.2          | 2.10.3     |            | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  63 | pydantic-extra-types      | 2.9.0           | 2.10.0     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  64 | pyinstrument              | 4.6.2           | 5.0.0      | **MAJOR**  | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  65 | pylint                    | 3.3.0           | 3.3.2      |            | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  66 | pyparsing                 | 3.1.4           | 3.2.0      | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  67 | pyproject-hooks           | 1.1.0           | 1.2.0      | *minor*    | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  68 | pytest                    | 8.3.3           | 8.3.4      |            | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  69 | pytest-cov                | 5.0.0           | 6.0.0      | **MAJOR**  | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  70 | redis                     | 5.0.4           | 5.2.1      | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  71 | referencing               | 0.29.3          | 0.35.1     | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  72 | regex                     | 2024.9.11       | 2024.11.6  | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  73 | rich                      | 13.7.1          | 13.9.4     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  74 | rpds-py                   | 0.18.1          | 0.22.3     | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  75 | ruff                      | 0.6.7           | 0.8.2      | *minor*    | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  76 | s3transfer                | 0.10.1          | 0.10.4     |            | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  77 | setuptools                | 74.0.0          | 75.6.0     | **MAJOR**  | 4 | autoscaling🧪🔧</br>clusters-keeper🧪🔧 |
|  78 | sh                        | 2.0.6           | 2.1.0      | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  79 | six                       | 1.16.0          | 1.17.0     | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  80 | starlette                 | 0.41.2          | 0.41.3     |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  81 | tenacity                  | 8.5.0           | 9.0.0      | **MAJOR**  | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  82 | termcolor                 | 2.4.0           | 2.5.0      | *minor*    | 1 | autoscaling🧪 |
|  83 | tqdm                      | 4.66.4          | 4.67.1     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  84 | typer                     | 0.12.3          | 0.15.1     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  85 | types-aiobotocore         | 2.13.0          | 2.15.2.post3 | *minor*    | 3 | autoscaling⬆️🧪</br>clusters-keeper⬆️ |
|  86 | types-aiobotocore-ec2     | 2.13.0          | 2.15.2     | *minor*    | 3 | autoscaling⬆️🧪</br>clusters-keeper⬆️ |
|  87 | types-aiobotocore-iam     | 2.13.3          | 2.15.2     | *minor*    | 1 | autoscaling🧪 |
|  88 | types-aiobotocore-s3      | 2.13.0          | 2.15.2.post1 | *minor*    | 3 | autoscaling⬆️🧪</br>clusters-keeper⬆️ |
|  89 | types-aiobotocore-ssm     | 2.13.0, 2.13.1  | 2.15.2     | *minor*    | 3 | autoscaling⬆️🧪</br>clusters-keeper⬆️ |
|  90 | types-awscrt              | 0.20.9          | 0.23.3     | *minor*    | 3 | autoscaling⬆️🧪</br>clusters-keeper⬆️ |
|  91 | types-python-dateutil     | 2.9.0.20240316  | 2.9.0.20241206 |            | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  92 | uvicorn                   | 0.29.0          | 0.32.1     | *minor*    | 2 | autoscaling⬆️</br>clusters-keeper⬆️ |
|  93 | virtualenv                | 20.26.5         | 20.28.0    | *minor*    | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  94 | watchdog                  | 5.0.2           | 6.0.0      | **MAJOR**  | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  95 | werkzeug                  | 3.0.4           | 3.1.3      | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  96 | wheel                     | 0.44.0          | 0.45.1     | *minor*    | 2 | autoscaling🔧</br>clusters-keeper🔧 |
|  97 | wrapt                     | 1.16.0          | 1.17.0     | *minor*    | 4 | autoscaling⬆️🧪</br>clusters-keeper⬆️🧪 |
|  98 | xmltodict                 | 0.13.0          | 0.14.2     | *minor*    | 2 | autoscaling🧪</br>clusters-keeper🧪 |
|  99 | yarl                      | 1.9.4           | 1.18.3     | *minor*    | 3 | autoscaling⬆️</br>clusters-keeper⬆️🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency