### PR TITLE
🎨Director-v0: set default timeout to 20s and potentially allow setting it up

### DIFF
--- a/packages/service-library/src/servicelib/fastapi/client_session.py
+++ b/packages/service-library/src/servicelib/fastapi/client_session.py
@@ -1,12 +1,20 @@
+import datetime
+
 import httpx
 from fastapi import FastAPI
 
 
-def setup_client_session(app: FastAPI, *, max_keepalive_connections: int = 20) -> None:
+def setup_client_session(
+    app: FastAPI,
+    *,
+    default_timeout: datetime.timedelta = datetime.timedelta(seconds=20),
+    max_keepalive_connections: int = 20
+) -> None:
     async def on_startup() -> None:
         session = httpx.AsyncClient(
             transport=httpx.AsyncHTTPTransport(http2=True),
             limits=httpx.Limits(max_keepalive_connections=max_keepalive_connections),
+            timeout=default_timeout.total_seconds(),
         )
         app.state.aiohttp_client_session = session
 

--- a/services/director/src/simcore_service_director/core/application.py
+++ b/services/director/src/simcore_service_director/core/application.py
@@ -56,6 +56,7 @@ def create_app(settings: ApplicationSettings) -> FastAPI:
     setup_client_session(
         app,
         max_keepalive_connections=settings.DIRECTOR_REGISTRY_CLIENT_MAX_KEEPALIVE_CONNECTIONS,
+        timeout=settings.DIRECTOR_REGISTRY_CLIENT_TIMEOUT,
     )
     setup_registry(app)
 

--- a/services/director/src/simcore_service_director/core/application.py
+++ b/services/director/src/simcore_service_director/core/application.py
@@ -56,7 +56,7 @@ def create_app(settings: ApplicationSettings) -> FastAPI:
     setup_client_session(
         app,
         max_keepalive_connections=settings.DIRECTOR_REGISTRY_CLIENT_MAX_KEEPALIVE_CONNECTIONS,
-        timeout=settings.DIRECTOR_REGISTRY_CLIENT_TIMEOUT,
+        default_timeout=settings.DIRECTOR_REGISTRY_CLIENT_TIMEOUT,
     )
     setup_registry(app)
 

--- a/services/director/src/simcore_service_director/core/settings.py
+++ b/services/director/src/simcore_service_director/core/settings.py
@@ -121,10 +121,11 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
 
     @field_validator("DIRECTOR_REGISTRY_CLIENT_TIMEOUT")
     @classmethod
-    def _check_positive(cls, value: datetime.timedelta) -> None:
+    def _check_positive(cls, value: datetime.timedelta) -> datetime.timedelta:
         if value.total_seconds() < 0:
             msg = "DIRECTOR_REGISTRY_CLIENT_TIMEOUT must be positive"
             raise ValueError(msg)
+        return value
 
     @field_validator("DIRECTOR_GENERIC_RESOURCE_PLACEMENT_CONSTRAINTS_SUBSTITUTIONS")
     @classmethod

--- a/services/director/src/simcore_service_director/core/settings.py
+++ b/services/director/src/simcore_service_director/core/settings.py
@@ -112,9 +112,19 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
         ),
     )
 
-    DIRECTOR_REGISTRY_CLIENT_MAX_KEEPALIVE_CONNECTIONS: NonNegativeInt = 0
+    DIRECTOR_REGISTRY_CLIENT_MAX_KEEPALIVE_CONNECTIONS: NonNegativeInt = 5
+    DIRECTOR_REGISTRY_CLIENT_TIMEOUT: datetime.timedelta = datetime.timedelta(
+        seconds=20
+    )
     DIRECTOR_REGISTRY_CLIENT_MAX_CONCURRENT_CALLS: PositiveInt = 20
     DIRECTOR_REGISTRY_CLIENT_MAX_NUMBER_OF_RETRIEVED_OBJECTS: PositiveInt = 30
+
+    @field_validator("DIRECTOR_REGISTRY_CLIENT_TIMEOUT")
+    @classmethod
+    def _check_positive(cls, value: datetime.timedelta) -> None:
+        if value.total_seconds() < 0:
+            msg = "DIRECTOR_REGISTRY_CLIENT_TIMEOUT must be positive"
+            raise ValueError(msg)
 
     @field_validator("DIRECTOR_GENERIC_RESOURCE_PLACEMENT_CONSTRAINTS_SUBSTITUTIONS")
     @classmethod

--- a/services/director/tests/unit/test_core_settings.py
+++ b/services/director/tests/unit/test_core_settings.py
@@ -4,7 +4,10 @@
 # pylint: disable=too-many-arguments
 
 
+import datetime
+
 import pytest
+from pydantic import ValidationError
 from pytest_simcore.helpers.monkeypatch_envs import (
     setenvs_from_dict,
     setenvs_from_envfile,
@@ -35,6 +38,16 @@ def test_valid_web_application_settings(app_environment: EnvVarsDict):
         )
         == f"{settings.DIRECTOR_DEFAULT_MAX_MEMORY}"
     )
+
+
+def test_invalid_client_timeout_raises(
+    app_environment: EnvVarsDict, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv(
+        "DIRECTOR_REGISTRY_CLIENT_TIMEOUT", f"{datetime.timedelta(seconds=-10)}"
+    )
+    with pytest.raises(ValidationError):
+        ApplicationSettings.create_from_envs()
 
 
 def test_docker_container_env_sample(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
- adds `DIRECTOR_REGISTRY_CLIENT_TIMEOUT` as a potential ENV variable. default value is now set to 20 seconds to be similar with old aiohttp client

If this really needs to become a fully fledged ENV, let me know @mrnicegyu11 

## Related issue/s
- solves https://github.com/ITISFoundation/osparc-simcore/issues/7456
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
