### PR TITLE
🐛 fixes failure due to nullable doi in licensed-items web-api response

### DIFF
--- a/packages/models-library/src/models_library/api_schemas_webserver/licensed_items.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/licensed_items.py
@@ -56,7 +56,7 @@ class _ItisVipRestData(OutputSchema):
     description: str
     thumbnail: str
     features: FeaturesDict  # NOTE: here there is a bit of coupling with domain model
-    doi: str
+    doi: str | None
 
 
 class _ItisVipResourceRestData(OutputSchema):
@@ -92,13 +92,14 @@ class LicensedItemRestGet(OutputSchema):
                             {
                                 "categoryId": "HumanWholeBody",
                                 "categoryDisplay": "Humans",
-                                "source": VIP_DETAILS_EXAMPLE,
+                                "source": {**VIP_DETAILS_EXAMPLE, "doi": doi},
                             },
                         ),
                         "pricingPlanId": "15",
                         "createdAt": "2024-12-12 09:59:26.422140",
                         "modifiedAt": "2024-12-12 09:59:26.422140",
                     }
+                    for doi in ["10.1000/xyz123", None]
                 ]
             }
         )

--- a/packages/models-library/src/models_library/licenses.py
+++ b/packages/models-library/src/models_library/licenses.py
@@ -110,7 +110,14 @@ class LicensedItem(BaseModel):
                         "display_name": "my best model",
                         "licensed_resource_name": "best-model",
                         "licensed_resource_type": f"{LicensedResourceType.VIP_MODEL}",
-                        "licensed_resource_data": cast(JsonDict, VIP_DETAILS_EXAMPLE),
+                        "licensed_resource_data": cast(
+                            JsonDict,
+                            {
+                                "category_id": "HumanWholeBody",
+                                "category_display": "Humans",
+                                "source": VIP_DETAILS_EXAMPLE,
+                            },
+                        ),
                         "pricing_plan_id": "15",
                         "created_at": "2024-12-12 09:59:26.422140",
                         "modified_at": "2024-12-12 09:59:26.422140",

--- a/packages/models-library/tests/test_licenses.py
+++ b/packages/models-library/tests/test_licenses.py
@@ -4,13 +4,17 @@ from models_library.licenses import LicensedItem
 
 def test_licensed_item_from_domain_model():
     for example in LicensedItem.model_json_schema()["examples"]:
-        example["licensed_resource_data"]["source"]["doi"] = None
-
         item = LicensedItem.model_validate(example)
+
         payload = LicensedItemRestGet.from_domain_model(item)
 
         assert item.display_name == payload.display_name
+
+        # nullable doi
         assert (
-            item.licensed_resource_data["source"]["doi"]
-            == payload.licensed_resource_data.source.doi
+            payload.licensed_resource_data.source.doi
+            == item.licensed_resource_data["source"]["doi"]
         )
+
+        # date is required
+        assert payload.licensed_resource_data.source.features["date"]

--- a/packages/models-library/tests/test_licenses.py
+++ b/packages/models-library/tests/test_licenses.py
@@ -1,0 +1,16 @@
+from models_library.api_schemas_webserver.licensed_items import LicensedItemRestGet
+from models_library.licenses import LicensedItem
+
+
+def test_licensed_item_from_domain_model():
+    for example in LicensedItem.model_json_schema()["examples"]:
+        example["licensed_resource_data"]["source"]["doi"] = None
+
+        item = LicensedItem.model_validate(example)
+        payload = LicensedItemRestGet.from_domain_model(item)
+
+        assert item.display_name == payload.display_name
+        assert (
+            item.licensed_resource_data["source"]["doi"]
+            == payload.licensed_resource_data.source.doi
+        )

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -15542,7 +15542,9 @@ components:
         features:
           $ref: '#/components/schemas/FeaturesDict'
         doi:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Doi
       type: object
       required:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

Fixes validation error in master deploy
```
  File "/home/scu/.venv/lib/python3.11/site-packages/pydantic/main.py", line 627, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for LicensedItemRestGet
licensed_resource_data.source.doi
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.10/v/string_type
```

## Related issue/s

- master deploy error reported by @odeimaiz 

## How to test

```
cd packages/models-library
make install-dev
pytest -vv tests/test_licenses
```
## Dev-ops
