### PR TITLE
🎨E2E: Fail fast conditions + websocket logging in case of error

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -1,3 +1,8 @@
+# pylint:disable=unused-variable
+# pylint:disable=unused-argument
+# pylint:disable=redefined-outer-name
+# pylint:disable=too-many-instance-attributes
+
 import contextlib
 import json
 import logging

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -471,21 +471,11 @@ def expected_service_running(
         )
         service_running = ServiceRunning(iframe_locator=None)
 
-        try:
-            with websocket.expect_event("framereceived", waiter, timeout=timeout):
-                if press_start_button:
-                    _trigger_service_start(page, node_id)
+        with websocket.expect_event("framereceived", waiter, timeout=timeout):
+            if press_start_button:
+                _trigger_service_start(page, node_id)
 
-                yield service_running
-
-        except PlaywrightTimeoutError:
-            if waiter.got_expected_node_progress_types():
-                ctx.logger.warning(
-                    "⚠️ Progress bar didn't receive 100 percent but all expected node-progress-types are in place: %s ⚠️",  # https://github.com/ITISFoundation/osparc-simcore/issues/6449
-                    waiter.get_current_progress(),
-                )
-            else:
-                raise
+            yield service_running
 
     service_running.iframe_locator = page.frame_locator(
         f'[osparc-test-id="iframe_{node_id}"]'

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright_sim4life.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright_sim4life.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Final, TypedDict
 
 import arrow
@@ -107,6 +108,7 @@ def wait_for_launched_s4l(
     copy_workspace: bool,
     product_url: AnyUrl,
     is_service_legacy: bool,
+    assertion_output_folder: Path,
 ) -> WaitForS4LDict:
     with log_context(logging.INFO, "launch S4L") as ctx:
         predicate = S4LWaitForWebsocket(logger=ctx.logger)
@@ -134,6 +136,7 @@ def wait_for_launched_s4l(
                 press_start_button=False,
                 product_url=product_url,
                 is_service_legacy=is_service_legacy,
+                assertion_output_folder=assertion_output_folder,
             )
         s4l_websocket = ws_info.value
         ctx.logger.info("acquired S4L websocket!")

--- a/tests/e2e-playwright/tests/conftest.py
+++ b/tests/e2e-playwright/tests/conftest.py
@@ -14,6 +14,7 @@ import re
 import urllib.parse
 from collections.abc import Callable, Iterator
 from contextlib import ExitStack
+from pathlib import Path
 from typing import Any, Final
 
 import arrow
@@ -794,3 +795,10 @@ def start_and_stop_pipeline(
             logging.INFO, f"Stop computation with {pipeline_id=} in {product_url=}"
         ):
             api_request_context.post(f"{product_url}v0/computations/{pipeline_id}:stop")
+
+
+@pytest.fixture
+def playwright_test_results_dir() -> Path:
+    results_dir = Path.cwd() / "test-results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    return results_dir

--- a/tests/e2e-playwright/tests/conftest.py
+++ b/tests/e2e-playwright/tests/conftest.py
@@ -470,7 +470,7 @@ def _select_service_version(page: Page, *, version: str) -> None:
 
 
 @pytest.fixture
-def create_new_project_and_delete(
+def create_new_project_and_delete(  # noqa: C901, PLR0915
     page: Page,
     log_in_and_out: RestartableWebSocket,
     is_product_billable: bool,
@@ -484,7 +484,7 @@ def create_new_project_and_delete(
     """
     created_project_uuids = []
 
-    def _(
+    def _(  # noqa: C901
         expected_states: tuple[RunningState],
         press_open: bool,
         template_id: str | None,
@@ -503,72 +503,74 @@ def create_new_project_and_delete(
                 if template_id is not None
                 else _OPENING_NEW_EMPTY_PROJECT_MAX_WAIT_TIME
             )
-            with (
-                log_in_and_out.expect_event(
-                    "framereceived", waiter, timeout=timeout + 10 * SECOND
-                ),
-                page.expect_response(
-                    re.compile(r"/projects/[^:]+:open"), timeout=timeout + 5 * SECOND
-                ) as response_info,
+            with log_in_and_out.expect_event(
+                "framereceived", waiter, timeout=timeout + 10 * SECOND
             ):
-                open_with_resources_clicked = False
-                # Project detail view pop-ups shows
-                if press_open:
-                    open_button = page.get_by_test_id("openResource")
-                    if template_id is not None:
-                        if is_product_billable:
-                            open_button.click()
-                            open_button = _open_with_resources(page, click_it=False)
-                        # it returns a Long Running Task
-                        with page.expect_response(
-                            re.compile(rf"/projects\?from_study\={template_id}")
-                        ) as lrt:
-                            open_button.click()
-                        open_with_resources_clicked = True
-                        lrt_data = lrt.value.json()
-                        lrt_data = lrt_data["data"]
-                        with log_context(
-                            logging.INFO,
-                            "Copying template data",
-                        ) as copying_logger:
-                            # From the long running tasks response's urls, only their path is relevant
-                            def url_to_path(url):
-                                return urllib.parse.urlparse(url).path
-
-                            def wait_for_done(response):
-                                if url_to_path(response.url) == url_to_path(
-                                    lrt_data["status_href"]
-                                ):
-                                    resp_data = response.json()
-                                    resp_data = resp_data["data"]
-                                    assert "task_progress" in resp_data
-                                    task_progress = resp_data["task_progress"]
-                                    copying_logger.logger.info(
-                                        "task progress: %s %s",
-                                        task_progress["percent"],
-                                        task_progress["message"],
-                                    )
-                                    return False
-                                if url_to_path(response.url) == url_to_path(
-                                    lrt_data["result_href"]
-                                ):
-                                    copying_logger.logger.info("project created")
-                                    return response.status == 201
-                                return False
-
-                            with page.expect_response(wait_for_done, timeout=timeout):
-                                # if the above calls go to fast, this test could fail
-                                # not expected in the sim4life context though
-                                ...
-                    else:
-                        if service_version is not None:
-                            _select_service_version(page, version=service_version)
-                        open_button.click()
-                        if is_product_billable:
-                            _open_with_resources(page, click_it=True)
+                with page.expect_response(
+                    re.compile(r"/projects/[^:]+:open"), timeout=timeout + 5 * SECOND
+                ) as response_info:
+                    open_with_resources_clicked = False
+                    # Project detail view pop-ups shows
+                    if press_open:
+                        open_button = page.get_by_test_id("openResource")
+                        if template_id is not None:
+                            if is_product_billable:
+                                open_button.click()
+                                open_button = _open_with_resources(page, click_it=False)
+                            # it returns a Long Running Task
+                            with page.expect_response(
+                                re.compile(rf"/projects\?from_study\={template_id}")
+                            ) as lrt:
+                                open_button.click()
                             open_with_resources_clicked = True
-                if is_product_billable and not open_with_resources_clicked:
-                    _open_with_resources(page, click_it=True)
+                            lrt_data = lrt.value.json()
+                            lrt_data = lrt_data["data"]
+                            with log_context(
+                                logging.INFO,
+                                "Copying template data",
+                            ) as copying_logger:
+                                # From the long running tasks response's urls, only their path is relevant
+                                def url_to_path(url):
+                                    return urllib.parse.urlparse(url).path
+
+                                def wait_for_done(response):
+                                    if url_to_path(response.url) == url_to_path(
+                                        lrt_data["status_href"]
+                                    ):
+                                        resp_data = response.json()
+                                        resp_data = resp_data["data"]
+                                        assert "task_progress" in resp_data
+                                        task_progress = resp_data["task_progress"]
+                                        copying_logger.logger.info(
+                                            "task progress: %s %s",
+                                            task_progress["percent"],
+                                            task_progress["message"],
+                                        )
+                                        return False
+                                    if url_to_path(response.url) == url_to_path(
+                                        lrt_data["result_href"]
+                                    ):
+                                        copying_logger.logger.info("project created")
+                                        return response.status == 201
+                                    return False
+
+                                with page.expect_response(
+                                    wait_for_done, timeout=timeout
+                                ):
+                                    # if the above calls go to fast, this test could fail
+                                    # not expected in the sim4life context though
+                                    ...
+                        else:
+                            if service_version is not None:
+                                _select_service_version(page, version=service_version)
+                            open_button.click()
+                            if is_product_billable:
+                                _open_with_resources(page, click_it=True)
+                                open_with_resources_clicked = True
+                    if is_product_billable and not open_with_resources_clicked:
+                        _open_with_resources(page, click_it=True)
+
+                assert response_info.value.ok, f"{response_info.value.json()}"
             project_data = response_info.value.json()
             assert project_data
             project_uuid = project_data["data"]["uuid"]

--- a/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
@@ -11,6 +11,7 @@ import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Final, Literal
 
 from playwright.sync_api import Page, WebSocket
@@ -72,6 +73,7 @@ def test_jupyterlab(
     large_file_block_size: ByteSize,
     product_url: AnyUrl,
     is_service_legacy: bool,
+    playwright_test_results_dir: Path,
 ):
     # NOTE: this waits for the jupyter to send message, but is not quite enough
     with (
@@ -104,6 +106,7 @@ def test_jupyterlab(
             press_start_button=False,
             product_url=product_url,
             is_service_legacy=is_service_legacy,
+            assertion_output_folder=playwright_test_results_dir,
         )
 
     iframe = page.frame_locator("iframe")

--- a/tests/e2e-playwright/tests/sim4life/test_sim4life.py
+++ b/tests/e2e-playwright/tests/sim4life/test_sim4life.py
@@ -8,6 +8,7 @@
 
 
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from playwright.sync_api import Page
@@ -34,6 +35,7 @@ def test_sim4life(
     check_videostreaming: bool,
     product_url: AnyUrl,
     is_service_legacy: bool,
+    playwright_test_results_dir: Path,
 ):
     if use_plus_button:
         project_data = create_project_from_new_button(service_key)
@@ -57,6 +59,7 @@ def test_sim4life(
         copy_workspace=False,
         product_url=product_url,
         is_service_legacy=is_service_legacy,
+        assertion_output_folder=playwright_test_results_dir,
     )
     s4l_websocket = resp["websocket"]
     s4l_iframe = resp["iframe"]

--- a/tests/e2e-playwright/tests/sim4life/test_template.py
+++ b/tests/e2e-playwright/tests/sim4life/test_template.py
@@ -8,6 +8,7 @@
 
 
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from playwright.sync_api import Page
@@ -29,6 +30,7 @@ def test_template(
     check_videostreaming: bool,
     product_url: AnyUrl,
     is_service_legacy: bool,
+    playwright_test_results_dir: Path,
 ):
     project_data = create_project_from_template_dashboard(template_id)
 
@@ -47,6 +49,7 @@ def test_template(
         copy_workspace=True,
         product_url=product_url,
         is_service_legacy=is_service_legacy,
+        assertion_output_folder=playwright_test_results_dir,
     )
     s4l_websocket = resp["websocket"]
     s4l_iframe = resp["iframe"]

--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -11,6 +11,7 @@ import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Final
 
 from playwright.sync_api import Page, WebSocket
@@ -96,6 +97,7 @@ def test_classic_ti_plan(  # noqa: PLR0915
     create_tip_plan_from_dashboard: Callable[[str], dict[str, Any]],
     product_url: AnyUrl,
     is_service_legacy: bool,
+    playwright_test_results_dir: Path,
 ):
     with log_context(logging.INFO, "Checking 'Access TIP' teaser"):
         # click to open and expand
@@ -147,6 +149,7 @@ def test_classic_ti_plan(  # noqa: PLR0915
             press_start_button=False,
             product_url=product_url,
             is_service_legacy=is_service_legacy,
+            assertion_output_folder=playwright_test_results_dir,
         )
         # NOTE: Sometimes this iframe flicks and shows a white page. This wait will avoid it
         page.wait_for_timeout(_ELECTRODE_SELECTOR_FLICKERING_WAIT_TIME)
@@ -212,6 +215,7 @@ def test_classic_ti_plan(  # noqa: PLR0915
                 press_start_button=False,
                 product_url=product_url,
                 is_service_legacy=is_service_legacy,
+                assertion_output_folder=playwright_test_results_dir,
             ) as service_running:
                 app_mode_trigger_next_app(page)
             ti_iframe = service_running.iframe_locator
@@ -326,6 +330,7 @@ def test_classic_ti_plan(  # noqa: PLR0915
                 press_start_button=False,
                 product_url=product_url,
                 is_service_legacy=is_service_legacy,
+                assertion_output_folder=playwright_test_results_dir,
             ) as service_running:
                 app_mode_trigger_next_app(page)
             s4l_postpro_iframe = service_running.iframe_locator


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- added fail fast conditions when:
  - computational pipeline goes into FAILED,ABORTED state instead of waiting super long
  - dynamic service goes into IDLE, FAILED service state by checking websocket ServiceStatus message
  - 409 is raised when opening a project
- added missing states when checking for node progress types
- catch exception in playwright callback (that is very bad as this implies infinite loops)
- in case of dynamic service failing on start, **all** the websocket messages are json-formatted and written into `websocket.json` file in the test-results output for later debugging

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
E2E TIP issues
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
