### PR TITLE
🎨 New `OEC:{traceback}-{timestamp}` format for de-duplication purposes

### DIFF
--- a/packages/common-library/src/common_library/error_codes.py
+++ b/packages/common-library/src/common_library/error_codes.py
@@ -41,14 +41,14 @@ def _create_fingerprint(exc: BaseException) -> str:
     return hashlib.sha256(fingerprint.encode()).hexdigest()[:_LEN]
 
 
-_MILISECONDS: Final[int] = 1000
+_SECS_TO_MILISECS: Final[int] = 1000  # ms
 
 
 def _create_timestamp() -> int:
     """Timestamp as milliseconds since epoch
     NOTE: this reduces the precission to milliseconds but it is good enough for our purpose
     """
-    ts = datetime.now(UTC).timestamp() * _MILISECONDS
+    ts = datetime.now(UTC).timestamp() * _SECS_TO_MILISECS
     return int(ts)
 
 
@@ -79,5 +79,7 @@ def parse_error_code_parts(oec: ErrorCodeStr) -> tuple[str, datetime]:
         msg = f"Invalid error code format: {oec}"
         raise ValueError(msg)
     fingerprint = match.group("fingerprint")
-    timestamp = arrow.get(int(match.group("timestamp")) / _MILISECONDS).datetime
+    timestamp = datetime.fromtimestamp(
+        float(match.group("timestamp")) / _SECS_TO_MILISECS, tz=UTC
+    )
     return fingerprint, timestamp

--- a/packages/common-library/src/common_library/error_codes.py
+++ b/packages/common-library/src/common_library/error_codes.py
@@ -1,4 +1,4 @@
-""" osparc ERROR CODES (OEC)
+"""osparc ERROR CODES (OEC)
   Unique identifier of an exception instance
   Intended to report a user about unexpected errors.
     Unexpected exceptions can be traced by matching the
@@ -7,13 +7,15 @@
 SEE test_error_codes for some use cases
 """
 
+import hashlib
 import re
+import traceback
 from typing import TYPE_CHECKING, Annotated
 
 from pydantic import StringConstraints, TypeAdapter
 
 _LABEL = "OEC:{}"
-_PATTERN = r"OEC:\d+"
+_PATTERN = r"OEC:[a-zA-Z0-9]+"
 
 if TYPE_CHECKING:
     ErrorCodeStr = str
@@ -22,9 +24,24 @@ else:
         str, StringConstraints(strip_whitespace=True, pattern=_PATTERN)
     ]
 
+_LEN = 12  # chars (~48 bits)
+
+
+def _generate_error_fingerprint(exc: BaseException) -> str:
+    """
+    Unique error fingerprint for deduplication purposes
+    """
+    tb = traceback.extract_tb(exc.__traceback__)
+    frame_sigs = [f"{frame.name}:{frame.lineno}" for frame in tb]
+    fingerprint = f"{type(exc).__name__}|" + "|".join(frame_sigs)
+    # E.g. ZeroDivisionError|foo:23|main:10
+    return hashlib.sha256(fingerprint.encode()).hexdigest()[:_LEN]
+
 
 def create_error_code(exception: BaseException) -> ErrorCodeStr:
-    return TypeAdapter(ErrorCodeStr).validate_python(_LABEL.format(id(exception)))
+    return TypeAdapter(ErrorCodeStr).validate_python(
+        _LABEL.format(_generate_error_fingerprint(exception))
+    )
 
 
 def parse_error_code(obj) -> set[ErrorCodeStr]:

--- a/packages/common-library/src/common_library/error_codes.py
+++ b/packages/common-library/src/common_library/error_codes.py
@@ -10,10 +10,9 @@ SEE test_error_codes for some use cases
 import hashlib
 import re
 import traceback
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated, Final, TypeAlias
 
-import arrow
 from pydantic import StringConstraints, TypeAdapter
 
 _LABEL = "OEC:{fingerprint}-{timestamp}"
@@ -49,7 +48,7 @@ def _create_timestamp() -> int:
     """Timestamp as milliseconds since epoch
     NOTE: this reduces the precission to milliseconds but it is good enough for our purpose
     """
-    ts = arrow.utcnow().float_timestamp * _MILISECONDS
+    ts = datetime.now(UTC).timestamp() * _MILISECONDS
     return int(ts)
 
 

--- a/packages/common-library/tests/test_error_codes.py
+++ b/packages/common-library/tests/test_error_codes.py
@@ -36,8 +36,8 @@ def test_exception_fingerprint_consistency():
         # emulates different runs of the same function (e.g. different sessions)
         try:
             _level_one(v)  # same even if different value!
-            time.sleep(0.1)
         except Exception as err:
+            time.sleep(1)
             error_code = create_error_code(err)
             error_codes.append(error_code)
 
@@ -51,11 +51,11 @@ def test_exception_fingerprint_consistency():
     assert fingerprints[0] == fingerprints[1]
     assert timestamps[0] < timestamps[1]
 
-    time.sleep(0.1)
     try:
         # Same function but different location
         _level_one(0)
     except Exception as e2:
+        time.sleep(1)
         error_code_2 = create_error_code(e2)
         fingerprint_2, timestamp_2 = parse_error_code_parts(error_code_2)
 

--- a/packages/service-library/tests/aiohttp/test_rest_middlewares.py
+++ b/packages/service-library/tests/aiohttp/test_rest_middlewares.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient
-from common_library.error_codes import parse_error_code
+from common_library.error_codes import parse_error_codes
 from common_library.json_serialization import json_dumps
 from servicelib.aiohttp import status
 from servicelib.aiohttp.rest_middlewares import (
@@ -30,8 +30,7 @@ class Data:
     y: str = "foo"
 
 
-class SomeUnexpectedError(Exception):
-    ...
+class SomeUnexpectedError(Exception): ...
 
 
 class Handlers:
@@ -237,7 +236,7 @@ async def test_raised_unhandled_exception(
 
         # user friendly message with OEC reference
         assert "OEC" in error["message"]
-        parsed_oec = parse_error_code(error["message"]).pop()
+        parsed_oec = parse_error_codes(error["message"]).pop()
         assert (
             _FMSG_INTERNAL_ERROR_USER_FRIENDLY_WITH_OEC.format(error_code=parsed_oec)
             == error["message"]


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?


### What this PR changes

This PR introduces a new fingerprinting mechanism for generating the *osparc error code* (OEC). Instead of computing the OEC from the exception instance, which produced a different OEC for every occurrence, we now generate the OEC from a fingerprint of the exception’s type and relevant context. This change ensures that identical errors will consistently yield the same OEC across multiple occurrences.

### What the OEC is used for

The OEC is included in the logs and passed to the front-end as a `supportId` (SEE OAS below), enabling users and support teams to trace and identify unexpected errors. It is also extracted by the logging system as `log_oec` and `log_userid` to associate errors with users and provide better observability across the platform.

<img width="581" alt="image" src="https://github.com/user-attachments/assets/c73a2d88-e6f8-43a6-a00e-683b2e629955" />

### Why we introduced this change

Previously, identical errors thrown in different instances (even with the same stack trace) would result in different OECs. This made it difficult to group and analyze recurring issues. With the new fingerprint-based approach, repeated occurrences of the same underlying error—possibly affecting multiple users—can now be identified and grouped under a single OEC. This improves our ability to detect and prioritize common issues, simplifies debugging, and enhances the efficiency of support workflows.

## Related issue/s

- Closes #7362

## How to test

```
cd packages/common-library
make install-dev
pytest -vv tests/test_error_codes.py
```

## Dev-ops 
None