### PR TITLE
🎨 Improves empty-trash to avoid misleading the user

### DIFF
--- a/services/web/server/src/simcore_service_webserver/trash/_rest.py
+++ b/services/web/server/src/simcore_service_webserver/trash/_rest.py
@@ -50,16 +50,16 @@ async def empty_trash(request: web.Request):
     user_id = get_user_id(request)
     product_name = get_product_name(request)
 
-    is_running = asyncio.Event()
+    is_fired = asyncio.Event()
 
-    async def _run():
-        is_running.set()
+    async def _empty_trash():
+        is_fired.set()
         await _service.safe_empty_trash(
             request.app, product_name=product_name, user_id=user_id
         )
 
     fire_and_forget_task(
-        _run(),
+        _empty_trash(),
         task_suffix_name="rest.empty_trash",
         fire_and_forget_tasks_collection=request.app[APP_FIRE_AND_FORGET_TASKS_KEY],
     )
@@ -68,6 +68,6 @@ async def empty_trash(request: web.Request):
     # when the front-end requests the trash item list,
     # it may still display items, misleading the user into
     # thinking the `empty trash` operation failed.
-    await is_running.wait()
+    await is_fired.wait()
 
     return web.json_response(status=status.HTTP_204_NO_CONTENT)

--- a/services/web/server/src/simcore_service_webserver/trash/_rest.py
+++ b/services/web/server/src/simcore_service_webserver/trash/_rest.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from aiohttp import web
@@ -20,10 +21,6 @@ from . import _service
 
 _logger = logging.getLogger(__name__)
 
-#
-# EXCEPTIONS HANDLING
-#
-
 
 _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
     ProjectRunningConflictError: HttpErrorInfo(
@@ -41,10 +38,6 @@ _handle_exceptions = exception_handling_decorator(
     to_exceptions_handlers_map(_TO_HTTP_ERROR_MAP)
 )
 
-
-#
-# ROUTES
-#
 
 routes = web.RouteTableDef()
 
@@ -64,5 +57,11 @@ async def empty_trash(request: web.Request):
         task_suffix_name="rest.empty_trash",
         fire_and_forget_tasks_collection=request.app[APP_FIRE_AND_FORGET_TASKS_KEY],
     )
+
+    # NOTE: Ensures `fire_and_forget_task` is triggered; otherwise,
+    # when the front-end requests the trash item list,
+    # it may still display items, misleading the user into
+    # thinking the `empty trash` operation failed.
+    await asyncio.sleep(1)
 
     return web.json_response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

Prevents that when the front-end requests `empty-trash` and subsequently requests the trash item list, it may still display items, misleading the user into thinking the `empty trash` operation failed.


## Related issue/s

- issue reported by @odeimaiz 
- enhancements on ITISFoundation/osparc-issues#468


## How to test

Manually tested:
- trash many items
- Go to "Recently Deleted"
- Click `Delete all`
![image](https://github.com/user-attachments/assets/3bde3301-0fca-411f-85be-a7f976fcc98f)
-  shows none
![image](https://github.com/user-attachments/assets/c60ef61b-c712-4259-8dc3-e83fcaf1dfa4)



## Dev-ops