### PR TITLE
🎨Storage: display path field is url encoded by parts

### DIFF
--- a/packages/models-library/src/models_library/api_schemas_storage/storage_schemas.py
+++ b/packages/models-library/src/models_library/api_schemas_storage/storage_schemas.py
@@ -407,7 +407,10 @@ class SoftCopyBody(BaseModel):
 class PathMetaDataGet(BaseModel):
     path: Annotated[Path, Field(description="the path to the current path")]
     display_path: Annotated[
-        Path, Field(description="the path to display with UUID replaced")
+        Path,
+        Field(
+            description="the path to display with UUID replaced (URL Encoded by parts as names may contain '/')"
+        ),
     ]
 
     file_meta_data: Annotated[

--- a/services/storage/src/simcore_service_storage/models.py
+++ b/services/storage/src/simcore_service_storage/models.py
@@ -353,7 +353,12 @@ GenericCursor: TypeAlias = str | bytes
 
 class PathMetaData(BaseModel):
     path: Path
-    display_path: Path
+    display_path: Annotated[
+        Path,
+        Field(
+            description="Path with names instead of IDs (URL Encoded by parts as names may contain '/')"
+        ),
+    ]
     location_id: LocationID
     location: LocationName
     bucket_name: str

--- a/services/storage/src/simcore_service_storage/models.py
+++ b/services/storage/src/simcore_service_storage/models.py
@@ -369,7 +369,7 @@ class PathMetaData(BaseModel):
     def update_display_fields(self, id_name_mapping: dict[str, str]) -> None:
         display_path = f"{self.path}"
         for old, new in id_name_mapping.items():
-            display_path = display_path.replace(old, new)
+            display_path = display_path.replace(old, urllib.parse.quote(new, safe=""))
         self.display_path = Path(display_path)
 
         if self.file_meta_data:

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -847,7 +847,6 @@ async def with_random_project_with_files(
         ],
     ],
     project_params: ProjectWithFilesParams,
-    faker: Faker,
 ) -> tuple[dict[str, Any], dict[NodeID, dict[SimcoreS3FileID, FileIDDict]],]:
     return await random_project_with_files(project_params)
 

--- a/services/storage/tests/unit/test_handlers_paths.py
+++ b/services/storage/tests/unit/test_handlers_paths.py
@@ -484,8 +484,14 @@ async def test_list_paths_with_display_name_containing_slashes(
             expected_paths=expected_paths,
             check_total=False,
         )
+
+        expected_display_path = "/".join(
+            [
+                quote(project_name_with_slashes, safe=""),
+                quote(node_name_with_non_ascii, safe=""),
+                *(expected_paths[0][0].parts[2:]),
+            ],
+        )
         assert page_of_paths.items[0].display_path == Path(
-            quote(project_name_with_slashes, safe="")
-        ) / quote(
-            node_name_with_non_ascii, safe=""
+            expected_display_path
         ), "display path parts should be url encoded"

--- a/services/storage/tests/unit/test_handlers_paths.py
+++ b/services/storage/tests/unit/test_handlers_paths.py
@@ -475,7 +475,7 @@ async def test_list_paths_with_display_name_containing_slashes(
         expected_paths = _filter_and_group_paths_one_level_deeper(
             selected_node_s3_keys, selected_path_filter[0]
         )
-        await _assert_list_paths(
+        page_of_paths = await _assert_list_paths(
             initialized_app,
             client,
             location_id,
@@ -484,3 +484,8 @@ async def test_list_paths_with_display_name_containing_slashes(
             expected_paths=expected_paths,
             check_total=False,
         )
+        assert page_of_paths.items[0].display_path == Path(
+            quote(project_name_with_slashes, safe="")
+        ) / quote(
+            node_name_with_non_ascii, safe=""
+        ), "display path parts should be url encoded"


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
This PR brings url encoding (including `/` characters) for the `display_path` field in `PathMetaData` object.

This is needed as project names and node names may contain any kind of characters including `/` characters.


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
