### PR TITLE
🐛 [e2e] click the first ``New Launcher`` button

### DIFF
--- a/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
@@ -112,7 +112,7 @@ def test_jupyterlab(
             logging.INFO,
             f"Creating multiple files and 1 file of about {large_file_size.human_readable()}",
         ):
-            iframe.get_by_role("button", name="New Launcher").click()
+            iframe.get_by_role("button", name="New Launcher").first().click()
             with page.expect_websocket(_JLabWaitForTerminalWebSocket()) as ws_info:
                 iframe.get_by_label("Launcher").get_by_text("Terminal").click()
 

--- a/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
@@ -153,7 +153,7 @@ def test_jupyterlab(
         return
     # Wait until iframe is shown and create new notebook with print statement
     with log_context(logging.INFO, "Running new notebook"):
-        iframe.get_by_role("button", name="New Launcher").click()
+        iframe.get_by_role("button", name="New Launcher").first().click()
         iframe.locator(".jp-LauncherCard-icon").first.click()
         iframe.get_by_role("tab", name="Untitled.ipynb").click()
         _jupyterlab_ui = iframe.get_by_label("Untitled.ipynb").get_by_role("textbox")

--- a/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
@@ -112,7 +112,7 @@ def test_jupyterlab(
             logging.INFO,
             f"Creating multiple files and 1 file of about {large_file_size.human_readable()}",
         ):
-            iframe.get_by_role("button", name="New Launcher").first().click()
+            iframe.get_by_role("button", name="New Launcher").nth(0).click()
             with page.expect_websocket(_JLabWaitForTerminalWebSocket()) as ws_info:
                 iframe.get_by_label("Launcher").get_by_text("Terminal").click()
 
@@ -153,7 +153,7 @@ def test_jupyterlab(
         return
     # Wait until iframe is shown and create new notebook with print statement
     with log_context(logging.INFO, "Running new notebook"):
-        iframe.get_by_role("button", name="New Launcher").first().click()
+        iframe.get_by_role("button", name="New Launcher").nth(0).click()
         iframe.locator(".jp-LauncherCard-icon").first.click()
         iframe.get_by_role("tab", name="Untitled.ipynb").click()
         _jupyterlab_ui = iframe.get_by_label("Untitled.ipynb").get_by_role("textbox")


### PR DESCRIPTION
## What do these changes do?

In the latest jupyter-smash there are 2 "New Launcher" buttons, this PR fixes the e2e by clicking the first match.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
