### PR TITLE
⬆️ invitations service: upgrades requirements

### DIFF
--- a/services/invitations/openapi.json
+++ b/services/invitations/openapi.json
@@ -286,6 +286,9 @@
           },
           "invitation_url": {
             "type": "string",
+            "maxLength": 2083,
+            "minLength": 1,
+            "format": "uri",
             "title": "Invitation Url",
             "description": "Invitation link"
           }
@@ -434,6 +437,9 @@
           },
           "docs_url": {
             "type": "string",
+            "maxLength": 2083,
+            "minLength": 1,
+            "format": "uri",
             "title": "Docs Url"
           }
         },

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -1,4 +1,4 @@
-aio-pika==9.5.0
+aio-pika==9.5.5
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiocache==0.12.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
@@ -8,9 +8,9 @@ aiodocker==0.24.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.7
+aiohttp==3.11.13
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -27,11 +27,11 @@ aiohttp==3.11.7
     #   aiodocker
 aiormq==6.8.1
     # via aio-pika
-aiosignal==1.3.1
+aiosignal==1.3.2
     # via aiohttp
 annotated-types==0.7.0
     # via pydantic
-anyio==4.6.2.post1
+anyio==4.8.0
     # via
     #   fast-depends
     #   faststream
@@ -45,12 +45,12 @@ arrow==1.3.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
-attrs==24.2.0
+attrs==25.2.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
-certifi==2024.8.30
+certifi==2025.1.31
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -69,13 +69,13 @@ certifi==2024.8.30
     #   requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via
     #   typer
     #   uvicorn
-cryptography==43.0.3
+cryptography==44.0.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -90,7 +90,7 @@ cryptography==43.0.3
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
-deprecated==1.2.15
+deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -104,24 +104,24 @@ exceptiongroup==1.2.2
     # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.5
+fastapi==0.115.11
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
     #   fastapi-lifespan-manager
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-faststream==0.5.31
+faststream==0.5.35
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-googleapis-common-protos==1.66.0
+googleapis-common-protos==1.69.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.68.0
+grpcio==1.71.0
     # via opentelemetry-exporter-otlp-proto-grpc
 h11==0.14.0
     # via
@@ -131,7 +131,7 @@ httpcore==1.0.7
     # via httpx
 httptools==0.6.4
     # via uvicorn
-httpx==0.27.2
+httpx==0.28.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -153,7 +153,7 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via opentelemetry-api
 jsonschema==4.23.0
     # via
@@ -169,7 +169,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.28.2
+opentelemetry-api==1.31.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -183,17 +183,17 @@ opentelemetry-api==1.28.2
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.28.2
+opentelemetry-exporter-otlp==1.31.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.28.2
+opentelemetry-exporter-otlp-proto-common==1.31.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.28.2
+opentelemetry-exporter-otlp-proto-grpc==1.31.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.28.2
+opentelemetry-exporter-otlp-proto-http==1.31.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.49b2
+opentelemetry-instrumentation==0.52b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -201,29 +201,29 @@ opentelemetry-instrumentation==0.49b2
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-asgi==0.49b2
+opentelemetry-instrumentation-asgi==0.52b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-fastapi==0.49b2
+opentelemetry-instrumentation-fastapi==0.52b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.49b2
+opentelemetry-instrumentation-httpx==0.52b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-logging==0.49b2
+opentelemetry-instrumentation-logging==0.52b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.49b2
+opentelemetry-instrumentation-redis==0.52b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.49b2
+opentelemetry-instrumentation-requests==0.52b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.28.2
+opentelemetry-proto==1.31.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.28.2
+opentelemetry-sdk==1.31.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.49b2
+opentelemetry-semantic-conventions==0.52b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
@@ -232,13 +232,13 @@ opentelemetry-semantic-conventions==0.49b2
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.49b2
+opentelemetry-util-http==0.52b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
-orjson==3.10.12
+orjson==3.10.15
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -266,27 +266,27 @@ packaging==24.2
     #   opentelemetry-instrumentation
 pamqp==3.3.0
     # via aiormq
-prometheus-client==0.21.0
+prometheus-client==0.21.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   prometheus-fastapi-instrumentator
-prometheus-fastapi-instrumentator==7.0.0
+prometheus-fastapi-instrumentator==7.0.2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-propcache==0.2.0
+propcache==0.3.0
     # via
     #   aiohttp
     #   yarl
-protobuf==5.28.3
+protobuf==5.29.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.1.0
+psutil==7.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 pycparser==2.22
     # via cffi
 pycryptodome==3.21.0
     # via stream-zip
-pydantic==2.10.2
+pydantic==2.10.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -315,9 +315,9 @@ pydantic==2.10.2
     #   fastapi
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via pydantic
-pydantic-extra-types==2.10.0
+pydantic-extra-types==2.10.3
     # via
     #   -r requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -327,15 +327,27 @@ pydantic-extra-types==2.10.0
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-pydantic-settings==2.6.1
+pydantic-settings==2.7.0
     # via
+    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-pygments==2.18.0
+pygments==2.19.1
     # via rich
-pyinstrument==5.0.0
+pyinstrument==5.0.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via arrow
@@ -397,19 +409,17 @@ rich==13.9.4
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-rpds-py==0.21.0
+rpds-py==0.23.1
     # via
     #   jsonschema
     #   referencing
 shellingham==1.5.4
     # via typer
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
-starlette==0.41.3
+    # via anyio
+starlette==0.46.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -433,16 +443,17 @@ toolz==1.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 tqdm==4.67.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.13.1
+typer==0.15.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
-types-python-dateutil==2.9.0.20241003
+types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
     # via
     #   aiodebug
+    #   anyio
     #   fastapi
     #   faststream
     #   opentelemetry-sdk
@@ -450,7 +461,7 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   pydantic-extra-types
     #   typer
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -465,23 +476,23 @@ urllib3==2.2.3
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.32.1
+uvicorn==0.34.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   -r requirements/_base.in
 uvloop==0.21.0
     # via uvicorn
-watchfiles==1.0.0
+watchfiles==1.0.4
     # via uvicorn
-websockets==14.1
+websockets==15.0.1
     # via uvicorn
-wrapt==1.17.0
+wrapt==1.17.2
     # via
     #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
-yarl==1.18.0
+yarl==1.18.3
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aio-pika

--- a/services/invitations/requirements/_test.txt
+++ b/services/invitations/requirements/_test.txt
@@ -1,12 +1,12 @@
-anyio==4.6.2.post1
+anyio==4.8.0
     # via
     #   -c requirements/_base.txt
     #   httpx
-attrs==24.2.0
+attrs==25.2.0
     # via
     #   -c requirements/_base.txt
     #   hypothesis
-certifi==2024.8.30
+certifi==2025.1.31
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -16,7 +16,7 @@ coverage==7.6.12
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-faker==36.1.1
+faker==37.0.0
     # via -r requirements/_test.in
 h11==0.14.0
     # via
@@ -26,12 +26,12 @@ httpcore==1.0.7
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.27.2
+httpx==0.28.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-hypothesis==6.127.5
+hypothesis==6.129.0
     # via -r requirements/_test.in
 idna==3.10
     # via
@@ -71,10 +71,13 @@ sniffio==1.3.1
     # via
     #   -c requirements/_base.txt
     #   anyio
-    #   httpx
 sortedcontainers==2.4.0
     # via hypothesis
 termcolor==2.5.0
     # via pytest-sugar
+typing-extensions==4.12.2
+    # via
+    #   -c requirements/_base.txt
+    #   anyio
 tzdata==2025.1
     # via faker

--- a/services/invitations/requirements/_tools.txt
+++ b/services/invitations/requirements/_tools.txt
@@ -1,4 +1,4 @@
-astroid==3.3.8
+astroid==3.3.9
     # via pylint
 black==25.1.0
     # via -r requirements/../../../requirements/devenv.txt
@@ -8,7 +8,7 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
-click==8.1.7
+click==8.1.8
     # via
     #   -c requirements/_base.txt
     #   black
@@ -19,7 +19,7 @@ distlib==0.3.9
     # via virtualenv
 filelock==3.17.0
     # via virtualenv
-identify==2.6.8
+identify==2.6.9
     # via pre-commit
 isort==6.0.1
     # via
@@ -54,7 +54,7 @@ platformdirs==4.3.6
     #   virtualenv
 pre-commit==4.1.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.3.4
+pylint==3.3.5
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.2.0
     # via
@@ -66,17 +66,18 @@ pyyaml==6.0.2
     #   -c requirements/_base.txt
     #   pre-commit
     #   watchdog
-ruff==0.9.9
+ruff==0.9.10
     # via -r requirements/../../../requirements/devenv.txt
-setuptools==75.8.2
+setuptools==76.0.0
     # via pip-tools
 tomlkit==0.13.2
     # via pylint
 typing-extensions==4.12.2
     # via
     #   -c requirements/_base.txt
+    #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.29.2
+virtualenv==20.29.3
     # via pre-commit
 watchdog==6.0.0
     # via -r requirements/_tools.in


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 64
- #packages after ~ 65

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.5.0           | 9.5.5      |            | 1 | invitations⬆️ |
|   2 | aiohappyeyeballs          | 2.4.3           | 2.6.1      | *minor*    | 1 | invitations⬆️ |
|   3 | aiohttp                   | 3.11.7          | 3.11.13    |            | 1 | invitations⬆️ |
|   4 | aiosignal                 | 1.3.1           | 1.3.2      |            | 1 | invitations⬆️ |
|   5 | anyio                     | 4.6.2.post1     | 4.8.0      | *minor*    | 2 | invitations⬆️🧪 |
|   6 | astroid                   | 3.3.8           | 3.3.9      |            | 1 | invitations🔧 |
|   7 | attrs                     | 24.2.0          | 25.2.0     | **MAJOR**  | 2 | invitations⬆️🧪 |
|   8 | certifi                   | 2024.8.30       | 2025.1.31  | **MAJOR**  | 2 | invitations⬆️🧪 |
|   9 | charset-normalizer        | 3.4.0           | 3.4.1      |            | 1 | invitations⬆️ |
|  10 | click                     | 8.1.7           | 8.1.8      |            | 2 | invitations⬆️🔧 |
|  11 | cryptography              | 43.0.3          | 44.0.2     | **MAJOR**  | 1 | invitations⬆️ |
|  12 | deprecated                | 1.2.15          | 1.2.18     |            | 1 | invitations⬆️ |
|  13 | faker                     | 36.1.1          | 37.0.0     | **MAJOR**  | 1 | invitations🧪 |
|  14 | fastapi                   | 0.115.5         | 0.115.11   |            | 1 | invitations⬆️ |
|  15 | faststream                | 0.5.31          | 0.5.35     |            | 1 | invitations⬆️ |
|  16 | googleapis-common-protos  | 1.66.0          | 1.69.1     | *minor*    | 1 | invitations⬆️ |
|  17 | grpcio                    | 1.68.0          | 1.71.0     | *minor*    | 1 | invitations⬆️ |
|  18 | httpx                     | 0.27.2          | 0.28.1     | *minor*    | 2 | invitations⬆️🧪 |
|  19 | hypothesis                | 6.127.5         | 6.129.0    | *minor*    | 1 | invitations🧪 |
|  20 | identify                  | 2.6.8           | 2.6.9      |            | 1 | invitations🔧 |
|  21 | importlib-metadata        | 8.5.0           | 8.6.1      | *minor*    | 1 | invitations⬆️ |
|  22 | opentelemetry-api         | 1.28.2          | 1.31.0     | *minor*    | 1 | invitations⬆️ |
|  23 | opentelemetry-exporter-otlp | 1.28.2          | 1.31.0     | *minor*    | 1 | invitations⬆️ |
|  24 | opentelemetry-exporter-otlp-proto-common | 1.28.2          | 1.31.0     | *minor*    | 1 | invitations⬆️ |
|  25 | opentelemetry-exporter-otlp-proto-grpc | 1.28.2          | 1.31.0     | *minor*    | 1 | invitations⬆️ |
|  26 | opentelemetry-exporter-otlp-proto-http | 1.28.2          | 1.31.0     | *minor*    | 1 | invitations⬆️ |
|  27 | opentelemetry-instrumentation | 0.49            | 0.52       | *minor*    | 1 | invitations⬆️ |
|  28 | opentelemetry-instrumentation-asgi | 0.49            | 0.52       | *minor*    | 1 | invitations⬆️ |
|  29 | opentelemetry-instrumentation-fastapi | 0.49            | 0.52       | *minor*    | 1 | invitations⬆️ |
|  30 | opentelemetry-instrumentation-httpx | 0.49            | 0.52       | *minor*    | 1 | invitations⬆️ |
|  31 | opentelemetry-instrumentation-logging | 0.49            | 0.52       | *minor*    | 1 | invitations⬆️ |
|  32 | opentelemetry-instrumentation-redis | 0.49            | 0.52       | *minor*    | 1 | invitations⬆️ |
|  33 | opentelemetry-instrumentation-requests | 0.49            | 0.52       | *minor*    | 1 | invitations⬆️ |
|  34 | opentelemetry-proto       | 1.28.2          | 1.31.0     | *minor*    | 1 | invitations⬆️ |
|  35 | opentelemetry-sdk         | 1.28.2          | 1.31.0     | *minor*    | 1 | invitations⬆️ |
|  36 | opentelemetry-semantic-conventions | 0.49            | 0.52       | *minor*    | 1 | invitations⬆️ |
|  37 | opentelemetry-util-http   | 0.49            | 0.52       | *minor*    | 1 | invitations⬆️ |
|  38 | orjson                    | 3.10.12         | 3.10.15    |            | 1 | invitations⬆️ |
|  39 | prometheus-client         | 0.21.0          | 0.21.1     |            | 1 | invitations⬆️ |
|  40 | prometheus-fastapi-instrumentator | 7.0.0           | 7.0.2      |            | 1 | invitations⬆️ |
|  41 | propcache                 | 0.2.0           | 0.3.0      | *minor*    | 1 | invitations⬆️ |
|  42 | protobuf                  | 5.28.3          | 5.29.3     | *minor*    | 1 | invitations⬆️ |
|  43 | psutil                    | 6.1.0           | 7.0.0      | **MAJOR**  | 1 | invitations⬆️ |
|  44 | pydantic                  | 2.10.2          | 2.10.6     |            | 1 | invitations⬆️ |
|  45 | pydantic-core             | 2.27.1          | 2.27.2     |            | 1 | invitations⬆️ |
|  46 | pydantic-extra-types      | 2.10.0          | 2.10.3     |            | 1 | invitations⬆️ |
|  47 | pydantic-settings         | 2.6.1           | 2.7.0      | *minor*    | 1 | invitations⬆️ |
|  48 | pygments                  | 2.18.0          | 2.19.1     | *minor*    | 1 | invitations⬆️ |
|  49 | pyinstrument              | 5.0.0           | 5.0.1      |            | 1 | invitations⬆️ |
|  50 | pylint                    | 3.3.4           | 3.3.5      |            | 1 | invitations🔧 |
|  51 | rpds-py                   | 0.21.0          | 0.23.1     | *minor*    | 1 | invitations⬆️ |
|  52 | ruff                      | 0.9.9           | 0.9.10     |            | 1 | invitations🔧 |
|  53 | setuptools                | 75.8.2          | 76.0.0     | **MAJOR**  | 1 | invitations🔧 |
|  54 | six                       | 1.16.0          | 1.17.0     | *minor*    | 1 | invitations⬆️ |
|  55 | starlette                 | 0.41.3          | 0.46.1     | *minor*    | 1 | invitations⬆️ |
|  56 | typer                     | 0.13.1          | 0.15.2     | *minor*    | 1 | invitations⬆️ |
|  57 | types-python-dateutil     | 2.9.0.20241003  | 2.9.0.20241206 |            | 1 | invitations⬆️ |
|  58 | urllib3                   | 2.2.3           | 2.3.0      | *minor*    | 1 | invitations⬆️ |
|  59 | uvicorn                   | 0.32.1          | 0.34.0     | *minor*    | 1 | invitations⬆️ |
|  60 | virtualenv                | 20.29.2         | 20.29.3    |            | 1 | invitations🔧 |
|  61 | watchfiles                | 1.0.0           | 1.0.4      |            | 1 | invitations⬆️ |
|  62 | websockets                | 14.1            | 15.0.1     | **MAJOR**  | 1 | invitations⬆️ |
|  63 | wrapt                     | 1.17.0          | 1.17.2     |            | 1 | invitations⬆️ |
|  64 | yarl                      | 1.18.0          | 1.18.3     |            | 1 | invitations⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 99

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.1.2, 9.4.1, 9.4.3, 9.5.1, 9.5.3, 9.5.4, 9.5.5 | 9.5.5                     |                           |
|   2 | aioboto3                  | 13.1.0, 13.2.0, 13.3.0    | 13.3.0                    |                           |
|   3 | aiobotocore               | 2.13.1, 2.15.2, 2.16.0    | 2.16.0                    |                           |
|   4 | aiocache                  | 0.11.1, 0.12.2, 0.12.3    | 0.12.3                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.21.0, 0.23.0, 0.24.0    | 0.23.0, 0.24.0            |                           |
|   7 | aiofiles                  | 0.8.0, 23.2.1, 24.1.0     | 24.1.0                    |                           |
|   8 | aiohappyeyeballs          | 2.4.3, 2.4.4, 2.4.6, 2.5.0, 2.6.1 | 2.4.3, 2.4.4, 2.4.6, 2.5.0 |                           |
|   9 | aiohttp                   | 3.8.5, 3.9.3, 3.10.10, 3.11.8, 3.11.10, 3.11.12, 3.11.13 | 3.8.5, 3.10.10, 3.11.8, 3.11.10, 3.11.12, 3.11.13 |                           |
|  10 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  11 | aiohttp-security          | 0.4.0                     |                           |                           |
|  12 | aiohttp-session           | 2.11.0                    |                           |                           |
|  13 | aioitertools              | 0.11.0, 0.12.0            | 0.12.0                    |                           |
|  14 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  15 | aioprocessing             | 2.0.1                     |                           |                           |
|  16 | aioresponses              |                           | 0.7.8                     |                           |
|  17 | aiormq                    | 6.7.6, 6.8.0, 6.8.1       | 6.8.1                     |                           |
|  18 | aiosignal                 | 1.2.0, 1.3.1, 1.3.2       | 1.2.0, 1.3.1, 1.3.2       |                           |
|  19 | aiosmtplib                | 1.1.6, 3.0.2, 4.0.0       |                           |                           |
|  20 | alembic                   | 1.8.1, 1.13.1, 1.13.3, 1.14.0, 1.14.1, 1.15.1 | 1.8.1, 1.13.1, 1.14.0, 1.14.1, 1.15.1 |                           |
|  21 | amqp                      | 5.3.1                     | 5.3.1                     |                           |
|  22 | annotated-types           | 0.7.0                     | 0.7.0                     |                           |
|  23 | antlr4-python3-runtime    |                           | 4.13.2                    |                           |
|  24 | anyio                     | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0 | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0 |                           |
|  25 | appdirs                   | 1.4.4                     |                           |                           |
|  26 | arrow                     | 1.2.3, 1.3.0              | 1.3.0                     |                           |
|  27 | asgi-lifespan             | 2.1.0                     | 2.1.0                     |                           |
|  28 | asgiref                   | 3.8.1                     |                           |                           |
|  29 | astroid                   |                           |                           | 3.3.8, 3.3.9              |
|  30 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  31 | async-timeout             | 4.0.3                     | 4.0.3                     |                           |
|  32 | asyncpg                   | 0.27.0, 0.29.0, 0.30.0    | 0.27.0, 0.30.0            |                           |
|  33 | asyncpg-stubs             |                           | 0.27.1, 0.30.0            |                           |
|  34 | attrs                     | 21.4.0, 23.2.0, 24.2.0, 25.1.0, 25.2.0 | 21.4.0, 23.2.0, 24.2.0, 25.1.0, 25.2.0 |                           |
|  35 | aws-sam-translator        |                           | 1.55.0, 1.95.0            |                           |
|  36 | aws-xray-sdk              |                           | 2.14.0                    |                           |
|  37 | bidict                    | 0.22.0, 0.23.1            | 0.23.1                    |                           |
|  38 | billiard                  | 4.2.1                     | 4.2.1                     |                           |
|  39 | binaryornot               | 0.4.4                     |                           |                           |
|  40 | black                     |                           |                           | 25.1.0                    |
|  41 | blinker                   |                           | 1.9.0                     |                           |
|  42 | blosc                     | 1.11.2                    |                           |                           |
|  43 | bokeh                     | 3.6.2                     | 3.6.3                     |                           |
|  44 | boto3                     | 1.34.75, 1.34.131, 1.35.36, 1.35.81 | 1.34.131, 1.35.36, 1.35.81, 1.35.99 |                           |
|  45 | boto3-stubs               |                           | 1.37.4                    |                           |
|  46 | botocore                  | 1.34.75, 1.34.131, 1.35.36, 1.35.81 | 1.34.131, 1.35.36, 1.35.81, 1.35.99, 1.37.4 |                           |
|  47 | botocore-stubs            | 1.34.69, 1.35.43, 1.35.76, 1.36.17, 1.37.4 | 1.35.76, 1.37.4           |                           |
|  48 | build                     |                           |                           | 1.2.2.post1               |
|  49 | bump2version              |                           |                           | 1.0.1                     |
|  50 | captcha                   | 0.5.0                     |                           |                           |
|  51 | celery                    | 5.4.0                     | 5.4.0                     |                           |
|  52 | certifi                   | 2023.7.22, 2024.2.2, 2024.8.30, 2025.1.31 | 2023.7.22, 2024.2.2, 2024.8.30, 2025.1.31 |                           |
|  53 | cffi                      | 1.17.1                    | 1.17.1                    |                           |
|  54 | cfgv                      |                           |                           | 3.4.0                     |
|  55 | cfn-lint                  |                           | 0.72.0, 1.27.0, 1.28.0    |                           |
|  56 | change-case               |                           |                           | 0.5.2                     |
|  57 | chardet                   | 5.2.0                     |                           |                           |
|  58 | charset-normalizer        | 2.0.12, 3.3.2, 3.4.0, 3.4.1 | 2.0.12, 3.3.2, 3.4.0, 3.4.1 |                           |
|  59 | click                     | 8.1.3, 8.1.7, 8.1.8       | 8.1.3, 8.1.7, 8.1.8       | 8.1.3, 8.1.7, 8.1.8       |
|  60 | click-didyoumean          | 0.3.1                     | 0.3.1                     |                           |
|  61 | click-plugins             | 1.1.1                     | 1.1.1                     |                           |
|  62 | click-repl                | 0.3.0                     | 0.3.0                     |                           |
|  63 | cloudpickle               | 3.1.0, 3.1.1              | 3.1.0                     |                           |
|  64 | contourpy                 | 1.2.0, 1.3.1              | 1.3.1                     |                           |
|  65 | cookiecutter              | 2.6.0                     |                           |                           |
|  66 | coverage                  |                           | 7.6.12                    |                           |
|  67 | cryptography              | 41.0.7, 44.0.0, 44.0.2    | 44.0.0, 44.0.2            |                           |
|  68 | cycler                    | 0.12.1                    |                           |                           |
|  69 | dask                      | 2024.12.0, 2025.2.0       | 2024.12.0                 |                           |
|  70 | dateparser                | 1.2.0                     |                           |                           |
|  71 | debugpy                   |                           | 1.8.12                    |                           |
|  72 | deepdiff                  | 8.1.1                     | 8.2.0                     |                           |
|  73 | deprecated                | 1.2.14, 1.2.15, 1.2.18    | 1.2.18                    |                           |
|  74 | dill                      |                           |                           | 0.3.9                     |
|  75 | distlib                   |                           |                           | 0.3.9                     |
|  76 | distributed               | 2024.12.0, 2025.2.0       | 2024.12.0                 |                           |
|  77 | dnspython                 | 2.2.1, 2.6.1, 2.7.0       | 2.2.1, 2.7.0              |                           |
|  78 | docker                    | 7.1.0                     | 7.1.0                     |                           |
|  79 | docutils                  | 0.21.2                    |                           |                           |
|  80 | ecdsa                     | 0.19.0                    | 0.19.0                    |                           |
|  81 | email-validator           | 2.1.1, 2.2.0              | 2.2.0                     |                           |
|  82 | et-xmlfile                | 1.1.0                     |                           |                           |
|  83 | exceptiongroup            | 1.2.2                     | 1.2.2                     |                           |
|  84 | execnet                   |                           | 2.1.1                     |                           |
|  85 | faker                     | 19.6.1                    | 19.6.1, 36.1.1, 36.2.2, 37.0.0 |                           |
|  86 | fakeredis                 |                           | 2.27.0                    |                           |
|  87 | fast-depends              | 2.4.12                    | 2.4.12                    |                           |
|  88 | fastapi                   | 0.115.5, 0.115.6, 0.115.8, 0.115.11 | 0.115.6, 0.115.11         |                           |
|  89 | fastapi-cli               | 0.0.6, 0.0.7              | 0.0.5                     |                           |
|  90 | fastapi-lifespan-manager  | 0.1.4                     | 0.1.4                     |                           |
|  91 | fastapi-pagination        | 0.12.31, 0.12.32, 0.12.34 | 0.12.34                   |                           |
|  92 | faststream                | 0.5.31, 0.5.33, 0.5.34, 0.5.35 | 0.5.35                    |                           |
|  93 | filelock                  |                           |                           | 3.17.0                    |
|  94 | flaky                     |                           | 3.8.1                     |                           |
|  95 | flask                     |                           | 2.1.3, 3.1.0              |                           |
|  96 | flask-cors                |                           | 5.0.1                     |                           |
|  97 | flexcache                 | 0.3                       | 0.3                       |                           |
|  98 | flexparser                | 0.3.1, 0.4                | 0.4                       |                           |
|  99 | fonttools                 | 4.50.0                    |                           |                           |
| 100 | frozenlist                | 1.4.1, 1.5.0              | 1.4.1, 1.5.0              |                           |
| 101 | fsspec                    | 2024.10.0, 2025.2.0       | 2024.10.0                 |                           |
| 102 | googleapis-common-protos  | 1.65.0, 1.66.0, 1.68.0, 1.69.1 | 1.68.0                    |                           |
| 103 | graphql-core              |                           | 3.2.6                     |                           |
| 104 | greenlet                  | 2.0.2, 3.0.3, 3.1.1       | 2.0.2, 3.0.3, 3.1.1       |                           |
| 105 | grpcio                    | 1.66.0, 1.67.0, 1.68.0, 1.68.1, 1.70.0, 1.71.0 | 1.70.0                    |                           |
| 106 | gunicorn                  | 23.0.0                    |                           |                           |
| 107 | h11                       | 0.14.0                    | 0.14.0                    |                           |
| 108 | h2                        | 4.1.0                     | 4.2.0                     |                           |
| 109 | hpack                     | 4.0.0                     | 4.1.0                     |                           |
| 110 | httmock                   | 1.4.0                     |                           |                           |
| 111 | httpcore                  | 1.0.4, 1.0.5, 1.0.6, 1.0.7 | 1.0.4, 1.0.5, 1.0.6, 1.0.7 |                           |
| 112 | httptools                 | 0.6.1, 0.6.4              | 0.6.4                     |                           |
| 113 | httpx                     | 0.27.0, 0.27.2, 0.28.1    | 0.27.0, 0.27.2, 0.28.1    |                           |
| 114 | hypercorn                 |                           | 0.17.3                    |                           |
| 115 | hyperframe                | 6.0.1                     | 6.1.0                     |                           |
| 116 | hypothesis                |                           | 6.91.0, 6.129.0           |                           |
| 117 | icdiff                    |                           | 2.0.7                     |                           |
| 118 | identify                  |                           |                           | 2.6.8, 2.6.9              |
| 119 | idna                      | 3.3, 3.6, 3.10            | 3.3, 3.6, 3.10            |                           |
| 120 | ifaddr                    | 0.2.0                     |                           |                           |
| 121 | importlib-metadata        | 8.0.0, 8.4.0, 8.5.0, 8.6.1 | 8.5.0                     |                           |
| 122 | iniconfig                 | 2.0.0                     | 2.0.0                     |                           |
| 123 | inotify                   |                           |                           | 0.2.10                    |
| 124 | isort                     |                           |                           | 6.0.1                     |
| 125 | itsdangerous              | 2.2.0                     | 2.2.0                     |                           |
| 126 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 127 | jinja2                    | 3.1.2, 3.1.4, 3.1.5, 3.1.6 | 3.1.2, 3.1.4, 3.1.5, 3.1.6 | 3.1.4                     |
| 128 | jinja2-time               | 0.2.0                     |                           |                           |
| 129 | jmespath                  | 1.0.1                     | 1.0.1                     |                           |
| 130 | joserfc                   |                           | 1.0.4                     |                           |
| 131 | jschema-to-python         |                           | 1.2.3                     |                           |
| 132 | json2html                 | 1.3.0                     |                           |                           |
| 133 | jsondiff                  | 2.0.0                     | 2.2.1                     |                           |
| 134 | jsonpatch                 |                           | 1.33                      |                           |
| 135 | jsonpath-ng               |                           | 1.7.0                     |                           |
| 136 | jsonpickle                |                           | 4.0.2                     |                           |
| 137 | jsonpointer               |                           | 3.0.0                     |                           |
| 138 | jsonref                   |                           | 1.1.0                     |                           |
| 139 | jsonschema                | 3.2.0, 4.21.1, 4.23.0     | 3.2.0, 4.21.1, 4.23.0     |                           |
| 140 | jsonschema-path           |                           | 0.3.4                     |                           |
| 141 | jsonschema-specifications | 2023.7.1, 2024.10.1       | 2023.7.1, 2024.10.1       |                           |
| 142 | junit-xml                 |                           | 1.9                       |                           |
| 143 | kiwisolver                | 1.4.5                     |                           |                           |
| 144 | kombu                     | 5.4.2                     | 5.4.2                     |                           |
| 145 | lazy-object-proxy         |                           | 1.10.0                    |                           |
| 146 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 147 | lupa                      |                           | 2.4                       |                           |
| 148 | lz4                       | 4.3.3                     |                           |                           |
| 149 | mako                      | 1.2.2, 1.3.2, 1.3.5, 1.3.6, 1.3.7, 1.3.9 | 1.2.2, 1.3.2, 1.3.7, 1.3.9 |                           |
| 150 | markdown-it-py            | 3.0.0                     | 3.0.0                     | 3.0.0                     |
| 151 | markdown2                 | 2.5.3                     |                           |                           |
| 152 | markupsafe                | 2.1.1, 2.1.5, 3.0.1, 3.0.2 | 2.1.1, 2.1.5, 3.0.1, 3.0.2 | 3.0.2                     |
| 153 | matplotlib                | 3.8.3                     |                           |                           |
| 154 | mccabe                    |                           |                           | 0.7.0                     |
| 155 | mdurl                     | 0.1.2                     | 0.1.2                     | 0.1.2                     |
| 156 | moto                      |                           | 4.0.1, 5.0.20             |                           |
| 157 | mpmath                    |                           | 1.3.0                     |                           |
| 158 | msgpack                   | 1.1.0                     | 1.1.0                     |                           |
| 159 | multidict                 | 6.0.5, 6.1.0              | 6.1.0                     |                           |
| 160 | mypy                      |                           | 1.15.0                    | 1.15.0                    |
| 161 | mypy-extensions           |                           | 1.0.0                     | 1.0.0                     |
| 162 | nest-asyncio              | 1.6.0                     |                           |                           |
| 163 | networkx                  | 3.4.2                     | 2.8.8, 3.4.2              |                           |
| 164 | nicegui                   | 2.12.1                    |                           |                           |
| 165 | nodeenv                   |                           |                           | 1.9.1                     |
| 166 | nose                      |                           |                           | 1.3.7                     |
| 167 | numpy                     | 1.26.4, 2.1.3             | 2.1.3, 2.2.3              |                           |
| 168 | openapi-schema-validator  |                           | 0.2.3, 0.6.3              |                           |
| 169 | openapi-spec-validator    |                           | 0.4.0, 0.7.1              |                           |
| 170 | openpyxl                  | 3.0.9                     |                           |                           |
| 171 | opentelemetry-api         | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0 | 1.30.0                    |                           |
| 172 | opentelemetry-exporter-otlp | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0 | 1.30.0                    |                           |
| 173 | opentelemetry-exporter-otlp-proto-common | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0 | 1.30.0                    |                           |
| 174 | opentelemetry-exporter-otlp-proto-grpc | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0 | 1.30.0                    |                           |
| 175 | opentelemetry-exporter-otlp-proto-http | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0 | 1.30.0                    |                           |
| 176 | opentelemetry-instrumentation | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0 | 0.51b0                    |                           |
| 177 | opentelemetry-instrumentation-aiohttp-client | 0.48b0                    |                           |                           |
| 178 | opentelemetry-instrumentation-aiohttp-server | 0.48b0                    |                           |                           |
| 179 | opentelemetry-instrumentation-aiopg | 0.48b0, 0.49b2, 0.51b0    | 0.51b0                    |                           |
| 180 | opentelemetry-instrumentation-asgi | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0 |                           |                           |
| 181 | opentelemetry-instrumentation-asyncpg | 0.47b0, 0.48b0, 0.49b2, 0.51b0 | 0.51b0                    |                           |
| 182 | opentelemetry-instrumentation-botocore | 0.47b0, 0.48b0, 0.49b2, 0.51b0 |                           |                           |
| 183 | opentelemetry-instrumentation-dbapi | 0.48b0, 0.49b2, 0.51b0    | 0.51b0                    |                           |
| 184 | opentelemetry-instrumentation-fastapi | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0 |                           |                           |
| 185 | opentelemetry-instrumentation-httpx | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0 |                           |                           |
| 186 | opentelemetry-instrumentation-logging | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0 | 0.51b0                    |                           |
| 187 | opentelemetry-instrumentation-redis | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0 | 0.51b0                    |                           |
| 188 | opentelemetry-instrumentation-requests | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0 | 0.51b0                    |                           |
| 189 | opentelemetry-propagator-aws-xray | 1.0.1, 1.0.2              |                           |                           |
| 190 | opentelemetry-proto       | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0 | 1.30.0                    |                           |
| 191 | opentelemetry-sdk         | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0 | 1.30.0                    |                           |
| 192 | opentelemetry-semantic-conventions | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0 | 0.51b0                    |                           |
| 193 | opentelemetry-util-http   | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0 | 0.51b0                    |                           |
| 194 | ordered-set               | 4.1.0                     |                           |                           |
| 195 | orderly-set               | 5.2.3                     | 5.3.0                     |                           |
| 196 | orjson                    | 3.10.0, 3.10.7, 3.10.12, 3.10.15 | 3.10.15                   |                           |
| 197 | osparc                    | 0.8.3                     |                           |                           |
| 198 | osparc-client             | 0.8.3                     |                           |                           |
| 199 | packaging                 | 24.0, 24.1, 24.2          | 24.0, 24.1, 24.2          | 24.0, 24.1, 24.2          |
| 200 | pact-python               |                           | 2.3.1                     |                           |
| 201 | pamqp                     | 3.2.1, 3.3.0              | 3.3.0                     |                           |
| 202 | pandas                    | 2.2.1, 2.2.3              | 2.2.3                     |                           |
| 203 | parse                     | 1.20.2                    | 1.20.2                    |                           |
| 204 | partd                     | 1.4.2                     | 1.4.2                     |                           |
| 205 | passlib                   | 1.7.4                     |                           |                           |
| 206 | pathable                  |                           | 0.4.4                     |                           |
| 207 | pathspec                  |                           |                           | 0.12.1                    |
| 208 | pbr                       |                           | 6.1.1                     |                           |
| 209 | pillow                    | 10.2.0, 10.3.0, 11.0.0    | 11.1.0                    |                           |
| 210 | pint                      | 0.24.3, 0.24.4            | 0.24.4                    |                           |
| 211 | pip                       |                           | 25.0.1                    | 25.0.1                    |
| 212 | pip-tools                 |                           |                           | 7.4.1                     |
| 213 | platformdirs              | 4.3.6                     | 4.3.6                     | 4.3.6                     |
| 214 | playwright                |                           | 1.50.0                    |                           |
| 215 | pluggy                    | 1.5.0                     | 1.5.0                     |                           |
| 216 | ply                       |                           | 3.11                      |                           |
| 217 | pprintpp                  |                           | 0.4.0                     |                           |
| 218 | pre-commit                |                           |                           | 4.1.0                     |
| 219 | priority                  |                           | 2.0.0                     |                           |
| 220 | prometheus-api-client     | 0.5.5                     |                           |                           |
| 221 | prometheus-client         | 0.14.1, 0.20.0, 0.21.0, 0.21.1 |                           |                           |
| 222 | prometheus-fastapi-instrumentator | 6.1.0, 7.0.0, 7.0.2       |                           |                           |
| 223 | prompt-toolkit            | 3.0.50                    | 3.0.50                    |                           |
| 224 | propcache                 | 0.2.0, 0.2.1, 0.3.0       | 0.2.0, 0.2.1, 0.3.0       |                           |
| 225 | protobuf                  | 4.25.4, 4.25.5, 5.29.0, 5.29.1, 5.29.3 | 5.29.3                    |                           |
| 226 | pscript                   | 0.7.7                     |                           |                           |
| 227 | psutil                    | 6.0.0, 6.1.0, 6.1.1, 7.0.0 | 6.1.0, 6.1.1, 7.0.0       |                           |
| 228 | psycopg2-binary           | 2.9.6, 2.9.9, 2.9.10      | 2.9.10                    |                           |
| 229 | ptvsd                     |                           | 4.3.2                     |                           |
| 230 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 231 | py-partiql-parser         |                           | 0.5.6                     |                           |
| 232 | pyasn1                    | 0.6.1                     | 0.6.1                     |                           |
| 233 | pycountry                 | 23.12.11                  |                           |                           |
| 234 | pycparser                 | 2.21, 2.22                | 2.22                      |                           |
| 235 | pycryptodome              | 3.21.0                    | 3.21.0                    |                           |
| 236 | pydantic                  | 2.10.2, 2.10.3, 2.10.6    | 2.10.2, 2.10.3, 2.10.6    |                           |
| 237 | pydantic-core             | 2.27.1, 2.27.2            | 2.27.1, 2.27.2            |                           |
| 238 | pydantic-extra-types      | 2.9.0, 2.10.0, 2.10.2, 2.10.3 | 2.10.2                    |                           |
| 239 | pydantic-settings         | 2.5.2, 2.6.1, 2.7.0       | 2.7.0                     |                           |
| 240 | pyee                      |                           | 12.1.1                    |                           |
| 241 | pyftpdlib                 |                           | 2.0.1                     |                           |
| 242 | pygments                  | 2.15.1, 2.17.2, 2.18.0, 2.19.1 | 2.15.1, 2.19.1            | 2.19.1                    |
| 243 | pyinstrument              | 4.6.1, 4.6.2, 5.0.0, 5.0.1 | 5.0.0, 5.0.1              |                           |
| 244 | pyjwt                     | 2.4.0                     |                           |                           |
| 245 | pylint                    |                           |                           | 3.3.4, 3.3.5              |
| 246 | pyopenssl                 |                           | 25.0.0                    |                           |
| 247 | pyparsing                 | 3.1.2                     | 3.1.2, 3.2.1              |                           |
| 248 | pyproject-hooks           |                           |                           | 1.2.0                     |
| 249 | pyrsistent                | 0.18.1, 0.20.0            | 0.18.1, 0.20.0            |                           |
| 250 | pytest                    | 8.3.5                     | 8.3.5                     |                           |
| 251 | pytest-aiohttp            |                           | 1.0.5, 1.1.0              |                           |
| 252 | pytest-asyncio            |                           | 0.21.2, 0.23.8            |                           |
| 253 | pytest-base-url           |                           | 2.1.0                     |                           |
| 254 | pytest-benchmark          |                           | 5.1.0                     |                           |
| 255 | pytest-celery             |                           | 1.1.3                     |                           |
| 256 | pytest-cov                |                           | 6.0.0                     |                           |
| 257 | pytest-docker             |                           | 3.2.0                     |                           |
| 258 | pytest-docker-tools       |                           | 3.1.3                     |                           |
| 259 | pytest-html               |                           | 4.1.1                     |                           |
| 260 | pytest-icdiff             |                           | 0.9                       |                           |
| 261 | pytest-instafail          |                           | 0.5.0                     |                           |
| 262 | pytest-localftpserver     |                           | 1.3.2                     |                           |
| 263 | pytest-metadata           |                           | 3.1.1                     |                           |
| 264 | pytest-mock               |                           | 3.14.0                    |                           |
| 265 | pytest-playwright         |                           | 0.7.0                     |                           |
| 266 | pytest-runner             |                           | 6.0.1                     |                           |
| 267 | pytest-sugar              |                           | 1.0.0                     |                           |
| 268 | pytest-xdist              |                           | 3.6.1                     |                           |
| 269 | python-dateutil           | 2.8.2, 2.9.0.post0        | 2.8.2, 2.9.0.post0        |                           |
| 270 | python-dotenv             | 1.0.1                     | 1.0.1                     |                           |
| 271 | python-engineio           | 4.3.4, 4.10.1, 4.11.2     | 4.10.1                    |                           |
| 272 | python-jose               | 3.3.0                     | 3.4.0                     |                           |
| 273 | python-magic              | 0.4.25, 0.4.27            |                           |                           |
| 274 | python-multipart          | 0.0.9, 0.0.17, 0.0.19, 0.0.20 | 0.0.20                    |                           |
| 275 | python-slugify            | 8.0.4                     | 8.0.4                     |                           |
| 276 | python-socketio           | 5.8.0, 5.11.4, 5.12.1     | 5.11.4                    |                           |
| 277 | pytz                      | 2022.1, 2024.1, 2024.2    | 2025.1                    |                           |
| 278 | pyyaml                    | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              |
| 279 | redis                     | 5.2.1                     | 5.2.1                     |                           |
| 280 | referencing               | 0.29.3, 0.35.1            | 0.8.11, 0.29.3, 0.35.1    |                           |
| 281 | regex                     | 2023.12.25                | 2023.12.25, 2024.11.6     |                           |
| 282 | repro-zipfile             | 0.3.1                     |                           |                           |
| 283 | requests                  | 2.32.2, 2.32.3            | 2.32.2, 2.32.3            |                           |
| 284 | requests-mock             |                           | 1.12.1                    |                           |
| 285 | responses                 |                           | 0.25.6                    |                           |
| 286 | respx                     |                           | 0.22.0                    |                           |
| 287 | rfc3339-validator         |                           | 0.1.4                     |                           |
| 288 | rich                      | 13.4.2, 13.7.1, 13.9.2, 13.9.4 | 13.4.2, 13.9.4            | 13.9.4                    |
| 289 | rich-toolkit              | 0.12.0, 0.13.2            |                           |                           |
| 290 | rpds-py                   | 0.18.0, 0.20.0, 0.21.0, 0.22.3, 0.23.1 | 0.18.0, 0.20.0, 0.22.3, 0.23.1 |                           |
| 291 | rsa                       | 4.9                       | 4.9                       |                           |
| 292 | ruff                      |                           |                           | 0.9.9, 0.9.10             |
| 293 | s3fs                      | 2024.10.0                 |                           |                           |
| 294 | s3transfer                | 0.10.1, 0.10.3, 0.10.4    | 0.10.1, 0.10.3, 0.10.4    |                           |
| 295 | sarif-om                  |                           | 1.0.4                     |                           |
| 296 | setproctitle              | 1.3.3                     |                           |                           |
| 297 | setuptools                | 69.1.1, 74.0.0, 75.2.0, 75.6.0 | 69.1.1, 74.0.0, 75.2.0, 75.6.0, 75.8.2 | 69.1.1, 74.0.0, 75.2.0, 75.6.0, 75.8.2, 76.0.0 |
| 298 | sh                        | 2.0.6, 2.1.0, 2.2.1, 2.2.2 |                           |                           |
| 299 | shellingham               | 1.5.4                     | 1.5.4                     | 1.5.4                     |
| 300 | shortuuid                 | 1.0.13                    |                           |                           |
| 301 | simple-websocket          | 1.1.0                     | 1.1.0                     |                           |
| 302 | six                       | 1.16.0, 1.17.0            | 1.16.0, 1.17.0            |                           |
| 303 | sniffio                   | 1.3.1                     | 1.3.1                     |                           |
| 304 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 305 | sqlalchemy                | 1.4.47, 1.4.52, 1.4.54    | 1.4.47, 1.4.52, 1.4.54    |                           |
| 306 | sqlalchemy2-stubs         |                           | 0.0.2a38                  |                           |
| 307 | sshpubkeys                |                           | 3.3.1                     |                           |
| 308 | starlette                 | 0.41.0, 0.41.2, 0.41.3, 0.45.3, 0.46.0, 0.46.1 | 0.41.3, 0.46.0            |                           |
| 309 | stream-zip                | 0.0.83                    | 0.0.83                    |                           |
| 310 | swagger-ui-py             | 23.9.23                   |                           |                           |
| 311 | sympy                     |                           | 1.13.3                    |                           |
| 312 | tblib                     | 3.0.0                     | 3.0.0                     |                           |
| 313 | tenacity                  | 8.5.0, 9.0.0              | 8.5.0, 9.0.0              |                           |
| 314 | termcolor                 |                           | 2.5.0                     |                           |
| 315 | text-unidecode            | 1.3                       | 1.3                       |                           |
| 316 | tomlkit                   |                           |                           | 0.13.2                    |
| 317 | toolz                     | 0.12.0, 0.12.1, 1.0.0     | 1.0.0                     |                           |
| 318 | tornado                   | 6.4.2                     | 6.4.2                     |                           |
| 319 | tqdm                      | 4.64.0, 4.66.2, 4.66.5, 4.67.1 | 4.67.1                    |                           |
| 320 | twilio                    | 7.12.0                    |                           |                           |
| 321 | typer                     | 0.12.3, 0.12.5, 0.13.1, 0.15.1, 0.15.2 | 0.12.3, 0.15.2            | 0.15.2                    |
| 322 | types-aioboto3            |                           | 14.0.0                    |                           |
| 323 | types-aiobotocore         | 2.19.0, 2.21.0            | 2.19.0, 2.21.0            |                           |
| 324 | types-aiobotocore-ec2     | 2.19.0, 2.21.0            | 2.19.0                    |                           |
| 325 | types-aiobotocore-iam     |                           | 2.19.0                    |                           |
| 326 | types-aiobotocore-s3      | 2.19.0, 2.19.0.post1, 2.21.0 | 2.19.0, 2.21.0, 2.21.1    |                           |
| 327 | types-aiobotocore-ssm     | 2.19.0, 2.21.0            | 2.19.0                    |                           |
| 328 | types-aiofiles            |                           | 24.1.0.20241221           |                           |
| 329 | types-awscrt              | 0.20.5, 0.22.0, 0.23.3, 0.23.10 | 0.23.3, 0.23.10           |                           |
| 330 | types-boto3               |                           | 1.37.4                    |                           |
| 331 | types-cachetools          |                           |                           | 5.5.0.20240820            |
| 332 | types-docker              |                           | 7.1.0.20241229            |                           |
| 333 | types-jsonschema          |                           | 4.23.0.20241208           |                           |
| 334 | types-networkx            |                           | 3.4.2.20250304            |                           |
| 335 | types-openpyxl            |                           | 3.1.5.20241225            |                           |
| 336 | types-passlib             |                           | 1.7.7.20241221            |                           |
| 337 | types-psutil              |                           | 7.0.0.20250218            |                           |
| 338 | types-psycopg2            |                           | 2.9.21.20250121           |                           |
| 339 | types-pyasn1              |                           | 0.6.0.20250208            |                           |
| 340 | types-python-dateutil     | 2.9.0.20240316, 2.9.0.20241003, 2.9.0.20241206 | 2.9.0.20241206            |                           |
| 341 | types-python-jose         |                           | 3.4.0.20250224            |                           |
| 342 | types-pyyaml              |                           | 6.0.12.20241230           |                           |
| 343 | types-requests            |                           | 2.32.0.20250301           |                           |
| 344 | types-s3transfer          |                           | 0.11.3                    |                           |
| 345 | types-tqdm                |                           | 4.67.0.20250301           |                           |
| 346 | typing-extensions         | 4.12.2                    | 4.12.2                    | 4.12.2                    |
| 347 | tzdata                    | 2024.1, 2024.2, 2025.1    | 2024.1, 2024.2, 2025.1    |                           |
| 348 | tzlocal                   | 5.2                       |                           |                           |
| 349 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 350 | ujson                     | 5.10.0                    |                           |                           |
| 351 | urllib3                   | 2.2.3, 2.3.0              | 2.2.3, 2.3.0              |                           |
| 352 | uvicorn                   | 0.29.0, 0.32.0, 0.32.1, 0.34.0 | 0.32.1, 0.34.0            |                           |
| 353 | uvloop                    | 0.19.0, 0.21.0            | 0.21.0                    |                           |
| 354 | vbuild                    | 0.8.2                     |                           |                           |
| 355 | vine                      | 5.1.0                     | 5.1.0                     |                           |
| 356 | virtualenv                |                           |                           | 20.29.2, 20.29.3          |
| 357 | watchdog                  | 6.0.0                     |                           | 6.0.0                     |
| 358 | watchfiles                | 0.21.0, 1.0.0, 1.0.4      | 1.0.4                     |                           |
| 359 | wcwidth                   | 0.2.13                    | 0.2.13                    |                           |
| 360 | websockets                | 12.0, 14.1, 14.2, 15.0.1  | 15.0                      |                           |
| 361 | werkzeug                  | 2.1.2                     | 2.1.2, 3.1.3              |                           |
| 362 | wheel                     |                           |                           | 0.45.1                    |
| 363 | wrapt                     | 1.16.0, 1.17.0, 1.17.2    | 1.16.0, 1.17.0, 1.17.2    |                           |
| 364 | wsproto                   | 1.2.0                     | 1.2.0                     |                           |
| 365 | xmltodict                 |                           | 0.14.2                    |                           |
| 366 | xyzservices               | 2024.9.0                  | 2025.1.0                  |                           |
| 367 | yarl                      | 1.9.4, 1.15.4, 1.18.0, 1.18.3 | 1.9.4, 1.15.4, 1.18.0, 1.18.3 |                           |
| 368 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 369 | zipp                      | 3.20.1, 3.20.2, 3.21.0    | 3.21.0                    |                           |
