### PR TITLE
🐛 catalog-api: Fixes validation errors on /services entrypoint

### DIFF
--- a/packages/models-library/src/models_library/services_base.py
+++ b/packages/models-library/src/models_library/services_base.py
@@ -67,6 +67,6 @@ class ServiceBaseDisplay(BaseModel):
         ),
     ] = None
 
-    _empty_is_none = field_validator("thumbnail", mode="before")(
-        empty_str_to_none_pre_validator
-    )
+    _empty_is_none = field_validator(
+        "icon", "thumbnail", "version_display", mode="before"
+    )(empty_str_to_none_pre_validator)

--- a/packages/models-library/src/models_library/services_base.py
+++ b/packages/models-library/src/models_library/services_base.py
@@ -41,7 +41,10 @@ class ServiceBaseDisplay(BaseModel):
             validate_default=True,
         ),
     ] = None
-    icon: Annotated[HttpUrl | None, Field(description="URL to the service icon")] = None
+    icon: Annotated[
+        HttpUrl | None,
+        Field(description="URL to the service icon"),
+    ] = None
     description: Annotated[
         str,
         Field(

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/163b11424cb1_convert_empty_str_to_null.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/163b11424cb1_convert_empty_str_to_null.py
@@ -17,6 +17,8 @@ depends_on = None
 
 def upgrade():
 
+    # SEE https://github.com/ITISFoundation/osparc-simcore/pull/7268
+
     op.execute(
         sa.DDL(
             """

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/163b11424cb1_convert_empty_str_to_null.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/163b11424cb1_convert_empty_str_to_null.py
@@ -47,4 +47,6 @@ def upgrade():
 
 
 def downgrade():
-    pass
+    """
+    Nothing to be done here
+    """

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/163b11424cb1_convert_empty_str_to_null.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/163b11424cb1_convert_empty_str_to_null.py
@@ -1,0 +1,48 @@
+"""enforce null
+
+Revision ID: 163b11424cb1
+Revises: a8d336ca9379
+Create Date: 2025-02-24 12:44:10.538469+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "163b11424cb1"
+down_revision = "a8d336ca9379"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    op.execute(
+        sa.DDL(
+            """
+        UPDATE services_meta_data
+        SET thumbnail = NULL
+        WHERE thumbnail = '';
+        """
+        )
+    )
+    op.execute(
+        sa.DDL(
+            """
+        UPDATE services_meta_data
+        SET version_display = NULL
+        WHERE version_display = '';
+        """
+        )
+    )
+    op.execute(
+        """
+        UPDATE services_meta_data
+        SET icon = NULL
+        WHERE icon = '';
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/services/catalog/src/simcore_service_catalog/models/services_db.py
+++ b/services/catalog/src/simcore_service_catalog/models/services_db.py
@@ -8,7 +8,7 @@ from models_library.services_access import ServiceGroupAccessRights
 from models_library.services_base import ServiceKeyVersion
 from models_library.services_types import ServiceKey, ServiceVersion
 from models_library.utils.common_validators import empty_str_to_none_pre_validator
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.config import JsonDict
 from pydantic.types import PositiveInt
 from simcore_postgres_database.models.services_compatibility import CompatiblePolicyDict
@@ -26,24 +26,9 @@ class ServiceMetaDataDBGet(BaseModel):
     name: str
     description: str
     description_ui: bool
-    thumbnail: Annotated[
-        str | None,
-        # NOTE: Prevents validation errors caused by empty strings mistakenly
-        # set instead of null in the database.
-        BeforeValidator(empty_str_to_none_pre_validator),
-    ]
-    icon: Annotated[
-        str | None,
-        # NOTE: Prevents validation errors caused by empty strings mistakenly
-        # set instead of null in the database.
-        BeforeValidator(empty_str_to_none_pre_validator),
-    ]
-    version_display: Annotated[
-        str | None,
-        # NOTE: Prevents validation errors caused by empty strings mistakenly
-        # set instead of null in the database.
-        BeforeValidator(empty_str_to_none_pre_validator),
-    ]
+    thumbnail: str | None
+    icon: str | None
+    version_display: str | None
 
     # tagging
     classifiers: list[str]
@@ -97,6 +82,14 @@ class ServiceMetaDataDBGet(BaseModel):
         from_attributes=True, json_schema_extra=_update_json_schema_extra
     )
 
+    _prevents_empty_strings_in_nullable_string_cols = field_validator(
+        "icon", "thumbnail", "version_display", mode="before"
+    )(
+        # NOTE: Prevents validation errors caused by empty strings
+        # mistakenly manually set instead of null in the database.
+        empty_str_to_none_pre_validator
+    )
+
 
 class ServiceMetaDataDBCreate(BaseModel):
     # primary-keys
@@ -139,6 +132,13 @@ class ServiceMetaDataDBCreate(BaseModel):
 
     model_config = ConfigDict(json_schema_extra=_update_json_schema_extra)
 
+    _prevents_empty_strings_in_nullable_string_cols = field_validator(
+        "icon", "thumbnail", "version_display", mode="before"
+    )(
+        # NOTE: Prevents empty strings in nullable string columns
+        empty_str_to_none_pre_validator
+    )
+
 
 class ServiceMetaDataDBPatch(BaseModel):
     # ownership
@@ -175,6 +175,13 @@ class ServiceMetaDataDBPatch(BaseModel):
 
     model_config = ConfigDict(json_schema_extra=_update_json_schema_extra)
 
+    _prevents_empty_strings_in_nullable_string_cols = field_validator(
+        "icon", "thumbnail", "version_display", mode="before"
+    )(
+        # NOTE: Prevents empty strings in nullable string columns
+        empty_str_to_none_pre_validator
+    )
+
 
 class ReleaseDBGet(BaseModel):
     version: ServiceVersion
@@ -205,6 +212,14 @@ class ServiceWithHistoryDBGet(BaseModel):
     deprecated: datetime | None
     # releases
     history: list[ReleaseDBGet]
+
+    _prevents_empty_strings_in_nullable_string_cols = field_validator(
+        "icon", "thumbnail", "version_display", mode="before"
+    )(
+        # NOTE: Prevents validation errors caused by empty strings
+        # mistakenly manually set instead of null in the database.
+        empty_str_to_none_pre_validator
+    )
 
 
 assert (  # nosec

--- a/services/catalog/src/simcore_service_catalog/models/services_db.py
+++ b/services/catalog/src/simcore_service_catalog/models/services_db.py
@@ -7,7 +7,8 @@ from models_library.products import ProductName
 from models_library.services_access import ServiceGroupAccessRights
 from models_library.services_base import ServiceKeyVersion
 from models_library.services_types import ServiceKey, ServiceVersion
-from pydantic import BaseModel, ConfigDict, Field
+from models_library.utils.common_validators import empty_str_to_none_pre_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 from pydantic.config import JsonDict
 from pydantic.types import PositiveInt
 from simcore_postgres_database.models.services_compatibility import CompatiblePolicyDict
@@ -25,9 +26,24 @@ class ServiceMetaDataDBGet(BaseModel):
     name: str
     description: str
     description_ui: bool
-    thumbnail: str | None
-    icon: str | None
-    version_display: str | None
+    thumbnail: Annotated[
+        str | None,
+        # NOTE: Prevents validation errors caused by empty strings mistakenly
+        # set instead of null in the database.
+        BeforeValidator(empty_str_to_none_pre_validator),
+    ]
+    icon: Annotated[
+        str | None,
+        # NOTE: Prevents validation errors caused by empty strings mistakenly
+        # set instead of null in the database.
+        BeforeValidator(empty_str_to_none_pre_validator),
+    ]
+    version_display: Annotated[
+        str | None,
+        # NOTE: Prevents validation errors caused by empty strings mistakenly
+        # set instead of null in the database.
+        BeforeValidator(empty_str_to_none_pre_validator),
+    ]
 
     # tagging
     classifiers: list[str]

--- a/services/catalog/src/simcore_service_catalog/models/services_db.py
+++ b/services/catalog/src/simcore_service_catalog/models/services_db.py
@@ -82,14 +82,6 @@ class ServiceMetaDataDBGet(BaseModel):
         from_attributes=True, json_schema_extra=_update_json_schema_extra
     )
 
-    _prevents_empty_strings_in_nullable_string_cols = field_validator(
-        "icon", "thumbnail", "version_display", mode="before"
-    )(
-        # NOTE: Prevents validation errors caused by empty strings
-        # mistakenly manually set instead of null in the database.
-        empty_str_to_none_pre_validator
-    )
-
 
 class ServiceMetaDataDBCreate(BaseModel):
     # primary-keys

--- a/services/catalog/src/simcore_service_catalog/models/services_db.py
+++ b/services/catalog/src/simcore_service_catalog/models/services_db.py
@@ -205,14 +205,6 @@ class ServiceWithHistoryDBGet(BaseModel):
     # releases
     history: list[ReleaseDBGet]
 
-    _prevents_empty_strings_in_nullable_string_cols = field_validator(
-        "icon", "thumbnail", "version_display", mode="before"
-    )(
-        # NOTE: Prevents validation errors caused by empty strings
-        # mistakenly manually set instead of null in the database.
-        empty_str_to_none_pre_validator
-    )
-
 
 assert (  # nosec
     set(ReleaseDBGet.model_fields)

--- a/services/catalog/src/simcore_service_catalog/models/services_db.py
+++ b/services/catalog/src/simcore_service_catalog/models/services_db.py
@@ -124,12 +124,9 @@ class ServiceMetaDataDBCreate(BaseModel):
 
     model_config = ConfigDict(json_schema_extra=_update_json_schema_extra)
 
-    _prevents_empty_strings_in_nullable_string_cols = field_validator(
+    _prevent_empty_strings_in_nullable_string_cols = field_validator(
         "icon", "thumbnail", "version_display", mode="before"
-    )(
-        # NOTE: Prevents empty strings in nullable string columns
-        empty_str_to_none_pre_validator
-    )
+    )(empty_str_to_none_pre_validator)
 
 
 class ServiceMetaDataDBPatch(BaseModel):
@@ -167,12 +164,9 @@ class ServiceMetaDataDBPatch(BaseModel):
 
     model_config = ConfigDict(json_schema_extra=_update_json_schema_extra)
 
-    _prevents_empty_strings_in_nullable_string_cols = field_validator(
+    _prevent_empty_strings_in_nullable_string_cols = field_validator(
         "icon", "thumbnail", "version_display", mode="before"
-    )(
-        # NOTE: Prevents empty strings in nullable string columns
-        empty_str_to_none_pre_validator
-    )
+    )(empty_str_to_none_pre_validator)
 
 
 class ReleaseDBGet(BaseModel):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This PR fixes a validation issue caused by invalid values in the database.


A request to the catalog service was failing due to an invalid value in the database:

```sh
curl http://master_catalog:8000/v0/services/simcore%2Fservices%2Fdynamic%2Fjupyter-math/3.0.3?user_id=530
{"errors":["1 validation errors:\n  {'type': 'url_parsing', 'loc': ('response', 'icon'), 'msg': 'Input should be a valid URL, input is empty', 'input': '', 'ctx': {'error': 'input is empty'}}\n"]}
```

The issue occurred because the `icon` column in the second row **was set to an empty string** instead of either a valid URL or `NULL`.

![image](https://github.com/user-attachments/assets/bcff0394-1827-4b5c-8353-ff48284a32e1)

This could have been introduced manually in the database or as a result of an unintended transformation between models in the system.

To address this, we implemented the following changes:

- **Database Migration**: Replaces existing empty strings with `NULL` in nullable string columns.
- **Validation Mechanism**: Prevents writing empty strings to the database at the model level.

Since these values should not be modified in the database directly, we consider additional constraints at the database level unnecessary, as the existing code-level checks are sufficient.


## Related issue/s

- Issue  reported by @GitHK in master deploy


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops 

None
