### PR TITLE
🐛 Fixed issue where GC stopping too early

### DIFF
--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
@@ -50,7 +50,7 @@ async def _remove_service(
         except (UserNotFoundError, ValueError):
             save_service_state = False
 
-    with log_context(
+    with log_catch(_logger, reraise=False), log_context(
         _logger,
         logging.INFO,
         msg=f"removing {(service.node_uuid, service.host)} with {save_service_state=}",
@@ -134,7 +134,7 @@ async def remove_orphaned_services(
                     ),
                     exc_info=True,
                 )
-                return
+                continue
 
         potentially_running_service_ids_set: set[NodeID] = set().union(
             *(node_id for node_id in potentially_running_service_ids)

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_orphans.py
@@ -89,73 +89,72 @@ async def remove_orphaned_services(
     # otherwise if some time goes it could very well be that there are new projects opened
     # in between and the GC would remove services that actually should be running.
 
-    with log_catch(_logger, reraise=False):
-        running_services = await dynamic_scheduler_service.list_dynamic_services(app)
-        if not running_services:
-            # nothing to do
-            return
-        _logger.debug(
-            "Actual running dynamic services: %s",
-            [(x.node_uuid, x.host) for x in running_services],
-        )
-        running_services_by_id: dict[NodeID, DynamicServiceGet] = {
-            service.node_uuid: service for service in running_services
-        }
+    running_services = await dynamic_scheduler_service.list_dynamic_services(app)
+    if not running_services:
+        # nothing to do
+        return
+    _logger.debug(
+        "Actual running dynamic services: %s",
+        [(x.node_uuid, x.host) for x in running_services],
+    )
+    running_services_by_id: dict[NodeID, DynamicServiceGet] = {
+        service.node_uuid: service for service in running_services
+    }
 
-        known_opened_project_ids = await _list_opened_project_ids(registry)
+    known_opened_project_ids = await _list_opened_project_ids(registry)
 
-        # NOTE: Always skip orphan repmoval when `list_node_ids_in_project` raises an error.
-        # Why? If a service is running but the nodes form the correspondign project cannot be listed,
-        # the service will be considered as orphaned and closed.
-        potentially_running_service_ids: list[set[NodeID]] = []
-        async for project_nodes_future in limited_as_completed(
-            (
-                list_node_ids_in_project(app, project_id)
-                for project_id in known_opened_project_ids
-            ),
-            limit=_MAX_CONCURRENT_CALLS,
-        ):
-            try:
-                project_nodes = await project_nodes_future
-                potentially_running_service_ids.append(project_nodes)
-            except BaseException as e:  # pylint:disable=broad-exception-caught
-                _logger.warning(
-                    create_troubleshotting_log_kwargs(
-                        (
-                            "Skipping orpahn services removal, call to "
-                            "`list_node_ids_in_project` raised"
-                        ),
-                        error=e,
-                        error_context={
-                            "running_services": running_services,
-                            "running_services_by_id": running_services_by_id,
-                            "known_opened_project_ids": known_opened_project_ids,
-                        },
+    # NOTE: Always skip orphan repmoval when `list_node_ids_in_project` raises an error.
+    # Why? If a service is running but the nodes form the correspondign project cannot be listed,
+    # the service will be considered as orphaned and closed.
+    potentially_running_service_ids: list[set[NodeID]] = []
+    async for project_nodes_future in limited_as_completed(
+        (
+            list_node_ids_in_project(app, project_id)
+            for project_id in known_opened_project_ids
+        ),
+        limit=_MAX_CONCURRENT_CALLS,
+    ):
+        try:
+            project_nodes = await project_nodes_future
+            potentially_running_service_ids.append(project_nodes)
+        except BaseException as e:  # pylint:disable=broad-exception-caught
+            _logger.warning(
+                create_troubleshotting_log_kwargs(
+                    (
+                        "Skipping orpahn services removal, call to "
+                        "`list_node_ids_in_project` raised"
                     ),
-                    exc_info=True,
-                )
-                continue
+                    error=e,
+                    error_context={
+                        "running_services": running_services,
+                        "running_services_by_id": running_services_by_id,
+                        "known_opened_project_ids": known_opened_project_ids,
+                    },
+                ),
+                exc_info=True,
+            )
+            continue
 
-        potentially_running_service_ids_set: set[NodeID] = set().union(
-            *(node_id for node_id in potentially_running_service_ids)
-        )
-        _logger.debug(
-            "Allowed service UUIDs from known opened projects: %s",
-            potentially_running_service_ids_set,
-        )
+    potentially_running_service_ids_set: set[NodeID] = set().union(
+        *(node_id for node_id in potentially_running_service_ids)
+    )
+    _logger.debug(
+        "Allowed service UUIDs from known opened projects: %s",
+        potentially_running_service_ids_set,
+    )
 
-        # compute the difference to find the orphaned services
-        orphaned_running_service_ids = (
-            set(running_services_by_id) - potentially_running_service_ids_set
-        )
-        _logger.debug("Found orphaned services: %s", orphaned_running_service_ids)
-        # NOTE: no need to not reraise here, since we catch everything above
-        # and logged_gather first runs everything
-        await logged_gather(
-            *(
-                _remove_service(app, node_id, running_services_by_id[node_id])
-                for node_id in orphaned_running_service_ids
-            ),
-            log=_logger,
-            max_concurrency=_MAX_CONCURRENT_CALLS,
-        )
+    # compute the difference to find the orphaned services
+    orphaned_running_service_ids = (
+        set(running_services_by_id) - potentially_running_service_ids_set
+    )
+    _logger.debug("Found orphaned services: %s", orphaned_running_service_ids)
+    # NOTE: no need to not reraise here, since we catch everything above
+    # and logged_gather first runs everything
+    await logged_gather(
+        *(
+            _remove_service(app, node_id, running_services_by_id[node_id])
+            for node_id in orphaned_running_service_ids
+        ),
+        log=_logger,
+        max_concurrency=_MAX_CONCURRENT_CALLS,
+    )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

There where situations in which Step 3 of the GC was never executed, causing sidecars to be accumulated.


- in case of errors in step 1 and step 2 the GC would stop and not reach step 3 which is very important for removing system resource
- Instead of continuing the process wen `list_node_ids_in_project`  raised, the process is stopped. This could cause the GC to stop when services still required removal. (Issue introduced by  https://github.com/ITISFoundation/osparc-simcore/pull/7354)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
