### PR TITLE
🎨 Add Reusable Lifespan Contexts for RabbitMQ and Redis in `servicelib.fastapi`

### DIFF
--- a/packages/service-library/src/servicelib/fastapi/lifespan_utils.py
+++ b/packages/service-library/src/servicelib/fastapi/lifespan_utils.py
@@ -20,25 +20,37 @@ class LifespanAlreadyCalledError(LifespanError):
     msg_template = "The lifespan '{lifespan_name}' has already been called."
 
 
+class LifespanExpectedCalledError(LifespanError):
+    msg_template = "The lifespan '{lifespan_name}' was not called. Ensure it is properly configured and invoked."
+
+
 _CALLED_LIFESPANS_KEY: Final[str] = "_CALLED_LIFESPANS"
 
 
 def is_lifespan_called(state: State, lifespan_name: str) -> bool:
-    called_lifespans = state.get(_CALLED_LIFESPANS_KEY, set())
-    return lifespan_name in called_lifespans
-
-
-def record_lifespan_called_once(state: State, lifespan_name: str) -> State:
-    """Validates if a lifespan has already been called and records it in the state.
-    Raises LifespanAlreadyCalledError if the lifespan has already been called.
-    """
     assert not isinstance(  # nosec
         state, FastAPI
     ), "TIP: lifespan func has (app, state) positional arguments"
 
+    called_lifespans = state.get(_CALLED_LIFESPANS_KEY, set())
+    return lifespan_name in called_lifespans
+
+
+def mark_lifespace_called(state: State, lifespan_name: str) -> State:
+    """Validates if a lifespan has already been called and records it in the state.
+    Raises LifespanAlreadyCalledError if the lifespan has already been called.
+    """
     if is_lifespan_called(state, lifespan_name):
         raise LifespanAlreadyCalledError(lifespan_name=lifespan_name)
 
     called_lifespans = state.get(_CALLED_LIFESPANS_KEY, set())
     called_lifespans.add(lifespan_name)
     return {_CALLED_LIFESPANS_KEY: called_lifespans}
+
+
+def ensure_lifespan_called(state: State, lifespan_name: str) -> None:
+    """Ensures that a lifespan has been called.
+    Raises LifespanNotCalledError if the lifespan has not been called.
+    """
+    if not is_lifespan_called(state, lifespan_name):
+        raise LifespanExpectedCalledError(lifespan_name=lifespan_name)

--- a/packages/service-library/src/servicelib/fastapi/lifespan_utils.py
+++ b/packages/service-library/src/servicelib/fastapi/lifespan_utils.py
@@ -5,7 +5,8 @@ from typing import Final
 from common_library.errors_classes import OsparcErrorMixin
 from fastapi import FastAPI
 from fastapi_lifespan_manager import State
-from servicelib.logging_utils import log_context
+
+from ..logging_utils import log_context
 
 
 class LifespanError(OsparcErrorMixin, RuntimeError): ...

--- a/packages/service-library/src/servicelib/fastapi/lifespan_utils.py
+++ b/packages/service-library/src/servicelib/fastapi/lifespan_utils.py
@@ -1,12 +1,44 @@
+from typing import Final
+
 from common_library.errors_classes import OsparcErrorMixin
+from fastapi import FastAPI
+from fastapi_lifespan_manager import State
 
 
 class LifespanError(OsparcErrorMixin, RuntimeError): ...
 
 
 class LifespanOnStartupError(LifespanError):
-    msg_template = "Failed during startup of {module}"
+    msg_template = "Failed during startup of {lifespan_name}"
 
 
 class LifespanOnShutdownError(LifespanError):
-    msg_template = "Failed during shutdown of {module}"
+    msg_template = "Failed during shutdown of {lifespan_name}"
+
+
+class LifespanAlreadyCalledError(LifespanError):
+    msg_template = "The lifespan '{lifespan_name}' has already been called."
+
+
+_CALLED_LIFESPANS_KEY: Final[str] = "_CALLED_LIFESPANS"
+
+
+def is_lifespan_called(state: State, lifespan_name: str) -> bool:
+    called_lifespans = state.get(_CALLED_LIFESPANS_KEY, set())
+    return lifespan_name in called_lifespans
+
+
+def record_lifespan_called_once(state: State, lifespan_name: str) -> State:
+    """Validates if a lifespan has already been called and records it in the state.
+    Raises LifespanAlreadyCalledError if the lifespan has already been called.
+    """
+    assert not isinstance(  # nosec
+        state, FastAPI
+    ), "TIP: lifespan func has (app, state) positional arguments"
+
+    if is_lifespan_called(state, lifespan_name):
+        raise LifespanAlreadyCalledError(lifespan_name=lifespan_name)
+
+    called_lifespans = state.get(_CALLED_LIFESPANS_KEY, set())
+    called_lifespans.add(lifespan_name)
+    return {_CALLED_LIFESPANS_KEY: called_lifespans}

--- a/packages/service-library/src/servicelib/fastapi/lifespan_utils.py
+++ b/packages/service-library/src/servicelib/fastapi/lifespan_utils.py
@@ -32,9 +32,13 @@ _CALLED_LIFESPANS_KEY: Final[str] = "_CALLED_LIFESPANS"
 
 
 def is_lifespan_called(state: State, lifespan_name: str) -> bool:
+    # NOTE: This assert is meant to catch a common mistake:
+    # The `lifespan` function should accept up to two *optional* positional arguments: (app: FastAPI, state: State).
+    # Valid signatures include: `()`, `(app)`, `(app, state)`, or even `(_, state)`.
+    # It's easy to accidentally swap or misplace these arguments.
     assert not isinstance(  # nosec
         state, FastAPI
-    ), "TIP: lifespan func has (app, state) positional arguments"
+    ), "Did you swap arguments? `lifespan(app, state)` expects (app: FastAPI, state: State)"
 
     called_lifespans = state.get(_CALLED_LIFESPANS_KEY, set())
     return lifespan_name in called_lifespans

--- a/packages/service-library/src/servicelib/fastapi/postgres_lifespan.py
+++ b/packages/service-library/src/servicelib/fastapi/postgres_lifespan.py
@@ -5,11 +5,11 @@ from enum import Enum
 
 from fastapi import FastAPI
 from fastapi_lifespan_manager import State
-from servicelib.logging_utils import log_catch
 from settings_library.postgres import PostgresSettings
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from ..db_asyncpg_utils import create_async_engine_and_database_ready
+from ..logging_utils import log_catch
 from .lifespan_utils import LifespanOnStartupError, lifespan_context
 
 _logger = logging.getLogger(__name__)

--- a/packages/service-library/src/servicelib/fastapi/postgres_lifespan.py
+++ b/packages/service-library/src/servicelib/fastapi/postgres_lifespan.py
@@ -10,7 +10,7 @@ from settings_library.postgres import PostgresSettings
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from ..db_asyncpg_utils import create_async_engine_and_database_ready
-from .lifespan_utils import LifespanOnStartupError, record_lifespan_called_once
+from .lifespan_utils import LifespanOnStartupError, mark_lifespace_called
 
 _logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ async def postgres_database_lifespan(_: FastAPI, state: State) -> AsyncIterator[
     with log_context(_logger, logging.INFO, f"{__name__}"):
 
         # Mark lifespan as called
-        called_state = record_lifespan_called_once(state, "postgres_database_lifespan")
+        called_state = mark_lifespace_called(state, "postgres_database_lifespan")
 
         settings = state[PostgresLifespanState.POSTGRES_SETTINGS]
 

--- a/packages/service-library/src/servicelib/fastapi/rabbitmq.py
+++ b/packages/service-library/src/servicelib/fastapi/rabbitmq.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 from fastapi import FastAPI
 from models_library.rabbitmq_messages import RabbitMessageBase
@@ -55,6 +56,13 @@ def setup_rabbit(
         settings -- Rabbit settings or if None, the connection to rabbit is not done upon startup
         name -- name for the rmq client name
     """
+    warnings.warn(
+        "The 'setup_rabbit' function is deprecated and will be removed in a future release. "
+        "Please use 'rabbitmq_lifespan' for managing RabbitMQ connections.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     app.state.rabbitmq_client = None  # RabbitMQClient | None
     app.state.rabbitmq_client_name = name
     app.state.rabbitmq_settings = settings

--- a/packages/service-library/src/servicelib/fastapi/rabbitmq_lifespan.py
+++ b/packages/service-library/src/servicelib/fastapi/rabbitmq_lifespan.py
@@ -4,13 +4,12 @@ from collections.abc import AsyncIterator
 from fastapi import FastAPI
 from fastapi_lifespan_manager import State
 from pydantic import BaseModel, ValidationError
-from servicelib.logging_utils import log_context
 from servicelib.rabbitmq import wait_till_rabbitmq_responsive
 from settings_library.rabbit import RabbitSettings
 
 from .lifespan_utils import (
     LifespanOnStartupError,
-    mark_lifespace_called,
+    lifespan_context,
 )
 
 _logger = logging.getLogger(__name__)
@@ -33,10 +32,7 @@ async def rabbitmq_connectivity_lifespan(
     """
     _lifespan_name = f"{__name__}.{rabbitmq_connectivity_lifespan.__name__}"
 
-    with log_context(_logger, logging.INFO, _lifespan_name):
-
-        # Check if lifespan has already been called
-        called_state = mark_lifespace_called(state, _lifespan_name)
+    with lifespan_context(_logger, logging.INFO, _lifespan_name, state) as called_state:
 
         # Validate input state
         try:

--- a/packages/service-library/src/servicelib/fastapi/rabbitmq_lifespan.py
+++ b/packages/service-library/src/servicelib/fastapi/rabbitmq_lifespan.py
@@ -4,9 +4,9 @@ from collections.abc import AsyncIterator
 from fastapi import FastAPI
 from fastapi_lifespan_manager import State
 from pydantic import BaseModel, ValidationError
-from servicelib.rabbitmq import wait_till_rabbitmq_responsive
 from settings_library.rabbit import RabbitSettings
 
+from ..rabbitmq import wait_till_rabbitmq_responsive
 from .lifespan_utils import (
     LifespanOnStartupError,
     lifespan_context,

--- a/packages/service-library/src/servicelib/fastapi/rabbitmq_lifespan.py
+++ b/packages/service-library/src/servicelib/fastapi/rabbitmq_lifespan.py
@@ -1,0 +1,48 @@
+import logging
+from collections.abc import AsyncIterator
+
+from fastapi import FastAPI
+from fastapi_lifespan_manager import State
+from pydantic import BaseModel, ValidationError
+from servicelib.logging_utils import log_context
+from servicelib.rabbitmq import wait_till_rabbitmq_responsive
+from settings_library.rabbit import RabbitSettings
+
+from .lifespan_utils import LifespanOnStartupError, record_lifespan_called_once
+
+_logger = logging.getLogger(__name__)
+
+
+class RabbitMQConfigurationError(LifespanOnStartupError):
+    msg_template = "Invalid RabbitMQ config on startup : {validation_error}"
+
+
+class RabbitMQLifespanState(BaseModel):
+    RABBIT_SETTINGS: RabbitSettings
+
+
+async def rabbitmq_connectivity_lifespan(
+    _: FastAPI, state: State
+) -> AsyncIterator[State]:
+    """Ensures RabbitMQ connectivity during lifespan.
+
+    For creating clients, use additional lifespans like rabbitmq_rpc_client_context.
+    """
+    _lifespan_name = f"{__name__}.{rabbitmq_connectivity_lifespan.__name__}"
+
+    with log_context(_logger, logging.INFO, _lifespan_name):
+
+        # Check if lifespan has already been called
+        called_state = record_lifespan_called_once(state, _lifespan_name)
+
+        # Validate input state
+        try:
+            rabbit_state = RabbitMQLifespanState.model_validate(state)
+            rabbit_dsn_with_secrets = rabbit_state.RABBIT_SETTINGS.dsn
+        except ValidationError as exc:
+            raise RabbitMQConfigurationError(validation_error=exc, state=state) from exc
+
+        # Wait for RabbitMQ to be responsive
+        await wait_till_rabbitmq_responsive(rabbit_dsn_with_secrets)
+
+        yield {"RABBIT_CONNECTIVITY_LIFESPAN_NAME": _lifespan_name, **called_state}

--- a/packages/service-library/src/servicelib/fastapi/rabbitmq_lifespan.py
+++ b/packages/service-library/src/servicelib/fastapi/rabbitmq_lifespan.py
@@ -8,7 +8,10 @@ from servicelib.logging_utils import log_context
 from servicelib.rabbitmq import wait_till_rabbitmq_responsive
 from settings_library.rabbit import RabbitSettings
 
-from .lifespan_utils import LifespanOnStartupError, record_lifespan_called_once
+from .lifespan_utils import (
+    LifespanOnStartupError,
+    mark_lifespace_called,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -33,7 +36,7 @@ async def rabbitmq_connectivity_lifespan(
     with log_context(_logger, logging.INFO, _lifespan_name):
 
         # Check if lifespan has already been called
-        called_state = record_lifespan_called_once(state, _lifespan_name)
+        called_state = mark_lifespace_called(state, _lifespan_name)
 
         # Validate input state
         try:

--- a/packages/service-library/src/servicelib/fastapi/redis_lifespan.py
+++ b/packages/service-library/src/servicelib/fastapi/redis_lifespan.py
@@ -1,0 +1,69 @@
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from typing import Annotated
+
+from fastapi import FastAPI
+from fastapi_lifespan_manager import State
+from pydantic import BaseModel, ConfigDict, StringConstraints, ValidationError
+from servicelib.logging_utils import log_catch, log_context
+from settings_library.redis import RedisDatabase, RedisSettings
+
+from ..redis import RedisClientSDK
+from .lifespan_utils import LifespanOnStartupError, record_lifespan_called_once
+
+_logger = logging.getLogger(__name__)
+
+
+class RedisConfigurationError(LifespanOnStartupError):
+    msg_template = "Invalid redis config on startup : {validation_error}"
+
+
+class RedisLifespanState(BaseModel):
+    REDIS_SETTINGS: RedisSettings
+    REDIS_CLIENT_NAME: Annotated[str, StringConstraints(min_length=3, max_length=32)]
+    REDIS_CLIENT_DB: RedisDatabase
+
+    model_config = ConfigDict(
+        extra="allow",
+        arbitrary_types_allowed=True,  # RedisClientSDK has some arbitrary types and this class will never be serialized
+    )
+
+
+async def redis_database_lifespan(_: FastAPI, state: State) -> AsyncIterator[State]:
+    with log_context(_logger, logging.INFO, f"{__name__}"):
+
+        # Check if lifespan has already been called
+        called_state = record_lifespan_called_once(state, "redis_database_lifespan")
+
+        # Validate input state
+        try:
+            redis_state = RedisLifespanState.model_validate(state)
+            redis_dsn_with_secrets = redis_state.REDIS_SETTINGS.build_redis_dsn(
+                redis_state.REDIS_CLIENT_DB
+            )
+        except ValidationError as exc:
+            raise RedisConfigurationError(validation_error=exc, state=state) from exc
+
+        # Setup client
+        with log_context(
+            _logger,
+            logging.INFO,
+            f"Creating redis client with name={redis_state.REDIS_CLIENT_NAME}",
+        ):
+            redis_client = RedisClientSDK(
+                redis_dsn_with_secrets,
+                client_name=redis_state.REDIS_CLIENT_NAME,
+            )
+
+        try:
+            yield {"REDIS_CLIENT_SDK": redis_client, **called_state}
+        finally:
+            # Teardown client
+            if redis_client:
+                with log_catch(_logger, reraise=False):
+                    await asyncio.wait_for(
+                        redis_client.shutdown(),
+                        # NOTE: shutdown already has a _HEALTHCHECK_TASK_TIMEOUT_S of 10s
+                        timeout=20,
+                    )

--- a/packages/service-library/src/servicelib/fastapi/redis_lifespan.py
+++ b/packages/service-library/src/servicelib/fastapi/redis_lifespan.py
@@ -10,7 +10,7 @@ from servicelib.logging_utils import log_catch, log_context
 from settings_library.redis import RedisDatabase, RedisSettings
 
 from ..redis import RedisClientSDK
-from .lifespan_utils import LifespanOnStartupError, record_lifespan_called_once
+from .lifespan_utils import LifespanOnStartupError, mark_lifespace_called
 
 _logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ async def redis_database_lifespan(_: FastAPI, state: State) -> AsyncIterator[Sta
     with log_context(_logger, logging.INFO, f"{__name__}"):
 
         # Check if lifespan has already been called
-        called_state = record_lifespan_called_once(state, "redis_database_lifespan")
+        called_state = mark_lifespace_called(state, "redis_database_lifespan")
 
         # Validate input state
         try:

--- a/packages/service-library/src/servicelib/rabbitmq/__init__.py
+++ b/packages/service-library/src/servicelib/rabbitmq/__init__.py
@@ -1,7 +1,7 @@
 from models_library.rabbitmq_basic_types import RPCNamespace
 
 from ._client import RabbitMQClient
-from ._client_rpc import RabbitMQRPCClient
+from ._client_rpc import RabbitMQRPCClient, rabbitmq_rpc_client_context
 from ._constants import BIND_TO_ALL_TOPICS, RPC_REQUEST_DEFAULT_TIMEOUT_S
 from ._errors import (
     RemoteMethodNotRegisteredError,
@@ -28,6 +28,7 @@ __all__: tuple[str, ...] = (
     "RabbitMQRPCClient",
     "RemoteMethodNotRegisteredError",
     "is_rabbitmq_responsive",
+    "rabbitmq_rpc_client_context",
     "wait_till_rabbitmq_responsive",
 )
 

--- a/packages/service-library/tests/fastapi/test_rabbitmq_lifespan.py
+++ b/packages/service-library/tests/fastapi/test_rabbitmq_lifespan.py
@@ -1,0 +1,142 @@
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from collections.abc import AsyncIterator
+
+import pytest
+import servicelib.fastapi.rabbitmq_lifespan
+import servicelib.rabbitmq
+from asgi_lifespan import LifespanManager as ASGILifespanManager
+from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
+from pydantic import Field
+from pytest_mock import MockerFixture, MockType
+from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from servicelib.fastapi.rabbitmq_lifespan import (
+    RabbitMQConfigurationError,
+    RabbitMQLifespanState,
+    rabbitmq_connectivity_lifespan,
+)
+from servicelib.rabbitmq import rabbitmq_rpc_client_context
+from settings_library.application import BaseApplicationSettings
+from settings_library.rabbit import RabbitSettings
+
+
+@pytest.fixture
+def mock_rabbitmq_connection(mocker: MockerFixture) -> MockType:
+    return mocker.patch.object(
+        servicelib.fastapi.rabbitmq_lifespan,
+        "wait_till_rabbitmq_responsive",
+        return_value=mocker.AsyncMock(),
+    )
+
+
+@pytest.fixture
+def mock_rabbitmq_rpc_client_class(mocker: MockerFixture) -> MockType:
+    return mocker.patch.object(
+        servicelib.rabbitmq._client_rpc,
+        "RabbitMQRPCClient",
+        return_value=mocker.AsyncMock(),
+    )
+
+
+@pytest.fixture
+def app_environment(monkeypatch: pytest.MonkeyPatch) -> EnvVarsDict:
+    return setenvs_from_dict(
+        monkeypatch, RabbitSettings.model_json_schema()["examples"][0]
+    )
+
+
+@pytest.fixture
+def app_lifespan(
+    app_environment: EnvVarsDict,
+    mock_rabbitmq_connection: MockType,
+    mock_rabbitmq_rpc_client_class: MockType,
+) -> LifespanManager:
+    assert app_environment
+
+    class AppSettings(BaseApplicationSettings):
+        RABBITMQ: RabbitSettings = Field(
+            ..., json_schema_extra={"auto_default_from_env": True}
+        )
+
+    async def my_app_settings(app: FastAPI) -> AsyncIterator[State]:
+        app.state.settings = AppSettings.create_from_envs()
+
+        yield RabbitMQLifespanState(
+            RABBIT_SETTINGS=app.state.settings.RABBITMQ,
+        ).model_dump()
+
+    async def my_app_rpc_server(app: FastAPI, state: State) -> AsyncIterator[State]:
+
+        async with rabbitmq_rpc_client_context(
+            "rpc_server", app.state.settings.RABBITMQ
+        ) as rpc_server:
+            app.state.rpc_server = rpc_server
+            yield {}
+
+    app_lifespan = LifespanManager()
+    app_lifespan.add(my_app_settings)
+    app_lifespan.add(rabbitmq_connectivity_lifespan)
+    app_lifespan.add(my_app_rpc_server)
+
+    assert not mock_rabbitmq_connection.called
+    assert not mock_rabbitmq_rpc_client_class.called
+
+    return app_lifespan
+
+
+async def test_lifespan_rabbitmq_in_an_app(
+    is_pdb_enabled: bool,
+    app_environment: EnvVarsDict,
+    mock_rabbitmq_connection: MockType,
+    mock_rabbitmq_rpc_client_class: MockType,
+    app_lifespan: LifespanManager,
+):
+    app = FastAPI(lifespan=app_lifespan)
+
+    async with ASGILifespanManager(
+        app,
+        startup_timeout=None if is_pdb_enabled else 10,
+        shutdown_timeout=None if is_pdb_enabled else 10,
+    ) as asgi_manager:
+        # Verify that RabbitMQ responsiveness was checked
+        mock_rabbitmq_connection.assert_called_once_with(
+            app.state.settings.RABBITMQ.dsn
+        )
+
+        # Verify that RabbitMQ settings are in the lifespan manager state
+        assert app.state.settings.RABBITMQ
+
+    # No explicit shutdown logic for RabbitMQ in this case
+    assert mock_rabbitmq_rpc_client_class.called
+
+
+async def test_lifespan_rabbitmq_with_invalid_settings(
+    is_pdb_enabled: bool,
+):
+    async def my_app_settings(app: FastAPI) -> AsyncIterator[State]:
+        yield {"RABBIT_SETTINGS": None}
+
+    app_lifespan = LifespanManager()
+    app_lifespan.add(my_app_settings)
+    app_lifespan.add(rabbitmq_connectivity_lifespan)
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    with pytest.raises(RabbitMQConfigurationError, match="Invalid RabbitMQ") as excinfo:
+        async with ASGILifespanManager(
+            app,
+            startup_timeout=None if is_pdb_enabled else 10,
+            shutdown_timeout=None if is_pdb_enabled else 10,
+        ):
+            ...
+
+    exception = excinfo.value
+    assert isinstance(exception, RabbitMQConfigurationError)
+    assert exception.validation_error
+    assert exception.state["RABBIT_SETTINGS"] is None

--- a/packages/service-library/tests/fastapi/test_redis_lifespan.py
+++ b/packages/service-library/tests/fastapi/test_redis_lifespan.py
@@ -19,7 +19,7 @@ from pytest_simcore.helpers.typing_env import EnvVarsDict
 from servicelib.fastapi.redis_lifespan import (
     RedisConfigurationError,
     RedisLifespanState,
-    redis_database_lifespan,
+    redis_client_sdk_lifespan,
 )
 from settings_library.application import BaseApplicationSettings
 from settings_library.redis import RedisDatabase, RedisSettings
@@ -65,7 +65,7 @@ def app_lifespan(
 
     app_lifespan = LifespanManager()
     app_lifespan.add(my_app_settings)
-    app_lifespan.add(redis_database_lifespan)
+    app_lifespan.add(redis_client_sdk_lifespan)
 
     assert not mock_redis_client_sdk.called
 
@@ -112,7 +112,7 @@ async def test_lifespan_redis_database_with_invalid_settings(
 
     app_lifespan = LifespanManager()
     app_lifespan.add(my_app_settings)
-    app_lifespan.add(redis_database_lifespan)
+    app_lifespan.add(redis_client_sdk_lifespan)
 
     app = FastAPI(lifespan=app_lifespan)
 

--- a/packages/service-library/tests/fastapi/test_redis_lifespan.py
+++ b/packages/service-library/tests/fastapi/test_redis_lifespan.py
@@ -1,0 +1,130 @@
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from collections.abc import AsyncIterator
+from typing import Annotated, Any
+
+import pytest
+import servicelib.fastapi.redis_lifespan
+from asgi_lifespan import LifespanManager as ASGILifespanManager
+from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
+from pydantic import Field
+from pytest_mock import MockerFixture, MockType
+from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from servicelib.fastapi.redis_lifespan import (
+    RedisConfigurationError,
+    RedisLifespanState,
+    redis_database_lifespan,
+)
+from settings_library.application import BaseApplicationSettings
+from settings_library.redis import RedisDatabase, RedisSettings
+
+
+@pytest.fixture
+def mock_redis_client_sdk(mocker: MockerFixture) -> MockType:
+    return mocker.patch.object(
+        servicelib.fastapi.redis_lifespan,
+        "RedisClientSDK",
+        return_value=mocker.AsyncMock(),
+    )
+
+
+@pytest.fixture
+def app_environment(monkeypatch: pytest.MonkeyPatch) -> EnvVarsDict:
+    return setenvs_from_dict(
+        monkeypatch, RedisSettings.model_json_schema()["examples"][0]
+    )
+
+
+@pytest.fixture
+def app_lifespan(
+    app_environment: EnvVarsDict,
+    mock_redis_client_sdk: MockType,
+) -> LifespanManager:
+    assert app_environment
+
+    class AppSettings(BaseApplicationSettings):
+        CATALOG_REDIS: Annotated[
+            RedisSettings,
+            Field(json_schema_extra={"auto_default_from_env": True}),
+        ]
+
+    async def my_app_settings(app: FastAPI) -> AsyncIterator[State]:
+        app.state.settings = AppSettings.create_from_envs()
+
+        yield RedisLifespanState(
+            REDIS_SETTINGS=app.state.settings.CATALOG_REDIS,
+            REDIS_CLIENT_NAME="test_client",
+            REDIS_CLIENT_DB=RedisDatabase.LOCKS,
+        ).model_dump()
+
+    app_lifespan = LifespanManager()
+    app_lifespan.add(my_app_settings)
+    app_lifespan.add(redis_database_lifespan)
+
+    assert not mock_redis_client_sdk.called
+
+    return app_lifespan
+
+
+async def test_lifespan_redis_database_in_an_app(
+    is_pdb_enabled: bool,
+    app_environment: EnvVarsDict,
+    mock_redis_client_sdk: MockType,
+    app_lifespan: LifespanManager,
+):
+    app = FastAPI(lifespan=app_lifespan)
+
+    async with ASGILifespanManager(
+        app,
+        startup_timeout=None if is_pdb_enabled else 10,
+        shutdown_timeout=None if is_pdb_enabled else 10,
+    ) as asgi_manager:
+        # Verify that the Redis client SDK was created
+        mock_redis_client_sdk.assert_called_once_with(
+            app.state.settings.CATALOG_REDIS.build_redis_dsn(RedisDatabase.LOCKS),
+            client_name="test_client",
+        )
+
+        # Verify that the Redis client SDK is in the lifespan manager state
+        assert "REDIS_CLIENT_SDK" in asgi_manager._state  # noqa: SLF001
+        assert app.state.settings.CATALOG_REDIS
+        assert (
+            asgi_manager._state["REDIS_CLIENT_SDK"]  # noqa: SLF001
+            == mock_redis_client_sdk.return_value
+        )
+
+    # Verify that the Redis client SDK was shut down
+    redis_client: Any = mock_redis_client_sdk.return_value
+    redis_client.shutdown.assert_called_once()
+
+
+async def test_lifespan_redis_database_with_invalid_settings(
+    is_pdb_enabled: bool,
+):
+    async def my_app_settings(app: FastAPI) -> AsyncIterator[State]:
+        yield {"REDIS_SETTINGS": None}
+
+    app_lifespan = LifespanManager()
+    app_lifespan.add(my_app_settings)
+    app_lifespan.add(redis_database_lifespan)
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    with pytest.raises(RedisConfigurationError, match="Invalid redis") as excinfo:
+        async with ASGILifespanManager(
+            app,
+            startup_timeout=None if is_pdb_enabled else 10,
+            shutdown_timeout=None if is_pdb_enabled else 10,
+        ):
+            ...
+
+    exception = excinfo.value
+    assert isinstance(exception, RedisConfigurationError)
+    assert exception.validation_error
+    assert exception.state["REDIS_SETTINGS"] is None

--- a/packages/settings-library/src/settings_library/rabbit.py
+++ b/packages/settings-library/src/settings_library/rabbit.py
@@ -2,6 +2,7 @@ from functools import cached_property
 
 from pydantic.networks import AnyUrl
 from pydantic.types import SecretStr
+from pydantic_settings import SettingsConfigDict
 
 from .base import BaseCustomSettings
 from .basic_types import PortInt
@@ -33,3 +34,17 @@ class RabbitSettings(BaseCustomSettings):
             )
         )
         return rabbit_dsn
+
+    model_config = SettingsConfigDict(
+        json_schema_extra={
+            "examples": [
+                # minimal required
+                {
+                    "RABBIT_SECURE": "1",
+                    "RABBIT_HOST": "localhost",
+                    "RABBIT_USER": "user",
+                    "RABBIT_PASSWORD": "foobar",  # NOSONAR
+                }
+            ],
+        }
+    )

--- a/packages/settings-library/src/settings_library/redis.py
+++ b/packages/settings-library/src/settings_library/redis.py
@@ -52,9 +52,6 @@ class RedisSettings(BaseCustomSettings):
             "examples": [
                 # minimal required
                 {
-                    "REDIS_SECURE": "0",
-                    "REDIS_HOST": "localhost",
-                    "REDIS_PORT": "6379",
                     "REDIS_USER": "user",
                     "REDIS_PASSWORD": "foobar",  # NOSONAR
                 }

--- a/packages/settings-library/src/settings_library/redis.py
+++ b/packages/settings-library/src/settings_library/redis.py
@@ -2,6 +2,7 @@ from enum import IntEnum
 
 from pydantic.networks import RedisDsn
 from pydantic.types import SecretStr
+from pydantic_settings import SettingsConfigDict
 
 from .base import BaseCustomSettings
 from .basic_types import PortInt
@@ -45,3 +46,18 @@ class RedisSettings(BaseCustomSettings):
                 path=f"{db_index}",
             )
         )
+
+    model_config = SettingsConfigDict(
+        json_schema_extra={
+            "examples": [
+                # minimal required
+                {
+                    "REDIS_SECURE": "0",
+                    "REDIS_HOST": "localhost",
+                    "REDIS_PORT": "6379",
+                    "REDIS_USER": "user",
+                    "REDIS_PASSWORD": "foobar",  # NOSONAR
+                }
+            ],
+        }
+    )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?


Enhances the `servicelib.fastapi` module by extending its lifespan management functionality using a context manager pattern (`on_startup`/`on_shutdown`). This update introduces reusable lifespan contexts for managing RabbitMQ (both connection and RPC clients) and Redis resources (only clients).

All these new functions are reusable and should drastically reduce the boilerplate to create simcore-service. Please check tests to see usage

## Related issue/s

- Preparations for https://github.com/ITISFoundation/osparc-simcore/pull/7546

## How to test

```
cd packages/service-library
make "install-dev[all]"
pytest -vv tests/fastapi/test_*lifespan*.py
```

## Dev-ops 

None