### PR TITLE
🐛web-api:  Fixes missing `supportID` on default `5XX` responses

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/rest_middlewares.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_middlewares.py
@@ -51,14 +51,13 @@ def error_middleware_factory(
             "request.path": f"{request.path}",
         }
 
-        user_error_msg = _FMSG_INTERNAL_ERROR_USER_FRIENDLY.format(
-            error_code=error_code
-        )
+        user_error_msg = _FMSG_INTERNAL_ERROR_USER_FRIENDLY
         http_error = create_http_error(
             err,
             user_error_msg,
             web.HTTPInternalServerError,
             skip_internal_error_details=_is_prod,
+            error_code=error_code,
         )
         _logger.exception(
             **create_troubleshotting_log_kwargs(

--- a/packages/service-library/src/servicelib/aiohttp/rest_responses.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_responses.py
@@ -1,13 +1,12 @@
 """Utils to check, convert and compose server responses for the RESTApi"""
 
 import inspect
-from typing import Any, cast
+from typing import Any
 
 from aiohttp import web, web_exceptions
 from aiohttp.web_exceptions import HTTPError, HTTPException
 from common_library.error_codes import ErrorCodeStr
 from common_library.json_serialization import json_dumps
-from models_library.basic_types import IDStr
 from models_library.rest_error import ErrorGet, ErrorItemType
 from servicelib.rest_constants import RESPONSE_MODEL_POLICY
 
@@ -65,24 +64,26 @@ def create_http_error(
     if not isinstance(errors, list):
         errors = [errors]
 
-    support_id: IDStr | None = cast(IDStr, error_code) if error_code else None
-
     is_internal_error: bool = http_error_cls == web.HTTPInternalServerError
     default_message = reason or get_code_description(http_error_cls.status_code)
 
     if is_internal_error and skip_internal_error_details:
-        error = ErrorGet(
-            status=http_error_cls.status_code,
-            message=default_message,
-            support_id=support_id,
+        error = ErrorGet.model_validate(
+            {
+                "status": http_error_cls.status_code,
+                "message": default_message,
+                "support_id": error_code,
+            }
         )
     else:
         items = [ErrorItemType.from_error(err) for err in errors]
-        error = ErrorGet(
-            errors=items,  # NOTE: deprecated!
-            status=http_error_cls.status_code,
-            message=default_message,
-            support_id=support_id,
+        error = ErrorGet.model_validate(
+            {
+                "errors": items,  # NOTE: deprecated!
+                "status": http_error_cls.status_code,
+                "message": default_message,
+                "support_id": error_code,
+            }
         )
 
     assert not http_error_cls.empty_body  # nosec

--- a/packages/service-library/src/servicelib/aiohttp/rest_responses.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_responses.py
@@ -9,6 +9,7 @@ from common_library.error_codes import ErrorCodeStr
 from common_library.json_serialization import json_dumps
 from models_library.basic_types import IDStr
 from models_library.rest_error import ErrorGet, ErrorItemType
+from servicelib.rest_constants import RESPONSE_MODEL_POLICY
 
 from ..aiohttp.status import HTTP_200_OK
 from ..mimetype_constants import MIMETYPE_APPLICATION_JSON
@@ -85,11 +86,15 @@ def create_http_error(
         )
 
     assert not http_error_cls.empty_body  # nosec
-    payload = wrap_as_envelope(error=error)
+    payload = wrap_as_envelope(
+        error=error.model_dump(mode="json", **RESPONSE_MODEL_POLICY)
+    )
 
     return http_error_cls(
         reason=reason,
-        text=json_dumps(payload),
+        text=json_dumps(
+            payload,
+        ),
         content_type=MIMETYPE_APPLICATION_JSON,
     )
 

--- a/packages/service-library/src/servicelib/aiohttp/rest_responses.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_responses.py
@@ -1,11 +1,13 @@
 """Utils to check, convert and compose server responses for the RESTApi"""
 
 import inspect
-from typing import Any
+from typing import Any, cast
 
 from aiohttp import web, web_exceptions
 from aiohttp.web_exceptions import HTTPError, HTTPException
+from common_library.error_codes import ErrorCodeStr
 from common_library.json_serialization import json_dumps
+from models_library.basic_types import IDStr
 from models_library.rest_error import ErrorGet, ErrorItemType
 
 from ..aiohttp.status import HTTP_200_OK
@@ -52,6 +54,7 @@ def create_http_error(
     http_error_cls: type[HTTPError] = web.HTTPInternalServerError,
     *,
     skip_internal_error_details: bool = False,
+    error_code: ErrorCodeStr | None = None
 ) -> HTTPError:
     """
     - Response body conforms OAS schema model
@@ -61,25 +64,24 @@ def create_http_error(
     if not isinstance(errors, list):
         errors = [errors]
 
-    # TODO: guarantee no throw!
+    support_id: IDStr | None = cast(IDStr, error_code) if error_code else None
 
     is_internal_error: bool = http_error_cls == web.HTTPInternalServerError
     default_message = reason or get_code_description(http_error_cls.status_code)
 
     if is_internal_error and skip_internal_error_details:
         error = ErrorGet(
-            errors=[],
-            logs=[],
             status=http_error_cls.status_code,
             message=default_message,
+            support_id=support_id,
         )
     else:
         items = [ErrorItemType.from_error(err) for err in errors]
         error = ErrorGet(
-            errors=items,
-            logs=[],
+            errors=items,  # NOTE: deprecated!
             status=http_error_cls.status_code,
             message=default_message,
+            support_id=support_id,
         )
 
     assert not http_error_cls.empty_body  # nosec


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Fixes missing `supportID` on default `5XX` responses from the web-api:

![image](https://github.com/user-attachments/assets/fa1b39ed-9a61-44e2-9fe2-67a91185fbab)



## Related issue/s

- Issue reported by @odeimaiz  in the internal chat (see screenshot above)
- Follows up on https://github.com/ITISFoundation/osparc-simcore/pull/7394


## How to test


```
cd packages/service-library
make "install-dev[aiohttp]"
pytest -vv tests/aiohttp -k tests_exception_to_response
```

## Dev-ops

None