### PR TITLE
🐛 [Frontend] Bugfix: handle better ``groups/${gid}/users`` error

### DIFF
--- a/services/static-webserver/client/source/class/osparc/desktop/organizations/MembersList.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/organizations/MembersList.js
@@ -137,12 +137,14 @@ qx.Class.define("osparc.desktop.organizations.MembersList", {
             const usersStore = osparc.store.Users.getInstance();
             selectedMembers.forEach(selectedMemberGId => promises.push(usersStore.getUser(selectedMemberGId)));
             Promise.all(promises)
-              .then(users => {
-                users.forEach(user => this.__addMember(user.getUsername()));
+              .then(values => {
+                values.forEach(user => {
+                  if (user) {
+                    this.__addMember(user.getUsername());
+                  }
+                });
               })
-              .catch(err => {
-                console.error(err);
-              })
+              .catch(err => console.error(err))
               .finally(collaboratorsManager.close());
           } else {
             collaboratorsManager.close();

--- a/services/static-webserver/client/source/class/osparc/desktop/organizations/MembersList.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/organizations/MembersList.js
@@ -144,7 +144,7 @@ qx.Class.define("osparc.desktop.organizations.MembersList", {
                   }
                 });
               })
-              .catch(err => console.error(err))
+              .catch(console.error)
               .finally(collaboratorsManager.close());
           } else {
             collaboratorsManager.close();

--- a/services/static-webserver/client/source/class/osparc/store/Users.js
+++ b/services/static-webserver/client/source/class/osparc/store/Users.js
@@ -28,7 +28,7 @@ qx.Class.define("osparc.store.Users", {
   },
 
   members: {
-    fetchUser: function(groupId) {
+    __fetchUser: function(groupId) {
       const params = {
         url: {
           gid: groupId
@@ -41,14 +41,23 @@ qx.Class.define("osparc.store.Users", {
         });
     },
 
-    getUser: function(groupId, fetchIfNotFound = true) {
+    getUser: async function(groupId, fetchIfNotFound = true) {
       const userFound = this.getUsers().find(user => user.getGroupId() === groupId);
       if (userFound) {
-        return new Promise(resolve => resolve(userFound));
-      } else if (fetchIfNotFound) {
-        return this.fetchUser(groupId);
+        return userFound;
       }
-      return new Promise(reject => reject());
+      if (fetchIfNotFound) {
+        try {
+          const user = await this.__fetchUser(groupId);
+          if (user) {
+            return user;
+          }
+        } catch (error) {
+          console.error(error);
+          return null;
+        }
+      }
+      return null;
     },
 
     addUser: function(userData) {

--- a/services/static-webserver/client/source/class/osparc/store/Users.js
+++ b/services/static-webserver/client/source/class/osparc/store/Users.js
@@ -54,7 +54,6 @@ qx.Class.define("osparc.store.Users", {
           }
         } catch (error) {
           console.error(error);
-          return null;
         }
       }
       return null;


### PR DESCRIPTION
## What do these changes do?

When a group is not ``read``able  by a user, but a resource is shared with them and this group is part of the sharees, the listing of members will fail showing an empty list.

Before:
![Before](https://github.com/user-attachments/assets/bfa6872e-5dd2-4878-b9c2-78afee49d144)


After:
![Fixed](https://github.com/user-attachments/assets/81083ad3-9df3-4c0e-b22a-523169b82383)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
