### PR TITLE
🐛 Add legacy tasks to webserver openapi specs

### DIFF
--- a/api/specs/web-server/_long_running_tasks_legacy.py
+++ b/api/specs/web-server/_long_running_tasks_legacy.py
@@ -1,0 +1,61 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+# pylint: disable=too-many-arguments
+
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from models_library.generics import Envelope
+from servicelib.aiohttp.long_running_tasks._routes import _PathParam
+from servicelib.long_running_tasks._models import TaskGet, TaskStatus
+from simcore_service_webserver._meta import API_VTAG
+
+router = APIRouter(
+    prefix=f"/{API_VTAG}/tasks-legacy",
+    tags=[
+        "long-running-tasks-legacy",
+    ],
+)
+
+
+@router.get(
+    "",
+    response_model=Envelope[list[TaskGet]],
+    name="list_tasks",
+    description="Lists all long running tasks",
+)
+def list_tasks(): ...
+
+
+@router.get(
+    "/{task_id}",
+    response_model=Envelope[TaskStatus],
+    name="get_task_status",
+    description="Retrieves the status of a task",
+)
+def get_task_status(
+    _path_params: Annotated[_PathParam, Depends()],
+): ...
+
+
+@router.delete(
+    "/{task_id}",
+    name="cancel_and_delete_task",
+    description="Cancels and deletes a task",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def cancel_and_delete_task(
+    _path_params: Annotated[_PathParam, Depends()],
+): ...
+
+
+@router.get(
+    "/{task_id}/result",
+    name="get_task_result",
+    description="Retrieves the result of a task",
+)
+def get_task_result(
+    _path_params: Annotated[_PathParam, Depends()],
+): ...

--- a/api/specs/web-server/openapi.py
+++ b/api/specs/web-server/openapi.py
@@ -36,6 +36,7 @@ openapi_modules = [
         "_exporter",
         "_folders",
         "_long_running_tasks",
+        "_long_running_tasks_legacy",
         "_licensed_items",
         "_licensed_items_purchases",
         "_licensed_items_checkouts",

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -3125,6 +3125,77 @@ paths:
               schema:
                 $ref: '#/components/schemas/EnvelopedError'
           description: Internal Server Error
+  /v0/tasks-legacy:
+    get:
+      tags:
+      - long-running-tasks-legacy
+      summary: List Tasks
+      description: Lists all long running tasks
+      operationId: list_tasks
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Envelope_list_TaskGet__'
+  /v0/tasks-legacy/{task_id}:
+    get:
+      tags:
+      - long-running-tasks-legacy
+      summary: Get Task Status
+      description: Retrieves the status of a task
+      operationId: get_task_status
+      parameters:
+      - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Task Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Envelope_TaskStatus_'
+    delete:
+      tags:
+      - long-running-tasks-legacy
+      summary: Cancel And Delete Task
+      description: Cancels and deletes a task
+      operationId: cancel_and_delete_task
+      parameters:
+      - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Task Id
+      responses:
+        '204':
+          description: Successful Response
+  /v0/tasks-legacy/{task_id}/result:
+    get:
+      tags:
+      - long-running-tasks-legacy
+      summary: Get Task Result
+      description: Retrieves the result of a task
+      operationId: get_task_result
+      parameters:
+      - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Task Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
   /v0/catalog/licensed-items:
     get:
       tags:

--- a/services/web/server/tests/unit/with_dbs/03/test__openapi_specs.py
+++ b/services/web/server/tests/unit/with_dbs/03/test__openapi_specs.py
@@ -13,7 +13,6 @@ from faker import Faker
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from pytest_simcore.openapi_specs import Entrypoint
-from simcore_service_webserver._meta import API_VTAG
 from simcore_service_webserver.application import create_application
 from simcore_service_webserver.application_settings import get_application_settings
 from simcore_service_webserver.rest._utils import get_openapi_specs_path
@@ -76,16 +75,7 @@ def test_app_named_resources_against_openapi_specs(
     openapi_specs_entrypoints: set[Entrypoint],
     app_rest_entrypoints: set[Entrypoint],
 ):
-    # remove task-legacy routes. These should not be exposed.
-    # this test compares directly against the openapi specs. In future it would be
-    # cleaner to compare against the fastapi app entry points in specs and
-    # avoid including the endpoints there
-    required_entry_points = {
-        e
-        for e in app_rest_entrypoints
-        if not e.path.startswith(f"/{API_VTAG}/tasks-legacy")
-    }
-    assert required_entry_points == openapi_specs_entrypoints
+    assert app_rest_entrypoints == openapi_specs_entrypoints
 
     # NOTE: missing here is:
     # - input schemas (path, query and body)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
- Add legacy tasks to openapi specs. The old long running tasks (before we had the celery storage worker) were exposed in `/tasks` in the webserver. I removed them from there when the storage worker was added to our stack. For technical reasons it was needed to keep the old implementation (now in `/tasks-legacy`) but I didn't include them in the OAS because I felt it would cause confusion (the frontend is really only supposed to know about `/tasks`). But in https://github.com/ITISFoundation/osparc-simcore/pull/7541 I realized we need to have all endpoints exposed in the OAS because this is used in several places for testing.

## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
