### PR TITLE
🎨 [Frontend] Enh service calls: avoid request deduplication

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
@@ -526,12 +526,7 @@ qx.Class.define("osparc.dashboard.CardBase", {
       });
 
       if (resourceData["resourceType"] === "study" || resourceData["resourceType"] === "template") {
-        const params = {
-          url: {
-            studyId: this.getResourceData()["uuid"]
-          }
-        };
-        osparc.data.Resources.fetch("studies", "getServices", params)
+        osparc.store.Services.getStudyServices(this.getResourceData()["uuid"])
           .then(resp => {
             const services = resp["services"];
             resourceData["services"] = services;

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -194,7 +194,7 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
       };
       Promise.all([
         osparc.data.Resources.fetch("studies", "getOne", params),
-        osparc.data.Resources.fetch("studies", "getServices", params)
+        osparc.store.Services.getStudyServices(this.__resourceData["uuid"]),
       ])
         .then(values => {
           const updatedStudyData = values[0];

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -569,21 +569,6 @@ qx.Class.define("osparc.data.Resources", {
        * SERVICES
        */
       "services": {
-        useCache: true,
-        idField: ["key", "version"],
-        endpoints: {
-          pricingPlans: {
-            useCache: false,
-            method: "GET",
-            url: statics.API + "/catalog/services/{key}/{version}/pricing-plan"
-          }
-        }
-      },
-
-      /*
-       * SERVICES V2
-       */
-      "servicesV2": {
         useCache: false, // handled in osparc.store.Services
         idField: ["key", "version"],
         endpoints: {
@@ -598,7 +583,12 @@ qx.Class.define("osparc.data.Resources", {
           patch: {
             method: "PATCH",
             url: statics.API + "/catalog/services/{key}/{version}"
-          }
+          },
+          pricingPlans: {
+            useCache: false,
+            method: "GET",
+            url: statics.API + "/catalog/services/{key}/{version}/pricing-plan"
+          },
         }
       },
 

--- a/services/static-webserver/client/source/class/osparc/metadata/ServicesInStudyUpdate.js
+++ b/services/static-webserver/client/source/class/osparc/metadata/ServicesInStudyUpdate.js
@@ -57,12 +57,7 @@ qx.Class.define("osparc.metadata.ServicesInStudyUpdate", {
       });
       this._introText.add(introText);
       let msg = "";
-      const params = {
-        url: {
-          studyId: this._studyData["uuid"]
-        }
-      };
-      osparc.data.Resources.fetch("studies", "getServices", params)
+      osparc.store.Services.getStudyServices(this._studyData["uuid"])
         .then(resp => {
           const services = resp["services"];
           if (osparc.study.Utils.getCantExecuteServices(services).length) {

--- a/services/static-webserver/client/source/class/osparc/store/Services.js
+++ b/services/static-webserver/client/source/class/osparc/store/Services.js
@@ -21,6 +21,7 @@ qx.Class.define("osparc.store.Services", {
   statics: {
     __servicesCached: {},
     __servicesPromisesCached: {},
+    __studyServicesPromisesCached: {},
 
     getServicesLatest: function(useCache = true) {
       return new Promise(resolve => {
@@ -139,6 +140,25 @@ qx.Class.define("osparc.store.Services", {
             delete this.__servicesPromisesCached[key][version];
           });
       });
+    },
+
+    getStudyServices: function(studyId) {
+      // avoid request deduplication
+      if (studyId in this.__studyServicesPromisesCached) {
+        return this.__studyServicesPromisesCached[studyId];
+      }
+
+      const params = {
+        url: {
+          studyId
+        }
+      };
+      this.__studyServicesPromisesCached[studyId] = osparc.data.Resources.fetch("studies", "getServices", params)
+        .finally(() => {
+          delete this.__studyServicesPromisesCached[studyId];
+        });
+
+      return this.__studyServicesPromisesCached[studyId]
     },
 
     __getAllVersions: function(key) {

--- a/services/static-webserver/client/source/class/osparc/store/Services.js
+++ b/services/static-webserver/client/source/class/osparc/store/Services.js
@@ -32,7 +32,7 @@ qx.Class.define("osparc.store.Services", {
           return;
         }
 
-        osparc.data.Resources.getInstance().getAllPages("servicesV2")
+        osparc.data.Resources.getInstance().getAllPages("services")
           .then(servicesArray => {
             const servicesObj = osparc.service.Utils.convertArrayToObject(servicesArray);
             this.__addHits(servicesObj);
@@ -122,7 +122,7 @@ qx.Class.define("osparc.store.Services", {
         const params = {
           url: osparc.data.Resources.getServiceUrl(key, version)
         };
-        this.__servicesPromisesCached[key][version] = osparc.data.Resources.fetch("servicesV2", "getOne", params)
+        this.__servicesPromisesCached[key][version] = osparc.data.Resources.fetch("services", "getOne", params)
           .then(service => {
             this.__addHit(service);
             this.__addTSRInfo(service);
@@ -269,7 +269,7 @@ qx.Class.define("osparc.store.Services", {
         url: osparc.data.Resources.getServiceUrl(key, version),
         data: patchData
       };
-      return osparc.data.Resources.fetch("servicesV2", "patch", params)
+      return osparc.data.Resources.fetch("services", "patch", params)
         .then(() => {
           this.__servicesCached[key][version][fieldKey] = value;
           serviceData[fieldKey] = value;

--- a/services/static-webserver/client/source/class/osparc/study/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/study/Utils.js
@@ -342,12 +342,11 @@ qx.Class.define("osparc.study.Utils", {
       return Object.values(studyData["workbench"]).filter(nodeData => !osparc.data.model.Node.isFrontend(nodeData));
     },
 
-    guessIcon: async function(studyData) {
+    guessIcon: function(studyData) {
       if (osparc.product.Utils.isProduct("tis") || osparc.product.Utils.isProduct("tiplite")) {
-        return this.__guessTIPIcon(studyData);
+        return new Promise(resolve => resolve(this.__guessTIPIcon(studyData)));
       }
-      const icon = await this.__guessIcon(studyData);
-      return icon;
+      return this.__guessIcon(studyData);
     },
 
     __guessIcon: function(studyData) {


### PR DESCRIPTION
## What do these changes do?

This PR fixes the classic "duplicate requests flood" problem. It happens a lot when multiple cards in the dashboard fetch the same service's metadata in parallel.

To solve it, a shared fetch cache or request deduplication was implemented.

Before:
![deduplication](https://github.com/user-attachments/assets/472d465d-e068-4fa6-acdd-c6961818e4fc)

After:
![deduplicationAfter](https://github.com/user-attachments/assets/70992c09-5ea1-494d-adc4-69e0f9345407)


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
