### PR TITLE
⚗️CI: Separate image building of frontend

### DIFF
--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -304,7 +304,7 @@ jobs:
       - name: upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-backend
           path: /${{ runner.temp }}/build
 
   build-test-images-frontend:
@@ -351,7 +351,7 @@ jobs:
       - name: upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-frontend
           path: /${{ runner.temp }}/build
 
   unit-test-webserver-01:
@@ -1915,7 +1915,7 @@ jobs:
         with:
           action: actions/download-artifact@v4
           with: |
-            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-backend
             path: /${{ runner.temp }}/build
           attempt_limit: 5
           attempt_delay: 1000
@@ -1979,7 +1979,7 @@ jobs:
         with:
           action: actions/download-artifact@v4
           with: |
-            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-backend
             path: /${{ runner.temp }}/build
           attempt_limit: 5
           attempt_delay: 1000
@@ -2043,7 +2043,7 @@ jobs:
         with:
           action: actions/download-artifact@v4
           with: |
-            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-backend
             path: /${{ runner.temp }}/build
           attempt_limit: 5
           attempt_delay: 1000
@@ -2114,7 +2114,7 @@ jobs:
         with:
           action: actions/download-artifact@v4
           with: |
-            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-backend
             path: /${{ runner.temp }}/build
           attempt_limit: 5
           attempt_delay: 1000
@@ -2180,7 +2180,7 @@ jobs:
         with:
           action: actions/download-artifact@v4
           with: |
-            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-backend
             path: /${{ runner.temp }}/build
           attempt_limit: 5
           attempt_delay: 1000
@@ -2246,7 +2246,7 @@ jobs:
         with:
           action: actions/download-artifact@v4
           with: |
-            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-backend
             path: /${{ runner.temp }}/build
           attempt_limit: 5
           attempt_delay: 1000
@@ -2333,7 +2333,7 @@ jobs:
         with:
           action: actions/download-artifact@v4
           with: |
-            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            pattern: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-*
             path: /${{ runner.temp }}/build
           attempt_limit: 5
           attempt_delay: 1000
@@ -2393,7 +2393,7 @@ jobs:
         with:
           action: actions/download-artifact@v4
           with: |
-            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            pattern: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-*
             path: /${{ runner.temp }}/build
           attempt_limit: 5
           attempt_delay: 1000
@@ -2464,7 +2464,7 @@ jobs:
         with:
           action: actions/download-artifact@v4
           with: |
-            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            pattern: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-*
             path: /${{ runner.temp }}/build
           attempt_limit: 5
           attempt_delay: 1000
@@ -2544,7 +2544,7 @@ jobs:
       - name: download docker images
         uses: actions/download-artifact@v4
         with:
-          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+          pattern: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-*
           path: /${{ runner.temp }}/build
       - name: load docker images
         run: make load-images local-src=/${{ runner.temp }}/build
@@ -2663,7 +2663,7 @@ jobs:
         with:
           action: actions/download-artifact@v4
           with: |
-            name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+            pattern: docker-buildx-images-${{ runner.os }}-${{ github.sha }}-*
             path: /${{ runner.temp }}/build
           attempt_limit: 5
           attempt_delay: 1000

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -274,18 +274,6 @@ jobs:
       fail-fast: false
     name: "[build] docker images (all but frontend)"
     steps:
-      - name: Remove unused software
-        run: |
-          echo "Available storage before:"
-          sudo df -h
-          echo
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          echo "Available storage after:"
-          sudo df -h
-          echo
       - uses: actions/checkout@v4
       - name: setup docker buildx
         id: buildx
@@ -321,18 +309,6 @@ jobs:
       fail-fast: false
     name: "[build] docker images (frontend-only)"
     steps:
-      - name: Remove unused software
-        run: |
-          echo "Available storage before:"
-          sudo df -h
-          echo
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          echo "Available storage after:"
-          sudo df -h
-          echo
       - uses: actions/checkout@v4
       - name: setup docker buildx
         id: buildx

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -272,7 +272,7 @@ jobs:
         python: ["3.11"]
         os: [ubuntu-22.04]
       fail-fast: false
-    name: "[build] docker images (all but frontend)"
+    name: "[build] docker images (excluding frontend)"
     steps:
       - uses: actions/checkout@v4
       - name: setup docker buildx

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -311,7 +311,7 @@ jobs:
     # this step comes first, so that it is executed as first job in push calls
     # in PR calls this step is anyway skipped
     needs: changes
-    if: ${{ needs.changes.outputs.anything-js == 'true' || github.event_name == 'push' }}
+    if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -272,7 +272,7 @@ jobs:
         python: ["3.11"]
         os: [ubuntu-22.04]
       fail-fast: false
-    name: "[build] docker images"
+    name: "[build] docker images (all but frontend)"
     steps:
       - name: Remove unused software
         run: |
@@ -319,7 +319,7 @@ jobs:
         python: ["3.11"]
         os: [ubuntu-22.04]
       fail-fast: false
-    name: "[build] docker images"
+    name: "[build] docker images (frontend-only)"
     steps:
       - name: Remove unused software
         run: |

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -2304,7 +2304,7 @@ jobs:
         run: echo "::notice All good!"
 
   system-test-public-api:
-    needs: [changes, build-test-images]
+    needs: [changes, build-test-images, build-test-images-frontend]
     if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
     timeout-minutes: 25 # if this timeout gets too small, then split the tests
     name: "[sys] public api"
@@ -2364,7 +2364,7 @@ jobs:
         run: ./ci/github/system-testing/public-api.bash clean_up
 
   system-test-swarm-deploy:
-    needs: [changes, build-test-images]
+    needs: [changes, build-test-images, build-test-images-frontend]
     if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[sys] deploy simcore"
@@ -2429,7 +2429,7 @@ jobs:
         run: ./ci/github/system-testing/swarm-deploy.bash clean_up
 
   system-test-e2e:
-    needs: [changes, build-test-images]
+    needs: [changes, build-test-images, build-test-images-frontend]
     if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[sys] e2e"
@@ -2509,7 +2509,7 @@ jobs:
         run: ./ci/github/system-testing/e2e.bash clean_up
 
   system-test-e2e-playwright:
-    needs: [changes, build-test-images]
+    needs: [changes, build-test-images, build-test-images-frontend]
     if: ${{ needs.changes.outputs.anything == 'true' || github.event_name == 'push' }}
     timeout-minutes: 30 # if this timeout gets too small, then split the tests
     name: "[sys] e2e-playwright"

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -300,7 +300,54 @@ jobs:
         run: |
           export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag.bash)
           mkdir --parents /${{ runner.temp }}/build
-          make build local-dest=/${{ runner.temp }}/build
+          make build local-dest=/${{ runner.temp }}/build exclude=static-webserver
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-buildx-images-${{ runner.os }}-${{ github.sha }}
+          path: /${{ runner.temp }}/build
+
+  build-test-images-frontend:
+    # this step comes first, so that it is executed as first job in push calls
+    # in PR calls this step is anyway skipped
+    needs: changes
+    if: ${{ needs.changes.outputs.anything-js == 'true' || github.event_name == 'push' }}
+    timeout-minutes: 30
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python: ["3.11"]
+        os: [ubuntu-22.04]
+      fail-fast: false
+    name: "[build] docker images"
+    steps:
+      - name: Remove unused software
+        run: |
+          echo "Available storage before:"
+          sudo df -h
+          echo
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          echo "Available storage after:"
+          sudo df -h
+          echo
+      - uses: actions/checkout@v4
+      - name: setup docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+      - name: expose github runtime for buildx
+        uses: crazy-max/ghaction-github-runtime@v3
+      - name: show system environs
+        run: ./ci/helpers/show_system_versions.bash
+      - name: build images
+        run: |
+          export DOCKER_IMAGE_TAG=$(exec ci/helpers/build_docker_image_tag.bash)
+          mkdir --parents /${{ runner.temp }}/build
+          make build local-dest=/${{ runner.temp }}/build target=static-webserver
       - name: upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ $(foreach service, $(SERVICES_NAMES_TO_BUILD),\
 		export $(subst -,_,$(shell echo $(service) | tr a-z A-Z))_VERSION=$(shell cat services/$(service)/VERSION);\
 	,) \
 )\
-docker buildx bake \
+docker buildx bake --allow=fs.read=.. \
 	$(if $(findstring -devel,$@),,\
 	--set *.platform=$(DOCKER_TARGET_PLATFORMS) \
 	)\

--- a/Makefile
+++ b/Makefile
@@ -190,10 +190,8 @@ build build-nc: .env ## Builds production images and tags them as 'local/{servic
 	@docker images --filter="reference=local/*:production"
 
 load-images: guard-local-src ## loads images from local-src
-	# loading from images from $(local-src)...
-	@$(foreach service, $(SERVICES_NAMES_TO_BUILD),\
-		docker load --input $(local-src)/$(service).tar; \
-	)
+	# loading from any tar images from $(local-src)...
+	@find $(local-src) -name '*.tar' -print0 | xargs -0 -n1 -P $(shell nproc) --no-run-if-empty --verbose docker load --input
 	# all images loaded
 	@docker images
 

--- a/packages/service-integration/Dockerfile
+++ b/packages/service-integration/Dockerfile
@@ -12,8 +12,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -54,8 +53,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 FROM base AS build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/packages/service-integration/Dockerfile
+++ b/packages/service-integration/Dockerfile
@@ -12,7 +12,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -53,7 +53,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 FROM base AS build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/packages/service-integration/Dockerfile
+++ b/packages/service-integration/Dockerfile
@@ -12,7 +12,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN  --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
   --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
   set -eux \
   && apt-get update \

--- a/packages/service-integration/Dockerfile
+++ b/packages/service-integration/Dockerfile
@@ -12,7 +12,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -53,7 +53,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 FROM base AS build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/requirements/tools/Dockerfile
+++ b/requirements/tools/Dockerfile
@@ -16,7 +16,7 @@ FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 
 ENV VIRTUAL_ENV=/home/scu/.venv
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update \
   && apt-get -y install --no-install-recommends\

--- a/requirements/tools/Dockerfile
+++ b/requirements/tools/Dockerfile
@@ -16,8 +16,7 @@ FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 
 ENV VIRTUAL_ENV=/home/scu/.venv
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update \
   && apt-get -y install --no-install-recommends\

--- a/requirements/tools/Dockerfile
+++ b/requirements/tools/Dockerfile
@@ -16,7 +16,7 @@ FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 
 ENV VIRTUAL_ENV=/home/scu/.venv
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update \
   && apt-get -y install --no-install-recommends\

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=GitHK
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -70,7 +70,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -20,8 +20,7 @@ LABEL maintainer=GitHK
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -71,8 +70,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=GitHK
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -70,7 +70,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/api-server/Dockerfile
+++ b/services/api-server/Dockerfile
@@ -19,7 +19,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,7 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/api-server/Dockerfile
+++ b/services/api-server/Dockerfile
@@ -25,6 +25,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   apt-get install -y --no-install-recommends \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 

--- a/services/api-server/Dockerfile
+++ b/services/api-server/Dockerfile
@@ -19,7 +19,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,7 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/api-server/Dockerfile
+++ b/services/api-server/Dockerfile
@@ -19,8 +19,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,8 +66,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/autoscaling/Dockerfile
+++ b/services/autoscaling/Dockerfile
@@ -23,8 +23,7 @@ ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
@@ -87,8 +86,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/autoscaling/Dockerfile
+++ b/services/autoscaling/Dockerfile
@@ -23,7 +23,7 @@ ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
@@ -86,7 +86,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/autoscaling/Dockerfile
+++ b/services/autoscaling/Dockerfile
@@ -23,7 +23,7 @@ ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
@@ -86,7 +86,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   apt-get install -y --no-install-recommends \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,7 +68,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -20,8 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,8 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,7 +68,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/clusters-keeper/Dockerfile
+++ b/services/clusters-keeper/Dockerfile
@@ -23,8 +23,7 @@ ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
@@ -87,8 +86,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/clusters-keeper/Dockerfile
+++ b/services/clusters-keeper/Dockerfile
@@ -23,7 +23,7 @@ ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
@@ -86,7 +86,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/clusters-keeper/Dockerfile
+++ b/services/clusters-keeper/Dockerfile
@@ -23,7 +23,7 @@ ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
@@ -86,7 +86,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -22,8 +22,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -78,8 +77,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -78,7 +78,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -78,7 +78,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN  --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
   --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
   set -eux \
   && apt-get update \
@@ -78,7 +78,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN  --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
   --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
   set -eux \
   && apt-get update \

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -30,6 +30,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   curl \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 

--- a/services/datcore-adapter/Dockerfile
+++ b/services/datcore-adapter/Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   apt-get install -y --no-install-recommends \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 

--- a/services/datcore-adapter/Dockerfile
+++ b/services/datcore-adapter/Dockerfile
@@ -20,8 +20,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,8 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/datcore-adapter/Dockerfile
+++ b/services/datcore-adapter/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,7 +68,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/datcore-adapter/Dockerfile
+++ b/services/datcore-adapter/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,7 +68,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/director-v2/Dockerfile
+++ b/services/director-v2/Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   apt-get install -y --no-install-recommends \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 

--- a/services/director-v2/Dockerfile
+++ b/services/director-v2/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,7 +68,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/director-v2/Dockerfile
+++ b/services/director-v2/Dockerfile
@@ -20,8 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,8 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/director-v2/Dockerfile
+++ b/services/director-v2/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,7 +68,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/director/Dockerfile
+++ b/services/director/Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   apt-get install -y --no-install-recommends \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 

--- a/services/director/Dockerfile
+++ b/services/director/Dockerfile
@@ -20,8 +20,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,8 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/director/Dockerfile
+++ b/services/director/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,7 +68,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/director/Dockerfile
+++ b/services/director/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,7 +68,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/dynamic-scheduler/Dockerfile
+++ b/services/dynamic-scheduler/Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   apt-get install -y --no-install-recommends \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 

--- a/services/dynamic-scheduler/Dockerfile
+++ b/services/dynamic-scheduler/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,7 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/dynamic-scheduler/Dockerfile
+++ b/services/dynamic-scheduler/Dockerfile
@@ -20,8 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,8 +66,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/dynamic-scheduler/Dockerfile
+++ b/services/dynamic-scheduler/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,7 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -108,7 +108,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -108,7 +108,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -108,8 +108,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/efs-guardian/Dockerfile
+++ b/services/efs-guardian/Dockerfile
@@ -23,7 +23,7 @@ ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
@@ -104,7 +104,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/efs-guardian/Dockerfile
+++ b/services/efs-guardian/Dockerfile
@@ -23,8 +23,7 @@ ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
@@ -105,8 +104,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/efs-guardian/Dockerfile
+++ b/services/efs-guardian/Dockerfile
@@ -23,7 +23,7 @@ ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
@@ -104,7 +104,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/invitations/Dockerfile
+++ b/services/invitations/Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   apt-get install -y --no-install-recommends \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 

--- a/services/invitations/Dockerfile
+++ b/services/invitations/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,7 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/invitations/Dockerfile
+++ b/services/invitations/Dockerfile
@@ -20,8 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,8 +66,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/invitations/Dockerfile
+++ b/services/invitations/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,7 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/migration/Dockerfile
+++ b/services/migration/Dockerfile
@@ -40,7 +40,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 # --------------------------------------------
 FROM base AS build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/migration/Dockerfile
+++ b/services/migration/Dockerfile
@@ -40,8 +40,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 # --------------------------------------------
 FROM base AS build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/migration/Dockerfile
+++ b/services/migration/Dockerfile
@@ -40,7 +40,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 # --------------------------------------------
 FROM base AS build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   apt-get install -y --no-install-recommends \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,7 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -20,8 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,8 +66,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -67,7 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/resource-usage-tracker/Dockerfile
+++ b/services/resource-usage-tracker/Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   apt-get install -y --no-install-recommends \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 

--- a/services/resource-usage-tracker/Dockerfile
+++ b/services/resource-usage-tracker/Dockerfile
@@ -20,8 +20,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,8 +67,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/resource-usage-tracker/Dockerfile
+++ b/services/resource-usage-tracker/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,7 +68,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/resource-usage-tracker/Dockerfile
+++ b/services/resource-usage-tracker/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer=sanderegg
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -68,7 +68,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET=build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/storage/Dockerfile
+++ b/services/storage/Dockerfile
@@ -25,6 +25,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   apt-get install -y --no-install-recommends \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 

--- a/services/storage/Dockerfile
+++ b/services/storage/Dockerfile
@@ -19,7 +19,7 @@ LABEL maintainer=mguidon
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -75,7 +75,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/storage/Dockerfile
+++ b/services/storage/Dockerfile
@@ -19,7 +19,7 @@ LABEL maintainer=mguidon
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -75,7 +75,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/storage/Dockerfile
+++ b/services/storage/Dockerfile
@@ -19,8 +19,7 @@ LABEL maintainer=mguidon
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -75,8 +74,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -21,7 +21,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -78,7 +78,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET build
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -21,8 +21,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -78,8 +77,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET build
 
-RUN --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
+RUN --mount=type=cache,target=/var/cache/apt \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -21,7 +21,7 @@ LABEL maintainer=pcrespov
 # for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
 RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -78,7 +78,7 @@ FROM base AS build
 
 ENV SC_BUILD_TARGET build
 
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -28,6 +28,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   libmagic1 \
   gosu \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
Building the frontend docker image seems to become more and more resource intensive on the github runners, especially when USA wakes up.

This PR:
- separates in 2 separate jobs building of the backend and the frontend,
- both upload now to an CI artifact named `docker-buildx-images-${{ runner.os }}-${{ github.sha }}-backend` and `docker-buildx-images-${{ runner.os }}-${{ github.sha }}-frontend` ,
- integration tests that _only_ need the backend depend only on the backend images being built
- system tests need both the backend and frontend now have that additional dependency
- improved `load images` step by parallelizing (gain of ~50%, ~1m20 to 30-40s),
- some small changes in dockerfile caching that might bring some help
- removed step to delete data that takes 1minute for deletion
## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
