### PR TITLE
♻️ [Frontend] Storage calls: Deprecate old endpoints

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -1176,33 +1176,25 @@ qx.Class.define("osparc.data.Resources", {
       "storageLocations": {
         useCache: true,
         endpoints: {
-          get: {
+          getLocations: {
             method: "GET",
             url: statics.API + "/storage/locations"
           }
         }
       },
       /*
-       * STORAGE DATASETS
-       */
-      "storageDatasets": {
-        useCache: false,
-        endpoints: {
-          getByLocation: {
-            method: "GET",
-            url: statics.API + "/storage/locations/{locationId}/datasets"
-          }
-        }
-      },
-      /*
-       * STORAGE FILES
+       * STORAGE
        */
       "storageFiles": {
         useCache: false,
         endpoints: {
-          getByLocationAndDataset: {
+          getByLocation: {
             method: "GET",
-            url: statics.API + "/storage/locations/{locationId}/datasets/{datasetId}/metadata"
+            url: statics.API + "/storage/locations/{locationId}/files/metadata"
+          },
+          getByStudy: {
+            method: "GET",
+            url: statics.API + "/storage/locations/0/files/metadata?uuid_filter={studyId}"
           },
           getByNode: {
             method: "GET",

--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -155,10 +155,10 @@ qx.Class.define("osparc.file.FilePicker", {
         const params = {
           url: {
             locationId: outValue.store,
-            datasetId: outValue.dataset
+            studyId: outValue.dataset
           }
         };
-        osparc.data.Resources.fetch("storageFiles", "getByLocationAndDataset", params)
+        osparc.data.Resources.fetch("storageFiles", "getByStudy", params)
           .then(files => {
             const fileMetadata = files.find(file => file.file_id === outValue.path);
             if (fileMetadata) {

--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -155,7 +155,7 @@ qx.Class.define("osparc.file.FilePicker", {
         const params = {
           url: {
             locationId: outValue.store,
-            studyId: outValue.dataset
+            datasetId: outValue.dataset
           }
         };
         osparc.data.Resources.fetch("storageFiles", "getByStudy", params)

--- a/services/static-webserver/client/source/class/osparc/file/FilesTree.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilesTree.js
@@ -441,10 +441,11 @@ qx.Class.define("osparc.file.FilesTree", {
       locationModel.getChildren().removeAll();
       let openThis = null;
       datasets.forEach(dataset => {
+        const studyId = dataset["file_uuid"].split("/")[0];
         const datasetData = osparc.data.Converters.createDirEntry(
-          dataset.display_name,
+          dataset["label"],
           locationId,
-          dataset.dataset_id
+          studyId,
         );
         datasetData.isDataset = true;
         datasetData.loaded = false;
@@ -454,7 +455,7 @@ qx.Class.define("osparc.file.FilesTree", {
         locationModel.getChildren().append(datasetModel);
 
         // add cached files
-        const datasetId = dataset.dataset_id;
+        const datasetId = studyId;
         const cachedData = dataStore.getFilesByLocationAndDatasetCached(locationId, datasetId);
         if (cachedData) {
           this.__filesToDataset(cachedData.location, cachedData.dataset, cachedData.files);

--- a/services/static-webserver/client/source/class/osparc/store/Data.js
+++ b/services/static-webserver/client/source/class/osparc/store/Data.js
@@ -162,7 +162,7 @@ qx.Class.define("osparc.store.Data", {
           const params = {
             url: {
               locationId,
-              studyId: datasetId
+              datasetId,
             }
           };
           osparc.data.Resources.fetch("storageFiles", "getByStudy", params)

--- a/services/static-webserver/client/source/class/osparc/store/Data.js
+++ b/services/static-webserver/client/source/class/osparc/store/Data.js
@@ -63,7 +63,7 @@ qx.Class.define("osparc.store.Data", {
           resolve(cachedData);
         } else {
           // Get available storage locations
-          osparc.data.Resources.get("storageLocations")
+          osparc.data.Resources.fetch("storageLocations", "getLocations")
             .then(locations => {
               // Add them to cache
               this.__locationsCached = locations;
@@ -109,7 +109,7 @@ qx.Class.define("osparc.store.Data", {
               locationId
             }
           };
-          osparc.data.Resources.fetch("storageDatasets", "getByLocation", params)
+          osparc.data.Resources.fetch("storageFiles", "getByLocation", params)
             .then(datasets => {
               const data = {
                 location: locationId,
@@ -162,10 +162,10 @@ qx.Class.define("osparc.store.Data", {
           const params = {
             url: {
               locationId,
-              datasetId
+              studyId: datasetId
             }
           };
-          osparc.data.Resources.fetch("storageFiles", "getByLocationAndDataset", params)
+          osparc.data.Resources.fetch("storageFiles", "getByStudy", params)
             .then(files => {
               const data = {
                 location: locationId,


### PR DESCRIPTION
## What do these changes do?

- [ ] Stop using ``/datasets`` calls

## Related issue/s

- related to https://github.com/ITISFoundation/osparc-issues/issues/1635


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
