### PR TITLE
🐛 remove noisy errors form logs

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/aws_s3_cli_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/aws_s3_cli_utils.py
@@ -13,6 +13,8 @@ _logger = logging.getLogger(__name__)
 def _parse_size(log_string):
     match = re.search(r"^\w+ (?P<size>[^\/]+)", log_string)
     if match:
+        # NOTE: ByteSize does not know what `Bytes` are.
+        # It only knows about `b` and omitting the word bytes if they are just bytes.
         return match.group("size").replace("Bytes", "")
     return None
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/aws_s3_cli_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/aws_s3_cli_utils.py
@@ -13,7 +13,7 @@ _logger = logging.getLogger(__name__)
 def _parse_size(log_string):
     match = re.search(r"^\w+ (?P<size>[^\/]+)", log_string)
     if match:
-        return match.group("size")
+        return match.group("size").replace("Bytes", "")
     return None
 
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/aws_s3_cli_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/aws_s3_cli_utils.py
@@ -13,9 +13,9 @@ _logger = logging.getLogger(__name__)
 def _parse_size(log_string):
     match = re.search(r"^\w+ (?P<size>[^\/]+)", log_string)
     if match:
-        # NOTE: ByteSize does not know what `Bytes` are.
+        # NOTE: ByteSize does not know what `Bytes` or `Byte` are.
         # It only knows about `b` and omitting the word bytes if they are just bytes.
-        return match.group("size").replace("Bytes", "")
+        return match.group("size").replace("Bytes", "").replace("Byte", "")
     return None
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

While per se this only generates tracebacks which have no impact on the functionality. It is creates noise when trying to check errors.

This fixes the below issue. ByteSize does not know what `Bytes` are. It only knows about `b` and omitting the word bytes if they are just bytes.

```python
2025-01-27 09:31:32 ERROR Unhandled exception:
Traceback (most recent call last):
  File "/home/runner/work/osparc-simcore/osparc-simcore/.venv/lib/python3.11/site-packages/servicelib/logging_utils.py", line 383, in log_catch
    yield
  File "/home/runner/work/osparc-simcore/osparc-simcore/.venv/lib/python3.11/site-packages/simcore_sdk/node_ports_common/aws_s3_cli_utils.py", line 38, in __call__
    _bytes = TypeAdapter(ByteSize).validate_python(_size)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/osparc-simcore/osparc-simcore/.venv/lib/python3.11/site-packages/pydantic/type_adapter.py", line 412, in validate_python
    return self.validator.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for function-after[_validate(), union[constrained-str,constrained-int]]
  could not interpret byte unit: Bytes [type=byte_size_unit, input_value='10 Bytes', input_type=str]
```


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
