### PR TITLE
🐛 [Frontend] Fix: Credits Summary indicator's offset

### DIFF
--- a/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsIndicatorButton.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsIndicatorButton.js
@@ -84,7 +84,7 @@ qx.Class.define("osparc.desktop.credits.CreditsIndicatorButton", {
     },
 
     __handleOutsideEvent: function(event) {
-      const offset = 2;
+      const offset = 0;
       const onContainer = osparc.utils.Utils.isMouseOnElement(this.__creditsContainer, event, offset);
       const onButton = osparc.utils.Utils.isMouseOnElement(this, event, offset);
       if (!onContainer && !onButton) {

--- a/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsIndicatorButton.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsIndicatorButton.js
@@ -84,11 +84,10 @@ qx.Class.define("osparc.desktop.credits.CreditsIndicatorButton", {
     },
 
     __handleOutsideEvent: function(event) {
-      const offset = 30;
-      if (
-        !osparc.utils.Utils.isMouseOnElement(this.__creditsContainer, event, offset) &&
-        !osparc.utils.Utils.isMouseOnElement(this, event, offset)
-      ) {
+      const offset = 2;
+      const onContainer = osparc.utils.Utils.isMouseOnElement(this.__creditsContainer, event, offset);
+      const onButton = osparc.utils.Utils.isMouseOnElement(this, event, offset);
+      if (!onContainer && !onButton) {
         this.__hideCreditsContainer();
       }
     },

--- a/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsPerService.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsPerService.js
@@ -90,7 +90,8 @@ qx.Class.define("osparc.desktop.credits.CreditsPerService", {
             });
           } else {
             const nothingFound = new qx.ui.basic.Label(this.tr("No usage found")).set({
-              font: "text-14"
+              font: "text-14",
+              padding: 20,
             });
             this._add(nothingFound);
           }

--- a/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsSummary.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsSummary.js
@@ -27,6 +27,7 @@ qx.Class.define("osparc.desktop.credits.CreditsSummary", {
       appearance: "floating-menu",
       padding: 8,
       maxWidth: this.self().WIDTH,
+      minHeight: 150,
       zIndex: osparc.utils.Utils.FLOATING_Z_INDEX,
     });
     osparc.utils.Utils.setIdToWidget(this, "creditsSummary");


### PR DESCRIPTION
## What do these changes do?

Reported by @capbrown 

The Credits Summary widget used to have a 30px offset, making the widget stay when tapping other buttons in the navigation bar. This PR fixes this issue.

Buggy:
![Buffy](https://github.com/user-attachments/assets/4ca6041b-4f94-445f-ac21-8a389244af38)

Fixed:
![Fixed](https://github.com/user-attachments/assets/3a8dc785-e3d2-4644-8808-5d09ecdb6766)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
