### PR TITLE
🐛 [Frontend] Disable Autocompletion

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/SearchBarFilter.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/SearchBarFilter.js
@@ -110,6 +110,7 @@ qx.Class.define("osparc.dashboard.SearchBarFilter", {
           this._add(control, {
             flex: 1
           });
+          osparc.utils.Utils.disableAutocomplete(control);
           break;
         case "reset-button":
           control = new qx.ui.toolbar.Button(null, "@MaterialIcons/close/20").set({

--- a/services/static-webserver/client/source/class/osparc/filter/TextFilter.js
+++ b/services/static-webserver/client/source/class/osparc/filter/TextFilter.js
@@ -72,9 +72,7 @@ qx.Class.define("osparc.filter.TextFilter", {
             paddingRight: 15,
             placeholder: this.tr("Filter")
           });
-          control.getContentElement().setAttribute("autocomplete", "off");
-          // FIXME: autocomplete "off" doesn't work on Chrome
-          // https://www.codementor.io/leonardofaria/disabling-autofill-in-chrome-zec47xcui
+          osparc.utils.Utils.disableAutocomplete(control);
           this._add(control, {
             width: "100%"
           });

--- a/services/static-webserver/client/source/class/osparc/form/tag/TagItem.js
+++ b/services/static-webserver/client/source/class/osparc/form/tag/TagItem.js
@@ -122,8 +122,8 @@ qx.Class.define("osparc.form.tag.TagItem", {
           control = new qx.ui.form.TextField().set({
             required: true
           });
+          osparc.utils.Utils.disableAutocomplete(control);
           this.__validationManager.add(control);
-          control.getContentElement().setAttribute("autocomplete", "off");
           break;
         case "description-input":
           control = new qx.ui.form.TextArea().set({

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -91,6 +91,13 @@ qx.Class.define("osparc.utils.Utils", {
 
     FLOATING_Z_INDEX: 1000001 + 1,
 
+    disableAutocomplete: function(control) {
+      if (control && control.getContentElement()) {
+        control.getContentElement().setAttribute("autocomplete", "off");
+        control.getContentElement().setAttribute("type", "search");
+      }
+    },
+
     checkImageExists: function(url) {
       return new Promise(resolve => {
         const img = new Image();


### PR DESCRIPTION
## What do these changes do?

I can't reproduce it in my local deployment, so this is an attempt to disable the autocompletion in the Dashboards Search tool by setting the ``autocomplete`` attribute to ``off``, and the input ``type`` from the default ``text`` to ``search``.

## Related issue/s

- closes https://github.com/ITISFoundation/osparc-issues/issues/1874

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
