### PR TITLE
⬆️ upgraded director-v2 requirements

### DIFF
--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -1,9 +1,9 @@
-aio-pika==9.4.1
+aio-pika==9.5.5
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiocache==0.12.2
+aiocache==0.12.3
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -13,17 +13,19 @@ aiodebug==2.3.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-aiodocker==0.21.0
+aiodocker==0.24.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiofiles==23.2.1
+aiofiles==24.1.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-aiohttp==3.9.5
+aiohappyeyeballs==2.5.0
+    # via aiohttp
+aiohttp==3.11.13
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -65,25 +67,23 @@ aiopg==1.4.0
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-aiormq==6.8.0
+aiormq==6.8.1
     # via aio-pika
-aiosignal==1.3.1
+aiosignal==1.3.2
     # via aiohttp
-alembic==1.13.1
+alembic==1.15.1
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
 annotated-types==0.7.0
     # via pydantic
-anyio==4.3.0
+anyio==4.8.0
     # via
     #   fast-depends
     #   faststream
     #   httpx
     #   starlette
     #   watchfiles
-appdirs==1.4.4
-    # via pint
 arrow==1.3.0
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
@@ -96,12 +96,10 @@ arrow==1.3.0
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
 async-timeout==4.0.3
-    # via
-    #   aiopg
-    #   asyncpg
-asyncpg==0.29.0
+    # via aiopg
+asyncpg==0.30.0
     # via sqlalchemy
-attrs==23.2.0
+attrs==25.1.0
     # via
     #   aiohttp
     #   jsonschema
@@ -110,7 +108,7 @@ bidict==0.23.1
     # via python-socketio
 blosc==1.11.2
     # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
-certifi==2024.2.2
+certifi==2025.1.31
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -149,13 +147,14 @@ certifi==2024.2.2
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via requests
 click==8.1.7
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
+    #   rich-toolkit
     #   typer
     #   uvicorn
 cloudpickle==3.1.0
@@ -168,7 +167,7 @@ dask==2024.12.0
     #   -r requirements/../../../packages/dask-task-models-library/requirements/_base.in
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-deprecated==1.2.14
+deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -178,33 +177,34 @@ distributed==2024.12.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-dnspython==2.6.1
+dnspython==2.7.0
     # via email-validator
-email-validator==2.1.1
+email-validator==2.2.0
     # via
     #   fastapi
     #   pydantic
+exceptiongroup==1.2.2
+    # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.5
+fastapi==0.115.6
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   fastapi-lifespan-manager
-    #   prometheus-fastapi-instrumentator
-fastapi-cli==0.0.5
+fastapi-cli==0.0.7
     # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-faststream==0.5.31
+faststream==0.5.35
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 flexcache==0.3
     # via pint
-flexparser==0.3.1
+flexparser==0.4
     # via pint
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
@@ -212,24 +212,24 @@ fsspec==2024.10.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-googleapis-common-protos==1.65.0
+googleapis-common-protos==1.69.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-greenlet==3.0.3
+greenlet==3.1.1
     # via sqlalchemy
-grpcio==1.66.0
+grpcio==1.70.0
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
     #   wsproto
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httptools==0.6.1
+httptools==0.6.4
     # via uvicorn
-httpx==0.27.0
+httpx==0.28.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -268,7 +268,7 @@ httpx==0.27.0
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   fastapi
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   email-validator
@@ -321,14 +321,14 @@ jinja2==3.1.4
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
     #   fastapi
-jsonschema==4.22.0
+jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
 locket==1.0.0
     # via
@@ -337,7 +337,7 @@ locket==1.0.0
     #   partd
 lz4==4.3.3
     # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
-mako==1.3.5
+mako==1.3.9
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -388,15 +388,15 @@ msgpack==1.1.0
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   aiocache
     #   distributed
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-networkx==3.3
+networkx==3.4.2
     # via -r requirements/_base.in
 numpy==2.1.3
     # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
-opentelemetry-api==1.28.2
+opentelemetry-api==1.30.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -414,19 +414,19 @@ opentelemetry-api==1.28.2
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.28.2
+opentelemetry-exporter-otlp==1.30.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.28.2
+opentelemetry-exporter-otlp-proto-common==1.30.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.28.2
+opentelemetry-exporter-otlp-proto-grpc==1.30.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.28.2
+opentelemetry-exporter-otlp-proto-http==1.30.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.49b2
+opentelemetry-instrumentation==0.51b0
     # via
     #   opentelemetry-instrumentation-aiopg
     #   opentelemetry-instrumentation-asgi
@@ -437,44 +437,44 @@ opentelemetry-instrumentation==0.49b2
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aiopg==0.49b2
+opentelemetry-instrumentation-aiopg==0.51b0
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.49b2
+opentelemetry-instrumentation-asgi==0.51b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.49b2
+opentelemetry-instrumentation-asyncpg==0.51b0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-opentelemetry-instrumentation-dbapi==0.49b2
+opentelemetry-instrumentation-dbapi==0.51b0
     # via opentelemetry-instrumentation-aiopg
-opentelemetry-instrumentation-fastapi==0.49b2
+opentelemetry-instrumentation-fastapi==0.51b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.49b2
+opentelemetry-instrumentation-httpx==0.51b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-logging==0.49b2
+opentelemetry-instrumentation-logging==0.51b0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.49b2
+opentelemetry-instrumentation-redis==0.51b0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.49b2
+opentelemetry-instrumentation-requests==0.51b0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.28.2
+opentelemetry-proto==1.30.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.28.2
+opentelemetry-sdk==1.30.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.49b2
+opentelemetry-semantic-conventions==0.51b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
@@ -485,7 +485,7 @@ opentelemetry-semantic-conventions==0.49b2
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.49b2
+opentelemetry-util-http==0.51b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -493,7 +493,7 @@ opentelemetry-util-http==0.49b2
     #   opentelemetry-instrumentation-requests
 ordered-set==4.1.0
     # via -r requirements/_base.in
-orjson==3.10.3
+orjson==3.10.15
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -566,15 +566,21 @@ partd==1.4.2
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
-pint==0.24.3
+pint==0.24.4
     # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-prometheus-client==0.20.0
+platformdirs==4.3.6
+    # via pint
+prometheus-client==0.21.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   prometheus-fastapi-instrumentator
-prometheus-fastapi-instrumentator==6.1.0
+prometheus-fastapi-instrumentator==7.0.2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-protobuf==5.29.0
+propcache==0.3.0
+    # via
+    #   aiohttp
+    #   yarl
+protobuf==5.29.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
@@ -584,13 +590,13 @@ psutil==6.1.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.10
     # via
     #   aiopg
     #   sqlalchemy
 pycryptodome==3.21.0
     # via stream-zip
-pydantic==2.10.2
+pydantic==2.10.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -664,9 +670,9 @@ pydantic==2.10.2
     #   fastapi
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via pydantic
-pydantic-extra-types==2.10.0
+pydantic-extra-types==2.10.2
     # via
     #   -r requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -691,8 +697,42 @@ pydantic-extra-types==2.10.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   fastapi
-pydantic-settings==2.6.1
+pydantic-settings==2.7.0
     # via
+    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -704,9 +744,9 @@ pydantic-settings==2.6.1
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
     #   fastapi
-pygments==2.18.0
+pygments==2.19.1
     # via rich
-pyinstrument==4.6.2
+pyinstrument==5.0.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -716,11 +756,11 @@ python-dotenv==1.0.1
     # via
     #   pydantic-settings
     #   uvicorn
-python-engineio==4.9.1
+python-engineio==4.11.2
     # via python-socketio
-python-multipart==0.0.9
+python-multipart==0.0.20
     # via fastapi
-python-socketio==5.11.2
+python-socketio==5.12.1
     # via -r requirements/_base.in
 pyyaml==6.0.2
     # via
@@ -805,7 +845,7 @@ redis==5.2.1
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
     #   aiocache
-referencing==0.29.3
+referencing==0.35.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -845,7 +885,7 @@ referencing==0.29.3
     #   jsonschema-specifications
 requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
-rich==13.7.1
+rich==13.9.4
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
@@ -853,26 +893,27 @@ rich==13.7.1
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
+    #   rich-toolkit
     #   typer
-rpds-py==0.18.1
+rich-toolkit==0.13.2
+    # via fastapi-cli
+rpds-py==0.23.1
     # via
     #   jsonschema
     #   referencing
 shellingham==1.5.4
     # via typer
-simple-websocket==1.0.0
+simple-websocket==1.1.0
     # via python-engineio
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 sortedcontainers==2.4.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-sqlalchemy==1.4.52
+sqlalchemy==1.4.54
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -912,7 +953,7 @@ sqlalchemy==1.4.52
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
     #   aiopg
     #   alembic
-starlette==0.41.2
+starlette==0.41.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -949,6 +990,7 @@ starlette==0.41.2
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   fastapi
+    #   prometheus-fastapi-instrumentator
 stream-zip==0.0.83
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -957,7 +999,7 @@ tblib==3.0.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-tenacity==8.5.0
+tenacity==9.0.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -975,12 +1017,12 @@ tornado==6.4.2
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-tqdm==4.66.4
+tqdm==4.67.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-typer==0.12.3
+typer==0.15.2
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
@@ -988,13 +1030,13 @@ typer==0.12.3
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
     #   fastapi-cli
-types-python-dateutil==2.9.0.20240316
+types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
     # via
     #   aiodebug
-    #   aiodocker
     #   alembic
+    #   anyio
     #   fastapi
     #   faststream
     #   flexcache
@@ -1004,6 +1046,7 @@ typing-extensions==4.12.2
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   rich-toolkit
     #   typer
 ujson==5.10.0
     # via
@@ -1081,18 +1124,18 @@ urllib3==2.2.3
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
     #   requests
-uvicorn==0.29.0
+uvicorn==0.34.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   fastapi
     #   fastapi-cli
-uvloop==0.19.0
+uvloop==0.21.0
     # via uvicorn
-watchfiles==0.21.0
+watchfiles==1.0.4
     # via uvicorn
-websockets==12.0
+websockets==15.0.1
     # via uvicorn
-wrapt==1.16.0
+wrapt==1.17.2
     # via
     #   deprecated
     #   opentelemetry-instrumentation
@@ -1102,7 +1145,7 @@ wrapt==1.16.0
     #   opentelemetry-instrumentation-redis
 wsproto==1.2.0
     # via simple-websocket
-yarl==1.9.4
+yarl==1.18.3
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -1,4 +1,4 @@
-aio-pika==9.4.1
+aio-pika==9.5.5
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -6,30 +6,34 @@ aioboto3==13.3.0
     # via -r requirements/_test.in
 aiobotocore==2.16.0
     # via aioboto3
-aiofiles==23.2.1
+aiofiles==24.1.0
     # via
     #   -c requirements/_base.txt
     #   aioboto3
-aiohttp==3.9.5
+aiohappyeyeballs==2.5.0
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+aiohttp==3.11.13
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aiobotocore
 aioitertools==0.12.0
     # via aiobotocore
-aiormq==6.8.0
+aiormq==6.8.1
     # via
     #   -c requirements/_base.txt
     #   aio-pika
-aiosignal==1.3.1
+aiosignal==1.3.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-alembic==1.13.1
+alembic==1.15.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-anyio==4.3.0
+anyio==4.8.0
     # via
     #   -c requirements/_base.txt
     #   httpx
@@ -37,7 +41,7 @@ asgi-lifespan==2.1.0
     # via -r requirements/_test.in
 async-asgi-testclient==1.4.11
     # via -r requirements/_test.in
-attrs==23.2.0
+attrs==25.1.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -53,14 +57,14 @@ botocore==1.35.81
     #   aiobotocore
     #   boto3
     #   s3transfer
-certifi==2024.2.2
+certifi==2025.1.31
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via
     #   -c requirements/_base.txt
     #   requests
@@ -89,13 +93,17 @@ distributed==2024.12.0
     #   dask
 docker==7.1.0
     # via -r requirements/_test.in
+exceptiongroup==1.2.2
+    # via
+    #   -c requirements/_base.txt
+    #   aio-pika
 execnet==2.1.1
     # via pytest-xdist
-faker==36.1.1
+faker==36.2.2
     # via -r requirements/_test.in
 flaky==3.8.1
     # via -r requirements/_test.in
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -104,7 +112,7 @@ fsspec==2024.10.0
     # via
     #   -c requirements/_base.txt
     #   dask
-greenlet==3.0.3
+greenlet==3.1.1
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
@@ -112,18 +120,18 @@ h11==0.14.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.27.0
+httpx==0.28.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   respx
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.7
+idna==3.10
     # via
     #   -c requirements/_base.txt
     #   anyio
@@ -152,7 +160,7 @@ locket==1.0.0
     #   -c requirements/_base.txt
     #   distributed
     #   partd
-mako==1.3.5
+mako==1.3.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -166,7 +174,7 @@ msgpack==1.1.0
     # via
     #   -c requirements/_base.txt
     #   distributed
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -206,6 +214,11 @@ pluggy==1.5.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
+propcache==0.3.0
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   yarl
 psutil==6.1.0
     # via
     #   -c requirements/_base.txt
@@ -258,7 +271,7 @@ respx==0.22.0
     # via -r requirements/_test.in
 s3transfer==0.10.4
     # via boto3
-six==1.16.0
+six==1.17.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil
@@ -267,12 +280,11 @@ sniffio==1.3.1
     #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
-    #   httpx
 sortedcontainers==2.4.0
     # via
     #   -c requirements/_base.txt
     #   distributed
-sqlalchemy==1.4.52
+sqlalchemy==1.4.54
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -295,7 +307,7 @@ tornado==6.4.2
     #   -c requirements/_base.txt
     #   bokeh
     #   distributed
-types-networkx==3.4.2.20250227
+types-networkx==3.4.2.20250304
     # via -r requirements/_test.in
 types-psycopg2==2.9.21.20250121
     # via -r requirements/_test.in
@@ -305,6 +317,7 @@ typing-extensions==4.12.2
     # via
     #   -c requirements/_base.txt
     #   alembic
+    #   anyio
     #   mypy
     #   sqlalchemy2-stubs
 tzdata==2025.1
@@ -319,13 +332,13 @@ urllib3==2.2.3
     #   distributed
     #   docker
     #   requests
-wrapt==1.16.0
+wrapt==1.17.2
     # via
     #   -c requirements/_base.txt
     #   aiobotocore
 xyzservices==2025.1.0
     # via bokeh
-yarl==1.9.4
+yarl==1.18.3
     # via
     #   -c requirements/_base.txt
     #   aio-pika

--- a/services/director-v2/requirements/_tools.txt
+++ b/services/director-v2/requirements/_tools.txt
@@ -53,6 +53,7 @@ pip-tools==7.4.1
     # via -r requirements/../../../requirements/devenv.txt
 platformdirs==4.3.6
     # via
+    #   -c requirements/_base.txt
     #   black
     #   pylint
     #   virtualenv
@@ -82,7 +83,7 @@ typing-extensions==4.12.2
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.29.2
+virtualenv==20.29.3
     # via pre-commit
 watchdog==6.0.0
     # via -r requirements/_tools.in


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 88
- #packages after ~ 92

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.4.1           | 9.5.5      | *minor*    | 2 | director-v2⬆️🧪 |
|   2 | aiocache                  | 0.12.2          | 0.12.3     |            | 1 | director-v2⬆️ |
|   3 | aiodocker                 | 0.21.0          | 0.24.0     | *minor*    | 1 | director-v2⬆️ |
|   4 | aiofiles                  | 23.2.1          | 24.1.0     | **MAJOR**  | 2 | director-v2⬆️🧪 |
|   5 | aiohttp                   | 3.9.5           | 3.11.13    | *minor*    | 2 | director-v2⬆️🧪 |
|   6 | aiormq                    | 6.8.0           | 6.8.1      |            | 2 | director-v2⬆️🧪 |
|   7 | aiosignal                 | 1.3.1           | 1.3.2      |            | 2 | director-v2⬆️🧪 |
|   8 | alembic                   | 1.13.1          | 1.15.1     | *minor*    | 2 | director-v2⬆️🧪 |
|   9 | anyio                     | 4.3.0           | 4.8.0      | *minor*    | 2 | director-v2⬆️🧪 |
|  10 | appdirs                   | 1.4.4           | 🗑️ removed |  | 1 | director-v2⬆️ |
|  11 | asyncpg                   | 0.29.0          | 0.30.0     | *minor*    | 1 | director-v2⬆️ |
|  12 | attrs                     | 23.2.0          | 25.1.0     | **MAJOR**  | 2 | director-v2⬆️🧪 |
|  13 | certifi                   | 2024.2.2        | 2025.1.31  | **MAJOR**  | 2 | director-v2⬆️🧪 |
|  14 | charset-normalizer        | 3.3.2           | 3.4.1      | *minor*    | 2 | director-v2⬆️🧪 |
|  15 | deprecated                | 1.2.14          | 1.2.18     |            | 1 | director-v2⬆️ |
|  16 | dnspython                 | 2.6.1           | 2.7.0      | *minor*    | 1 | director-v2⬆️ |
|  17 | email-validator           | 2.1.1           | 2.2.0      | *minor*    | 1 | director-v2⬆️ |
|  18 | faker                     | 36.1.1          | 36.2.2     | *minor*    | 1 | director-v2🧪 |
|  19 | fastapi                   | 0.115.5         | 0.115.6    |            | 1 | director-v2⬆️ |
|  20 | fastapi-cli               | 0.0.5           | 0.0.7      |            | 1 | director-v2⬆️ |
|  21 | faststream                | 0.5.31          | 0.5.35     |            | 1 | director-v2⬆️ |
|  22 | flexparser                | 0.3.1           | 0.4        | *minor*    | 1 | director-v2⬆️ |
|  23 | frozenlist                | 1.4.1           | 1.5.0      | *minor*    | 2 | director-v2⬆️🧪 |
|  24 | googleapis-common-protos  | 1.65.0          | 1.69.1     | *minor*    | 1 | director-v2⬆️ |
|  25 | greenlet                  | 3.0.3           | 3.1.1      | *minor*    | 2 | director-v2⬆️🧪 |
|  26 | grpcio                    | 1.66.0          | 1.70.0     | *minor*    | 1 | director-v2⬆️ |
|  27 | httpcore                  | 1.0.5           | 1.0.7      |            | 2 | director-v2⬆️🧪 |
|  28 | httptools                 | 0.6.1           | 0.6.4      |            | 1 | director-v2⬆️ |
|  29 | httpx                     | 0.27.0          | 0.28.1     | *minor*    | 2 | director-v2⬆️🧪 |
|  30 | idna                      | 3.7             | 3.10       | *minor*    | 2 | director-v2⬆️🧪 |
|  31 | jsonschema                | 4.22.0          | 4.23.0     | *minor*    | 1 | director-v2⬆️ |
|  32 | jsonschema-specifications | 2023.7.1        | 2024.10.1  | **MAJOR**  | 1 | director-v2⬆️ |
|  33 | mako                      | 1.3.5           | 1.3.9      |            | 2 | director-v2⬆️🧪 |
|  34 | multidict                 | 6.0.5           | 6.1.0      | *minor*    | 2 | director-v2⬆️🧪 |
|  35 | networkx                  | 3.3             | 3.4.2      | *minor*    | 1 | director-v2⬆️ |
|  36 | opentelemetry-api         | 1.28.2          | 1.30.0     | *minor*    | 1 | director-v2⬆️ |
|  37 | opentelemetry-exporter-otlp | 1.28.2          | 1.30.0     | *minor*    | 1 | director-v2⬆️ |
|  38 | opentelemetry-exporter-otlp-proto-common | 1.28.2          | 1.30.0     | *minor*    | 1 | director-v2⬆️ |
|  39 | opentelemetry-exporter-otlp-proto-grpc | 1.28.2          | 1.30.0     | *minor*    | 1 | director-v2⬆️ |
|  40 | opentelemetry-exporter-otlp-proto-http | 1.28.2          | 1.30.0     | *minor*    | 1 | director-v2⬆️ |
|  41 | opentelemetry-instrumentation | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  42 | opentelemetry-instrumentation-aiopg | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  43 | opentelemetry-instrumentation-asgi | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  44 | opentelemetry-instrumentation-asyncpg | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  45 | opentelemetry-instrumentation-dbapi | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  46 | opentelemetry-instrumentation-fastapi | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  47 | opentelemetry-instrumentation-httpx | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  48 | opentelemetry-instrumentation-logging | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  49 | opentelemetry-instrumentation-redis | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  50 | opentelemetry-instrumentation-requests | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  51 | opentelemetry-proto       | 1.28.2          | 1.30.0     | *minor*    | 1 | director-v2⬆️ |
|  52 | opentelemetry-sdk         | 1.28.2          | 1.30.0     | *minor*    | 1 | director-v2⬆️ |
|  53 | opentelemetry-semantic-conventions | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  54 | opentelemetry-util-http   | 0.49            | 0.51       | *minor*    | 1 | director-v2⬆️ |
|  55 | orjson                    | 3.10.3          | 3.10.15    |            | 1 | director-v2⬆️ |
|  56 | pint                      | 0.24.3          | 0.24.4     |            | 1 | director-v2⬆️ |
|  57 | prometheus-client         | 0.20.0          | 0.21.1     | *minor*    | 1 | director-v2⬆️ |
|  58 | prometheus-fastapi-instrumentator | 6.1.0           | 7.0.2      | **MAJOR**  | 1 | director-v2⬆️ |
|  59 | protobuf                  | 5.29.0          | 5.29.3     |            | 1 | director-v2⬆️ |
|  60 | psycopg2-binary           | 2.9.9           | 2.9.10     |            | 1 | director-v2⬆️ |
|  61 | pydantic                  | 2.10.2          | 2.10.6     |            | 1 | director-v2⬆️ |
|  62 | pydantic-core             | 2.27.1          | 2.27.2     |            | 1 | director-v2⬆️ |
|  63 | pydantic-extra-types      | 2.10.0          | 2.10.2     |            | 1 | director-v2⬆️ |
|  64 | pydantic-settings         | 2.6.1           | 2.7.0      | *minor*    | 1 | director-v2⬆️ |
|  65 | pygments                  | 2.18.0          | 2.19.1     | *minor*    | 1 | director-v2⬆️ |
|  66 | pyinstrument              | 4.6.2           | 5.0.1      | **MAJOR**  | 1 | director-v2⬆️ |
|  67 | python-engineio           | 4.9.1           | 4.11.2     | *minor*    | 1 | director-v2⬆️ |
|  68 | python-multipart          | 0.0.9           | 0.0.20     |            | 1 | director-v2⬆️ |
|  69 | python-socketio           | 5.11.2          | 5.12.1     | *minor*    | 1 | director-v2⬆️ |
|  70 | referencing               | 0.29.3          | 0.35.1     | *minor*    | 1 | director-v2⬆️ |
|  71 | rich                      | 13.7.1          | 13.9.4     | *minor*    | 1 | director-v2⬆️ |
|  72 | rpds-py                   | 0.18.1          | 0.23.1     | *minor*    | 1 | director-v2⬆️ |
|  73 | simple-websocket          | 1.0.0           | 1.1.0      | *minor*    | 1 | director-v2⬆️ |
|  74 | six                       | 1.16.0          | 1.17.0     | *minor*    | 2 | director-v2⬆️🧪 |
|  75 | sqlalchemy                | 1.4.52          | 1.4.54     |            | 2 | director-v2⬆️🧪 |
|  76 | starlette                 | 0.41.2          | 0.41.3     |            | 1 | director-v2⬆️ |
|  77 | tenacity                  | 8.5.0           | 9.0.0      | **MAJOR**  | 1 | director-v2⬆️ |
|  78 | tqdm                      | 4.66.4          | 4.67.1     | *minor*    | 1 | director-v2⬆️ |
|  79 | typer                     | 0.12.3          | 0.15.2     | *minor*    | 1 | director-v2⬆️ |
|  80 | types-networkx            | 3.4.2.20250227  | 3.4.2.20250304 |            | 1 | director-v2🧪 |
|  81 | types-python-dateutil     | 2.9.0.20240316  | 2.9.0.20241206 |            | 1 | director-v2⬆️ |
|  82 | uvicorn                   | 0.29.0          | 0.34.0     | *minor*    | 1 | director-v2⬆️ |
|  83 | uvloop                    | 0.19.0          | 0.21.0     | *minor*    | 1 | director-v2⬆️ |
|  84 | virtualenv                | 20.29.2         | 20.29.3    |            | 1 | director-v2🔧 |
|  85 | watchfiles                | 0.21.0          | 1.0.4      | **MAJOR**  | 1 | director-v2⬆️ |
|  86 | websockets                | 12.0            | 15.0.1     | **MAJOR**  | 1 | director-v2⬆️ |
|  87 | wrapt                     | 1.16.0          | 1.17.2     | *minor*    | 2 | director-v2⬆️🧪 |
|  88 | yarl                      | 1.9.4           | 1.18.3     | *minor*    | 2 | director-v2⬆️🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 99

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.1.2, 9.4.1, 9.4.3, 9.5.0, 9.5.1, 9.5.3, 9.5.4, 9.5.5 | 9.5.5                     |                           |
|   2 | aioboto3                  | 13.1.0, 13.2.0, 13.3.0    | 13.3.0                    |                           |
|   3 | aiobotocore               | 2.13.1, 2.15.2, 2.16.0    | 2.16.0                    |                           |
|   4 | aiocache                  | 0.11.1, 0.12.2, 0.12.3    | 0.12.3                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.21.0, 0.23.0, 0.24.0    | 0.23.0, 0.24.0            |                           |
|   7 | aiofiles                  | 0.8.0, 23.2.1, 24.1.0     | 24.1.0                    |                           |
|   8 | aiohappyeyeballs          | 2.4.3, 2.4.4, 2.4.6, 2.5.0 | 2.4.3, 2.4.4, 2.4.6, 2.5.0 |                           |
|   9 | aiohttp                   | 3.8.5, 3.9.3, 3.10.10, 3.11.7, 3.11.8, 3.11.10, 3.11.12, 3.11.13 | 3.8.5, 3.10.10, 3.11.7, 3.11.8, 3.11.10, 3.11.12, 3.11.13 |                           |
|  10 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  11 | aiohttp-security          | 0.4.0                     |                           |                           |
|  12 | aiohttp-session           | 2.11.0                    |                           |                           |
|  13 | aioitertools              | 0.11.0, 0.12.0            | 0.12.0                    |                           |
|  14 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  15 | aioprocessing             | 2.0.1                     |                           |                           |
|  16 | aioresponses              |                           | 0.7.8                     |                           |
|  17 | aiormq                    | 6.7.6, 6.8.0, 6.8.1       | 6.8.1                     |                           |
|  18 | aiosignal                 | 1.2.0, 1.3.1, 1.3.2       | 1.2.0, 1.3.1, 1.3.2       |                           |
|  19 | aiosmtplib                | 1.1.6, 3.0.2, 4.0.0       |                           |                           |
|  20 | alembic                   | 1.8.1, 1.13.1, 1.13.3, 1.14.0, 1.14.1, 1.15.1 | 1.8.1, 1.13.1, 1.14.0, 1.14.1, 1.15.1 |                           |
|  21 | annotated-types           | 0.7.0                     | 0.7.0                     |                           |
|  22 | antlr4-python3-runtime    |                           | 4.13.2                    |                           |
|  23 | anyio                     | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0 | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0 |                           |
|  24 | appdirs                   | 1.4.4                     |                           |                           |
|  25 | arrow                     | 1.2.3, 1.3.0              | 1.3.0                     |                           |
|  26 | asgi-lifespan             |                           | 2.1.0                     |                           |
|  27 | asgiref                   | 3.8.1                     |                           |                           |
|  28 | astroid                   |                           |                           | 3.3.8                     |
|  29 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  30 | async-timeout             | 4.0.3                     | 4.0.3                     |                           |
|  31 | asyncpg                   | 0.27.0, 0.29.0, 0.30.0    | 0.27.0, 0.30.0            |                           |
|  32 | asyncpg-stubs             |                           | 0.27.1, 0.30.0            |                           |
|  33 | attrs                     | 21.4.0, 23.2.0, 24.2.0, 25.1.0 | 21.4.0, 23.2.0, 24.2.0, 25.1.0 |                           |
|  34 | aws-sam-translator        |                           | 1.55.0, 1.95.0            |                           |
|  35 | aws-xray-sdk              |                           | 2.14.0                    |                           |
|  36 | bidict                    | 0.22.0, 0.23.1            | 0.23.1                    |                           |
|  37 | binaryornot               | 0.4.4                     |                           |                           |
|  38 | black                     |                           |                           | 25.1.0                    |
|  39 | blinker                   |                           | 1.9.0                     |                           |
|  40 | blosc                     | 1.11.2                    |                           |                           |
|  41 | bokeh                     | 3.6.2                     | 3.6.3                     |                           |
|  42 | boto3                     | 1.34.75, 1.34.131, 1.35.36, 1.35.81 | 1.34.131, 1.35.36, 1.35.81, 1.35.99 |                           |
|  43 | boto3-stubs               |                           | 1.37.4                    |                           |
|  44 | botocore                  | 1.34.75, 1.34.131, 1.35.36, 1.35.81 | 1.34.131, 1.35.36, 1.35.81, 1.35.99, 1.37.4 |                           |
|  45 | botocore-stubs            | 1.34.69, 1.35.43, 1.35.76, 1.36.17, 1.37.4 | 1.35.76, 1.37.4           |                           |
|  46 | build                     |                           |                           | 1.2.2.post1               |
|  47 | bump2version              |                           |                           | 1.0.1                     |
|  48 | captcha                   | 0.5.0                     |                           |                           |
|  49 | certifi                   | 2023.7.22, 2024.2.2, 2024.8.30, 2025.1.31 | 2023.7.22, 2024.2.2, 2024.8.30, 2025.1.31 |                           |
|  50 | cffi                      | 1.17.1                    | 1.17.1                    |                           |
|  51 | cfgv                      |                           |                           | 3.4.0                     |
|  52 | cfn-lint                  |                           | 0.72.0, 1.27.0            |                           |
|  53 | change-case               |                           |                           | 0.5.2                     |
|  54 | chardet                   | 5.2.0                     |                           |                           |
|  55 | charset-normalizer        | 2.0.12, 3.3.2, 3.4.0, 3.4.1 | 2.0.12, 3.3.2, 3.4.0, 3.4.1 |                           |
|  56 | click                     | 8.1.3, 8.1.7, 8.1.8       | 8.1.3, 8.1.7, 8.1.8       | 8.1.3, 8.1.7, 8.1.8       |
|  57 | cloudpickle               | 3.1.0, 3.1.1              | 3.1.0                     |                           |
|  58 | contourpy                 | 1.2.0, 1.3.1              | 1.3.1                     |                           |
|  59 | cookiecutter              | 2.6.0                     |                           |                           |
|  60 | coverage                  |                           | 7.6.12                    |                           |
|  61 | cryptography              | 41.0.7, 43.0.3, 44.0.0    | 44.0.0, 44.0.2            |                           |
|  62 | cycler                    | 0.12.1                    |                           |                           |
|  63 | dask                      | 2024.12.0, 2025.2.0       | 2024.12.0                 |                           |
|  64 | dateparser                | 1.2.0                     |                           |                           |
|  65 | debugpy                   |                           | 1.8.12                    |                           |
|  66 | deepdiff                  | 8.1.1                     | 8.2.0                     |                           |
|  67 | deprecated                | 1.2.14, 1.2.15, 1.2.18    | 1.2.18                    |                           |
|  68 | dill                      |                           |                           | 0.3.9                     |
|  69 | distlib                   |                           |                           | 0.3.9                     |
|  70 | distributed               | 2024.12.0, 2025.2.0       | 2024.12.0                 |                           |
|  71 | dnspython                 | 2.2.1, 2.6.1, 2.7.0       | 2.2.1, 2.7.0              |                           |
|  72 | docker                    | 7.1.0                     | 7.1.0                     |                           |
|  73 | docutils                  | 0.21.2                    |                           |                           |
|  74 | ecdsa                     | 0.19.0                    | 0.19.0                    |                           |
|  75 | email-validator           | 2.1.1, 2.2.0              | 2.2.0                     |                           |
|  76 | et-xmlfile                | 1.1.0                     |                           |                           |
|  77 | exceptiongroup            | 1.2.2                     | 1.2.2                     |                           |
|  78 | execnet                   |                           | 2.1.1                     |                           |
|  79 | faker                     | 19.6.1                    | 19.6.1, 36.1.1, 36.2.2    |                           |
|  80 | fakeredis                 |                           | 2.27.0                    |                           |
|  81 | fast-depends              | 2.4.12                    | 2.4.12                    |                           |
|  82 | fastapi                   | 0.115.5, 0.115.6, 0.115.8 | 0.115.6, 0.115.11         |                           |
|  83 | fastapi-cli               | 0.0.6, 0.0.7              | 0.0.5                     |                           |
|  84 | fastapi-lifespan-manager  | 0.1.4                     | 0.1.4                     |                           |
|  85 | fastapi-pagination        | 0.12.31, 0.12.32, 0.12.34 | 0.12.34                   |                           |
|  86 | faststream                | 0.5.31, 0.5.33, 0.5.34, 0.5.35 | 0.5.35                    |                           |
|  87 | filelock                  |                           |                           | 3.17.0                    |
|  88 | flaky                     |                           | 3.8.1                     |                           |
|  89 | flask                     |                           | 2.1.3, 3.1.0              |                           |
|  90 | flask-cors                |                           | 5.0.1                     |                           |
|  91 | flexcache                 | 0.3                       | 0.3                       |                           |
|  92 | flexparser                | 0.3.1, 0.4                | 0.4                       |                           |
|  93 | fonttools                 | 4.50.0                    |                           |                           |
|  94 | frozenlist                | 1.4.1, 1.5.0              | 1.4.1, 1.5.0              |                           |
|  95 | fsspec                    | 2024.10.0, 2025.2.0       | 2024.10.0                 |                           |
|  96 | googleapis-common-protos  | 1.65.0, 1.66.0, 1.68.0, 1.69.1 | 1.68.0                    |                           |
|  97 | graphql-core              |                           | 3.2.6                     |                           |
|  98 | greenlet                  | 2.0.2, 3.0.3, 3.1.1       | 2.0.2, 3.0.3, 3.1.1       |                           |
|  99 | grpcio                    | 1.66.0, 1.67.0, 1.68.0, 1.68.1, 1.70.0 | 1.70.0                    |                           |
| 100 | gunicorn                  | 23.0.0                    |                           |                           |
| 101 | h11                       | 0.14.0                    | 0.14.0                    |                           |
| 102 | h2                        | 4.1.0                     | 4.2.0                     |                           |
| 103 | hpack                     | 4.0.0                     | 4.1.0                     |                           |
| 104 | httmock                   | 1.4.0                     |                           |                           |
| 105 | httpcore                  | 1.0.4, 1.0.5, 1.0.6, 1.0.7 | 1.0.4, 1.0.5, 1.0.6, 1.0.7 |                           |
| 106 | httptools                 | 0.6.1, 0.6.4              | 0.6.4                     |                           |
| 107 | httpx                     | 0.27.0, 0.27.2, 0.28.1    | 0.27.0, 0.27.2, 0.28.1    |                           |
| 108 | hypercorn                 |                           | 0.17.3                    |                           |
| 109 | hyperframe                | 6.0.1                     | 6.1.0                     |                           |
| 110 | hypothesis                |                           | 6.91.0, 6.127.5           |                           |
| 111 | icdiff                    |                           | 2.0.7                     |                           |
| 112 | identify                  |                           |                           | 2.6.8                     |
| 113 | idna                      | 3.3, 3.6, 3.10            | 3.3, 3.6, 3.10            |                           |
| 114 | ifaddr                    | 0.2.0                     |                           |                           |
| 115 | importlib-metadata        | 8.0.0, 8.4.0, 8.5.0, 8.6.1 | 8.5.0                     |                           |
| 116 | iniconfig                 | 2.0.0                     | 2.0.0                     |                           |
| 117 | inotify                   |                           |                           | 0.2.10                    |
| 118 | isort                     |                           |                           | 6.0.1                     |
| 119 | itsdangerous              | 2.2.0                     | 2.2.0                     |                           |
| 120 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 121 | jinja2                    | 3.1.2, 3.1.4, 3.1.5       | 3.1.2, 3.1.4, 3.1.5       | 3.1.4                     |
| 122 | jinja2-time               | 0.2.0                     |                           |                           |
| 123 | jmespath                  | 1.0.1                     | 1.0.1                     |                           |
| 124 | joserfc                   |                           | 1.0.4                     |                           |
| 125 | jschema-to-python         |                           | 1.2.3                     |                           |
| 126 | json2html                 | 1.3.0                     |                           |                           |
| 127 | jsondiff                  | 2.0.0                     | 2.2.1                     |                           |
| 128 | jsonpatch                 |                           | 1.33                      |                           |
| 129 | jsonpath-ng               |                           | 1.7.0                     |                           |
| 130 | jsonpickle                |                           | 4.0.2                     |                           |
| 131 | jsonpointer               |                           | 3.0.0                     |                           |
| 132 | jsonref                   |                           | 1.1.0                     |                           |
| 133 | jsonschema                | 3.2.0, 4.21.1, 4.23.0     | 3.2.0, 4.21.1, 4.23.0     |                           |
| 134 | jsonschema-path           |                           | 0.3.4                     |                           |
| 135 | jsonschema-specifications | 2023.7.1, 2024.10.1       | 2023.7.1, 2024.10.1       |                           |
| 136 | junit-xml                 |                           | 1.9                       |                           |
| 137 | kiwisolver                | 1.4.5                     |                           |                           |
| 138 | lazy-object-proxy         |                           | 1.10.0                    |                           |
| 139 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 140 | lupa                      |                           | 2.4                       |                           |
| 141 | lz4                       | 4.3.3                     |                           |                           |
| 142 | mako                      | 1.2.2, 1.3.2, 1.3.5, 1.3.6, 1.3.7, 1.3.9 | 1.2.2, 1.3.2, 1.3.7, 1.3.9 |                           |
| 143 | markdown-it-py            | 3.0.0                     | 3.0.0                     | 3.0.0                     |
| 144 | markdown2                 | 2.5.1                     |                           |                           |
| 145 | markupsafe                | 2.1.1, 2.1.5, 3.0.1, 3.0.2 | 2.1.1, 2.1.5, 3.0.1, 3.0.2 | 3.0.2                     |
| 146 | matplotlib                | 3.8.3                     |                           |                           |
| 147 | mccabe                    |                           |                           | 0.7.0                     |
| 148 | mdurl                     | 0.1.2                     | 0.1.2                     | 0.1.2                     |
| 149 | moto                      |                           | 4.0.1, 5.0.20             |                           |
| 150 | mpmath                    |                           | 1.3.0                     |                           |
| 151 | msgpack                   | 1.1.0                     | 1.1.0                     |                           |
| 152 | multidict                 | 6.0.5, 6.1.0              | 6.1.0                     |                           |
| 153 | mypy                      |                           | 1.15.0                    | 1.15.0                    |
| 154 | mypy-extensions           |                           | 1.0.0                     | 1.0.0                     |
| 155 | nest-asyncio              | 1.6.0                     |                           |                           |
| 156 | networkx                  | 3.4.2                     | 2.8.8, 3.4.2              |                           |
| 157 | nicegui                   | 2.7.0                     |                           |                           |
| 158 | nodeenv                   |                           |                           | 1.9.1                     |
| 159 | nose                      |                           |                           | 1.3.7                     |
| 160 | numpy                     | 1.26.4, 2.1.3             | 2.1.3, 2.2.3              |                           |
| 161 | openapi-schema-validator  |                           | 0.2.3, 0.6.3              |                           |
| 162 | openapi-spec-validator    |                           | 0.4.0, 0.7.1              |                           |
| 163 | openpyxl                  | 3.0.9                     |                           |                           |
| 164 | opentelemetry-api         | 1.26.0, 1.27.0, 1.28.2, 1.30.0 | 1.30.0                    |                           |
| 165 | opentelemetry-exporter-otlp | 1.26.0, 1.27.0, 1.28.2, 1.30.0 | 1.30.0                    |                           |
| 166 | opentelemetry-exporter-otlp-proto-common | 1.26.0, 1.27.0, 1.28.2, 1.30.0 | 1.30.0                    |                           |
| 167 | opentelemetry-exporter-otlp-proto-grpc | 1.26.0, 1.27.0, 1.28.2, 1.30.0 | 1.30.0                    |                           |
| 168 | opentelemetry-exporter-otlp-proto-http | 1.26.0, 1.27.0, 1.28.2, 1.30.0 | 1.30.0                    |                           |
| 169 | opentelemetry-instrumentation | 0.47b0, 0.48b0, 0.49b2, 0.51b0 | 0.51b0                    |                           |
| 170 | opentelemetry-instrumentation-aiohttp-client | 0.48b0                    |                           |                           |
| 171 | opentelemetry-instrumentation-aiohttp-server | 0.48b0                    |                           |                           |
| 172 | opentelemetry-instrumentation-aiopg | 0.48b0, 0.49b2, 0.51b0    | 0.51b0                    |                           |
| 173 | opentelemetry-instrumentation-asgi | 0.47b0, 0.48b0, 0.49b2, 0.51b0 |                           |                           |
| 174 | opentelemetry-instrumentation-asyncpg | 0.47b0, 0.48b0, 0.49b2, 0.51b0 | 0.51b0                    |                           |
| 175 | opentelemetry-instrumentation-botocore | 0.47b0, 0.48b0, 0.49b2, 0.51b0 |                           |                           |
| 176 | opentelemetry-instrumentation-dbapi | 0.48b0, 0.49b2, 0.51b0    | 0.51b0                    |                           |
| 177 | opentelemetry-instrumentation-fastapi | 0.47b0, 0.48b0, 0.49b2, 0.51b0 |                           |                           |
| 178 | opentelemetry-instrumentation-httpx | 0.47b0, 0.48b0, 0.49b2, 0.51b0 |                           |                           |
| 179 | opentelemetry-instrumentation-logging | 0.47b0, 0.48b0, 0.49b2, 0.51b0 | 0.51b0                    |                           |
| 180 | opentelemetry-instrumentation-redis | 0.47b0, 0.48b0, 0.49b2, 0.51b0 | 0.51b0                    |                           |
| 181 | opentelemetry-instrumentation-requests | 0.47b0, 0.48b0, 0.49b2, 0.51b0 | 0.51b0                    |                           |
| 182 | opentelemetry-propagator-aws-xray | 1.0.1, 1.0.2              |                           |                           |
| 183 | opentelemetry-proto       | 1.26.0, 1.27.0, 1.28.2, 1.30.0 | 1.30.0                    |                           |
| 184 | opentelemetry-sdk         | 1.26.0, 1.27.0, 1.28.2, 1.30.0 | 1.30.0                    |                           |
| 185 | opentelemetry-semantic-conventions | 0.47b0, 0.48b0, 0.49b2, 0.51b0 | 0.51b0                    |                           |
| 186 | opentelemetry-util-http   | 0.47b0, 0.48b0, 0.49b2, 0.51b0 | 0.51b0                    |                           |
| 187 | ordered-set               | 4.1.0                     |                           |                           |
| 188 | orderly-set               | 5.2.3                     | 5.3.0                     |                           |
| 189 | orjson                    | 3.10.0, 3.10.7, 3.10.12, 3.10.15 | 3.10.15                   |                           |
| 190 | osparc                    | 0.8.3                     |                           |                           |
| 191 | osparc-client             | 0.8.3                     |                           |                           |
| 192 | packaging                 | 24.0, 24.1, 24.2          | 24.0, 24.1, 24.2          | 24.0, 24.1, 24.2          |
| 193 | pact-python               |                           | 2.3.1                     |                           |
| 194 | pamqp                     | 3.2.1, 3.3.0              | 3.3.0                     |                           |
| 195 | pandas                    | 2.2.1, 2.2.3              | 2.2.3                     |                           |
| 196 | parse                     | 1.20.2                    | 1.20.2                    |                           |
| 197 | partd                     | 1.4.2                     | 1.4.2                     |                           |
| 198 | passlib                   | 1.7.4                     |                           |                           |
| 199 | pathable                  |                           | 0.4.4                     |                           |
| 200 | pathspec                  |                           |                           | 0.12.1                    |
| 201 | pbr                       |                           | 6.1.1                     |                           |
| 202 | pillow                    | 10.2.0, 10.3.0, 11.0.0    | 11.1.0                    |                           |
| 203 | pint                      | 0.24.3, 0.24.4            | 0.24.4                    |                           |
| 204 | pip                       |                           | 25.0.1                    | 25.0.1                    |
| 205 | pip-tools                 |                           |                           | 7.4.1                     |
| 206 | platformdirs              | 4.3.6                     | 4.3.6                     | 4.3.6                     |
| 207 | playwright                |                           | 1.50.0                    |                           |
| 208 | pluggy                    | 1.5.0                     | 1.5.0                     |                           |
| 209 | ply                       |                           | 3.11                      |                           |
| 210 | pprintpp                  |                           | 0.4.0                     |                           |
| 211 | pre-commit                |                           |                           | 4.1.0                     |
| 212 | priority                  |                           | 2.0.0                     |                           |
| 213 | prometheus-api-client     | 0.5.5                     |                           |                           |
| 214 | prometheus-client         | 0.14.1, 0.20.0, 0.21.0, 0.21.1 |                           |                           |
| 215 | prometheus-fastapi-instrumentator | 6.1.0, 7.0.0, 7.0.2       |                           |                           |
| 216 | propcache                 | 0.2.0, 0.2.1, 0.3.0       | 0.2.0, 0.2.1, 0.3.0       |                           |
| 217 | protobuf                  | 4.25.4, 4.25.5, 5.28.3, 5.29.0, 5.29.1, 5.29.3 | 5.29.3                    |                           |
| 218 | pscript                   | 0.7.7                     |                           |                           |
| 219 | psutil                    | 6.0.0, 6.1.0, 6.1.1, 7.0.0 | 6.1.0, 7.0.0              |                           |
| 220 | psycopg2-binary           | 2.9.6, 2.9.9, 2.9.10      | 2.9.10                    |                           |
| 221 | ptvsd                     |                           | 4.3.2                     |                           |
| 222 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 223 | py-partiql-parser         |                           | 0.5.6                     |                           |
| 224 | pyasn1                    | 0.6.1                     | 0.6.1                     |                           |
| 225 | pycountry                 | 23.12.11                  |                           |                           |
| 226 | pycparser                 | 2.21, 2.22                | 2.22                      |                           |
| 227 | pycryptodome              | 3.21.0                    | 3.21.0                    |                           |
| 228 | pydantic                  | 2.10.2, 2.10.3, 2.10.6    | 2.10.2, 2.10.3, 2.10.6    |                           |
| 229 | pydantic-core             | 2.27.1, 2.27.2            | 2.27.1, 2.27.2            |                           |
| 230 | pydantic-extra-types      | 2.9.0, 2.10.0, 2.10.2     | 2.10.2                    |                           |
| 231 | pydantic-settings         | 2.5.2, 2.6.1, 2.7.0       | 2.7.0                     |                           |
| 232 | pyee                      |                           | 12.1.1                    |                           |
| 233 | pyftpdlib                 |                           | 2.0.1                     |                           |
| 234 | pygments                  | 2.15.1, 2.17.2, 2.18.0, 2.19.1 | 2.15.1, 2.19.1            | 2.19.1                    |
| 235 | pyinstrument              | 4.6.1, 4.6.2, 5.0.0, 5.0.1 | 5.0.0, 5.0.1              |                           |
| 236 | pyjwt                     | 2.4.0                     |                           |                           |
| 237 | pylint                    |                           |                           | 3.3.4                     |
| 238 | pyopenssl                 |                           | 25.0.0                    |                           |
| 239 | pyparsing                 | 3.1.2                     | 3.1.2, 3.2.1              |                           |
| 240 | pyproject-hooks           |                           |                           | 1.2.0                     |
| 241 | pyrsistent                | 0.18.1, 0.20.0            | 0.18.1, 0.20.0            |                           |
| 242 | pytest                    | 8.3.5                     | 8.3.5                     |                           |
| 243 | pytest-aiohttp            |                           | 1.0.5, 1.1.0              |                           |
| 244 | pytest-asyncio            |                           | 0.21.2, 0.23.8            |                           |
| 245 | pytest-base-url           |                           | 2.1.0                     |                           |
| 246 | pytest-benchmark          |                           | 5.1.0                     |                           |
| 247 | pytest-cov                |                           | 6.0.0                     |                           |
| 248 | pytest-docker             |                           | 3.2.0                     |                           |
| 249 | pytest-html               |                           | 4.1.1                     |                           |
| 250 | pytest-icdiff             |                           | 0.9                       |                           |
| 251 | pytest-instafail          |                           | 0.5.0                     |                           |
| 252 | pytest-localftpserver     |                           | 1.3.2                     |                           |
| 253 | pytest-metadata           |                           | 3.1.1                     |                           |
| 254 | pytest-mock               |                           | 3.14.0                    |                           |
| 255 | pytest-playwright         |                           | 0.7.0                     |                           |
| 256 | pytest-runner             |                           | 6.0.1                     |                           |
| 257 | pytest-sugar              |                           | 1.0.0                     |                           |
| 258 | pytest-xdist              |                           | 3.6.1                     |                           |
| 259 | python-dateutil           | 2.8.2, 2.9.0.post0        | 2.8.2, 2.9.0.post0        |                           |
| 260 | python-dotenv             | 1.0.1                     | 1.0.1                     |                           |
| 261 | python-engineio           | 4.3.4, 4.10.1, 4.11.2     | 4.10.1                    |                           |
| 262 | python-jose               | 3.3.0                     | 3.4.0                     |                           |
| 263 | python-magic              | 0.4.25, 0.4.27            |                           |                           |
| 264 | python-multipart          | 0.0.9, 0.0.17, 0.0.19, 0.0.20 | 0.0.20                    |                           |
| 265 | python-slugify            | 8.0.4                     | 8.0.4                     |                           |
| 266 | python-socketio           | 5.8.0, 5.11.4, 5.12.1     | 5.11.4                    |                           |
| 267 | pytz                      | 2022.1, 2024.1, 2024.2    | 2025.1                    |                           |
| 268 | pyyaml                    | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              |
| 269 | redis                     | 5.2.1                     | 5.2.1                     |                           |
| 270 | referencing               | 0.29.3, 0.35.1            | 0.8.11, 0.29.3, 0.35.1    |                           |
| 271 | regex                     | 2023.12.25                | 2023.12.25, 2024.11.6     |                           |
| 272 | repro-zipfile             | 0.3.1                     |                           |                           |
| 273 | requests                  | 2.32.2, 2.32.3            | 2.32.2, 2.32.3            |                           |
| 274 | requests-mock             |                           | 1.12.1                    |                           |
| 275 | responses                 |                           | 0.25.6                    |                           |
| 276 | respx                     |                           | 0.22.0                    |                           |
| 277 | rfc3339-validator         |                           | 0.1.4                     |                           |
| 278 | rich                      | 13.4.2, 13.7.1, 13.9.2, 13.9.4 | 13.4.2, 13.9.4            | 13.9.4                    |
| 279 | rich-toolkit              | 0.12.0, 0.13.2            |                           |                           |
| 280 | rpds-py                   | 0.18.0, 0.20.0, 0.21.0, 0.22.3, 0.23.1 | 0.18.0, 0.20.0, 0.21.0, 0.22.3, 0.23.1 |                           |
| 281 | rsa                       | 4.9                       | 4.9                       |                           |
| 282 | ruff                      |                           |                           | 0.9.9                     |
| 283 | s3fs                      | 2024.10.0                 |                           |                           |
| 284 | s3transfer                | 0.10.1, 0.10.3, 0.10.4    | 0.10.1, 0.10.3, 0.10.4    |                           |
| 285 | sarif-om                  |                           | 1.0.4                     |                           |
| 286 | setproctitle              | 1.3.3                     |                           |                           |
| 287 | setuptools                | 69.1.1, 74.0.0, 75.2.0, 75.6.0 | 69.1.1, 74.0.0, 75.2.0, 75.6.0, 75.8.2 | 69.1.1, 74.0.0, 75.2.0, 75.6.0, 75.8.2 |
| 288 | sh                        | 2.0.6, 2.1.0, 2.2.1, 2.2.2 |                           |                           |
| 289 | shellingham               | 1.5.4                     | 1.5.4                     | 1.5.4                     |
| 290 | shortuuid                 | 1.0.13                    |                           |                           |
| 291 | simple-websocket          | 1.1.0                     | 1.1.0                     |                           |
| 292 | six                       | 1.16.0, 1.17.0            | 1.16.0, 1.17.0            |                           |
| 293 | sniffio                   | 1.3.1                     | 1.3.1                     |                           |
| 294 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 295 | sqlalchemy                | 1.4.47, 1.4.52, 1.4.54    | 1.4.47, 1.4.52, 1.4.54    |                           |
| 296 | sqlalchemy2-stubs         |                           | 0.0.2a38                  |                           |
| 297 | sshpubkeys                |                           | 3.3.1                     |                           |
| 298 | starlette                 | 0.41.0, 0.41.2, 0.41.3, 0.45.3 | 0.41.3, 0.46.0            |                           |
| 299 | stream-zip                | 0.0.83                    | 0.0.83                    |                           |
| 300 | swagger-ui-py             | 23.9.23                   |                           |                           |
| 301 | sympy                     |                           | 1.13.3                    |                           |
| 302 | tblib                     | 3.0.0                     | 3.0.0                     |                           |
| 303 | tenacity                  | 8.5.0, 9.0.0              | 8.5.0, 9.0.0              |                           |
| 304 | termcolor                 |                           | 2.5.0                     |                           |
| 305 | text-unidecode            | 1.3                       | 1.3                       |                           |
| 306 | tomlkit                   |                           |                           | 0.13.2                    |
| 307 | toolz                     | 0.12.0, 0.12.1, 1.0.0     | 1.0.0                     |                           |
| 308 | tornado                   | 6.4.2                     | 6.4.2                     |                           |
| 309 | tqdm                      | 4.64.0, 4.66.2, 4.66.5, 4.67.1 | 4.67.1                    |                           |
| 310 | twilio                    | 7.12.0                    |                           |                           |
| 311 | typer                     | 0.12.3, 0.12.5, 0.13.1, 0.15.1, 0.15.2 | 0.12.3, 0.15.2            | 0.15.2                    |
| 312 | types-aioboto3            |                           | 14.0.0                    |                           |
| 313 | types-aiobotocore         | 2.19.0, 2.21.0            | 2.19.0, 2.21.0            |                           |
| 314 | types-aiobotocore-ec2     | 2.19.0, 2.21.0            | 2.19.0                    |                           |
| 315 | types-aiobotocore-iam     |                           | 2.19.0                    |                           |
| 316 | types-aiobotocore-s3      | 2.19.0, 2.19.0.post1, 2.21.0 | 2.19.0, 2.21.0            |                           |
| 317 | types-aiobotocore-ssm     | 2.19.0, 2.21.0            | 2.19.0                    |                           |
| 318 | types-aiofiles            |                           | 24.1.0.20241221           |                           |
| 319 | types-awscrt              | 0.20.5, 0.22.0, 0.23.3, 0.23.10 | 0.23.3, 0.23.10           |                           |
| 320 | types-boto3               |                           | 1.37.4                    |                           |
| 321 | types-cachetools          |                           |                           | 5.5.0.20240820            |
| 322 | types-docker              |                           | 7.1.0.20241229            |                           |
| 323 | types-jsonschema          |                           | 4.23.0.20241208           |                           |
| 324 | types-networkx            |                           | 3.4.2.20250304            |                           |
| 325 | types-openpyxl            |                           | 3.1.5.20241225            |                           |
| 326 | types-passlib             |                           | 1.7.7.20241221            |                           |
| 327 | types-psutil              |                           | 7.0.0.20250218            |                           |
| 328 | types-psycopg2            |                           | 2.9.21.20250121           |                           |
| 329 | types-pyasn1              |                           | 0.6.0.20250208            |                           |
| 330 | types-python-dateutil     | 2.9.0.20240316, 2.9.0.20241003, 2.9.0.20241206 | 2.9.0.20241206            |                           |
| 331 | types-python-jose         |                           | 3.4.0.20250224            |                           |
| 332 | types-pyyaml              |                           | 6.0.12.20241230           |                           |
| 333 | types-requests            |                           | 2.32.0.20250301           |                           |
| 334 | types-s3transfer          |                           | 0.11.3                    |                           |
| 335 | types-tqdm                |                           | 4.67.0.20250301           |                           |
| 336 | typing-extensions         | 4.12.2                    | 4.12.2                    | 4.12.2                    |
| 337 | tzdata                    | 2024.1, 2024.2            | 2024.1, 2024.2, 2025.1    |                           |
| 338 | tzlocal                   | 5.2                       |                           |                           |
| 339 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 340 | ujson                     | 5.10.0                    |                           |                           |
| 341 | urllib3                   | 2.2.3, 2.3.0              | 2.2.3, 2.3.0              |                           |
| 342 | uvicorn                   | 0.29.0, 0.32.0, 0.32.1, 0.34.0 | 0.32.1, 0.34.0            |                           |
| 343 | uvloop                    | 0.19.0, 0.21.0            | 0.21.0                    |                           |
| 344 | vbuild                    | 0.8.2                     |                           |                           |
| 345 | virtualenv                |                           |                           | 20.29.2, 20.29.3          |
| 346 | watchdog                  | 6.0.0                     |                           | 6.0.0                     |
| 347 | watchfiles                | 0.21.0, 1.0.0, 1.0.4      | 1.0.4                     |                           |
| 348 | websockets                | 12.0, 14.1, 14.2, 15.0.1  | 15.0                      |                           |
| 349 | werkzeug                  | 2.1.2                     | 2.1.2, 3.1.3              |                           |
| 350 | wheel                     |                           |                           | 0.45.1                    |
| 351 | wrapt                     | 1.16.0, 1.17.0, 1.17.2    | 1.16.0, 1.17.0, 1.17.2    |                           |
| 352 | wsproto                   | 1.2.0                     | 1.2.0                     |                           |
| 353 | xmltodict                 |                           | 0.14.2                    |                           |
| 354 | xyzservices               | 2024.9.0                  | 2025.1.0                  |                           |
| 355 | yarl                      | 1.9.4, 1.15.4, 1.18.0, 1.18.3 | 1.9.4, 1.15.4, 1.18.0, 1.18.3 |                           |
| 356 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 357 | zipp                      | 3.20.1, 3.20.2, 3.21.0    | 3.21.0                    |                           |


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
