### PR TITLE
 ✨ web-server RPC: exposes `list_my_projects_marked_as_jobs` 

### DIFF
--- a/packages/models-library/src/models_library/rpc/webserver/projects.py
+++ b/packages/models-library/src/models_library/rpc/webserver/projects.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from typing import Annotated, TypeAlias
+
+from models_library.projects import NodesDict, ProjectID
+from models_library.rpc_pagination import PageRpc
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProjectRpcGet(BaseModel):
+    uuid: Annotated[
+        ProjectID,
+        Field(description="project unique identifier"),
+    ]
+    name: Annotated[
+        str,
+        Field(description="project display name"),
+    ]
+    description: str
+
+    # timestamps
+    creation_date: datetime
+    last_change_date: datetime
+
+    workbench: Annotated[NodesDict, Field(description="Project's pipeline")]
+
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+    )
+
+
+PageRpcProjectRpcGet: TypeAlias = PageRpc[
+    # WARNING: keep this definition in models_library and not in the RPC interface
+    # otherwise the metaclass PageRpc[*] will create *different* classes in server/client side
+    # and will fail to serialize/deserialize these parameters when transmitted/received
+    ProjectRpcGet
+]

--- a/packages/models-library/src/models_library/rpc/webserver/projects.py
+++ b/packages/models-library/src/models_library/rpc/webserver/projects.py
@@ -1,12 +1,18 @@
 from datetime import datetime
 from typing import Annotated, TypeAlias
 
-from models_library.projects import NodesDict, ProjectID
+from models_library.projects import ProjectID
 from models_library.rpc_pagination import PageRpc
 from pydantic import BaseModel, ConfigDict, Field
 
 
 class ProjectRpcGet(BaseModel):
+    """
+    Minimal information about a project that (for now) will fullfill
+    the needs of the api-server. Specifically, the fields needed in
+    project to call create_job_from_project
+    """
+
     uuid: Annotated[
         ProjectID,
         Field(description="project unique identifier"),
@@ -20,8 +26,6 @@ class ProjectRpcGet(BaseModel):
     # timestamps
     creation_date: datetime
     last_change_date: datetime
-
-    workbench: Annotated[NodesDict, Field(description="Project's pipeline")]
 
     model_config = ConfigDict(
         extra="forbid",

--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/webserver/projects.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/webserver/projects.py
@@ -1,4 +1,5 @@
 import logging
+from typing import cast
 
 from models_library.api_schemas_webserver import WEBSERVER_RPC_NAMESPACE
 from models_library.products import ProductName
@@ -63,4 +64,4 @@ async def list_my_projects_marked_as_jobs(
         job_parent_resource_name_filter=job_parent_resource_name_filter,
     )
     assert TypeAdapter(PageRpcProjectRpcGet).validate_python(result)  # nosec
-    return result
+    return cast(PageRpcProjectRpcGet, result)

--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/webserver/projects.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/webserver/projects.py
@@ -4,6 +4,12 @@ from models_library.api_schemas_webserver import WEBSERVER_RPC_NAMESPACE
 from models_library.products import ProductName
 from models_library.projects import ProjectID
 from models_library.rabbitmq_basic_types import RPCMethodName
+from models_library.rest_pagination import PageOffsetInt
+from models_library.rpc.webserver.projects import PageRpcProjectRpcGet
+from models_library.rpc_pagination import (
+    DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
+    PageLimitInt,
+)
 from models_library.users import UserID
 from pydantic import TypeAdapter, validate_call
 from servicelib.logging_utils import log_decorator
@@ -32,3 +38,29 @@ async def mark_project_as_job(
         job_parent_resource_name=job_parent_resource_name,
     )
     assert result is None
+
+
+@log_decorator(_logger, level=logging.DEBUG)
+@validate_call(config={"arbitrary_types_allowed": True})
+async def list_my_projects_marked_as_jobs(
+    rpc_client: RabbitMQRPCClient,
+    *,
+    product_name: ProductName,
+    user_id: UserID,
+    # pagination
+    offset: PageOffsetInt = 0,
+    limit: PageLimitInt = DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
+    # filters
+    job_parent_resource_name_filter: str | None = None,
+) -> PageRpcProjectRpcGet:
+    result = await rpc_client.request(
+        WEBSERVER_RPC_NAMESPACE,
+        TypeAdapter(RPCMethodName).validate_python("list_my_projects_marked_as_jobs"),
+        product_name=product_name,
+        user_id=user_id,
+        offset=offset,
+        limit=limit,
+        job_parent_resource_name_filter=job_parent_resource_name_filter,
+    )
+    assert TypeAdapter(PageRpcProjectRpcGet).validate_python(result)  # nosec
+    return result

--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/webserver/projects.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/webserver/projects.py
@@ -43,7 +43,7 @@ async def mark_project_as_job(
 
 @log_decorator(_logger, level=logging.DEBUG)
 @validate_call(config={"arbitrary_types_allowed": True})
-async def list_my_projects_marked_as_jobs(
+async def list_projects_marked_as_jobs(
     rpc_client: RabbitMQRPCClient,
     *,
     product_name: ProductName,
@@ -56,7 +56,7 @@ async def list_my_projects_marked_as_jobs(
 ) -> PageRpcProjectRpcGet:
     result = await rpc_client.request(
         WEBSERVER_RPC_NAMESPACE,
-        TypeAdapter(RPCMethodName).validate_python("list_my_projects_marked_as_jobs"),
+        TypeAdapter(RPCMethodName).validate_python("list_projects_marked_as_jobs"),
         product_name=product_name,
         user_id=user_id,
         offset=offset,

--- a/services/web/server/src/simcore_service_webserver/projects/_controller/projects_rpc.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_controller/projects_rpc.py
@@ -54,7 +54,7 @@ async def mark_project_as_job(
 
 @router.expose(reraise_if_error_type=(ValidationError,))
 @validate_call(config={"arbitrary_types_allowed": True})
-async def list_my_projects_marked_as_jobs(
+async def list_projects_marked_as_jobs(
     app: web.Application,
     *,
     product_name: ProductName,

--- a/services/web/server/src/simcore_service_webserver/projects/_controller/projects_rpc.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_controller/projects_rpc.py
@@ -82,7 +82,6 @@ async def list_my_projects_marked_as_jobs(
             description=project.description,
             creation_date=project.creation_date,
             last_change_date=project.last_change_date,
-            workbench={},
         )
         for project in projects
     ]

--- a/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
@@ -25,13 +25,10 @@ from .models import ProjectDBGet, ProjectJobDBGet
 _logger = logging.getLogger(__name__)
 
 
-_PROJECT_JOB_DB_COLS = [
-    *get_columns_from_db_model(
-        projects,
-        ProjectDBGet,
-    ),
-    projects_to_jobs.c.job_parent_resource_name,  # Add job_parent_resource_name
-]
+_PROJECT_DB_COLS = get_columns_from_db_model(
+    projects,
+    ProjectDBGet,
+)
 
 
 class ProjectJobsRepository(BaseRepository):
@@ -81,7 +78,7 @@ class ProjectJobsRepository(BaseRepository):
 
         # Step 2: Create access_query to filter projects based on product_name and read access
         access_query = (
-            sa.select(projects_to_jobs.c.project_uuid)
+            sa.select(projects_to_jobs)
             .select_from(
                 projects_to_jobs.join(
                     projects_to_products,
@@ -115,7 +112,10 @@ class ProjectJobsRepository(BaseRepository):
 
         # Step 4: Query to get the paginated list with full selection
         list_query = (
-            sa.select(*_PROJECT_JOB_DB_COLS)
+            sa.select(
+                *_PROJECT_DB_COLS,
+                base_query.c.job_parent_resource_name,
+            )
             .select_from(
                 base_query.join(
                     projects,

--- a/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
@@ -1,5 +1,4 @@
 import logging
-from typing import cast
 
 import sqlalchemy as sa
 from models_library.products import ProductName
@@ -140,4 +139,4 @@ class ProjectJobsRepository(BaseRepository):
                 result.fetchall()
             )
 
-            return cast(int, total_count), projects_list
+            return total_count, projects_list

--- a/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
@@ -1,14 +1,37 @@
 import logging
+from typing import cast
 
+import sqlalchemy as sa
+from models_library.products import ProductName
 from models_library.projects import ProjectID
+from models_library.users import UserID
+from pydantic import TypeAdapter
+from simcore_postgres_database.models.groups import user_to_groups
+from simcore_postgres_database.models.project_to_groups import project_to_groups
+from simcore_postgres_database.models.projects import projects
 from simcore_postgres_database.models.projects_to_jobs import projects_to_jobs
-from simcore_postgres_database.utils_repos import transaction_context
+from simcore_postgres_database.models.projects_to_products import projects_to_products
+from simcore_postgres_database.utils_repos import (
+    get_columns_from_db_model,
+    pass_or_acquire_connection,
+    transaction_context,
+)
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from ..db.base_repository import BaseRepository
+from .models import ProjectDBGet, ProjectJobDBGet
 
 _logger = logging.getLogger(__name__)
+
+
+_PROJECT_JOB_DB_COLS = [
+    *get_columns_from_db_model(
+        projects,
+        ProjectDBGet,
+    ),
+    projects_to_jobs.c.job_parent_resource_name,  # Add job_parent_resource_name
+]
 
 
 class ProjectJobsRepository(BaseRepository):
@@ -34,3 +57,87 @@ class ProjectJobsRepository(BaseRepository):
             )
 
             await conn.execute(stmt)
+
+    async def list_projects_marked_as_jobs(
+        self,
+        connection: AsyncConnection | None = None,
+        *,
+        product_name: ProductName,
+        user_id: UserID,
+        offset: int = 0,
+        limit: int = 10,
+        job_parent_resource_name_filter: str | None = None,
+    ) -> tuple[int, list[ProjectJobDBGet]]:
+        """
+        Lists projects marked as jobs for a specific user and product
+        """
+
+        # Step 1: Get group IDs associated with the user
+        user_groups_query = (
+            sa.select(user_to_groups.c.gid)
+            .where(user_to_groups.c.uid == user_id)
+            .subquery()
+        )
+
+        # Step 2: Create access_query to filter projects based on product_name and read access
+        access_query = (
+            sa.select(projects_to_jobs.c.project_uuid)
+            .select_from(
+                projects_to_jobs.join(
+                    projects_to_products,
+                    projects_to_jobs.c.project_uuid
+                    == projects_to_products.c.project_uuid,
+                ).join(
+                    project_to_groups,
+                    projects_to_jobs.c.project_uuid == project_to_groups.c.project_uuid,
+                )
+            )
+            .where(
+                projects_to_products.c.product_name == product_name,
+                project_to_groups.c.gid.in_(sa.select(user_groups_query.c.gid)),
+                project_to_groups.c.read.is_(True),
+            )
+        )
+
+        # Apply job_parent_resource_name_filter if provided
+        if job_parent_resource_name_filter:
+            access_query = access_query.where(
+                projects_to_jobs.c.job_parent_resource_name.like(
+                    f"%{job_parent_resource_name_filter}%"
+                )
+            )
+
+        # Convert access_query to a subquery
+        base_query = access_query.subquery()
+
+        # Step 3: Query to get the total count
+        total_query = sa.select(sa.func.count()).select_from(base_query)
+
+        # Step 4: Query to get the paginated list with full selection
+        list_query = (
+            sa.select(*_PROJECT_JOB_DB_COLS)
+            .select_from(
+                base_query.join(
+                    projects,
+                    projects.c.uuid == base_query.c.project_uuid,
+                )
+            )
+            .order_by(
+                projects.c.creation_date.desc(),  # latests first
+                projects.c.id.desc(),
+            )
+            .limit(limit)
+            .offset(offset)
+        )
+
+        # Step 5: Execute queries
+        async with pass_or_acquire_connection(self.engine, connection) as conn:
+            total_count = await conn.scalar(total_query)
+            assert isinstance(total_count, int)  # nosec
+
+            result = await conn.execute(list_query)
+            projects_list = TypeAdapter(list[ProjectJobDBGet]).validate_python(
+                result.fetchall()
+            )
+
+            return cast(int, total_count), projects_list

--- a/services/web/server/src/simcore_service_webserver/projects/_jobs_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_jobs_service.py
@@ -6,7 +6,7 @@ from models_library.products import ProductName
 from models_library.projects import ProjectID
 from models_library.users import UserID
 from pydantic import AfterValidator, validate_call
-from simcore_service_webserver.projects.models import ProjectDBGet
+from simcore_service_webserver.projects.models import ProjectJobDBGet
 
 from ._access_rights_service import check_user_project_permission
 from ._jobs_repository import ProjectJobsRepository
@@ -57,7 +57,7 @@ async def list_my_projects_marked_as_jobs(
     offset: int = 0,
     limit: int = 10,
     job_parent_resource_name_filter: str | None = None,
-) -> tuple[int, list[ProjectDBGet]]:
+) -> tuple[int, list[ProjectJobDBGet]]:
     """
     Lists paginated projects marked as jobs for the given user and product.
     Optionally filters by job_parent_resource_name using SQL-like wildcard patterns.

--- a/services/web/server/src/simcore_service_webserver/projects/models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/models.py
@@ -71,6 +71,10 @@ class ProjectDBGet(BaseModel):
     )
 
 
+class ProjectJobDBGet(ProjectDBGet):
+    job_parent_resource_name: str
+
+
 class ProjectWithTrashExtra(ProjectDBGet):
     # This field is not part of the tables
     trashed_by_primary_gid: GroupID | None = None

--- a/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
@@ -11,25 +11,26 @@ from simcore_service_webserver.projects.models import ProjectDict
 async def test_list_my_projects_marked_as_jobs_empty(
     client: TestClient,
     logged_user: UserInfoDict,  # owns `user_project`
-    osparc_product_name: ProductName,
     user_project: ProjectDict,
+    osparc_product_name: ProductName,
 ):
     assert client.app
     assert user_project
 
-    result = await list_my_projects_marked_as_jobs(
+    total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
         user_id=logged_user["id"],
     )
+    assert total_count == 0
     assert result == []
 
 
 async def test_list_my_projects_marked_as_jobs_with_one_marked(
     client: TestClient,
     logged_user: UserInfoDict,  # owns `user_project`
-    osparc_product_name: ProductName,
     user_project: ProjectDict,
+    osparc_product_name: ProductName,
 ):
     assert client.app
 
@@ -45,35 +46,49 @@ async def test_list_my_projects_marked_as_jobs_with_one_marked(
         job_parent_resource_name=job_parent_resource_name,
     )
 
-    result = await list_my_projects_marked_as_jobs(
+    total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
         user_id=user_id,
     )
+    assert total_count == 1
     assert len(result) == 1
-    assert result[0]["project_uuid"] == project_uuid
-    assert result[0]["job_parent_resource_name"] == job_parent_resource_name
 
-    result = await list_my_projects_marked_as_jobs(
+    project = result[0]
+    assert project.uuid == project_uuid
+    assert project.job_parent_resource_name == job_parent_resource_name
+
+    total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
         user_id=user_id,
         job_parent_resource_name_filter=job_parent_resource_name,
     )
+    assert total_count == 1
     assert len(result) == 1
 
-    result = await list_my_projects_marked_as_jobs(
+    project = result[0]
+    assert project.uuid == project_uuid
+    assert project.job_parent_resource_name == job_parent_resource_name
+
+    total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
         user_id=user_id,
         job_parent_resource_name_filter="test/%",
     )
+    assert total_count == 1
     assert len(result) == 1
 
-    result = await list_my_projects_marked_as_jobs(
+    project = result[0]
+    assert project.project_uuid == project_uuid
+    assert project.job_parent_resource_name == job_parent_resource_name
+
+    total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
         user_id=user_id,
         job_parent_resource_name_filter="other/%",
     )
+    assert total_count == 0
     assert len(result) == 0

--- a/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
@@ -1,0 +1,79 @@
+from aiohttp.test_utils import TestClient
+from models_library.products import ProductName
+from pytest_simcore.helpers.webserver_login import UserInfoDict
+from simcore_service_webserver.projects._jobs_service import (
+    list_my_projects_marked_as_jobs,
+    set_project_as_job,
+)
+from simcore_service_webserver.projects.models import ProjectDict
+
+
+async def test_list_my_projects_marked_as_jobs_empty(
+    client: TestClient,
+    logged_user: UserInfoDict,  # owns `user_project`
+    osparc_product_name: ProductName,
+    user_project: ProjectDict,
+):
+    assert client.app
+    assert user_project
+
+    result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=logged_user["id"],
+    )
+    assert result == []
+
+
+async def test_list_my_projects_marked_as_jobs_with_one_marked(
+    client: TestClient,
+    logged_user: UserInfoDict,  # owns `user_project`
+    osparc_product_name: ProductName,
+    user_project: ProjectDict,
+):
+    assert client.app
+
+    user_id = logged_user["id"]
+    project_uuid = user_project["uuid"]
+    job_parent_resource_name = "test/resource"
+
+    await set_project_as_job(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+        project_uuid=project_uuid,
+        job_parent_resource_name=job_parent_resource_name,
+    )
+
+    result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+    )
+    assert len(result) == 1
+    assert result[0]["project_uuid"] == project_uuid
+    assert result[0]["job_parent_resource_name"] == job_parent_resource_name
+
+    result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+        job_parent_resource_name_filter=job_parent_resource_name,
+    )
+    assert len(result) == 1
+
+    result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+        job_parent_resource_name_filter="test/%",
+    )
+    assert len(result) == 1
+
+    result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+        job_parent_resource_name_filter="other/%",
+    )
+    assert len(result) == 0

--- a/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
@@ -1,8 +1,16 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+# pylint: disable=too-many-arguments
+
+from dataclasses import dataclass
+
 import pytest
 from aiohttp.test_utils import TestClient
 from common_library.users_enums import UserRole
 from models_library.products import ProductName
 from models_library.projects import ProjectID
+from models_library.users import UserID
 from pytest_simcore.helpers.webserver_login import UserInfoDict
 from simcore_service_webserver.projects._jobs_service import (
     list_my_projects_marked_as_jobs,
@@ -11,10 +19,44 @@ from simcore_service_webserver.projects._jobs_service import (
 from simcore_service_webserver.projects.models import ProjectDict
 
 
+@dataclass
+class ProjectJobFixture:
+    user_id: UserID
+    project_uuid: ProjectID
+    job_parent_resource_name: str
+
+
 @pytest.fixture
 def user_role() -> UserRole:
     # for logged_user
     return UserRole.USER
+
+
+@pytest.fixture
+async def project_job_fixture(
+    client: TestClient,
+    logged_user: UserInfoDict,
+    user_project: ProjectDict,
+    osparc_product_name: ProductName,
+) -> ProjectJobFixture:
+    assert client.app
+
+    user_id = logged_user["id"]
+    project_uuid = ProjectID(user_project["uuid"])
+    job_parent_resource_name = "test/resource"
+
+    await set_project_as_job(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+        project_uuid=project_uuid,
+        job_parent_resource_name=job_parent_resource_name,
+    )
+    return ProjectJobFixture(
+        user_id=user_id,
+        project_uuid=project_uuid,
+        job_parent_resource_name=job_parent_resource_name,
+    )
 
 
 async def test_list_my_projects_marked_as_jobs_empty(
@@ -35,45 +77,37 @@ async def test_list_my_projects_marked_as_jobs_empty(
     assert result == []
 
 
-async def test_list_my_projects_marked_as_jobs_with_one_marked(
+async def test_user_can_see_marked_project(
     client: TestClient,
-    logged_user: UserInfoDict,  # owns `user_project`
-    user_project: ProjectDict,
-    user: UserInfoDict,
     osparc_product_name: ProductName,
+    project_job_fixture: ProjectJobFixture,
 ):
     assert client.app
-
-    user_id = logged_user["id"]
-    project_uuid = ProjectID(user_project["uuid"])
-    other_user_id = user["id"]
-
-    assert user_id != other_user_id
-    assert user_project["prjOwner"] == logged_user["email"]  # owns `user_project`
-
-    job_parent_resource_name = "test/resource"
-    await set_project_as_job(
-        app=client.app,
-        product_name=osparc_product_name,
-        user_id=user_id,
-        project_uuid=project_uuid,
-        job_parent_resource_name=job_parent_resource_name,
-    )
-
-    # user can see the project
     total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
-        user_id=user_id,
+        user_id=project_job_fixture.user_id,
     )
     assert total_count == 1
     assert len(result) == 1
 
     project = result[0]
-    assert project.uuid == project_uuid
-    assert project.job_parent_resource_name == job_parent_resource_name
+    assert project.uuid == project_job_fixture.project_uuid
+    assert (
+        project.job_parent_resource_name == project_job_fixture.job_parent_resource_name
+    )
 
-    # other-user cannot see the project even if it is marked as a job
+
+async def test_other_user_cannot_see_marked_project(
+    client: TestClient,
+    user: UserInfoDict,
+    osparc_product_name: ProductName,
+    project_job_fixture: ProjectJobFixture,
+):
+    assert client.app
+    other_user_id = user["id"]
+    assert project_job_fixture.user_id != other_user_id
+
     total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
@@ -82,39 +116,51 @@ async def test_list_my_projects_marked_as_jobs_with_one_marked(
     assert total_count == 0
     assert len(result) == 0
 
-    # user can see the project with a filter
+
+async def test_user_can_filter_marked_project(
+    client: TestClient,
+    osparc_product_name: ProductName,
+    project_job_fixture: ProjectJobFixture,
+):
+    assert client.app
+
+    # Exact filter
     total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
-        user_id=user_id,
-        job_parent_resource_name_filter=job_parent_resource_name,
+        user_id=project_job_fixture.user_id,
+        job_parent_resource_name_filter=project_job_fixture.job_parent_resource_name,
     )
     assert total_count == 1
     assert len(result) == 1
 
     project = result[0]
-    assert project.uuid == project_uuid
-    assert project.job_parent_resource_name == job_parent_resource_name
+    assert project.uuid == project_job_fixture.project_uuid
+    assert (
+        project.job_parent_resource_name == project_job_fixture.job_parent_resource_name
+    )
 
-    # user can see the project with a wildcard filter
+    # Wildcard filter
     total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
-        user_id=user_id,
+        user_id=project_job_fixture.user_id,
         job_parent_resource_name_filter="test/%",
     )
     assert total_count == 1
     assert len(result) == 1
 
     project = result[0]
-    assert project.uuid == project_uuid
-    assert project.job_parent_resource_name == job_parent_resource_name
+    assert project.uuid == project_job_fixture.project_uuid
+    assert (
+        project.job_parent_resource_name == project_job_fixture.job_parent_resource_name
+    )
 
-    # user cannot see the project with another wildcard filter
+    # Non-matching filter
     total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
-        user_id=user_id,
+        user_id=project_job_fixture.user_id,
         job_parent_resource_name_filter="other/%",
     )
     assert total_count == 0

--- a/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
@@ -1,11 +1,20 @@
+import pytest
 from aiohttp.test_utils import TestClient
+from common_library.users_enums import UserRole
 from models_library.products import ProductName
+from models_library.projects import ProjectID
 from pytest_simcore.helpers.webserver_login import UserInfoDict
 from simcore_service_webserver.projects._jobs_service import (
     list_my_projects_marked_as_jobs,
     set_project_as_job,
 )
 from simcore_service_webserver.projects.models import ProjectDict
+
+
+@pytest.fixture
+def user_role() -> UserRole:
+    # for logged_user
+    return UserRole.USER
 
 
 async def test_list_my_projects_marked_as_jobs_empty(
@@ -30,14 +39,19 @@ async def test_list_my_projects_marked_as_jobs_with_one_marked(
     client: TestClient,
     logged_user: UserInfoDict,  # owns `user_project`
     user_project: ProjectDict,
+    user: UserInfoDict,
     osparc_product_name: ProductName,
 ):
     assert client.app
 
     user_id = logged_user["id"]
-    project_uuid = user_project["uuid"]
-    job_parent_resource_name = "test/resource"
+    project_uuid = ProjectID(user_project["uuid"])
+    other_user_id = user["id"]
 
+    assert user_id != other_user_id
+    assert user_project["prjOwner"] == logged_user["email"]  # owns `user_project`
+
+    job_parent_resource_name = "test/resource"
     await set_project_as_job(
         app=client.app,
         product_name=osparc_product_name,
@@ -46,6 +60,7 @@ async def test_list_my_projects_marked_as_jobs_with_one_marked(
         job_parent_resource_name=job_parent_resource_name,
     )
 
+    # user can see the project
     total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
@@ -58,6 +73,16 @@ async def test_list_my_projects_marked_as_jobs_with_one_marked(
     assert project.uuid == project_uuid
     assert project.job_parent_resource_name == job_parent_resource_name
 
+    # other-user cannot see the project even if it is marked as a job
+    total_count, result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=other_user_id,
+    )
+    assert total_count == 0
+    assert len(result) == 0
+
+    # user can see the project with a filter
     total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
@@ -71,6 +96,7 @@ async def test_list_my_projects_marked_as_jobs_with_one_marked(
     assert project.uuid == project_uuid
     assert project.job_parent_resource_name == job_parent_resource_name
 
+    # user can see the project with a wildcard filter
     total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,
@@ -81,9 +107,10 @@ async def test_list_my_projects_marked_as_jobs_with_one_marked(
     assert len(result) == 1
 
     project = result[0]
-    assert project.project_uuid == project_uuid
+    assert project.uuid == project_uuid
     assert project.job_parent_resource_name == job_parent_resource_name
 
+    # user cannot see the project with another wildcard filter
     total_count, result = await list_my_projects_marked_as_jobs(
         app=client.app,
         product_name=osparc_product_name,

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_rpc.py
@@ -12,6 +12,7 @@ from aiohttp.test_utils import TestClient
 from common_library.users_enums import UserRole
 from models_library.products import ProductName
 from models_library.projects import ProjectID
+from models_library.rpc.webserver.projects import PageRpcProjectRpcGet, ProjectRpcGet
 from pydantic import ValidationError
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
@@ -85,6 +86,38 @@ async def test_rpc_client_mark_project_as_job(
         project_uuid=project_uuid,
         job_parent_resource_name="solvers/solver123/version/1.2.3",
     )
+
+
+async def test_rpc_client_list_my_projects_marked_as_jobs(
+    rpc_client: RabbitMQRPCClient,
+    product_name: ProductName,
+    logged_user: UserInfoDict,
+    user_project: ProjectDict,
+):
+    project_uuid = ProjectID(user_project["uuid"])
+    user_id = logged_user["id"]
+
+    # Mark the project as a job first
+    await projects_rpc.mark_project_as_job(
+        rpc_client=rpc_client,
+        product_name=product_name,
+        user_id=user_id,
+        project_uuid=project_uuid,
+        job_parent_resource_name="solvers/solver123/version/1.2.3",
+    )
+
+    # List projects marked as jobs
+    page: PageRpcProjectRpcGet = await projects_rpc.list_my_projects_marked_as_jobs(
+        rpc_client=rpc_client,
+        product_name=product_name,
+        user_id=user_id,
+        job_parent_resource_name_filter="solvers/solver123",
+    )
+
+    assert page.meta.total == 1
+    assert page.meta.offset == 0
+    assert isinstance(page.data[0], ProjectRpcGet)
+    assert page.data[0].uuid == project_uuid
 
 
 @pytest.fixture

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_rpc.py
@@ -107,7 +107,7 @@ async def test_rpc_client_list_my_projects_marked_as_jobs(
     )
 
     # List projects marked as jobs
-    page: PageRpcProjectRpcGet = await projects_rpc.list_my_projects_marked_as_jobs(
+    page: PageRpcProjectRpcGet = await projects_rpc.list_projects_marked_as_jobs(
         rpc_client=rpc_client,
         product_name=product_name,
         user_id=user_id,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

Exposes the `list_my_projects_marked_as_jobs` method on the `web-server` RPC interface to enable the `api-server` to retrieve a paginated list of all projects marked as jobs.

- Implements service-layer: `simcore_service_webserver.projects._jobs_service`
- Implements repository-layer: `simcore_service_webserver.projects._jobs_repository`
- Exposes function to RPC API
    - server side: `projects._controller.projects_rpc`
    - client side: `servicelib.rabbitmq.rpc_interfaces.webserver.projects`
    - models: `models_library.rpc.webserver.projects` (shared)
    - exceptions: `servicelib.rabbitmq.rpc_interfaces.webserver.errors` (shared)


**NOTE**: The current organization of RPC interfaces feels fragmented and hard to work with. We should consider restructuring them into dedicated Python packages (e.g., `webserver-rpc-client`, `webserver-rest-client`) to improve clarity and maintainability.  The only inconvenient with the proposed approach is that the client has to be installed in the server in order to share models and exceptions. In any case, we already do that with the current setup.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->

-  Main part of the RPC interface needed for #7399


## How to test

```
cd services/web/server
make install-dev
pytest -vv tests/unit/with_dbs/02/test_projects_rpc.py
pytest -vv tests/unit/with_dbs/02/test_projects__jobs_service.py
```

## Dev-ops

None
