### PR TITLE
 ✨ Adds filtering for Service Listing in Catalog's RPC API

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ branch = True
 omit =
     */tests/*
     */generated_code/*
+    */_original_fastapi_encoders.py
 parallel = True
 
 [report]

--- a/packages/models-library/src/models_library/api_schemas_catalog/services.py
+++ b/packages/models-library/src/models_library/api_schemas_catalog/services.py
@@ -9,6 +9,7 @@ from pydantic.config import JsonDict
 from ..boot_options import BootOptions
 from ..emails import LowerCaseEmailStr
 from ..groups import GroupID
+from ..rest_filters import Filters
 from ..services_access import ServiceAccessRights, ServiceGroupAccessRightsV2
 from ..services_authoring import Author
 from ..services_enums import ServiceType
@@ -374,6 +375,15 @@ class MyServiceGet(CatalogOutputSchema):
 
     owner: GroupID | None
     my_access_rights: ServiceGroupAccessRightsV2
+
+
+class ServiceListFilters(Filters):
+    service_type: Annotated[
+        ServiceType | None,
+        Field(
+            description="Filter only services of a given type. If None, then all types are returned"
+        ),
+    ] = None
 
 
 __all__: tuple[str, ...] = ("ServiceRelease",)

--- a/packages/models-library/src/models_library/function_services_catalog/_key_labels.py
+++ b/packages/models-library/src/models_library/function_services_catalog/_key_labels.py
@@ -1,7 +1,7 @@
 from typing import Final
 
 from ..services import ServiceKey
-from ..services_regex import FRONTEND_SERVICE_KEY_PREFIX
+from ..services_constants import FRONTEND_SERVICE_KEY_PREFIX
 
 # NOTE: due to legacy reasons, the name remains with 'frontend' in it but
 # it now refers to a more general group: function sections that contains front-end services as well

--- a/packages/models-library/src/models_library/function_services_catalog/_key_labels.py
+++ b/packages/models-library/src/models_library/function_services_catalog/_key_labels.py
@@ -1,10 +1,11 @@
 from typing import Final
 
 from ..services import ServiceKey
+from ..services_regex import FRONTEND_SERVICE_KEY_PREFIX
 
 # NOTE: due to legacy reasons, the name remains with 'frontend' in it but
 # it now refers to a more general group: function sections that contains front-end services as well
-FUNCTION_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/frontend"
+FUNCTION_SERVICE_KEY_PREFIX: Final[str] = FRONTEND_SERVICE_KEY_PREFIX
 
 
 def is_function_service(service_key: ServiceKey) -> bool:

--- a/packages/models-library/src/models_library/rpc_filters.py
+++ b/packages/models-library/src/models_library/rpc_filters.py
@@ -1,0 +1,5 @@
+from .rest_filters import Filters
+
+__all__: tuple[str, ...] = ("Filters",)
+
+# nopycln:file

--- a/packages/models-library/src/models_library/services_constants.py
+++ b/packages/models-library/src/models_library/services_constants.py
@@ -1,6 +1,27 @@
+from types import MappingProxyType
 from typing import Final
+
+from .services_enums import ServiceType
 
 LATEST_INTEGRATION_VERSION: Final[str] = "1.0.0"
 
-
 ANY_FILETYPE: Final[str] = "data:*/*"
+
+SERVICE_TYPE_TO_NAME_MAP = MappingProxyType(
+    {
+        ServiceType.COMPUTATIONAL: "comp",
+        ServiceType.DYNAMIC: "dynamic",
+        ServiceType.FRONTEND: "frontend",
+    }
+)
+
+
+def _create_key_prefix(service_type: ServiceType) -> str:
+    return f"simcore/services/{SERVICE_TYPE_TO_NAME_MAP[service_type]}"
+
+
+COMPUTATIONAL_SERVICE_KEY_PREFIX: Final[str] = _create_key_prefix(
+    ServiceType.COMPUTATIONAL
+)
+DYNAMIC_SERVICE_KEY_PREFIX: Final[str] = _create_key_prefix(ServiceType.DYNAMIC)
+FRONTEND_SERVICE_KEY_PREFIX: Final[str] = _create_key_prefix(ServiceType.FRONTEND)

--- a/packages/models-library/src/models_library/services_regex.py
+++ b/packages/models-library/src/models_library/services_regex.py
@@ -1,6 +1,8 @@
 import re
 from typing import Final
 
+from models_library.services_enums import ServiceType
+
 PROPERTY_TYPE_RE = r"^(number|integer|boolean|string|ref_contentSchema|data:([^/\s,]+/[^/\s,]+|\[[^/\s,]+/[^/\s,]+(,[^/\s]+/[^/,\s]+)*\]))$"
 PROPERTY_TYPE_TO_PYTHON_TYPE_MAP = {
     "integer": int,
@@ -27,18 +29,32 @@ SERVICE_ENCODED_KEY_RE: Final[re.Pattern[str]] = re.compile(
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
 
+# Add key prefixes for dynamic and computational services
+DYNAMIC_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/dynamic"
 DYNAMIC_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
-    r"^simcore/services/dynamic/"
+    rf"^{DYNAMIC_SERVICE_KEY_PREFIX}/"
     r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
-DYNAMIC_SERVICE_KEY_FORMAT = "simcore/services/dynamic/{service_name}"
 
-
-# Computational regex & format
+COMPUTATIONAL_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/comp"
 COMPUTATIONAL_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
-    r"^simcore/services/comp/"
+    rf"^{COMPUTATIONAL_SERVICE_KEY_PREFIX}/"
     r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
-COMPUTATIONAL_SERVICE_KEY_FORMAT: Final[str] = "simcore/services/comp/{service_name}"
+
+FRONTEND_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/frontend"
+
+FRONTEND_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
+    rf"^{FRONTEND_SERVICE_KEY_PREFIX}/"
+    r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
+    r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
+)
+
+# Add service type prefixes mapping (moved from _services_sql.py)
+SERVICE_TYPE_PREFIXES = {
+    ServiceType.COMPUTATIONAL: COMPUTATIONAL_SERVICE_KEY_PREFIX,
+    ServiceType.DYNAMIC: DYNAMIC_SERVICE_KEY_PREFIX,
+    ServiceType.FRONTEND: FRONTEND_SERVICE_KEY_PREFIX,
+}

--- a/packages/models-library/src/models_library/services_regex.py
+++ b/packages/models-library/src/models_library/services_regex.py
@@ -2,6 +2,12 @@ import re
 from types import MappingProxyType
 from typing import Final
 
+from .services_constants import (
+    COMPUTATIONAL_SERVICE_KEY_PREFIX,
+    DYNAMIC_SERVICE_KEY_PREFIX,
+    FRONTEND_SERVICE_KEY_PREFIX,
+    SERVICE_TYPE_TO_NAME_MAP,
+)
 from .services_enums import ServiceType
 
 PROPERTY_TYPE_RE = r"^(number|integer|boolean|string|ref_contentSchema|data:([^/\s,]+/[^/\s,]+|\[[^/\s,]+/[^/\s,]+(,[^/\s]+/[^/,\s]+)*\]))$"
@@ -13,15 +19,6 @@ PROPERTY_TYPE_TO_PYTHON_TYPE_MAP = {
 }
 
 FILENAME_RE = r".+"
-
-
-SERVICE_TYPE_TO_NAME_MAP = MappingProxyType(
-    {
-        ServiceType.COMPUTATIONAL: "comp",
-        ServiceType.DYNAMIC: "dynamic",
-        ServiceType.FRONTEND: "frontend",
-    }
-)
 
 # e.g. simcore/services/comp/opencor
 SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
@@ -40,18 +37,7 @@ SERVICE_ENCODED_KEY_RE: Final[re.Pattern[str]] = re.compile(
 )
 
 
-def create_key_prefix(service_type: ServiceType) -> str:
-    return f"simcore/services/{SERVICE_TYPE_TO_NAME_MAP[service_type]}"
-
-
-COMPUTATIONAL_SERVICE_KEY_PREFIX: Final[str] = create_key_prefix(
-    ServiceType.COMPUTATIONAL
-)
-DYNAMIC_SERVICE_KEY_PREFIX: Final[str] = create_key_prefix(ServiceType.DYNAMIC)
-FRONTEND_SERVICE_KEY_PREFIX: Final[str] = create_key_prefix(ServiceType.FRONTEND)
-
-
-def create_key_regex(service_type: ServiceType) -> re.Pattern[str]:
+def _create_key_regex(service_type: ServiceType) -> re.Pattern[str]:
     return re.compile(
         rf"^simcore/services/{SERVICE_TYPE_TO_NAME_MAP[service_type]}/"
         r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
@@ -59,22 +45,24 @@ def create_key_regex(service_type: ServiceType) -> re.Pattern[str]:
     )
 
 
-def create_key_format(service_type: ServiceType) -> str:
+def _create_key_format(service_type: ServiceType) -> str:
     return f"simcore/services/{SERVICE_TYPE_TO_NAME_MAP[service_type]}/{{service_name}}"
 
 
-COMPUTATIONAL_SERVICE_KEY_RE: Final[re.Pattern[str]] = create_key_regex(
+COMPUTATIONAL_SERVICE_KEY_RE: Final[re.Pattern[str]] = _create_key_regex(
     ServiceType.COMPUTATIONAL
 )
-COMPUTATIONAL_SERVICE_KEY_FORMAT: Final[str] = create_key_format(
+COMPUTATIONAL_SERVICE_KEY_FORMAT: Final[str] = _create_key_format(
     ServiceType.COMPUTATIONAL
 )
 
-DYNAMIC_SERVICE_KEY_RE: Final[re.Pattern[str]] = create_key_regex(ServiceType.DYNAMIC)
-DYNAMIC_SERVICE_KEY_FORMAT: Final[str] = create_key_format(ServiceType.DYNAMIC)
+DYNAMIC_SERVICE_KEY_RE: Final[re.Pattern[str]] = _create_key_regex(ServiceType.DYNAMIC)
+DYNAMIC_SERVICE_KEY_FORMAT: Final[str] = _create_key_format(ServiceType.DYNAMIC)
 
-FRONTEND_SERVICE_KEY_RE: Final[re.Pattern[str]] = create_key_regex(ServiceType.FRONTEND)
-FRONTEND_SERVICE_KEY_FORMAT: Final[str] = create_key_format(ServiceType.FRONTEND)
+FRONTEND_SERVICE_KEY_RE: Final[re.Pattern[str]] = _create_key_regex(
+    ServiceType.FRONTEND
+)
+FRONTEND_SERVICE_KEY_FORMAT: Final[str] = _create_key_format(ServiceType.FRONTEND)
 
 
 SERVICE_TYPE_TO_PREFIX_MAP = MappingProxyType(

--- a/packages/models-library/src/models_library/services_regex.py
+++ b/packages/models-library/src/models_library/services_regex.py
@@ -15,55 +15,69 @@ PROPERTY_TYPE_TO_PYTHON_TYPE_MAP = {
 FILENAME_RE = r".+"
 
 
-# Add key prefixes for dynamic and computational services
-DYNAMIC_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/dynamic"
-COMPUTATIONAL_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/comp"
-FRONTEND_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/frontend"
+SERVICE_TYPE_TO_NAME_MAP = MappingProxyType(
+    {
+        ServiceType.COMPUTATIONAL: "comp",
+        ServiceType.DYNAMIC: "dynamic",
+        ServiceType.FRONTEND: "frontend",
+    }
+)
 
-
+# e.g. simcore/services/comp/opencor
 SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
-    rf"^(?P<key_prefix>{COMPUTATIONAL_SERVICE_KEY_PREFIX}|{DYNAMIC_SERVICE_KEY_PREFIX}|{FRONTEND_SERVICE_KEY_PREFIX})"
-    r"/(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
+    r"^simcore/services/"
+    rf"(?P<type>({ '|'.join(SERVICE_TYPE_TO_NAME_MAP.values()) }))/"
+    r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
+
+# e.g. simcore%2Fservices%2Fcomp%2Fopencor
 SERVICE_ENCODED_KEY_RE: Final[re.Pattern[str]] = re.compile(
-    rf"^(?P<key_prefix>{COMPUTATIONAL_SERVICE_KEY_PREFIX.replace('/', '%2F')}|{DYNAMIC_SERVICE_KEY_PREFIX.replace('/', '%2F')}|{FRONTEND_SERVICE_KEY_PREFIX.replace('/', '%2F')})"
-    r"(?P<subdir>(%2F[a-z0-9][a-z0-9_.-]*)*%2F)?"
+    r"^simcore%2Fservices%2F"
+    rf"(?P<type>({'|'.join(SERVICE_TYPE_TO_NAME_MAP.values())}))%2F"
+    r"(?P<subdir>[a-z0-9][a-z0-9_.-]*%2F)*"
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
 
 
-DYNAMIC_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
-    rf"^{DYNAMIC_SERVICE_KEY_PREFIX}/"
-    r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
-    r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
-)
-DYNAMIC_SERVICE_KEY_FORMAT: Final[str] = (
-    f"{DYNAMIC_SERVICE_KEY_PREFIX}/{{service_name}}"
-)
+def create_key_prefix(service_type: ServiceType) -> str:
+    return f"simcore/services/{SERVICE_TYPE_TO_NAME_MAP[service_type]}"
 
 
-COMPUTATIONAL_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
-    rf"^{COMPUTATIONAL_SERVICE_KEY_PREFIX}/"
-    r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
-    r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
+COMPUTATIONAL_SERVICE_KEY_PREFIX: Final[str] = create_key_prefix(
+    ServiceType.COMPUTATIONAL
 )
-COMPUTATIONAL_SERVICE_KEY_FORMAT: Final[str] = (
-    f"{COMPUTATIONAL_SERVICE_KEY_PREFIX}/{{service_name}}"
-)
+DYNAMIC_SERVICE_KEY_PREFIX: Final[str] = create_key_prefix(ServiceType.DYNAMIC)
+FRONTEND_SERVICE_KEY_PREFIX: Final[str] = create_key_prefix(ServiceType.FRONTEND)
 
 
-FRONTEND_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
-    rf"^{FRONTEND_SERVICE_KEY_PREFIX}/"
-    r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
-    r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
-)
-FRONTEND_SERVICE_KEY_FORMAT: Final[str] = (
-    f"{FRONTEND_SERVICE_KEY_PREFIX}/{{service_name}}"
-)
+def create_key_regex(service_type: ServiceType) -> re.Pattern[str]:
+    return re.compile(
+        rf"^simcore/services/{SERVICE_TYPE_TO_NAME_MAP[service_type]}/"
+        r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
+        r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
+    )
 
 
-SERVICE_TYPE_PREFIXES = MappingProxyType(
+def create_key_format(service_type: ServiceType) -> str:
+    return f"simcore/services/{SERVICE_TYPE_TO_NAME_MAP[service_type]}/{{service_name}}"
+
+
+COMPUTATIONAL_SERVICE_KEY_RE: Final[re.Pattern[str]] = create_key_regex(
+    ServiceType.COMPUTATIONAL
+)
+COMPUTATIONAL_SERVICE_KEY_FORMAT: Final[str] = create_key_format(
+    ServiceType.COMPUTATIONAL
+)
+
+DYNAMIC_SERVICE_KEY_RE: Final[re.Pattern[str]] = create_key_regex(ServiceType.DYNAMIC)
+DYNAMIC_SERVICE_KEY_FORMAT: Final[str] = create_key_format(ServiceType.DYNAMIC)
+
+FRONTEND_SERVICE_KEY_RE: Final[re.Pattern[str]] = create_key_regex(ServiceType.FRONTEND)
+FRONTEND_SERVICE_KEY_FORMAT: Final[str] = create_key_format(ServiceType.FRONTEND)
+
+
+SERVICE_TYPE_TO_PREFIX_MAP = MappingProxyType(
     {
         ServiceType.COMPUTATIONAL: COMPUTATIONAL_SERVICE_KEY_PREFIX,
         ServiceType.DYNAMIC: DYNAMIC_SERVICE_KEY_PREFIX,
@@ -72,5 +86,5 @@ SERVICE_TYPE_PREFIXES = MappingProxyType(
 )
 
 assert all(  # nosec
-    not prefix.endswith("/") for prefix in SERVICE_TYPE_PREFIXES.values()
+    not prefix.endswith("/") for prefix in SERVICE_TYPE_TO_PREFIX_MAP.values()
 ), "Service type prefixes must not end with '/'"

--- a/packages/models-library/src/models_library/services_regex.py
+++ b/packages/models-library/src/models_library/services_regex.py
@@ -1,4 +1,5 @@
 import re
+from types import MappingProxyType
 from typing import Final
 
 from models_library.services_enums import ServiceType
@@ -14,37 +15,34 @@ PROPERTY_TYPE_TO_PYTHON_TYPE_MAP = {
 FILENAME_RE = r".+"
 
 
-# e.g. simcore/services/comp/opencor
+# Add key prefixes for dynamic and computational services
+DYNAMIC_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/dynamic"
+COMPUTATIONAL_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/comp"
+FRONTEND_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/frontend"
+
+
 SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
-    r"^simcore/services/"
-    r"(?P<type>(comp|dynamic|frontend))/"
-    r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
+    rf"^(?P<key_prefix>{COMPUTATIONAL_SERVICE_KEY_PREFIX}|{DYNAMIC_SERVICE_KEY_PREFIX}|{FRONTEND_SERVICE_KEY_PREFIX})"
+    r"/(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
-# e.g. simcore%2Fservices%2Fcomp%2Fopencor
 SERVICE_ENCODED_KEY_RE: Final[re.Pattern[str]] = re.compile(
-    r"^simcore%2Fservices%2F"
-    r"(?P<type>(comp|dynamic|frontend))%2F"
-    r"(?P<subdir>[a-z0-9][a-z0-9_.-]*%2F)*"
+    rf"^(?P<key_prefix>{COMPUTATIONAL_SERVICE_KEY_PREFIX.replace('/', '%2F')}|{DYNAMIC_SERVICE_KEY_PREFIX.replace('/', '%2F')}|{FRONTEND_SERVICE_KEY_PREFIX.replace('/', '%2F')})"
+    r"(?P<subdir>(%2F[a-z0-9][a-z0-9_.-]*)*%2F)?"
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
 
-# Add key prefixes for dynamic and computational services
-DYNAMIC_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/dynamic"
 DYNAMIC_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
     rf"^{DYNAMIC_SERVICE_KEY_PREFIX}/"
     r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
 
-COMPUTATIONAL_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/comp"
 COMPUTATIONAL_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
     rf"^{COMPUTATIONAL_SERVICE_KEY_PREFIX}/"
     r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
-
-FRONTEND_SERVICE_KEY_PREFIX: Final[str] = "simcore/services/frontend"
 
 FRONTEND_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
     rf"^{FRONTEND_SERVICE_KEY_PREFIX}/"
@@ -52,9 +50,15 @@ FRONTEND_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
 
-# Add service type prefixes mapping (moved from _services_sql.py)
-SERVICE_TYPE_PREFIXES = {
-    ServiceType.COMPUTATIONAL: COMPUTATIONAL_SERVICE_KEY_PREFIX,
-    ServiceType.DYNAMIC: DYNAMIC_SERVICE_KEY_PREFIX,
-    ServiceType.FRONTEND: FRONTEND_SERVICE_KEY_PREFIX,
-}
+
+SERVICE_TYPE_PREFIXES = MappingProxyType(
+    {
+        ServiceType.COMPUTATIONAL: COMPUTATIONAL_SERVICE_KEY_PREFIX,
+        ServiceType.DYNAMIC: DYNAMIC_SERVICE_KEY_PREFIX,
+        ServiceType.FRONTEND: FRONTEND_SERVICE_KEY_PREFIX,
+    }
+)
+
+assert all(  # nosec
+    not prefix.endswith("/") for prefix in SERVICE_TYPE_PREFIXES.values()
+), "Service type prefixes must not end with '/'"

--- a/packages/models-library/src/models_library/services_regex.py
+++ b/packages/models-library/src/models_library/services_regex.py
@@ -32,22 +32,34 @@ SERVICE_ENCODED_KEY_RE: Final[re.Pattern[str]] = re.compile(
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
 
+
 DYNAMIC_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
     rf"^{DYNAMIC_SERVICE_KEY_PREFIX}/"
     r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
+DYNAMIC_SERVICE_KEY_FORMAT: Final[str] = (
+    f"{DYNAMIC_SERVICE_KEY_PREFIX}/{{service_name}}"
+)
+
 
 COMPUTATIONAL_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
     rf"^{COMPUTATIONAL_SERVICE_KEY_PREFIX}/"
     r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
 )
+COMPUTATIONAL_SERVICE_KEY_FORMAT: Final[str] = (
+    f"{COMPUTATIONAL_SERVICE_KEY_PREFIX}/{{service_name}}"
+)
+
 
 FRONTEND_SERVICE_KEY_RE: Final[re.Pattern[str]] = re.compile(
     rf"^{FRONTEND_SERVICE_KEY_PREFIX}/"
     r"(?P<subdir>[a-z0-9][a-z0-9_.-]*/)*"
     r"(?P<name>[a-z0-9-_]+[a-z0-9])$"
+)
+FRONTEND_SERVICE_KEY_FORMAT: Final[str] = (
+    f"{FRONTEND_SERVICE_KEY_PREFIX}/{{service_name}}"
 )
 
 

--- a/packages/models-library/src/models_library/services_regex.py
+++ b/packages/models-library/src/models_library/services_regex.py
@@ -2,7 +2,7 @@ import re
 from types import MappingProxyType
 from typing import Final
 
-from models_library.services_enums import ServiceType
+from .services_enums import ServiceType
 
 PROPERTY_TYPE_RE = r"^(number|integer|boolean|string|ref_contentSchema|data:([^/\s,]+/[^/\s,]+|\[[^/\s,]+/[^/\s,]+(,[^/\s]+/[^/,\s]+)*\]))$"
 PROPERTY_TYPE_TO_PYTHON_TYPE_MAP = {

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/catalog_rpc_server.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/catalog_rpc_server.py
@@ -5,7 +5,11 @@
 # pylint: disable=unused-variable
 
 
-from models_library.api_schemas_catalog.services import LatestServiceGet, ServiceGetV2
+from models_library.api_schemas_catalog.services import (
+    LatestServiceGet,
+    ServiceGetV2,
+    ServiceListFilters,
+)
 from models_library.api_schemas_webserver.catalog import (
     CatalogServiceUpdate,
 )
@@ -34,10 +38,12 @@ class CatalogRpcSideEffects:
         user_id: UserID,
         limit: PageLimitInt,
         offset: NonNegativeInt,
+        filters: ServiceListFilters | None = None,
     ):
         assert rpc_client
         assert product_name
         assert user_id
+        assert filters is None, "filters not mocked yet"
 
         items = TypeAdapter(list[LatestServiceGet]).validate_python(
             LatestServiceGet.model_json_schema()["examples"],
@@ -110,12 +116,14 @@ class CatalogRpcSideEffects:
         service_key: ServiceKey,
         offset: PageOffsetInt,
         limit: PageLimitInt,
+        filters: ServiceListFilters | None = None,
     ) -> PageRpc[ServiceRelease]:
 
         assert rpc_client
         assert product_name
         assert user_id
         assert service_key
+        assert filters is None, "filters not mocked yet"
 
         items = TypeAdapter(list[ServiceRelease]).validate_python(
             ServiceRelease.model_json_schema()["examples"],

--- a/packages/service-integration/src/service_integration/osparc_config.py
+++ b/packages/service-integration/src/service_integration/osparc_config.py
@@ -1,4 +1,4 @@
-""" 'osparc config' is a set of stardard file forms (yaml) that the user fills to describe how his/her service works and
+"""'osparc config' is a set of stardard file forms (yaml) that the user fills to describe how his/her service works and
 integrates with osparc.
 
     - config files are stored under '.osparc/' folder in the root repo folder (analogous to other configs like .github, .vscode, etc)
@@ -26,11 +26,7 @@ from models_library.service_settings_labels import (
     RestartPolicy,
 )
 from models_library.service_settings_nat_rule import NATRule
-from models_library.services import BootOptions, ServiceMetaDataPublished, ServiceType
-from models_library.services_regex import (
-    COMPUTATIONAL_SERVICE_KEY_FORMAT,
-    DYNAMIC_SERVICE_KEY_FORMAT,
-)
+from models_library.services import BootOptions, ServiceMetaDataPublished
 from models_library.services_types import ServiceKey
 from models_library.utils.labels_annotations import (
     OSPARC_LABEL_PREFIXES,
@@ -60,12 +56,6 @@ OSPARC_CONFIG_DIRNAME: Final[str] = ".osparc"
 OSPARC_CONFIG_COMPOSE_SPEC_NAME: Final[str] = "docker-compose.overwrite.yml"
 OSPARC_CONFIG_METADATA_NAME: Final[str] = "metadata.yml"
 OSPARC_CONFIG_RUNTIME_NAME: Final[str] = "runtime.yml"
-
-
-SERVICE_KEY_FORMATS = {
-    ServiceType.COMPUTATIONAL: COMPUTATIONAL_SERVICE_KEY_FORMAT,
-    ServiceType.DYNAMIC: DYNAMIC_SERVICE_KEY_FORMAT,
-}
 
 
 class DockerComposeOverwriteConfig(ComposeSpecification):
@@ -231,9 +221,9 @@ class RuntimeConfig(BaseModel):
 
     containers_allowed_outgoing_internet: set[str] | None = None
 
-    settings: Annotated[
-        list[SettingsItem], Field(default_factory=list)
-    ] = DEFAULT_FACTORY
+    settings: Annotated[list[SettingsItem], Field(default_factory=list)] = (
+        DEFAULT_FACTORY
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/catalog/services.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/catalog/services.py
@@ -10,6 +10,7 @@ from models_library.api_schemas_catalog.services import (
     PageRpcLatestServiceGet,
     PageRpcServiceRelease,
     ServiceGetV2,
+    ServiceListFilters,
     ServiceRelease,
     ServiceUpdateV2,
 )
@@ -24,10 +25,10 @@ from models_library.rpc_pagination import (
 from models_library.services_types import ServiceKey, ServiceVersion
 from models_library.users import UserID
 from pydantic import TypeAdapter, validate_call
-from servicelib.logging_utils import log_decorator
-from servicelib.rabbitmq._constants import RPC_REQUEST_DEFAULT_TIMEOUT_S
 
+from ....logging_utils import log_decorator
 from ..._client_rpc import RabbitMQRPCClient
+from ..._constants import RPC_REQUEST_DEFAULT_TIMEOUT_S
 
 _logger = logging.getLogger(__name__)
 
@@ -39,6 +40,7 @@ async def list_services_paginated(  # pylint: disable=too-many-arguments
     user_id: UserID,
     limit: PageLimitInt = DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
     offset: PageOffsetInt = 0,
+    filters: ServiceListFilters | None = None,
 ) -> PageRpcLatestServiceGet:
     """
     Raises:
@@ -52,6 +54,7 @@ async def list_services_paginated(  # pylint: disable=too-many-arguments
         user_id: UserID,
         limit: PageLimitInt,
         offset: PageOffsetInt,
+        filters: ServiceListFilters | None = None,
     ):
         return await rpc_client.request(
             CATALOG_RPC_NAMESPACE,
@@ -60,11 +63,16 @@ async def list_services_paginated(  # pylint: disable=too-many-arguments
             user_id=user_id,
             limit=limit,
             offset=offset,
+            filters=filters,
             timeout_s=40 * RPC_REQUEST_DEFAULT_TIMEOUT_S,
         )
 
     result = await _call(
-        product_name=product_name, user_id=user_id, limit=limit, offset=offset
+        product_name=product_name,
+        user_id=user_id,
+        limit=limit,
+        offset=offset,
+        filters=filters,
     )
     assert (  # nosec
         TypeAdapter(PageRpc[LatestServiceGet]).validate_python(result) is not None
@@ -249,6 +257,7 @@ async def list_my_service_history_paginated(  # pylint: disable=too-many-argumen
     service_key: ServiceKey,
     limit: PageLimitInt = DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
     offset: PageOffsetInt = 0,
+    filters: ServiceListFilters | None = None,
 ) -> PageRpcServiceRelease:
     """
     Raises:
@@ -262,6 +271,7 @@ async def list_my_service_history_paginated(  # pylint: disable=too-many-argumen
         service_key: ServiceKey,
         limit: PageLimitInt,
         offset: PageOffsetInt,
+        filters: ServiceListFilters | None,
     ):
         return await rpc_client.request(
             CATALOG_RPC_NAMESPACE,
@@ -273,6 +283,7 @@ async def list_my_service_history_paginated(  # pylint: disable=too-many-argumen
             service_key=service_key,
             limit=limit,
             offset=offset,
+            filters=filters,
         )
 
     result = await _call(
@@ -281,6 +292,7 @@ async def list_my_service_history_paginated(  # pylint: disable=too-many-argumen
         service_key=service_key,
         limit=limit,
         offset=offset,
+        filters=filters,
     )
 
     assert (  # nosec

--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/catalog/services.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/catalog/services.py
@@ -1,4 +1,12 @@
-"""RPC client-side for the RPC server at the payments service"""
+"""RPC client-side for the RPC server at the payments service
+
+In this interface (and all belows), the context of the caller is passed in the following arguments:
+- `user_id` is intended for the caller's identifer. Do not add other user_id that is not the callers!.
+    - Ideally this could be injected by an authentication layer (as in the rest API)
+        but  for now we are passing it as an argument.
+- `product_name` is the name of the product at the caller's context as well
+
+"""
 
 import logging
 from typing import cast
@@ -31,14 +39,6 @@ from ..._client_rpc import RabbitMQRPCClient
 from ..._constants import RPC_REQUEST_DEFAULT_TIMEOUT_S
 
 _logger = logging.getLogger(__name__)
-
-#
-# In this interface, the context of the caller is passed in the following arguments:
-#   - `user_id` is intended for the caller's identifer. Do not add other user_id that is not the callers!.
-#      - Ideally this could be injected by an authentication layer (as in the rest API)
-#        but  for now we are passing it as an argument.
-#   - `product_name` is the name of the product at the caller's context as well
-#
 
 
 @validate_call(config={"arbitrary_types_allowed": True})

--- a/services/catalog/src/simcore_service_catalog/models/services_db.py
+++ b/services/catalog/src/simcore_service_catalog/models/services_db.py
@@ -5,8 +5,10 @@ from common_library.basic_types import DEFAULT_FACTORY
 from models_library.basic_types import IdInt
 from models_library.groups import GroupID
 from models_library.products import ProductName
+from models_library.rest_filters import Filters
 from models_library.services_access import ServiceGroupAccessRights
 from models_library.services_base import ServiceKeyVersion
+from models_library.services_enums import ServiceType
 from models_library.services_types import ServiceKey, ServiceVersion
 from models_library.utils.common_validators import empty_str_to_none_pre_validator
 from pydantic import (
@@ -244,3 +246,19 @@ class ServiceAccessRightsAtDB(ServiceKeyVersion, ServiceGroupAccessRights):
     model_config = ConfigDict(
         from_attributes=True, json_schema_extra=_update_json_schema_extra
     )
+
+
+class ServiceFiltersDB(Filters):
+    service_type: ServiceType | None = None
+
+    @staticmethod
+    def _update_json_schema_extra(schema: JsonDict) -> None:
+        schema.update(
+            {
+                "example": {
+                    "by_service_type": "computational",
+                }
+            }
+        )
+
+    model_config = ConfigDict(json_schema_extra=_update_json_schema_extra)

--- a/services/catalog/src/simcore_service_catalog/repository/_services_sql.py
+++ b/services/catalog/src/simcore_service_catalog/repository/_services_sql.py
@@ -3,7 +3,7 @@ from typing import Any
 import sqlalchemy as sa
 from models_library.products import ProductName
 from models_library.services_regex import (
-    SERVICE_TYPE_PREFIXES,
+    SERVICE_TYPE_TO_PREFIX_MAP,
 )
 from models_library.services_types import ServiceKey, ServiceVersion
 from models_library.users import UserID
@@ -121,7 +121,7 @@ def apply_services_filters(
     filters: ServiceFiltersDB,
 ):
     if filters.service_type:
-        prefix = SERVICE_TYPE_PREFIXES.get(filters.service_type)
+        prefix = SERVICE_TYPE_TO_PREFIX_MAP.get(filters.service_type)
         if prefix is None:
             msg = f"Undefined service type {filters.service_type}. Please update prefix expressions"
             raise ValueError(msg)

--- a/services/catalog/src/simcore_service_catalog/repository/_services_sql.py
+++ b/services/catalog/src/simcore_service_catalog/repository/_services_sql.py
@@ -116,10 +116,10 @@ def _has_access_rights(
     )
 
 
-def apply_services_filters(
-    stmt,
+def _apply_services_filters(
+    stmt: sa.sql.Select,
     filters: ServiceFiltersDB,
-):
+) -> sa.sql.Select:
     if filters.service_type:
         prefix = SERVICE_TYPE_TO_PREFIX_MAP.get(filters.service_type)
         if prefix is None:
@@ -156,7 +156,7 @@ def latest_services_total_count_stmt(
     )
 
     if filters:
-        stmt = apply_services_filters(stmt, filters)
+        stmt = _apply_services_filters(stmt, filters)
 
     return stmt
 
@@ -200,7 +200,7 @@ def list_latest_services_stmt(
     )
 
     if filters:
-        cte_stmt = apply_services_filters(cte_stmt, filters)
+        cte_stmt = _apply_services_filters(cte_stmt, filters)
 
     cte = cte_stmt.cte("cte")
 

--- a/services/catalog/src/simcore_service_catalog/repository/_services_sql.py
+++ b/services/catalog/src/simcore_service_catalog/repository/_services_sql.py
@@ -125,8 +125,9 @@ def apply_services_filters(
         if prefix is None:
             msg = f"Undefined service type {filters.service_type}. Please update prefix expressions"
             raise ValueError(msg)
-        prefix = prefix.rstrip("/")  # safety
-        stmt = stmt.where(services_meta_data.c.service_key.like(f"{prefix}/%"))
+
+        assert not prefix.endswith("/")  # nosec
+        return stmt.where(services_meta_data.c.key.like(f"{prefix}/%"))
     return stmt
 
 
@@ -155,7 +156,7 @@ def latest_services_total_count_stmt(
     )
 
     if filters:
-        apply_services_filters(stmt, filters)
+        stmt = apply_services_filters(stmt, filters)
 
     return stmt
 
@@ -199,7 +200,7 @@ def list_latest_services_stmt(
     )
 
     if filters:
-        apply_services_filters(cte_stmt, filters)
+        cte_stmt = apply_services_filters(cte_stmt, filters)
 
     cte = cte_stmt.cte("cte")
 

--- a/services/catalog/src/simcore_service_catalog/repository/services.py
+++ b/services/catalog/src/simcore_service_catalog/repository/services.py
@@ -411,6 +411,11 @@ class ServicesRepository(BaseRepository):
             filters=filters,
         )
 
+        from simcore_postgres_database.utils import as_postgres_sql_query_str
+
+        print(as_postgres_sql_query_str(stmt_total))
+        print(as_postgres_sql_query_str(stmt_page))
+
         async with self.db_engine.connect() as conn:
             result = await conn.execute(stmt_total)
             total_count = result.scalar() or 0
@@ -514,7 +519,7 @@ class ServicesRepository(BaseRepository):
         )
 
         if filters:
-            apply_services_filters(base_stmt, filters)
+            base_stmt = apply_services_filters(base_stmt, filters)
 
         base_subquery = base_stmt.subquery()
 

--- a/services/catalog/src/simcore_service_catalog/repository/services.py
+++ b/services/catalog/src/simcore_service_catalog/repository/services.py
@@ -411,11 +411,6 @@ class ServicesRepository(BaseRepository):
             filters=filters,
         )
 
-        from simcore_postgres_database.utils import as_postgres_sql_query_str
-
-        print(as_postgres_sql_query_str(stmt_total))
-        print(as_postgres_sql_query_str(stmt_page))
-
         async with self.db_engine.connect() as conn:
             result = await conn.execute(stmt_total)
             total_count = result.scalar() or 0

--- a/services/catalog/src/simcore_service_catalog/repository/services.py
+++ b/services/catalog/src/simcore_service_catalog/repository/services.py
@@ -28,7 +28,6 @@ from simcore_postgres_database.models.services_compatibility import (
 from simcore_postgres_database.models.services_specifications import (
     services_specifications,
 )
-from simcore_postgres_database.utils import as_postgres_sql_query_str
 from simcore_postgres_database.utils_repos import pass_or_acquire_connection
 from simcore_postgres_database.utils_services import create_select_latest_services_query
 from sqlalchemy import sql
@@ -37,6 +36,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from ..models.services_db import (
     ReleaseDBGet,
     ServiceAccessRightsAtDB,
+    ServiceFiltersDB,
     ServiceMetaDataDBCreate,
     ServiceMetaDataDBGet,
     ServiceMetaDataDBPatch,
@@ -47,6 +47,7 @@ from ._base import BaseRepository
 from ._services_sql import (
     SERVICES_META_DATA_COLS,
     AccessRightsClauses,
+    apply_services_filters,
     by_version,
     can_get_service_stmt,
     get_service_history_stmt,
@@ -391,6 +392,7 @@ class ServicesRepository(BaseRepository):
         # list args: pagination
         limit: int | None = None,
         offset: int | None = None,
+        filters: ServiceFiltersDB | None = None,
     ) -> tuple[PositiveInt, list[ServiceWithHistoryDBGet]]:
 
         # get page
@@ -398,6 +400,7 @@ class ServicesRepository(BaseRepository):
             product_name=product_name,
             user_id=user_id,
             access_rights=AccessRightsClauses.can_read,
+            filters=filters,
         )
         stmt_page = list_latest_services_stmt(
             product_name=product_name,
@@ -405,6 +408,7 @@ class ServicesRepository(BaseRepository):
             access_rights=AccessRightsClauses.can_read,
             limit=limit,
             offset=offset,
+            filters=filters,
         )
 
         async with self.db_engine.connect() as conn:
@@ -480,9 +484,10 @@ class ServicesRepository(BaseRepository):
         # list args: pagination
         limit: int | None = None,
         offset: int | None = None,
+        filters: ServiceFiltersDB | None = None,
     ) -> tuple[PositiveInt, list[ReleaseDBGet]]:
 
-        base_subquery = (
+        base_stmt = (
             # Search on service (key, *) for (product_name, user_id w/ access)
             sql.select(
                 services_meta_data.c.key,
@@ -506,11 +511,15 @@ class ServicesRepository(BaseRepository):
                 & (user_to_groups.c.uid == user_id)
                 & AccessRightsClauses.can_read
             )
-        ).subquery()
+        )
+
+        if filters:
+            apply_services_filters(base_stmt, filters)
+
+        base_subquery = base_stmt.subquery()
 
         # Query to count the TOTAL number of rows
         count_query = sql.select(sql.func.count()).select_from(base_subquery)
-        _logger.debug("count_query=\n%s", as_postgres_sql_query_str(count_query))
 
         # Query to retrieve page with additional columns, ordering, offset, and limit
         page_query = (
@@ -541,7 +550,6 @@ class ServicesRepository(BaseRepository):
             .offset(offset)
             .limit(limit)
         )
-        _logger.debug("page_query=\n%s", as_postgres_sql_query_str(page_query))
 
         async with pass_or_acquire_connection(self.db_engine) as conn:
             total_count: PositiveInt = await conn.scalar(count_query) or 0

--- a/services/catalog/src/simcore_service_catalog/repository/services.py
+++ b/services/catalog/src/simcore_service_catalog/repository/services.py
@@ -47,7 +47,7 @@ from ._base import BaseRepository
 from ._services_sql import (
     SERVICES_META_DATA_COLS,
     AccessRightsClauses,
-    apply_services_filters,
+    _apply_services_filters,
     by_version,
     can_get_service_stmt,
     get_service_history_stmt,
@@ -514,7 +514,7 @@ class ServicesRepository(BaseRepository):
         )
 
         if filters:
-            base_stmt = apply_services_filters(base_stmt, filters)
+            base_stmt = _apply_services_filters(base_stmt, filters)
 
         base_subquery = base_stmt.subquery()
 

--- a/services/catalog/src/simcore_service_catalog/service/catalog_services.py
+++ b/services/catalog/src/simcore_service_catalog/service/catalog_services.py
@@ -191,6 +191,10 @@ async def list_latest_catalog_services(
                     missing_services=missing_services,
                     user_id=user_id,
                     product_name=product_name,
+                    filters=filters,
+                    limit=limit,
+                    offset=offset,
+                    access_rights=access_rights,
                 ),
                 tip="This might be due to malfunction of the background-task or that this call was done while the sync was taking place",
             )

--- a/services/catalog/src/simcore_service_catalog/service/catalog_services.py
+++ b/services/catalog/src/simcore_service_catalog/service/catalog_services.py
@@ -32,6 +32,7 @@ from servicelib.rabbitmq.rpc_interfaces.catalog.errors import (
 from ..clients.director import DirectorClient
 from ..models.services_db import (
     ServiceAccessRightsAtDB,
+    ServiceFiltersDB,
     ServiceMetaDataDBPatch,
     ServiceWithHistoryDBGet,
 )
@@ -134,11 +135,16 @@ async def list_latest_catalog_services(
     user_id: UserID,
     limit: PageLimitInt | None,
     offset: NonNegativeInt = 0,
+    filters: ServiceFiltersDB | None = None,
 ) -> tuple[PageTotalCount, list[LatestServiceGet]]:
 
     # defines the order
     total_count, services = await repo.list_latest_services(
-        product_name=product_name, user_id=user_id, limit=limit, offset=offset
+        product_name=product_name,
+        user_id=user_id,
+        limit=limit,
+        offset=offset,
+        filters=filters,
     )
 
     if services:
@@ -507,6 +513,8 @@ async def list_user_service_release_history(
     # pagination
     limit: PageLimitInt | None = None,
     offset: NonNegativeInt | None = None,
+    # filters
+    filters: ServiceFiltersDB | None = None,
     # options
     include_compatibility: bool = False,
 ) -> tuple[PageTotalCount, list[ServiceRelease]]:
@@ -519,6 +527,7 @@ async def list_user_service_release_history(
         key=service_key,
         limit=limit,
         offset=offset,
+        filters=filters,
     )
 
     compatibility_map: dict[ServiceVersion, Compatibility | None] = {}

--- a/services/catalog/src/simcore_service_catalog/service/catalog_services.py
+++ b/services/catalog/src/simcore_service_catalog/service/catalog_services.py
@@ -194,7 +194,6 @@ async def list_latest_catalog_services(
                     filters=filters,
                     limit=limit,
                     offset=offset,
-                    access_rights=access_rights,
                 ),
                 tip="This might be due to malfunction of the background-task or that this call was done while the sync was taking place",
             )

--- a/services/catalog/tests/unit/with_dbs/test_api_rpc.py
+++ b/services/catalog/tests/unit/with_dbs/test_api_rpc.py
@@ -14,9 +14,6 @@ from fastapi import FastAPI
 from models_library.products import ProductName
 from models_library.rest_pagination import MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE
 from models_library.services_history import ServiceRelease
-from models_library.services_regex import (
-    DYNAMIC_SERVICE_KEY_PREFIX,
-)
 from models_library.services_types import ServiceKey, ServiceVersion
 from models_library.users import UserID
 from packaging import version
@@ -128,6 +125,35 @@ async def test_rpc_list_services_paginated_with_no_services_returns_empty_page(
     assert page.links.next is None
     assert page.links.prev is None
     assert page.meta.count == 0
+    assert page.meta.total == 0
+
+
+async def test_rpc_list_services_paginated_with_filters(
+    background_sync_task_mocked: None,
+    mocked_director_rest_api: MockRouter,
+    rpc_client: RabbitMQRPCClient,
+    product_name: ProductName,
+    user_id: UserID,
+    app: FastAPI,
+):
+    assert app
+
+    # only computational services introduced by the background_sync_task_mocked
+    page = await list_services_paginated(
+        rpc_client,
+        product_name=product_name,
+        user_id=user_id,
+        filters={"service_type": "computational"},
+    )
+    assert page.meta.total == page.meta.count
+    assert page.meta.total > 0
+
+    page = await list_services_paginated(
+        rpc_client,
+        product_name=product_name,
+        user_id=user_id,
+        filters={"service_type": "dynamic"},
+    )
     assert page.meta.total == 0
 
 
@@ -556,68 +582,3 @@ async def test_rpc_list_my_service_history_paginated(
     assert len(release_history) == 2
     assert release_history[0].version == service_version_2, "expected newest first"
     assert release_history[1].version == service_version_1
-
-
-async def test_rpc_list_services_paginated_with_filters(
-    background_sync_task_mocked: None,
-    mocked_director_rest_api: MockRouter,
-    rpc_client: RabbitMQRPCClient,
-    product_name: ProductName,
-    user_id: UserID,
-    app: FastAPI,
-    create_fake_service_data: Callable,
-    services_db_tables_injector: Callable,
-):
-    assert app
-
-    # only computational services introduced by the background_sync_task_mocked
-    page = await list_services_paginated(
-        rpc_client,
-        product_name=product_name,
-        user_id=user_id,
-        filters={"service_type": "computational"},
-    )
-    assert page.meta.total == page.meta.count
-    assert page.meta.total > 0
-
-    page = await list_services_paginated(
-        rpc_client,
-        product_name=product_name,
-        user_id=user_id,
-        filters={"service_type": "dynamic"},
-    )
-    assert page.meta.total == 0
-
-    # Create fake services with different types
-    service_key_1 = f"{DYNAMIC_SERVICE_KEY_PREFIX}/test-filter-service"
-    service_version = "1.2.3"
-
-    fake_services = [
-        create_fake_service_data(
-            service_key_1,
-            service_version,
-            team_access=None,
-            everyone_access=None,
-            product=product_name,
-        ),
-    ]
-
-    # Inject fake services into the database
-    await services_db_tables_injector(fake_services)
-
-    # Apply a filter to match only computational services
-    page = await list_services_paginated(
-        rpc_client,
-        product_name=product_name,
-        user_id=user_id,
-        filters={"service_type": "dynamic"},
-    )
-
-    # Validate the response
-    assert page.meta.total == 1
-    assert page.meta.count == 1
-    assert len(page.data) == 1
-    assert page.data[0].key == service_key_1
-    assert page.data[0].service_type == "frontend"
-    assert page.links.next is None
-    assert page.links.prev is None

--- a/services/catalog/tests/unit/with_dbs/test_api_rpc.py
+++ b/services/catalog/tests/unit/with_dbs/test_api_rpc.py
@@ -14,6 +14,10 @@ from fastapi import FastAPI
 from models_library.products import ProductName
 from models_library.rest_pagination import MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE
 from models_library.services_history import ServiceRelease
+from models_library.services_regex import (
+    COMPUTATIONAL_SERVICE_KEY_PREFIX,
+    FRONTEND_SERVICE_KEY_PREFIX,
+)
 from models_library.services_types import ServiceKey, ServiceVersion
 from models_library.users import UserID
 from packaging import version
@@ -568,8 +572,8 @@ async def test_rpc_list_services_paginated_with_filters(
     assert app
 
     # Create fake services with different types
-    service_key_1 = "simcore/services/comp/test-filter-service-1"
-    service_key_2 = "simcore/services/frontend/test-filter-service-2"
+    service_key_1 = f"{COMPUTATIONAL_SERVICE_KEY_PREFIX}/test-filter-service-1"
+    service_key_2 = f"{FRONTEND_SERVICE_KEY_PREFIX}/test-filter-service-2"
     service_version = "1.0.0"
 
     fake_services = [
@@ -579,7 +583,6 @@ async def test_rpc_list_services_paginated_with_filters(
             team_access=None,
             everyone_access=None,
             product=product_name,
-            service_type="computational",
         ),
         create_fake_service_data(
             service_key_2,
@@ -587,7 +590,6 @@ async def test_rpc_list_services_paginated_with_filters(
             team_access=None,
             everyone_access=None,
             product=product_name,
-            service_type="frontend",
         ),
     ]
 

--- a/services/catalog/tests/unit/with_dbs/test_repositories.py
+++ b/services/catalog/tests/unit/with_dbs/test_repositories.py
@@ -17,7 +17,7 @@ from models_library.services_enums import ServiceType  # Import ServiceType enum
 from models_library.services_regex import (
     COMPUTATIONAL_SERVICE_KEY_PREFIX,
     DYNAMIC_SERVICE_KEY_PREFIX,
-    SERVICE_TYPE_PREFIXES,
+    SERVICE_TYPE_TO_PREFIX_MAP,
 )
 from models_library.users import UserID
 from packaging import version
@@ -633,7 +633,7 @@ async def test_get_service_history_page(
 
 
 @pytest.mark.parametrize(
-    "expected_service_type,service_prefix", SERVICE_TYPE_PREFIXES.items()
+    "expected_service_type,service_prefix", SERVICE_TYPE_TO_PREFIX_MAP.items()
 )
 async def test_get_service_history_page_with_filters(
     target_product: ProductName,

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_catalog.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_catalog.py
@@ -9,6 +9,10 @@ from aiopg.sa.connection import SAConnection
 from aiopg.sa.engine import Engine
 from models_library.groups import EVERYONE_GROUP_ID
 from models_library.services import ServiceKey, ServiceVersion
+from models_library.services_regex import (
+    COMPUTATIONAL_SERVICE_KEY_PREFIX,
+    DYNAMIC_SERVICE_KEY_PREFIX,
+)
 from pydantic import HttpUrl, PositiveInt, TypeAdapter, ValidationError
 from servicelib.logging_utils import log_decorator
 from simcore_postgres_database.models.services import (
@@ -92,8 +96,8 @@ async def iter_latest_product_services(
         )
         .where(
             (
-                services_meta_data.c.key.like("simcore/services/dynamic/%%")
-                | (services_meta_data.c.key.like("simcore/services/comp/%%"))
+                services_meta_data.c.key.like(f"{DYNAMIC_SERVICE_KEY_PREFIX}/%")
+                | services_meta_data.c.key.like(f"{COMPUTATIONAL_SERVICE_KEY_PREFIX}/%")
             )
             & (services_meta_data.c.deprecated.is_(None))
             & (services_access_rights.c.gid == EVERYONE_GROUP_ID)

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_catalog.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_catalog.py
@@ -9,7 +9,7 @@ from aiopg.sa.connection import SAConnection
 from aiopg.sa.engine import Engine
 from models_library.groups import EVERYONE_GROUP_ID
 from models_library.services import ServiceKey, ServiceVersion
-from models_library.services_regex import (
+from models_library.services_constants import (
     COMPUTATIONAL_SERVICE_KEY_PREFIX,
     DYNAMIC_SERVICE_KEY_PREFIX,
 )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->


## What do these changes do?

Introduces a `filters: ServiceListFilters` argument in the listing functions of the catalog RPC API to enable service filtering.


- **`catalog` rpc-client**  
  - Added `filters: ServiceListFilters` to `list_services_paginated` and `list_my_service_history_paginated`

- **`catalog` simcore-service**
  - **Controller layer (`api.rpc`)**  
    - Accepts `filters: ServiceListFilters` in listing endpoints  
    - Maps `ServiceListFilters` to domain model `ServiceFiltersDB`  
    - Updates RPC server mocks (`pytest_simcore.helpers.catalog_rpc_service`)
  - **Service layer (`service.catalog_services`)**  
    - Handles `filter: ServiceFiltersDB` in listing logic  
  - **Repository layer (`repository.services`)**  
    - Accepts `filter: ServiceFiltersDB`  
    - Applies filters using `apply_services_filters` in SQLAlchemy queries


## Related issue/s

- resolves #7532

## How to test

```
cd services/catalog
make install-dev
pytest -vv tests/unit/with_dbs/test_api_rpc.py
pytest -vv tests/unit/with_dbs/test_repositories.py
```

## Dev-ops 