### PR TITLE
 ♻️ Update traefik router hardcoded priorities

### DIFF
--- a/services/docker-compose-dev-vendors.yml
+++ b/services/docker-compose-dev-vendors.yml
@@ -24,7 +24,6 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_manual.loadbalancer.healthcheck.interval=2000ms
         - traefik.http.services.${SWARM_STACK_NAME}_manual.loadbalancer.healthcheck.timeout=1000ms
         - traefik.http.routers.${SWARM_STACK_NAME}_manual.entrypoints=http
-        - traefik.http.routers.${SWARM_STACK_NAME}_manual.priority=10
         - traefik.http.routers.${SWARM_STACK_NAME}_manual.rule=HostRegexp(`${VENDOR_DEV_MANUAL_SUBDOMAIN}\.(?P<host>.+)`)
         - traefik.http.routers.${SWARM_STACK_NAME}_manual.middlewares=${SWARM_STACK_NAME}_gzip@swarm, ${SWARM_STACK_NAME}_manual-auth
     networks:

--- a/services/docker-compose.local.yml
+++ b/services/docker-compose.local.yml
@@ -134,7 +134,7 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_local.service=${SWARM_STACK_NAME}_webserver
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_local.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_local.rule=PathPrefix(`/dev/`)
-        - traefik.http.routers.${SWARM_STACK_NAME}_webserver_local.priority=3
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver_local.priority=9
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_local.middlewares=${SWARM_STACK_NAME}_gzip@swarm, ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader@swarm, ${SWARM_STACK_NAME}_webserver_retry
 
   wb-api-server:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -59,7 +59,7 @@ services:
         - traefik.http.services.${SWARM_STACK_NAME}_api-server.loadbalancer.healthcheck.timeout=1000ms
         - traefik.http.routers.${SWARM_STACK_NAME}_api-server.rule=(Path(`/`) || Path(`/v0`) ||  PathPrefix(`/v0/`) || Path(`/api/v0/openapi.json`))
         - traefik.http.routers.${SWARM_STACK_NAME}_api-server.entrypoints=simcore_api
-        - traefik.http.routers.${SWARM_STACK_NAME}_api-server.priority=1
+        - traefik.http.routers.${SWARM_STACK_NAME}_api-server.priority=3
         - traefik.http.routers.${SWARM_STACK_NAME}_api-server.middlewares=${SWARM_STACK_NAME}_gzip@swarm,ratelimit-${SWARM_STACK_NAME}_api-server,inflightreq-${SWARM_STACK_NAME}_api-server
     networks:
       - default
@@ -595,11 +595,11 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.rule=(Path(`/osparc`) || Path(`/s4l`) || Path(`/s4llite`) || Path(`/s4lacad`) || Path(`/s4lengine`) || Path(`/s4ldesktop`) || Path(`/s4ldesktopacad`) || Path(`/tis`) || Path(`/tiplite`) || Path(`/transpiled`) || Path(`/resource`) || PathPrefix(`/osparc/`) || PathPrefix(`/s4l/`) || PathPrefix(`/s4llite/`) || PathPrefix(`/s4lacad/`) || PathPrefix(`/s4lengine/`) || PathPrefix(`/s4ldesktop/`) || PathPrefix(`/s4ldesktopacad/`) || PathPrefix(`/tis/`) || PathPrefix(`/tiplite/`) || PathPrefix(`/transpiled/`) || PathPrefix(`/resource/`))
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.service=${SWARM_STACK_NAME}_static_webserver
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.entrypoints=http
-        - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.priority=2
+        - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.priority=6
         - traefik.http.routers.${SWARM_STACK_NAME}_static_webserver.middlewares=${SWARM_STACK_NAME}_gzip@swarm,${SWARM_STACK_NAME}_static_webserver_retry
         # catchall for legacy services (this happens if a backend disappears and a frontend tries to reconnect, the right return value is a 503)
         - traefik.http.routers.${SWARM_STACK_NAME}_legacy_services_catchall.service=${SWARM_STACK_NAME}_legacy_services_catchall
-        - traefik.http.routers.${SWARM_STACK_NAME}_legacy_services_catchall.priority=1
+        - traefik.http.routers.${SWARM_STACK_NAME}_legacy_services_catchall.priority=3
         - traefik.http.routers.${SWARM_STACK_NAME}_legacy_services_catchall.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_legacy_services_catchall.rule=PathRegexp(`^/x/(?P<node_uuid>\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b)[\/]?`)
         # this tricks traefik into a 502 (bad gateway) since the service does not exist on this port
@@ -612,7 +612,7 @@ services:
         # catchall for dynamic-sidecar powered-services (this happens if a backend disappears and a frontend tries to reconnect, the right return value is a 503)
         - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.service=${SWARM_STACK_NAME}_modern_services_catchall
         # the priority is a bit higher than webserver, the webserver is the fallback to everything and has prio 2
-        - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.priority=3
+        - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.priority=9
         - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.entrypoints=http
         # in theory the pattern should be uuid.services.OSPARC_DOMAIN, but anything could go through.. so let's catch everything
         - traefik.http.routers.${SWARM_STACK_NAME}_modern_services_catchall.rule=HostRegexp(`(?P<node_uuid>\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b)\.services\.(?P<host>.+)`)
@@ -836,7 +836,7 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.service=${SWARM_STACK_NAME}_webserver
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.rule=(Path(`/`) || Path(`/v0`) || Path(`/socket.io/`) || Path(`/static-frontend-data.json`) || PathRegexp(`^/study/(?P<study_uuid>\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b)`) || Path(`/view`) || Path(`/#/view`) || Path(`/#/error`) || PathPrefix(`/v0/`))
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.entrypoints=http
-        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.priority=2
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver.priority=6
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver.middlewares=${SWARM_STACK_NAME}_gzip@swarm, ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader@swarm, ${SWARM_STACK_NAME}_webserver_retry
     networks: &webserver_networks
       - default


### PR DESCRIPTION
## What do these changes do?

* Update traefik router hardcoded priorities according to the rules below
  - 1 --> 3
  - 2 --> 6
  -  3 --> 9
* Remove unnecessary priority from `manual` service

This PR introduces some space in-between the routers which we can use to flexibly add new routers. It shouldn't break existing priority hierarchy since numbers <10 are still below any other non-hardcoded priorities.

Remarks for future:
* Whenever introducing some priorities to traefik routers (or other similar cases) one better to make them spacious to retain flexibility. This case is a good example why "spacious" approach makes sense

## Related issue/s
* unblocks https://github.com/ITISFoundation/osparc-ops-environments/issues/218 

## Related PRs
* https://github.com/ITISFoundation/osparc-ops-environments/pull/953
* https://github.com/ITISFoundation/osparc-ops-environments/pull/950

## How to test

## Dev-ops checklist
- [X] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))