### PR TITLE
🎨 Mergify queue takes over keeping in sync with master

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,5 +1,6 @@
 # NOTE: the PR is added to the queue when all checks have passed
-# and the CI is fully grean and ready to be merged
+# and the CI is fully green.
+# If the PR is behind the queue will take care of updating it
 queue_rules:
   - name: default
     queue_conditions:
@@ -21,17 +22,11 @@ queue_rules:
       - check-success=integration-tests
       - check-success=system-tests
 
-# NOTE: these rules help you to forget about the PR
-# and let mergify update it and deal with flaky tests
+# NOTE: in case of flaky tests you above checks will fail
+# the PR will be removed from the queue.
+# This retries the checks, as soon as they become green,
+# the PR will be pusehd to the queu again
 pull_request_rules:
-  - name: update branch if behind master
-    conditions:
-      - label=🤖-automerge
-      - label!=🤖-do-not-merge
-      - base=master
-    actions:
-      update:
-
   - name: retry CI on fails (used for flaky tests)
     conditions:
       - label=🤖-automerge


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

I did not realise how the `Queue` worked. Now it will do all the heavy lifting, leaving the `Workflow Automation` to deal with only flaky tests.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
